### PR TITLE
[core] Core worker + Cython cleanup unnecessary paths

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -793,23 +793,19 @@ class Worker:
     def put_object(
         self,
         value: Any,
-        object_ref: Optional["ray.ObjectRef"] = None,
         owner_address: Optional[str] = None,
         _is_experimental_channel: bool = False,
     ):
-        """Put value in the local object store with object reference `object_ref`.
+        """Put value in the local object store.
 
-        This assumes that the value for `object_ref` has not yet been placed in
-        the local object store. If the plasma store is full, the worker will
-        automatically retry up to DEFAULT_PUT_OBJECT_RETRIES times. Each
-        retry will delay for an exponentially doubling amount of time,
+        If the plasma store is full, the worker will automatically
+        retry up to DEFAULT_PUT_OBJECT_RETRIES times. Each retry
+        will delay for an exponentially doubling amount of time,
         starting with DEFAULT_PUT_OBJECT_DELAY. After this, exception
         will be raised.
 
         Args:
             value: The value to put in the object store.
-            object_ref: The object ref of the value to be
-                put. If None, one will be generated.
             owner_address: The serialized address of object's owner.
             _is_experimental_channel: An experimental flag for mutable
                 objects. If True, then the returned object will not have a
@@ -831,11 +827,6 @@ class Worker:
                 "If you really want to do this, you can wrap the "
                 "ray.ObjectRef in a list and call 'put' on it."
             )
-
-        if self.mode == LOCAL_MODE:
-            assert (
-                object_ref is None
-            ), "Local Mode does not support inserting with an ObjectRef"
 
         try:
             serialized_value = self.get_serialization_context().serialize(value)
