### PR TITLE
Add perf metrics for 2.48.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 89.755648,
+    "_dashboard_memory_usage_mb": 110.235648,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.29,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1159\t7.51GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3382\t1.86GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4875\t0.86GiB\tpython distributed/test_many_actors.py\n2702\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3582\t0.2GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n585\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3498\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4100\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2962\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4102\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
-    "actors_per_second": 553.5098466276525,
+    "_peak_memory": 4.85,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1129\t7.16GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3533\t2.04GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4961\t1.06GiB\tpython distributed/test_many_actors.py\n3034\t0.46GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3734\t0.32GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n585\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3649\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4254\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3001\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4256\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "actors_per_second": 657.1702061376596,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 553.5098466276525
+            "perf_metric_value": 657.1702061376596
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.779
+            "perf_metric_value": 9.35
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3114.217
+            "perf_metric_value": 2197.485
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4934.573
+            "perf_metric_value": 2572.496
         }
     ],
     "success": "1",
-    "time": 18.06652593612671
+    "time": 15.216758012771606
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 94.80192,
+    "_dashboard_memory_usage_mb": 96.54272,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.25,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3683\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2672\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5140\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1070\t0.14GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3887\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n4394\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n5449\t0.09GiB\tray::StateAPIGeneratorActor.start\n3799\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2566\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3890\t0.08GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp",
+    "_peak_memory": 2.26,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3357\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2796\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5171\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3555\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n1083\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4094\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2769\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5398\t0.09GiB\tray::StateAPIGeneratorActor.start\n3473\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4096\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 192.87246715163326
+            "perf_metric_value": 191.95909855877267
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.69
+            "perf_metric_value": 5.204
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.541
+            "perf_metric_value": 13.297
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 44.385
+            "perf_metric_value": 54.703
         }
     ],
     "success": "1",
-    "tasks_per_second": 192.87246715163326,
-    "time": 305.1847732067108,
+    "tasks_per_second": 191.95909855877267,
+    "time": 305.2094430923462,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 96.088064,
+    "_dashboard_memory_usage_mb": 93.515776,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.7,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n2031\t7.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3407\t0.91GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4846\t0.37GiB\tpython distributed/test_many_pgs.py\n2948\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n580\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2641\t0.11GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4125\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3605\t0.09GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2820\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3523\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
+    "_peak_memory": 2.69,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1130\t7.9GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3522\t0.91GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4967\t0.36GiB\tpython distributed/test_many_pgs.py\n2980\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n580\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4243\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3724\t0.09GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n2794\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n3106\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3642\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.282795863244178
+            "perf_metric_value": 13.215254403739163
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.298
+            "perf_metric_value": 4.194
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.186
+            "perf_metric_value": 7.454
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 412.087
+            "perf_metric_value": 219.05
         }
     ],
-    "pgs_per_second": 13.282795863244178,
+    "pgs_per_second": 13.215254403739163,
     "success": "1",
-    "time": 75.28535485267639
+    "time": 75.67012858390808
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 110.903296,
+    "_dashboard_memory_usage_mb": 95.08864,
     "_dashboard_test_success": true,
     "_peak_memory": 3.91,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3415\t1.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4873\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3615\t0.45GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2685\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3618\t0.18GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n2051\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4122\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3531\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n5038\t0.09GiB\tray::DashboardTester.run\n5103\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3526\t1.07GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5070\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3724\t0.45GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n3054\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3727\t0.2GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s\n1120\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4243\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3642\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n3021\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5380\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 381.53414000942394
+            "perf_metric_value": 364.43726497335643
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.797
+            "perf_metric_value": 5.277
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 486.283
+            "perf_metric_value": 492.608
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 763.093
+            "perf_metric_value": 787.075
         }
     ],
     "success": "1",
