### PR TITLE
[Data] Add release test for JSONL

### DIFF
--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -56,6 +56,7 @@ def main(args):
 
 
 def _validate_expected_count(args: argparse.Namespace):
+    # TODO: Add support for `--expected-count` for the other consume options.
     for attr in ["iter_batches", "iter_torch_batches", "to_tf", "write"]:
         if getattr(args, attr) is not None and args.expected_count is not None:
             raise NotImplementedError(

--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -89,7 +89,9 @@ def get_consume_fn(args: argparse.Namespace) -> Callable[[ray.data.Dataset], Non
             count = ds.count()
 
             if args.expected_count is not None:
-                assert count == args.expected_count
+                assert (
+                    count == args.expected_count
+                ), f"Expected {args.expected_count} rows, got {count}."
 
     elif args.iter_bundles:
 
@@ -100,7 +102,9 @@ def get_consume_fn(args: argparse.Namespace) -> Callable[[ray.data.Dataset], Non
                 count += bundle.num_rows()
 
             if args.expected_count is not None:
-                assert count == args.expected_count
+                assert (
+                    count == args.expected_count
+                ), f"Expected {args.expected_count} bundles, got {count}."
 
     elif args.iter_batches:
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -58,6 +58,14 @@
       s3://ray-benchmark-data-internal-us-west-2/imagenet/tfrecords --format tfrecords
       --iter-bundles
 
+- name: read_jsonl
+  run:
+    timeout: 3600
+    script: >
+      python read_and_consume_benchmark.py
+      s3://ray-benchmark-data-internal/10TiB-jsonl-images --format jsonl
+      --iter-bundles --expected-count 7168000
+
 - name: "read_from_uris_{{scaling}}"
 
   cluster:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -58,7 +58,7 @@
       s3://ray-benchmark-data-internal-us-west-2/imagenet/tfrecords --format tfrecords
       --iter-bundles
 
-- name: read_jsonl
+- name: read_jsonl_fixed_size
   run:
     timeout: 3600
     script: >


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

JSONL is a common format for batch inference workloads. So, this PR adds a release test for reading it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
