### PR TITLE
[data.llm] Allow vLLM deployments to be shared by sequential processors

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -29,16 +29,10 @@ from ray.data._internal.execution.interfaces import (
     TaskContext,
 )
 from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
-from ray.data._internal.execution.interfaces.op_runtime_metrics import OpRuntimeMetrics
-from ray.data._internal.execution.operators.map_operator import (
-    MapOperator,
-    _map_task,
-    _BlockRefBundler,
-)
+from ray.data._internal.execution.operators.map_operator import MapOperator, _map_task
 from ray.data._internal.execution.operators.map_transformer import MapTransformer
 from ray.data._internal.execution.util import locality_string
 from ray.data._internal.remote_fn import _add_system_error_to_retry_exceptions
-from ray.data._internal.stats import Timer
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import DataContext
 from ray.types import ObjectRef
@@ -62,79 +56,6 @@ class ActorPoolMapOperator(MapOperator):
     limits after adding put, then there isn't any way to "take back" the inputs prior
     to actual execution).
     """
-
-    @classmethod
-    def create(
-        cls,
-        map_transformer: "MapTransformer",
-        input_op: "PhysicalOperator",
-        data_context: "DataContext",
-        target_max_block_size: Optional[int],
-        compute_strategy: "ActorPoolStrategy",
-        name: str = "ActorPoolMap",
-        min_rows_per_bundle: Optional[int] = None,
-        supports_fusion: bool = True,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-        shared_key: Optional[str] = None,
-    ) -> "ActorPoolMapOperator":
-        """Create an ActorPoolMapOperator with support for operator sharing.
-
-        Args:
-            map_transformer: The transformer to apply to input data.
-            input_op: Operator generating input data for this op.
-            data_context: DataContext for this operator.
-            target_max_block_size: The target maximum number of bytes to
-                include in an output block.
-            compute_strategy: ActorPoolStrategy used for this operator.
-            name: The name of this operator.
-            min_rows_per_bundle: The number of rows to gather per batch passed to the
-                transform_fn, or None to use the block size.
-            supports_fusion: Whether this operator supports fusion with other operators.
-            ray_remote_args_fn: A function that returns a dictionary of remote args
-                passed to each map worker.
-            ray_remote_args: Customize the ray remote args for this op's tasks.
-            shared_key: Optional key for sharing this operator across executions.
-
-        Returns:
-            ActorPoolMapOperator instance (either new or shared).
-        """
-        if shared_key is not None:
-            existing_operator = _shared_operator_registry.get(shared_key)
-            # Clean up old input dependency connection
-            if existing_operator is not None:
-                if existing_operator._input_dependencies:
-                    # ActorPoolMapOperator is a OneToOneOperator and therefore has only
-                    # one input dependency
-                    old_input_op = existing_operator._input_dependencies[0]
-                    if existing_operator in old_input_op._output_dependencies:
-                        old_input_op._output_dependencies.remove(existing_operator)
-
-                existing_operator._input_dependencies = [input_op]
-                input_op._output_dependencies.append(existing_operator)
-
-                existing_operator._reset()
-
-                return _shared_operator_registry.register(shared_key, existing_operator)
-
-        operator = cls(
-            map_transformer=map_transformer,
-            input_op=input_op,
-            data_context=data_context,
-            target_max_block_size=target_max_block_size,
-            compute_strategy=compute_strategy,
-            name=name,
-            min_rows_per_bundle=min_rows_per_bundle,
-            supports_fusion=supports_fusion,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
-            shared_key=shared_key,
-        )
-
-        if shared_key is not None:
-            return _shared_operator_registry.register(shared_key, operator)
-
-        return operator
 
     def __init__(
         self,
@@ -177,7 +98,7 @@ class ActorPoolMapOperator(MapOperator):
                 advanced, experimental feature.
             ray_remote_args: Customize the ray remote args for this op's tasks.
                 See :func:`ray.remote` for details.
-            shared_key: Optional key for sharing this operator across executions.
+            shared_key: Optional key for sharing the actor pool across executions.
         """
         super().__init__(
             map_transformer,
@@ -191,7 +112,6 @@ class ActorPoolMapOperator(MapOperator):
             ray_remote_args_fn,
             ray_remote_args,
         )
-        self._reuse_actors = shared_key is not None
         self._shared_key = shared_key
         self._ray_actor_task_remote_args = {}
         actor_task_errors = self.data_context.actor_task_retry_on_errors
@@ -225,22 +145,49 @@ class ActorPoolMapOperator(MapOperator):
 
         max_actor_concurrency = self._ray_remote_args.get("max_concurrency", 1)
 
