### PR TITLE
Add perf metrics for 2.48.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 89.755648,
+    "_dashboard_memory_usage_mb": 108.781568,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.29,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1159\t7.51GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3382\t1.86GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4875\t0.86GiB\tpython distributed/test_many_actors.py\n2702\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3582\t0.2GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n585\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3498\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4100\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2962\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4102\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
-    "actors_per_second": 553.5098466276525,
+    "_peak_memory": 4.69,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1179\t7.96GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3535\t2.02GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5153\t0.99GiB\tpython distributed/test_many_actors.py\n3032\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3750\t0.28GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n587\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3656\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4257\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2987\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4259\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "actors_per_second": 637.3864975035225,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 553.5098466276525
+            "perf_metric_value": 637.3864975035225
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.779
+            "perf_metric_value": 7.645
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3114.217
+            "perf_metric_value": 2166.956
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4934.573
+            "perf_metric_value": 2386.766
         }
     ],
     "success": "1",
-    "time": 18.06652593612671
+    "time": 15.689067840576172
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 94.80192,
+    "_dashboard_memory_usage_mb": 96.886784,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.25,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3683\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2672\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5140\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1070\t0.14GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3887\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n4394\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n5449\t0.09GiB\tray::StateAPIGeneratorActor.start\n3799\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2566\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3890\t0.08GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp",
+    "_peak_memory": 2.26,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n5140\t0.49GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4588\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n6746\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5340\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n1060\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5848\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n5256\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4688\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n7032\t0.09GiB\tray::StateAPIGeneratorActor.start\n5343\t0.08GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 192.87246715163326
+            "perf_metric_value": 210.26240791660297
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.69
+            "perf_metric_value": 5.598
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.541
+            "perf_metric_value": 13.31
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 44.385
+            "perf_metric_value": 49.257
         }
     ],
     "success": "1",
-    "tasks_per_second": 192.87246715163326,
-    "time": 305.1847732067108,
+    "tasks_per_second": 210.26240791660297,
+    "time": 304.755961894989,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 96.088064,
+    "_dashboard_memory_usage_mb": 89.10848,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.7,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n2031\t7.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3407\t0.91GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4846\t0.37GiB\tpython distributed/test_many_pgs.py\n2948\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n580\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2641\t0.11GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4125\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3605\t0.09GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2820\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3523\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
+    "_peak_memory": 2.72,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1172\t7.84GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3515\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5058\t0.37GiB\tpython distributed/test_many_pgs.py\n2955\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n590\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4235\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3716\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n2788\t0.1GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n2918\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4237\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.282795863244178
+            "perf_metric_value": 13.249636783617742
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.298
+            "perf_metric_value": 4.164
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.186
+            "perf_metric_value": 9.007
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 412.087
+            "perf_metric_value": 295.477
         }
     ],
-    "pgs_per_second": 13.282795863244178,
+    "pgs_per_second": 13.249636783617742,
     "success": "1",
-    "time": 75.28535485267639
+    "time": 75.47376704216003
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 110.903296,
+    "_dashboard_memory_usage_mb": 99.81952,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.91,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3415\t1.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4873\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3615\t0.45GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2685\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3618\t0.18GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n2051\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4122\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3531\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n5038\t0.09GiB\tray::DashboardTester.run\n5103\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 3.95,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3474\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4934\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3689\t0.49GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n2965\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3692\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s\n1116\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4197\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3590\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2894\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5158\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 381.53414000942394
+            "perf_metric_value": 360.3280864724041
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.797
+            "perf_metric_value": 5.172
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 486.283
+            "perf_metric_value": 507.35
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 763.093
+            "perf_metric_value": 788.758
         }
     ],
     "success": "1",
