### PR TITLE
[core] support ipv6 in host network mode

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -213,6 +213,7 @@ ray_cc_library(
         "//src/ray/common:ray_config",
         "//src/ray/common:status",
         "//src/ray/util:thread_utils",
+        "//src/ray/util:env",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_github_grpc_grpc//:grpcpp_admin",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -146,6 +146,7 @@ ray_cc_library(
         ":rpc_chaos",
         ":rpc_client_call",
         "//src/ray/common:grpc_util",
+        "//src/ray/common:network",
         "//src/ray/common:ray_config",
         "//src/ray/common:status",
     ],

--- a/python/ray/_private/internal_api.py
+++ b/python/ray/_private/internal_api.py
@@ -71,7 +71,7 @@ def get_memory_info_reply(state, node_manager_address=None, node_manager_port=No
             raylet["NodeManagerAddress"], raylet["NodeManagerPort"]
         )
     else:
-        raylet_address = "{}:{}".format(node_manager_address, node_manager_port)
+        raylet_address = ray._private.network_utils.build_address(node_manager_address, node_manager_port)
 
     channel = utils.init_grpc_channel(
         raylet_address,
@@ -98,7 +98,7 @@ def node_stats(
 
     # We can ask any Raylet for the global memory info.
     assert node_manager_address is not None and node_manager_port is not None
-    raylet_address = "{}:{}".format(node_manager_address, node_manager_port)
+    raylet_address = ray._private.network_utils.build_address(node_manager_address, node_manager_port)
     channel = utils.init_grpc_channel(
         raylet_address,
         options=[

--- a/python/ray/_private/network_utils.py
+++ b/python/ray/_private/network_utils.py
@@ -1,0 +1,23 @@
+import ipaddress
+
+def is_ipv6_address(ip):
+    if ip is None:
+        return False
+    if len(ip) >= 2 and ip[0] == "[":
+        ip = ip[1:-1]
+    try:
+        ip_obj = ipaddress.ip_address(ip)
+        return ip_obj.version == 6
+    except ValueError:
+        return False
+
+def parse_address(address):
+    host, port = address.rsplit(":", 1)
+    host = host.strip("[]")
+    return (host, port)
+
+def build_address(host, port):
+    if ':' in host:
+        return f"[{host}]:{port}"
+    else:
+        return f"{host}:{port}"

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -199,9 +199,7 @@ class Node:
                 assert not self._default_worker
                 self._webui_url = ray._private.services.get_webui_url_from_internal_kv()
             else:
-                self._webui_url = (
-                    f"{ray_params.dashboard_host}:{ray_params.dashboard_port}"
-                )
+                self._webui_url = ray._private.network_utils.build_address(ray_params.dashboard_host, ray_params.dashboard_port)
 
         # It creates a session_dir.
         self._init_temp()
@@ -700,7 +698,7 @@ class Node:
     @property
     def runtime_env_agent_address(self):
         """Get the address that exposes runtime env agent as http"""
-        return f"http://{self._raylet_ip_address}:{self._runtime_env_agent_port}"
+        return "http://"+ ray._private.network_utils.build_address(self._raylet_ip_address, self._runtime_env_agent_port)
 
     @property
     def dashboard_agent_listen_port(self):

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -108,7 +108,7 @@ class Node:
             # instance provided.
             if len(external_redis) == 1:
                 external_redis.append(external_redis[0])
-            [primary_redis_ip, port] = external_redis[0].rsplit(":", 1)
+            [primary_redis_ip, port] = ray._private.network_utils.parse_address(external_redis[0])
             ray_params.external_addresses = external_redis
             ray_params.num_redis_shards = len(external_redis) - 1
 
@@ -1228,7 +1228,7 @@ class Node:
         # e.g. https://github.com/ray-project/ray/issues/15780
         # TODO(mwtian): figure out a way to use 127.0.0.1 for local connection
         # when possible.
-        self._gcs_address = f"{self._node_ip_address}:" f"{gcs_server_port}"
+        self._gcs_address = ray._private.network_utils.build_address(self._node_ip_address, gcs_server_port)
 
     def start_raylet(
         self,

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -592,3 +592,7 @@ RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT = env_bool(
 RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE = env_bool(
     "RAY_experimental_enable_open_telemetry_on_core", False
 )
+
+
+# Whether prefer ipv6 in ray runtime
+RAY_PREFER_IPV6 = env_bool("RAY_PREFER_IPV6", False)

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
         "127.0.0.1" if args.node_ip_address == "127.0.0.1" else "0.0.0.0"
     )
 
-    if os.environ.get("RAY_PREFER_IPV6") is not None:
+    if ray_constants.RAY_PREFER_IPV6:
         runtime_env_agent_ip = "::"
     try:
         web.run_app(

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -221,6 +221,9 @@ if __name__ == "__main__":
     runtime_env_agent_ip = (
         "127.0.0.1" if args.node_ip_address == "127.0.0.1" else "0.0.0.0"
     )
+
+    if os.environ.get("RAY_PREFER_IPV6") is not None:
+        runtime_env_agent_ip = "::"
     try:
         web.run_app(
             app,

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -607,14 +607,6 @@ def resolve_ip_for_localhost(address: str):
     if address_parts[0] == "127.0.0.1" or address_parts[0] == "localhost":
         # Make sure localhost isn't resolved to the loopback ip
         ip_address = get_node_ip_address()
-        my_pod_ip6 = os.environ.get("RAY_POD_IPV6")
-        if my_pod_ip6 is not None and my_pod_ip6 != "":
-            if len(address_parts) > 1:
-                return (
-                    "[" + ip_address + "]:" + os.environ.get("RAY_GCS_SPECIFIC_PORT", "6379")
-                )
-            else:
-                return ip_address
         return ":".join([ip_address] + address_parts[1:])
     else:
         return address

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -610,7 +610,9 @@ def resolve_ip_for_localhost(address: str):
         my_pod_ip6 = os.environ.get("RAY_POD_IPV6")
         if my_pod_ip6 is not None and my_pod_ip6 != "":
             if len(address_parts) > 1:
-                return ip_address + ":" + os.environ.get("RAY_GCS_SPECIFIC_PORT", "6379")
+                return (
+                    ip_address + ":" + os.environ.get("RAY_GCS_SPECIFIC_PORT", "6379")
+                )
             else:
                 return ip_address
         return ":".join([ip_address] + address_parts[1:])

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -4,7 +4,6 @@ import json
 import logging
 import multiprocessing
 import os
-import ipaddress
 import platform
 import re
 import signal
@@ -1625,15 +1624,3 @@ def is_in_test():
             for env_var in ("PYTEST_CURRENT_TEST", "BUILDKITE")
         )
     return in_test
-
-
-def is_ipv6_address(ip):
-    if ip is None:
-        return False
-    if len(ip) >= 2 and ip[0] == "[":
-        ip = ip[1:-1]
-    try:
-        ip_obj = ipaddress.ip_address(ip)
-        return ip_obj.version == 6
-    except ValueError:
-        return False

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -4,6 +4,7 @@ import json
 import logging
 import multiprocessing
 import os
+import ipaddress
 import platform
 import re
 import signal
@@ -1624,3 +1625,15 @@ def is_in_test():
             for env_var in ("PYTEST_CURRENT_TEST", "BUILDKITE")
         )
     return in_test
+
+
+def is_ipv6_address(ip):
+    if ip is None:
+        return False
+    if len(ip) >= 2 and ip[0] == "[":
+        ip = ip[1:-1]
+    try:
+        ip_obj = ipaddress.ip_address(ip)
+        return ip_obj.version == 6
+    except ValueError:
+        return False

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2799,7 +2799,7 @@ cdef class _GcsSubscriber:
         # subscriber_id needs to match the binary format of a random
         # SubscriberID / UniqueID, which is 28 (kUniqueIDSize) random bytes.
         subscriber_id = bytes(bytearray(random.getrandbits(8) for _ in range(28)))
-        gcs_address, gcs_port = address.rsplit(":", 1)
+        gcs_address, gcs_port = ray._private.network_utils.parse_address(address)
         self.inner.reset(new CPythonGcsSubscriber(
             gcs_address, int(gcs_port), channel, subscriber_id, c_worker_id))
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2799,7 +2799,7 @@ cdef class _GcsSubscriber:
         # subscriber_id needs to match the binary format of a random
         # SubscriberID / UniqueID, which is 28 (kUniqueIDSize) random bytes.
         subscriber_id = bytes(bytearray(random.getrandbits(8) for _ in range(28)))
-        gcs_address, gcs_port = address.split(":")
+        gcs_address, gcs_port = address.rsplit(":", 1)
         self.inner.reset(new CPythonGcsSubscriber(
             gcs_address, int(gcs_port), channel, subscriber_id, c_worker_id))
 

--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -140,7 +140,7 @@ def init_torch_dist_process_group(
 
     # Assume the first worker is the master.
     master_addr, master_port = ray.get(workers[0].execute.remote(get_address_and_port))
-    
+
     # fix problem if master is ipv6 address
     master_addr = master_addr.strip("[]")
 

--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -140,6 +140,9 @@ def init_torch_dist_process_group(
 
     # Assume the first worker is the master.
     master_addr, master_port = ray.get(workers[0].execute.remote(get_address_and_port))
+    
+    # fix problem if master is ipv6 address
+    master_addr = master_addr.strip("[]")
 
     setup_futures = []
     world_size = len(workers)

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -149,14 +149,14 @@ class Monitor:
         _initialize_internal_kv(self.gcs_client)
 
         if monitor_ip:
-            monitor_addr = f"{monitor_ip}:{AUTOSCALER_METRIC_PORT}"
+            monitor_addr = ray._private.network_utils.build_address(monitor_ip, AUTOSCALER_METRIC_PORT)
             self.gcs_client.internal_kv_put(
                 b"AutoscalerMetricsAddress", monitor_addr.encode(), True, None
             )
         self._session_name = self.get_session_name(self.gcs_client)
         logger.info(f"session_name: {self._session_name}")
         worker.mode = 0
-        head_node_ip = self.gcs_address.rsplit(":", 1)[0]
+        head_node_ip = ray._private.network_utils.parse_address(self.gcs_address)[0]
 
         self.load_metrics = LoadMetrics()
         self.last_avail_resources = None

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -192,7 +192,7 @@ class Monitor:
                     )
                 )
                 kwargs = {"addr": "127.0.0.1"} if head_node_ip == "127.0.0.1" else {}
-                if os.environ.get("RAY_PREFER_IPV6") is not None:
+                if ray_constants.RAY_PREFER_IPV6:
                     kwargs = {"addr": "::"}
                 prometheus_client.start_http_server(
                     port=AUTOSCALER_METRIC_PORT,

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -192,6 +192,8 @@ class Monitor:
                     )
                 )
                 kwargs = {"addr": "127.0.0.1"} if head_node_ip == "127.0.0.1" else {}
+                if os.environ.get("RAY_PREFER_IPV6") is not None:
+                    kwargs = {"addr": "::"}
                 prometheus_client.start_http_server(
                     port=AUTOSCALER_METRIC_PORT,
                     registry=self.prom_metrics.registry,

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -156,7 +156,7 @@ class Monitor:
         self._session_name = self.get_session_name(self.gcs_client)
         logger.info(f"session_name: {self._session_name}")
         worker.mode = 0
-        head_node_ip = self.gcs_address.split(":")[0]
+        head_node_ip = self.gcs_address.rsplit(":", 1)[0]
 
         self.load_metrics = LoadMetrics()
         self.last_avail_resources = None

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -76,14 +76,14 @@ class AutoscalerMonitor:
         self.gcs_client = GcsClient(address=self.gcs_address)
 
         if monitor_ip:
-            monitor_addr = f"{monitor_ip}:{AUTOSCALER_METRIC_PORT}"
+            monitor_addr = ray._private.network_utils.build_address(monitor_ip, AUTOSCALER_METRIC_PORT)
             self.gcs_client.internal_kv_put(
                 b"AutoscalerMetricsAddress", monitor_addr.encode(), True, None
             )
         self._session_name = self._get_session_name(self.gcs_client)
         logger.info(f"session_name: {self._session_name}")
         worker.set_mode(SCRIPT_MODE)
-        head_node_ip = self.gcs_address.rsplit(":", 1)[0]
+        head_node_ip = ray._private.network_utils.parse_address(self.gcs_address)[0]
 
         self.autoscaler = None
         if log_dir:

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -111,7 +111,7 @@ class AutoscalerMonitor:
                     )
                 )
                 kwargs = {"addr": "127.0.0.1"} if head_node_ip == "127.0.0.1" else {}
-                if os.environ.get("RAY_PREFER_IPV6") is not None:
+                if ray_constants.RAY_PREFER_IPV6:
                     kwargs = {"addr": "::"}
                 prometheus_client.start_http_server(
                     port=AUTOSCALER_METRIC_PORT,

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -111,6 +111,8 @@ class AutoscalerMonitor:
                     )
                 )
                 kwargs = {"addr": "127.0.0.1"} if head_node_ip == "127.0.0.1" else {}
+                if os.environ.get("RAY_PREFER_IPV6") is not None:
+                    kwargs = {"addr": "::"}
                 prometheus_client.start_http_server(
                     port=AUTOSCALER_METRIC_PORT,
                     registry=prom_metrics.registry,

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -83,7 +83,7 @@ class AutoscalerMonitor:
         self._session_name = self._get_session_name(self.gcs_client)
         logger.info(f"session_name: {self._session_name}")
         worker.set_mode(SCRIPT_MODE)
-        head_node_ip = self.gcs_address.split(":")[0]
+        head_node_ip = self.gcs_address.rsplit(":", 1)[0]
 
         self.autoscaler = None
         if log_dir:

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -109,7 +109,7 @@ class DashboardAgent:
             )  # noqa
         )
         grpc_ip = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
-        if os.environ.get("RAY_PREFER_IPV6") is not None:
+        if ray_constants.RAY_PREFER_IPV6:
             grpc_ip = "[::]"
         try:
             self.grpc_port = add_port_to_grpc_server(

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -109,7 +109,7 @@ class DashboardAgent:
             )  # noqa
         )
         grpc_ip = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