-        self._actor_pool = _ActorPool(
-            self._start_actor,
-            per_actor_resource_usage,
-            min_size=compute_strategy.min_size,
-            max_size=compute_strategy.max_size,
-            max_actor_concurrency=max_actor_concurrency,
-            max_tasks_in_flight_per_actor=(
-                # NOTE: Unless explicitly configured by the user, max tasks-in-flight config
-                #       will fall back to be 2 x of `max_concurrency`, entailing that for every
-                #       running task we'd allow 1 more task to be enqueued
-                compute_strategy.max_tasks_in_flight_per_actor
-                or data_context.max_tasks_in_flight_per_actor
-                or max_actor_concurrency * 2
-            ),
-            _enable_actor_pool_on_exit_hook=self.data_context._enable_actor_pool_on_exit_hook,
-        )
+
+        if shared_key is not None:
+            existing_pool = _shared_actor_pool_registry.get(shared_key)
+            if existing_pool is not None:
+                self._verify_actor_pool_compatibility(
+                    existing_pool, compute_strategy, self._ray_remote_args, data_context
+                )
+                self._actor_pool = existing_pool
+            else:
+                self._actor_pool = _ActorPool(
+                    self._start_actor,
+                    per_actor_resource_usage,
+                    min_size=compute_strategy.min_size,
+                    max_size=compute_strategy.max_size,
+                    max_actor_concurrency=max_actor_concurrency,
+                    max_tasks_in_flight_per_actor=(
+                        # NOTE: Unless explicitly configured by the user, max tasks-in-flight config
+                        #       will fall back to be 2 x of `max_concurrency`, entailing that for every
+                        #       running task we'd allow 1 more task to be enqueued
+                        compute_strategy.max_tasks_in_flight_per_actor
+                        or data_context.max_tasks_in_flight_per_actor
+                        or max_actor_concurrency * 2
+                    ),
+                    _enable_actor_pool_on_exit_hook=self.data_context._enable_actor_pool_on_exit_hook,
+                )
+            _shared_actor_pool_registry.register(shared_key, self._actor_pool)
+        else:
+            self._actor_pool = _ActorPool(
+                self._start_actor,
+                per_actor_resource_usage,
+                min_size=compute_strategy.min_size,
+                max_size=compute_strategy.max_size,
+                max_actor_concurrency=max_actor_concurrency,
+                max_tasks_in_flight_per_actor=(
+                    # NOTE: Unless explicitly configured by the user, max tasks-in-flight config
+                    #       will fall back to be 2 x of `max_concurrency`, entailing that for every
+                    #       running task we'd allow 1 more task to be enqueued
+                    compute_strategy.max_tasks_in_flight_per_actor
+                    or data_context.max_tasks_in_flight_per_actor
+                    or max_actor_concurrency * 2
+                ),
+                _enable_actor_pool_on_exit_hook=self.data_context._enable_actor_pool_on_exit_hook,
+            )
 
         self._actor_task_selector = self._create_task_selector(self._actor_pool)
         # A queue of bundles awaiting dispatch to actors.
@@ -446,12 +393,14 @@ class ActorPoolMapOperator(MapOperator):
             )
 
     def _do_shutdown(self, force: bool = False):
-        if self._reuse_actors and not force:
+        if self._shared_key is not None and not force:
+            _shared_actor_pool_registry.release(self._shared_key, force=False)
             return
-        if self._reuse_actors:
-            _shared_operator_registry.release(self._shared_key, force)
 
-        self._actor_pool.shutdown(force=force)
+        if self._shared_key is not None and force:
+            _shared_actor_pool_registry.release(self._shared_key, force=True)
+        else:
+            self._actor_pool.shutdown(force=force)
 
         # NOTE: It's critical for Actor Pool to release actors before calling into
         #       the base method that will attempt to cancel and join pending.
@@ -550,7 +499,7 @@ class ActorPoolMapOperator(MapOperator):
         # autoscaler logic to scale the pool down to zero after the operator
         # finishes, otherwise the next execution would have to spin them up
         # again. In that case, we simply opt-out of autoscaling.
-        if self._reuse_actors:
+        if self._shared_key is not None:
             return []
         return [self._actor_pool]
 
@@ -576,71 +525,50 @@ class ActorPoolMapOperator(MapOperator):
         """Returns Actor counts for Alive, Restarting and Pending Actors."""
         return self._actor_pool.get_actor_info()
 
-    def _reset(self):
-        """Reset the operator's essential state for reuse across executions."""
-        self._inputs_complete = False
-        self._execution_finished = False
-        self._inputs_done = False
-        self._bundle_queue.clear()
+    def _verify_actor_pool_compatibility(
+        self,
+        existing_pool: "_ActorPool",
+        compute_strategy: ActorPoolStrategy,
+        ray_remote_args: Dict[str, Any],
+        data_context: DataContext,
+    ):
+        """Verify that the new operator's configuration is compatible with the existing shared actor pool."""
+        if (
+            existing_pool.min_size() != compute_strategy.min_size
+            or existing_pool.max_size() != compute_strategy.max_size
+            or existing_pool.max_tasks_in_flight_per_actor()
+            != (
+                compute_strategy.max_tasks_in_flight_per_actor
+                or DEFAULT_MAX_TASKS_IN_FLIGHT
+            )
+        ):
+            raise ValueError(
+                f"Cannot reuse shared actor pool with key '{self._shared_key}': "
+                f"Compute strategy mismatch. "
+                f"Existing pool: min_size={existing_pool.min_size()}, max_size={existing_pool.max_size()}, "
+                f"max_tasks_in_flight={existing_pool.max_tasks_in_flight_per_actor()}. "
+                f"New operator: min_size={compute_strategy.min_size}, max_size={compute_strategy.max_size}, "
+                f"max_tasks_in_flight={compute_strategy.max_tasks_in_flight_per_actor or DEFAULT_MAX_TASKS_IN_FLIGHT}."
+            )
 
+        existing_resources = existing_pool.per_actor_resource_usage()
+        new_per_actor_cpu = ray_remote_args.get("num_cpus", 0)
+        new_per_actor_gpu = ray_remote_args.get("num_gpus", 0)
 
