### PR TITLE
[tune][typing] type reset_config to return bool

### DIFF
--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -647,7 +647,7 @@ class Trainable:
 
         return True
 
-    def reset_config(self, new_config: Dict):
+    def reset_config(self, new_config: Dict) -> bool:
         """Resets configuration without restarting the trial.
 
         This method is optional, but can be implemented to speed up algorithms


### PR DESCRIPTION
Signed-off-by: Daraan <github.blurry@9ox.net>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently `reset_config` is defined as:

    def reset_config(self, new_config: Dict):
        return False

Because of the literal `False` pyright implicitly infers that the method always returns `Literal[False]` during subclassing it will complain with a `reportIncompatibleMethodOverride` when `bool` or `True` is returned:

> Method "reset_config" overrides class "Trainable" in an incompatible manner
  Return type mismatch: base method returns type "Literal[False]", override returns type "bool"
    "bool" is not assignable to type "Literal[False]"

or

> Method "reset_config" overrides class "Trainable" in an incompatible manner
  Return type mismatch: base method returns type "Literal[False]", override returns type "Literal[True]"
    "Literal[True]" is not assignable to type "Literal[False]"


This PR adds the intended annotation `reset_config(...) -> bool` to prevent this message.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number


NA
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] This PR is not tested; simple typing only.
