### PR TITLE
[core] adding retries and exponential backoff to starting the runtime_env agent's server when there's a port conflict

### DIFF
--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -16,8 +16,6 @@ from ray.core.generated import (
     runtime_env_agent_pb2,
 )
 
-logger = logging.getLogger(__name__)
-
 
 def import_libs():
     my_dir = os.path.abspath(os.path.dirname(__file__))
@@ -249,7 +247,7 @@ if __name__ == "__main__":
             last_exception = e
             if attempt < max_retries:
                 delay = base_delay * (2**attempt)
-                logger.warning(
+                agent._logger.warning(
                     f"Failed to bind to port {args.runtime_env_agent_port} (attempt {attempt + 1}/"
                     f"{max_retries + 1}). Retrying in {delay:.2f}s. Error: {e}"
                 )

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -243,6 +243,7 @@ if __name__ == "__main__":
                 loop=loop,
             )
             started = True
+            break
         except OSError as e:
             last_exception = e
             if attempt < max_retries:

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 import os
-import random
 import sys
 import time
 from typing import Optional
@@ -229,10 +228,10 @@ if __name__ == "__main__":
 
     last_exception: Optional[OSError] = None
 
-    # When starting the server, you can get an OS error for port conflicts.
-    # This usually happens in testing. The retries with exponential backoff
-    # eliminate false positives caused by a delay in ports being freed
-    # between tests.
+    # There can be a port conflict when starting the server. This raises an
+    # OSError. In CI testing, there are false positives when the port hasn't
+    # been freed from the previous test. Retries with exponential backoff
+    # can eliminate this.
     max_retries: int = 5
     base_delay: float = 0.1
     started: bool = False
@@ -249,7 +248,7 @@ if __name__ == "__main__":
         except OSError as e:
             last_exception = e
             if attempt < max_retries:
-                delay = base_delay * (2**attempt) + random.uniform(0, 0.1)
+                delay = base_delay * (2**attempt)
                 logger.warning(
                     f"Failed to bind to port {args.runtime_env_agent_port} (attempt {attempt + 1}/"
                     f"{max_retries + 1}). Retrying in {delay:.2f}s. Error: {e}"


### PR DESCRIPTION
Attempting to fix flaky windows://python/ray/tests:test_streaming_generator_backpressure. 

The test failed in these examples because the runtime_env_agent could not start its server because of a port conflict. 
* https://buildkite.com/ray-project/postmerge/builds/11476#019809ae-f9a1-4317-a638-e1c65d4158cc
* https://buildkite.com/ray-project/postmerge/builds/11406#0197f5f1-0fb2-4104-a15c-0ba7d3410bf7

```
Traceback (most recent call last):
  File "C:\rayci\python\ray\_private\runtime_env\agent\main.py", line 225, in <module>
    web.run_app(
  File "C:\rayci\python\ray\_private\runtime_env\agent\thirdparty_files\aiohttp\web.py", line 530, in run_app
    loop.run_until_complete(main_task)
  File "C:\Miniconda3\lib\asyncio\base_events.py", line 642, in run_until_complete
    return future.result()
  File "C:\rayci\python\ray\_private\runtime_env\agent\thirdparty_files\aiohttp\web.py", line 523, in run_app
    loop.run_until_complete(main_task)
  File "C:\Miniconda3\lib\asyncio\base_events.py", line 642, in run_until_complete
    return future.result()
  File "C:\rayci\python\ray\_private\runtime_env\agent\thirdparty_files\aiohttp\web.py", line 427, in _run_app
    await site.start()
  File "C:\rayci\python\ray\_private\runtime_env\agent\thirdparty_files\aiohttp\web_runner.py", line 121, in start
    self._server = await loop.create_server(
  File "C:\Miniconda3\lib\asyncio\base_events.py", line 1494, in create_server
    raise OSError(err.errno, 'error while attempting '
OSError: [Errno 10048] error while attempting to bind on address ('0.0.0.0', 65504): only one usage of each socket address (protocol/network address/port) is normally permitted
```

The fix is identical to https://github.com/ray-project/ray/pull/53975 which fixes it for the dashboard_agent's server by adding retries and exponential backoff.

The implementations of the two servers (runtime_env and dashboard) are different so the same code cannot be reused. 
