### PR TITLE
[Data] Prefetch data for `PandasJSONDatasource`

### DIFF
--- a/python/ray/data/_internal/datasource/json_datasource.py
+++ b/python/ray/data/_internal/datasource/json_datasource.py
@@ -1,5 +1,6 @@
+import io
 import logging
-from io import BytesIO
+from io import BufferedReader, BytesIO
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import pandas as pd
@@ -159,6 +160,15 @@ class ArrowJSONDatasource(FileBasedDatasource):
 
 
 class PandasJSONDatasource(FileBasedDatasource):
+
+    # Buffer size in bytes for reading files.
+    #
+    # pandas reads data in small chunks (~8 KiB), which leads to many costly
+    # small read requests when accessing cloud storage. To reduce overhead and
+    # improve performance, we wrap the file in a larger buffered reader that
+    # reads bigger blocks at once.
+    _BUFFER_SIZE = 128 * 1024
+
     def __init__(
         self,
         paths: Union[str, List[str]],
@@ -171,22 +181,24 @@ class PandasJSONDatasource(FileBasedDatasource):
 
     def _read_stream(self, f: "pyarrow.NativeFile", path: str):
         chunksize = self._estimate_chunksize(f)
-        with pd.read_json(f, chunksize=chunksize, lines=True) as reader:
+        stream = StrictBufferedReader(f, buffer_size=self._BUFFER_SIZE)
+        with pd.read_json(stream, chunksize=chunksize, lines=True) as reader:
             for df in reader:
                 yield _cast_range_index_to_string(df)
 
     def _estimate_chunksize(self, f: "pyarrow.NativeFile") -> int:
         assert f.tell() == 0, "File pointer must be at the beginning"
 
-        with pd.read_json(f, chunksize=1, lines=True) as reader:
+        stream = StrictBufferedReader(f, buffer_size=self._BUFFER_SIZE)
+        with pd.read_json(stream, chunksize=1, lines=True) as reader:
             df = _cast_range_index_to_string(next(reader))
 
         block_accessor = PandasBlockAccessor.for_block(df)
         if block_accessor.num_rows() == 0:
-            return 1
-
-        bytes_per_row = block_accessor.size_bytes() / block_accessor.num_rows()
-        chunksize = max(round(self._target_output_size_bytes / bytes_per_row), 1)
+            chunksize = 1
+        else:
+            bytes_per_row = block_accessor.size_bytes() / block_accessor.num_rows()
+            chunksize = max(round(self._target_output_size_bytes / bytes_per_row), 1)
 
         # Reset file pointer to the beginning.
         f.seek(0)
@@ -199,7 +211,7 @@ class PandasJSONDatasource(FileBasedDatasource):
         path: str,
         **open_args,
     ) -> "pyarrow.NativeFile":
-        # Use seekable file to ensure we can correctly sample the first row.
+        # Use seekable file so we can reset the file after sampling the first row.
         file = filesystem.open_input_file(path, **open_args)
         assert file.seekable(), "File must be seekable"
         return file
@@ -211,3 +223,34 @@ def _cast_range_index_to_string(df: pd.DataFrame):
     if isinstance(df.columns, pd.RangeIndex):
         df.columns = df.columns.astype(str)
     return df
+
+
+class StrictBufferedReader(io.RawIOBase):
+    """Wrapper that prevents premature file closure and ensures full-buffered reads.
+
+    This is necessary for two reasons:
+    1. The datasource reads the file twice -- first to sample and determine the chunk size,
+       and again to load the actual data. Since pandas assumes ownership of the file and
+       may close it, we prevent that by explicitly detaching the underlying file before
+       closing the buffer.
+
+    2. pandas wraps the file in a TextIOWrapper to decode bytes into text. TextIOWrapper
+       prefers calling read1(), which doesn't prefetch for random-access files (e.g.,
+       from PyArrow), resulting in slow reads. This wrapper ensures that all reads go
+       through the full buffer and avoids read1().
+    """
+
+    def __init__(self, file, buffer_size: int):
+        self._file = BufferedReader(file, buffer_size=buffer_size)
+
+    def read(self, size=-1, /):
+        return self._file.read(size)
+
+    def readable(self) -> bool:
+        return True
+
+    def close(self):
+        if not self.closed:
+            self._file.detach()
+            self._file.close()
+            super().close()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`PandasJSONDatasource` reads a file twice: once to sample a row and infer the numbers of rows to read per batch, and again to actually load the data. To reset the file after sampling, the datasource opens the file as a random-access file. 

The issue is that PyArrow's random-access file doesn't prefetch enough data, which leads to many costly small requests and poor performance.

To mitigate this issue, this PR wraps the file in `io.BufferedReader` and prefetches more data.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
