### PR TITLE
Address the case where min_rows_per_group exceeds arrow's default for write_dataset

### DIFF
--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1899,7 +1899,7 @@ def test_write_partition_cols_with_max_rows_per_file(
     pd.testing.assert_frame_equal(actual_df, expected_df, check_dtype=False)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RowGroupLimitCase:
     row_group_size: Optional[int]
     min_rows_per_file: Optional[int]
@@ -1910,12 +1910,62 @@ class RowGroupLimitCase:
 
 
 ROW_GROUP_LIMIT_CASES = [
-    RowGroupLimitCase(None, None, None, None, None, None),
-    RowGroupLimitCase(1000, None, None, 1000, 1000, None),
-    RowGroupLimitCase(None, 500, None, 500, None, None),
-    RowGroupLimitCase(None, None, 2000, None, 2000, 2000),
-    RowGroupLimitCase(1000, 500, 2000, 1000, 1000, 2000),
-    RowGroupLimitCase(3000, 500, 2000, 2000, 2000, 2000),
+    RowGroupLimitCase(
+        row_group_size=None,
+        min_rows_per_file=None,
+        max_rows_per_file=None,
+        expected_min=None,
+        expected_max=None,
+        expected_max_file=None,
+    ),
+    RowGroupLimitCase(
+        row_group_size=1000,
+        min_rows_per_file=None,
+        max_rows_per_file=None,
+        expected_min=1000,
+        expected_max=1000,
+        expected_max_file=None,
+    ),
+    RowGroupLimitCase(
+        row_group_size=None,
+        min_rows_per_file=500,
+        max_rows_per_file=None,
+        expected_min=500,
+        expected_max=None,
+        expected_max_file=None,
+    ),
+    RowGroupLimitCase(
+        row_group_size=None,
+        min_rows_per_file=None,
+        max_rows_per_file=2000,
+        expected_min=None,
+        expected_max=2000,
+        expected_max_file=2000,
+    ),
+    RowGroupLimitCase(
+        row_group_size=1000,
+        min_rows_per_file=500,
+        max_rows_per_file=2000,
+        expected_min=1000,
+        expected_max=1000,
+        expected_max_file=2000,
+    ),
+    RowGroupLimitCase(
+        row_group_size=3000,
+        min_rows_per_file=500,
+        max_rows_per_file=2000,
+        expected_min=2000,
+        expected_max=2000,
+        expected_max_file=2000,
+    ),
+    RowGroupLimitCase(
+        row_group_size=None,
+        min_rows_per_file=2000000,  # Greater than 1024 * 1024 (1048576)
+        max_rows_per_file=None,
+        expected_min=2000000,
+        expected_max=2000000,
+        expected_max_file=2000000,
+    ),
 ]
 
 
@@ -1941,6 +1991,31 @@ def test_choose_row_group_limits_parameterized(case):
     min_rows, max_rows, _ = result
     if min_rows is not None and max_rows is not None:
         assert min_rows <= max_rows
+
+
+def test_write_parquet_large_min_rows_per_file_exceeds_arrow_default(
+    tmp_path, ray_start_regular_shared
+):
+    """Test that min_rows_per_file > ARROW_DEFAULT_MAX_ROWS_PER_GROUP triggers max_rows_per_group setting."""
+    # ARROW_DEFAULT_MAX_ROWS_PER_GROUP = 1024 * 1024 = 1048576
+    # We'll use a min_rows_per_file that exceeds this threshold
+    min_rows_per_file = 2 * 1024 * 1024  # 2097152, which is > 1048576
+
+    # Create a dataset with the required number of rows
+    ds = ray.data.range(min_rows_per_file, override_num_blocks=1)
+
+    # Write with min_rows_per_file > ARROW_DEFAULT_MAX_ROWS_PER_GROUP
+    # This should trigger the condition where max_rows_per_group and max_rows_per_file
+    # are set to min_rows_per_group (which comes from min_rows_per_file)
+    ds.write_parquet(tmp_path, min_rows_per_file=min_rows_per_file)
+
+    # Verify that the parquet files were written correctly
+    written_files = [f for f in os.listdir(tmp_path) if f.endswith(".parquet")]
+    assert len(written_files) == 1
+
+    # Read back the data to verify correctness
+    ds_read = ray.data.read_parquet(tmp_path)
+    assert ds_read.count() == min_rows_per_file
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1996,10 +1996,16 @@ def test_choose_row_group_limits_parameterized(case):
 def test_write_parquet_large_min_rows_per_file_exceeds_arrow_default(
     tmp_path, ray_start_regular_shared
 ):
+    from ray.data._internal.datasource.parquet_datasink import (
+        ARROW_DEFAULT_MAX_ROWS_PER_GROUP,
+    )
+
     """Test that min_rows_per_file > ARROW_DEFAULT_MAX_ROWS_PER_GROUP triggers max_rows_per_group setting."""
     # ARROW_DEFAULT_MAX_ROWS_PER_GROUP = 1024 * 1024 = 1048576
     # We'll use a min_rows_per_file that exceeds this threshold
-    min_rows_per_file = 2 * 1024 * 1024  # 2097152, which is > 1048576
+    min_rows_per_file = (
+        2 * ARROW_DEFAULT_MAX_ROWS_PER_GROUP
+    )  # 2097152, which is > 1048576
 
     # Create a dataset with the required number of rows
     ds = ray.data.range(min_rows_per_file, override_num_blocks=1)

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1899,7 +1899,7 @@ def test_write_partition_cols_with_max_rows_per_file(
     pd.testing.assert_frame_equal(actual_df, expected_df, check_dtype=False)
 
 
-@dataclass(kw_only=True)
+@dataclass
 class RowGroupLimitCase:
     row_group_size: Optional[int]
     min_rows_per_file: Optional[int]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When `min_rows_per_group` exceeds arrow's default of 1024*1024 and `max_rows_per_group` remains null, pyarrow returns an error stating that `pyarrow.lib.ArrowInvalid: min_rows_per_group must be less than or equal to max_rows_per_group`. In this change we cap `max_rows_per_group` to `min_rows_per_group` in this scenario.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
