### PR TITLE
[serve] add timeout to test_cancel_on_http_timeout_during_execution

### DIFF
--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -321,8 +321,8 @@ def test_cancel_on_http_timeout_during_execution(
 
     # Request should time out, causing the handler and handle call to be cancelled.
     assert httpx.get(get_application_url(use_localhost=True)).status_code == 408
-    ray.get(inner_signal_actor.wait.remote())
-    ray.get(outer_signal_actor.wait.remote())
+    ray.get(inner_signal_actor.wait.remote(), timeout=10)
+    ray.get(outer_signal_actor.wait.remote(), timeout=10)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In `test_cancel_on_http_timeout_during_execution`, we wait for `inner_signal_actor` and `outer_signal_actor` because we expect the cancellation to propagate. However if cancellation doesn't work and the test fails, it doesn't error out and instead hangs forever until pytest/bazel timeout. Add a timeout to the `ray.get` calls so that it will error out and clearly indicate that the test failed.
