### PR TITLE
[Serve.llm] choose better default values for deployment configs so that they are not the bottleneck

### DIFF
--- a/python/ray/llm/_internal/serve/configs/constants.py
+++ b/python/ray/llm/_internal/serve/configs/constants.py
@@ -18,8 +18,6 @@ DEFAULT_MULTIPLEX_DOWNLOAD_TRIES = int(
     os.getenv("DEFAULT_MULTIPLEX_DOWNLOAD_RETRIES", "3")
 )
 
-DEFAULT_TARGET_ONGOING_REQUESTS = 16
-
 
 # If true, a default runtime_env will be injected to import rayllm on worker startup.
 # This is a startup time optimization to avoid the latency penalty of sequentially
@@ -36,11 +34,20 @@ CLOUD_OBJECT_EXISTS_EXPIRE_S = 60 * 60
 LORA_ADAPTER_CONFIG_NAME = "adapter_config.json"
 
 DEFAULT_HEALTH_CHECK_PERIOD_S = int(
-    os.getenv("RAYLLM_DEFAULT_HEALTH_CHECK_PERIOD_S", "10")
+    os.getenv("RAY_SERVE_LLM_DEFAULT_HEALTH_CHECK_PERIOD_S", "10")
 )
 DEFAULT_HEALTH_CHECK_TIMEOUT_S = int(
-    os.getenv("RAYLLM_DEFAULT_HEALTH_CHECK_TIMEOUT_S", "10")
+    os.getenv("RAY_SERVE_LLM_DEFAULT_HEALTH_CHECK_TIMEOUT_S", "10")
 )
+DEFAULT_MAX_ONGOING_REQUESTS = int(
+    os.getenv("RAY_SERVE_LLM_DEFAULT_MAX_ONGOING_REQUESTS", str(int(1e9)))
+)
+DEFAULT_MAX_REPLICAS = int(os.getenv("RAY_SERVE_LLM_DEFAULT_MAX_REPLICAS", "10"))
+DEFAULT_MAX_TARGET_ONGOING_REQUESTS = int(
+    os.getenv("RAY_SERVE_LLM_DEFAULT_MAX_TARGET_ONGOING_REQUESTS", str(int(1e9)))
+)
+
+
 ENGINE_START_TIMEOUT_S = int(os.getenv("RAYLLM_ENGINE_START_TIMEOUT_S", str(60 * 60)))
 
 MIN_NUM_TOPLOGPROBS_ALLOWED = 0
@@ -61,27 +68,33 @@ ENV_VARS_TO_PROPAGATE = {
     "HF_TOKEN",
 }
 # timeout in 10 minutes. Streaming can take longer than 3 min
-RAYLLM_ROUTER_HTTP_TIMEOUT = float(os.environ.get("RAYLLM_ROUTER_HTTP_TIMEOUT", 600))
+DEFAULT_LLM_ROUTER_HTTP_TIMEOUT = float(
+    os.environ.get("RAY_SERVE_LLM_ROUTER_HTTP_TIMEOUT", 600)
+)
 
 ENABLE_VERBOSE_TELEMETRY = bool(int(os.getenv("RAYLLM_ENABLE_VERBOSE_TELEMETRY", "0")))
 
 RAYLLM_VLLM_ENGINE_CLS_ENV = "RAYLLM_VLLM_ENGINE_CLS"
 
