### PR TITLE
add request id in proxy logs in files

### DIFF
--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -370,6 +370,8 @@ def configure_component_logger(
 
     if logging_config.enable_access_log is False:
         file_handler.addFilter(log_access_log_filter)
+    else:
+        file_handler.addFilter(ServeContextFilter())
 
     # Remove unwanted attributes from the log record.
     file_handler.addFilter(ServeLogAttributeRemovalFilter())

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -6,6 +6,7 @@ import re
 import string
 import sys
 import time
+import uuid
 from contextlib import redirect_stderr
 from pathlib import Path
 from typing import List, Tuple
@@ -452,14 +453,13 @@ def test_http_access_log_in_proxy_logs_file(serve_instance):
 
     url = get_application_url(use_localhost=True)
 
-    request_id = "0cd9c491-6921-4e59-b8a3-f42865481806"
+    request_id = str(uuid.uuid4())
     response = httpx.get(url, headers={"X-Request-ID": request_id})
     assert response.status_code == 200
 
     def verify_request_id_in_logs(proxy_log_path, request_id):
         with open(proxy_log_path, "r") as f:
             for line in f:
-                print("ns ,i m in line :::", line)
                 if request_id in line:
                     return True
         return False

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -433,9 +433,6 @@ def test_http_access_log_in_proxy_logs_file(serve_instance):
     @serve.deployment(name=name)
     @serve.ingress(fastapi_app)
     class Handler:
-        def __init__(self):
-            self._replica_unique_id = serve.get_replica_context().replica_id.unique_id
-
         @fastapi_app.get("/")
         def get_root(self):
             return "Hello World!"


### PR DESCRIPTION
fixes: https://github.com/ray-project/ray/issues/54400 by adding request_id and other fields in proxy logs in the files.

the issue was in the proxy access logs, when we were printing them to the file.

before:
it has no request id in the logs
<img width="1034" height="537" alt="Screenshot 2025-07-22 at 07 44 12" src="https://github.com/user-attachments/assets/cbfbae78-7111-4d69-b4b8-7d182076b2d3" />


after:
it has request id in the logs
<img width="1187" height="342" alt="Screenshot 2025-07-22 at 07 41 07" src="https://github.com/user-attachments/assets/8c675416-1a30-494b-832b-37ba79b9589d" />