-        if os.environ.get("RAY_PREFER_IPV6") is not None and grpc_ip == "0.0.0.0":
+        if os.environ.get("RAY_PREFER_IPV6") is not None:
             grpc_ip = "[::]"
         try:
             self.grpc_port = add_port_to_grpc_server(

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -109,6 +109,8 @@ class DashboardAgent:
             )  # noqa
         )
         grpc_ip = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
+        if os.environ.get("RAY_PREFER_IPV6") is not None and grpc_ip == "0.0.0.0":
+            grpc_ip = "[::]"
         try:
             self.grpc_port = add_port_to_grpc_server(
                 self.server, f"{grpc_ip}:{self.dashboard_agent_port}"

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -313,6 +313,8 @@ class DashboardHead:
                     )
                 )
                 kwargs = {"addr": "127.0.0.1"} if self.ip == "127.0.0.1" else {}
+                if os.environ.get("RAY_PREFER_IPV6") is not None:
+                    kwargs = {"addr": "::"}
                 prometheus_client.start_http_server(
                     port=DASHBOARD_METRIC_PORT,
                     registry=metrics.registry,

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -313,7 +313,7 @@ class DashboardHead:
                     )
                 )
                 kwargs = {"addr": "127.0.0.1"} if self.ip == "127.0.0.1" else {}