-# The ratio of number of router replicas to number of model replicas. Default to 2
-# meaning that there are 2 router replicas for every model replica.
-ROUTER_TO_MODEL_REPLICA_RATIO = float(
-    os.getenv("RAYLLM_ROUTER_TO_MODEL_REPLICA_RATIO", "2")
+# The ratio of number of router replicas to number of model replicas.
+# Default to 2 meaning that there are 2 router replicas for every model replica.
+DEFAULT_ROUTER_TO_MODEL_REPLICA_RATIO = float(
+    os.getenv("RAY_SERVE_LLM_ROUTER_TO_MODEL_REPLICA_RATIO", "2")
 )
 
-RAYLLM_ROUTER_MIN_REPLICAS = int(os.environ.get("RAYLLM_ROUTER_MIN_REPLICAS", 0))
-RAYLLM_ROUTER_INITIAL_REPLICAS = int(
-    os.environ.get("RAYLLM_ROUTER_INITIAL_REPLICAS", 2)
+DEFAULT_LLM_ROUTER_MIN_REPLICAS = int(
+    os.environ.get("RAY_SERVE_LLM_ROUTER_MIN_REPLICAS", 0)
 )
-RAYLLM_ROUTER_MAX_REPLICAS = int(os.environ.get("RAYLLM_ROUTER_MAX_REPLICAS", 16))
-RAYLLM_ROUTER_TARGET_ONGOING_REQUESTS = int(
+DEFAULT_LLM_ROUTER_INITIAL_REPLICAS = int(
+    os.environ.get("RAY_SERVE_LLM_ROUTER_INITIAL_REPLICAS", 2)
+)
+DEFAULT_LLM_ROUTER_MAX_REPLICAS = int(
+    os.environ.get("RAY_SERVE_LLM_ROUTER_MAX_REPLICAS", 16)
+)
+DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS = int(
     os.environ.get(
-        "RAYLLM_ROUTER_TARGET_ONGOING_REQUESTS",
-        DEFAULT_TARGET_ONGOING_REQUESTS,  # 16
+        "RAY_SERVE_LLM_ROUTER_TARGET_ONGOING_REQUESTS",
+        DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
     )
 )
 

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -18,6 +18,9 @@ from ray._common.utils import import_attr
 from ray.llm._internal.serve.configs.constants import (
     DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_HEALTH_CHECK_TIMEOUT_S,
+    DEFAULT_MAX_ONGOING_REQUESTS,
+    DEFAULT_MAX_REPLICAS,
+    DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
     ENGINE_START_TIMEOUT_S,
     MODEL_RESPONSE_BATCH_TIMEOUT_MS,
     RAYLLM_VLLM_ENGINE_CLS_ENV,
@@ -351,17 +354,10 @@ class LLMServer(_LLMServerBase):
     autoscaling_config={
         "min_replicas": 1,
         "initial_replicas": 1,
-        "max_replicas": 10,
-        "target_ongoing_requests": int(
-            os.environ.get(
-                "RAYLLM_ROUTER_TARGET_ONGOING_REQUESTS",
-                os.environ.get(
-                    "RAYLLM_ROUTER_TARGET_NUM_ONGOING_REQUESTS_PER_REPLICA", 10
-                ),
-            )
-        ),
+        "max_replicas": DEFAULT_MAX_REPLICAS,
+        "target_ongoing_requests": DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
     },
-    max_ongoing_requests=20,  # Maximum backlog for a single replica
+    max_ongoing_requests=DEFAULT_MAX_ONGOING_REQUESTS,
     health_check_period_s=DEFAULT_HEALTH_CHECK_PERIOD_S,
     health_check_timeout_s=DEFAULT_HEALTH_CHECK_TIMEOUT_S,
 )

--- a/python/ray/llm/tests/serve/cpu/builders/test_application_builders.py
+++ b/python/ray/llm/tests/serve/cpu/builders/test_application_builders.py
@@ -15,7 +15,7 @@ from ray.llm._internal.serve.builders.application_builders import (
     build_openai_app,
 )
 from ray.llm._internal.serve.configs.constants import (
-    RAYLLM_ROUTER_TARGET_ONGOING_REQUESTS,
+    DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS,
 )
 from ray.llm._internal.serve.configs.server_models import (
     LLMConfig,
@@ -180,7 +180,7 @@ class TestBuildOpenaiApp:
         assert router_autoscaling_config.max_replicas == 12  # (1 + 1 + 4) * 2
         assert (
             router_autoscaling_config.target_ongoing_requests
-            == RAYLLM_ROUTER_TARGET_ONGOING_REQUESTS
+            == DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS
         )
 
 

--- a/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_quantized_tp1.yaml
+++ b/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_quantized_tp1.yaml
@@ -1,4 +1,3 @@
-# NOTE: This is used for perf testing as well, so cuda graph must be enabled.
 model_loading_config:
   model_id: neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
 
@@ -7,3 +6,5 @@ accelerator_type: A10G
 engine_kwargs:
   max_model_len: 8192
   tensor_parallel_size: 1
+  # NOTE: This is used for perf testing as well, so cuda graph must be enabled.
+  enforce_eager: false

--- a/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_quantized_tp1.yaml
+++ b/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_quantized_tp1.yaml
@@ -1,3 +1,4 @@
+# NOTE: This is used for perf testing as well, so cuda graph must be enabled.
 model_loading_config:
   model_id: neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
 
@@ -6,4 +7,3 @@ accelerator_type: A10G
 engine_kwargs:
   max_model_len: 8192
   tensor_parallel_size: 1
-  enforce_eager: true

--- a/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_tp2.yaml
+++ b/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_tp2.yaml
@@ -1,3 +1,4 @@
+# NOTE: This is used for perf testing as well, so cuda graph must be enabled.
 model_loading_config:
   model_id: meta-llama/Llama-3.1-8B-Instruct
 
@@ -6,4 +7,3 @@ accelerator_type: A10G
 engine_kwargs:
   max_model_len: 8192
   tensor_parallel_size: 2
-  enforce_eager: true

--- a/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_tp2.yaml
+++ b/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_tp2.yaml
@@ -1,4 +1,3 @@
-# NOTE: This is used for perf testing as well, so cuda graph must be enabled.
 model_loading_config:
   model_id: meta-llama/Llama-3.1-8B-Instruct
 
@@ -7,3 +6,5 @@ accelerator_type: A10G
 engine_kwargs:
   max_model_len: 8192
   tensor_parallel_size: 2
+  # NOTE: This is used for perf testing as well, so cuda graph must be enabled.
+  enforce_eager: false


### PR DESCRIPTION
In ray serve, the default (not setting anything from user) should have the following expectations: 

1. It should not autoscale at a low num concurrency unless user specifies the threshold explicilty -- therefore the default target ongoing request should be set super high (1e9)
2. It should not limit the max ongoing request and let vllm manage the internal scheduling -- therefore the default max_ongoing_request should also be set super high (1e9)

This PR also modifies the naming of a few env variables and removes the RAYLLM prefix from them. None of these env variables are meant to be public or documented yet. The documented versions are the flags passed to LLMConfig.


Hopefully after this PR the regression on perf on our perf tests would also be addressed (changing eager --> cuda graph and setting higher default for concurrency=32)