### PR TITLE
WIP: Allow Dict and Tuple spaces when concatenating using `SingleAgentEpisode`

### DIFF
--- a/rllib/env/single_agent_episode.py
+++ b/rllib/env/single_agent_episode.py
@@ -616,7 +616,7 @@ class SingleAgentEpisode:
         other.validate()
 
         # Make sure, end matches other episode chunk's beginning.
-        assert np.all(other.observations[0] == self.observations[-1])
+        np.testing.assert_equal(other.observations[0], self.observations[-1])
         # Pop out our last observations and infos (as these are identical
         # to the first obs and infos in the next episode).
         self.observations.pop()

--- a/rllib/env/tests/test_single_agent_episode.py
+++ b/rllib/env/tests/test_single_agent_episode.py
@@ -29,11 +29,19 @@ class TestEnv(gym.Env):
         self.action_space = gym.spaces.Discrete(200)
         self.t = 0
 
+    def _obs(self):
+        if isinstance(self.observation_space, gym.spaces.Dict):
+            return {f"obs_{i}": self.t for i in range(5)}
+        elif isinstance(self.observation_space, gym.spaces.Tuple):
+            return tuple(self.t for _ in range(5))
+        else:
+            return self.t
+
     def reset(
         self, *, seed: Optional[int] = None, options=Optional[Dict[str, Any]]
     ) -> Tuple[ObsType, Dict[str, Any]]:
         self.t = 0
-        return 0, {}
+        return self.obs(), {}
 
     def step(
         self, action: ActType
@@ -44,7 +52,7 @@ class TestEnv(gym.Env):
         else:
             is_terminated = False
 
-        return self.t, self.t, is_terminated, False, {}
+        return self.obs(), self.t, is_terminated, False, {}
 
 
 class TestSingelAgentEpisode(unittest.TestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allows for dict and tuple wrapping spaces when concatenating using `SingleAgentEpisode`
## Related issue number

Solves https://github.com/ray-project/ray/issues/54659

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