-                if os.environ.get("RAY_PREFER_IPV6") is not None:
+                if ray_constants.RAY_PREFER_IPV6:
                     kwargs = {"addr": "::"}
                 prometheus_client.start_http_server(
                     port=DASHBOARD_METRIC_PORT,

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -449,6 +449,7 @@ class DashboardHead:
             if self.http_host != ray_constants.DEFAULT_DASHBOARD_IP
             else http_host
         )
+        dashboard_address = ray._private.network_utils.build_address(dashboard_http_host, http_port)
         # This synchronous code inside an async context is not great.
         # It is however acceptable, because this only gets run once
         # during initialization and therefore cannot block the event loop.
@@ -457,7 +458,7 @@ class DashboardHead:
         # server address to Ray via stdin / stdout or a pipe.
         self.gcs_client.internal_kv_put(
             ray_constants.DASHBOARD_ADDRESS.encode(),
-            f"{dashboard_http_host}:{http_port}".encode(),
+            dashboard_address.encode(),
             True,
             namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
         )

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -41,14 +41,14 @@ class HttpServerAgent:
         last_exception: Optional[OSError] = None
 
         http_address = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
-        if os.environ.get("RAY_PREFER_IPV6") is not None and http_address == "0.0.0.0":
-                http_address = "::"
+        if os.environ.get("RAY_PREFER_IPV6") is not None:
+            http_address = "::"
 
         for attempt in range(max_retries + 1):  # +1 for initial attempt
             try:
                 site = aiohttp.web.TCPSite(
                     self.runner,
-                    "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0",
+                    http_address,
                     self.listen_port,
                 )
                 await site.start()

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from packaging.version import Version
 