@@ -862,7 +853,6 @@ class Worker:
         return ray.ObjectRef(
             self.core_worker.put_serialized_object_and_increment_local_ref(
                 serialized_value,
-                object_ref=object_ref,
                 pin_object=pin_object,
                 owner_address=owner_address,
                 _is_experimental_channel=_is_experimental_channel,

--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -139,10 +139,10 @@ cdef class CoreWorker:
         object event_loop_executor
 
     cdef _create_put_buffer(self, shared_ptr[CBuffer] &metadata,
-                            size_t data_size, ObjectRef object_ref,
+                            size_t data_size,
                             c_vector[CObjectID] contained_ids,
-                            CObjectID *c_object_id, shared_ptr[CBuffer] *data,
-                            c_bool created_by_worker,
+                            CObjectID *c_object_id,
+                            shared_ptr[CBuffer] *data,
                             owner_address=*,
                             c_bool inline_small_object=*,
                             c_bool is_experimental_channel=*)

--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -138,14 +138,6 @@ cdef class CoreWorker:
         dict _task_id_to_future
         object event_loop_executor
 
-    cdef _create_put_buffer(self, shared_ptr[CBuffer] &metadata,
-                            size_t data_size,
-                            c_vector[CObjectID] contained_ids,
-                            CObjectID *c_object_id,
-                            shared_ptr[CBuffer] *data,
-                            owner_address=*,
-                            c_bool inline_small_object=*,
-                            c_bool is_experimental_channel=*)
     cdef unique_ptr[CAddress] _convert_python_address(self, address=*)
     cdef store_task_output(
             self, serialized_object,

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -259,7 +259,6 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                     const size_t data_size,
                     const c_vector[CObjectID] &contained_object_ids,
                     CObjectID *object_id, shared_ptr[CBuffer] *data,
-                    c_bool created_by_worker,
                     const unique_ptr[CAddress] &owner_address,
                     c_bool inline_small_object)
         CRayStatus CreateExisting(const shared_ptr[CBuffer] &metadata,

--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -29,7 +29,7 @@ def test_dying_worker_get(ray_start_2_cpus):
     signal_2 = SignalActor.remote()
 
     x_id = wait_on_signal.remote(signal_1, signal_2)
-    ray.get(signal_1.send.remote())
+    ray.get(signal_1.wait.remote())
     # Get the PID of the other worker.
     worker_pid = ray.get(get_worker_pid.remote())
 

--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -3,7 +3,6 @@ import signal
 import sys
 import time
 
-import numpy as np
 import pytest
 
 import ray
@@ -51,10 +50,6 @@ def test_dying_worker_get(ray_start_2_cpus):
     # Make sure the sleep task hasn't finished.
     ready_ids, _ = ray.wait([x_id], timeout=0)
     assert len(ready_ids) == 0
-    # Seal the object so the store attempts to notify the worker that the
-    # get has been fulfilled.
-    obj = np.ones(200 * 1024, dtype=np.uint8)
-    ray._private.worker.global_worker.put_object(obj, x_id)
     time.sleep(0.1)
 
     # Make sure that nothing has died.
@@ -94,10 +89,6 @@ ray.get(ray.ObjectRef(ray._common.utils.hex_to_binary("{}")))
     # Make sure the original task hasn't finished.
     ready_ids, _ = ray.wait([x_id], timeout=0)
     assert len(ready_ids) == 0
-    # Seal the object so the store attempts to notify the worker that the
-    # get has been fulfilled.
-    obj = np.ones(200 * 1024, dtype=np.uint8)
-    ray._private.worker.global_worker.put_object(obj, x_id)
     time.sleep(0.1)
 
     # Make sure that nothing has died.
@@ -131,11 +122,6 @@ def test_dying_worker_wait(ray_start_2_cpus):
 
     # Kill the worker.
     os.kill(worker_pid, SIGKILL)
-    time.sleep(0.1)
-
-    # Create the object.
-    obj = np.ones(200 * 1024, dtype=np.uint8)
-    ray._private.worker.global_worker.put_object(obj, x_id)
     time.sleep(0.1)
 
     # Make sure that nothing has died.
@@ -175,10 +161,6 @@ ray.wait([ray.ObjectRef(ray._common.utils.hex_to_binary("{}"))])
     # Make sure the original task hasn't finished.
     ready_ids, _ = ray.wait([x_id], timeout=0)
     assert len(ready_ids) == 0
-    # Seal the object so the store attempts to notify the worker that the
-    # wait can return.
-    obj = np.ones(200 * 1024, dtype=np.uint8)
-    ray._private.worker.global_worker.put_object(obj, x_id)
     time.sleep(0.1)
 
     # Make sure that nothing has died.

--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -12,8 +12,7 @@ from ray._private.test_utils import run_string_as_driver_nonblocking
 SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
 
-# This test checks that when a worker dies in the middle of a get, the plasma
-# store and raylet will not die.
+# This test checks that when a worker dies in the middle of a get, the raylet will not die.
 def test_dying_worker_get(ray_start_2_cpus):
     @ray.remote
     def sleep_forever(signal):
@@ -56,8 +55,7 @@ def test_dying_worker_get(ray_start_2_cpus):
     assert ray._private.services.remaining_processes_alive()
 
 
-# This test checks that when a driver dies in the middle of a get, the plasma
-# store and raylet will not die.
+# This test checks that when a driver dies in the middle of a get, the raylet will not die.
 def test_dying_driver_get(ray_start_regular):
     # Start the Ray processes.
     address_info = ray_start_regular
@@ -95,8 +93,7 @@ ray.get(ray.ObjectRef(ray._common.utils.hex_to_binary("{}")))
     assert ray._private.services.remaining_processes_alive()
 
 
-# This test checks that when a worker dies in the middle of a wait, the plasma
-# store and raylet will not die.
+# This test checks that when a worker dies in the middle of a wait, the raylet will not die.
 def test_dying_worker_wait(ray_start_2_cpus):
     @ray.remote
     def sleep_forever():
@@ -128,8 +125,7 @@ def test_dying_worker_wait(ray_start_2_cpus):
     assert ray._private.services.remaining_processes_alive()
 
 
-# This test checks that when a driver dies in the middle of a wait, the plasma
-# store and raylet will not die.
+# This test checks that when a driver dies in the middle of a wait, the raylet will not die.
 def test_dying_driver_wait(ray_start_regular):
     # Start the Ray processes.
     address_info = ray_start_regular

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -4001,11 +4001,6 @@ void CoreWorker::HandleGetObjectStatus(rpc::GetObjectStatusRequest request,
 
   ObjectID object_id = ObjectID::FromBinary(request.object_id());
   RAY_LOG(DEBUG).WithField(object_id) << "Received GetObjectStatus";
-  // Acquire a reference to the object. This prevents the object from being
-  // evicted out from under us while we check the object status and start the
-  // Get. If the object ref count drops to 0 and memory store Delete is called before
-  // GetAsync stores the callback, the callback would never get called.
-  AddLocalReference(object_id, "<temporary (get object status)>");
 
   rpc::Address owner_address;
   auto has_owner = reference_counter_->GetOwner(object_id, &owner_address);
@@ -4025,7 +4020,6 @@ void CoreWorker::HandleGetObjectStatus(rpc::GetObjectStatusRequest request,
                               send_reply_callback(Status::OK(), nullptr, nullptr);
                             });
   }
-  RemoveLocalReference(object_id);
 }
 
 void CoreWorker::PopulateObjectStatus(const ObjectID &object_id,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1611,7 +1611,6 @@ Status CoreWorker::CreateOwnedAndIncrementLocalRef(
     const std::vector<ObjectID> &contained_object_ids,
     ObjectID *object_id,
     std::shared_ptr<Buffer> *data,
-    bool created_by_worker,
     const std::unique_ptr<rpc::Address> &owner_address,
     bool inline_small_object) {
   auto status = WaitForActorRegistered(contained_object_ids);
@@ -1680,7 +1679,7 @@ Status CoreWorker::CreateOwnedAndIncrementLocalRef(
                                               *object_id,
                                               /* owner_address = */ real_owner_address,
                                               data,
-                                              created_by_worker,
+                                              /*created_by_worker=*/true,
                                               is_experimental_mutable_object);
     }
     if (!status.ok()) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -416,27 +416,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                           rpc::Address *owner_address,
                           std::string *serialized_object_status);
 
-  /// Get the owner information of an object. This should be
-  /// called when serializing an object ID, and the returned information should
-  /// be stored with the serialized object ID. If the ownership of the object
-  /// cannot be established, then we terminate the process.
-  ///
-  /// This can only be called on object IDs that we created via task
-  /// submission, ray.put, or object IDs that we deserialized. It cannot be
-  /// called on object IDs that were created randomly, e.g.,
-  /// ObjectID::FromRandom.
-  ///
-  /// Postcondition: Get(object_id) is valid.
-  ///
-  /// \param[in] object_id The object ID to serialize.
-  /// appended to the serialized object ID.
-  /// \param[out] owner_address The address of the object's owner. This should
-  /// be appended to the serialized object ID.
-  /// \param[out] serialized_object_status The serialized object status protobuf.
-  void GetOwnershipInfoOrDie(const ObjectID &object_id,
-                             rpc::Address *owner_address,
-                             std::string *serialized_object_status);
-
   /// Add a reference to an ObjectID that was deserialized by the language
   /// frontend. This will also start the process to resolve the future.
   /// Specifically, we will periodically contact the owner, until we learn that

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -481,7 +481,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] contained_object_ids The IDs serialized in this object.
   /// \param[out] object_id Object ID generated for the put.
   /// \param[out] data Buffer for the user to write the object into.