-class SharedActorPoolOperatorRegistry:
-    """
-    Thread-safe registry for shared ActorPoolMapOperator instances across executions.
-    """
+        if (
+            existing_resources.cpu != new_per_actor_cpu
+            or existing_resources.gpu != new_per_actor_gpu
+        ):
+            raise ValueError(
+                f"Cannot reuse shared actor pool with key '{self._shared_key}': "
+                f"Resource requirements mismatch. "
+                f"Existing pool per-actor resources: CPU={existing_resources.cpu}, GPU={existing_resources.gpu}. "
+                f"New operator per-actor resources: CPU={new_per_actor_cpu}, GPU={new_per_actor_gpu}."
+            )
 
-    def __init__(self):
-        self._lock = threading.RLock()
-        self._operators: Dict[str, ActorPoolMapOperator] = {}
-        self._usage_count = defaultdict(int)
-
-    def register(
-        self, shared_key: str, operator: ActorPoolMapOperator
-    ) -> ActorPoolMapOperator:
-        """Register or retrieve a shared operator."""
-        with self._lock:
-            self._operators[shared_key] = operator
-            self._usage_count[shared_key] += 1
-            return operator
-
-    def get(self, shared_key: str) -> Optional[ActorPoolMapOperator]:
-        """Get a shared operator if it exists."""
-        with self._lock:
-            return self._operators.get(shared_key)
-
-    def release(self, shared_key: str, force: bool = False) -> bool:
-        """Release a shared operator."""
-        with self._lock:
-            if not force and shared_key not in self._usage_count:
-                return False
-
-            if force or self._usage_count[shared_key] == 1:
-                op = self._operators.pop(shared_key, None)
-                if op:
-                    self._usage_count.pop(shared_key, None)
-                    if not getattr(op, "_shutdown", False):
-                        op.shutdown(Timer(), force=True)
-                    elif hasattr(op, "_actor_pool"):
-                        op._actor_pool.shutdown(force=True)
-                    return True
-                return False
-
-            self._usage_count[shared_key] -= 1
-            return False
-
-    def shutdown(self):
-        """Shutdown all shared operators."""
-        with self._lock:
-            keys = list(self._operators.keys())
-            for key in keys:
-                self.release(key, force=True)
-
-
-_shared_operator_registry = SharedActorPoolOperatorRegistry()
-
-# Register an atexit hook to ensure all shared operators are cleaned up when the
-# Python process exits. This prevents lingering Ray actors when sharing operators.
-atexit.register(_shared_operator_registry.shutdown)
+        # Note: We don't check scheduling_strategy, max_restarts, max_task_retries etc.
+        # because these don't affect whether actors can be shared - they're execution-level
+        # settings that can vary between operators using the same actor pool.
 
 
 class _MapWorker:
@@ -1258,3 +1186,58 @@ class _ActorPool(AutoscalingActorPool):
             return self.num_tasks_in_flight() / (
                 self._max_actor_concurrency * self.num_running_actors()
             )
+
+class SharedActorPoolRegistry:
+    """
+    Thread-safe registry for shared ActorPool instances across ActorPoolMapOperator executions.
+    This allows multiple operators to share the same actor pool while maintaining separate operator state.
+    """
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._pools: Dict[str, _ActorPool] = {}
+        self._usage_count = defaultdict(int)
+
+    def register(self, shared_key: str, pool: _ActorPool) -> _ActorPool:
+        """Register or retrieve a shared pool and increment usage count."""
+        with self._lock:
+            self._pools[shared_key] = pool
+            self._usage_count[shared_key] += 1
+            return pool
+
+    def get(self, shared_key: str) -> Optional[_ActorPool]:
+        """Get a shared pool if it exists."""
+        with self._lock:
+            return self._pools.get(shared_key)
+
+    def release(self, shared_key: str, force: bool = False) -> bool:
+        """Release a shared pool and decrement usage count."""
+        with self._lock:
+            if shared_key not in self._usage_count:
+                return False
+
+            if force:
+                pool = self._pools.pop(shared_key, None)
+                if pool:
+                    self._usage_count.pop(shared_key, None)
+                    pool.shutdown(force=True)
+                    return True
+                return False
+
+            if self._usage_count[shared_key] > 0:
+                self._usage_count[shared_key] -= 1
+            return False
+
+    def shutdown(self):
+        """Shutdown all shared pools."""
+        with self._lock:
+            keys = list(self._pools.keys())
+            for key in keys:
+                self.release(key, force=True)
+
+
+_shared_actor_pool_registry = SharedActorPoolRegistry()
+
+# Register an atexit hook to ensure all shared pools are cleaned up when the
+# Python process exits. This prevents lingering Ray actors when sharing pools.
+atexit.register(_shared_actor_pool_registry.shutdown)

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -243,10 +243,10 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
                 ActorPoolMapOperator,
             )
 