-    "tasks_per_second": 381.53414000942394,
-    "time": 326.20997428894043,
+    "tasks_per_second": 360.3280864724041,
+    "time": 327.75248551368713,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.47.0"}
+{"release_version": "2.48.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8219.795071008975,
-        188.48085637821475
+        8010.702905260102,
+        136.68009432490436
     ],
     "1_1_actor_calls_concurrent": [
-        5377.1496113254725,
-        129.23618916367775
+        5509.597235482224,
+        276.04483198618993
     ],
     "1_1_actor_calls_sync": [
-        1959.5608579309087,
-        40.05183288077636
+        1911.653938349526,
+        49.178257985477806
     ],
     "1_1_async_actor_calls_async": [
-        4171.456937936633,
-        195.42830490503232
+        4354.072994220345,
+        415.85939242881625
     ],
     "1_1_async_actor_calls_sync": [
-        1468.0999827232097,
-        23.907868237519033
+        1447.7881568911705,
+        36.882437725035345
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2899.87628971332,
-        104.68861949721845
+        2737.346750018072,
+        104.04841636731089
     ],
     "1_n_actor_calls_async": [
-        8008.806358661164,
-        94.9223246657888
+        8346.988543416383,
+        87.86702835108683
     ],
     "1_n_async_actor_calls_async": [
-        7625.6992962916975,
-        77.78852390836784
+        7501.079333162652,
+        36.041278507333026
     ],
     "client__1_1_actor_calls_async": [
-        1065.4228066614364,
-        8.475130628383317
+        1024.7712082804317,
+        15.216795365973105
     ],
     "client__1_1_actor_calls_concurrent": [
-        1051.155045997863,
-        7.587242014430166
+        1022.6313616275817,
+        35.642304257576434
     ],
     "client__1_1_actor_calls_sync": [
-        530.5569126625701,
-        3.4917100983628964
+        472.3043298925543,
+        15.3902021531748
     ],
     "client__get_calls": [
-        1018.2939193917422,
-        68.37887040310822
+        1154.6849204758523,
+        15.493776302369774
     ],
     "client__put_calls": [
-        805.9876892520514,
-        20.246218021849156
+        801.9081406653205,
+        15.107120480890663
     ],
     "client__put_gigabytes": [
-        0.1525808986433169,
-        0.0005260267465087514
+        0.15474075982547877,
+        0.001018445965452485
     ],
     "client__tasks_and_get_batch": [
-        0.909684480871914,
-        0.04209123366651788
+        0.9748425129062579,
+        0.018954212435789708
     ],
     "client__tasks_and_put_batch": [
-        14411.155262801181,
-        565.6637142873228
+        14121.731373360428,
+        246.34655253410108
     ],
     "multi_client_put_calls_Plasma_Store": [
-        16769.891858063707,
-        160.7727767543324
+        16176.149026191037,
+        433.3067047835461
     ],
     "multi_client_put_gigabytes": [
-        37.84234603653026,
-        1.9543159500637872
+        42.38975341233942,
+        4.065844995486081
     ],
     "multi_client_tasks_async": [
-        22162.855018822152,
-        1636.6665214042862
+        22282.913263059603,
+        1989.0644475513711
     ],
     "n_n_actor_calls_async": [
-        27105.63998087682,
-        858.8741533351254
+        26104.619985938712,
+        1285.9312523956648
     ],
     "n_n_actor_calls_with_arg_async": [
-        2723.737298735755,
-        15.223156908588408
+        2667.5129581096394,
+        32.14345111236193
     ],
     "n_n_async_actor_calls_async": [
-        23052.03512506016,
-        818.6796601118019
+        23054.834921198915,
+        808.5595628862385
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10841.440823259276
+            "perf_metric_value": 10254.67384052621
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5110.344528620948
+            "perf_metric_value": 5104.604000086833
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16769.891858063707
+            "perf_metric_value": 16176.149026191037
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.561225172916046
+            "perf_metric_value": 19.756750789978025
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6.069186157221194
+            "perf_metric_value": 5.672177149975918
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 37.84234603653026
+            "perf_metric_value": 42.38975341233942
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.67868528378648
+            "perf_metric_value": 13.272241155827192
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.895502802318484
+            "perf_metric_value": 4.914155182305777
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 961.1131766783709
+            "perf_metric_value": 940.8156205876578
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7971.849053459262
+            "perf_metric_value": 7882.36677760533
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22162.855018822152
+            "perf_metric_value": 22282.913263059603
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1959.5608579309087
+            "perf_metric_value": 1911.653938349526
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8219.795071008975
+            "perf_metric_value": 8010.702905260102
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5377.1496113254725
+            "perf_metric_value": 5509.597235482224
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8008.806358661164
+            "perf_metric_value": 8346.988543416383
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27105.63998087682
+            "perf_metric_value": 26104.619985938712
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2723.737298735755
+            "perf_metric_value": 2667.5129581096394
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1468.0999827232097
+            "perf_metric_value": 1447.7881568911705
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4171.456937936633
+            "perf_metric_value": 4354.072994220345
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2899.87628971332
+            "perf_metric_value": 2737.346750018072
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7625.6992962916975
+            "perf_metric_value": 7501.079333162652
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23052.03512506016
+            "perf_metric_value": 23054.834921198915
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 762.110356621388
+            "perf_metric_value": 754.7012799419338
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1018.2939193917422
+            "perf_metric_value": 1154.6849204758523
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 805.9876892520514
+            "perf_metric_value": 801.9081406653205
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.1525808986433169
+            "perf_metric_value": 0.15474075982547877
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14411.155262801181
+            "perf_metric_value": 14121.731373360428
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 530.5569126625701
+            "perf_metric_value": 472.3043298925543
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1065.4228066614364
+            "perf_metric_value": 1024.7712082804317
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1051.155045997863
+            "perf_metric_value": 1022.6313616275817
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.909684480871914
+            "perf_metric_value": 0.9748425129062579
         }
     ],
     "placement_group_create/removal": [
-        762.110356621388,
-        8.435625535387086
+        754.7012799419338,
+        6.3999574391515655
     ],
     "single_client_get_calls_Plasma_Store": [
-        10841.440823259276,
-        238.0109613877782
+        10254.67384052621,
+        244.21315890844684
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.67868528378648,
-        0.08852439852998363
+        13.272241155827192,
+        0.0780169314352631
     ],
     "single_client_put_calls_Plasma_Store": [
-        5110.344528620948,
-        8.717022369486246
+        5104.604000086833,
+        57.30627070189804
     ],
     "single_client_put_gigabytes": [
-        19.561225172916046,
-        9.220541281624417
+        19.756750789978025,
+        7.11965401543364
     ],
     "single_client_tasks_and_get_batch": [
-        6.069186157221194,
-        3.075434344096306
+        5.672177149975918,
+        2.873001976282519
     ],
     "single_client_tasks_async": [
-        7971.849053459262,
-        344.6188539061271
+        7882.36677760533,
+        434.4642577518828
     ],
     "single_client_tasks_sync": [
-        961.1131766783709,
-        17.69357028295797
+        940.8156205876578,
+        12.399379467507757
     ],
     "single_client_wait_1k_refs": [
-        4.895502802318484,
-        0.03612176674731559
+        4.914155182305777,
+        0.04584763123189137
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.597426240999994,
+    "broadcast_time": 15.061206666999993,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.597426240999994
+            "perf_metric_value": 15.061206666999993
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.828636121000002,
-    "get_time": 23.034279295000005,
+    "args_time": 18.591390595999997,
+    "get_time": 23.98139714300001,
     "large_object_size": 107374182400,
-    "large_object_time": 31.951921509999977,
+    "large_object_time": 28.486703989000034,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.828636121000002
+            "perf_metric_value": 18.591390595999997
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.7005318469999935
+            "perf_metric_value": 5.817427993999999
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.034279295000005
+            "perf_metric_value": 23.98139714300001
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 199.80789056199998
+            "perf_metric_value": 204.864057644
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.951921509999977
+            "perf_metric_value": 28.486703989000034
         }
     ],
