### PR TITLE
[core][1event/02] gcs AddEvent: TaskDefinition support

### DIFF
--- a/src/ray/gcs/gcs_server/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/BUILD.bazel
@@ -151,10 +151,22 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "gcs_ray_event_converter",
+    srcs = ["gcs_ray_event_converter.cc"],
+    hdrs = ["gcs_ray_event_converter.h"],
+    deps = [
+        "//src/ray/protobuf:events_event_aggregator_service_cc_proto",
+        "//src/ray/protobuf:gcs_service_cc_proto",
+        "//src/ray/util:logging",
+    ],
+)
+
+ray_cc_library(
     name = "gcs_task_manager",
     srcs = ["gcs_task_manager.cc"],
     hdrs = ["gcs_task_manager.h"],
     deps = [
+        ":gcs_ray_event_converter",
         ":gcs_usage_stats_client",
         "//src/ray/common:asio",
         "//src/ray/common:id",

--- a/src/ray/gcs/gcs_server/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_server/gcs_ray_event_converter.cc
@@ -1,0 +1,82 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/gcs_server/gcs_ray_event_converter.h"
+
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace gcs {
+
+void GcsRayEventConverter::ConvertToTaskEventDataRequest(
+    rpc::events::AddEventsRequest &&request, rpc::AddTaskEventDataRequest &data) {
+  auto *task_event_data = data.mutable_data();
+
+  // Move dropped task attempts from the metadata
+  *task_event_data->mutable_dropped_task_attempts() =
+      std::move(request.events_data().task_events_metadata().dropped_task_attempts());
+
+  // Move RayEvents to TaskEvents
+  for (auto &event : *request.mutable_events_data()->mutable_events()) {
+    rpc::TaskEvents task_event;
+    switch (event.event_type()) {
+    case rpc::events::RayEvent::TASK_DEFINITION_EVENT: {
+      ConvertToTaskEvents(std::move(*event.mutable_task_definition_event()), task_event);
+      break;
+    }
+    default:
+      // TODO(can-anyscale): Handle other event types
+      break;
+    }
+    *task_event_data->add_events_by_task() = std::move(task_event);
+  }
+  if (task_event_data->events_by_task_size() > 0) {
+    task_event_data->set_job_id(task_event_data->events_by_task(0).job_id());
+  }
+}
+
+void GcsRayEventConverter::ConvertToTaskEvents(rpc::events::TaskDefinitionEvent &&event,
+                                               rpc::TaskEvents &task_event) {
+  task_event.set_task_id(event.task_id());
+  task_event.set_attempt_number(event.task_attempt());
+  task_event.set_job_id(event.job_id());
+
+  rpc::TaskInfoEntry *task_info = task_event.mutable_task_info();
+  task_info->set_type(event.task_type());
+  task_info->set_name(event.task_name());
+  task_info->set_language(event.language());
+  task_info->set_task_id(event.task_id());
+  task_info->set_job_id(event.job_id());
+  *task_info->mutable_runtime_env_info() = std::move(event.runtime_env_info());
+  task_info->set_parent_task_id(event.parent_task_id());
+  if (!event.placement_group_id().empty()) {
+    task_info->set_placement_group_id(event.placement_group_id());
+  }
+
+  auto function_descriptor = event.task_func();
+  if (event.language() == rpc::Language::CPP && function_descriptor.has_cpp_function_descriptor()) {
+    task_info->set_func_or_class_name(
+        function_descriptor.cpp_function_descriptor().function_name());
+  } else if (event.language() == rpc::Language::PYTHON && function_descriptor.has_python_function_descriptor()) {
+    task_info->set_func_or_class_name(
+        function_descriptor.python_function_descriptor().function_name());
+  } else if (event.language() == rpc::Language::JAVA && function_descriptor.has_java_function_descriptor()) {
+    task_info->set_func_or_class_name(
+        function_descriptor.java_function_descriptor().function_name());
+  }
+  *task_info->mutable_required_resources() = std::move(event.required_resources());
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_server/gcs_ray_event_converter.cc
@@ -65,13 +65,16 @@ void GcsRayEventConverter::ConvertToTaskEvents(rpc::events::TaskDefinitionEvent 
   }
 
   auto function_descriptor = event.task_func();
-  if (event.language() == rpc::Language::CPP && function_descriptor.has_cpp_function_descriptor()) {
+  if (event.language() == rpc::Language::CPP &&
+      function_descriptor.has_cpp_function_descriptor()) {
     task_info->set_func_or_class_name(
         function_descriptor.cpp_function_descriptor().function_name());
-  } else if (event.language() == rpc::Language::PYTHON && function_descriptor.has_python_function_descriptor()) {
+  } else if (event.language() == rpc::Language::PYTHON &&
+             function_descriptor.has_python_function_descriptor()) {
     task_info->set_func_or_class_name(
         function_descriptor.python_function_descriptor().function_name());
-  } else if (event.language() == rpc::Language::JAVA && function_descriptor.has_java_function_descriptor()) {
+  } else if (event.language() == rpc::Language::JAVA &&
+             function_descriptor.has_java_function_descriptor()) {
     task_info->set_func_or_class_name(
         function_descriptor.java_function_descriptor().function_name());
   }

--- a/src/ray/gcs/gcs_server/gcs_ray_event_converter.h
+++ b/src/ray/gcs/gcs_server/gcs_ray_event_converter.h
@@ -1,0 +1,46 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
+#include "src/ray/protobuf/gcs_service.pb.h"
+
+namespace ray {
+namespace gcs {
+
+/// GcsRayEventConverter converts RayEvents to TaskEvents.
+class GcsRayEventConverter {
+ public:
+  GcsRayEventConverter() = default;
+  ~GcsRayEventConverter() = default;
+
+  /// Convert an AddEventsRequest to an AddTaskEventDataRequest.
+  ///
+  /// \param request The AddEventsRequest to convert.
+  /// \param data The output AddTaskEventDataRequest to populate.
+  void ConvertToTaskEventDataRequest(rpc::events::AddEventsRequest &&request,
+                                     rpc::AddTaskEventDataRequest &data);
+
+ private:
+  /// Convert a TaskDefinitionEvent to a TaskEvents.
+  ///
+  /// \param event The TaskDefinitionEvent to convert.
+  /// \param task_event The output TaskEvents to populate.
+  void ConvertToTaskEvents(rpc::events::TaskDefinitionEvent &&event,
+                           rpc::TaskEvents &task_event);
+};
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -38,6 +38,7 @@ GcsTaskManager::GcsTaskManager(instrumented_io_context &io_service)
           RayConfig::instance().task_events_max_num_task_in_gcs(),
           stats_counter_,
           std::make_unique<FinishedTaskActorTaskGcPolicy>())),
+      ray_event_converter_(std::make_unique<GcsRayEventConverter>()),
       periodical_runner_(PeriodicalRunner::Create(io_service_)) {
   periodical_runner_->RunFnPeriodically([this] { task_event_storage_->GcJobSummary(); },
                                         5 * 1000,
@@ -638,9 +639,7 @@ void GcsTaskManager::GcsTaskManagerStorage::RecordDataLossFromWorker(
   }
 }
 
-void GcsTaskManager::HandleAddTaskEventData(rpc::AddTaskEventDataRequest request,
-                                            rpc::AddTaskEventDataReply *reply,
-                                            rpc::SendReplyCallback send_reply_callback) {
+void GcsTaskManager::RecordTaskEventData(rpc::AddTaskEventDataRequest &request) {
   auto data = std::move(*request.mutable_data());
   task_event_storage_->RecordDataLossFromWorker(data);
 
@@ -648,6 +647,12 @@ void GcsTaskManager::HandleAddTaskEventData(rpc::AddTaskEventDataRequest request
     stats_counter_.Increment(kTotalNumTaskEventsReported);
     task_event_storage_->AddOrReplaceTaskEvent(std::move(events_by_task));
   }
+}
+
+void GcsTaskManager::HandleAddTaskEventData(rpc::AddTaskEventDataRequest request,
+                                            rpc::AddTaskEventDataReply *reply,
+                                            rpc::SendReplyCallback send_reply_callback) {
+  RecordTaskEventData(request);
 
   // Processed all the task events
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -656,7 +661,12 @@ void GcsTaskManager::HandleAddTaskEventData(rpc::AddTaskEventDataRequest request
 void GcsTaskManager::HandleAddEvents(rpc::events::AddEventsRequest request,
                                      rpc::events::AddEventsReply *reply,
                                      rpc::SendReplyCallback send_reply_callback) {
-  // TODO(can-anyscale): Implement this.
+  rpc::AddTaskEventDataRequest task_event_data;
+  ray_event_converter_->ConvertToTaskEventDataRequest(std::move(request),
+                                                      task_event_data);
+  RecordTaskEventData(task_event_data);
+
+  // Processed all the task events
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }
 

--- a/src/ray/gcs/gcs_server/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.h
@@ -24,6 +24,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
+#include "ray/gcs/gcs_server/gcs_ray_event_converter.h"
 #include "ray/gcs/gcs_server/usage_stats_client.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/util/counter_map.h"
@@ -469,6 +470,7 @@ class GcsTaskManager : public rpc::TaskInfoHandler, public rpc::RayEventExportHa
     std::vector<std::list<rpc::TaskEvents>> task_events_list_;
 
     friend class GcsTaskManager;
+    FRIEND_TEST(GcsTaskManagerTest, TestHandleAddEventBasic);
     FRIEND_TEST(GcsTaskManagerTest, TestHandleAddTaskEventBasic);
     FRIEND_TEST(GcsTaskManagerTest, TestMergeTaskEventsSameTaskAttempt);
     FRIEND_TEST(GcsTaskManagerMemoryLimitedTest, TestLimitTaskEvents);
@@ -479,6 +481,8 @@ class GcsTaskManager : public rpc::TaskInfoHandler, public rpc::RayEventExportHa
   };
 
  private:
+  void RecordTaskEventData(rpc::AddTaskEventDataRequest &request);
+
   /// Record data loss from worker.
   ///
   /// TODO(rickyx): This will be updated to record task attempt loss properly.
@@ -519,9 +523,13 @@ class GcsTaskManager : public rpc::TaskInfoHandler, public rpc::RayEventExportHa
   // the io_service_thread_. Access to it is *not* thread safe.
   std::unique_ptr<GcsTaskManagerStorage> task_event_storage_;
 
+  // Converter for converting RayEvents to TaskEvents.
+  std::unique_ptr<GcsRayEventConverter> ray_event_converter_;
+
   /// The runner to run function periodically.
   std::shared_ptr<PeriodicalRunner> periodical_runner_;
 
+  FRIEND_TEST(GcsTaskManagerTest, TestHandleAddEventBasic);
   FRIEND_TEST(GcsTaskManagerTest, TestHandleAddTaskEventBasic);
   FRIEND_TEST(GcsTaskManagerTest, TestMergeTaskEventsSameTaskAttempt);
   FRIEND_TEST(GcsTaskManagerMemoryLimitedTest, TestLimitTaskEvents);

--- a/src/ray/gcs/gcs_server/test/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/test/BUILD.bazel
@@ -402,3 +402,14 @@ ray_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+ray_cc_test(
+    name = "gcs_ray_event_converter_test",
+    size = "small",
+    srcs = ["gcs_ray_event_converter_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/gcs/gcs_server:gcs_ray_event_converter",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/gcs/gcs_server/test/gcs_ray_event_converter_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_ray_event_converter_test.cc
@@ -1,0 +1,125 @@
+// Copyright 2022 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/gcs_server/gcs_ray_event_converter.h"
+
+#include "gtest/gtest.h"
+#include "src/ray/protobuf/events_base_event.pb.h"
+#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
+#include "src/ray/protobuf/gcs_service.pb.h"
+#include "src/ray/protobuf/common.pb.h"
+
+namespace ray {
+namespace gcs {
+
+class GcsRayEventConverterTest : public ::testing::Test {
+ public:
+  GcsRayEventConverterTest() {}
+};
+
+TEST_F(GcsRayEventConverterTest, TestConvertToTaskEventData) {
+  rpc::events::AddEventsRequest request;
+  rpc::AddTaskEventDataRequest task_event_data;
+  GcsRayEventConverter converter;
+
+  // Test empty request
+  converter.ConvertToTaskEventDataRequest(std::move(request), task_event_data);
+  EXPECT_EQ(task_event_data.data().events_by_task_size(), 0);
+  EXPECT_EQ(task_event_data.data().dropped_task_attempts_size(), 0);
+}
+
+TEST_F(GcsRayEventConverterTest, TestConvertTaskDefinitionEvent) {
+  rpc::events::AddEventsRequest request;
+  rpc::AddTaskEventDataRequest task_event_data;
+  GcsRayEventConverter converter;
+
+  // Create a task definition event
+  auto *event = request.mutable_events_data()->add_events();
+  event->set_event_id("test_event_id");
+  event->set_event_type(rpc::events::RayEvent::TASK_DEFINITION_EVENT);
+  event->set_source_type(rpc::events::RayEvent::CORE_WORKER);
+  event->set_severity(rpc::events::RayEvent::INFO);
+  event->set_message("test message");
+
+  auto *task_def_event = event->mutable_task_definition_event();
+  task_def_event->set_task_type(rpc::TaskType::NORMAL_TASK);
+  task_def_event->set_language(rpc::Language::PYTHON);
+  task_def_event->mutable_task_func()->mutable_python_function_descriptor()->set_function_name(
+      "test_task_name");
+  task_def_event->set_task_id("test_task_id");
+  task_def_event->set_task_attempt(1);
+  task_def_event->set_job_id("test_job_id");
+  task_def_event->set_task_name("test_task_name");
+  task_def_event->set_parent_task_id("parent_task_id");
+  task_def_event->set_placement_group_id("pg_id");
+
+  // Add some required resources
+  (*task_def_event->mutable_required_resources())["CPU"] = 1.0;
+  (*task_def_event->mutable_required_resources())["memory"] = 1024.0;
+
+  // Set runtime env info
+  auto *runtime_env = task_def_event->mutable_runtime_env_info();
+  runtime_env->set_serialized_runtime_env("test_env");
+
+  // Convert
+  converter.ConvertToTaskEventDataRequest(std::move(request), task_event_data);
+
+  // Verify conversion
+  EXPECT_EQ(task_event_data.data().events_by_task_size(), 1);
+  const auto &converted_task = task_event_data.data().events_by_task(0);
+  EXPECT_EQ(converted_task.task_id(), "test_task_id");
+  EXPECT_EQ(converted_task.attempt_number(), 1);
+  EXPECT_EQ(converted_task.job_id(), "test_job_id");
+  EXPECT_EQ(task_event_data.data().job_id(), "test_job_id");
+
+  // Verify task info
+  EXPECT_TRUE(converted_task.has_task_info());
+  const auto &task_info = converted_task.task_info();
+  EXPECT_EQ(task_info.name(), "test_task_name");
+  EXPECT_EQ(task_info.type(), rpc::TaskType::NORMAL_TASK);
+  EXPECT_EQ(task_info.language(), rpc::Language::PYTHON);
+  EXPECT_EQ(task_info.func_or_class_name(), "test_task_name");
+  EXPECT_EQ(task_info.runtime_env_info().serialized_runtime_env(), "test_env");
+  EXPECT_EQ(task_info.parent_task_id(), "parent_task_id");
+  EXPECT_EQ(task_info.placement_group_id(), "pg_id");
+
+  // Verify required resources
+  EXPECT_EQ(task_info.required_resources().at("CPU"), 1.0);
+  EXPECT_EQ(task_info.required_resources().at("memory"), 1024.0);
+}
+
+TEST_F(GcsRayEventConverterTest, TestConvertWithDroppedTaskAttempts) {
+  rpc::events::AddEventsRequest request;
+  rpc::AddTaskEventDataRequest task_event_data;
+  GcsRayEventConverter converter;
+
+  // Add dropped task attempts to metadata
+  auto *dropped_attempt = request.mutable_events_data()
+                              ->mutable_task_events_metadata()
+                              ->add_dropped_task_attempts();
+  dropped_attempt->set_task_id("dropped_task_id");
+  dropped_attempt->set_attempt_number(2);
+
+  // Convert
+  converter.ConvertToTaskEventDataRequest(std::move(request), task_event_data);
+
+  // Verify dropped task attempts are copied
+  EXPECT_EQ(task_event_data.data().dropped_task_attempts_size(), 1);
+  const auto &converted_dropped = task_event_data.data().dropped_task_attempts(0);
+  EXPECT_EQ(converted_dropped.task_id(), "dropped_task_id");
+  EXPECT_EQ(converted_dropped.attempt_number(), 2);
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_ray_event_converter_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_ray_event_converter_test.cc
@@ -15,10 +15,10 @@
 #include "ray/gcs/gcs_server/gcs_ray_event_converter.h"
 
 #include "gtest/gtest.h"
+#include "src/ray/protobuf/common.pb.h"
 #include "src/ray/protobuf/events_base_event.pb.h"
 #include "src/ray/protobuf/events_event_aggregator_service.pb.h"
 #include "src/ray/protobuf/gcs_service.pb.h"
-#include "src/ray/protobuf/common.pb.h"
 
 namespace ray {
 namespace gcs {
@@ -55,8 +55,9 @@ TEST_F(GcsRayEventConverterTest, TestConvertTaskDefinitionEvent) {
   auto *task_def_event = event->mutable_task_definition_event();
   task_def_event->set_task_type(rpc::TaskType::NORMAL_TASK);
   task_def_event->set_language(rpc::Language::PYTHON);
-  task_def_event->mutable_task_func()->mutable_python_function_descriptor()->set_function_name(
-      "test_task_name");
+  task_def_event->mutable_task_func()
+      ->mutable_python_function_descriptor()
+      ->set_function_name("test_task_name");
   task_def_event->set_task_id("test_task_id");
   task_def_event->set_task_attempt(1);
   task_def_event->set_job_id("test_job_id");

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -146,6 +146,32 @@ class GcsTaskManagerTest : public ::testing::Test {
     return reply;
   }
 
+  rpc::events::AddEventsReply SyncAddEvents(
+      const rpc::events::RayEventsData &events_data) {
+    rpc::events::AddEventsRequest request;
+    rpc::events::AddEventsReply reply;
+    std::promise<bool> promise;
+
+    request.mutable_events_data()->CopyFrom(events_data);
+    // Dispatch so that it runs in GcsTaskManager's io service.
+    io_context_->GetIoService().dispatch(
+        [this, &promise, &request, &reply]() {
+          task_manager->HandleAddEvents(
+              request,
+              &reply,
+              [&promise](Status, std::function<void()>, std::function<void()>) {
+                promise.set_value(true);
+              });
+        },
+        "SyncAddEvent");
+
+    promise.get_future().get();
+
+    // Assert on RPC reply.
+    EXPECT_EQ(StatusCode(reply.status().code()), StatusCode::OK);
+    return reply;
+  }
+
   rpc::GetTaskEventsReply SyncGetTaskEvents(
       const std::vector<TaskID> task_ids,
       const std::vector<rpc::FilterPredicate> task_id_predicates,
@@ -400,6 +426,21 @@ class GcsTaskManagerDroppedTaskAttemptsLimit : public GcsTaskManagerTest {
   )");
   }
 };
+
+TEST_F(GcsTaskManagerTest, TestHandleAddEventBasic) {
+  size_t num_task_events = 100;
+  auto task_ids = GenTaskIDs(num_task_events);
+  auto events = GenTaskEvents(task_ids, 0);
+  auto events_data = Mocker::GenRayEventsData(events, {});
+  auto reply = SyncAddEvents(events_data);
+
+  // Assert on RPC reply.
+  EXPECT_EQ(StatusCode(reply.status().code()), StatusCode::OK);
+
+  // Assert on actual data.
+  EXPECT_EQ(task_manager->task_event_storage_->GetTaskEvents().size(), num_task_events);
+  EXPECT_EQ(task_manager->GetTotalNumTaskEventsReported(), num_task_events);
+}
 
 TEST_F(GcsTaskManagerTest, TestHandleAddTaskEventBasic) {
   size_t num_task_events = 100;


### PR DESCRIPTION
This is a series of PRs that connects each worker's EventAggregator to GCS, completing the OneEvent implementation for task events.
For more details, see: https://docs.google.com/document/d/1WjdlKprMqLqyPvmR1OGRQNhCD93SWrCXj21jZXXUcSk/edit?tab=t.0#heading=h.mmmgp2sapmts.

------------

This PR implements the AddEvent gRPC endpoint. Specifically, it translates AddEventRequest into AddTaskEventDataRequest, enabling reuse of the existing HandleAddTaskEventData logic.
- Introduces the GcsRayEventConverter class, responsible for converting RayEvent messages into the existing AddTaskEventData format.
- RayEvent has several subtypes (e.g., task definitions, task execution, etc.). This PR focuses on converting task definition events.

Test:
- CI
- build