-            return ActorPoolMapOperator.create(
-                map_transformer=map_transformer,
-                input_op=input_op,
-                data_context=data_context,
+            return ActorPoolMapOperator(
+                map_transformer,
+                input_op,
+                data_context,
                 target_max_block_size=target_max_block_size,
                 compute_strategy=compute_strategy,
                 name=name,

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -214,7 +214,6 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
         if compute_strategy is None:
             compute_strategy = TaskPoolStrategy()
 
-        # Create new operator based on compute strategy
         if isinstance(compute_strategy, TaskPoolStrategy):
             if shared_key is not None:
                 logger.warning(

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -29,7 +29,6 @@ class TaskPoolMapOperator(MapOperator):
         map_task_kwargs: Optional[Dict[str, Any]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
-        shared_key: Optional[str] = None,
     ):
         """Create an TaskPoolMapOperator instance.
 
@@ -55,7 +54,6 @@ class TaskPoolMapOperator(MapOperator):
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
             ray_remote_args: Customize the :func:`ray.remote` args for this op's tasks.
-            shared_key: Optional key for sharing this operator across executions.
         """
         super().__init__(
             map_transformer,
@@ -68,7 +66,6 @@ class TaskPoolMapOperator(MapOperator):
             map_task_kwargs,
             ray_remote_args_fn,
             ray_remote_args,
-            shared_key,
         )
         self._concurrency = concurrency
 

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -29,6 +29,7 @@ class TaskPoolMapOperator(MapOperator):
         map_task_kwargs: Optional[Dict[str, Any]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        shared_key: Optional[str] = None,
     ):
         """Create an TaskPoolMapOperator instance.
 
@@ -54,6 +55,7 @@ class TaskPoolMapOperator(MapOperator):
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
             ray_remote_args: Customize the :func:`ray.remote` args for this op's tasks.
+            shared_key: Optional key for sharing this operator across executions.
         """
         super().__init__(
             map_transformer,
@@ -66,6 +68,7 @@ class TaskPoolMapOperator(MapOperator):
             map_task_kwargs,
             ray_remote_args_fn,
             ray_remote_args,
+            shared_key,
         )
         self._concurrency = concurrency
 

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -32,7 +32,6 @@ class AbstractMap(AbstractOneToOne):
         ray_remote_args: Optional[Dict[str, Any]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         compute: Optional[ComputeStrategy] = None,
-        shared_key: Optional[str] = None,
     ):
         """
         Args:
@@ -49,14 +48,12 @@ class AbstractMap(AbstractOneToOne):
                 prior to initializing the worker. Args returned from this dict
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
-            shared_key: Optional key for sharing the physical operator across executions.
         """
         super().__init__(name, input_op, num_outputs)
         self._min_rows_per_bundled_input = min_rows_per_bundled_input
         self._ray_remote_args = ray_remote_args or {}
         self._ray_remote_args_fn = ray_remote_args_fn
         self._compute = compute or TaskPoolStrategy()
-        self._shared_key = shared_key
 
 
 class AbstractUDFMap(AbstractMap):
@@ -78,7 +75,6 @@ class AbstractUDFMap(AbstractMap):
         compute: Optional[ComputeStrategy] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
-        shared_key: Optional[str] = None,
     ):
         """
         Args:
@@ -104,7 +100,6 @@ class AbstractUDFMap(AbstractMap):
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
             ray_remote_args: Args to provide to :func:`ray.remote`.
-            shared_key: Optional key for sharing the physical operator across executions.
         """
         name = self._get_operator_name(name, fn)
         super().__init__(
@@ -113,7 +108,6 @@ class AbstractUDFMap(AbstractMap):
             min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
             compute=compute,
-            shared_key=shared_key,
         )
         self._fn = fn
         self._fn_args = fn_args
@@ -184,11 +178,11 @@ class MapBatches(AbstractUDFMap):
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
             ray_remote_args=ray_remote_args,
-            shared_key=shared_key,
         )
         self._batch_size = batch_size
         self._batch_format = batch_format
         self._zero_copy_batch = zero_copy_batch
+        self._shared_key = shared_key
 
     def can_modify_num_rows(self) -> bool:
         return False

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -32,6 +32,7 @@ class AbstractMap(AbstractOneToOne):
         ray_remote_args: Optional[Dict[str, Any]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         compute: Optional[ComputeStrategy] = None,
+        shared_key: Optional[str] = None,
     ):
         """
         Args:
@@ -48,12 +49,14 @@ class AbstractMap(AbstractOneToOne):
                 prior to initializing the worker. Args returned from this dict
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
+            shared_key: Optional key for sharing the physical operator across executions.
         """
         super().__init__(name, input_op, num_outputs)
         self._min_rows_per_bundled_input = min_rows_per_bundled_input
         self._ray_remote_args = ray_remote_args or {}
         self._ray_remote_args_fn = ray_remote_args_fn
         self._compute = compute or TaskPoolStrategy()
+        self._shared_key = shared_key
 
 
 class AbstractUDFMap(AbstractMap):
@@ -75,6 +78,7 @@ class AbstractUDFMap(AbstractMap):
         compute: Optional[ComputeStrategy] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        shared_key: Optional[str] = None,
     ):
         """
         Args:
@@ -100,6 +104,7 @@ class AbstractUDFMap(AbstractMap):
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
             ray_remote_args: Args to provide to :func:`ray.remote`.
+            shared_key: Optional key for sharing the physical operator across executions.
         """
         name = self._get_operator_name(name, fn)
         super().__init__(
@@ -108,6 +113,7 @@ class AbstractUDFMap(AbstractMap):
             min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
             compute=compute,
+            shared_key=shared_key,
         )
         self._fn = fn
         self._fn_args = fn_args