-    "tasks_per_second": 381.53414000942394,
-    "time": 326.20997428894043,
+    "tasks_per_second": 364.43726497335643,
+    "time": 327.4395649433136,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.47.0"}
+{"release_version": "2.48.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8219.795071008975,
-        188.48085637821475
+        8663.654839458402,
+        182.98906836658583
     ],
     "1_1_actor_calls_concurrent": [
-        5377.1496113254725,
-        129.23618916367775
+        5775.020315522301,
+        166.03207664123752
     ],
     "1_1_actor_calls_sync": [
-        1959.5608579309087,
-        40.05183288077636
+        2011.916260420167,
+        34.20258828426277
     ],
     "1_1_async_actor_calls_async": [
-        4171.456937936633,
-        195.42830490503232
+        4259.771844696956,
+        244.58821485834815
     ],
     "1_1_async_actor_calls_sync": [
-        1468.0999827232097,
-        23.907868237519033
+        1459.7289131365046,
+        14.372300668103277
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2899.87628971332,
-        104.68861949721845
+        2836.298297310687,
+        165.56556787435736
     ],
     "1_n_actor_calls_async": [
-        8008.806358661164,
-        94.9223246657888
+        8038.166251679982,
+        223.66382715772104
     ],
     "1_n_async_actor_calls_async": [
-        7625.6992962916975,
-        77.78852390836784
+        7382.681881276498,
+        130.69555045858203
     ],
     "client__1_1_actor_calls_async": [
-        1065.4228066614364,
-        8.475130628383317
+        1098.863141897179,
+        11.579112801667774
     ],
     "client__1_1_actor_calls_concurrent": [
-        1051.155045997863,
-        7.587242014430166
+        1085.0288964711467,
+        4.148700210547401
     ],
     "client__1_1_actor_calls_sync": [
-        530.5569126625701,
-        3.4917100983628964
+        537.8164788509748,
+        4.282391401398279
     ],
     "client__get_calls": [
-        1018.2939193917422,
-        68.37887040310822
+        1159.3513798913632,
+        25.153079890432657
     ],
     "client__put_calls": [
-        805.9876892520514,
-        20.246218021849156
+        817.4136861603523,
+        35.13575238987404
     ],
     "client__put_gigabytes": [
-        0.1525808986433169,
-        0.0005260267465087514
+        0.1559990403715773,
+        0.0006899703405647251
     ],
     "client__tasks_and_get_batch": [
-        0.909684480871914,
-        0.04209123366651788
+        1.009944931213749,
+        0.0320718636380897
     ],
     "client__tasks_and_put_batch": [
-        14411.155262801181,
-        565.6637142873228
+        14560.030073574557,
+        146.72299114824276
     ],
     "multi_client_put_calls_Plasma_Store": [
-        16769.891858063707,
-        160.7727767543324
+        16526.35985553258,
+        400.3514368958908
     ],
     "multi_client_put_gigabytes": [
-        37.84234603653026,
-        1.9543159500637872
+        38.137310138893675,
+        1.3860853941620797
     ],
     "multi_client_tasks_async": [
-        22162.855018822152,
-        1636.6665214042862
+        21229.843138559452,
+        1404.0869837056882
     ],
     "n_n_actor_calls_async": [
-        27105.63998087682,
-        858.8741533351254
+        27375.624367126635,
+        674.8368191945152
     ],
     "n_n_actor_calls_with_arg_async": [
-        2723.737298735755,
-        15.223156908588408
+        2759.3212097473174,
+        60.45186810112816
     ],
     "n_n_async_actor_calls_async": [
-        23052.03512506016,
-        818.6796601118019
+        23674.50106467489,
+        547.7052271058876
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10841.440823259276
+            "perf_metric_value": 10620.405550394937
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5110.344528620948
+            "perf_metric_value": 5173.290112206238
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16769.891858063707
+            "perf_metric_value": 16526.35985553258
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.561225172916046
+            "perf_metric_value": 19.85639156989914
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6.069186157221194
+            "perf_metric_value": 5.800654754787365
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 37.84234603653026
+            "perf_metric_value": 38.137310138893675
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.67868528378648
+            "perf_metric_value": 13.371722002108683
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.895502802318484
+            "perf_metric_value": 5.079952667320649
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 961.1131766783709
+            "perf_metric_value": 980.7121217208985
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7971.849053459262
+            "perf_metric_value": 8040.530786886751
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22162.855018822152
+            "perf_metric_value": 21229.843138559452
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1959.5608579309087
+            "perf_metric_value": 2011.916260420167
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8219.795071008975
+            "perf_metric_value": 8663.654839458402
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5377.1496113254725
+            "perf_metric_value": 5775.020315522301
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8008.806358661164
+            "perf_metric_value": 8038.166251679982
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27105.63998087682
+            "perf_metric_value": 27375.624367126635
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2723.737298735755
+            "perf_metric_value": 2759.3212097473174
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1468.0999827232097
+            "perf_metric_value": 1459.7289131365046
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4171.456937936633
+            "perf_metric_value": 4259.771844696956
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2899.87628971332
+            "perf_metric_value": 2836.298297310687
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7625.6992962916975
+            "perf_metric_value": 7382.681881276498
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23052.03512506016
+            "perf_metric_value": 23674.50106467489
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 762.110356621388
+            "perf_metric_value": 764.5677165695956
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1018.2939193917422
+            "perf_metric_value": 1159.3513798913632
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 805.9876892520514
+            "perf_metric_value": 817.4136861603523
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.1525808986433169
+            "perf_metric_value": 0.1559990403715773
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14411.155262801181
+            "perf_metric_value": 14560.030073574557
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 530.5569126625701
+            "perf_metric_value": 537.8164788509748
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1065.4228066614364
+            "perf_metric_value": 1098.863141897179
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1051.155045997863
+            "perf_metric_value": 1085.0288964711467
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.909684480871914
+            "perf_metric_value": 1.009944931213749
         }
     ],
     "placement_group_create/removal": [
-        762.110356621388,
-        8.435625535387086
+        764.5677165695956,
+        11.50741876717501
     ],
     "single_client_get_calls_Plasma_Store": [
-        10841.440823259276,
-        238.0109613877782
+        10620.405550394937,
+        95.5780186318987
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.67868528378648,
-        0.08852439852998363
+        13.371722002108683,
+        0.2715300404352367
     ],
     "single_client_put_calls_Plasma_Store": [
-        5110.344528620948,
-        8.717022369486246
+        5173.290112206238,
+        50.54867941540244
     ],
     "single_client_put_gigabytes": [
-        19.561225172916046,
-        9.220541281624417
+        19.85639156989914,
+        8.982486882151242
     ],
     "single_client_tasks_and_get_batch": [
-        6.069186157221194,
-        3.075434344096306
+        5.800654754787365,
+        3.260748466569974
     ],
     "single_client_tasks_async": [
-        7971.849053459262,
-        344.6188539061271
+        8040.530786886751,
+        508.5067401143829
     ],
     "single_client_tasks_sync": [
-        961.1131766783709,
-        17.69357028295797
+        980.7121217208985,
+        15.070879654529714
     ],
     "single_client_wait_1k_refs": [
-        4.895502802318484,
-        0.03612176674731559
+        5.079952667320649,
+        0.11950057107198113
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.597426240999994,
+    "broadcast_time": 17.324763202,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.597426240999994
+            "perf_metric_value": 17.324763202
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.828636121000002,
-    "get_time": 23.034279295000005,
+    "args_time": 18.84486551900001,
+    "get_time": 23.075941746000012,
     "large_object_size": 107374182400,
-    "large_object_time": 31.951921509999977,
+    "large_object_time": 32.03462247800002,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.828636121000002
+            "perf_metric_value": 18.84486551900001
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.7005318469999935
+            "perf_metric_value": 6.088559257
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.034279295000005
+            "perf_metric_value": 23.075941746000012
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 199.80789056199998
+            "perf_metric_value": 199.176572467
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.951921509999977
+            "perf_metric_value": 32.03462247800002
         }
     ],