+from ray._private import ray_constants
 import ray.dashboard.optional_utils as dashboard_optional_utils
 from ray._common.utils import get_or_create_event_loop
 from ray.dashboard.optional_deps import aiohttp, aiohttp_cors, hdrs
@@ -41,7 +42,7 @@ class HttpServerAgent:
         last_exception: Optional[OSError] = None
 
         http_address = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
-        if os.environ.get("RAY_PREFER_IPV6") is not None:
+        if ray_constants.RAY_PREFER_IPV6:
             http_address = "::"
 
         for attempt in range(max_retries + 1):  # +1 for initial attempt

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import random
 from typing import List, Optional
 
@@ -38,6 +39,10 @@ class HttpServerAgent:
             OSError: If all retry attempts fail
         """
         last_exception: Optional[OSError] = None
+
+        http_address = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
+        if os.environ.get("RAY_PREFER_IPV6") is not None and http_address == "0.0.0.0":
+                http_address = "::"
 
         for attempt in range(max_retries + 1):  # +1 for initial attempt
             try:

--- a/python/ray/dashboard/http_server_head.py
+++ b/python/ray/dashboard/http_server_head.py
@@ -88,7 +88,7 @@ class HttpServerDashboardHead:
         self.http_host = http_host
         self.http_port = http_port
         self.http_port_retries = http_port_retries
-        self.head_node_ip = gcs_address.rsplit(":", 1)[0]
+        self.head_node_ip = ray._private.network_utils.parse_address(gcs_address)[0]
         self.metrics = metrics
         self._session_name = session_name
 

--- a/python/ray/dashboard/http_server_head.py
+++ b/python/ray/dashboard/http_server_head.py
@@ -88,7 +88,7 @@ class HttpServerDashboardHead:
         self.http_host = http_host
         self.http_port = http_port
         self.http_port_retries = http_port_retries
-        self.head_node_ip = gcs_address.split(":")[0]
+        self.head_node_ip = gcs_address.rsplit(":", 1)[0]
         self.metrics = metrics
         self._session_name = session_name
 

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -324,7 +324,7 @@ class JobHead(SubprocessModule):
                 # JobAgentSubmissionClient. May raise if the node_id is removed in
                 # InternalKV after the _fetch_all_agent_node_ids, though unlikely.
                 ip, http_port, _ = await self._fetch_agent_info(node_id)
-                agent_http_address = f"http://{ip}:{http_port}"
+                agent_http_address = ray._private.network_utils.build_address(ip, http_port)
                 self._agents[node_id] = JobAgentSubmissionClient(agent_http_address)
 
             return self._agents[node_id]
@@ -339,7 +339,7 @@ class JobHead(SubprocessModule):
 
         if head_node_id not in self._agents:
             ip, http_port, _ = await self._fetch_agent_info(head_node_id)
-            agent_http_address = f"http://{ip}:{http_port}"
+            agent_http_address = ray._private.network_utils.build_address(ip, http_port)
             self._agents[head_node_id] = JobAgentSubmissionClient(agent_http_address)
 
         return self._agents[head_node_id]

--- a/python/ray/dashboard/modules/job/job_supervisor.py
+++ b/python/ray/dashboard/modules/job/job_supervisor.py
@@ -336,9 +336,7 @@ class JobSupervisor:
             await _start_signal_actor.wait.remote()
 
         node = ray._private.worker.global_worker.node
-        driver_agent_http_address = (
-            f"http://{node.node_ip_address}:{node.dashboard_agent_listen_port}"
-        )
+        driver_agent_http_address = "http://"+ ray._private.network_utils.build_address(node.node_ip_address, node.dashboard_agent_listen_port)
         driver_node_id = ray.get_runtime_context().get_node_id()
 
         await self._job_info_client.put_status(

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -271,9 +271,7 @@ class NodeHead(SubprocessModule):
                 self._stubs.pop(node_id, None)
         DataSource.nodes[node_id] = node
         # TODO(fyrestone): Handle exceptions.
-        address = "{}:{}".format(
-            node["nodeManagerAddress"], int(node["nodeManagerPort"])
-        )
+        address = ray._private.network_utils.build_address(node["nodeManagerAddress"], int(node["nodeManagerPort"]))
         options = ray_constants.GLOBAL_GRPC_OPTIONS
         channel = ray._private.utils.init_grpc_channel(
             address, options, asynchronous=True

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -434,7 +434,7 @@ class ReporterAgent(
         self._gcs_client = dashboard_agent.gcs_client
         self._ip = dashboard_agent.ip
         self._log_dir = dashboard_agent.log_dir
-        self._is_head_node = self._ip == dashboard_agent.gcs_address.rsplit(":", 1)[0]
+        self._is_head_node = self._ip == ray._private.network_utils.parse_address(dashboard_agent.gcs_address)[0]
         self._hostname = socket.gethostname()
         # (pid, created_time) -> psutil.Process
         self._workers = {}

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -453,12 +453,15 @@ class ReporterAgent(
         self._open_telemetry_metric_recorder = None
         self._session_name = dashboard_agent.session_name
         if not self._metrics_collection_disabled:
+            http_address="127.0.0.1" if self._ip == "127.0.0.1" else "",
+            if os.environ.get("RAY_PREFER_IPV6") is not None:
+                http_address = "::"
             try:
                 stats_exporter = prometheus_exporter.new_stats_exporter(
                     prometheus_exporter.Options(
                         namespace="ray",
                         port=dashboard_agent.metrics_export_port,
-                        address="127.0.0.1" if self._ip == "127.0.0.1" else "",
+                        address=http_address,
                     )
                 )
             except Exception:

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -453,7 +453,7 @@ class ReporterAgent(
         self._open_telemetry_metric_recorder = None
         self._session_name = dashboard_agent.session_name
         if not self._metrics_collection_disabled:
-            http_address="127.0.0.1" if self._ip == "127.0.0.1" else "",
+            http_address = ("127.0.0.1" if self._ip == "127.0.0.1" else "")
             if os.environ.get("RAY_PREFER_IPV6") is not None:
                 http_address = "::"
             try:

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -34,6 +34,7 @@ from ray._private.ray_constants import (
     RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT,
     RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE,
     env_integer,
+    RAY_PREFER_IPV6,
 )
 from ray._private.telemetry.open_telemetry_metric_recorder import (
     OpenTelemetryMetricRecorder,
@@ -454,7 +455,7 @@ class ReporterAgent(
         self._session_name = dashboard_agent.session_name
         if not self._metrics_collection_disabled:
             http_address = ("127.0.0.1" if self._ip == "127.0.0.1" else "")
-            if os.environ.get("RAY_PREFER_IPV6") is not None:
+            if RAY_PREFER_IPV6:
                 http_address = "::"
             try:
                 stats_exporter = prometheus_exporter.new_stats_exporter(

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -434,7 +434,7 @@ class ReporterAgent(
         self._gcs_client = dashboard_agent.gcs_client
         self._ip = dashboard_agent.ip
         self._log_dir = dashboard_agent.log_dir
-        self._is_head_node = self._ip == dashboard_agent.gcs_address.split(":")[0]
+        self._is_head_node = self._ip == dashboard_agent.gcs_address.rsplit(":", 1)[0]
         self._hostname = socket.gethostname()
         # (pid, created_time) -> psutil.Process
         self._workers = {}

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -345,7 +345,7 @@ def to_posix_time(dt):
 def address_tuple(address):
     if isinstance(address, tuple):
         return address
-    ip, port = address.rsplit(":", 1)
+    ip, port = ray._private.network_utils.parse_address(address)
     return ip, int(port)
 
 

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -345,7 +345,7 @@ def to_posix_time(dt):
 def address_tuple(address):
     if isinstance(address, tuple):
         return address
-    ip, port = address.split(":")
+    ip, port = address.rsplit(":", 1)
     return ip, int(port)
 
 

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -15,6 +15,7 @@ from ray.includes.common cimport (
     kGcsAutoscalerClusterConfigKey,
     kGcsPidKey,
 )
+from ray._private import network_utils
 
 from ray.exceptions import (
     RayActorError,
@@ -50,7 +51,7 @@ cdef class GcsClientOptions:
             c_cluster_id = CClusterID.FromHex(cluster_id_hex)
         self = GcsClientOptions()
         try:
-            ip, port = gcs_address.rsplit(":", 1)
+            ip, port = network_utils.parse_address(gcs_address)
             port = int(port)
             self.inner.reset(
                 new CGcsClientOptions(

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -50,7 +50,7 @@ cdef class GcsClientOptions:
             c_cluster_id = CClusterID.FromHex(cluster_id_hex)
         self = GcsClientOptions()
         try:
-            ip, port = gcs_address.split(":", 2)
+            ip, port = gcs_address.rsplit(":", 1)
             port = int(port)
             self.inner.reset(
                 new CGcsClientOptions(

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -74,7 +74,7 @@ cdef class InnerGcsClient:
         cdef c_pair[c_string, int] pair = self.inner.get().GetGcsServerAddress()
         host = pair.first.decode("utf-8")
         port = pair.second
-        return f"{host}:{port}"
+        return ray._private.network_utils.build_address(host, port)
 
     @property
     def cluster_id(self) -> ray.ClusterID:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -730,10 +730,9 @@ def start(
     include_node_ip_address = False
 
     if node_ip_address is not None and is_ipv6_address(node_ip_address):
+        node_ip_address = node_ip_address.strip("[]")
         os.environ.update({"RAY_POD_IPV6": node_ip_address})
         os.environ.update({"RAY_PREFER_IPV6": "true"})
-        if head and port is not None:
-            os.environ.update({"RAY_GCS_SPECIFIC_PORT": str(port)})
     if node_ip_address is not None:
         include_node_ip_address = True
         node_ip_address = services.resolve_ip_for_localhost(node_ip_address)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -727,11 +727,13 @@ def start(
     # Whether the original arguments include node_ip_address.
     include_node_ip_address = False
 
-    if node_ip_address is None and is_ipv6_address(node_ip_address):
+    if node_ip_address is not None and is_ipv6_address(node_ip_address):
         if not node_ip_address.startswith("["):
             node_ip_address = "[" + node_ip_address + "]"
         os.environ.update({"RAY_POD_IPV6": node_ip_address})
         os.environ.update({"RAY_PREFER_IPV6": "true"})
+        if head and port is not None:
+            os.environ.update({"RAY_GCS_SPECIFIC_PORT": str(port)})
     if node_ip_address is not None:
         include_node_ip_address = True
         node_ip_address = services.resolve_ip_for_localhost(node_ip_address)

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -167,6 +167,7 @@ class _TorchBackend(Backend):
             master_addr, master_port = worker_group.execute_single(
                 0, get_address_and_port
             )
+            master_addr = master_addr.strip("[]")
             if backend_config.init_method == "env":
 
                 def set_env_vars(addr, port):

--- a/python/ray/util/collective/collective_group/gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/gloo_collective_group.py
@@ -45,7 +45,7 @@ class Rendezvous:
         self._context = context
         redis_address = ray._private.worker._global_node.redis_address
         (self._redis_ip_address, self._redis_port) = (
-            redis_address.rsplit(":", 1) if store_type == "redis" else (None, None)
+            ray._private.network_utils.parse_address(redis_address) if store_type == "redis" else (None, None)
         )
         self._process_ip_address = ray.util.get_node_ip_address()
         logger.debug(

--- a/python/ray/util/collective/collective_group/gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/gloo_collective_group.py
@@ -45,7 +45,7 @@ class Rendezvous:
         self._context = context
         redis_address = ray._private.worker._global_node.redis_address
         (self._redis_ip_address, self._redis_port) = (
-            redis_address.split(":") if store_type == "redis" else (None, None)
+            redis_address.rsplit(":", 1) if store_type == "redis" else (None, None)
         )
         self._process_ip_address = ray.util.get_node_ip_address()
         logger.debug(

--- a/python/ray/util/rpdb.py
+++ b/python/ray/util/rpdb.py
@@ -228,7 +228,7 @@ def _connect_ray_pdb(
     """
     Opens a remote PDB on first available port.
     """
-    if os.environ.get("RAY_PREFER_IPV6") is not None:
+    if ray_constants.RAY_PREFER_IPV6:
         host = "::"
     elif debugger_external:
         assert not host, "Cannot specify both host and debugger_external"

--- a/python/ray/util/rpdb.py
+++ b/python/ray/util/rpdb.py
@@ -102,7 +102,10 @@ class _RemotePdb(Pdb):
         self._breakpoint_uuid = breakpoint_uuid
         self._quiet = quiet
         self._patch_stdstreams = patch_stdstreams
-        self._listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if host == "::":
+            self._listen_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        else:
+            self._listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
         self._listen_socket.bind((host, port))
         self._ip_address = ip_address
@@ -225,7 +228,9 @@ def _connect_ray_pdb(
     """
     Opens a remote PDB on first available port.
     """
-    if debugger_external:
+    if os.environ.get("RAY_PREFER_IPV6") is not None:
+        host = "::"
+    elif debugger_external:
         assert not host, "Cannot specify both host and debugger_external"
         host = "0.0.0.0"
     elif host is None:
@@ -344,8 +349,12 @@ def _post_mortem():
 def _connect_pdb_client(host, port):
     if sys.platform == "win32":
         import msvcrt
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect((host, port))
+    if host.startswith("[") and host.endswith("]"):
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        s.connect((host[1:-1], port))
+    else:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((host, port))
 
     while True:
         # Get the list of sockets which are readable.

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -130,7 +130,7 @@ class RayClusterOnSpark:
             ray.init(address=self.address)
 
             if self.ray_dashboard_port is not None and _wait_service_up(
-                self.address.rsplit(":", 1)[0],
+                ray._private.network_utils.parse_address(self.address)[0],
                 self.ray_dashboard_port,
                 _RAY_DASHBOARD_STARTUP_TIMEOUT,
             ):
@@ -1206,8 +1206,8 @@ def _setup_ray_cluster_internal(
                 pass
             raise RuntimeError("Launch Ray-on-Spark cluster failed") from e
 
-    head_ip = cluster.address.rsplit(":", 1)[0]
-    remote_connection_address = f"ray://{head_ip}:{cluster.ray_client_server_port}"
+    head_ip = ray._private.network_utils.parse_address(cluster.address)[0]
+    remote_connection_address = f"ray://{ray._private.network_utils.build_address(head_ip, cluster.ray_client_server_port)}"
     return cluster.address, remote_connection_address
 
 

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -130,7 +130,7 @@ class RayClusterOnSpark:
             ray.init(address=self.address)
 
             if self.ray_dashboard_port is not None and _wait_service_up(
-                self.address.split(":")[0],
+                self.address.rsplit(":", 1)[0],
                 self.ray_dashboard_port,
                 _RAY_DASHBOARD_STARTUP_TIMEOUT,
             ):
@@ -1206,7 +1206,7 @@ def _setup_ray_cluster_internal(
                 pass
             raise RuntimeError("Launch Ray-on-Spark cluster failed") from e
 
-    head_ip = cluster.address.split(":")[0]
+    head_ip = cluster.address.rsplit(":", 1)[0]
     remote_connection_address = f"ray://{head_ip}:{cluster.ray_client_server_port}"
     return cluster.address, remote_connection_address
 

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -807,7 +807,7 @@ def _get_head_node_ip(address: Optional[str] = None):
     """
     try:
         address = services.canonicalize_bootstrap_address_or_die(address)
