### PR TITLE
Train Tests: Update timeout for skip_training.jpeg.preserve_order

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2191,7 +2191,7 @@
 
     - __suffix__: skip_training.jpeg.preserve_order
       run:
-        timeout: 1200
+        timeout: 2400
         script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --preserve_order
 
     - __suffix__: skip_training.jpeg.torch_dataloader


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Train Tests: Update timeout for skip_training.jpeg.preserve_order from 1200 to 2400 secs for [test failure](https://buildkite.com/ray-project/release/builds/49206#0198170e-4c70-488c-8a5c-72a58ad74a31
).

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