-    "queued_time": 199.80789056199998,
-    "returns_time": 5.7005318469999935,
+    "queued_time": 199.176572467,
+    "returns_time": 6.088559257,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.2696449542045594,
-    "max_iteration_time": 4.179541110992432,
-    "min_iteration_time": 0.034151315689086914,
+    "avg_iteration_time": 1.1874613547325135,
+    "max_iteration_time": 3.250436544418335,
+    "min_iteration_time": 0.05550789833068848,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2696449542045594
+            "perf_metric_value": 1.1874613547325135
         }
     ],
     "success": 1,
-    "total_time": 126.96463394165039
+    "total_time": 118.7462546825409
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.885871648788452
+            "perf_metric_value": 7.344109535217285
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.311162948608398
+            "perf_metric_value": 12.96969530582428
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 33.59187984466553
+            "perf_metric_value": 33.957920932769774
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.0375380516052246
+            "perf_metric_value": 1.8526091575622559
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1822.3623061180115
+            "perf_metric_value": 1826.5975222587585
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4685331640891067
+            "perf_metric_value": 0.48570817077228695
         }
     ],
-    "stage_0_time": 6.885871648788452,
-    "stage_1_avg_iteration_time": 12.311162948608398,
-    "stage_1_max_iteration_time": 12.973528861999512,
-    "stage_1_min_iteration_time": 10.784329891204834,
-    "stage_1_time": 123.11168432235718,
-    "stage_2_avg_iteration_time": 33.59187984466553,
-    "stage_2_max_iteration_time": 34.43732571601868,
-    "stage_2_min_iteration_time": 33.067967653274536,
-    "stage_2_time": 167.95994234085083,
-    "stage_3_creation_time": 2.0375380516052246,
-    "stage_3_time": 1822.3623061180115,
-    "stage_4_spread": 0.4685331640891067,
+    "stage_0_time": 7.344109535217285,
+    "stage_1_avg_iteration_time": 12.96969530582428,
+    "stage_1_max_iteration_time": 13.717556715011597,
+    "stage_1_min_iteration_time": 11.527287244796753,
+    "stage_1_time": 129.69700860977173,
+    "stage_2_avg_iteration_time": 33.957920932769774,
+    "stage_2_max_iteration_time": 34.32049250602722,
+    "stage_2_min_iteration_time": 33.68821382522583,
+    "stage_2_time": 169.79015111923218,
+    "stage_3_creation_time": 1.8526091575622559,
+    "stage_3_time": 1826.5975222587585,
+    "stage_4_spread": 0.48570817077228695,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.4907771591586358,
-    "avg_pg_remove_time_ms": 1.2416502777781075,
+    "avg_pg_create_time_ms": 1.4493968768766456,
+    "avg_pg_remove_time_ms": 1.2057934429429915,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4907771591586358
+            "perf_metric_value": 1.4493968768766456
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2416502777781075
+            "perf_metric_value": 1.2057934429429915
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 4.48%: tasks_per_second (THROUGHPUT) regresses from 381.53414000942394 to 364.43726497335643 in benchmarks/many_tasks.json
REGRESSION 4.42%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 6.069186157221194 to 5.800654754787365 in microbenchmark.json
REGRESSION 4.21%: multi_client_tasks_async (THROUGHPUT) regresses from 22162.855018822152 to 21229.843138559452 in microbenchmark.json
REGRESSION 3.19%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7625.6992962916975 to 7382.681881276498 in microbenchmark.json
REGRESSION 2.19%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2899.87628971332 to 2836.298297310687 in microbenchmark.json
REGRESSION 2.04%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10841.440823259276 to 10620.405550394937 in microbenchmark.json
REGRESSION 1.45%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 16769.891858063707 to 16526.35985553258 in microbenchmark.json
REGRESSION 0.57%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1468.0999827232097 to 1459.7289131365046 in microbenchmark.json
REGRESSION 0.51%: pgs_per_second (THROUGHPUT) regresses from 13.282795863244178 to 13.215254403739163 in benchmarks/many_pgs.json
REGRESSION 0.47%: tasks_per_second (THROUGHPUT) regresses from 192.87246715163326 to 191.95909855877267 in benchmarks/many_nodes.json
REGRESSION 37.53%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 12.597426240999994 to 17.324763202 in scalability/object_store.json
REGRESSION 23.25%: dashboard_p99_latency_ms (LATENCY) regresses from 44.385 to 54.703 in benchmarks/many_nodes.json
REGRESSION 10.01%: dashboard_p50_latency_ms (LATENCY) regresses from 4.797 to 5.277 in benchmarks/many_tasks.json
REGRESSION 6.81%: 3000_returns_time (LATENCY) regresses from 5.7005318469999935 to 6.088559257 in scalability/single_node.json
REGRESSION 6.65%: stage_0_time (LATENCY) regresses from 6.885871648788452 to 7.344109535217285 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.50%: dashboard_p50_latency_ms (LATENCY) regresses from 8.779 to 9.35 in benchmarks/many_actors.json
REGRESSION 6.03%: dashboard_p95_latency_ms (LATENCY) regresses from 12.541 to 13.297 in benchmarks/many_nodes.json
REGRESSION 5.35%: stage_1_avg_iteration_time (LATENCY) regresses from 12.311162948608398 to 12.96969530582428 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.67%: stage_4_spread (LATENCY) regresses from 0.4685331640891067 to 0.48570817077228695 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.14%: dashboard_p99_latency_ms (LATENCY) regresses from 763.093 to 787.075 in benchmarks/many_tasks.json
REGRESSION 1.30%: dashboard_p95_latency_ms (LATENCY) regresses from 486.283 to 492.608 in benchmarks/many_tasks.json
REGRESSION 1.09%: stage_2_avg_iteration_time (LATENCY) regresses from 33.59187984466553 to 33.957920932769774 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.26%: 107374182400_large_object_time (LATENCY) regresses from 31.951921509999977 to 32.03462247800002 in scalability/single_node.json
REGRESSION 0.23%: stage_3_time (LATENCY) regresses from 1822.3623061180115 to 1826.5975222587585 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.18%: 10000_get_time (LATENCY) regresses from 23.034279295000005 to 23.075941746000012 in scalability/single_node.json
REGRESSION 0.09%: 10000_args_time (LATENCY) regresses from 18.828636121000002 to 18.84486551900001 in scalability/single_node.json
```