### PR TITLE
[Data] BundleQueue has_next

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -120,9 +120,6 @@ python/ray/_private/ray_logging/__init__.py
     DOC101: Function `run_callback_on_events_in_ipython`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `run_callback_on_events_in_ipython`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [event: str].
 --------------------
-python/ray/_private/ray_option_utils.py
-    DOC201: Function `_counting_option` does not have a return section in docstring
---------------------
 python/ray/_private/resource_isolation_config.py
     DOC101: Method `ResourceIsolationConfig.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `ResourceIsolationConfig.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cgroup_path: Optional[str], enable_resource_isolation: bool, system_reserved_cpu: Optional[float], system_reserved_memory: Optional[int]].
@@ -1096,9 +1093,6 @@ python/ray/data/_internal/equalize.py
     DOC101: Function `_equalize`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `_equalize`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [owned_by_consumer: bool].
     DOC103: Function `_shave_all_splits`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [per_split_num_rows: List[List[int]]].
---------------------
-python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
-    DOC201: Method `BundleQueue.pop` does not have a return section in docstring
 --------------------
 python/ray/data/_internal/execution/interfaces/execution_options.py
     DOC201: Method `ExecutionResources.for_limits` does not have a return section in docstring

--- a/python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
+++ b/python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
@@ -43,10 +43,7 @@ class BundleQueue(abc.ABC):
 
     @abc.abstractmethod
     def has_next(self) -> bool:
-        """Check if the queue has a valid bundle.
-
-        A valid bundle is one that has all its objects in the object store.
-        """
+        """Check if the queue has a valid bundle."""
         ...
 
     @abc.abstractmethod

--- a/python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
+++ b/python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
@@ -22,7 +22,7 @@ class BundleQueue(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def pop(self) -> "RefBundle":
+    def get_next(self) -> "RefBundle":
         """Remove and return the head of the queue.
 
         Raises:
@@ -31,10 +31,18 @@ class BundleQueue(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def peek(self) -> Optional["RefBundle"]:
+    def peek_next(self) -> Optional["RefBundle"]:
         """Return the head of the queue without removing it.
 
         If the queue is empty, return `None`.
+        """
+        ...
+
+    @abc.abstractmethod
+    def has_next(self) -> bool:
+        """Check if the queue has a valid bundle.
+
+        A valid bundle is one that has all its objects in the object store.
         """
         ...
 

--- a/python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
+++ b/python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
@@ -27,6 +27,9 @@ class BundleQueue(abc.ABC):
 
         Raises:
             IndexError: If the queue is empty.
+
+        Returns:
+            A Refbundle if has_next() is True
         """
         ...
 

--- a/python/ray/data/_internal/execution/bundle_queue/fifo_bundle_queue.py
+++ b/python/ray/data/_internal/execution/bundle_queue/fifo_bundle_queue.py
@@ -56,7 +56,7 @@ class FIFOBundleQueue(BundleQueue):
         self._nbytes += bundle.size_bytes()
         self._num_bundles += 1
 
-    def pop(self) -> "RefBundle":
+    def get_next(self) -> "RefBundle":
         """Return the first (left) bundle in the queue."""
         # Case 1: The queue is empty.
         if not self._head:
@@ -67,7 +67,10 @@ class FIFOBundleQueue(BundleQueue):
 
         return bundle
 
-    def peek(self) -> Optional["RefBundle"]:
+    def has_next(self) -> bool:
+        return self._num_bundles > 0
+
+    def peek_next(self) -> Optional["RefBundle"]:
         """Return the first (left) bundle in the queue without removing it."""
         if self._head is None:
             return None

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -233,6 +233,7 @@ class ActorPoolMapOperator(MapOperator):
 
         Args:
             labels: The key-value labels to launch the actor with.
+            logical_actor_id: The logical id of the actor.
 
         Returns:
             A tuple of the actor handle and the object ref to the actor's location.

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -26,7 +26,7 @@ from ray.data._internal.execution.interfaces import (
     TaskContext,
 )
 from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
-from ray.data._internal.execution.node_trackers import (
+from ray.data._internal.execution.node_trackers.actor_location import (
     ActorLocationTracker,
     get_or_create_actor_location_tracker,
 )
@@ -159,7 +159,6 @@ class ActorPoolMapOperator(MapOperator):
             ),
             _enable_actor_pool_on_exit_hook=self.data_context._enable_actor_pool_on_exit_hook,
         )