-        return address.rsplit(":", 1)[0]
+        return ray._private.network_utils.parse_address(address)[0]
     except (ConnectionError, ValueError) as e:
         # Hide all the stack trace
         raise click.UsageError(str(e))

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -807,7 +807,7 @@ def _get_head_node_ip(address: Optional[str] = None):
     """
     try:
         address = services.canonicalize_bootstrap_address_or_die(address)
-        return address.split(":")[0]
+        return address.rsplit(":", 1)[0]
     except (ConnectionError, ValueError) as e:
         # Hide all the stack trace
         raise click.UsageError(str(e))

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -145,8 +145,9 @@ class StateDataSourceClient:
 
     def get_raylet_stub(self, ip: str, port: int):
         options = _STATE_MANAGER_GRPC_OPTIONS
+        address = ray._private.network_utils.build_address(ip, port)
         channel = ray._private.utils.init_grpc_channel(
-            f"{ip}:{port}", options, asynchronous=True
+            address, options, asynchronous=True
         )
         return NodeManagerServiceStub(channel)
 
@@ -161,8 +162,9 @@ class StateDataSourceClient:
             return None
         ip, http_port, grpc_port = json.loads(agent_addr)
         options = ray_constants.GLOBAL_GRPC_OPTIONS
+        address = ray._private.network_utils.build_address(ip, grpc_port)
         channel = ray._private.utils.init_grpc_channel(
-            f"{ip}:{grpc_port}", options=options, asynchronous=True
+            address, options=options, asynchronous=True
         )
         return LogServiceStub(channel)
 
@@ -422,7 +424,7 @@ class StateDataSourceClient:
                 f"Expected non empty node ip and runtime env agent port, got {node_ip} and {runtime_env_agent_port}."
             )
         timeout = aiohttp.ClientTimeout(total=timeout)
-        url = f"http://{node_ip}:{runtime_env_agent_port}/get_runtime_envs_info"
+        url = "http://"+ ray._private.network_utils.build_address(node_ip, runtime_env_agent_port) + "/get_runtime_envs_info"
         request = GetRuntimeEnvsInfoRequest(limit=limit)
         data = request.SerializeToString()
         async with self._client_session.post(url, data=data, timeout=timeout) as resp:

--- a/src/ray/common/network_util.cc
+++ b/src/ray/common/network_util.cc
@@ -14,6 +14,7 @@
 
 #include "ray/common/network_util.h"
 
+#include "absl/strings/str_format.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/util/logging.h"
 
@@ -27,4 +28,13 @@ bool CheckPortFree(int port) {
   socket.bind(boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port), ec);
   socket.close();
   return !ec.failed();
+}
+
+std::string BuildAddress(const std::string &host, int port) {
+  if (host.find(':') != std::string::npos) {
+      // If the host contains a colon, assume it's an IPv6 address
+      return absl::StrFormat("[%s]:%d", host, port);
+  } else {
+      return absl::StrFormat("%s:%d", host, port);
+  }
 }

--- a/src/ray/common/network_util.h
+++ b/src/ray/common/network_util.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <string>
+
 // Check whether the given [port] is available, via attempt to bind a socket to the port.
 // Notice, the check could be non-authentic if there're concurrent port assignments.
 bool CheckPortFree(int port);
+
+std::string BuildAddress(const std::string &host, int port);

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -33,6 +33,7 @@
 #include "ray/rpc/gcs_server/gcs_rpc_client.h"
 #include "ray/util/logging.h"
 #include "src/ray/protobuf/autoscaler.grpc.pb.h"
+#include "ray/util/util.h"
 
 namespace ray {
 
@@ -65,7 +66,7 @@ class GcsClientOptions {
       : cluster_id_(cluster_id),
         should_fetch_cluster_id_(ShouldFetchClusterId(
             cluster_id, allow_cluster_id_nil, fetch_cluster_id_if_nil)) {
-    std::vector<std::string> address = absl::StrSplit(gcs_address, ':');
+    std::vector<std::string> address = SplitIpPort(gcs_address);
     RAY_LOG(DEBUG) << "Connect to gcs server via address: " << gcs_address;
     RAY_CHECK(address.size() == 2);
     gcs_address_ = address[0];

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -405,7 +405,7 @@ std::optional<std::pair<std::string, int>> ParseIffMovedError(
     return std::nullopt;
   }
   RAY_CHECK_EQ(parts.size(), 3u);
-  std::vector<std::string> ip_port = absl::StrSplit(parts[2], ":");
+  std::vector<std::string> ip_port = SplitIpPort(parts[2]);
   RAY_CHECK_EQ(ip_port.size(), 2u);
   return std::make_pair(ip_port[0], std::stoi(ip_port[1]));
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -210,15 +210,9 @@ NodeManager::NodeManager(
   dashboard_agent_manager_ = CreateDashboardAgentManager(self_node_id, config);
   runtime_env_agent_manager_ = CreateRuntimeEnvAgentManager(self_node_id, config);
 
-  std::string runtime_env_agent_ip = std::string(config.node_manager_address);
-  bool is_ipv6 = std::getenv("RAY_PREFER_IPV6") != nullptr;
-  if (is_ipv6) {
-    runtime_env_agent_ip =
-        runtime_env_agent_ip.substr(1, runtime_env_agent_ip.length() - 2);
-  }
   auto runtime_env_agent_client = RuntimeEnvAgentClient::Create(
       io_service_,
-      runtime_env_agent_ip,
+      config.node_manager_address,
       config.runtime_env_agent_port, /*delay_executor=*/
       [this](std::function<void()> task, uint32_t delay_ms) {
         return execute_after(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -210,9 +210,15 @@ NodeManager::NodeManager(
   dashboard_agent_manager_ = CreateDashboardAgentManager(self_node_id, config);
   runtime_env_agent_manager_ = CreateRuntimeEnvAgentManager(self_node_id, config);
 
+  std::string runtime_env_agent_ip = std::string(config.node_manager_address);
+  bool is_ipv6 = std::getenv("RAY_PREFER_IPV6") != nullptr;
+  if (is_ipv6) {
+    runtime_env_agent_ip =
+        runtime_env_agent_ip.substr(1, runtime_env_agent_ip.length() - 2);
+  }
   auto runtime_env_agent_client = RuntimeEnvAgentClient::Create(
       io_service_,
-      config.node_manager_address,
+      runtime_env_agent_ip,
       config.runtime_env_agent_port, /*delay_executor=*/
       [this](std::function<void()> task, uint32_t delay_ms) {
         return execute_after(

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "ray/common/grpc_util.h"
+#include "ray/common/network_util.h"
 #include "ray/common/ray_config.h"
 #include "ray/common/status.h"
 #include "ray/rpc/client_call.h"
@@ -83,9 +84,9 @@ inline std::shared_ptr<grpc::Channel> BuildChannel(
     ssl_opts.pem_cert_chain = server_cert_chain;
     auto ssl_creds = grpc::SslCredentials(ssl_opts);
     channel = grpc::CreateCustomChannel(
-        address + ":" + std::to_string(port), ssl_creds, *arguments);
+        BuildAddress(address, port), ssl_creds, *arguments);
   } else {
-    channel = grpc::CreateCustomChannel(address + ":" + std::to_string(port),
+    channel = grpc::CreateCustomChannel(BuildAddress(address, port),
                                         grpc::InsecureChannelCredentials(),
                                         *arguments);
   }

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -27,6 +27,7 @@
 #include "ray/common/ray_config.h"
 #include "ray/rpc/common.h"
 #include "ray/util/thread_utils.h"
+#include "ray/util/util.h"
 
 namespace ray {
 namespace rpc {
@@ -61,8 +62,7 @@ void GrpcServer::Shutdown() {
 
 void GrpcServer::Run() {
   uint32_t specified_port = port_;
-  const char *ray_ip = std::getenv("RAY_PREFER_IPV6");
-  bool use_ipv6 = ray_ip != nullptr;
+  const bool use_ipv6 = IsEnvTrue("RAY_PREFER_IPV6")
   std::string server_address(
       (listen_to_localhost_only_ ? "127.0.0.1:" : (use_ipv6 ? "[::]:" : "0.0.0.0:")) +
       std::to_string(port_));

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -61,8 +61,11 @@ void GrpcServer::Shutdown() {
 
 void GrpcServer::Run() {
   uint32_t specified_port = port_;
-  std::string server_address((listen_to_localhost_only_ ? "127.0.0.1:" : "0.0.0.0:") +
-                             std::to_string(port_));
+  const char *ray_ip = std::getenv("RAY_PREFER_IPV6");
+  bool use_ipv6 = ray_ip != nullptr;
+  std::string server_address(
+      (listen_to_localhost_only_ ? "127.0.0.1:" : (use_ipv6 ? "[::]:" : "0.0.0.0:")) +
+      std::to_string(port_));
   grpc::ServerBuilder builder;
   // Disable the SO_REUSEPORT option. We don't need it in ray. If the option is enabled
   // (default behavior in grpc), we may see multiple workers listen on the same port and

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -70,6 +70,12 @@ inline std::vector<std::string> SplitIpPort(const std::string &address) {
   }
 
   result.push_back(address.substr(0, found));
+  if (result[0].front() == '[') {
+    result[0].erase(0, 1);  // Remove the leading '[' if present.
+  }
+  if (result[0].back() == ']') {
+    result[0].pop_back();  // Remove the trailing ']' if present.
+  }
   result.push_back(address.substr(found + 1));
   return result;
 }

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -61,6 +61,19 @@ class stream_protocol;
 
 }  // namespace boost::asio::generic
 
+inline std::vector<std::string> SplitIpPort(const std::string &address) {
+  std::vector<std::string> result;
+  size_t found;
+  found = address.find_last_of(":");
+  if (found == std::string::npos) {
+    return result;
+  }
+
+  result.push_back(address.substr(0, found));
+  result.push_back(address.substr(found + 1));
+  return result;
+}
+
 // Append append_str to the beginning of each line of str.
 inline std::string AppendToEachLine(const std::string &str,
                                     const std::string &append_str) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Some previous issues also describe requirements for the use of IPv6. I think IPv6 mode is important feature for Ray. Many online environments have IPv6 network cards, and ray could not running on machines which only support IPv6 cards.

In our enviroment, we are running ray in ipv6 host network mode kubernetes pod.

## Related issue number
https://github.com/ray-project/ray/issues/54660
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
