### PR TITLE
chore: if keypair doesnt exist create one automatically + doc typo fix

### DIFF
--- a/doc/source/cluster/vms/user-guides/launching-clusters/azure.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/azure.md
@@ -60,38 +60,46 @@ Download the reference example locally:
 wget https://raw.githubusercontent.com/ray-project/ray/master/python/ray/autoscaler/azure/example-full.yaml
 ```
 
-To connect to the provisioned head node VM, you need to ensure that you properly configure the `auth.ssh_private_key`, `auth.ssh_public_key`, and `file_mounts` configuration values to point to file paths on your local environment that have a valid key pair. By default the configuration assumes `$HOME/.ssh/id_rsa` and `$HOME/.ssh/id_rsa.pub`. If you have a different set of key pair files you want to use (for example a `ed25519` pair), update the `example-full.yaml` configurations to use them.
 
-For example a custom-configured `example-full.yaml` file might look like the following if you're using a `ed25519` key pair:
 
-```sh
-$ git diff example-full.yaml 
-diff --git a/python/ray/autoscaler/azure/example-full.yaml b/python/ray/autoscaler/azure/example-full.yaml
-index b25f1b07f1..c65fb77219 100644
---- a/python/ray/autoscaler/azure/example-full.yaml
-+++ b/python/ray/autoscaler/azure/example-full.yaml
-@@ -61,9 +61,9 @@ auth:
-     ssh_user: ubuntu
-     # You must specify paths to matching private and public key pair files.
-     # Use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair.
--    ssh_private_key: ~/.ssh/id_rsa
-+    ssh_private_key: ~/.ssh/id_ed25519
-     # Changes to this should match what is specified in file_mounts.
--    ssh_public_key: ~/.ssh/id_rsa.pub
-+    ssh_public_key: ~/.ssh/id_ed25519.pub
- 
- # You can make more specific customization to node configurations can be made using the ARM template azure-vm-template.json file.
- # See this documentation here: https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/2019-03-01/virtualmachines
-@@ -128,7 +128,7 @@ head_node_type: ray.head.default
- file_mounts: {
-     #    "/path1/on/remote/machine": "/path1/on/local/machine",
-     #    "/path2/on/remote/machine": "/path2/on/local/machine",
--    "~/.ssh/id_rsa.pub": "~/.ssh/id_rsa.pub"}
-+    "~/.ssh/id_ed25519.pub": "~/.ssh/id_ed25519.pub"}
- 
- # Files or directories to copy from the head node to the worker nodes. The format is a
- # list of paths. Ray copies the same path on the head node to the worker node.
- ```
+##### Automatic SSH Key Generation
+
+To connect to the provisioned head node VM, Ray has automatic SSH Key Generation if none are specified in the config. This is the simplest approach and requires no manual key management.
+
+The default configuration in `example-full.yaml` uses automatic key generation:
+
+```yaml
+auth:
+    ssh_user: ubuntu
+    # SSH keys are auto-generated if not specified
+    # Uncomment and specify custom paths if you want to use existing keys:
+    # ssh_private_key: /path/to/your/key.pem
+    # ssh_public_key: /path/to/your/key.pub
+```
+
+##### (Optional) Manual SSH Key Configuration
+
+If you prefer to use your own existing SSH keys, uncomment and specify both of the key paths in the `auth` section. 
+
+For example, to use an existing `ed25519` key pair:
+
+```yaml
+auth:
+    ssh_user: ubuntu
+    ssh_private_key: ~/.ssh/id_ed25519
+    ssh_public_key: ~/.ssh/id_ed25519.pub
+```
+
+Or for RSA keys:
+
+```yaml
+auth:
+    ssh_user: ubuntu
+    ssh_private_key: ~/.ssh/id_rsa
+    ssh_public_key: ~/.ssh/id_rsa.pub
+```
+
+Both methods inject the public key directly into the VM's `~/.ssh/authorized_keys` via Azure ARM templates.
 
 #### Launch the Ray cluster on Azure
 

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -990,3 +990,47 @@ def format_no_node_type_string(node_type: dict):
         output_lines.append(output_line)
 
     return "\n  ".join(output_lines)
+
+
+def generate_rsa_key_pair():
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(
+        backend=default_backend(), public_exponent=65537, key_size=2048
+    )
+
+    public_key = (
+        key.public_key()
+        .public_bytes(
+            serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH
+        )
+        .decode("utf-8")
+    )
+
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+    return public_key, pem
+
+
+def generate_ssh_key_paths(key_name):
+    public_key_path = os.path.expanduser("~/.ssh/{}.pub".format(key_name))
+    private_key_path = os.path.expanduser("~/.ssh/{}.pem".format(key_name))
+    return public_key_path, private_key_path
+
+
+def generate_ssh_key_name(provider, i, region, identifier, ssh_user):
+    RAY_PREFIX = "ray-autoscaler"
+    if i is not None:
+        return "{}_{}_{}_{}_{}_{}".format(
+            RAY_PREFIX, provider, region, identifier, ssh_user, i
+        )
+    else:
+        return "{}_{}_{}_{}_{}".format(
+            RAY_PREFIX, provider, region, identifier, ssh_user
+        )

--- a/python/ray/autoscaler/azure/defaults.yaml
+++ b/python/ray/autoscaler/azure/defaults.yaml
@@ -36,11 +36,10 @@ provider:
 # How Ray will authenticate with newly launched nodes.
 auth:
     ssh_user: ubuntu
-    # you must specify paths to matching private and public key pair files
-    # use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair
-    ssh_private_key: ~/.ssh/id_rsa
-    # changes to this should match what is specified in file_mounts
-    ssh_public_key: ~/.ssh/id_rsa.pub
+    # SSH keys will be auto-generated with Ray-specific names if not specified
+    # Uncomment and specify custom paths if you want to use different existing keys:
+    # ssh_private_key: /path/to/your/key.pem
+    # ssh_public_key: /path/to/your/key.pub
 
 # More specific customization to node configurations can be made using the ARM template azure-vm-template.json file
 # See documentation here: https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/2019-03-01/virtualmachines
@@ -92,7 +91,6 @@ head_node_type: ray.head.default
 file_mounts: {
 #    "/path1/on/remote/machine": "/path1/on/local/machine",
 #    "/path2/on/remote/machine": "/path2/on/local/machine",
-     "~/.ssh/id_rsa.pub": "~/.ssh/id_rsa.pub"
 }
 
 # Files or directories to copy from the head node to the worker nodes. The format is a

--- a/python/ray/autoscaler/azure/example-full.yaml
+++ b/python/ray/autoscaler/azure/example-full.yaml
@@ -59,11 +59,10 @@ provider:
 # How Ray will authenticate with newly launched nodes.
 auth:
     ssh_user: ubuntu
-    # You must specify paths to matching private and public key pair files.
-    # Use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair.
-    ssh_private_key: ~/.ssh/id_rsa
-    # Changes to this should match what is specified in file_mounts.
-    ssh_public_key: ~/.ssh/id_rsa.pub
+    # SSH keys will be auto-generated with Ray-specific names if not specified
+    # Uncomment and specify custom paths if you want to use different existing keys:
+    # ssh_private_key: /path/to/your/key.pem
+    # ssh_public_key: /path/to/your/key.pub
 
 # You can make more specific customization to node configurations can be made using the ARM template azure-vm-template.json file.
 # See this documentation here: https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/2019-03-01/virtualmachines
@@ -127,7 +126,7 @@ head_node_type: ray.head.default
 file_mounts: {
     #    "/path1/on/remote/machine": "/path1/on/local/machine",
     #    "/path2/on/remote/machine": "/path2/on/local/machine",
-    "~/.ssh/id_rsa.pub": "~/.ssh/id_rsa.pub"}
+}
 
 # Files or directories to copy from the head node to the worker nodes. The format is a
 # list of paths. Ray copies the same path on the head node to the worker node.

--- a/python/ray/autoscaler/azure/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/azure/example-gpu-docker.yaml
@@ -43,11 +43,10 @@ provider:
 # How Ray will authenticate with newly launched nodes.
 auth:
     ssh_user: ubuntu
-    # you must specify paths to matching private and public key pair files
-    # use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair
-    ssh_private_key: ~/.ssh/id_rsa
-    # changes to this should match what is specified in file_mounts
-    ssh_public_key: ~/.ssh/id_rsa.pub
+    # SSH keys will be auto-generated with Ray-specific names if not specified
+    # Uncomment and specify custom paths if you want to use different existing keys:
+    # ssh_private_key: /path/to/your/key.pem
+    # ssh_public_key: /path/to/your/key.pub
 
 # Tell the autoscaler the allowed node types and the resources they provide.
 # The key is the name of the node type, which is just for debugging purposes.
@@ -98,7 +97,6 @@ head_node_type: ray.head.gpu
 file_mounts: {
 #    "/path1/on/remote/machine": "/path1/on/local/machine",
 #    "/path2/on/remote/machine": "/path2/on/local/machine",
-     "~/.ssh/id_rsa.pub": "~/.ssh/id_rsa.pub"
 }
 
 # List of commands that will be run before `setup_commands`. If docker is

--- a/python/ray/autoscaler/azure/example-minimal.yaml
+++ b/python/ray/autoscaler/azure/example-minimal.yaml
@@ -14,13 +14,14 @@ provider:
 # How Ray will authenticate with newly launched nodes.
 auth:
     ssh_user: ubuntu
-    # you must specify paths to matching private and public key pair files
-    # use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair
-    ssh_private_key: ~/.ssh/id_rsa
-    # changes to this should match what is specified in file_mounts
-    ssh_public_key: ~/.ssh/id_rsa.pub
+    # SSH keys will be auto-generated with Ray-specific names if not specified
+    # Uncomment and specify custom paths if you want to use different existing keys:
+    # ssh_private_key: /path/to/your/key.pem
+    # ssh_public_key: /path/to/your/key.pub
 
 # Files or directories to copy to the head and worker nodes. The format is a
 # dictionary from REMOTE_PATH: LOCAL_PATH, e.g.
 file_mounts: {
-    "~/.ssh/id_rsa.pub": "~/.ssh/id_rsa.pub"}
+#    "/path1/on/remote/machine": "/path1/on/local/machine",
+#    "/path2/on/remote/machine": "/path2/on/local/machine",
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For the Azure cluster launcher, if the auth keypair is not specified, auto-create one.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #54545

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