@@ -164,6 +170,7 @@ class MapBatches(AbstractUDFMap):
         compute: Optional[ComputeStrategy] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        shared_key: Optional[str] = None,
     ):
         super().__init__(
             "MapBatches",
@@ -177,6 +184,7 @@ class MapBatches(AbstractUDFMap):
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
             ray_remote_args=ray_remote_args,
+            shared_key=shared_key,
         )
         self._batch_size = batch_size
         self._batch_format = batch_format

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -277,6 +277,7 @@ def plan_udf_map_op(
         min_rows_per_bundle=op._min_rows_per_bundled_input,
         ray_remote_args_fn=op._ray_remote_args_fn,
         ray_remote_args=op._ray_remote_args,
+        shared_key=getattr(op, "_shared_key", None),
     )
 
 

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -705,6 +705,7 @@ def _generate_transform_fn_for_async_map(
         #       to keep the output ordering the same as that one of the input
         #       iterator.
         completed_tasks_queue = asyncio.Queue(maxsize=max_concurrency)
+
         # NOTE: This method is nested to support Python 3.9 where we only can
         #       init `asyncio.Queue` inside the async function
         async def _reorder() -> None:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -465,6 +465,7 @@ class Dataset:
         memory: Optional[float] = None,
         concurrency: Optional[Union[int, Tuple[int, int]]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
+        shared_key: Optional[str] = None,  # NEW: Add shared_key parameter
         **ray_remote_args,
     ) -> "Dataset":
         """Apply the given function to batches of data.
@@ -700,6 +701,7 @@ class Dataset:
             memory=memory,
             concurrency=concurrency,
             ray_remote_args_fn=ray_remote_args_fn,
+            shared_key=shared_key,  # NEW: Pass shared_key to internal method
             **ray_remote_args,
         )
 
@@ -720,6 +722,7 @@ class Dataset:
         memory: Optional[float],
         concurrency: Optional[Union[int, Tuple[int, int]]],
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]],
+        shared_key: Optional[str],  # NEW: Add shared_key parameter
         **ray_remote_args,
     ):
         # NOTE: The `map_groups` implementation calls `map_batches` with
@@ -774,6 +777,7 @@ class Dataset:
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
             ray_remote_args=ray_remote_args,
+            shared_key=shared_key,  # NEW: Pass shared_key to internal method
         )
         logical_plan = LogicalPlan(map_batches_op, self.context)
         return Dataset(plan, logical_plan)
@@ -5622,9 +5626,9 @@ class Dataset:
         import pyarrow as pa
 
         ref_bundles: Iterator[RefBundle] = self.iter_internal_ref_bundles()
-        block_refs: List[
-            ObjectRef["pyarrow.Table"]
-        ] = _ref_bundles_iterator_to_block_refs_list(ref_bundles)
+        block_refs: List[ObjectRef["pyarrow.Table"]] = (
+            _ref_bundles_iterator_to_block_refs_list(ref_bundles)
+        )
         # Schema is safe to call since we have already triggered execution with
         # iter_internal_ref_bundles.
         schema = self.schema(fetch_if_missing=True)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -465,7 +465,7 @@ class Dataset:
         memory: Optional[float] = None,
         concurrency: Optional[Union[int, Tuple[int, int]]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        shared_key: Optional[str] = None,  # NEW: Add shared_key parameter
+        shared_key: Optional[str] = None,
         **ray_remote_args,
     ) -> "Dataset":
         """Apply the given function to batches of data.
@@ -701,7 +701,7 @@ class Dataset:
             memory=memory,
             concurrency=concurrency,
             ray_remote_args_fn=ray_remote_args_fn,
-            shared_key=shared_key,  # NEW: Pass shared_key to internal method
+            shared_key=shared_key,
             **ray_remote_args,
         )
 
@@ -722,7 +722,7 @@ class Dataset:
         memory: Optional[float],
         concurrency: Optional[Union[int, Tuple[int, int]]],
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]],
-        shared_key: Optional[str],  # NEW: Add shared_key parameter
+        shared_key: Optional[str],
         **ray_remote_args,
     ):
         # NOTE: The `map_groups` implementation calls `map_batches` with
@@ -777,7 +777,7 @@ class Dataset:
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
             ray_remote_args=ray_remote_args,
-            shared_key=shared_key,  # NEW: Pass shared_key to internal method
+            shared_key=shared_key,
         )
         logical_plan = LogicalPlan(map_batches_op, self.context)
         return Dataset(plan, logical_plan)

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -761,8 +761,7 @@ def test_actor_pool_fault_tolerance_e2e(ray_start_cluster, restore_data_context)
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 2}], indirect=True)
 def test_shared_key_actor_pool_reuse(ray_start_regular, clean_registry):
-    """Test that ActorPoolMapOperator with the same shared_key share actor pools but remain separate operators."""
-
+    # Test that ActorPoolMapOperator with the same shared_key share actor pools
     @ray.remote
     class Counter:
         def __init__(self):
@@ -823,8 +822,7 @@ def test_shared_key_actor_pool_reuse(ray_start_regular, clean_registry):
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 2}], indirect=True)
 def test_shared_key_actor_pool_chaining(ray_start_regular, clean_registry):
-    """Test that chained operations with shared actor pools work without materialization."""
-
+    # Test that chained operations with shared actor pools work without materialization.
     @ray.remote
     class Counter:
         def __init__(self):
@@ -876,8 +874,7 @@ def test_shared_key_actor_pool_chaining(ray_start_regular, clean_registry):
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 2}], indirect=True)
 def test_shared_key_actor_pool_compatibility_error(ray_start_regular, clean_registry):
