### PR TITLE
[Data] Update Export API metadata and refresh the dataset/operator state when there is a change

### DIFF
--- a/python/ray/data/_internal/execution/dataset_state.py
+++ b/python/ray/data/_internal/execution/dataset_state.py
@@ -1,0 +1,22 @@
+import enum
+
+
+class DatasetState(enum.IntEnum):
+    """Enum representing the possible states of a dataset during execution."""
+
+    UNKNOWN = 0
+    RUNNING = 1
+    FINISHED = 2
+    FAILED = 3
+    PENDING = 4
+
+    def __str__(self):
+        return self.name
+
+    @classmethod
+    def from_string(cls, text):
+        """Get enum by name."""
+        try:
+            return cls[text]  # This uses the name to lookup the enum
+        except KeyError:
+            return cls.UNKNOWN

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -13,6 +13,7 @@ from ray._private.event.export_event_logger import (
     check_export_api_enabled,
     get_export_event_logger,
 )
+from ray.data._internal.execution.dataset_state import DatasetState
 from ray.data.context import DataContext
 
 if TYPE_CHECKING:
@@ -60,11 +61,17 @@ class Operator:
         sub_stages: List of sub-stages contained within this operator.
         args: User-specified arguments associated with the operator, which may
             include configuration settings, options, or other relevant data for the operator.
+        execution_start_time: The timestamp when the operator execution begins.
+        execution_end_time: The timestamp when the operator execution ends.
+        state: The state of the operator.
     """
 
     name: str
     id: str
     uuid: str
+    execution_start_time: Optional[float]
+    execution_end_time: Optional[float]
+    state: str
     input_dependencies: List[str] = field(default_factory=list)
     sub_stages: List[SubStage] = field(default_factory=list)
     args: Dict[str, Any] = field(default_factory=dict)
@@ -108,6 +115,9 @@ class Topology:
                     op_to_id[dep] for dep in op.input_dependencies if dep in op_to_id
                 ],
                 args=sanitize_for_struct(op._get_logical_args()),
+                execution_start_time=None,
+                execution_end_time=None,
+                state=DatasetState.PENDING.name,
             )
 
             # Add sub-stages if they exist
@@ -131,8 +141,11 @@ class DatasetMetadata:
         job_id: The ID of the job running this dataset.
         topology: The structure of the dataset's operator DAG.
         dataset_id: The unique ID of the dataset.
-        start_time: The timestamp when the dataset execution started.
+        start_time: The timestamp when the dataset is registered.
         data_context: The DataContext attached to the dataset.
+        execution_start_time: The timestamp when the dataset execution starts.
+        execution_end_time: The timestamp when the dataset execution ends.
+        state: The state of the dataset.
     """
 
     job_id: str
@@ -140,6 +153,9 @@ class DatasetMetadata:
     dataset_id: str
     start_time: float
     data_context: DataContext
+    execution_start_time: Optional[float]
+    execution_end_time: Optional[float]
+    state: str
 
 
 def _add_ellipsis(s, truncate_length):
@@ -202,6 +218,9 @@ def dataset_metadata_to_proto(dataset_metadata: DatasetMetadata) -> Any:
             id=op.id,
             uuid=op.uuid,
             args=args,
+            execution_start_time=op.execution_start_time,
+            execution_end_time=op.execution_end_time,
+            state=ProtoOperator.OperatorState.Value(op.state),
         )
 
         # Add input dependencies
@@ -227,6 +246,9 @@ def dataset_metadata_to_proto(dataset_metadata: DatasetMetadata) -> Any:
         job_id=dataset_metadata.job_id,
         start_time=dataset_metadata.start_time,
         data_context=data_context,
+        execution_start_time=dataset_metadata.execution_start_time,
+        execution_end_time=dataset_metadata.execution_end_time,
+        state=ProtoDatasetMetadata.DatasetState.Value(dataset_metadata.state),
     )
     proto_dataset_metadata.topology.CopyFrom(proto_topology)
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1,5 +1,4 @@
 import collections
-import enum
 import logging
 import threading
 import time
@@ -14,6 +13,7 @@ import numpy as np
 import ray
 from ray.actor import ActorHandle
 from ray.data._internal.block_list import BlockList
