### PR TITLE
[V2][Autoscaler] Fix `_compute_to_launch` rate limiting upscaling on cold start

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -848,7 +848,7 @@ class Reconciler:
             # Enforce the max allowed pending nodes based on current running nodes
             num_desired_to_upscale = max(
                 1,
-                math.ceil(upscaling_speed * len(running_instances_for_type)),
+                math.ceil(upscaling_speed * max(len(running_instances_for_type), 1)),
             )
 
             # Enforce global limit, at most we can launch `max_concurrent_launches`

--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -9,10 +9,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
 from ray._private.protobuf_compat import message_to_dict
-from ray.autoscaler._private.constants import (
-    AUTOSCALER_CONSERVE_GPU_NODES,
-    AUTOSCALER_MAX_CONCURRENT_LAUNCHES,
-)
+from ray.autoscaler._private.constants import AUTOSCALER_CONSERVE_GPU_NODES
 from ray.autoscaler._private.resource_demand_scheduler import (
     UtilizationScore,
     _fits,
@@ -1409,12 +1406,7 @@ class ResourceDemandScheduler(IResourceScheduler):
         while len(requests_to_sched) > 0 and len(node_pools) > 0:
             # Max number of nodes reached.
             max_num_nodes = ctx.get_max_num_nodes()
-            current_target_nodes = [
-                n for n in target_nodes if n.status == SchedulingNodeStatus.TO_LAUNCH
-            ]
-            if (
-                max_num_nodes is not None and len(target_nodes) >= max_num_nodes
-            ) or len(current_target_nodes) >= AUTOSCALER_MAX_CONCURRENT_LAUNCHES:
+            if max_num_nodes is not None and len(target_nodes) >= max_num_nodes:
                 logger.debug(
                     "Max number of nodes reached: {}, "
                     "cannot launch more nodes.".format(max_num_nodes)

--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -9,7 +9,10 @@ from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
 from ray._private.protobuf_compat import message_to_dict
-from ray.autoscaler._private.constants import AUTOSCALER_CONSERVE_GPU_NODES
+from ray.autoscaler._private.constants import (
+    AUTOSCALER_CONSERVE_GPU_NODES,
+    AUTOSCALER_MAX_CONCURRENT_LAUNCHES,
+)
 from ray.autoscaler._private.resource_demand_scheduler import (
     UtilizationScore,
     _fits,
@@ -1406,7 +1409,12 @@ class ResourceDemandScheduler(IResourceScheduler):
         while len(requests_to_sched) > 0 and len(node_pools) > 0:
             # Max number of nodes reached.
             max_num_nodes = ctx.get_max_num_nodes()
-            if max_num_nodes is not None and len(target_nodes) >= max_num_nodes:
+            current_target_nodes = [
+                n for n in target_nodes if n.status == SchedulingNodeStatus.TO_LAUNCH
+            ]
+            if (
+                max_num_nodes is not None and len(target_nodes) >= max_num_nodes
+            ) or len(current_target_nodes) >= AUTOSCALER_MAX_CONCURRENT_LAUNCHES:
                 logger.debug(
                     "Max number of nodes reached: {}, "
                     "cannot launch more nodes.".format(max_num_nodes)

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -713,7 +713,7 @@ class TestReconciler:
             TestReconciler._add_instances(instance_storage, [instance])
             next_id += 1
 
-        num_desired_upscale = max(1, math.ceil(upscaling_speed * (num_running)))
+        num_desired_upscale = max(1, math.ceil(upscaling_speed * (max(num_running, 1))))
         expected_launch_num = min(
             num_desired_upscale,
             max(0, max_concurrent_launches - num_requested),  # global limit


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when the v2 autoscaler calculates the number of `QUEUED` nodes to transition to `REQUESTED` or "launch", the number of nodes is rate limited to `upscaling_speed * running_instances`. For all current Ray releases, it was previously:
```
upscaling_speed
    * (
       len(requested_instances_for_type)
       + len(allocated_instances_for_type)
      )
```

For default upscaling mode with KubeRay, `upscaling_speed` will equal 0 and otherwise will be a value greater than 0 (for default/aggressive `upscaling_speed = 1000`). Thus, for both the above calculations of `upscaling_speed` on cold start of a Ray autoscaling cluster (i.e 0 queued instances have been launched yet), the autoscaler will always launch 1 node on the initial iteration before launching the remaining nodes to satisfy the resource requests. This contributes to the issue in https://github.com/ray-project/kuberay/issues/3794 where a large number of requests cause the autoscaler to hang calling `try_schedule` on the first in-flight node.

I manually tested this fix in the related issue thread.

## Related issue number

[#3794](https://github.com/ray-project/kuberay/issues/3794)

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests - already covered by `test_max_concurrent_launches`
   - [ ] Release tests
   - [ ] This PR is not tested :(
