### PR TITLE
[core][oneevent/01] gcs AddEvent: scaffolding

### DIFF
--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -214,7 +214,7 @@ class AggregatorAgent(
                     f", and {len(error_messages) - truncate_num} more events dropped"
                 )
         status = events_event_aggregator_service_pb2.AddEventStatus(
-            status_code=status_code, status_message=status_message
+            code=status_code, message=status_message
         )
         return events_event_aggregator_service_pb2.AddEventReply(status=status)
 

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -89,8 +89,8 @@ def test_aggregator_agent_receive_publish_events_normally(
     )
 
     reply = stub.AddEvents(request)
-    assert reply.status.status_code == 0
-    assert reply.status.status_message == "all events received"
+    assert reply.status.code == 0
+    assert reply.status.message == "all events received"
 
     wait_for_condition(lambda: len(httpserver.log) == 1)
 
@@ -150,12 +150,12 @@ def test_aggregator_agent_receive_event_full(
     )
 
     reply = stub.AddEvents(request)
-    assert reply.status.status_code == 0
-    assert reply.status.status_message == "all events received"
+    assert reply.status.code == 0
+    assert reply.status.message == "all events received"
 
     reply = stub.AddEvents(request)
-    assert reply.status.status_code == 5
-    assert reply.status.status_message == "event 1 dropped because event buffer full"
+    assert reply.status.code == 5
+    assert reply.status.message == "event 1 dropped because event buffer full"
 
 
 def test_aggregator_agent_receive_dropped_at_core_worker(
@@ -200,8 +200,8 @@ def test_aggregator_agent_receive_dropped_at_core_worker(
     )
 
     reply = stub.AddEvents(request)
-    assert reply.status.status_code == 0
-    assert reply.status.status_message == "all events received"
+    assert reply.status.code == 0
+    assert reply.status.message == "all events received"
 
     wait_for_condition(lambda: len(httpserver.log) == 1)
 
@@ -245,8 +245,8 @@ def test_aggregator_agent_receive_multiple_events(ray_start_cluster_head, httpse
         )
     )
     reply = stub.AddEvents(request)
-    assert reply.status.status_code == 0
-    assert reply.status.status_message == "all events received"
+    assert reply.status.code == 0
+    assert reply.status.message == "all events received"
     wait_for_condition(lambda: len(httpserver.log) == 1)
     req, _ = httpserver.log[0]
     req_json = json.loads(req.data)
@@ -308,9 +308,9 @@ def test_aggregator_agent_receive_multiple_events_failures(
         )
     )
     reply = stub.AddEvents(request)
-    assert reply.status.status_code == 5
+    assert reply.status.code == 5
     assert (
-        reply.status.status_message
+        reply.status.message
         == "event 1 dropped because event buffer full, event 2 dropped because event buffer full"
     )
 
@@ -330,8 +330,8 @@ def test_aggregator_agent_receive_empty_events(ray_start_cluster_head, httpserve
         )
     )
     reply = stub.AddEvents(request)
-    assert reply.status.status_code == 0
-    assert reply.status.status_message == "all events received"
+    assert reply.status.code == 0
+    assert reply.status.message == "all events received"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -574,8 +574,8 @@ def test_metrics_export_event_aggregator_agent(
     )
 
     reply = stub.AddEvents(request)
-    assert reply.status.status_code == 5
-    assert reply.status.status_message == "event 1 dropped because event buffer full"
+    assert reply.status.code == 5
+    assert reply.status.message == "event 1 dropped because event buffer full"
     wait_for_condition(lambda: len(httpserver.log) == 1)
 
     wait_for_condition(test_case_value_correct, timeout=30, retry_interval_ms=1000)