+from ray.data._internal.execution.dataset_state import DatasetState
 from ray.data._internal.execution.interfaces.op_runtime_metrics import (
     NODE_UNKNOWN,
     MetricsGroup,
@@ -21,7 +21,11 @@ from ray.data._internal.execution.interfaces.op_runtime_metrics import (
     NodeMetrics,
     OpRuntimeMetrics,
 )
-from ray.data._internal.metadata_exporter import Topology, get_dataset_metadata_exporter
+from ray.data._internal.metadata_exporter import (
+    DatasetMetadata,
+    Topology,
+    get_dataset_metadata_exporter,
+)
 from ray.data._internal.util import capfirst
 from ray.data.block import BlockStats
 from ray.data.context import DataContext
@@ -170,6 +174,7 @@ class _StatsActor:
 
         # Initialize the metadata exporter
         self._metadata_exporter = get_dataset_metadata_exporter()
+        self.dataset_metadatas: Dict[str, DatasetMetadata] = {}
 
         # Ray Data dashboard metrics
         # Everything is a gauge because we need to reset all of
@@ -477,7 +482,7 @@ class _StatsActor:
         start_time = time.time()
         self.datasets[dataset_tag] = {
             "job_id": job_id,
-            "state": DatasetState.RUNNING.name,
+            "state": DatasetState.PENDING.name,
             "progress": 0,
             "total": 0,
             "total_rows": 0,
@@ -485,7 +490,7 @@ class _StatsActor:
             "end_time": None,
             "operators": {
                 operator: {
-                    "state": DatasetState.RUNNING.name,
+                    "state": DatasetState.PENDING.name,
                     "progress": 0,
                     "total": 0,
                     "queued_blocks": 0,
@@ -494,16 +499,19 @@ class _StatsActor:
             },
         }
         if self._metadata_exporter is not None:
-            from ray.data._internal.metadata_exporter import DatasetMetadata
-
-            dataset_metadata = DatasetMetadata(
+            self.dataset_metadatas[dataset_tag] = DatasetMetadata(
                 job_id=job_id,
                 topology=topology,
                 dataset_id=dataset_tag,
                 start_time=start_time,
                 data_context=data_context,
+                execution_start_time=None,
+                execution_end_time=None,
+                state=DatasetState.PENDING.name,
             )
-            self._metadata_exporter.export_dataset_metadata(dataset_metadata)
+            self._metadata_exporter.export_dataset_metadata(
+                self.dataset_metadatas[dataset_tag]
+            )
 
     def update_dataset(self, dataset_tag: str, state: Dict[str, Any]):
         self.datasets[dataset_tag].update(state)
@@ -553,6 +561,53 @@ class _StatsActor:
         if not job_id:
             return self.datasets
         return {k: v for k, v in self.datasets.items() if v["job_id"] == job_id}
+
+    def update_dataset_metadata_state(self, dataset_id: str, new_state: str):
+        if dataset_id not in self.dataset_metadatas:
+            return
+        update_time = time.time()
+        dataset_metadata = self.dataset_metadatas[dataset_id]
+        if dataset_metadata.state == new_state:
+            return
+        dataset_metadata.state = new_state
+        if new_state == DatasetState.RUNNING.name:
+            dataset_metadata.execution_start_time = update_time
+        elif new_state in (DatasetState.FINISHED.name, DatasetState.FAILED.name):
+            dataset_metadata.execution_end_time = update_time
+            # Update metadata of running operators
+            for operator in dataset_metadata.topology.operators:
+                if operator.state == DatasetState.RUNNING.name:
+                    operator.state = new_state
+                    operator.execution_end_time = update_time
+
+        self._metadata_exporter.export_dataset_metadata(dataset_metadata)
+
+    def update_dataset_metadata_operator_state(
+        self, dataset_id: str, operator_uuid: str, new_state: str
+    ):
+        if dataset_id not in self.dataset_metadatas:
+            return
+        update_time = time.time()
+        dataset_metadata = self.dataset_metadatas[dataset_id]
+        operator_metadata = None
+        for operator in dataset_metadata.topology.operators:
+            if operator.uuid == operator_uuid:
+                operator_metadata = operator
+                break
+
+        if operator_metadata is None or operator_metadata.state == new_state:
+            return
+        operator_metadata.state = new_state
+        if new_state == DatasetState.RUNNING.name:
+            operator_metadata.execution_start_time = update_time
+        elif new_state in (DatasetState.FINISHED.name, DatasetState.FAILED.name):
+            operator_metadata.execution_end_time = update_time
+            # Handle outlier case for InputDataBuffer, which is marked as finished immediately and does not have a RUNNING state.
+            # Set the execution time the same as its end time
+            if not operator_metadata.execution_start_time:
+                operator_metadata.execution_start_time = update_time
+
+        self._metadata_exporter.export_dataset_metadata(dataset_metadata)
 
     def _create_tags(
         self,
@@ -803,28 +858,18 @@ class _StatsManager:
             # fall back to uuid4
             return uuid4().hex
 
+    def update_dataset_metadata_state(self, dataset_id: str, new_state: str):
+        self._stats_actor().update_dataset_metadata_state.remote(dataset_id, new_state)
+
+    def update_dataset_metadata_operator_state(
+        self, dataset_id: str, operator_uuid: str, new_state: str
+    ):
+        self._stats_actor().update_dataset_metadata_operator_state.remote(
+            dataset_id, operator_uuid, new_state
+        )
+
 
 StatsManager = _StatsManager()
-
-
-class DatasetState(enum.IntEnum):
-    """Enum representing the possible states of a dataset during execution."""
-
-    UNKNOWN = 0
-    RUNNING = 1
-    FINISHED = 2
-    FAILED = 3
-
-    def __str__(self):
-        return self.name
-
-    @classmethod
-    def from_string(cls, text):
-        """Get enum by name."""
-        try:
-            return cls[text]  # This uses the name to lookup the enum
-        except KeyError:
-            return cls.UNKNOWN
 
 
 class DatasetStats:

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -6,6 +6,7 @@ import pytest
 
 import ray
 from ray.data import DataContext
+from ray.data._internal.execution.dataset_state import DatasetState
 from ray.data._internal.metadata_exporter import (
     UNKNOWN,
     Operator,
@@ -73,6 +74,9 @@ def dummy_dataset_topology():
                 uuid="uuid_0",
                 input_dependencies=[],
                 sub_stages=[],
+                execution_start_time=1.0,
+                execution_end_time=1.0,
+                state="FINISHED",
             ),
             Operator(
                 name="ReadRange->Map(<lambda>)->Filter(<lambda>)",
@@ -80,6 +84,9 @@ def dummy_dataset_topology():
                 uuid="uuid_1",
                 input_dependencies=["Input_0"],
                 sub_stages=[],
+                execution_start_time=0.0,
+                execution_end_time=0.0,
+                state="RUNNING",
             ),
         ],
     )
@@ -195,6 +202,9 @@ def test_export_multiple_datasets(
                 uuid="second_uuid_0",
                 input_dependencies=[],
                 sub_stages=[],
+                execution_start_time=1.0,
+                execution_end_time=1.0,
+                state="FINISHED",
             ),
             Operator(
                 name="ReadRange->Map(<lambda>)",
@@ -202,6 +212,9 @@ def test_export_multiple_datasets(
                 uuid="second_uuid_1",
                 input_dependencies=["Input_0"],
                 sub_stages=[],
+                execution_start_time=2.0,
+                execution_end_time=0.0,
+                state="RUNNING",
             ),
         ],
     )
@@ -332,6 +345,93 @@ def test_sanitize_for_struct(input_obj, expected_output, truncate_length):
     """Test sanitize_for_struct with various input types and truncation lengths."""
     result = sanitize_for_struct(input_obj, truncate_length)
     assert result == expected_output
+
+
+def test_update_dataset_metadata_state(
+    ray_start_cluster_with_export_api_write, dummy_dataset_topology
+):
+    """Test dataset state update at the export API"""
+    stats_actor = _get_or_create_stats_actor()
+    # Register dataset
+    ray.get(
+        stats_actor.register_dataset.remote(
+            job_id=STUB_JOB_ID,
+            dataset_tag=STUB_DATASET_ID,
+            operator_tags=["Input_0", "ReadRange->Map(<lambda>)->Filter(<lambda>)_1"],
+            topology=dummy_dataset_topology,
+            data_context=DataContext.get_current(),
+        )
+    )
+    # Check that export files were created as expected
+    data = _get_exported_data()
+    assert len(data) == 1
+    assert data[0]["event_data"]["state"] == DatasetState.PENDING.name
+
+    # Test update state to RUNNING
+    ray.get(
+        stats_actor.update_dataset_metadata_state.remote(
+            dataset_id=STUB_DATASET_ID, new_state=DatasetState.RUNNING.name
+        )
+    )
+    data = _get_exported_data()
+    assert len(data) == 2
+    assert data[1]["event_data"]["state"] == DatasetState.RUNNING.name
+    assert data[1]["event_data"]["execution_start_time"] > 0
+
+    # Test update to FINISHED
+    ray.get(
+        stats_actor.update_dataset_metadata_state.remote(
+            dataset_id=STUB_DATASET_ID, new_state=DatasetState.FINISHED.name
+        )
+    )
+    data = _get_exported_data()
+    assert len(data) == 3
+    assert data[2]["event_data"]["state"] == DatasetState.FINISHED.name
+    assert data[2]["event_data"]["execution_end_time"] > 0
+    assert (
+        data[2]["event_data"]["topology"]["operators"][1]["state"]
+        == DatasetState.FINISHED.name
+    )
+    assert data[2]["event_data"]["topology"]["operators"][1]["execution_end_time"] > 0
+
+
+def test_update_dataset_metadata_operator_state(
+    ray_start_cluster_with_export_api_write, dummy_dataset_topology
+):
+    stats_actor = _get_or_create_stats_actor()
+    # Register dataset
+    ray.get(
+        stats_actor.register_dataset.remote(
+            dataset_tag=STUB_DATASET_ID,
+            operator_tags=["Input_0", "ReadRange->Map(<lambda>)->Filter(<lambda>)_1"],
+            topology=dummy_dataset_topology,
+            job_id=STUB_JOB_ID,
+            data_context=DataContext.get_current(),
+        )
+    )
+    data = _get_exported_data()
+    assert len(data) == 1
+    assert (
+        data[0]["event_data"]["topology"]["operators"][1]["state"]
+        == DatasetState.RUNNING.name
+    )
+
+    # Test update to FINISHED
+    operator_uuid = "uuid_1"
+    ray.get(
+        stats_actor.update_dataset_metadata_operator_state.remote(
+            dataset_id=STUB_DATASET_ID,
+            operator_uuid=operator_uuid,
+            new_state=DatasetState.FINISHED.name,
+        )
+    )
+    data = _get_exported_data()
+    assert len(data) == 2
+    assert (
+        data[1]["event_data"]["topology"]["operators"][1]["state"]
+        == DatasetState.FINISHED.name
+    )
+    assert data[1]["event_data"]["topology"]["operators"][1]["execution_end_time"] > 0
 
 
 if __name__ == "__main__":

--- a/src/ray/protobuf/export_dataset_metadata.proto
+++ b/src/ray/protobuf/export_dataset_metadata.proto
@@ -30,6 +30,14 @@ message SubStage {
 
 // Represents a data processing operator in the DAG
 message Operator {
+  enum OperatorState {
+    UNKNOWN = 0;
+    RUNNING = 1;
+    FINISHED = 2;
+    FAILED = 3;
+    PENDING = 4;
+  }
+
   // Name of the operator
   string name = 1;
 
@@ -53,6 +61,15 @@ message Operator {
   // can be found in `_get_logical_args`, and is used to help understand how a
   // user's arguments lead to a dataset's state execution
   google.protobuf.Struct args = 6;
+
+  // The timestamp when execution starts (in seconds since epoch)
+  double execution_start_time = 7;
+
+  // The timestamp when execution ends (in seconds since epoch)
+  double execution_end_time = 8;
+
+  // The state of the operator
+  OperatorState state = 9;
 }
 
 // Represents the complete structure of the operator DAG
@@ -63,6 +80,14 @@ message Topology {
 
 // Top-level message containing full metadata about a Ray Data execution
 message ExportDatasetMetadata {
+  enum DatasetState {
+    UNKNOWN = 0;
+    RUNNING = 1;
+    FINISHED = 2;
+    FAILED = 3;
+    PENDING = 4;
+  }
+
   // The operator DAG structure
   Topology topology = 1;
 
@@ -72,9 +97,18 @@ message ExportDatasetMetadata {
   // The Ray Job ID
   string job_id = 3;
 
-  // The timestamp when execution started (in seconds since epoch)
+  // The timestamp when dataset is registered (in seconds since epoch)
   double start_time = 4;
 
   // The data context attached to the dataset.
   google.protobuf.Struct data_context = 5;
+
+  // The timestamp when execution starts (in seconds since epoch)
+  double execution_start_time = 6;
+
+  // The timestamp when execution ends (in seconds since epoch)
+  double execution_end_time = 7;
+
+  // The state of the dataset
+  DatasetState state = 8;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Some frequently used metadata fields are missing in the export API schema:
- For both dataset and operator: state, execution start and end time

These fields are important for us to observe the lifecycle of the datasets and operators, and can be used to improve the accuracy of reported metrics, such as throughput, which relies on the duration.

<!-- Please give a short summary of the change and the problem this solves. -->
Summary of change:
- Add state, execution start and end time at the export API schema
- Add a new state enum `PENDING` for dataset and operator, to represent the state when they are not running yet.
- Refresh the metadata when ever the state of dataset/operator gets updated. And the event will always contains the latest snapshot of all the metadata.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