-  /// \param[in] created_by_worker create by worker or not.
   /// \param[in] owner_address The address of object's owner. If not provided,
   /// defaults to this worker.
   /// \param[in] inline_small_object Whether to inline create this object if it's
@@ -494,7 +493,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
       const std::vector<ObjectID> &contained_object_ids,
       ObjectID *object_id,
       std::shared_ptr<Buffer> *data,
-      bool created_by_worker,
       const std::unique_ptr<rpc::Address> &owner_address = nullptr,
       bool inline_small_object = true);
 

--- a/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
@@ -53,7 +53,6 @@ Status PutSerializedObject(JNIEnv *env,
         nested_ids,
         out_object_id,
         &data,
-        /*created_by_worker=*/true,
         /*owner_address=*/owner_address);
   } else {
     status = CoreWorkerProcess::GetCoreWorker().CreateExisting(

--- a/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
@@ -239,8 +239,9 @@ Java_io_ray_runtime_object_NativeObjectStore_nativeGetOwnershipInfo(JNIEnv *env,
   rpc::Address address;
   // TODO(ekl) send serialized object status to Java land.
   std::string serialized_object_status;
-  CoreWorkerProcess::GetCoreWorker().GetOwnershipInfoOrDie(
+  auto status = CoreWorkerProcess::GetCoreWorker().GetOwnershipInfo(
       object_id, &address, &serialized_object_status);
+  RAY_CHECK_OK(status);
   auto address_str = address.SerializeAsString();
   auto arr = NativeStringToJavaByteArray(env, address_str);
   return arr;

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -149,24 +149,17 @@ CoreWorkerMemoryStore::CoreWorkerMemoryStore(
 
 void CoreWorkerMemoryStore::GetAsync(
     const ObjectID &object_id, std::function<void(std::shared_ptr<RayObject>)> callback) {
-  std::shared_ptr<RayObject> ptr;
-  {
-    absl::MutexLock lock(&mu_);
-    auto iter = objects_.find(object_id);
-    if (iter != objects_.end()) {
-      ptr = iter->second;
-    } else {
-      object_async_get_requests_[object_id].push_back(callback);
-    }
-    if (ptr != nullptr) {
-      ptr->SetAccessed();
-    }
+  absl::MutexLock lock(&mu_);
+  auto iter = objects_.find(object_id);
+  if (iter == objects_.end()) {
+    object_async_get_requests_[object_id].push_back(std::move(callback));
+    return;
   }
-  // It's important for performance to run the callback outside the lock.
-  if (ptr != nullptr) {
-    io_context_.post([callback = std::move(callback), ptr]() { callback(ptr); },
-                     "CoreWorkerMemoryStore.GetAsync.Callback");
-  }
+  auto object_ptr = iter->second;
+  object_ptr->SetAccessed();
+  io_context_.post(
+      [callback = std::move(callback), object_ptr]() { callback(object_ptr); },
+      "CoreWorkerMemoryStore.GetAsync.Callback");
 }
 
 std::shared_ptr<RayObject> CoreWorkerMemoryStore::GetIfExists(const ObjectID &object_id) {

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -155,7 +155,7 @@ void CoreWorkerMemoryStore::GetAsync(
     object_async_get_requests_[object_id].push_back(std::move(callback));
     return;
   }
-  auto object_ptr = iter->second;
+  auto &object_ptr = iter->second;
   object_ptr->SetAccessed();
   io_context_.post(
       [callback = std::move(callback), object_ptr]() { callback(object_ptr); },

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -192,7 +192,6 @@ message GetObjectStatusReply {
   enum ObjectStatus {
     CREATED = 0;
     OUT_OF_SCOPE = 1;
-    FREED = 2;
   }
   ObjectStatus status = 1;
   // The Ray object: either a concrete value, an in-Plasma indicator, or an

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -192,6 +192,7 @@ message GetObjectStatusReply {
   enum ObjectStatus {
     CREATED = 0;
     OUT_OF_SCOPE = 1;
+    FREED = 2;
   }
   ObjectStatus status = 1;
   // The Ray object: either a concrete value, an in-Plasma indicator, or an


### PR DESCRIPTION
## Why are these changes needed?
Some cleaning up to simplify things. No actual logical/functional changes
- Kill `GetOwnershipInfoAndDie` - only used for java api and just does a ray check on the status after calling `GetOwnershipInfo`. Just moved the status check to the java interface.
- Changed `find` / `count` calls to `contains` in reference_count - a little more performant + more readable
- Making `CoreWorkerMemoryStore::GetAsync` a little cleaner
- Inline `_create_put_buffer`. Only used in one spot and just called `CreateOwnedAndIncrementLocalRef` and did a one line if check.
- Remove `created_by_worker` from`CreateOwnedAndIncrementLocalRef`. It was always set to True.
- Remove `object_ref` as an optional parameter for `put_object` and `put_serialized_object_and_increment_local_ref`. This isn't used anywhere except test_component_failures and no public api exposes the option to put inside an existing ref. Removed the usage in test_component_failures, and replaced with signal_actor. where the test was added:  https://github.com/ray-project/ray/pull/2997/files#diff-458d70dfb56bb932dc0f0b7c8bb60cc759c72564ad036010dce02c50134042e2