--- a/src/ray/gcs/gcs_server/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/BUILD.bazel
@@ -162,6 +162,7 @@ ray_cc_library(
         "//src/ray/common:status",
         "//src/ray/gcs:gcs_pb_util",
         "//src/ray/protobuf:gcs_cc_proto",
+        "//src/ray/protobuf:events_event_aggregator_service_cc_proto",
         "//src/ray/util:counter_map",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -732,6 +732,8 @@ void GcsServer::InitGcsTaskManager() {
   // Register service.
   rpc_server_.RegisterService(
       std::make_unique<rpc::TaskInfoGrpcService>(io_context, *gcs_task_manager_));
+  rpc_server_.RegisterService(
+      std::make_unique<rpc::EventExportGrpcService>(io_context, *gcs_task_manager_));
 }
 
 void GcsServer::InstallEventListeners() {

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -653,6 +653,13 @@ void GcsTaskManager::HandleAddTaskEventData(rpc::AddTaskEventDataRequest request
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }
 
+void GcsTaskManager::HandleAddEvent(rpc::events::AddEventRequest request,
+                                    rpc::events::AddEventReply *reply,
+                                    rpc::SendReplyCallback send_reply_callback) {
+  // TODO(can-anyscale): Implement this.
+  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+}
+
 std::string GcsTaskManager::DebugString() {
   std::ostringstream ss;
   auto counters = stats_counter_.GetAll();

--- a/src/ray/gcs/gcs_server/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.h
@@ -91,7 +91,7 @@ class FinishedTaskActorTaskGcPolicy : public TaskEventsGcPolicyInterface {
 ///
 /// This class has its own io_context and io_thread, that's separate from other GCS
 /// services. All handling of all rpc should be posted to the single thread it owns.
-class GcsTaskManager : public rpc::TaskInfoHandler {
+class GcsTaskManager : public rpc::TaskInfoHandler, public rpc::EventExportHandler {
  public:
   /// Create a GcsTaskManager.
   explicit GcsTaskManager(instrumented_io_context &io_service);
@@ -104,6 +104,15 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
   void HandleAddTaskEventData(rpc::AddTaskEventDataRequest request,
                               rpc::AddTaskEventDataReply *reply,
                               rpc::SendReplyCallback send_reply_callback) override;
+
+  /// Handles a AddEvent request.
+  ///
+  /// \param request gRPC Request.
+  /// \param reply gRPC Reply.
+  /// \param send_reply_callback Callback to invoke when sending reply.
+  void HandleAddEvent(rpc::events::AddEventRequest request,
+                      rpc::events::AddEventReply *reply,
+                      rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle GetTaskEvent request.
   ///

--- a/src/ray/protobuf/BUILD
+++ b/src/ray/protobuf/BUILD
@@ -161,6 +161,7 @@ proto_library(
     srcs = ["gcs_service.proto"],
     deps = [
         ":common_proto",
+        ":events_event_aggregator_service_proto",
         ":gcs_proto",
         ":pubsub_proto",
     ],

--- a/src/ray/protobuf/events_event_aggregator_service.proto
+++ b/src/ray/protobuf/events_event_aggregator_service.proto
@@ -41,9 +41,9 @@ message AddEventRequest {
 message AddEventStatus {
   // Status code of the add event request result. The codes follow the codes in
   // `src/ray/common/status.h`
-  int32 status_code = 1;
+  int32 code = 1;
   // Status message of the add event request result.
-  string status_message = 2;
+  string message = 2;
 }
 
 message AddEventReply {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -19,6 +19,7 @@ package ray.rpc;
 import "src/ray/protobuf/common.proto";
 import "src/ray/protobuf/gcs.proto";
 import "src/ray/protobuf/pubsub.proto";
+import "src/ray/protobuf/events_event_aggregator_service.proto";
 
 message AddJobRequest {
   JobTableData data = 1;
@@ -863,6 +864,12 @@ service TaskInfoGcsService {
 
   // Get task events.
   rpc GetTaskEvents(GetTaskEventsRequest) returns (GetTaskEventsReply);
+}
+
+// Service for recording the unified ray events.
+service EventExportGcsService {
+  // Add OneEvent task data to GCS.
+  rpc AddEvent(events.AddEventRequest) returns (events.AddEventReply);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -38,13 +38,14 @@ namespace rpc {
 #define VOID_GCS_RPC_CLIENT_METHOD(                         \
     SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS) \
   VOID_GCS_RPC_CLIENT_METHOD_FULL(                          \
-      ray::rpc, SERVICE, METHOD, grpc_client, method_timeout_ms, true, SPECS)
+      ray::rpc, ray::rpc, SERVICE, METHOD, grpc_client, method_timeout_ms, true, SPECS)
 
 /// Define a void GCS RPC client method.
 ///
 /// Example:
 ///   VOID_GCS_RPC_CLIENT_METHOD_FULL(
 ///     ray::rpc,
+///     ray::rpc::events,
 ///     ActorInfoGcsService,
 ///     CreateActor,
 ///     actor_info_grpc_client_,
@@ -63,7 +64,8 @@ namespace rpc {
 ///   That says, when there's any RPC failure, the method will automatically retry
 ///   under the hood.
 ///
-/// \param NAMESPACE namespace of the service.
+/// \param SERVICE_NAMESPACE namespace of the service.
+/// \param METHOD_NAMESPACE namespace of the method.
 /// \param SERVICE name of the service.
 /// \param METHOD name of the RPC method.
 /// \param grpc_client The grpc client to invoke RPC.
@@ -77,40 +79,41 @@ namespace rpc {
 ///
 /// Currently, SyncMETHOD will copy the reply additionally.
 /// TODO(sang): Fix it.
-#define VOID_GCS_RPC_CLIENT_METHOD_FULL(NAMESPACE,                         \
-                                        SERVICE,                           \
-                                        METHOD,                            \
-                                        grpc_client,                       \
-                                        method_timeout_ms,                 \
-                                        handle_payload_status,             \
-                                        SPECS)                             \
-  void METHOD(const NAMESPACE::METHOD##Request &request,                   \
-              const ClientCallback<NAMESPACE::METHOD##Reply> &callback,    \
-              const int64_t timeout_ms = method_timeout_ms) SPECS {        \
-    invoke_async_method<NAMESPACE::SERVICE,                                \
-                        NAMESPACE::METHOD##Request,                        \
-                        NAMESPACE::METHOD##Reply,                          \
-                        handle_payload_status>(                            \
-        &NAMESPACE::SERVICE::Stub::PrepareAsync##METHOD,                   \
-        grpc_client,                                                       \
-        #NAMESPACE "::" #SERVICE ".grpc_client." #METHOD,                  \
-        request,                                                           \
-        callback,                                                          \
-        timeout_ms);                                                       \
-  }                                                                        \
-  ray::Status Sync##METHOD(const NAMESPACE::METHOD##Request &request,      \
-                           NAMESPACE::METHOD##Reply *reply_in,             \
-                           const int64_t timeout_ms = method_timeout_ms) { \
-    std::promise<Status> promise;                                          \
-    METHOD(                                                                \
-        request,                                                           \
-        [&promise, reply_in](const Status &status,                         \
-                             const NAMESPACE::METHOD##Reply &reply) {      \
-          reply_in->CopyFrom(reply);                                       \
-          promise.set_value(status);                                       \
-        },                                                                 \
-        timeout_ms);                                                       \
-    return promise.get_future().get();                                     \
+#define VOID_GCS_RPC_CLIENT_METHOD_FULL(SERVICE_NAMESPACE,                     \
+                                        METHOD_NAMESPACE,                      \
+                                        SERVICE,                               \
+                                        METHOD,                                \
+                                        grpc_client,                           \
+                                        method_timeout_ms,                     \
+                                        handle_payload_status,                 \
+                                        SPECS)                                 \
+  void METHOD(const METHOD_NAMESPACE::METHOD##Request &request,                \
+              const ClientCallback<METHOD_NAMESPACE::METHOD##Reply> &callback, \
+              const int64_t timeout_ms = method_timeout_ms) SPECS {            \
+    invoke_async_method<SERVICE_NAMESPACE::SERVICE,                            \
+                        METHOD_NAMESPACE::METHOD##Request,                     \
+                        METHOD_NAMESPACE::METHOD##Reply,                       \
+                        handle_payload_status>(                                \
+        &SERVICE_NAMESPACE::SERVICE::Stub::PrepareAsync##METHOD,               \
+        grpc_client,                                                           \
+        #SERVICE_NAMESPACE "::" #SERVICE ".grpc_client." #METHOD,              \
+        request,                                                               \
+        callback,                                                              \
+        timeout_ms);                                                           \
+  }                                                                            \
+  ray::Status Sync##METHOD(const METHOD_NAMESPACE::METHOD##Request &request,   \
+                           METHOD_NAMESPACE::METHOD##Reply *reply_in,          \
+                           const int64_t timeout_ms = method_timeout_ms) {     \
+    std::promise<Status> promise;                                              \
+    METHOD(                                                                    \
+        request,                                                               \
+        [&promise, reply_in](const Status &status,                             \
+                             const METHOD_NAMESPACE::METHOD##Reply &reply) {   \
+          reply_in->CopyFrom(reply);                                           \
+          promise.set_value(status);                                           \
+        },                                                                     \
+        timeout_ms);                                                           \
+    return promise.get_future().get();                                         \
   }
 
 /// Client used for communicating with gcs server.
@@ -174,6 +177,8 @@ class GcsRpcClient {
         channel_, client_call_manager);
     task_info_grpc_client_ =
         std::make_shared<GrpcClient<TaskInfoGcsService>>(channel_, client_call_manager);
+    event_export_grpc_client_ = std::make_shared<GrpcClient<EventExportGcsService>>(
+        channel_, client_call_manager);
     autoscaler_state_grpc_client_ =
         std::make_shared<GrpcClient<autoscaler::AutoscalerStateService>>(
             channel_, client_call_manager);
@@ -388,6 +393,15 @@ class GcsRpcClient {
                              task_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
+  /// Add one event data to GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc,
+                                  ray::rpc::events,
+                                  EventExportGcsService,
+                                  AddEvent,
+                                  event_export_grpc_client_,
+                                  /*method_timeout_ms*/ -1,
+                                  /*handle_payload_status=*/true, )
+
   /// Add task events info to GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(TaskInfoGcsService,
                              GetTaskEvents,
@@ -513,6 +527,7 @@ class GcsRpcClient {
 
   /// Operations for autoscaler
   VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  ray::rpc::autoscaler,
                                   AutoscalerStateService,
                                   GetClusterResourceState,
                                   autoscaler_state_grpc_client_,
@@ -520,6 +535,7 @@ class GcsRpcClient {
                                   /*handle_payload_status=*/false, )
 
   VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  ray::rpc::autoscaler,
                                   AutoscalerStateService,
                                   ReportAutoscalingState,
                                   autoscaler_state_grpc_client_,
@@ -527,6 +543,7 @@ class GcsRpcClient {
                                   /*handle_payload_status=*/false, )
 
   VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  ray::rpc::autoscaler,
                                   AutoscalerStateService,
                                   ReportClusterConfig,
                                   autoscaler_state_grpc_client_,
@@ -534,6 +551,7 @@ class GcsRpcClient {
                                   /*handle_payload_status=*/false, )
 
   VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  ray::rpc::autoscaler,
                                   AutoscalerStateService,
                                   RequestClusterResourceConstraint,
                                   autoscaler_state_grpc_client_,
@@ -541,6 +559,7 @@ class GcsRpcClient {
                                   /*handle_payload_status=*/false, )
 
   VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  ray::rpc::autoscaler,
                                   AutoscalerStateService,
                                   GetClusterStatus,
                                   autoscaler_state_grpc_client_,
@@ -548,6 +567,7 @@ class GcsRpcClient {
                                   /*handle_payload_status=*/false, )
 
   VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  ray::rpc::autoscaler,
                                   AutoscalerStateService,
                                   DrainNode,
                                   autoscaler_state_grpc_client_,
@@ -583,6 +603,7 @@ class GcsRpcClient {
   std::shared_ptr<GrpcClient<InternalKVGcsService>> internal_kv_grpc_client_;
   std::shared_ptr<GrpcClient<InternalPubSubGcsService>> internal_pubsub_grpc_client_;
   std::shared_ptr<GrpcClient<TaskInfoGcsService>> task_info_grpc_client_;
+  std::shared_ptr<GrpcClient<EventExportGcsService>> event_export_grpc_client_;
   std::shared_ptr<GrpcClient<RuntimeEnvGcsService>> runtime_env_grpc_client_;
   std::shared_ptr<GrpcClient<autoscaler::AutoscalerStateService>>
       autoscaler_state_grpc_client_;

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -22,10 +22,16 @@
 #include "ray/rpc/grpc_server.h"
 #include "ray/rpc/server_call.h"
 #include "src/ray/protobuf/autoscaler.grpc.pb.h"
+#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
 #include "src/ray/protobuf/gcs_service.grpc.pb.h"
 
 namespace ray {
 namespace rpc {
+// Most of our RPC templates, if not all, expect messages in the ray::rpc protobuf
+// namespace.  Since the following two messages are defined under the rpc::events
+// namespace, we treat them as if they were part of ray::rpc for compatibility.
+using ray::rpc::events::AddEventReply;
+using ray::rpc::events::AddEventRequest;
 namespace autoscaler {
 
 #define AUTOSCALER_STATE_SERVICE_RPC_HANDLER(HANDLER) \
@@ -124,6 +130,11 @@ namespace rpc {
 #define TASK_INFO_SERVICE_RPC_HANDLER(HANDLER) \
   RPC_SERVICE_HANDLER(TaskInfoGcsService,      \
                       HANDLER,                 \
+                      RayConfig::instance().gcs_max_active_rpcs_per_handler())
+
+#define EVENT_EXPORT_SERVICE_RPC_HANDLER(HANDLER) \
+  RPC_SERVICE_HANDLER(EventExportGcsService,      \
+                      HANDLER,                    \
                       RayConfig::instance().gcs_max_active_rpcs_per_handler())
 
 #define NODE_RESOURCE_INFO_SERVICE_RPC_HANDLER(HANDLER) \
@@ -645,9 +656,9 @@ class TaskInfoGcsServiceHandler {
                                       AddTaskEventDataReply *reply,
                                       SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetTaskEvents(rpc::GetTaskEventsRequest request,
-                                   rpc::GetTaskEventsReply *reply,
-                                   rpc::SendReplyCallback send_reply_callback) = 0;
+  virtual void HandleGetTaskEvents(GetTaskEventsRequest request,
+                                   GetTaskEventsReply *reply,
+                                   SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `TaskInfoGcsService`.
@@ -677,6 +688,37 @@ class TaskInfoGrpcService : public GrpcService {
   TaskInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
   TaskInfoGcsServiceHandler &service_handler_;
+};
+
+class EventExportGcsServiceHandler {
+ public:
+  virtual ~EventExportGcsServiceHandler() = default;
+  virtual void HandleAddEvent(AddEventRequest request,
+                              AddEventReply *reply,
+                              SendReplyCallback send_reply_callback) = 0;
+};
+
+/// The `GrpcService` for `EventExportGcsService`.
+class EventExportGrpcService : public GrpcService {
+ public:
+  explicit EventExportGrpcService(instrumented_io_context &io_service,
+                                  EventExportGcsServiceHandler &handler)
+      : GrpcService(io_service), service_handler_(handler) {}
+
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
+  void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
+      const ClusterID &cluster_id) override {
+    EVENT_EXPORT_SERVICE_RPC_HANDLER(AddEvent);
+  }
+
+ private:
+  /// The grpc async service object.
+  EventExportGcsService::AsyncService service_;
+  /// The service handler that actually handle the requests.
+  EventExportGcsServiceHandler &service_handler_;
 };
 
 class InternalPubSubGcsServiceHandler {
@@ -733,6 +775,7 @@ using InternalKVHandler = InternalKVGcsServiceHandler;
 using InternalPubSubHandler = InternalPubSubGcsServiceHandler;
 using RuntimeEnvHandler = RuntimeEnvGcsServiceHandler;
 using TaskInfoHandler = TaskInfoGcsServiceHandler;
+using EventExportHandler = EventExportGcsServiceHandler;
 
 }  // namespace rpc
 }  // namespace ray


### PR DESCRIPTION
This is a series of PRs that connects each worker's EventAggregator to GCS, completing the OneEvent implementation for task events.
For more details, see: https://docs.google.com/document/d/1WjdlKprMqLqyPvmR1OGRQNhCD93SWrCXj21jZXXUcSk/edit?tab=t.0#heading=h.mmmgp2sapmts.

------------

This PR specifically adds a new gRPC endpoint, AddEvent, to GCS, allowing the EventAggregator to send Ray task events.

Test:
- CI
- build