-
         self._actor_task_selector = self._create_task_selector(self._actor_pool)
         # A queue of bundles awaiting dispatch to actors.
         self._bundle_queue = create_bundle_queue()
@@ -234,7 +233,6 @@ class ActorPoolMapOperator(MapOperator):
 
         Args:
             labels: The key-value labels to launch the actor with.
-            logical_actor_id: A unique identifier for the actor.
 
         Returns:
             A tuple of the actor handle and the object ref to the actor's location.
@@ -599,7 +597,7 @@ class _ActorTaskSelectorImpl(_ActorTaskSelector):
         while input_queue:
             # Filter out actors that are invalid, i.e. actors with number of tasks in
             # flight >= _max_tasks_in_flight or actor_state is not ALIVE.
-            bundle = input_queue.peek()
+            bundle = input_queue.peek_next()
             valid_actors = [
                 actor
                 for actor in self._actor_pool.running_actors()
@@ -1095,18 +1093,3 @@ class _ActorPool(AutoscalingActorPool):
     def per_actor_resource_usage(self) -> ExecutionResources:
         """Per actor resource usage."""
         return self._per_actor_resource_usage
-
-    def get_pool_util(self) -> float:
-        if self.num_running_actors() == 0:
-            return 0.0
-        else:
-            # We compute utilization as a ration of
-            #  - Number of submitted tasks over
-            #  - Max number of tasks that Actor Pool could currently run
-            #
-            # This value could exceed 100%, since by default actors are allowed
-            # to queue tasks (to pipeline task execution by overlapping block
-            # fetching with the execution of the previous task)
-            return self.num_tasks_in_flight() / (
-                self._max_actor_concurrency * self.num_running_actors()
-            )

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1094,3 +1094,18 @@ class _ActorPool(AutoscalingActorPool):
     def per_actor_resource_usage(self) -> ExecutionResources:
         """Per actor resource usage."""
         return self._per_actor_resource_usage
+
+    def get_pool_util(self) -> float:
+        if self.num_running_actors() == 0:
+            return 0.0
+        else:
+            # We compute utilization as a ration of
+            #  - Number of submitted tasks over
+            #  - Max number of tasks that Actor Pool could currently run
+            #
+            # This value could exceed 100%, since by default actors are allowed
+            # to queue tasks (to pipeline task execution by overlapping block
+            # fetching with the execution of the previous task)
+            return self.num_tasks_in_flight() / (
+                self._max_actor_concurrency * self.num_running_actors()
+            )

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -266,10 +266,7 @@ class OpState:
 
     def has_valid_input_bundle(self) -> bool:
         """Check if the operator has a valid bundle in its input queue."""
-        for queue in self.input_queues:
-            if queue.has_valid_next():
-                return True
-        return False
+        return any(queue.has_valid_next() for queue in self.input_queues)
 
     def add_output(self, ref: RefBundle) -> None:
         """Move a bundle produced by the operator to its outqueue."""

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -97,6 +97,11 @@ class OpBufferQueue:
             with self._lock:
                 return self._num_per_split[output_split_idx] > 0
 
+    def has_valid_next(self) -> bool:
+        """Whether next RefBundle is available and valid."""
+        with self._lock:
+            return self._queue.has_next()
+
     def append(self, ref: RefBundle):
         """Append a RefBundle to the queue."""
         with self._lock:
@@ -117,7 +122,7 @@ class OpBufferQueue:
         if output_split_idx is None:
             try:
                 with self._lock:
-                    ret = self._queue.pop()
+                    ret = self._queue.get_next()
             except IndexError:
                 pass
         else:
@@ -132,10 +137,10 @@ class OpBufferQueue:
                 # preserve the order of ref bundles with different output splits.
                 with self._lock:
                     while len(self._queue) > 0:
-                        ref = self._queue.pop()
+                        ref = self._queue.get_next()
                         self._outputs_by_split[ref.output_split_idx].add(ref)
             try:
-                ret = split_queue.pop()
+                ret = split_queue.get_next()
             except IndexError:
                 pass
         if ret is None:
@@ -258,6 +263,13 @@ class OpState:
         """Return the number of input bundles that are pending dispatching to the
         operator across (external) input queues"""
         return sum(len(q) for q in self.input_queues)
+
+    def has_valid_input_bundle(self) -> bool:
+        """Check if the operator has a valid bundle in its input queue."""
+        for queue in self.input_queues:
+            if queue.has_valid_next():
+                return True
+        return False
 
     def add_output(self, ref: RefBundle) -> None:
         """Move a bundle produced by the operator to its outqueue."""
@@ -602,11 +614,11 @@ def get_eligible_operators(
         # Check whether operator could start executing immediately:
         #   - It's not completed
         #   - It can accept at least one input
-        #   - Its input queue is not empty
+        #   - Its input queue has a valid bundle
         if (
             not op.completed()
             and op.should_add_input()
-            and state._pending_dispatch_input_bundles_count() > 0
+            and state.has_valid_input_bundle()
         ):
             if not in_backpressure:
                 op_runnable = True

--- a/python/ray/data/tests/test_bundle_queue.py
+++ b/python/ray/data/tests/test_bundle_queue.py
@@ -26,7 +26,7 @@ def test_add_and_length():
     assert len(queue) == 2
 
 
-def test_pop():
+def test_get_next():
     queue = create_bundle_queue()
     bundle1 = _create_bundle("test1")
     queue.add(bundle1)
@@ -38,7 +38,7 @@ def test_pop():
     assert len(queue) == 1
 
 
-def test_peek():
+def test_peek_next():
     queue = create_bundle_queue()
     bundle1 = _create_bundle("test1")
     queue.add(bundle1)
@@ -50,13 +50,13 @@ def test_peek():
     assert len(queue) == 2  # Length should remain unchanged
 
 
-def test_pop_empty_queue():
+def test_get_next_empty_queue():
     queue = create_bundle_queue()
     with pytest.raises(IndexError):
         queue.get_next()
 
 
-def test_pop_does_not_leak_objects():
+def test_get_next_does_not_leak_objects():
     queue = create_bundle_queue()
     bundle1 = _create_bundle("test1")
     queue.add(bundle1)
@@ -64,7 +64,7 @@ def test_pop_does_not_leak_objects():
     assert queue.is_empty()
 
 
-def test_peek_empty_queue():
+def test_peek_next_empty_queue():
     queue = create_bundle_queue()
     assert queue.peek_next() is None
     assert queue.is_empty()

--- a/python/ray/data/tests/test_bundle_queue.py
+++ b/python/ray/data/tests/test_bundle_queue.py
@@ -33,7 +33,7 @@ def test_pop():
     bundle2 = _create_bundle("test2")
     queue.add(bundle2)
 
-    popped_bundle = queue.pop()
+    popped_bundle = queue.get_next()
     assert popped_bundle is bundle1
     assert len(queue) == 1
 
@@ -45,7 +45,7 @@ def test_peek():
     bundle2 = _create_bundle("test2")
     queue.add(bundle2)
 
-    peeked_bundle = queue.peek()
+    peeked_bundle = queue.peek_next()
     assert peeked_bundle is bundle1
     assert len(queue) == 2  # Length should remain unchanged
 
@@ -53,20 +53,20 @@ def test_peek():
 def test_pop_empty_queue():
     queue = create_bundle_queue()
     with pytest.raises(IndexError):
-        queue.pop()
+        queue.get_next()
 
 
 def test_pop_does_not_leak_objects():
     queue = create_bundle_queue()
     bundle1 = _create_bundle("test1")
     queue.add(bundle1)
-    queue.pop()
+    queue.get_next()
     assert queue.is_empty()
 
 
 def test_peek_empty_queue():
     queue = create_bundle_queue()
-    assert queue.peek() is None
+    assert queue.peek_next() is None
     assert queue.is_empty()
 
 
@@ -79,7 +79,7 @@ def test_remove():
 
     queue.remove(bundle1)
     assert len(queue) == 1
-    assert queue.peek() is bundle2
+    assert queue.peek_next() is bundle2
 
 
 def test_remove_does_not_leak_objects():
@@ -101,7 +101,7 @@ def test_add_and_remove_duplicates():
     assert len(queue) == 3
     queue.remove(bundle1)
     assert len(queue) == 2
-    assert queue.peek() is bundle2
+    assert queue.peek_next() is bundle2
 
 
 def test_clear():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds two methods:
- has_next
- has_valid_next

to external buffer, for abstracting the code better. We also rename use peek/next semantics to make the code easier to understand
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
