### PR TITLE
migrate ray_option_utils from private to common

### DIFF
--- a/python/ray/_common/constants.py
+++ b/python/ray/_common/constants.py
@@ -1,0 +1,5 @@
+# Prefix for the node id resource that is automatically added to each node.
+# For example, a node may have id `node:172.23.42.1`.
+NODE_ID_PREFIX = "node:"
+# The system resource that head node has.
+HEAD_NODE_RESOURCE_NAME = NODE_ID_PREFIX + "__internal_head__"

--- a/python/ray/_common/ray_option_utils.py
+++ b/python/ray/_common/ray_option_utils.py
@@ -49,6 +49,9 @@ def _counting_option(name: str, infinite: bool = True, default_value: Any = None
         name: The name of the option keyword.
         infinite: If True, user could use -1 to represent infinity.
         default_value: The default value for this option.
+
+    Returns:
+        An Option object.
     """
     if infinite:
         return Option(

--- a/python/ray/_common/tests/BUILD
+++ b/python/ray/_common/tests/BUILD
@@ -4,6 +4,7 @@ load("//bazel:python.bzl", "py_test_module_list")
 py_test_module_list(
     size = "small",
     files = [
+        "test_ray_option_utils.py",
         "test_signal_semaphore_utils.py",
         "test_signature.py",
         "test_utils.py",

--- a/python/ray/_common/tests/test_ray_option_utils.py
+++ b/python/ray/_common/tests/test_ray_option_utils.py
@@ -1,0 +1,220 @@
+import pytest
+import re
+import sys
+from unittest.mock import patch
+
+from ray.util.placement_group import PlacementGroup
+from ray._common.ray_option_utils import (
+    Option,
+    _counting_option,
+    _validate_resource_quantity,
+    _resource_option,
+    _validate_resources,
+    validate_task_options,
+    validate_actor_options,
+    update_options,
+    _check_deprecate_placement_group,
+)
+
+
+class TestOptionValidation:
+    def test_option_validate(self):
+        opt = Option(
+            type_constraint=int, value_constraint=lambda v: "error" if v < 0 else None
+        )
+        opt.validate("test", 1)
+        with pytest.raises(TypeError):
+            opt.validate("test", "a")
+        with pytest.raises(ValueError, match="error"):
+            opt.validate("test", -1)
+
+    def test_counting_option(self):
+        # Test infinite counting option
+        opt_inf = _counting_option("test_inf", infinite=True)
+        opt_inf.validate("test_inf", 5)
+        opt_inf.validate("test_inf", 0)
+        opt_inf.validate("test_inf", -1)  # Represents infinity
+        opt_inf.validate("test_inf", None)
+        with pytest.raises(ValueError):
+            opt_inf.validate("test_inf", -2)
+        with pytest.raises(TypeError):
+            opt_inf.validate("test_inf", 1.5)
+
+        # Test non-infinite counting option
+        opt_non_inf = _counting_option("test_non_inf", infinite=False)
+        opt_non_inf.validate("test_non_inf", 5)
+        opt_non_inf.validate("test_non_inf", 0)
+        opt_non_inf.validate("test_non_inf", None)
+        with pytest.raises(ValueError):
+            opt_non_inf.validate("test_non_inf", -1)
+
+    @patch("ray._raylet.RESOURCE_UNIT_SCALING", 10000)
+    @patch(
+        "ray._private.accelerators.get_all_accelerator_resource_names",
+        return_value={"GPU", "TPU"},
+    )
+    @patch("ray._private.accelerators.get_accelerator_manager_for_resource")
+    def test_validate_resource_quantity(self, mock_get_manager, mock_get_all_names):
+        # Valid cases
+        assert _validate_resource_quantity("CPU", 1) is None
+        assert _validate_resource_quantity("memory", 0) is None
+        assert _validate_resource_quantity("custom", 0.5) is None
+
+        # Invalid cases
+        err = _validate_resource_quantity("CPU", -1)
+        assert isinstance(err, str)
+        assert "cannot be negative" in err
+        err = _validate_resource_quantity("CPU", 0.00001)
+        assert isinstance(err, str)
+        assert "cannot go beyond 0.0001" in err
+
+        # Accelerator validation
+        mock_manager_instance = mock_get_manager.return_value
+        mock_manager_instance.validate_resource_request_quantity.return_value = (
+            False,
+            "mock error",
+        )
+        err = _validate_resource_quantity("GPU", 1.5)
+        assert isinstance(err, str)
+        assert "mock error" in err
+        mock_get_manager.assert_called_with("GPU")
+        mock_manager_instance.validate_resource_request_quantity.assert_called_with(1.5)
+
+        mock_manager_instance.validate_resource_request_quantity.return_value = (
+            True,
+            "",
+        )
+        assert _validate_resource_quantity("TPU", 1) is None
+
+    def test_resource_option(self):
+        opt = _resource_option("CPU")
+        opt.validate("CPU", 1)
+        opt.validate("CPU", 0.5)
+        opt.validate("CPU", None)
+        with pytest.raises(TypeError):
+            opt.validate("CPU", "1")
+        with pytest.raises(ValueError):
+            opt.validate("CPU", -1.0)
+
+    def test_validate_resources(self):
+        assert _validate_resources(None) is None
+        assert _validate_resources({"custom": 1}) is None
+        err = _validate_resources({"CPU": 1, "GPU": 1})
+        assert isinstance(err, str)
+        assert "Use the 'num_cpus' and 'num_gpus' keyword" in err
+        err = _validate_resources({"custom": -1})
+        assert isinstance(err, str)
+        assert "cannot be negative" in err
+
+
+class TestTaskActorOptionValidation:
+    def test_validate_task_options_valid(self):
+        validate_task_options({"num_cpus": 2, "max_retries": 3}, in_options=False)
+
+    def test_validate_task_options_invalid_keyword(self):
+        with pytest.raises(ValueError, match="Invalid option keyword"):
+            validate_task_options({"invalid_option": 1}, in_options=False)
+
+    def test_validate_task_options_in_options_invalid(self):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Setting 'max_calls' is not supported in '.options()'."),
+        ):
+            validate_task_options({"max_calls": 5}, in_options=True)
+
+    def test_validate_actor_options_valid(self):
+        validate_actor_options({"max_concurrency": 2, "name": "abc"}, in_options=False)
+
+    def test_validate_actor_options_invalid_keyword(self):
+        with pytest.raises(ValueError, match="Invalid option keyword"):
+            validate_actor_options({"invalid_option": 1}, in_options=False)
+
+    def test_validate_actor_options_in_options_invalid(self):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Setting 'concurrency_groups' is not supported in '.options()'."
+            ),
+        ):
+            validate_actor_options({"concurrency_groups": {}}, in_options=True)
+
+    def test_validate_actor_get_if_exists_no_name(self):
+        with pytest.raises(
+            ValueError, match="must be specified to use `get_if_exists`"
+        ):
+            validate_actor_options({"get_if_exists": True}, in_options=False)
+
+    def test_validate_actor_object_store_memory_warning(self):
+        with pytest.warns(
+            DeprecationWarning,
+            match="Setting 'object_store_memory' for actors is deprecated",
+        ):
+            validate_actor_options({"object_store_memory": 100}, in_options=False)
+
+    def test_check_deprecate_placement_group(self):
+        pg = PlacementGroup.empty()
+        # No error if only one is specified
+        _check_deprecate_placement_group({"placement_group": pg})
+        _check_deprecate_placement_group({"scheduling_strategy": "SPREAD"})
+
+        # Error if both are specified
+        with pytest.raises(
+            ValueError, match="Placement groups should be specified via"
+        ):
+            _check_deprecate_placement_group(
+                {"placement_group": pg, "scheduling_strategy": "SPREAD"}
+            )
+
+        # Check no error with default or None placement_group
+        _check_deprecate_placement_group(
+            {"placement_group": "default", "scheduling_strategy": "SPREAD"}
+        )
+        _check_deprecate_placement_group(
+            {"placement_group": None, "scheduling_strategy": "SPREAD"}
+        )
+
+
+class TestUpdateOptions:
+    def test_simple_update(self):
+        original = {"num_cpus": 1, "name": "a"}
+        new = {"num_cpus": 2, "num_gpus": 1}
+        updated = update_options(original, new)
+        assert updated == {"num_cpus": 2, "name": "a", "num_gpus": 1}
+
+    def test_metadata_update(self):
+        original = {"_metadata": {"ns1": {"config1": "val1"}}}
+        new = {"_metadata": {"ns1": {"config2": "val2"}, "ns2": {"config3": "val3"}}}
+        updated = update_options(original, new)
+        expected_metadata = {
+            "ns1": {"config1": "val1", "config2": "val2"},
+            "ns2": {"config3": "val3"},
+        }
+        assert updated["_metadata"] == expected_metadata
+
+    def test_metadata_update_no_original_metadata(self):
+        original = {"num_cpus": 1}
+        new = {"_metadata": {"ns1": {"config1": "val1"}}}
+        updated = update_options(original, new)
+        assert updated["num_cpus"] == 1
+        assert updated["_metadata"] == new["_metadata"]
+
+    def test_metadata_update_no_new_metadata(self):
+        original = {"_metadata": {"ns1": {"config1": "val1"}}}
+        new = {"num_cpus": 1}
+        updated = update_options(original, new)
+        assert updated["num_cpus"] == 1
+        assert updated["_metadata"] == original["_metadata"]
+
+    def test_update_with_empty_new(self):
+        original = {"num_cpus": 1}
+        updated = update_options(original, {})
+        assert updated == original
+
+    def test_update_empty_original(self):
+        new = {"num_cpus": 1}
+        updated = update_options({}, new)
+        assert updated == new
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -5,15 +5,10 @@ from typing import Optional
 
 import ray
 import ray._private.ray_constants as ray_constants
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME, NODE_ID_PREFIX
 from ray._common.utils import RESOURCE_CONSTRAINT_PREFIX
 
 logger = logging.getLogger(__name__)
-
-# Prefix for the node id resource that is automatically added to each node.
-# For example, a node may have id `node:172.23.42.1`.
-NODE_ID_PREFIX = "node:"
-# The system resource that head node has.
-HEAD_NODE_RESOURCE_NAME = NODE_ID_PREFIX + "__internal_head__"
 
 
 class ResourceSpec(

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -5,10 +5,10 @@ from collections import defaultdict
 from typing import Dict, Optional
 
 import ray
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME, NODE_ID_PREFIX
 from ray._common.utils import binary_to_hex, decode, hex_to_binary
 from ray._private.client_mode_hook import client_mode_hook
 from ray._private.protobuf_compat import message_to_dict
-from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME, NODE_ID_PREFIX
 from ray._private.utils import (
     validate_actor_state_name,
 )

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -55,8 +55,8 @@ import ray.cloudpickle as pickle  # noqa
 import ray.job_config
 import ray.remote_function
 from ray import ActorID, JobID, Language, ObjectRef
+from ray._common import ray_option_utils
 from ray._common.utils import load_class
-from ray._private import ray_option_utils
 from ray._private.client_mode_hook import client_mode_hook
 from ray._private.function_manager import FunctionActorManager
 from ray._private.inspect_util import is_cython

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -26,7 +26,7 @@ import ray._private.ray_constants as ray_constants
 import ray._common.signature as signature
 import ray._raylet
 from ray import ActorClassID, Language, cross_language, ObjectRef
-from ray._private import ray_option_utils
+from ray._common import ray_option_utils
 from ray._private.async_compat import has_async_methods
 from ray._private.auto_init_hook import wrap_auto_init
 from ray._private.client_mode_hook import (
@@ -39,7 +39,7 @@ from ray._private.inspect_util import (
     is_function_or_method,
     is_static_method,
 )
-from ray._private.ray_option_utils import _warn_if_using_deprecated_placement_group
+from ray._common.ray_option_utils import _warn_if_using_deprecated_placement_group
 from ray._private.utils import get_runtime_env_info, parse_runtime_env_for_task_or_actor
 from ray._raylet import (
     STREAMING_GENERATOR_RETURN,

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -8,7 +8,7 @@ import pytest
 
 import ray
 from ray._common.test_utils import wait_for_condition
-from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray._private.test_utils import run_string_as_driver_nonblocking
 from ray._private.usage.usage_lib import get_extra_usage_tags_to_report
 from ray._raylet import GcsClient

--- a/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/batch/observability/usage_telemetry/usage.py
@@ -107,7 +107,7 @@ class TelemetryAgent:
                 LLM_BATCH_TELEMETRY_ACTOR_NAME, namespace=LLM_BATCH_TELEMETRY_NAMESPACE
             )
         except ValueError:
-            from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
+            from ray._common.constants import HEAD_NODE_RESOURCE_NAME
             from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
             self.remote_telemetry_agent = _TelemetryAgent.options(

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -190,7 +190,7 @@ def _get_or_create_telemetry_agent() -> TelemetryAgent:
             LLM_SERVE_TELEMETRY_ACTOR_NAME, namespace=LLM_SERVE_TELEMETRY_NAMESPACE
         )
     except ValueError:
-        from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
+        from ray._common.constants import HEAD_NODE_RESOURCE_NAME
         from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
         telemetry_agent = TelemetryAgent.options(

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -8,13 +8,13 @@ from typing import Optional
 
 import ray._common.signature
 from ray import Language, cross_language
-from ray._private import ray_option_utils
+from ray._common import ray_option_utils
 from ray._private.auto_init_hook import wrap_auto_init
 from ray._private.client_mode_hook import (
     client_mode_convert_function,
     client_mode_should_convert,
 )
-from ray._private.ray_option_utils import _warn_if_using_deprecated_placement_group
+from ray._common.ray_option_utils import _warn_if_using_deprecated_placement_group
 from ray._private.serialization import pickle_dumps
 from ray._private.utils import get_runtime_env_info, parse_runtime_env_for_task_or_actor
 from ray._raylet import (

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -6,6 +6,7 @@ from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import Message
 
 from ray import cloudpickle
+from ray._common import ray_option_utils
 from ray._common.pydantic_compat import (
     BaseModel,
     Field,
@@ -16,7 +17,6 @@ from ray._common.pydantic_compat import (
     validator,
 )
 from ray._common.utils import resources_from_ray_options
-from ray._private import ray_option_utils
 from ray._private.serialization import pickle_dumps
 from ray.serve._private.constants import (
     DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S,

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional, Tuple
 
 import ray
-from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray._raylet import GcsClient
 from ray.serve._private.cluster_node_info_cache import (
     ClusterNodeInfoCache,

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -20,8 +20,8 @@ import requests
 
 import ray
 import ray.util.serialization_addons
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray._common.utils import get_random_alphanumeric_string, import_attr
-from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 from ray._private.worker import LOCAL_MODE, SCRIPT_MODE
 from ray._raylet import MessagePackSerializer
 from ray.actor import ActorHandle

--- a/python/ray/serve/tests/test_serve_ha.py
+++ b/python/ray/serve/tests/test_serve_ha.py
@@ -4,8 +4,8 @@ from time import sleep
 
 import pytest
 
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray._common.test_utils import wait_for_condition
-from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 from ray.tests.conftest_docker import *  # noqa
 
 scripts = """

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -9,7 +9,7 @@ from fastapi.encoders import jsonable_encoder
 
 import ray
 from ray import serve
-from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray.serve._private.utils import (
     calculate_remaining_timeout,
     get_all_live_placement_group_names,

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -466,7 +466,7 @@ def test_invalid_arguments():
 
 def test_options():
     """General test of option keywords in Ray."""
-    from ray._private import ray_option_utils
+    from ray._common import ray_option_utils
 
     def f():
         return 1

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -17,7 +17,7 @@ from ray._private.test_utils import (
     wait_for_pid_to_exit,
     client_test_enabled,
 )
-from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
+from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tune/utils/resource_updater.py
+++ b/python/ray/tune/utils/resource_updater.py
@@ -6,7 +6,7 @@ from numbers import Number
 from typing import Any, Dict, Optional
 
 import ray
-from ray._private.resource_spec import NODE_ID_PREFIX
+from ray._common.constants import NODE_ID_PREFIX
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -6,7 +6,7 @@ import logging
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 
-from ray._private import ray_option_utils
+from ray._common import ray_option_utils
 from ray.util.client.runtime_context import _ClientWorkerPropertyAPI
 
 if TYPE_CHECKING:

--- a/python/ray/util/client/options.py
+++ b/python/ray/util/client/options.py
@@ -2,7 +2,7 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
-from ray._private import ray_option_utils
+from ray._common import ray_option_utils
 from ray.util.placement_group import PlacementGroup, check_placement_group_index
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 


### PR DESCRIPTION
migrating the below mentioned from `_private` to `_common`
- ray_option_utils file
- HEAD_NODE_RESOURCE_NAME
- NODE_ID_PREFIX

as part of: https://github.com/ray-project/ray/issues/53478