### PR TITLE
test commit

### DIFF
--- a/python/ray/air/_internal/device_manager/__init__.py
+++ b/python/ray/air/_internal/device_manager/__init__.py
@@ -3,6 +3,7 @@ import threading
 from typing import Optional
 
 import ray
+import torch
 import ray._private.ray_constants as ray_constants
 from ray.air._internal.device_manager.cpu import CPUTorchDeviceManager
 from ray.air._internal.device_manager.hpu import HPUTorchDeviceManager
@@ -12,7 +13,7 @@ from ray.air._internal.device_manager.torch_device_manager import TorchDeviceMan
 
 logger = logging.getLogger(__name__)
 
-
+torch.cuda.is_available()
 DEFAULT_TORCH_DEVICE_MANAGER_CLS = CPUTorchDeviceManager
 
 

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -191,6 +191,7 @@ class RayTrainWorker:
         dataset_shards: Dict[str, DataIterator] = None,
         checkpoint: Optional[Checkpoint] = None,
     ):
+
         self._callbacks = [c for c in worker_callbacks if isinstance(c, WorkerCallback)]
         context_callbacks_to_propagate = [
             c for c in worker_callbacks if isinstance(c, TrainContextCallback)


### PR DESCRIPTION
causing this error when the head-node has gpus.
```
(TrainController pid=18772) [State Transition] INITIALIZING -> SCHEDULING.
(TrainController pid=18772) Attempting to start training worker group of size 3 with the following resources: [{'GPU': 1}] * 3
(TrainController pid=18772) Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.
(TrainController pid=18772) Started training worker group of size 3: 
(TrainController pid=18772) - (ip=10.0.174.102, pid=18983) world_rank=0, local_rank=0, node_rank=0
(TrainController pid=18772) - (ip=10.0.174.102, pid=18982) world_rank=1, local_rank=1, node_rank=0
(TrainController pid=18772) - (ip=10.0.174.102, pid=18979) world_rank=2, local_rank=2, node_rank=0
(TrainController pid=18772) [State Transition] SCHEDULING -> RUNNING.
(RayTrainWorker pid=18983) Setting up process group for: env:// [rank=0, world_size=3]
(RayTrainWorker pid=18982) Error in training function:
(RayTrainWorker pid=18982) Traceback (most recent call last):
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 252, in _check_capability
(RayTrainWorker pid=18982)     capability = get_device_capability(d)
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 560, in get_device_capability
(RayTrainWorker pid=18982)     prop = get_device_properties(device)
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 580, in get_device_properties
(RayTrainWorker pid=18982)     return _get_device_properties(device)  # type: ignore[name-defined]
(RayTrainWorker pid=18982) RuntimeError: device >= 0 && device < num_gpus INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/cuda/CUDAContext.cpp":52, please report a bug to PyTorch. device=1, num_gpus=1
(RayTrainWorker pid=18982) 
(RayTrainWorker pid=18982) The above exception was the direct cause of the following exception:
(RayTrainWorker pid=18982) 
(RayTrainWorker pid=18982) Traceback (most recent call last):
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/torch/config.py", line 27, in __enter__
(RayTrainWorker pid=18982)     torch.cuda.set_device(device)
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 529, in set_device
(RayTrainWorker pid=18982)     torch._C._cuda_setDevice(device)
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 389, in _lazy_init
(RayTrainWorker pid=18982)     raise DeferredCudaCallError(msg) from e
(RayTrainWorker pid=18982) torch.cuda.DeferredCudaCallError: CUDA call failed lazily at initialization with error: device >= 0 && device < num_gpus INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/cuda/CUDAContext.cpp":52, please report a bug to PyTorch. device=1, num_gpus=1
(RayTrainWorker pid=18982) 
(RayTrainWorker pid=18982) CUDA call was originally invoked at:
(RayTrainWorker pid=18982) 
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/workers/default_worker.py", line 321, in <module>
(RayTrainWorker pid=18982)     worker.main_loop()
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/worker.py", line 974, in main_loop
(RayTrainWorker pid=18982)     self.core_worker.run_task_loop()
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/worker.py", line 888, in deserialize_objects
(RayTrainWorker pid=18982)     return context.deserialize_objects(serialized_objects, object_refs)
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/serialization.py", line 527, in deserialize_objects
(RayTrainWorker pid=18982)     obj = self._deserialize_object(
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/serialization.py", line 378, in _deserialize_object
(RayTrainWorker pid=18982)     return self._deserialize_msgpack_data(
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/serialization.py", line 323, in _deserialize_msgpack_data
(RayTrainWorker pid=18982)     python_objects = self._deserialize_pickle5_data(
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/serialization.py", line 302, in _deserialize_pickle5_data
(RayTrainWorker pid=18982)     obj = pickle.loads(in_band)
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/torch/__init__.py", line 3, in <module>
(RayTrainWorker pid=18982)     import torch  # noqa: F401
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/__init__.py", line 2064, in <module>
(RayTrainWorker pid=18982)     _C._initExtension(_manager_path())
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
(RayTrainWorker pid=18982)   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 317, in <module>
(RayTrainWorker pid=18982)     _lazy_call(_check_capability)
(RayTrainWorker pid=18982)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 314, in _lazy_call
(RayTrainWorker pid=18982)     _queued_calls.append((callable, traceback.format_stack()))
(RayTrainWorker pid=18982) 
(RayTrainWorker pid=18982) 
(RayTrainWorker pid=18983) 
(RayTrainWorker pid=18983) 
(RayTrainWorker pid=18983) 
(RayTrainWorker pid=18983) 
(RayTrainWorker pid=18983) 
(RayTrainWorker pid=18983) 
(RayTrainWorker pid=18979) 
(RayTrainWorker pid=18979) 
(RayTrainWorker pid=18979) 
(RayTrainWorker pid=18979) 
(RayTrainWorker pid=18979) 
(RayTrainWorker pid=18979) 
Traceback (most recent call last):
  File "/home/ray/default/test.py", line 95, in <module>
    result = trainer.fit()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/api/data_parallel_trainer.py", line 127, in fit
    result = self._initialize_and_run_controller(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/api/data_parallel_trainer.py", line 217, in _initialize_and_run_controller
    ray.get(controller.run.remote())
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/worker.py", line 2858, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/worker.py", line 958, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(DeferredCudaCallError): ray::TrainController.run() (pid=18772, ip=10.0.174.102, actor_id=89d6101137c681b6175f2ce905000000, repr=<ray.train.v2._internal.execution.controller.controller.TrainController object at 0x765b8de120a0>)
  File "/home/ray/anaconda3/lib/python3.9/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/home/ray/anaconda3/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/execution/controller/controller.py", line 468, in run
    self._shutdown()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/execution/controller/controller.py", line 309, in _shutdown
    self._shutdown_worker_group()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/execution/controller/controller.py", line 316, in _shutdown_worker_group
    self._worker_group.shutdown()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/execution/worker_group/worker_group.py", line 418, in shutdown
    callback.before_worker_group_shutdown(self)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/callbacks/backend_setup.py", line 22, in before_worker_group_shutdown
    self._backend.on_shutdown(worker_group, self._backend_config)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/torch/config.py", line 205, in on_shutdown
    worker_group.execute(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/execution/worker_group/worker_group.py", line 600, in execute
    return ray_get_safe(self.execute_async(fn, *fn_args, **fn_kwargs))
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/util.py", line 149, in ray_get_safe
    for task, task_output in zip(ready, ray.get(ready)):
ray.exceptions.RayTaskError(DeferredCudaCallError): ray::execute._shutdown_torch() (pid=18982, ip=10.0.174.102, actor_id=4cc68899c19531a1800ca23205000000, repr=<ray.train.v2._internal.execution.worker_group.worker.RayTrainWorker object at 0x76174bba5e20>)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 252, in _check_capability
    capability = get_device_capability(d)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 560, in get_device_capability
    prop = get_device_properties(device)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 580, in get_device_properties
    return _get_device_properties(device)  # type: ignore[name-defined]
RuntimeError: device >= 0 && device < num_gpus INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/cuda/CUDAContext.cpp":52, please report a bug to PyTorch. device=1, num_gpus=1

The above exception was the direct cause of the following exception:

ray::execute._shutdown_torch() (pid=18982, ip=10.0.174.102, actor_id=4cc68899c19531a1800ca23205000000, repr=<ray.train.v2._internal.execution.worker_group.worker.RayTrainWorker object at 0x76174bba5e20>)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/execution/worker_group/worker.py", line 121, in execute
    return fn(*fn_args, **fn_kwargs)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/torch/config.py", line 132, in _shutdown_torch
    with torch.cuda.device(device):
  File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 495, in __enter__
    self.prev_idx = torch.cuda._exchange_device(self.idx)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 389, in _lazy_init
    raise DeferredCudaCallError(msg) from e
torch.cuda.DeferredCudaCallError: CUDA call failed lazily at initialization with error: device >= 0 && device < num_gpus INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/cuda/CUDAContext.cpp":52, please report a bug to PyTorch. device=1, num_gpus=1

CUDA call was originally invoked at:

  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/torch/__init__.py", line 3, in <module>
    import torch  # noqa: F401
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/__init__.py", line 2064, in <module>
    _C._initExtension(_manager_path())
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 317, in <module>
    _lazy_call(_check_capability)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 314, in _lazy_call
    _queued_calls.append((callable, traceback.format_stack()))
(TrainController pid=18772) Deciding to TERMINATE, since the total failure count (1) exceeded the maximum allowed failures: FailureConfig(max_failures=0).
(TrainController pid=18772) Terminating training worker group after encountering failure(s) on 3 worker(s):
(TrainController pid=18772) [Rank 0]
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) [Rank 1]
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) [Rank 2]
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) [State Transition] RUNNING -> ERRORED.
(TrainController pid=18772) Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::execute._shutdown_torch() (pid=18979, ip=10.0.174.102, actor_id=6e2d5c0c4d1ffe9d5c75616105000000, repr=<ray.train.v2._internal.execution.worker_group.worker.RayTrainWorker object at 0x7c2859518e50>)
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) ray::execute._shutdown_torch() (pid=18979, ip=10.0.174.102, actor_id=6e2d5c0c4d1ffe9d5c75616105000000, repr=<ray.train.v2._internal.execution.worker_group.worker.RayTrainWorker object at 0x7c2859518e50>)
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/execution/worker_group/worker.py", line 121, in execute
(TrainController pid=18772)     return fn(*fn_args, **fn_kwargs)
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/torch/config.py", line 132, in _shutdown_torch
(TrainController pid=18772)     with torch.cuda.device(device):
(TrainController pid=18772)     self.prev_idx = torch.cuda._exchange_device(self.idx)
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::execute._shutdown_torch() (pid=18983, ip=10.0.174.102, actor_id=0e6e609557a5620772509bf705000000, repr=<ray.train.v2._internal.execution.worker_group.worker.RayTrainWorker object at 0x7510a03d7e80>)
(TrainController pid=18772) 
(TrainController pid=18772) 
(TrainController pid=18772) ray::execute._shutdown_torch() (pid=18983, ip=10.0.174.102, actor_id=0e6e609557a5620772509bf705000000, repr=<ray.train.v2._internal.execution.worker_group.worker.RayTrainWorker object at 0x7510a03d7e80>)
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/v2/_internal/execution/worker_group/worker.py", line 121, in execute
(TrainController pid=18772)     return fn(*fn_args, **fn_kwargs)
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/train/torch/config.py", line 132, in _shutdown_torch
(TrainController pid=18772)     with torch.cuda.device(device):
(TrainController pid=18772)     self.prev_idx = torch.cuda._exchange_device(self.idx)
(TrainController pid=18772) 
(TrainController pid=18772) 
(RayTrainWorker pid=18979) Error in training function: [repeated 2x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)
(TrainController pid=18772) Traceback (most recent call last): [repeated 10x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 252, in _check_capability [repeated 7x across cluster]
(TrainController pid=18772)     capability = get_device_capability(d) [repeated 7x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 560, in get_device_capability [repeated 7x across cluster]
(TrainController pid=18772)     prop = get_device_properties(device) [repeated 7x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 580, in get_device_properties [repeated 7x across cluster]
(TrainController pid=18772)     return _get_device_properties(device)  # type: ignore[name-defined] [repeated 7x across cluster]
(TrainController pid=18772) RuntimeError: device >= 0 && device < num_gpus INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/cuda/CUDAContext.cpp":52, please report a bug to PyTorch. device=1, num_gpus=1 [repeated 7x across cluster]
(TrainController pid=18772) The above exception was the direct cause of the following exception: [repeated 7x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 495, in __enter__ [repeated 7x across cluster]
(TrainController pid=18772)     torch.cuda.set_device(device) [repeated 5x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 529, in set_device [repeated 5x across cluster]
(TrainController pid=18772)     torch._C._cuda_setDevice(device) [repeated 5x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 389, in _lazy_init [repeated 7x across cluster]
(TrainController pid=18772)     raise DeferredCudaCallError(msg) from e [repeated 7x across cluster]
(TrainController pid=18772) torch.cuda.DeferredCudaCallError: CUDA call failed lazily at initialization with error: device >= 0 && device < num_gpus INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/cuda/CUDAContext.cpp":52, please report a bug to PyTorch. device=1, num_gpus=1 [repeated 7x across cluster]
(TrainController pid=18772) CUDA call was originally invoked at: [repeated 7x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 317, in <module> [repeated 26x across cluster]
(TrainController pid=18772)     worker.main_loop() [repeated 5x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/worker.py", line 974, in main_loop [repeated 5x across cluster]
(TrainController pid=18772)     self.core_worker.run_task_loop() [repeated 5x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/serialization.py", line 527, in deserialize_objects [repeated 10x across cluster]
(TrainController pid=18772)     return context.deserialize_objects(serialized_objects, object_refs) [repeated 5x across cluster]
(TrainController pid=18772)     obj = self._deserialize_object( [repeated 5x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/serialization.py", line 378, in _deserialize_object [repeated 5x across cluster]
(TrainController pid=18772)     return self._deserialize_msgpack_data( [repeated 5x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/serialization.py", line 323, in _deserialize_msgpack_data [repeated 5x across cluster]
(TrainController pid=18772)     python_objects = self._deserialize_pickle5_data( [repeated 5x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/serialization.py", line 302, in _deserialize_pickle5_data [repeated 5x across cluster]
(TrainController pid=18772)     obj = pickle.loads(in_band) [repeated 5x across cluster]
(TrainController pid=18772)   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load [repeated 28x across cluster]
(TrainController pid=18772)   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked [repeated 28x across cluster]
(TrainController pid=18772)   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed [repeated 28x across cluster]
(TrainController pid=18772)   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked [repeated 21x across cluster]
(TrainController pid=18772)   File "<frozen importlib._bootstrap_external>", line 850, in exec_module [repeated 21x across cluster]
(TrainController pid=18772)     import torch  # noqa: F401 [repeated 7x across cluster]
(TrainController pid=18772)     _C._initExtension(_manager_path()) [repeated 7x across cluster]
(TrainController pid=18772)     _lazy_call(_check_capability) [repeated 7x across cluster]
(TrainController pid=18772)   File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/cuda/__init__.py", line 314, in _lazy_call [repeated 7x across cluster]
(TrainController pid=18772)     _queued_calls.append((callable, traceback.format_stack())) [repeated 7x across cluster]
(base) ray@ip-10-0-174-102:~/default$ 
```