-    """Test that incompatible configurations raise an error when trying to reuse actor pools."""
-
+    # Test that incompatible configurations raise an error when trying to reuse actor pools.
     class UDFClass:
         def __call__(self, x):
             return x
@@ -919,8 +916,7 @@ def test_shared_key_actor_pool_compatibility_error(ray_start_regular, clean_regi
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 2}], indirect=True)
 def test_shared_registry_shutdown(ray_start_regular, clean_registry):
-    """Test that the shared actor pool registry is cleaned up when the process exits."""
-
+    # Test that the shared actor pool registry is cleaned up when the process exits.
     class UDFClass:
         def __call__(self, x):
             return x

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -24,9 +24,11 @@ from ray.data._internal.execution.operators.actor_pool_map_operator import (
     ActorPoolMapOperator,
     _ActorPool,
     _ActorTaskSelector,
+    _shared_operator_registry
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.util import make_ref_bundles
+from ray.data._internal.stats import Timer
 from ray.tests.conftest import *  # noqa
 from ray.types import ObjectRef
 
@@ -749,6 +751,76 @@ def test_actor_pool_fault_tolerance_e2e(ray_start_cluster, restore_data_context)
 
     thread.join()
     assert sorted(res, key=lambda x: x["id"]) == [{"id": i} for i in range(num_items)]
+
+@pytest.fixture
+def clean_registry():
+    yield
+    _shared_operator_registry._operators.clear()
+    _shared_operator_registry._usage_count.clear()
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+def test_shared_key_actor_pool_operator_reuse(ray_start_regular, clean_registry):
+    """Test that ActorPoolMapOperator with the same shared_key are reused across dataset executions."""
+    class UDFClass:
+        def __call__(self, x):
+            return x
+
+    shared_key = "test_shared_key"
+
+    ds1 = ray.data.range(10)
+    ds1_result = ds1.map_batches(
+        UDFClass, batch_size=1, compute=ray.data.ActorPoolStrategy(size=1), shared_key=shared_key
+    ).take_all()
+
+    operator1 = _shared_operator_registry.get(shared_key)
+    assert operator1 is not None
+    operator1_id = id(operator1)
+
+    ds2 = ray.data.range(10)
+    ds2_result = ds2.map_batches(
+        UDFClass, batch_size=1, compute=ray.data.ActorPoolStrategy(size=1), shared_key=shared_key
+    ).take_all()
+
+    # With the same shared_key, the operator should be reused
+    operator2 = _shared_operator_registry.get(shared_key)
+    assert operator2 is not None
+    operator2_id = id(operator2)
+
+    assert operator1_id == operator2_id
+    assert operator1 is operator2
+
+    expected_result = [{"id": i} for i in range(10)]
+    assert sorted(ds1_result, key=lambda x: x["id"]) == expected_result
+    assert sorted(ds2_result, key=lambda x: x["id"]) == expected_result
+
+
+# # TODO: Look into how operators/actor pools are cleaned up without shared_key
+# @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+# def test_shared_key_cleanup_on_destruction(ray_start_regular, clean_registry):
+#     """Test that shared operators are properly cleaned up when shutdown with force=True."""
+#     class UDFClass:
+#         def __call__(self, x):
+#             return x
+
+#     shared_key = "test_shared_key"
+
+#     ds1 = ray.data.range(5)
+#     ds1_result = ds1.map_batches(
+#         UDFClass, compute=ray.data.ActorPoolStrategy(size=1), shared_key=shared_key
+#     ).take_all()
+
+#     # ds2 = ray.data.range(5)
+#     # ds2_result = ds2.map_batches(
+#     #     UDFClass, compute=ray.data.ActorPoolStrategy(size=1), shared_key=shared_key
+#     # )
+
+#     operator = _shared_operator_registry.get(shared_key)
+
+#     # ds2_result = ds2_result.take_all()
+#     # As there are two usages of the operator, the cleanup should happen on the second shutdown
+#     operator.shutdown(Timer(), force=True)
+#     assert shared_key not in _shared_operator_registry._operators
+#     assert shared_key not in _shared_operator_registry._usage_count
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -1,7 +1,6 @@
 """The vLLM engine processor."""
 
-from typing import Any, Dict, Optional, List
-import uuid
+from typing import Any, Dict, Optional
 
 import transformers
 from pydantic import Field, root_validator
@@ -165,8 +164,8 @@ def build_vllm_engine_processor(
             compute=ray.data.ActorPoolStrategy(
                 min_size=config.concurrency,
                 max_size=config.concurrency,
-                max_tasks_in_flight_per_actor=max(
-                    DEFAULT_MAX_TASKS_IN_FLIGHT, config.max_concurrent_batches
+                max_tasks_in_flight_per_actor=config.experimental.get(
+                    "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
                 ),
             ),
             # The number of running batches "per actor" in Ray Core level.

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -36,55 +36,6 @@ from ray.llm._internal.common.utils.download_utils import (
 DEFAULT_MODEL_ARCHITECTURE = "UNKNOWN_MODEL_ARCHITECTURE"
 
 
-class SharedvLLMStageManager:
-    """Manager for shared vLLM stage configurations."""
-
-    _shared_stages: Dict[str, Any] = {}
-    _usage_count: Dict[str, int] = {}
-
-    @classmethod
-    def get_or_create_shared_stage(cls, engine_key: str, stage_factory_fn):
-        """Get or create a shared stage."""
-        if engine_key not in cls._shared_stages:
-            print(f"SharedvLLMStageManager: Creating new stage for key: {engine_key}")
-            stage = stage_factory_fn()
-            cls._shared_stages[engine_key] = stage
-            cls._usage_count[engine_key] = 0
-        else:
-            print(
-                f"SharedvLLMStageManager: Reusing existing stage for key: {engine_key}"
-            )
-            stage = cls._shared_stages[engine_key]
-
-        cls._usage_count[engine_key] += 1
-        return cls._shared_stages[engine_key]
-
-    @classmethod
-    def release_shared_stage(cls, engine_key: str):
-        """Release a shared stage."""
-        if engine_key in cls._usage_count:
-            cls._usage_count[engine_key] -= 1
-
-            if cls._usage_count[engine_key] <= 0:
-                print(
-                    f"SharedvLLMStageManager: Cleaning up stage for key: {engine_key}"
-                )
-                if engine_key in cls._shared_stages:
-                    del cls._shared_stages[engine_key]
-                del cls._usage_count[engine_key]
-
-    @classmethod
-    def list_shared_stages(cls) -> Dict[str, Dict[str, Any]]:
-        """List all shared stages."""
-        return {
-            key: {
-                "stage": stage,
-                "usage_count": cls._usage_count.get(key, 0),
-            }
-            for key, stage in cls._shared_stages.items()
-        }
-
-
 class vLLMEngineProcessorConfig(OfflineProcessorConfig):
     """The configuration for the vLLM engine processor."""
 
@@ -108,19 +59,11 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
         "specified and LoRA is enabled, then the 'model' in LoRA "
         "requests will be interpreted as model ID used by HF transformers.",
     )
-    # Engine sharing configurations.
-    reuse_engine: bool = Field(
-        default=False,
-        description="Whether to reuse an existing vLLM engine stage if one "
-        "with compatible configuration already exists. This is useful for "
-        "sequential processing steps that use the same model configuration "
-        "to reduce resource requirements.",
-    )
+    # Engine sharing key.
     shared_engine_key: Optional[str] = Field(
         default=None,
-        description="Custom key for engine sharing. If not provided, a key "
-        "will be automatically generated based on model and engine configuration. "
-        "Use this to explicitly control which engines are shared.",
+        description="Custom key for engine sharing. Use this to explicitly "
+        "control which engines are shared.",
     )
 
     @root_validator(pre=True)
@@ -203,93 +146,41 @@ def build_vllm_engine_processor(
 
     # Core stage -- the vLLM engine.
 
-    # Determine if we should use stage sharing
-    if config.reuse_engine and config.shared_engine_key:
-        print(f"Attempting to reuse vLLM stage with key: {config.shared_engine_key}")
-
-        def stage_factory():
-            print(
-                f"Creating new vLLMEngineStage for shared key: {config.shared_engine_key}"
-            )
-            stage = vLLMEngineStage(
-                fn_constructor_kwargs=dict(
-                    batch_size=config.batch_size,
-                    max_concurrent_batches=config.max_concurrent_batches,
-                    model=config.model_source,
-                    engine_kwargs=config.engine_kwargs,
-                    task_type=config.task_type,
-                    max_pending_requests=config.max_pending_requests,
-                    dynamic_lora_loading_path=config.dynamic_lora_loading_path,
+    vllm_stage = vLLMEngineStage(
+        fn_constructor_kwargs=dict(
+            batch_size=config.batch_size,
+            max_concurrent_batches=config.max_concurrent_batches,
+            model=config.model_source,
+            engine_kwargs=config.engine_kwargs,
+            task_type=config.task_type,
+            max_pending_requests=config.max_pending_requests,
+            dynamic_lora_loading_path=config.dynamic_lora_loading_path,
+        ),
+        map_batches_kwargs=dict(
+            zero_copy_batch=True,
+            # The number of running replicas. This is a deprecated field, but
+            # we need to set `max_tasks_in_flight_per_actor` through `compute`,
+            # which initiates enough many overlapping UDF calls per actor, to
+            # saturate `max_concurrency`.
+            compute=ray.data.ActorPoolStrategy(
+                min_size=config.concurrency,
+                max_size=config.concurrency,
+                max_tasks_in_flight_per_actor=max(
+                    DEFAULT_MAX_TASKS_IN_FLIGHT, config.max_concurrent_batches
                 ),
-                map_batches_kwargs=dict(
-                    zero_copy_batch=True,
-                    # The number of running replicas. This is a deprecated field, but
-                    # we need to set `max_tasks_in_flight_per_actor` through `compute`,
-                    # which initiates enough many overlapping UDF calls per actor, to
-                    # saturate `max_concurrency`.
-                    compute=ray.data.ActorPoolStrategy(
-                        min_size=config.concurrency,
-                        max_size=config.concurrency,
-                        max_tasks_in_flight_per_actor=max(
-                            DEFAULT_MAX_TASKS_IN_FLIGHT, config.max_concurrent_batches
-                        ),
-                    ),
-                    # The number of running batches "per actor" in Ray Core level.
-                    # This is used to make sure we overlap batches to avoid the tail
-                    # latency of each batch.
-                    max_concurrency=config.max_concurrent_batches,
-                    resources=config.resources_per_bundle,
-                    accelerator_type=config.accelerator_type,
-                    runtime_env=config.runtime_env,
-                ),
-            )
-            # NEW: Set the shared key on the stage so it can pass it to map_batches
-            stage._shared_engine_key = config.shared_engine_key
-            return stage
-
-        # Get or create the shared stage
-        existing_stages = SharedvLLMStageManager.list_shared_stages()
-        print(f"Existing shared stages: {list(existing_stages.keys())}")
-
-        vllm_stage = SharedvLLMStageManager.get_or_create_shared_stage(
-            config.shared_engine_key, stage_factory
-        )
-    else:
-        print("Creating new vLLMEngineStage (no sharing)")
-        vllm_stage = vLLMEngineStage(
-            fn_constructor_kwargs=dict(
-                batch_size=config.batch_size,
-                max_concurrent_batches=config.max_concurrent_batches,
-                model=config.model_source,
-                engine_kwargs=config.engine_kwargs,
-                task_type=config.task_type,
-                max_pending_requests=config.max_pending_requests,
-                dynamic_lora_loading_path=config.dynamic_lora_loading_path,
             ),
-            map_batches_kwargs=dict(
-                zero_copy_batch=True,
-                # The number of running replicas. This is a deprecated field, but
-                # we need to set `max_tasks_in_flight_per_actor` through `compute`,
-                # which initiates enough many overlapping UDF calls per actor, to
-                # saturate `max_concurrency`.
-                compute=ray.data.ActorPoolStrategy(
-                    # vLLM start up time is significant, so if user give fixed
-                    # concurrency, start all instances without auto-scaling.
-                    min_size=config.concurrency,
-                    max_size=config.concurrency,
-                    max_tasks_in_flight_per_actor=config.experimental.get(
-                        "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
-                    ),
-                ),
-                # The number of running batches "per actor" in Ray Core level.
-                # This is used to make sure we overlap batches to avoid the tail
-                # latency of each batch.
-                max_concurrency=config.max_concurrent_batches,
-                resources=config.resources_per_bundle,
-                accelerator_type=config.accelerator_type,
-                runtime_env=config.runtime_env,
-            ),
-        )
+            # The number of running batches "per actor" in Ray Core level.
+            # This is used to make sure we overlap batches to avoid the tail
+            # latency of each batch.
+            max_concurrency=config.max_concurrent_batches,
+            resources=config.resources_per_bundle,
+            accelerator_type=config.accelerator_type,
+            runtime_env=config.runtime_env,
+        ),
+    )
+
+    if config.shared_engine_key:
+        vllm_stage._shared_engine_key = config.shared_engine_key
 
     stages.append(vllm_stage)
 

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -685,17 +685,6 @@ class vLLMEngineStage(StatefulStage):
         map_batches_kwargs.update(ray_remote_args)
         return values
 
-    def __init__(self, *args, **kwargs):
-        # Initialize normally first
-        super().__init__(*args, **kwargs)
-
-        # Check if this stage should support sharing and propagate to the logical operator level
-        shared_key = getattr(self, "_shared_engine_key", None)
-        if shared_key:
-            print(f"vLLMEngineStage: Setting up sharing support for key: {shared_key}")
-            # Store the shared key for later use during physical operator creation
-            self._shared_engine_key = shared_key
-
     def get_dataset_map_batches_kwargs(
         self,
         batch_size: int,
@@ -703,16 +692,8 @@ class vLLMEngineStage(StatefulStage):
     ) -> Dict[str, Any]:
         """Override to inject shared engine key for logical operator creation."""
         kwargs = super().get_dataset_map_batches_kwargs(batch_size, data_column)
-
-        # Inject shared engine key if this stage supports sharing
-        shared_key = getattr(self, "_shared_engine_key", None)
-        if shared_key:
-            print(
-                f"vLLMEngineStage get_dataset_map_batches_kwargs: Injecting shared key: {shared_key}"
-            )
-            # Use the native shared_key parameter in Ray Data
-            kwargs["shared_key"] = shared_key
-
+        if getattr(self, "_shared_engine_key", None):
+            kwargs["shared_key"] = self._shared_engine_key
         return kwargs
 
     def get_required_input_keys(self) -> Dict[str, str]:

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -690,7 +690,6 @@ class vLLMEngineStage(StatefulStage):
         batch_size: int,
         data_column: str,
     ) -> Dict[str, Any]:
-        """Override to inject shared engine key for logical operator creation."""
         kwargs = super().get_dataset_map_batches_kwargs(batch_size, data_column)
         if getattr(self, "_shared_engine_key", None):
             kwargs["shared_key"] = self._shared_engine_key


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Sequential batch inference with Ray Data LLM API requires creating separate processors for each step, and each processor inherently creates its own vLLM engine when UDF is dispatched to actors, leading to inefficient resource usage as each engine needs dedicated resources. It's ideal to enable engine sharing across sequential processors to reduce resource requirements. Please refer to #52277  for more details regarding the motivation.

In this PR, shared actor pool functionality for Ray Data's `ActorPoolMapOperator` is implemented to enable actor reuse across sequential processing steps by introducing `SharedActorPoolRegistry`. This addresses the core issue where each processor step was creating its own dedicated actor pool.

Planning to enable this functionality for `SGLangEngine` in a separate follow-up.

## Related issue number

<!-- For example: "Closes #1234" -->
Resolves #52277 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