-    "queued_time": 199.80789056199998,
-    "returns_time": 5.7005318469999935,
+    "queued_time": 204.864057644,
+    "returns_time": 5.817427993999999,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.2696449542045594,
-    "max_iteration_time": 4.179541110992432,
-    "min_iteration_time": 0.034151315689086914,
+    "avg_iteration_time": 1.22373774766922,
+    "max_iteration_time": 4.4698872566223145,
+    "min_iteration_time": 0.04696393013000488,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2696449542045594
+            "perf_metric_value": 1.22373774766922
         }
     ],
     "success": 1,
-    "total_time": 126.96463394165039
+    "total_time": 122.37390089035034
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.885871648788452
+            "perf_metric_value": 7.380897283554077
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.311162948608398
+            "perf_metric_value": 12.799301958084106
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 33.59187984466553
+            "perf_metric_value": 34.098729610443115
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.0375380516052246
+            "perf_metric_value": 2.37601637840271
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1822.3623061180115
+            "perf_metric_value": 1832.733226776123
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4685331640891067
+            "perf_metric_value": 0.5702403166336547
         }
     ],
-    "stage_0_time": 6.885871648788452,
-    "stage_1_avg_iteration_time": 12.311162948608398,
-    "stage_1_max_iteration_time": 12.973528861999512,
-    "stage_1_min_iteration_time": 10.784329891204834,
-    "stage_1_time": 123.11168432235718,
-    "stage_2_avg_iteration_time": 33.59187984466553,
-    "stage_2_max_iteration_time": 34.43732571601868,
-    "stage_2_min_iteration_time": 33.067967653274536,
-    "stage_2_time": 167.95994234085083,
-    "stage_3_creation_time": 2.0375380516052246,
-    "stage_3_time": 1822.3623061180115,
-    "stage_4_spread": 0.4685331640891067,
+    "stage_0_time": 7.380897283554077,
+    "stage_1_avg_iteration_time": 12.799301958084106,
+    "stage_1_max_iteration_time": 13.348021984100342,
+    "stage_1_min_iteration_time": 11.419013500213623,
+    "stage_1_time": 127.99307417869568,
+    "stage_2_avg_iteration_time": 34.098729610443115,
+    "stage_2_max_iteration_time": 34.73457980155945,
+    "stage_2_min_iteration_time": 33.69960141181946,
+    "stage_2_time": 170.49423050880432,
+    "stage_3_creation_time": 2.37601637840271,
+    "stage_3_time": 1832.733226776123,
+    "stage_4_spread": 0.5702403166336547,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.4907771591586358,
-    "avg_pg_remove_time_ms": 1.2416502777781075,
+    "avg_pg_create_time_ms": 1.504845716216014,
+    "avg_pg_remove_time_ms": 1.313020842342286,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4907771591586358
+            "perf_metric_value": 1.504845716216014
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2416502777781075
+            "perf_metric_value": 1.313020842342286
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 10.98%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 530.5569126625701 to 472.3043298925543 in microbenchmark.json
REGRESSION 6.54%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 6.069186157221194 to 5.672177149975918 in microbenchmark.json
REGRESSION 5.60%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2899.87628971332 to 2737.346750018072 in microbenchmark.json
REGRESSION 5.56%: tasks_per_second (THROUGHPUT) regresses from 381.53414000942394 to 360.3280864724041 in benchmarks/many_tasks.json
REGRESSION 5.41%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10841.440823259276 to 10254.67384052621 in microbenchmark.json
REGRESSION 3.82%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1065.4228066614364 to 1024.7712082804317 in microbenchmark.json
REGRESSION 3.69%: n_n_actor_calls_async (THROUGHPUT) regresses from 27105.63998087682 to 26104.619985938712 in microbenchmark.json
REGRESSION 3.54%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 16769.891858063707 to 16176.149026191037 in microbenchmark.json
REGRESSION 2.71%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1051.155045997863 to 1022.6313616275817 in microbenchmark.json
REGRESSION 2.54%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8219.795071008975 to 8010.702905260102 in microbenchmark.json
REGRESSION 2.44%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1959.5608579309087 to 1911.653938349526 in microbenchmark.json
REGRESSION 2.11%: single_client_tasks_sync (THROUGHPUT) regresses from 961.1131766783709 to 940.8156205876578 in microbenchmark.json
REGRESSION 2.06%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2723.737298735755 to 2667.5129581096394 in microbenchmark.json
REGRESSION 2.01%: client__tasks_and_put_batch (THROUGHPUT) regresses from 14411.155262801181 to 14121.731373360428 in microbenchmark.json
REGRESSION 1.63%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7625.6992962916975 to 7501.079333162652 in microbenchmark.json
REGRESSION 1.38%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1468.0999827232097 to 1447.7881568911705 in microbenchmark.json
REGRESSION 1.12%: single_client_tasks_async (THROUGHPUT) regresses from 7971.849053459262 to 7882.36677760533 in microbenchmark.json
REGRESSION 0.97%: placement_group_create/removal (THROUGHPUT) regresses from 762.110356621388 to 754.7012799419338 in microbenchmark.json
REGRESSION 0.51%: client__put_calls (THROUGHPUT) regresses from 805.9876892520514 to 801.9081406653205 in microbenchmark.json
REGRESSION 0.25%: pgs_per_second (THROUGHPUT) regresses from 13.282795863244178 to 13.249636783617742 in benchmarks/many_pgs.json
REGRESSION 0.11%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5110.344528620948 to 5104.604000086833 in microbenchmark.json
REGRESSION 21.71%: stage_4_spread (LATENCY) regresses from 0.4685331640891067 to 0.5702403166336547 in stress_tests/stress_test_many_tasks.json
REGRESSION 19.56%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 12.597426240999994 to 15.061206666999993 in scalability/object_store.json
REGRESSION 16.61%: stage_3_creation_time (LATENCY) regresses from 2.0375380516052246 to 2.37601637840271 in stress_tests/stress_test_many_tasks.json
REGRESSION 10.98%: dashboard_p99_latency_ms (LATENCY) regresses from 44.385 to 49.257 in benchmarks/many_nodes.json
REGRESSION 7.82%: dashboard_p50_latency_ms (LATENCY) regresses from 4.797 to 5.172 in benchmarks/many_tasks.json
REGRESSION 7.19%: stage_0_time (LATENCY) regresses from 6.885871648788452 to 7.380897283554077 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.13%: dashboard_p95_latency_ms (LATENCY) regresses from 12.541 to 13.31 in benchmarks/many_nodes.json
REGRESSION 5.75%: avg_pg_remove_time_ms (LATENCY) regresses from 1.2416502777781075 to 1.313020842342286 in stress_tests/stress_test_placement_group.json
REGRESSION 4.33%: dashboard_p95_latency_ms (LATENCY) regresses from 486.283 to 507.35 in benchmarks/many_tasks.json
REGRESSION 4.11%: 10000_get_time (LATENCY) regresses from 23.034279295000005 to 23.98139714300001 in scalability/single_node.json
REGRESSION 3.97%: stage_1_avg_iteration_time (LATENCY) regresses from 12.311162948608398 to 12.799301958084106 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.36%: dashboard_p99_latency_ms (LATENCY) regresses from 763.093 to 788.758 in benchmarks/many_tasks.json
REGRESSION 2.53%: 1000000_queued_time (LATENCY) regresses from 199.80789056199998 to 204.864057644 in scalability/single_node.json
REGRESSION 2.05%: 3000_returns_time (LATENCY) regresses from 5.7005318469999935 to 5.817427993999999 in scalability/single_node.json
REGRESSION 1.51%: stage_2_avg_iteration_time (LATENCY) regresses from 33.59187984466553 to 34.098729610443115 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.94%: avg_pg_create_time_ms (LATENCY) regresses from 1.4907771591586358 to 1.504845716216014 in stress_tests/stress_test_placement_group.json
REGRESSION 0.57%: stage_3_time (LATENCY) regresses from 1822.3623061180115 to 1832.733226776123 in stress_tests/stress_test_many_tasks.json
```