### PR TITLE
[llm][serve] Update ray-llm docker to ucx-1.18.1 nixl-0.3.1

### DIFF
--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -78,8 +78,8 @@ UCX_VERSION="1.18.1"
     echo "Installing UCX ${UCX_VERSION}"
     cd "${TEMP_DIR}"
     wget "https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz" -q
-    tar xzf ucx-${UCX_VERSION}.tar.gz; rm ucx-${UCX_VERSION}.tar.gz
-    cd ucx-${UCX_VERSION}
+    tar xzf "ucx-${UCX_VERSION}.tar.gz"; rm "ucx-${UCX_VERSION}.tar.gz"
+    cd "ucx-${UCX_VERSION}"
 
     # Additional options for Mellanox NICs, install by default
     MLX_OPTS="--with-rdmacm \
@@ -111,13 +111,13 @@ NIXL_VERSION="0.3.1"
     # NIXL needs meson pybind11 ninja, but should have been included in requirements_*.txt
     cd "${TEMP_DIR}"
     wget "https://github.com/ai-dynamo/nixl/archive/refs/tags/${NIXL_VERSION}.tar.gz" -q
-    tar xzf ${NIXL_VERSION}.tar.gz; rm ${NIXL_VERSION}.tar.gz
-    cd nixl-${NIXL_VERSION}
+    tar xzf "nixl-${NIXL_VERSION}.tar.gz"; rm "nixl-${NIXL_VERSION}.tar.gz"
+    cd "nixl-${NIXL_VERSION}"
     meson setup build --prefix=${NIXL_HOME} -Ducx_path=${UCX_HOME}
     cd build
     ninja
     sudo env "PATH=$PATH" ninja install
-    pip install --no-cache-dir nixl==${NIXL_VERSION}
+    pip install --no-cache-dir "nixl==${NIXL_VERSION}"
 )
 sudo rm -rf "${TEMP_DIR}"
 

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -111,7 +111,7 @@ NIXL_VERSION="0.3.1"
     # NIXL needs meson pybind11 ninja, but should have been included in requirements_*.txt
     cd "${TEMP_DIR}"
     wget "https://github.com/ai-dynamo/nixl/archive/refs/tags/${NIXL_VERSION}.tar.gz" -q
-    tar xzf "nixl-${NIXL_VERSION}.tar.gz"; rm "nixl-${NIXL_VERSION}.tar.gz"
+    tar xzf "${NIXL_VERSION}.tar.gz"; rm "${NIXL_VERSION}.tar.gz"
     cd "nixl-${NIXL_VERSION}"
     meson setup build --prefix=${NIXL_HOME} -Ducx_path=${UCX_HOME}
     cd build

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -73,12 +73,13 @@ sudo apt-get install -y kmod pkg-config librdmacm-dev
         --no-questions
 )
 
+UCX_VERSION="1.18.1"
 (
-    echo "Installing UCX"
+    echo "Installing UCX ${UCX_VERSION}"
     cd "${TEMP_DIR}"
-    wget "https://github.com/openucx/ucx/releases/download/v1.18.0/ucx-1.18.0.tar.gz" -q
-    tar xzf ucx-1.18.0.tar.gz; rm ucx-1.18.0.tar.gz
-    cd ucx-1.18.0
+    wget "https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz" -q
+    tar xzf ucx-${UCX_VERSION}.tar.gz; rm ucx-${UCX_VERSION}.tar.gz
+    cd ucx-${UCX_VERSION}
 
     # Additional options for Mellanox NICs, install by default
     MLX_OPTS="--with-rdmacm \
@@ -104,18 +105,19 @@ sudo apt-get install -y kmod pkg-config librdmacm-dev
     sudo ldconfig
 )
 
+NIXL_VERSION="0.3.1"
 (
-    echo "Installing NIXL"
+    echo "Installing NIXL ${NIXL_VERSION}"
     # NIXL needs meson pybind11 ninja, but should have been included in requirements_*.txt
     cd "${TEMP_DIR}"
-    wget "https://github.com/ai-dynamo/nixl/archive/refs/tags/0.2.0.tar.gz" -q
-    tar xzf 0.2.0.tar.gz; rm 0.2.0.tar.gz
-    cd nixl-0.2.0
+    wget "https://github.com/ai-dynamo/nixl/archive/refs/tags/${NIXL_VERSION}.tar.gz" -q
+    tar xzf ${NIXL_VERSION}.tar.gz; rm ${NIXL_VERSION}.tar.gz
+    cd nixl-${NIXL_VERSION}
     meson setup build --prefix=${NIXL_HOME} -Ducx_path=${UCX_HOME}
     cd build
     ninja
     sudo env "PATH=$PATH" ninja install
-    pip install --no-cache-dir nixl==0.2.0
+    pip install --no-cache-dir nixl==${NIXL_VERSION}
 )
 sudo rm -rf "${TEMP_DIR}"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Benchmarked on p5 instance (H100 GPU), the **intra-node** benchmark result is improved

| block size | nixl READ bandwidth before (GB/s) | nixl READ bandwidth after (GB/s) |
| -- | -- | -- |
| 65536 | 0.208175 | 5.20734 |
| 131072 | 0.226785 | 10.3284 |
| 262144 | 0.243221 | 19.8603 |

Using [nixlbench](https://github.com/ai-dynamo/nixl?tab=readme-ov-file#nixlbench-benchmark) with
```
nixlbench \
  --runtime_type=ETCD \
  --op_type=READ \
  --etcd-endpoints http://<etcd_ip>:2379 \
  --backend UCX \
  --initiator_seg_type VRAM \
  --target_seg_type VRAM
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually verified, see above
