### PR TITLE
[core] Remove gcs_client status return when always ok

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -405,14 +405,14 @@ cdef extern from "ray/gcs/gcs_client/python_callbacks.h" namespace "ray::gcs":
 
 cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
     cdef cppclass CActorInfoAccessor "ray::gcs::ActorInfoAccessor":
-        CRayStatus AsyncGetAllByFilter(
+        void AsyncGetAllByFilter(
             const optional[CActorID] &actor_id,
             const optional[CJobID] &job_id,
             const optional[c_string] &actor_state_name,
             const MultiItemPyCallback[CActorTableData] &callback,
             int64_t timeout_ms)
 
-        CRayStatus AsyncKillActor(const CActorID &actor_id,
+        void AsyncKillActor(const CActorID &actor_id,
                                   c_bool force_kill,
                                   c_bool no_restart,
                                   const StatusPyCallback &callback,
@@ -426,7 +426,7 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             c_vector[CJobTableData] &result,
             int64_t timeout_ms)
 
-        CRayStatus AsyncGetAll(
+        void AsyncGetAll(
             const optional[c_string] &job_or_submission_id,
             c_bool skip_submission_job_info_field,
             c_bool skip_is_running_tasks_field,
@@ -439,7 +439,7 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             int64_t timeout_ms,
             c_vector[c_bool] &result)
 
-        CRayStatus AsyncCheckAlive(
+        void AsyncCheckAlive(
             const c_vector[c_string] &raylet_addresses,
             int64_t timeout_ms,
             const MultiItemPyCallback[c_bool] &callback)
@@ -453,7 +453,7 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             int64_t timeout_ms,
             c_vector[CGcsNodeInfo] &result)
 
-        CRayStatus AsyncGetAll(
+        void AsyncGetAll(
             const MultiItemPyCallback[CGcsNodeInfo] &callback,
             int64_t timeout_ms,
             optional[CNodeID] node_id)
@@ -503,25 +503,25 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             int64_t timeout_ms,
             c_bool &exists)
 
-        CRayStatus AsyncInternalKVKeys(
+        void AsyncInternalKVKeys(
             const c_string &ns,
             const c_string &prefix,
             int64_t timeout_ms,
             const OptionalItemPyCallback[c_vector[c_string]] &callback)
 
-        CRayStatus AsyncInternalKVGet(
+        void AsyncInternalKVGet(
             const c_string &ns,
             const c_string &key,
             int64_t timeout_ms,
             const OptionalItemPyCallback[c_string] &callback)
 
-        CRayStatus AsyncInternalKVMultiGet(
+        void AsyncInternalKVMultiGet(
             const c_string &ns,
             const c_vector[c_string] &keys,
             int64_t timeout_ms,
             const OptionalItemPyCallback[unordered_map[c_string, c_string]] &callback)
 
-        CRayStatus AsyncInternalKVPut(
+        void AsyncInternalKVPut(
             const c_string &ns,
             const c_string &key,
             const c_string &value,
@@ -529,13 +529,13 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             int64_t timeout_ms,
             const OptionalItemPyCallback[c_bool] &callback)
 
-        CRayStatus AsyncInternalKVExists(
+        void AsyncInternalKVExists(
             const c_string &ns,
             const c_string &key,
             int64_t timeout_ms,
             const OptionalItemPyCallback[c_bool] &callback)
 
-        CRayStatus AsyncInternalKVDel(
+        void AsyncInternalKVDel(
             const c_string &ns,
             const c_string &key,
             c_bool del_by_prefix,
@@ -566,7 +566,7 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             c_string &serialized_reply
         )
 
-        CRayStatus AsyncGetClusterStatus(
+        void AsyncGetClusterStatus(
             int64_t timeout_ms,
             const OptionalItemPyCallback[CGetClusterStatusReply] &callback)
 
@@ -601,7 +601,7 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             CLogBatch data,
             int64_t timeout_ms)
 
-        CRayStatus AsyncPublishNodeResourceUsage(
+        void AsyncPublishNodeResourceUsage(
             c_string key_id,
             c_string node_resource_usage,
             const StatusPyCallback &callback

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -180,13 +180,12 @@ cdef class InnerGcsClient:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().InternalKV().AsyncInternalKVGet(
-                    ns, key, timeout_ms,
-                    OptionalItemPyCallback[c_string](
-                        &convert_optional_str_none_for_not_found,
-                        assign_and_decrement_fut,
-                        fut)))
+            self.inner.get().InternalKV().AsyncInternalKVGet(
+                ns, key, timeout_ms,
+                OptionalItemPyCallback[c_string](
+                    &convert_optional_str_none_for_not_found,
+                    assign_and_decrement_fut,
+                    fut))
         return asyncio.wrap_future(fut)
 
     def async_internal_kv_multi_get(
@@ -198,13 +197,12 @@ cdef class InnerGcsClient:
             c_vector[c_string] c_keys = [key for key in keys]
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().InternalKV().AsyncInternalKVMultiGet(
-                    ns, c_keys, timeout_ms,
-                    OptionalItemPyCallback[unordered_map[c_string, c_string]](
-                        &convert_optional_multi_get,
-                        assign_and_decrement_fut,
-                        fut)))
+            self.inner.get().InternalKV().AsyncInternalKVMultiGet(
+                ns, c_keys, timeout_ms,
+                OptionalItemPyCallback[unordered_map[c_string, c_string]](
+                    &convert_optional_multi_get,
+                    assign_and_decrement_fut,
+                    fut))
         return asyncio.wrap_future(fut)
 
     def async_internal_kv_put(
@@ -216,13 +214,12 @@ cdef class InnerGcsClient:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().InternalKV().AsyncInternalKVPut(
-                    ns, key, value, overwrite, timeout_ms,
-                    OptionalItemPyCallback[c_bool](
-                        &convert_optional_bool,
-                        assign_and_decrement_fut,
-                        fut)))
+            self.inner.get().InternalKV().AsyncInternalKVPut(
+                ns, key, value, overwrite, timeout_ms,
+                OptionalItemPyCallback[c_bool](
+                    &convert_optional_bool,
+                    assign_and_decrement_fut,
+                    fut))
         return asyncio.wrap_future(fut)
 
     def async_internal_kv_del(self, c_string key, c_bool del_by_prefix,
@@ -232,13 +229,12 @@ cdef class InnerGcsClient:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().InternalKV().AsyncInternalKVDel(
-                    ns, key, del_by_prefix, timeout_ms,
-                    OptionalItemPyCallback[int](
-                        &convert_optional_int,
-                        assign_and_decrement_fut,
-                        fut)))
+            self.inner.get().InternalKV().AsyncInternalKVDel(
+                ns, key, del_by_prefix, timeout_ms,
+                OptionalItemPyCallback[int](
+                    &convert_optional_int,
+                    assign_and_decrement_fut,
+                    fut))
         return asyncio.wrap_future(fut)
 
     def async_internal_kv_keys(self, c_string prefix, namespace=None, timeout=None
@@ -248,13 +244,12 @@ cdef class InnerGcsClient:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().InternalKV().AsyncInternalKVKeys(
-                    ns, prefix, timeout_ms,
-                    OptionalItemPyCallback[c_vector[c_string]](
-                        &convert_optional_vector_str,
-                        assign_and_decrement_fut,
-                        fut)))
+            self.inner.get().InternalKV().AsyncInternalKVKeys(
+                ns, prefix, timeout_ms,
+                OptionalItemPyCallback[c_vector[c_string]](
+                    &convert_optional_vector_str,
+                    assign_and_decrement_fut,
+                    fut))
         return asyncio.wrap_future(fut)
 
     def async_internal_kv_exists(self, c_string key, namespace=None, timeout=None
@@ -264,13 +259,12 @@ cdef class InnerGcsClient:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().InternalKV().AsyncInternalKVExists(
-                    ns, key, timeout_ms,
-                    OptionalItemPyCallback[c_bool](
-                        &convert_optional_bool,
-                        assign_and_decrement_fut,
-                        fut)))
+            self.inner.get().InternalKV().AsyncInternalKVExists(
+                ns, key, timeout_ms,
+                OptionalItemPyCallback[c_bool](
+                    &convert_optional_bool,
+                    assign_and_decrement_fut,
+                    fut))
         return asyncio.wrap_future(fut)
 
     #############################################################
@@ -297,13 +291,12 @@ cdef class InnerGcsClient:
             c_vector[c_string] c_node_ips = [ip for ip in node_ips]
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().Nodes().AsyncCheckAlive(
-                    c_node_ips, timeout_ms,
-                    MultiItemPyCallback[c_bool](
-                        &convert_multi_bool,
-                        assign_and_decrement_fut,
-                        fut)))
+            self.inner.get().Nodes().AsyncCheckAlive(
+                c_node_ips, timeout_ms,
+                MultiItemPyCallback[c_bool](
+                    &convert_multi_bool,
+                    assign_and_decrement_fut,
+                    fut))
         return asyncio.wrap_future(fut)
 
     def drain_nodes(
@@ -342,14 +335,13 @@ cdef class InnerGcsClient:
         if node_id:
             c_node_id = (<NodeID>node_id).native()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().Nodes().AsyncGetAll(
-                    MultiItemPyCallback[CGcsNodeInfo](
-                        convert_get_all_node_info,
-                        assign_and_decrement_fut,
-                        fut),
-                    timeout_ms,
-                    c_node_id))
+            self.inner.get().Nodes().AsyncGetAll(
+                MultiItemPyCallback[CGcsNodeInfo](
+                    convert_get_all_node_info,
+                    assign_and_decrement_fut,
+                    fut),
+                timeout_ms,
+                c_node_id)
         return asyncio.wrap_future(fut)
 
     #############################################################
@@ -397,14 +389,13 @@ cdef class InnerGcsClient:
             c_actor_state_name = <c_string>actor_state_name.encode()
 
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().Actors().AsyncGetAllByFilter(
-                    c_actor_id, c_job_id, c_actor_state_name,
-                    MultiItemPyCallback[CActorTableData](
-                        &convert_get_all_actor_info,
-                        assign_and_decrement_fut,
-                        fut),
-                    timeout_ms))
+            self.inner.get().Actors().AsyncGetAllByFilter(
+                c_actor_id, c_job_id, c_actor_state_name,
+                MultiItemPyCallback[CActorTableData](
+                    &convert_get_all_actor_info,
+                    assign_and_decrement_fut,
+                    fut),
+                timeout_ms)
         return asyncio.wrap_future(fut)
 
     def async_kill_actor(
@@ -474,16 +465,15 @@ cdef class InnerGcsClient:
             c_optional_job_or_submission_id = \
                 make_optional[c_string](c_job_or_submission_id)
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().Jobs().AsyncGetAll(
-                    c_optional_job_or_submission_id,
-                    c_skip_submission_job_info_field,
-                    c_skip_is_running_tasks_field,
-                    MultiItemPyCallback[CJobTableData](
-                        &convert_get_all_job_info,
-                        assign_and_decrement_fut,
-                        fut),
-                    timeout_ms))
+            self.inner.get().Jobs().AsyncGetAll(
+                c_optional_job_or_submission_id,
+                c_skip_submission_job_info_field,
+                c_skip_is_running_tasks_field,
+                MultiItemPyCallback[CJobTableData](
+                    &convert_get_all_job_info,
+                    assign_and_decrement_fut,
+                    fut),
+                timeout_ms)
         return asyncio.wrap_future(fut)
 
     #############################################################
@@ -555,18 +545,12 @@ cdef class InnerGcsClient:
             int64_t timeout_ms = round(1000 * timeout_s) if timeout_s else -1
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get()
-                .Autoscaler()
-                .AsyncGetClusterStatus(
-                    timeout_ms,
-                    OptionalItemPyCallback[CGetClusterStatusReply](
-                        &convert_get_cluster_status_reply,
-                        assign_and_decrement_fut,
-                        fut
-                    )
-                )
-            )
+            self.inner.get().Autoscaler().AsyncGetClusterStatus(
+                timeout_ms,
+                OptionalItemPyCallback[CGetClusterStatusReply](
+                    &convert_get_cluster_status_reply,
+                    assign_and_decrement_fut,
+                    fut))
         return asyncio.wrap_future(fut)
 
     def report_autoscaling_state(
@@ -662,10 +646,10 @@ cdef class InnerGcsClient:
             c_string c_node_resource_usage_json = node_resource_usage_json.encode()
             fut = incremented_fut()
         with nogil:
-            check_status_timeout_as_rpc_error(
-                self.inner.get().Publisher().AsyncPublishNodeResourceUsage(
-                    move(c_key_id), move(c_node_resource_usage_json),
-                    StatusPyCallback(convert_status, assign_and_decrement_fut, fut)))
+            self.inner.get().Publisher().AsyncPublishNodeResourceUsage(
+                move(c_key_id),
+                move(c_node_resource_usage_json),
+                StatusPyCallback(convert_status, assign_and_decrement_fut, fut))
         return asyncio.wrap_future(fut)
 
     def report_cluster_config(

--- a/src/mock/ray/core_worker/actor_creator.h
+++ b/src/mock/ray/core_worker/actor_creator.h
@@ -23,22 +23,22 @@ class MockActorCreatorInterface : public ActorCreatorInterface {
               RegisterActor,
               (const TaskSpecification &task_spec),
               (const, override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncRegisterActor,
               (const TaskSpecification &task_spec, gcs::StatusCallback callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncCreateActor,
               (const TaskSpecification &task_spec,
                const rpc::ClientCallback<rpc::CreateActorReply> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncRestartActorForLineageReconstruction,
               (const ActorID &actor_id,
                uint64_t num_restarts,
                gcs::StatusCallback callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncReportActorOutOfScope,
               (const ActorID &actor_id,
                uint64_t num_restarts_due_to_lineage_reconstruction,

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -20,12 +20,12 @@ namespace gcs {
 
 class MockActorInfoAccessor : public ActorInfoAccessor {
  public:
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGet,
               (const ActorID &actor_id,
                const OptionalItemCallback<rpc::ActorTableData> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetAllByFilter,
               (const std::optional<ActorID> &actor_id,
                const std::optional<JobID> &job_id,
@@ -33,21 +33,14 @@ class MockActorInfoAccessor : public ActorInfoAccessor {
                const MultiItemCallback<rpc::ActorTableData> &callback,
                int64_t timeout_ms),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetByName,
               (const std::string &name,
                const std::string &ray_namespace,
                const OptionalItemCallback<rpc::ActorTableData> &callback,
                int64_t timeout_ms),
               (override));
-  MOCK_METHOD(Status,
-              AsyncListNamedActors,
-              (bool all_namespaces,
-               const std::string &ray_namespace,
-               const OptionalItemCallback<std::vector<rpc::NamedActorInfo>> &callback,
-               int64_t timeout_ms),
-              (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncRegisterActor,
               (const TaskSpecification &task_spec,
                const StatusCallback &callback,
@@ -57,7 +50,7 @@ class MockActorInfoAccessor : public ActorInfoAccessor {
               SyncRegisterActor,
               (const TaskSpecification &task_spec),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncKillActor,
               (const ActorID &actor_id,
                bool force_kill,
@@ -65,7 +58,7 @@ class MockActorInfoAccessor : public ActorInfoAccessor {
                const StatusCallback &callback,
                int64_t timeout_ms),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncCreateActor,
               (const TaskSpecification &task_spec,
                const rpc::ClientCallback<rpc::CreateActorReply> &callback),
@@ -89,12 +82,12 @@ namespace gcs {
 
 class MockJobInfoAccessor : public JobInfoAccessor {
  public:
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncAdd,
               (const std::shared_ptr<rpc::JobTableData> &data_ptr,
                const StatusCallback &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncMarkFinished,
               (const JobID &job_id, const StatusCallback &callback),
               (override));
@@ -103,7 +96,7 @@ class MockJobInfoAccessor : public JobInfoAccessor {
               ((const SubscribeCallback<JobID, rpc::JobTableData> &subscribe),
                const StatusCallback &done),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetAll,
               (const std::optional<std::string> &job_or_submission_id,
                bool skip_submission_job_info_field,
@@ -112,10 +105,7 @@ class MockJobInfoAccessor : public JobInfoAccessor {
                int64_t timeout_ms),
               (override));
   MOCK_METHOD(void, AsyncResubscribe, (), (override));
-  MOCK_METHOD(Status,
-              AsyncGetNextJobID,
-              (const ItemCallback<JobID> &callback),
-              (override));
+  MOCK_METHOD(void, AsyncGetNextJobID, (const ItemCallback<JobID> &callback), (override));
 };
 
 }  // namespace gcs
@@ -132,21 +122,21 @@ class MockNodeInfoAccessor : public NodeInfoAccessor {
               (override));
   MOCK_METHOD(const NodeID &, GetSelfId, (), (const, override));
   MOCK_METHOD(const rpc::GcsNodeInfo &, GetSelfInfo, (), (const, override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncRegister,
               (const rpc::GcsNodeInfo &node_info, const StatusCallback &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncCheckSelfAlive,
               (const std::function<void(Status, bool)> &callback, int64_t timeout_ms),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncCheckAlive,
               (const std::vector<std::string> &raylet_addresses,
                int64_t timeout_ms,
                const MultiItemCallback<bool> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetAll,
               (const MultiItemCallback<rpc::GcsNodeInfo> &callback,
                int64_t timeout_ms,
@@ -183,12 +173,12 @@ namespace gcs {
 
 class MockNodeResourceInfoAccessor : public NodeResourceInfoAccessor {
  public:
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetAllAvailableResources,
               (const MultiItemCallback<rpc::AvailableResources> &callback),
               (override));
   MOCK_METHOD(void, AsyncResubscribe, (), (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetAllResourceUsage,
               (const ItemCallback<rpc::ResourceUsageBatchData> &callback),
               (override));
@@ -202,7 +192,7 @@ namespace gcs {
 
 class MockErrorInfoAccessor : public ErrorInfoAccessor {
  public:
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncReportJobError,
               (const std::shared_ptr<rpc::ErrorTableData> &data_ptr,
                const StatusCallback &callback),
@@ -217,7 +207,7 @@ namespace gcs {
 
 class MockTaskInfoAccessor : public TaskInfoAccessor {
  public:
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncAddTaskEventData,
               (std::unique_ptr<rpc::TaskEventData> data_ptr, StatusCallback callback),
               (override));
@@ -236,21 +226,21 @@ class MockWorkerInfoAccessor : public WorkerInfoAccessor {
               (const ItemCallback<rpc::WorkerDeltaData> &subscribe,
                const StatusCallback &done),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncReportWorkerFailure,
               (const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
                const StatusCallback &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGet,
               (const WorkerID &worker_id,
                const OptionalItemCallback<rpc::WorkerTableData> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetAll,
               (const MultiItemCallback<rpc::WorkerTableData> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncAdd,
               (const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
                const StatusCallback &callback),
@@ -270,19 +260,19 @@ class MockPlacementGroupInfoAccessor : public PlacementGroupInfoAccessor {
               SyncCreatePlacementGroup,
               (const PlacementGroupSpecification &placement_group_spec),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGet,
               (const PlacementGroupID &placement_group_id,
                const OptionalItemCallback<rpc::PlacementGroupTableData> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetByName,
               (const std::string &placement_group_name,
                const std::string &ray_namespace,
                const OptionalItemCallback<rpc::PlacementGroupTableData> &callback,
                int64_t timeout_ms),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetAll,
               (const MultiItemCallback<rpc::PlacementGroupTableData> &callback),
               (override));
@@ -304,21 +294,21 @@ namespace gcs {
 
 class MockInternalKVAccessor : public InternalKVAccessor {
  public:
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncInternalKVKeys,
               (const std::string &ns,
                const std::string &prefix,
                const int64_t timeout_ms,
                const OptionalItemCallback<std::vector<std::string>> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncInternalKVGet,
               (const std::string &ns,
                const std::string &key,
                const int64_t timeout_ms,
                const OptionalItemCallback<std::string> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncInternalKVPut,
               (const std::string &ns,
                const std::string &key,
@@ -327,14 +317,14 @@ class MockInternalKVAccessor : public InternalKVAccessor {
                const int64_t timeout_ms,
                const OptionalItemCallback<bool> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncInternalKVExists,
               (const std::string &ns,
                const std::string &key,
                const int64_t timeout_ms,
                const OptionalItemCallback<bool> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncInternalKVDel,
               (const std::string &ns,
                const std::string &key,
@@ -342,7 +332,7 @@ class MockInternalKVAccessor : public InternalKVAccessor {
                const int64_t timeout_ms,
                const OptionalItemCallback<int> &callback),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncGetInternalConfig,
               (const OptionalItemCallback<std::string> &callback),
               (override));

--- a/src/ray/core_worker/actor_creator.h
+++ b/src/ray/core_worker/actor_creator.h
@@ -37,16 +37,15 @@ class ActorCreatorInterface {
   /// \param task_spec The specification for the actor creation task.
   /// \param callback Callback that will be called after the actor info is registered to
   /// GCS
-  /// \return Status
-  virtual Status AsyncRegisterActor(const TaskSpecification &task_spec,
-                                    gcs::StatusCallback callback) = 0;
+  virtual void AsyncRegisterActor(const TaskSpecification &task_spec,
+                                  gcs::StatusCallback callback) = 0;
 
-  virtual Status AsyncRestartActorForLineageReconstruction(
+  virtual void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,
       gcs::StatusCallback callback) = 0;
 
-  virtual Status AsyncReportActorOutOfScope(
+  virtual void AsyncReportActorOutOfScope(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,
       gcs::StatusCallback callback) = 0;
@@ -55,8 +54,7 @@ class ActorCreatorInterface {
   ///
   /// \param task_spec The specification for the actor creation task.
   /// \param callback Callback that will be called after the actor info is written to GCS.
-  /// \return Status
-  virtual Status AsyncCreateActor(
+  virtual void AsyncCreateActor(
       const TaskSpecification &task_spec,
       const rpc::ClientCallback<rpc::CreateActorReply> &callback) = 0;
 
@@ -91,36 +89,35 @@ class DefaultActorCreator : public ActorCreatorInterface {
     return status;
   }
 
-  Status AsyncRegisterActor(const TaskSpecification &task_spec,
-                            gcs::StatusCallback callback) override {
+  void AsyncRegisterActor(const TaskSpecification &task_spec,
+                          gcs::StatusCallback callback) override {
     auto actor_id = task_spec.ActorCreationId();
     (*registering_actors_)[actor_id] = {};
     if (callback != nullptr) {
       (*registering_actors_)[actor_id].emplace_back(std::move(callback));
     }
-    return gcs_client_->Actors().AsyncRegisterActor(
-        task_spec, [actor_id, this](Status status) {
-          std::vector<ray::gcs::StatusCallback> cbs;
-          cbs = std::move((*registering_actors_)[actor_id]);
-          registering_actors_->erase(actor_id);
-          for (auto &cb : cbs) {
-            cb(status);
-          }
-        });
+    gcs_client_->Actors().AsyncRegisterActor(task_spec, [actor_id, this](Status status) {
+      std::vector<ray::gcs::StatusCallback> cbs;
+      cbs = std::move((*registering_actors_)[actor_id]);
+      registering_actors_->erase(actor_id);
+      for (auto &cb : cbs) {
+        cb(status);
+      }
+    });
   }
 
-  Status AsyncRestartActorForLineageReconstruction(
+  void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,
       gcs::StatusCallback callback) override {
-    return gcs_client_->Actors().AsyncRestartActorForLineageReconstruction(
+    gcs_client_->Actors().AsyncRestartActorForLineageReconstruction(
         actor_id, num_restarts_due_to_lineage_reconstructions, callback);
   }
 
-  Status AsyncReportActorOutOfScope(const ActorID &actor_id,
-                                    uint64_t num_restarts_due_to_lineage_reconstruction,
-                                    gcs::StatusCallback callback) override {
-    return gcs_client_->Actors().AsyncReportActorOutOfScope(
+  void AsyncReportActorOutOfScope(const ActorID &actor_id,
+                                  uint64_t num_restarts_due_to_lineage_reconstruction,
+                                  gcs::StatusCallback callback) override {
+    gcs_client_->Actors().AsyncReportActorOutOfScope(
         actor_id, num_restarts_due_to_lineage_reconstruction, callback);
   }
 
@@ -135,10 +132,10 @@ class DefaultActorCreator : public ActorCreatorInterface {
     iter->second.emplace_back(std::move(callback));
   }
 
-  Status AsyncCreateActor(
+  void AsyncCreateActor(
       const TaskSpecification &task_spec,
       const rpc::ClientCallback<rpc::CreateActorReply> &callback) override {
-    return gcs_client_->Actors().AsyncCreateActor(task_spec, callback);
+    gcs_client_->Actors().AsyncCreateActor(task_spec, callback);
   }
 
  private:

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1343,7 +1343,7 @@ void CoreWorker::RegisterToGcs(int64_t worker_launch_time_ms,
   worker_data->set_worker_launch_time_ms(worker_launch_time_ms);
   worker_data->set_worker_launched_time_ms(worker_launched_time_ms);
 
-  RAY_CHECK_OK(gcs_client_->Workers().AsyncAdd(worker_data, nullptr));
+  gcs_client_->Workers().AsyncAdd(worker_data, nullptr);
 }
 
 void CoreWorker::ExitIfParentRayletDies() {
@@ -2767,17 +2767,16 @@ Status CoreWorker::CreateActor(const RayFunction &function,
   if (actor_name.empty()) {
     io_service_.post(
         [this, task_spec = std::move(task_spec)]() {
-          RAY_UNUSED(actor_creator_->AsyncRegisterActor(
-              task_spec, [this, task_spec](Status status) {
-                if (!status.ok()) {
-                  RAY_LOG(ERROR).WithField(task_spec.ActorCreationId())
-                      << "Failed to register actor. Error message: " << status;
-                  task_manager_->FailPendingTask(
-                      task_spec.TaskId(), rpc::ErrorType::ACTOR_CREATION_FAILED, &status);
-                } else {
-                  RAY_UNUSED(actor_task_submitter_->SubmitActorCreationTask(task_spec));
-                }
-              }));
+          actor_creator_->AsyncRegisterActor(task_spec, [this, task_spec](Status status) {
+            if (!status.ok()) {
+              RAY_LOG(ERROR).WithField(task_spec.ActorCreationId())
+                  << "Failed to register actor. Error message: " << status;
+              task_manager_->FailPendingTask(
+                  task_spec.TaskId(), rpc::ErrorType::ACTOR_CREATION_FAILED, &status);
+            } else {
+              RAY_UNUSED(actor_task_submitter_->SubmitActorCreationTask(task_spec));
+            }
+          });
         },
         "ActorCreator.AsyncRegisterActor");
   } else {
@@ -3079,8 +3078,8 @@ Status CoreWorker::KillActor(const ActorID &actor_id, bool force_kill, bool no_r
       [this, p = &p, actor_id, force_kill, no_restart]() {
         auto cb = [this, p, actor_id, force_kill, no_restart](Status status) mutable {
           if (status.ok()) {
-            RAY_CHECK_OK(gcs_client_->Actors().AsyncKillActor(
-                actor_id, force_kill, no_restart, nullptr));
+            gcs_client_->Actors().AsyncKillActor(
+                actor_id, force_kill, no_restart, nullptr);
           }
           p->set_value(std::move(status));
         };

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -568,9 +568,7 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
     }
     grpc_in_progress_ = false;
   };
-
-  auto status = task_accessor->AsyncAddTaskEventData(std::move(data), on_complete);
-  RAY_CHECK_OK(status);
+  task_accessor->AsyncAddTaskEventData(std::move(data), on_complete);
 }
 
 void TaskEventBufferImpl::ResetCountersForFlush() {

--- a/src/ray/core_worker/test/actor_creator_test.cc
+++ b/src/ray/core_worker/test/actor_creator_test.cc
@@ -51,9 +51,8 @@ TEST_F(ActorCreatorTest, IsRegister) {
   std::function<void(Status)> cb;
   EXPECT_CALL(*gcs_client->mock_actor_accessor,
               AsyncRegisterActor(task_spec, ::testing::_, ::testing::_))
-      .WillOnce(
-          ::testing::DoAll(::testing::SaveArg<1>(&cb), ::testing::Return(Status::OK())));
-  ASSERT_TRUE(actor_creator->AsyncRegisterActor(task_spec, nullptr).ok());
+      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&cb)));
+  actor_creator->AsyncRegisterActor(task_spec, nullptr);
   ASSERT_TRUE(actor_creator->IsActorInRegistering(actor_id));
   cb(Status::OK());
   ASSERT_FALSE(actor_creator->IsActorInRegistering(actor_id));
@@ -65,14 +64,13 @@ TEST_F(ActorCreatorTest, AsyncWaitForFinish) {
   std::function<void(Status)> cb;
   EXPECT_CALL(*gcs_client->mock_actor_accessor,
               AsyncRegisterActor(::testing::_, ::testing::_, ::testing::_))
-      .WillRepeatedly(
-          ::testing::DoAll(::testing::SaveArg<1>(&cb), ::testing::Return(Status::OK())));
+      .WillRepeatedly(::testing::DoAll(::testing::SaveArg<1>(&cb)));
   int cnt = 0;
   auto per_finish_cb = [&cnt](Status status) {
     ASSERT_TRUE(status.ok());
     cnt++;
   };
-  ASSERT_TRUE(actor_creator->AsyncRegisterActor(task_spec, per_finish_cb).ok());
+  actor_creator->AsyncRegisterActor(task_spec, per_finish_cb);
   ASSERT_TRUE(actor_creator->IsActorInRegistering(actor_id));
   for (int i = 0; i < 100; ++i) {
     actor_creator->AsyncWaitForActorRegisterFinish(actor_id, per_finish_cb);

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -143,29 +143,21 @@ class MockActorCreator : public ActorCreatorInterface {
     return Status::OK();
   };
 
-  Status AsyncRegisterActor(const TaskSpecification &task_spec,
-                            gcs::StatusCallback callback) override {
-    return Status::OK();
-  }
+  void AsyncRegisterActor(const TaskSpecification &task_spec,
+                          gcs::StatusCallback callback) override {}
 
-  Status AsyncCreateActor(
+  void AsyncCreateActor(
       const TaskSpecification &task_spec,
-      const rpc::ClientCallback<rpc::CreateActorReply> &callback) override {
-    return Status::OK();
-  }
+      const rpc::ClientCallback<rpc::CreateActorReply> &callback) override {}
 
-  Status AsyncRestartActorForLineageReconstruction(
+  void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,
-      gcs::StatusCallback callback) override {
-    return Status::OK();
-  }
+      gcs::StatusCallback callback) override {}
 
-  Status AsyncReportActorOutOfScope(const ActorID &actor_id,
-                                    uint64_t num_restarts_due_to_lineage_reconstruction,
-                                    gcs::StatusCallback callback) override {
-    return Status::OK();
-  }
+  void AsyncReportActorOutOfScope(const ActorID &actor_id,
+                                  uint64_t num_restarts_due_to_lineage_reconstruction,
+                                  gcs::StatusCallback callback) override {}
 
   void AsyncWaitForActorRegisterFinish(const ActorID &,
                                        gcs::StatusCallback callback) override {

--- a/src/ray/core_worker/test/direct_actor_transport_mock_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_mock_test.cc
@@ -99,8 +99,7 @@ TEST_F(DirectTaskTransportTest, ActorCreationOk) {
   rpc::ClientCallback<rpc::CreateActorReply> create_cb;
   EXPECT_CALL(*gcs_client->mock_actor_accessor,
               AsyncCreateActor(creation_task_spec, ::testing::_))
-      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&create_cb),
-                                 ::testing::Return(Status::OK())));
+      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&create_cb)));
   ASSERT_TRUE(actor_task_submitter->SubmitActorCreationTask(creation_task_spec).ok());
   create_cb(Status::OK(), rpc::CreateActorReply());
 }
@@ -116,8 +115,7 @@ TEST_F(DirectTaskTransportTest, ActorCreationFail) {
   rpc::ClientCallback<rpc::CreateActorReply> create_cb;
   EXPECT_CALL(*gcs_client->mock_actor_accessor,
               AsyncCreateActor(creation_task_spec, ::testing::_))
-      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&create_cb),
-                                 ::testing::Return(Status::OK())));
+      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&create_cb)));
   ASSERT_TRUE(actor_task_submitter->SubmitActorCreationTask(creation_task_spec).ok());
   create_cb(Status::IOError(""), rpc::CreateActorReply());
 }
@@ -134,9 +132,8 @@ TEST_F(DirectTaskTransportTest, ActorRegisterFailure) {
   std::function<void(Status)> register_cb;
   EXPECT_CALL(*gcs_client->mock_actor_accessor,
               AsyncRegisterActor(creation_task_spec, ::testing::_, ::testing::_))
-      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&register_cb),
-                                 ::testing::Return(Status::OK())));
-  ASSERT_TRUE(actor_creator->AsyncRegisterActor(creation_task_spec, nullptr).ok());
+      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&register_cb)));
+  actor_creator->AsyncRegisterActor(creation_task_spec, nullptr);
   ASSERT_TRUE(actor_creator->IsActorInRegistering(actor_id));
   actor_task_submitter->AddActorQueueIfNotExists(actor_id,
                                                  -1,
@@ -163,9 +160,8 @@ TEST_F(DirectTaskTransportTest, ActorRegisterOk) {
   std::function<void(Status)> register_cb;
   EXPECT_CALL(*gcs_client->mock_actor_accessor,
               AsyncRegisterActor(creation_task_spec, ::testing::_, ::testing::_))
-      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&register_cb),
-                                 ::testing::Return(Status::OK())));
-  ASSERT_TRUE(actor_creator->AsyncRegisterActor(creation_task_spec, nullptr).ok());
+      .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&register_cb)));
+  actor_creator->AsyncRegisterActor(creation_task_spec, nullptr);
   ASSERT_TRUE(actor_creator->IsActorInRegistering(actor_id));
   actor_task_submitter->AddActorQueueIfNotExists(actor_id,
                                                  -1,

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -395,29 +395,21 @@ class MockActorCreator : public ActorCreatorInterface {
     return Status::OK();
   };
 
-  Status AsyncRegisterActor(const TaskSpecification &task_spec,
-                            gcs::StatusCallback callback) override {
-    return Status::OK();
-  }
+  void AsyncRegisterActor(const TaskSpecification &task_spec,
+                          gcs::StatusCallback callback) override {}
 
-  Status AsyncRestartActorForLineageReconstruction(
+  void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,
-      gcs::StatusCallback callback) override {
-    return Status::OK();
-  }
+      gcs::StatusCallback callback) override {}
 
-  Status AsyncReportActorOutOfScope(const ActorID &actor_id,
-                                    uint64_t num_restarts_due_to_lineage_reconstruction,
-                                    gcs::StatusCallback callback) override {
-    return Status::OK();
-  }
+  void AsyncReportActorOutOfScope(const ActorID &actor_id,
+                                  uint64_t num_restarts_due_to_lineage_reconstruction,
+                                  gcs::StatusCallback callback) override {}
 
-  Status AsyncCreateActor(
+  void AsyncCreateActor(
       const TaskSpecification &task_spec,
-      const rpc::ClientCallback<rpc::CreateActorReply> &callback) override {
-    return Status::OK();
-  }
+      const rpc::ClientCallback<rpc::CreateActorReply> &callback) override {}
 
   void AsyncWaitForActorRegisterFinish(const ActorID &,
                                        gcs::StatusCallback callback) override {

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -40,14 +40,14 @@ void ActorTaskSubmitter::NotifyGCSWhenActorOutOfScope(
         }
       }
     }
-    RAY_CHECK_OK(actor_creator_.AsyncReportActorOutOfScope(
+    actor_creator_.AsyncReportActorOutOfScope(
         actor_id, num_restarts_due_to_lineage_reconstruction, [actor_id](Status status) {
           if (!status.ok()) {
             RAY_LOG(ERROR).WithField(actor_id)
                 << "Failed to report actor out of scope: " << status
                 << ". The actor will not be killed";
           }
-        }));
+        });
   };
 
   if (!reference_counter_->AddObjectOutOfScopeOrFreedCallback(
@@ -116,7 +116,7 @@ Status ActorTaskSubmitter::SubmitActorCreationTask(TaskSpecification task_spec) 
     // more details please see the protocol of actor management based on gcs.
     // https://docs.google.com/document/d/1EAWide-jy05akJp6OMtDn58XOK7bUyruWMia4E-fV28/edit?usp=sharing
     RAY_LOG(DEBUG).WithField(actor_id).WithField(task_id) << "Creating actor via GCS";
-    RAY_CHECK_OK(actor_creator_.AsyncCreateActor(
+    actor_creator_.AsyncCreateActor(
         task_spec,
         [this, actor_id, task_id](Status status, const rpc::CreateActorReply &reply) {
           if (status.ok() || status.IsCreationTaskError()) {
@@ -161,7 +161,7 @@ Status ActorTaskSubmitter::SubmitActorCreationTask(TaskSpecification task_spec) 
                 &status,
                 ray_error_info.has_actor_died_error() ? &ray_error_info : nullptr));
           }
-        }));
+        });
   });
 
   return Status::OK();
@@ -345,7 +345,7 @@ void ActorTaskSubmitter::RestartActorForLineageReconstruction(const ActorID &act
   RAY_CHECK(queue->second.is_restartable) << "This actor is no longer restartable";
   queue->second.state = rpc::ActorTableData::RESTARTING;
   queue->second.num_restarts_due_to_lineage_reconstructions += 1;
-  RAY_CHECK_OK(actor_creator_.AsyncRestartActorForLineageReconstruction(
+  actor_creator_.AsyncRestartActorForLineageReconstruction(
       actor_id,
       queue->second.num_restarts_due_to_lineage_reconstructions,
       [this,
@@ -360,7 +360,7 @@ void ActorTaskSubmitter::RestartActorForLineageReconstruction(const ActorID &act
           NotifyGCSWhenActorOutOfScope(actor_id,
                                        num_restarts_due_to_lineage_reconstructions);
         }
-      }));
+      });
 }
 
 void ActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/common_protocol.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 #include "ray/util/container_util.h"
@@ -36,40 +35,36 @@ int64_t GetGcsTimeoutMs() {
 
 JobInfoAccessor::JobInfoAccessor(GcsClient *client_impl) : client_impl_(client_impl) {}
 
-Status JobInfoAccessor::AsyncAdd(const std::shared_ptr<rpc::JobTableData> &data_ptr,
-                                 const StatusCallback &callback) {
+void JobInfoAccessor::AsyncAdd(const std::shared_ptr<rpc::JobTableData> &data_ptr,
+                               const StatusCallback &callback) {
   JobID job_id = JobID::FromBinary(data_ptr->job_id());
   RAY_LOG(DEBUG).WithField(job_id)
       << "Adding job, driver pid = " << data_ptr->driver_pid();
   rpc::AddJobRequest request;
   request.mutable_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddJob(
-      request,
-      [job_id, data_ptr, callback](const Status &status, rpc::AddJobReply &&reply) {
+      request, [job_id, data_ptr, callback](const Status &status, rpc::AddJobReply &&) {
         if (callback) {
           callback(status);
         }
         RAY_LOG(DEBUG).WithField(job_id) << "Finished adding job, status = " << status
                                          << ", driver pid = " << data_ptr->driver_pid();
       });
-  return Status::OK();
 }
 
-Status JobInfoAccessor::AsyncMarkFinished(const JobID &job_id,
-                                          const StatusCallback &callback) {
+void JobInfoAccessor::AsyncMarkFinished(const JobID &job_id,
+                                        const StatusCallback &callback) {
   RAY_LOG(DEBUG).WithField(job_id) << "Marking job state";
   rpc::MarkJobFinishedRequest request;
   request.set_job_id(job_id.Binary());
   client_impl_->GetGcsRpcClient().MarkJobFinished(
-      request,
-      [job_id, callback](const Status &status, rpc::MarkJobFinishedReply &&reply) {
+      request, [job_id, callback](const Status &status, rpc::MarkJobFinishedReply &&) {
         if (callback) {
           callback(status);
         }
         RAY_LOG(DEBUG).WithField(job_id)
             << "Finished marking job state, status = " << status;
       });
-  return Status::OK();
 }
 
 Status JobInfoAccessor::AsyncSubscribeAll(
@@ -86,11 +81,11 @@ Status JobInfoAccessor::AsyncSubscribeAll(
         done(status);
       }
     };
-    RAY_CHECK_OK(AsyncGetAll(/*job_or_submission_id=*/std::nullopt,
-                             /*skip_submission_job_info_field=*/true,
-                             /*skip_is_running_tasks_field=*/true,
-                             callback,
-                             /*timeout_ms=*/-1));
+    AsyncGetAll(/*job_or_submission_id=*/std::nullopt,
+                /*skip_submission_job_info_field=*/true,
+                /*skip_is_running_tasks_field=*/true,
+                callback,
+                /*timeout_ms=*/-1);
   };
   subscribe_operation_ = [this, subscribe](const StatusCallback &done) {
     return client_impl_->GetGcsSubscriber().SubscribeAllJobs(subscribe, done);
@@ -107,18 +102,17 @@ void JobInfoAccessor::AsyncResubscribe() {
   };
 
   if (subscribe_operation_ != nullptr) {
-    RAY_CHECK_OK(subscribe_operation_([this, fetch_all_done](const Status &status) {
+    RAY_CHECK_OK(subscribe_operation_([this, fetch_all_done](const Status &) {
       fetch_all_data_operation_(fetch_all_done);
     }));
   }
 }
 
-Status JobInfoAccessor::AsyncGetAll(
-    const std::optional<std::string> &job_or_submission_id,
-    bool skip_submission_job_info_field,
-    bool skip_is_running_tasks_field,
-    const MultiItemCallback<rpc::JobTableData> &callback,
-    int64_t timeout_ms) {
+void JobInfoAccessor::AsyncGetAll(const std::optional<std::string> &job_or_submission_id,
+                                  bool skip_submission_job_info_field,
+                                  bool skip_is_running_tasks_field,
+                                  const MultiItemCallback<rpc::JobTableData> &callback,
+                                  int64_t timeout_ms) {
   RAY_LOG(DEBUG) << "Getting all job info.";
   RAY_CHECK(callback);
   rpc::GetAllJobInfoRequest request;
@@ -134,7 +128,6 @@ Status JobInfoAccessor::AsyncGetAll(
         RAY_LOG(DEBUG) << "Finished getting all job info.";
       },
       timeout_ms);
-  return Status::OK();
 }
 
 Status JobInfoAccessor::GetAll(const std::optional<std::string> &job_or_submission_id,
@@ -155,7 +148,7 @@ Status JobInfoAccessor::GetAll(const std::optional<std::string> &job_or_submissi
   return Status::OK();
 }
 
-Status JobInfoAccessor::AsyncGetNextJobID(const ItemCallback<JobID> &callback) {
+void JobInfoAccessor::AsyncGetNextJobID(const ItemCallback<JobID> &callback) {
   RAY_LOG(DEBUG) << "Getting next job id";
   rpc::GetNextJobIDRequest request;
   client_impl_->GetGcsRpcClient().GetNextJobID(
@@ -165,13 +158,12 @@ Status JobInfoAccessor::AsyncGetNextJobID(const ItemCallback<JobID> &callback) {
         RAY_LOG(DEBUG) << "Finished getting next job id = " << job_id;
         callback(std::move(job_id));
       });
-  return Status::OK();
 }
 
 ActorInfoAccessor::ActorInfoAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 
-Status ActorInfoAccessor::AsyncGet(
+void ActorInfoAccessor::AsyncGet(
     const ActorID &actor_id, const OptionalItemCallback<rpc::ActorTableData> &callback) {
   RAY_LOG(DEBUG).WithField(actor_id).WithField(actor_id.JobId()) << "Getting actor info";
   rpc::GetActorInfoRequest request;
@@ -187,10 +179,9 @@ Status ActorInfoAccessor::AsyncGet(
         RAY_LOG(DEBUG).WithField(actor_id).WithField(actor_id.JobId())
             << "Finished getting actor info, status = " << status;
       });
-  return Status::OK();
 }
 
-Status ActorInfoAccessor::AsyncGetAllByFilter(
+void ActorInfoAccessor::AsyncGetAllByFilter(
     const std::optional<ActorID> &actor_id,
     const std::optional<JobID> &job_id,
     const std::optional<std::string> &actor_state_name,
@@ -218,10 +209,9 @@ Status ActorInfoAccessor::AsyncGetAllByFilter(
         RAY_LOG(DEBUG) << "Finished getting all actor info, status = " << status;
       },
       timeout_ms);
-  return Status::OK();
 }
 
-Status ActorInfoAccessor::AsyncGetByName(
+void ActorInfoAccessor::AsyncGetByName(
     const std::string &name,
     const std::string &ray_namespace,
     const OptionalItemCallback<rpc::ActorTableData> &callback,
@@ -242,7 +232,6 @@ Status ActorInfoAccessor::AsyncGetByName(
                        << ", name = " << name;
       },
       timeout_ms);
-  return Status::OK();
 }
 
 Status ActorInfoAccessor::SyncGetByName(const std::string &name,
@@ -262,30 +251,6 @@ Status ActorInfoAccessor::SyncGetByName(const std::string &name,
   return status;
 }
 
-Status ActorInfoAccessor::AsyncListNamedActors(
-    bool all_namespaces,
-    const std::string &ray_namespace,
-    const OptionalItemCallback<std::vector<rpc::NamedActorInfo>> &callback,
-    int64_t timeout_ms) {
-  RAY_LOG(DEBUG) << "Listing actors";
-  rpc::ListNamedActorsRequest request;
-  request.set_all_namespaces(all_namespaces);
-  request.set_ray_namespace(ray_namespace);
-  client_impl_->GetGcsRpcClient().ListNamedActors(
-      request,
-      [callback](const Status &status, rpc::ListNamedActorsReply &&reply) {
-        if (!status.ok()) {
-          callback(status, std::nullopt);
-        } else {
-          callback(status,
-                   VectorFromProtobuf(std::move(*reply.mutable_named_actors_list())));
-        }
-        RAY_LOG(DEBUG) << "Finished getting named actor names, status = " << status;
-      },
-      timeout_ms);
-  return Status::OK();
-}
-
 Status ActorInfoAccessor::SyncListNamedActors(
     bool all_namespaces,
     const std::string &ray_namespace,
@@ -299,15 +264,15 @@ Status ActorInfoAccessor::SyncListNamedActors(
   if (!status.ok()) {
     return status;
   }
-
+  actors.reserve(reply.named_actors_list_size());
   for (const auto &actor_info :
        VectorFromProtobuf(std::move(*reply.mutable_named_actors_list()))) {
-    actors.push_back(std::make_pair(actor_info.ray_namespace(), actor_info.name()));
+    actors.emplace_back(actor_info.ray_namespace(), actor_info.name());
   }
   return status;
 }
 
-Status ActorInfoAccessor::AsyncRestartActorForLineageReconstruction(
+void ActorInfoAccessor::AsyncRestartActorForLineageReconstruction(
     const ray::ActorID &actor_id,
     uint64_t num_restarts_due_to_lineage_reconstruction,
     const ray::gcs::StatusCallback &callback,
@@ -323,7 +288,6 @@ Status ActorInfoAccessor::AsyncRestartActorForLineageReconstruction(
         callback(status);
       },
       timeout_ms);
-  return Status::OK();
 }
 
 namespace {
@@ -342,9 +306,9 @@ Status ComputeGcsStatus(const Status &grpc_status, const rpc::GcsStatus &gcs_sta
 
 }  // namespace
 
-Status ActorInfoAccessor::AsyncRegisterActor(const ray::TaskSpecification &task_spec,
-                                             const ray::gcs::StatusCallback &callback,
-                                             int64_t timeout_ms) {
+void ActorInfoAccessor::AsyncRegisterActor(const ray::TaskSpecification &task_spec,
+                                           const ray::gcs::StatusCallback &callback,
+                                           int64_t timeout_ms) {
   RAY_CHECK(task_spec.IsActorCreationTask() && callback);
   rpc::RegisterActorRequest request;
   request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
@@ -354,7 +318,6 @@ Status ActorInfoAccessor::AsyncRegisterActor(const ray::TaskSpecification &task_
         callback(ComputeGcsStatus(status, reply.status()));
       },
       timeout_ms);
-  return Status::OK();
 }
 
 Status ActorInfoAccessor::SyncRegisterActor(const ray::TaskSpecification &task_spec) {
@@ -367,11 +330,11 @@ Status ActorInfoAccessor::SyncRegisterActor(const ray::TaskSpecification &task_s
   return ComputeGcsStatus(status, reply.status());
 }
 
-Status ActorInfoAccessor::AsyncKillActor(const ActorID &actor_id,
-                                         bool force_kill,
-                                         bool no_restart,
-                                         const ray::gcs::StatusCallback &callback,
-                                         int64_t timeout_ms) {
+void ActorInfoAccessor::AsyncKillActor(const ActorID &actor_id,
+                                       bool force_kill,
+                                       bool no_restart,
+                                       const ray::gcs::StatusCallback &callback,
+                                       int64_t timeout_ms) {
   rpc::KillActorViaGcsRequest request;
   request.set_actor_id(actor_id.Binary());
   request.set_force_kill(force_kill);
@@ -384,10 +347,9 @@ Status ActorInfoAccessor::AsyncKillActor(const ActorID &actor_id,
         }
       },
       timeout_ms);
-  return Status::OK();
 }
 
-Status ActorInfoAccessor::AsyncCreateActor(
+void ActorInfoAccessor::AsyncCreateActor(
     const ray::TaskSpecification &task_spec,
     const rpc::ClientCallback<rpc::CreateActorReply> &callback) {
   RAY_CHECK(task_spec.IsActorCreationTask() && callback);
@@ -397,10 +359,9 @@ Status ActorInfoAccessor::AsyncCreateActor(
       request, [callback](const Status &status, rpc::CreateActorReply &&reply) {
         callback(status, std::move(reply));
       });
-  return Status::OK();
 }
 
-Status ActorInfoAccessor::AsyncReportActorOutOfScope(
+void ActorInfoAccessor::AsyncReportActorOutOfScope(
     const ActorID &actor_id,
     uint64_t num_restarts_due_to_lineage_reconstruction,
     const StatusCallback &callback,
@@ -417,7 +378,6 @@ Status ActorInfoAccessor::AsyncReportActorOutOfScope(
         }
       },
       timeout_ms);
-  return Status::OK();
 }
 
 Status ActorInfoAccessor::AsyncSubscribe(
@@ -440,7 +400,7 @@ Status ActorInfoAccessor::AsyncSubscribe(
             fetch_done(status);
           }
         };
-        RAY_CHECK_OK(AsyncGet(actor_id, callback));
+        AsyncGet(actor_id, callback);
       };
 
   {
@@ -554,8 +514,8 @@ const NodeID &NodeInfoAccessor::GetSelfId() const { return local_node_id_; }
 
 const rpc::GcsNodeInfo &NodeInfoAccessor::GetSelfInfo() const { return local_node_info_; }
 
-Status NodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_info,
-                                       const StatusCallback &callback) {
+void NodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_info,
+                                     const StatusCallback &callback) {
   NodeID node_id = NodeID::FromBinary(node_info.node_id());
   RAY_LOG(DEBUG).WithField(node_id) << "Registering node info";
   rpc::RegisterNodeRequest request;
@@ -568,32 +528,30 @@ Status NodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_info,
         RAY_LOG(DEBUG).WithField(node_id)
             << "Finished registering node info, status = " << status;
       });
-  return Status::OK();
 }
 
-Status NodeInfoAccessor::AsyncCheckSelfAlive(
+void NodeInfoAccessor::AsyncCheckSelfAlive(
     const std::function<void(Status, bool)> &callback, int64_t timeout_ms = -1) {
   std::vector<std::string> raylet_addresses = {
       local_node_info_.node_manager_address() + ":" +
       std::to_string(local_node_info_.node_manager_port())};
 
-  return AsyncCheckAlive(
-      raylet_addresses,
-      timeout_ms,
-      [callback](const Status &status, const std::vector<bool> &nodes_alive) {
-        if (!status.ok()) {
-          callback(status, false);
-          return;
-        } else {
-          RAY_CHECK_EQ(nodes_alive.size(), static_cast<size_t>(1));
-          callback(status, nodes_alive[0]);
-        }
-      });
+  AsyncCheckAlive(raylet_addresses,
+                  timeout_ms,
+                  [callback](const Status &status, const std::vector<bool> &nodes_alive) {
+                    if (!status.ok()) {
+                      callback(status, false);
+                      return;
+                    } else {
+                      RAY_CHECK_EQ(nodes_alive.size(), static_cast<size_t>(1));
+                      callback(status, nodes_alive[0]);
+                    }
+                  });
 }
 
-Status NodeInfoAccessor::AsyncCheckAlive(const std::vector<std::string> &raylet_addresses,
-                                         int64_t timeout_ms,
-                                         const MultiItemCallback<bool> &callback) {
+void NodeInfoAccessor::AsyncCheckAlive(const std::vector<std::string> &raylet_addresses,
+                                       int64_t timeout_ms,
+                                       const MultiItemCallback<bool> &callback) {
   rpc::CheckAliveRequest request;
   for (const auto &raylet_address : raylet_addresses) {
     request.add_raylet_address(raylet_address);
@@ -615,7 +573,6 @@ Status NodeInfoAccessor::AsyncCheckAlive(const std::vector<std::string> &raylet_
         }
       },
       timeout_ms);
-  return Status::OK();
 }
 
 Status NodeInfoAccessor::DrainNodes(const std::vector<NodeID> &node_ids,
@@ -637,9 +594,9 @@ Status NodeInfoAccessor::DrainNodes(const std::vector<NodeID> &node_ids,
   return Status::OK();
 }
 
-Status NodeInfoAccessor::AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &callback,
-                                     int64_t timeout_ms,
-                                     std::optional<NodeID> node_id) {
+void NodeInfoAccessor::AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &callback,
+                                   int64_t timeout_ms,
+                                   std::optional<NodeID> node_id) {
   RAY_LOG(DEBUG) << "Getting information of all nodes.";
   rpc::GetAllNodeInfoRequest request;
   if (node_id) {
@@ -658,7 +615,6 @@ Status NodeInfoAccessor::AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &
                        << status;
       },
       timeout_ms);
-  return Status::OK();
 }
 
 Status NodeInfoAccessor::AsyncSubscribeToNodeChange(
@@ -678,7 +634,7 @@ Status NodeInfoAccessor::AsyncSubscribeToNodeChange(
         done(status);
       }
     };
-    RAY_CHECK_OK(AsyncGetAll(callback, /*timeout_ms=*/-1));
+    AsyncGetAll(callback, /*timeout_ms=*/-1);
   };
 
   subscribe_node_operation_ = [this](const StatusCallback &done) {
@@ -735,13 +691,13 @@ Status NodeInfoAccessor::CheckAlive(const std::vector<std::string> &raylet_addre
                                     int64_t timeout_ms,
                                     std::vector<bool> &nodes_alive) {
   std::promise<Status> ret_promise;
-  RAY_RETURN_NOT_OK(AsyncCheckAlive(
+  AsyncCheckAlive(
       raylet_addresses,
       timeout_ms,
       [&ret_promise, &nodes_alive](Status status, const std::vector<bool> &alive) {
         nodes_alive = alive;
         ret_promise.set_value(status);
-      }));
+      });
   return ret_promise.get_future().get();
 }
 
@@ -825,7 +781,7 @@ void NodeInfoAccessor::AsyncResubscribe() {
 NodeResourceInfoAccessor::NodeResourceInfoAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 
-Status NodeResourceInfoAccessor::AsyncGetAllAvailableResources(
+void NodeResourceInfoAccessor::AsyncGetAllAvailableResources(
     const MultiItemCallback<rpc::AvailableResources> &callback) {
   rpc::GetAllAvailableResourcesRequest request;
   client_impl_->GetGcsRpcClient().GetAllAvailableResources(
@@ -835,10 +791,9 @@ Status NodeResourceInfoAccessor::AsyncGetAllAvailableResources(
         RAY_LOG(DEBUG) << "Finished getting available resources of all nodes, status = "
                        << status;
       });
-  return Status::OK();
 }
 
-Status NodeResourceInfoAccessor::AsyncGetAllTotalResources(
+void NodeResourceInfoAccessor::AsyncGetAllTotalResources(
     const MultiItemCallback<rpc::TotalResources> &callback) {
   rpc::GetAllTotalResourcesRequest request;
   client_impl_->GetGcsRpcClient().GetAllTotalResources(
@@ -847,10 +802,9 @@ Status NodeResourceInfoAccessor::AsyncGetAllTotalResources(
         RAY_LOG(DEBUG) << "Finished getting total resources of all nodes, status = "
                        << status;
       });
-  return Status::OK();
 }
 
-Status NodeResourceInfoAccessor::AsyncGetDrainingNodes(
+void NodeResourceInfoAccessor::AsyncGetDrainingNodes(
     const ItemCallback<std::unordered_map<NodeID, int64_t>> &callback) {
   rpc::GetDrainingNodesRequest request;
   client_impl_->GetGcsRpcClient().GetDrainingNodes(
@@ -863,7 +817,6 @@ Status NodeResourceInfoAccessor::AsyncGetDrainingNodes(
         }
         callback(std::move(draining_nodes));
       });
-  return Status::OK();
 }
 
 void NodeResourceInfoAccessor::AsyncResubscribe() {
@@ -876,7 +829,7 @@ void NodeResourceInfoAccessor::AsyncResubscribe() {
   }
 }
 
-Status NodeResourceInfoAccessor::AsyncGetAllResourceUsage(
+void NodeResourceInfoAccessor::AsyncGetAllResourceUsage(
     const ItemCallback<rpc::ResourceUsageBatchData> &callback) {
   rpc::GetAllResourceUsageRequest request;
   client_impl_->GetGcsRpcClient().GetAllResourceUsage(
@@ -885,7 +838,6 @@ Status NodeResourceInfoAccessor::AsyncGetAllResourceUsage(
         RAY_LOG(DEBUG) << "Finished getting resource usage of all nodes, status = "
                        << status;
       });
-  return Status::OK();
 }
 
 Status NodeResourceInfoAccessor::GetAllResourceUsage(
@@ -895,8 +847,8 @@ Status NodeResourceInfoAccessor::GetAllResourceUsage(
       request, &reply, timeout_ms);
 }
 
-Status TaskInfoAccessor::AsyncAddTaskEventData(
-    std::unique_ptr<rpc::TaskEventData> data_ptr, StatusCallback callback) {
+void TaskInfoAccessor::AsyncAddTaskEventData(std::unique_ptr<rpc::TaskEventData> data_ptr,
+                                             StatusCallback callback) {
   rpc::AddTaskEventDataRequest request;
   // Prevent copy here
   request.mutable_data()->Swap(data_ptr.get());
@@ -907,10 +859,9 @@ Status TaskInfoAccessor::AsyncAddTaskEventData(
         }
         RAY_LOG(DEBUG) << "Accessor added task events grpc OK";
       });
-  return Status::OK();
 }
 
-Status TaskInfoAccessor::AsyncGetTaskEvents(
+void TaskInfoAccessor::AsyncGetTaskEvents(
     const MultiItemCallback<rpc::TaskEvents> &callback) {
   RAY_LOG(DEBUG) << "Getting all task events info.";
   RAY_CHECK(callback);
@@ -919,14 +870,12 @@ Status TaskInfoAccessor::AsyncGetTaskEvents(
       request, [callback](const Status &status, rpc::GetTaskEventsReply &&reply) {
         callback(status, VectorFromProtobuf(std::move(*reply.mutable_events_by_task())));
       });
-
-  return Status::OK();
 }
 
 ErrorInfoAccessor::ErrorInfoAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 
-Status ErrorInfoAccessor::AsyncReportJobError(
+void ErrorInfoAccessor::AsyncReportJobError(
     const std::shared_ptr<rpc::ErrorTableData> &data_ptr,
     const StatusCallback &callback) {
   auto job_id = JobID::FromBinary(data_ptr->job_id());
@@ -941,7 +890,6 @@ Status ErrorInfoAccessor::AsyncReportJobError(
         }
         RAY_LOG(DEBUG) << "Finished publishing job error, job id = " << job_id;
       });
-  return Status::OK();
 }
 
 WorkerInfoAccessor::WorkerInfoAccessor(GcsClient *client_impl)
@@ -966,7 +914,7 @@ void WorkerInfoAccessor::AsyncResubscribe() {
   }
 }
 
-Status WorkerInfoAccessor::AsyncReportWorkerFailure(
+void WorkerInfoAccessor::AsyncReportWorkerFailure(
     const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
     const StatusCallback &callback) {
   rpc::Address worker_address = data_ptr->worker_address();
@@ -983,10 +931,9 @@ Status WorkerInfoAccessor::AsyncReportWorkerFailure(
         RAY_LOG(DEBUG) << "Finished reporting worker failure, "
                        << worker_address.DebugString() << ", status = " << status;
       });
-  return Status::OK();
 }
 
-Status WorkerInfoAccessor::AsyncGet(
+void WorkerInfoAccessor::AsyncGet(
     const WorkerID &worker_id,
     const OptionalItemCallback<rpc::WorkerTableData> &callback) {
   RAY_LOG(DEBUG) << "Getting worker info, worker id = " << worker_id;
@@ -1002,10 +949,9 @@ Status WorkerInfoAccessor::AsyncGet(
         }
         RAY_LOG(DEBUG) << "Finished getting worker info, worker id = " << worker_id;
       });
-  return Status::OK();
 }
 
-Status WorkerInfoAccessor::AsyncGetAll(
+void WorkerInfoAccessor::AsyncGetAll(
     const MultiItemCallback<rpc::WorkerTableData> &callback) {
   RAY_LOG(DEBUG) << "Getting all worker info.";
   rpc::GetAllWorkerInfoRequest request;
@@ -1015,11 +961,10 @@ Status WorkerInfoAccessor::AsyncGetAll(
                  VectorFromProtobuf(std::move(*reply.mutable_worker_table_data())));
         RAY_LOG(DEBUG) << "Finished getting all worker info, status = " << status;
       });
-  return Status::OK();
 }
 
-Status WorkerInfoAccessor::AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-                                    const StatusCallback &callback) {
+void WorkerInfoAccessor::AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
+                                  const StatusCallback &callback) {
   rpc::AddWorkerInfoRequest request;
   request.mutable_worker_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddWorkerInfo(
@@ -1028,12 +973,11 @@ Status WorkerInfoAccessor::AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> 
           callback(status);
         }
       });
-  return Status::OK();
 }
 
-Status WorkerInfoAccessor::AsyncUpdateDebuggerPort(const WorkerID &worker_id,
-                                                   uint32_t debugger_port,
-                                                   const StatusCallback &callback) {
+void WorkerInfoAccessor::AsyncUpdateDebuggerPort(const WorkerID &worker_id,
+                                                 uint32_t debugger_port,
+                                                 const StatusCallback &callback) {
   rpc::UpdateWorkerDebuggerPortRequest request;
   request.set_worker_id(worker_id.Binary());
   request.set_debugger_port(debugger_port);
@@ -1046,10 +990,9 @@ Status WorkerInfoAccessor::AsyncUpdateDebuggerPort(const WorkerID &worker_id,
           callback(status);
         }
       });
-  return Status::OK();
 }
 
-Status WorkerInfoAccessor::AsyncUpdateWorkerNumPausedThreads(
+void WorkerInfoAccessor::AsyncUpdateWorkerNumPausedThreads(
     const WorkerID &worker_id,
     const int num_paused_threads_delta,
     const StatusCallback &callback) {
@@ -1065,7 +1008,6 @@ Status WorkerInfoAccessor::AsyncUpdateWorkerNumPausedThreads(
           callback(status);
         }
       });
-  return Status::OK();
 }
 
 PlacementGroupInfoAccessor::PlacementGroupInfoAccessor(GcsClient *client_impl)
@@ -1098,7 +1040,7 @@ Status PlacementGroupInfoAccessor::SyncRemovePlacementGroup(
   return status;
 }
 
-Status PlacementGroupInfoAccessor::AsyncGet(
+void PlacementGroupInfoAccessor::AsyncGet(
     const PlacementGroupID &placement_group_id,
     const OptionalItemCallback<rpc::PlacementGroupTableData> &callback) {
   RAY_LOG(DEBUG).WithField(placement_group_id) << "Getting placement group info";
@@ -1116,10 +1058,9 @@ Status PlacementGroupInfoAccessor::AsyncGet(
         RAY_LOG(DEBUG).WithField(placement_group_id)
             << "Finished getting placement group info";
       });
-  return Status::OK();
 }
 
-Status PlacementGroupInfoAccessor::AsyncGetByName(
+void PlacementGroupInfoAccessor::AsyncGetByName(
     const std::string &name,
     const std::string &ray_namespace,
     const OptionalItemCallback<rpc::PlacementGroupTableData> &callback,
@@ -1140,10 +1081,9 @@ Status PlacementGroupInfoAccessor::AsyncGetByName(
                        << status << ", name = " << name;
       },
       timeout_ms);
-  return Status::OK();
 }
 
-Status PlacementGroupInfoAccessor::AsyncGetAll(
+void PlacementGroupInfoAccessor::AsyncGetAll(
     const MultiItemCallback<rpc::PlacementGroupTableData> &callback) {
   RAY_LOG(DEBUG) << "Getting all placement group info.";
   rpc::GetAllPlacementGroupRequest request;
@@ -1155,7 +1095,6 @@ Status PlacementGroupInfoAccessor::AsyncGetAll(
         RAY_LOG(DEBUG) << "Finished getting all placement group info, status = "
                        << status;
       });
-  return Status::OK();
 }
 
 Status PlacementGroupInfoAccessor::SyncWaitUntilReady(
@@ -1173,7 +1112,7 @@ Status PlacementGroupInfoAccessor::SyncWaitUntilReady(
 InternalKVAccessor::InternalKVAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 
-Status InternalKVAccessor::AsyncInternalKVGet(
+void InternalKVAccessor::AsyncInternalKVGet(
     const std::string &ns,
     const std::string &key,
     const int64_t timeout_ms,
@@ -1191,10 +1130,9 @@ Status InternalKVAccessor::AsyncInternalKVGet(
         }
       },
       timeout_ms);
-  return Status::OK();
 }
 
-Status InternalKVAccessor::AsyncInternalKVMultiGet(
+void InternalKVAccessor::AsyncInternalKVMultiGet(
     const std::string &ns,
     const std::vector<std::string> &keys,
     const int64_t timeout_ms,
@@ -1221,16 +1159,14 @@ Status InternalKVAccessor::AsyncInternalKVMultiGet(
         }
       },
       timeout_ms);
-  return Status::OK();
 }
 
-Status InternalKVAccessor::AsyncInternalKVPut(
-    const std::string &ns,
-    const std::string &key,
-    const std::string &value,
-    bool overwrite,
-    const int64_t timeout_ms,
-    const OptionalItemCallback<bool> &callback) {
+void InternalKVAccessor::AsyncInternalKVPut(const std::string &ns,
+                                            const std::string &key,
+                                            const std::string &value,
+                                            bool overwrite,
+                                            const int64_t timeout_ms,
+                                            const OptionalItemCallback<bool> &callback) {
   rpc::InternalKVPutRequest req;
   req.set_namespace_(ns);
   req.set_key(key);
@@ -1242,10 +1178,9 @@ Status InternalKVAccessor::AsyncInternalKVPut(
         callback(status, reply.added());
       },
       timeout_ms);
-  return Status::OK();
 }
 
-Status InternalKVAccessor::AsyncInternalKVExists(
+void InternalKVAccessor::AsyncInternalKVExists(
     const std::string &ns,
     const std::string &key,
     const int64_t timeout_ms,
@@ -1259,14 +1194,13 @@ Status InternalKVAccessor::AsyncInternalKVExists(
         callback(status, reply.exists());
       },
       timeout_ms);
-  return Status::OK();
 }
 
-Status InternalKVAccessor::AsyncInternalKVDel(const std::string &ns,
-                                              const std::string &key,
-                                              bool del_by_prefix,
-                                              const int64_t timeout_ms,
-                                              const OptionalItemCallback<int> &callback) {
+void InternalKVAccessor::AsyncInternalKVDel(const std::string &ns,
+                                            const std::string &key,
+                                            bool del_by_prefix,
+                                            const int64_t timeout_ms,
+                                            const OptionalItemCallback<int> &callback) {
   rpc::InternalKVDelRequest req;
   req.set_namespace_(ns);
   req.set_key(key);
@@ -1277,10 +1211,9 @@ Status InternalKVAccessor::AsyncInternalKVDel(const std::string &ns,
         callback(status, reply.deleted_num());
       },
       timeout_ms);
-  return Status::OK();
 }
 
-Status InternalKVAccessor::AsyncInternalKVKeys(
+void InternalKVAccessor::AsyncInternalKVKeys(
     const std::string &ns,
     const std::string &prefix,
     const int64_t timeout_ms,
@@ -1298,7 +1231,6 @@ Status InternalKVAccessor::AsyncInternalKVKeys(
         }
       },
       timeout_ms);
-  return Status::OK();
 }
 
 Status InternalKVAccessor::Put(const std::string &ns,
@@ -1308,7 +1240,7 @@ Status InternalKVAccessor::Put(const std::string &ns,
                                const int64_t timeout_ms,
                                bool &added) {
   std::promise<Status> ret_promise;
-  RAY_CHECK_OK(AsyncInternalKVPut(
+  AsyncInternalKVPut(
       ns,
       key,
       value,
@@ -1317,7 +1249,7 @@ Status InternalKVAccessor::Put(const std::string &ns,
       [&ret_promise, &added](Status status, std::optional<bool> was_added) {
         added = was_added.value_or(false);
         ret_promise.set_value(status);
-      }));
+      });
   return ret_promise.get_future().get();
 }
 
@@ -1326,7 +1258,7 @@ Status InternalKVAccessor::Keys(const std::string &ns,
                                 const int64_t timeout_ms,
                                 std::vector<std::string> &value) {
   std::promise<Status> ret_promise;
-  RAY_CHECK_OK(AsyncInternalKVKeys(
+  AsyncInternalKVKeys(
       ns,
       prefix,
       timeout_ms,
@@ -1338,7 +1270,7 @@ Status InternalKVAccessor::Keys(const std::string &ns,
           value = std::vector<std::string>();
         }
         ret_promise.set_value(status);
-      }));
+      });
   return ret_promise.get_future().get();
 }
 
@@ -1347,7 +1279,7 @@ Status InternalKVAccessor::Get(const std::string &ns,
                                const int64_t timeout_ms,
                                std::string &value) {
   std::promise<Status> ret_promise;
-  RAY_CHECK_OK(AsyncInternalKVGet(
+  AsyncInternalKVGet(
       ns,
       key,
       timeout_ms,
@@ -1358,7 +1290,7 @@ Status InternalKVAccessor::Get(const std::string &ns,
           value.clear();
         }
         ret_promise.set_value(status);
-      }));
+      });
   return ret_promise.get_future().get();
 }
 
@@ -1368,7 +1300,7 @@ Status InternalKVAccessor::MultiGet(
     const int64_t timeout_ms,
     std::unordered_map<std::string, std::string> &values) {
   std::promise<Status> ret_promise;
-  RAY_CHECK_OK(AsyncInternalKVMultiGet(
+  AsyncInternalKVMultiGet(
       ns,
       keys,
       timeout_ms,
@@ -1380,7 +1312,7 @@ Status InternalKVAccessor::MultiGet(
           values = std::move(*vs);
         }
         ret_promise.set_value(status);
-      }));
+      });
   return ret_promise.get_future().get();
 }
 
@@ -1390,7 +1322,7 @@ Status InternalKVAccessor::Del(const std::string &ns,
                                const int64_t timeout_ms,
                                int &num_deleted) {
   std::promise<Status> ret_promise;
-  RAY_CHECK_OK(AsyncInternalKVDel(
+  AsyncInternalKVDel(
       ns,
       key,
       del_by_prefix,
@@ -1398,7 +1330,7 @@ Status InternalKVAccessor::Del(const std::string &ns,
       [&ret_promise, &num_deleted](Status status, std::optional<int> &&value) {
         num_deleted = value.value_or(0);
         ret_promise.set_value(status);
-      }));
+      });
   return ret_promise.get_future().get();
 }
 
@@ -1407,18 +1339,18 @@ Status InternalKVAccessor::Exists(const std::string &ns,
                                   const int64_t timeout_ms,
                                   bool &exists) {
   std::promise<Status> ret_promise;
-  RAY_CHECK_OK(AsyncInternalKVExists(
+  AsyncInternalKVExists(
       ns,
       key,
       timeout_ms,
       [&ret_promise, &exists](Status status, std::optional<bool> &&value) {
         exists = value.value_or(false);
         ret_promise.set_value(status);
-      }));
+      });
   return ret_promise.get_future().get();
 }
 
-Status InternalKVAccessor::AsyncGetInternalConfig(
+void InternalKVAccessor::AsyncGetInternalConfig(
     const OptionalItemCallback<std::string> &callback) {
   rpc::GetInternalConfigRequest request;
   client_impl_->GetGcsRpcClient().GetInternalConfig(
@@ -1430,7 +1362,6 @@ Status InternalKVAccessor::AsyncGetInternalConfig(
         }
         callback(status, reply.config());
       });
-  return Status::OK();
 }
 
 RuntimeEnvAccessor::RuntimeEnvAccessor(GcsClient *client_impl)
@@ -1502,12 +1433,11 @@ Status AutoscalerStateAccessor::GetClusterStatus(int64_t timeout_ms,
   return Status::OK();
 }
 
-Status AutoscalerStateAccessor::AsyncGetClusterStatus(
+void AutoscalerStateAccessor::AsyncGetClusterStatus(
     int64_t timeout_ms,
     const OptionalItemCallback<rpc::autoscaler::GetClusterStatusReply> &callback) {
   rpc::autoscaler::GetClusterStatusRequest request;
   rpc::autoscaler::GetClusterStatusRequest reply;
-
   client_impl_->GetGcsRpcClient().GetClusterStatus(
       request,
       [callback](const Status &status, rpc::autoscaler::GetClusterStatusReply &&reply) {
@@ -1518,8 +1448,6 @@ Status AutoscalerStateAccessor::AsyncGetClusterStatus(
         callback(Status::OK(), std::move(reply));
       },
       timeout_ms);
-
-  return Status::OK();
 }
 
 Status AutoscalerStateAccessor::ReportAutoscalingState(
@@ -1598,7 +1526,7 @@ Status PublisherAccessor::PublishLogs(std::string key_id,
   return client_impl_->GetGcsRpcClient().SyncGcsPublish(request, &reply, timeout_ms);
 }
 
-Status PublisherAccessor::AsyncPublishNodeResourceUsage(
+void PublisherAccessor::AsyncPublishNodeResourceUsage(
     std::string key_id,
     std::string node_resource_usage_json,
     const StatusCallback &done) {
@@ -1611,7 +1539,6 @@ Status PublisherAccessor::AsyncPublishNodeResourceUsage(
   client_impl_->GetGcsRpcClient().GcsPublish(
       request,
       [done](const Status &status, rpc::GcsPublishReply &&reply) { done(status); });
-  return Status::OK();
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -56,9 +56,8 @@ class ActorInfoAccessor {
   ///
   /// \param actor_id The ID of actor to look up in the GCS.
   /// \param callback Callback that will be called after lookup finishes.
-  /// \return Status
-  virtual Status AsyncGet(const ActorID &actor_id,
-                          const OptionalItemCallback<rpc::ActorTableData> &callback);
+  virtual void AsyncGet(const ActorID &actor_id,
+                        const OptionalItemCallback<rpc::ActorTableData> &callback);
 
   /// Get all actor specification from the GCS asynchronously.
   ///
@@ -67,13 +66,11 @@ class ActorInfoAccessor {
   /// \param  actor_state_name To filter actors based on actor state.
   /// \param callback Callback that will be called after lookup finishes.
   /// \param timeout_ms -1 means infinite.
-  /// \return Status
-  virtual Status AsyncGetAllByFilter(
-      const std::optional<ActorID> &actor_id,
-      const std::optional<JobID> &job_id,
-      const std::optional<std::string> &actor_state_name,
-      const MultiItemCallback<rpc::ActorTableData> &callback,
-      int64_t timeout_ms = -1);
+  virtual void AsyncGetAllByFilter(const std::optional<ActorID> &actor_id,
+                                   const std::optional<JobID> &job_id,
+                                   const std::optional<std::string> &actor_state_name,
+                                   const MultiItemCallback<rpc::ActorTableData> &callback,
+                                   int64_t timeout_ms = -1);
 
   /// Get actor specification for a named actor from the GCS asynchronously.
   ///
@@ -81,11 +78,10 @@ class ActorInfoAccessor {
   /// \param ray_namespace The namespace to filter to.
   /// \param callback Callback that will be called after lookup finishes.
   /// \param timeout_ms RPC timeout in milliseconds. -1 means the default.
-  /// \return Status
-  virtual Status AsyncGetByName(const std::string &name,
-                                const std::string &ray_namespace,
-                                const OptionalItemCallback<rpc::ActorTableData> &callback,
-                                int64_t timeout_ms = -1);
+  virtual void AsyncGetByName(const std::string &name,
+                              const std::string &ray_namespace,
+                              const OptionalItemCallback<rpc::ActorTableData> &callback,
+                              int64_t timeout_ms = -1);
 
   /// Get actor specification for a named actor from the GCS synchronously.
   ///
@@ -100,19 +96,6 @@ class ActorInfoAccessor {
                                rpc::ActorTableData &actor_table_data,
                                rpc::TaskSpec &task_spec);
 
-  /// List all named actors from the GCS asynchronously.
-  ///
-  /// \param all_namespaces Whether or not to include actors from all Ray namespaces.
-  /// \param ray_namespace The namespace to filter to if all_namespaces is false.
-  /// \param callback Callback that will be called after lookup finishes.
-  /// \param timeout_ms The RPC timeout in milliseconds. -1 means the default.
-  /// \return Status
-  virtual Status AsyncListNamedActors(
-      bool all_namespaces,
-      const std::string &ray_namespace,
-      const OptionalItemCallback<std::vector<rpc::NamedActorInfo>> &callback,
-      int64_t timeout_ms = -1);
-
   /// List all named actors from the GCS synchronously.
   ///
   /// The RPC will timeout after the default GCS RPC timeout is exceeded.
@@ -126,7 +109,7 @@ class ActorInfoAccessor {
       const std::string &ray_namespace,
       std::vector<std::pair<std::string, std::string>> &actors);
 
-  virtual Status AsyncReportActorOutOfScope(
+  virtual void AsyncReportActorOutOfScope(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstruction,
       const StatusCallback &callback,
@@ -137,12 +120,11 @@ class ActorInfoAccessor {
   /// \param task_spec The specification for the actor creation task.
   /// \param callback Callback that will be called after the actor info is written to GCS.
   /// \param timeout_ms RPC timeout ms. -1 means there's no timeout.
-  /// \return Status
-  virtual Status AsyncRegisterActor(const TaskSpecification &task_spec,
-                                    const StatusCallback &callback,
-                                    int64_t timeout_ms = -1);
+  virtual void AsyncRegisterActor(const TaskSpecification &task_spec,
+                                  const StatusCallback &callback,
+                                  int64_t timeout_ms = -1);
 
-  virtual Status AsyncRestartActorForLineageReconstruction(
+  virtual void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,
       const StatusCallback &callback,
@@ -164,12 +146,11 @@ class ActorInfoAccessor {
   /// \param no_restart If set to true, the killed actor will not be restarted anymore.
   /// \param callback Callback that will be called after the actor is destroyed.
   /// \param timeout_ms RPC timeout in milliseconds. -1 means infinite.
-  /// \return Status
-  virtual Status AsyncKillActor(const ActorID &actor_id,
-                                bool force_kill,
-                                bool no_restart,
-                                const StatusCallback &callback,
-                                int64_t timeout_ms = -1);
+  virtual void AsyncKillActor(const ActorID &actor_id,
+                              bool force_kill,
+                              bool no_restart,
+                              const StatusCallback &callback,
+                              int64_t timeout_ms = -1);
 
   /// Asynchronously request GCS to create the actor.
   ///
@@ -180,8 +161,7 @@ class ActorInfoAccessor {
   ///
   /// \param task_spec The specification for the actor creation task.
   /// \param callback Callback that will be called after the actor info is written to GCS.
-  /// \return Status
-  virtual Status AsyncCreateActor(
+  virtual void AsyncCreateActor(
       const TaskSpecification &task_spec,
       const rpc::ClientCallback<rpc::CreateActorReply> &callback);
 
@@ -244,16 +224,14 @@ class JobInfoAccessor {
   /// \param data_ptr The job that will be add to GCS.
   /// \param callback Callback that will be called after job has been added
   /// to GCS.
-  /// \return Status
-  virtual Status AsyncAdd(const std::shared_ptr<rpc::JobTableData> &data_ptr,
-                          const StatusCallback &callback);
+  virtual void AsyncAdd(const std::shared_ptr<rpc::JobTableData> &data_ptr,
+                        const StatusCallback &callback);
 
   /// Mark job as finished in GCS asynchronously.
   ///
   /// \param job_id ID of the job that will be make finished to GCS.
   /// \param callback Callback that will be called after update finished.
-  /// \return Status
-  virtual Status AsyncMarkFinished(const JobID &job_id, const StatusCallback &callback);
+  virtual void AsyncMarkFinished(const JobID &job_id, const StatusCallback &callback);
 
   /// Subscribe to job updates.
   ///
@@ -268,12 +246,11 @@ class JobInfoAccessor {
   ///
   /// \param job_or_submission_id If not null, filter the jobs with this id.
   /// \param callback Callback that will be called after lookup finished.
-  /// \return Status
-  virtual Status AsyncGetAll(const std::optional<std::string> &job_or_submission_id,
-                             bool skip_submission_job_info_field,
-                             bool skip_is_running_tasks_field,
-                             const MultiItemCallback<rpc::JobTableData> &callback,
-                             int64_t timeout_ms);
+  virtual void AsyncGetAll(const std::optional<std::string> &job_or_submission_id,
+                           bool skip_submission_job_info_field,
+                           bool skip_is_running_tasks_field,
+                           const MultiItemCallback<rpc::JobTableData> &callback,
+                           int64_t timeout_ms);
 
   /// Get all job info from GCS synchronously.
   ///
@@ -297,8 +274,7 @@ class JobInfoAccessor {
   /// Increment and get next job id. This is not idempotent.
   ///
   /// \param done Callback that will be called when request successfully.
-  /// \return Status
-  virtual Status AsyncGetNextJobID(const ItemCallback<JobID> &callback);
+  virtual void AsyncGetNextJobID(const ItemCallback<JobID> &callback);
 
  private:
   /// Save the fetch data operation in this function, so we can call it again when GCS
@@ -351,36 +327,32 @@ class NodeInfoAccessor {
   ///
   /// \param node_info The information of node to register to GCS.
   /// \param callback Callback that will be called when registration is complete.
-  /// \return Status
-  virtual Status AsyncRegister(const rpc::GcsNodeInfo &node_info,
-                               const StatusCallback &callback);
+  virtual void AsyncRegister(const rpc::GcsNodeInfo &node_info,
+                             const StatusCallback &callback);
 
   /// Send a check alive request to GCS for the liveness of this node.
   ///
   /// \param callback The callback function once the request is finished.
   /// \param timeout_ms The timeout for this request.
-  /// \return Status
-  virtual Status AsyncCheckSelfAlive(const std::function<void(Status, bool)> &callback,
-                                     int64_t timeout_ms);
+  virtual void AsyncCheckSelfAlive(const std::function<void(Status, bool)> &callback,
+                                   int64_t timeout_ms);
 
   /// Send a check alive request to GCS for the liveness of some nodes.
   ///
   /// \param callback The callback function once the request is finished.
   /// \param timeout_ms The timeout for this request.
-  /// \return Status
-  virtual Status AsyncCheckAlive(const std::vector<std::string> &raylet_addresses,
-                                 int64_t timeout_ms,
-                                 const MultiItemCallback<bool> &callback);
+  virtual void AsyncCheckAlive(const std::vector<std::string> &raylet_addresses,
+                               int64_t timeout_ms,
+                               const MultiItemCallback<bool> &callback);
 
   /// Get information of all nodes from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.
   /// \param timeout_ms The timeout for this request.
   /// \param node_id If not nullopt, only return the node info of the specified node.
-  /// \return Status
-  virtual Status AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &callback,
-                             int64_t timeout_ms,
-                             std::optional<NodeID> node_id = std::nullopt);
+  virtual void AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &callback,
+                           int64_t timeout_ms,
+                           std::optional<NodeID> node_id = std::nullopt);
 
   /// Subscribe to node addition and removal events from GCS and cache those information.
   ///
@@ -509,22 +481,19 @@ class NodeResourceInfoAccessor {
   /// Get available resources of all nodes from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.
-  /// \return Status
-  virtual Status AsyncGetAllAvailableResources(
+  virtual void AsyncGetAllAvailableResources(
       const MultiItemCallback<rpc::AvailableResources> &callback);
 
   /// Get total resources of all nodes from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.
-  /// \return Status
-  virtual Status AsyncGetAllTotalResources(
+  virtual void AsyncGetAllTotalResources(
       const MultiItemCallback<rpc::TotalResources> &callback);
 
   /// Get draining nodes from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.
-  /// \return Status
-  virtual Status AsyncGetDrainingNodes(
+  virtual void AsyncGetDrainingNodes(
       const ItemCallback<std::unordered_map<NodeID, int64_t>> &callback);
 
   /// Reestablish subscription.
@@ -537,8 +506,7 @@ class NodeResourceInfoAccessor {
   /// Get newest resource usage of all nodes from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.
-  /// \return Status
-  virtual Status AsyncGetAllResourceUsage(
+  virtual void AsyncGetAllResourceUsage(
       const ItemCallback<rpc::ResourceUsageBatchData> &callback);
 
   /// Get newest resource usage of all nodes from GCS synchronously.
@@ -579,9 +547,8 @@ class ErrorInfoAccessor {
   ///
   /// \param data_ptr The error message that will be reported to GCS.
   /// \param callback Callback that will be called when report is complete.
-  /// \return Status
-  virtual Status AsyncReportJobError(const std::shared_ptr<rpc::ErrorTableData> &data_ptr,
-                                     const StatusCallback &callback);
+  virtual void AsyncReportJobError(const std::shared_ptr<rpc::ErrorTableData> &data_ptr,
+                                   const StatusCallback &callback);
 
  private:
   GcsClient *client_impl_;
@@ -600,15 +567,13 @@ class TaskInfoAccessor {
   ///
   /// \param data_ptr The task states event data that will be added to GCS.
   /// \param callback Callback that will be called when add is complete.
-  /// \return Status
-  virtual Status AsyncAddTaskEventData(std::unique_ptr<rpc::TaskEventData> data_ptr,
-                                       StatusCallback callback);
+  virtual void AsyncAddTaskEventData(std::unique_ptr<rpc::TaskEventData> data_ptr,
+                                     StatusCallback callback);
 
   /// Get all info/events of all tasks stored in GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.
-  /// \return Status
-  virtual Status AsyncGetTaskEvents(const MultiItemCallback<rpc::TaskEvents> &callback);
+  virtual void AsyncGetTaskEvents(const MultiItemCallback<rpc::TaskEvents> &callback);
 
  private:
   GcsClient *client_impl_;
@@ -637,8 +602,7 @@ class WorkerInfoAccessor {
   ///
   /// \param data_ptr The worker failure information that will be reported to GCS.
   /// \param callback Callback that will be called when report is complate.
-  /// \param Status
-  virtual Status AsyncReportWorkerFailure(
+  virtual void AsyncReportWorkerFailure(
       const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
       const StatusCallback &callback);
 
@@ -646,44 +610,39 @@ class WorkerInfoAccessor {
   ///
   /// \param worker_id The ID of worker to look up in the GCS.
   /// \param callback Callback that will be called after lookup finishes.
-  /// \return Status
-  virtual Status AsyncGet(const WorkerID &worker_id,
-                          const OptionalItemCallback<rpc::WorkerTableData> &callback);
+  virtual void AsyncGet(const WorkerID &worker_id,
+                        const OptionalItemCallback<rpc::WorkerTableData> &callback);
 
   /// Get all worker info from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finished.
-  /// \return Status
-  virtual Status AsyncGetAll(const MultiItemCallback<rpc::WorkerTableData> &callback);
+  virtual void AsyncGetAll(const MultiItemCallback<rpc::WorkerTableData> &callback);
 
   /// Add worker information to GCS asynchronously.
   ///
   /// \param data_ptr The worker that will be add to GCS.
   /// \param callback Callback that will be called after worker information has been added
   /// to GCS.
-  /// \return Status
-  virtual Status AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-                          const StatusCallback &callback);
+  virtual void AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
+                        const StatusCallback &callback);
 
   /// Update the worker debugger port in GCS asynchronously.
   ///
   /// \param worker_id The ID of worker to update in the GCS.
   /// \param debugger_port The debugger port of worker to update in the GCS.
   /// \param callback Callback that will be called after update finishes.
-  /// \return Status
-  virtual Status AsyncUpdateDebuggerPort(const WorkerID &worker_id,
-                                         uint32_t debugger_port,
-                                         const StatusCallback &callback);
+  virtual void AsyncUpdateDebuggerPort(const WorkerID &worker_id,
+                                       uint32_t debugger_port,
+                                       const StatusCallback &callback);
 
   /// Update the number of worker's paused threads in GCS asynchronously.
   ///
   /// \param worker_id The ID of worker to update in the GCS.
   /// \param num_paused_threads_delta The number of paused threads to update in the GCS.
   /// \param callback Callback that will be called after update finishes.
-  /// \return Status
-  virtual Status AsyncUpdateWorkerNumPausedThreads(const WorkerID &worker_id,
-                                                   int num_paused_threads_delta,
-                                                   const StatusCallback &callback);
+  virtual void AsyncUpdateWorkerNumPausedThreads(const WorkerID &worker_id,
+                                                 int num_paused_threads_delta,
+                                                 const StatusCallback &callback);
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   /// PubSub server restart will cause GCS server restart. In this case, we need to
@@ -718,8 +677,7 @@ class PlacementGroupInfoAccessor {
   /// Get a placement group data from GCS asynchronously by id.
   ///
   /// \param placement_group_id The id of a placement group to obtain from GCS.
-  /// \return Status.
-  virtual Status AsyncGet(
+  virtual void AsyncGet(
       const PlacementGroupID &placement_group_id,
       const OptionalItemCallback<rpc::PlacementGroupTableData> &callback);
 
@@ -729,8 +687,7 @@ class PlacementGroupInfoAccessor {
   /// \param ray_namespace The ray namespace.
   /// \param callback The callback that's called when the RPC is replied.
   /// \param timeout_ms The RPC timeout in milliseconds. -1 means the default.
-  /// \return Status.
-  virtual Status AsyncGetByName(
+  virtual void AsyncGetByName(
       const std::string &placement_group_name,
       const std::string &ray_namespace,
       const OptionalItemCallback<rpc::PlacementGroupTableData> &callback,
@@ -739,8 +696,7 @@ class PlacementGroupInfoAccessor {
   /// Get all placement group info from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finished.
-  /// \return Status
-  virtual Status AsyncGetAll(
+  virtual void AsyncGetAll(
       const MultiItemCallback<rpc::PlacementGroupTableData> &callback);
 
   /// Remove a placement group to GCS synchronously.
@@ -777,8 +733,7 @@ class InternalKVAccessor {
   /// \param prefix The prefix to scan.
   /// \param timeout_ms -1 means infinite.
   /// \param callback Callback that will be called after scanning.
-  /// \return Status
-  virtual Status AsyncInternalKVKeys(
+  virtual void AsyncInternalKVKeys(
       const std::string &ns,
       const std::string &prefix,
       const int64_t timeout_ms,
@@ -790,10 +745,10 @@ class InternalKVAccessor {
   /// \param key The key to lookup.
   /// \param timeout_ms -1 means infinite.
   /// \param callback Callback that will be called after get the value.
-  virtual Status AsyncInternalKVGet(const std::string &ns,
-                                    const std::string &key,
-                                    const int64_t timeout_ms,
-                                    const OptionalItemCallback<std::string> &callback);
+  virtual void AsyncInternalKVGet(const std::string &ns,
+                                  const std::string &key,
+                                  const int64_t timeout_ms,
+                                  const OptionalItemCallback<std::string> &callback);
 
   /// Asynchronously get the value for multiple keys.
   ///
@@ -801,7 +756,7 @@ class InternalKVAccessor {
   /// \param keys The keys to lookup.
   /// \param timeout_ms -1 means infinite.
   /// \param callback Callback that will be called after get the values.
-  virtual Status AsyncInternalKVMultiGet(
+  virtual void AsyncInternalKVMultiGet(
       const std::string &ns,
       const std::vector<std::string> &keys,
       const int64_t timeout_ms,
@@ -814,13 +769,12 @@ class InternalKVAccessor {
   /// \param value The value associated with the key
   /// \param timeout_ms -1 means infinite.
   /// \param callback Callback that will be called after the operation.
-  /// \return Status
-  virtual Status AsyncInternalKVPut(const std::string &ns,
-                                    const std::string &key,
-                                    const std::string &value,
-                                    bool overwrite,
-                                    const int64_t timeout_ms,
-                                    const OptionalItemCallback<bool> &callback);
+  virtual void AsyncInternalKVPut(const std::string &ns,
+                                  const std::string &key,
+                                  const std::string &value,
+                                  bool overwrite,
+                                  const int64_t timeout_ms,
+                                  const OptionalItemCallback<bool> &callback);
 
   /// Asynchronously check the existence of a given key
   ///
@@ -829,11 +783,10 @@ class InternalKVAccessor {
   /// \param timeout_ms -1 means infinite.
   /// \param callback Callback that will be called after the operation. Called with `true`
   /// if the key is deleted; `false` if it doesn't exist.
-  /// \return Status
-  virtual Status AsyncInternalKVExists(const std::string &ns,
-                                       const std::string &key,
-                                       const int64_t timeout_ms,
-                                       const OptionalItemCallback<bool> &callback);
+  virtual void AsyncInternalKVExists(const std::string &ns,
+                                     const std::string &key,
+                                     const int64_t timeout_ms,
+                                     const OptionalItemCallback<bool> &callback);
 
   /// Asynchronously delete a key
   ///
@@ -843,12 +796,11 @@ class InternalKVAccessor {
   /// \param timeout_ms -1 means infinite.
   /// \param callback Callback that will be called after the operation. Called with number
   /// of keys deleted.
-  /// \return Status
-  virtual Status AsyncInternalKVDel(const std::string &ns,
-                                    const std::string &key,
-                                    bool del_by_prefix,
-                                    const int64_t timeout_ms,
-                                    const OptionalItemCallback<int> &callback);
+  virtual void AsyncInternalKVDel(const std::string &ns,
+                                  const std::string &key,
+                                  bool del_by_prefix,
+                                  const int64_t timeout_ms,
+                                  const OptionalItemCallback<int> &callback);
 
   // These are sync functions of the async above
 
@@ -946,9 +898,7 @@ class InternalKVAccessor {
   /// Get the internal config string from GCS.
   ///
   /// \param callback Processes a map of config options
-  /// \return Status
-  virtual Status AsyncGetInternalConfig(
-      const OptionalItemCallback<std::string> &callback);
+  virtual void AsyncGetInternalConfig(const OptionalItemCallback<std::string> &callback);
 
  private:
   GcsClient *client_impl_;
@@ -992,7 +942,7 @@ class AutoscalerStateAccessor {
 
   virtual Status GetClusterStatus(int64_t timeout_ms, std::string &serialized_reply);
 
-  virtual Status AsyncGetClusterStatus(
+  virtual void AsyncGetClusterStatus(
       int64_t timeout_ms,
       const OptionalItemCallback<rpc::autoscaler::GetClusterStatusReply> &callback);
 
@@ -1030,9 +980,9 @@ class PublisherAccessor {
 
   virtual Status PublishLogs(std::string key_id, rpc::LogBatch data, int64_t timeout_ms);
 
-  virtual Status AsyncPublishNodeResourceUsage(std::string key_id,
-                                               std::string node_resource_usage_json,
-                                               const StatusCallback &done);
+  virtual void AsyncPublishNodeResourceUsage(std::string key_id,
+                                             std::string node_resource_usage_json,
+                                             const StatusCallback &done);
 
  private:
   GcsClient *client_impl_;

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -73,12 +73,12 @@ std::vector<std::string> GlobalStateAccessor::GetAllJobInfo(
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Jobs().AsyncGetAll(
+    gcs_client_->Jobs().AsyncGetAll(
         /*job_or_submission_id=*/std::nullopt,
         skip_submission_job_info_field,
         skip_is_running_tasks_field,
         TransformForMultiItemCallback<rpc::JobTableData>(job_table_data, promise),
-        /*timeout_ms=*/-1));
+        /*timeout_ms=*/-1);
   }
   promise.get_future().get();
   return job_table_data;
@@ -88,8 +88,8 @@ JobID GlobalStateAccessor::GetNextJobID() {
   std::promise<JobID> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Jobs().AsyncGetNextJobID(
-        [&promise](const JobID &job_id) { promise.set_value(job_id); }));
+    gcs_client_->Jobs().AsyncGetNextJobID(
+        [&promise](const JobID &job_id) { promise.set_value(job_id); });
   }
   return promise.get_future().get();
 }
@@ -101,9 +101,9 @@ std::vector<std::string> GlobalStateAccessor::GetAllNodeInfo() {
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Nodes().AsyncGetAll(
+    gcs_client_->Nodes().AsyncGetAll(
         TransformForMultiItemCallback<rpc::GcsNodeInfo>(node_table_data, promise),
-        /*timeout_ms=*/-1));
+        /*timeout_ms=*/-1);
   }
   promise.get_future().get();
   return node_table_data;
@@ -114,8 +114,8 @@ std::vector<std::string> GlobalStateAccessor::GetAllTaskEvents() {
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Tasks().AsyncGetTaskEvents(
-        TransformForMultiItemCallback<rpc::TaskEvents>(task_events, promise)));
+    gcs_client_->Tasks().AsyncGetTaskEvents(
+        TransformForMultiItemCallback<rpc::TaskEvents>(task_events, promise));
   }
   promise.get_future().get();
   return task_events;
@@ -126,9 +126,9 @@ std::vector<std::string> GlobalStateAccessor::GetAllAvailableResources() {
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->NodeResources().AsyncGetAllAvailableResources(
+    gcs_client_->NodeResources().AsyncGetAllAvailableResources(
         TransformForMultiItemCallback<rpc::AvailableResources>(available_resources,
-                                                               promise)));
+                                                               promise));
   }
   promise.get_future().get();
   return available_resources;
@@ -139,8 +139,8 @@ std::vector<std::string> GlobalStateAccessor::GetAllTotalResources() {
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->NodeResources().AsyncGetAllTotalResources(
-        TransformForMultiItemCallback<rpc::TotalResources>(total_resources, promise)));
+    gcs_client_->NodeResources().AsyncGetAllTotalResources(
+        TransformForMultiItemCallback<rpc::TotalResources>(total_resources, promise));
   }
   promise.get_future().get();
   return total_resources;
@@ -150,10 +150,10 @@ std::unordered_map<NodeID, int64_t> GlobalStateAccessor::GetDrainingNodes() {
   std::promise<std::unordered_map<NodeID, int64_t>> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->NodeResources().AsyncGetDrainingNodes(
+    gcs_client_->NodeResources().AsyncGetDrainingNodes(
         [&promise](const std::unordered_map<NodeID, int64_t> &draining_nodes) {
           promise.set_value(draining_nodes);
-        }));
+        });
   }
   return promise.get_future().get();
 }
@@ -163,9 +163,9 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetAllResourceUsage() {
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->NodeResources().AsyncGetAllResourceUsage(
+    gcs_client_->NodeResources().AsyncGetAllResourceUsage(
         TransformForItemCallback<rpc::ResourceUsageBatchData>(resource_batch_data,
-                                                              promise)));
+                                                              promise));
   }
   promise.get_future().get();
   return resource_batch_data;
@@ -179,11 +179,11 @@ std::vector<std::string> GlobalStateAccessor::GetAllActorInfo(
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Actors().AsyncGetAllByFilter(
+    gcs_client_->Actors().AsyncGetAllByFilter(
         actor_id,
         job_id,
         actor_state_name,
-        TransformForMultiItemCallback<rpc::ActorTableData>(actor_table_data, promise)));
+        TransformForMultiItemCallback<rpc::ActorTableData>(actor_table_data, promise));
   }
   promise.get_future().get();
   return actor_table_data;
@@ -194,10 +194,9 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetActorInfo(const ActorID &ac
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Actors().AsyncGet(
+    gcs_client_->Actors().AsyncGet(
         actor_id,
-        TransformForOptionalItemCallback<rpc::ActorTableData>(actor_table_data,
-                                                              promise)));
+        TransformForOptionalItemCallback<rpc::ActorTableData>(actor_table_data, promise));
   }
   promise.get_future().get();
   return actor_table_data;
@@ -209,10 +208,10 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetWorkerInfo(
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Workers().AsyncGet(
+    gcs_client_->Workers().AsyncGet(
         worker_id,
         TransformForOptionalItemCallback<rpc::WorkerTableData>(worker_table_data,
-                                                               promise)));
+                                                               promise));
   }
   promise.get_future().get();
   return worker_table_data;
@@ -223,8 +222,8 @@ std::vector<std::string> GlobalStateAccessor::GetAllWorkerInfo() {
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Workers().AsyncGetAll(
-        TransformForMultiItemCallback<rpc::WorkerTableData>(worker_table_data, promise)));
+    gcs_client_->Workers().AsyncGetAll(
+        TransformForMultiItemCallback<rpc::WorkerTableData>(worker_table_data, promise));
   }
   promise.get_future().get();
   return worker_table_data;
@@ -236,11 +235,10 @@ bool GlobalStateAccessor::AddWorkerInfo(const std::string &serialized_string) {
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(
-        gcs_client_->Workers().AsyncAdd(data_ptr, [&promise](const Status &status) {
-          RAY_CHECK_OK(status);
-          promise.set_value(true);
-        }));
+    gcs_client_->Workers().AsyncAdd(data_ptr, [&promise](const Status &status) {
+      RAY_CHECK_OK(status);
+      promise.set_value(true);
+    });
   }
   promise.get_future().get();
   return true;
@@ -251,7 +249,7 @@ uint32_t GlobalStateAccessor::GetWorkerDebuggerPort(const WorkerID &worker_id) {
   std::promise<uint32_t> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Workers().AsyncGet(
+    gcs_client_->Workers().AsyncGet(
         worker_id,
         [&promise](const Status &status,
                    const std::optional<rpc::WorkerTableData> &result) {
@@ -261,7 +259,7 @@ uint32_t GlobalStateAccessor::GetWorkerDebuggerPort(const WorkerID &worker_id) {
             return;
           }
           promise.set_value(0);
-        }));
+        });
   }
   // Setup a timeout
   auto future = promise.get_future();
@@ -281,11 +279,11 @@ bool GlobalStateAccessor::UpdateWorkerDebuggerPort(const WorkerID &worker_id,
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Workers().AsyncUpdateDebuggerPort(
+    gcs_client_->Workers().AsyncUpdateDebuggerPort(
         worker_id, debugger_port, [&promise](const Status &status) {
           RAY_CHECK_OK(status);
           promise.set_value(status.ok());
-        }));
+        });
   }
   // Setup a timeout for the update request
   auto future = promise.get_future();
@@ -311,11 +309,11 @@ bool GlobalStateAccessor::UpdateWorkerNumPausedThreads(
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Workers().AsyncUpdateWorkerNumPausedThreads(
+    gcs_client_->Workers().AsyncUpdateWorkerNumPausedThreads(
         worker_id, num_paused_threads_delta, [&promise](const Status &status) {
           RAY_CHECK_OK(status);
           promise.set_value(status.ok());
-        }));
+        });
   }
   // Setup a timeout for the update request
   auto future = promise.get_future();
@@ -334,9 +332,9 @@ std::vector<std::string> GlobalStateAccessor::GetAllPlacementGroupInfo() {
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->PlacementGroups().AsyncGetAll(
+    gcs_client_->PlacementGroups().AsyncGetAll(
         TransformForMultiItemCallback<rpc::PlacementGroupTableData>(
-            placement_group_table_data, promise)));
+            placement_group_table_data, promise));
   }
   promise.get_future().get();
   return placement_group_table_data;
@@ -348,10 +346,10 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetPlacementGroupInfo(
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->PlacementGroups().AsyncGet(
+    gcs_client_->PlacementGroups().AsyncGet(
         placement_group_id,
         TransformForOptionalItemCallback<rpc::PlacementGroupTableData>(
-            placement_group_table_data, promise)));
+            placement_group_table_data, promise));
   }
   promise.get_future().get();
   return placement_group_table_data;
@@ -363,11 +361,11 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetPlacementGroupByName(
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->PlacementGroups().AsyncGetByName(
+    gcs_client_->PlacementGroups().AsyncGetByName(
         placement_group_name,
         ray_namespace,
         TransformForOptionalItemCallback<rpc::PlacementGroupTableData>(
-            placement_group_table_data, promise)));
+            placement_group_table_data, promise));
   }
   promise.get_future().get();
   return placement_group_table_data;
@@ -386,12 +384,12 @@ std::string GlobalStateAccessor::GetSystemConfig() {
   std::promise<std::string> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->InternalKV().AsyncGetInternalConfig(
+    gcs_client_->InternalKV().AsyncGetInternalConfig(
         [&promise](const Status &status,
                    const std::optional<std::string> &stored_raylet_config) {
           RAY_CHECK_OK(status);
           promise.set_value(*stored_raylet_config);
-        }));
+        });
   }
   auto future = promise.get_future();
   if (future.wait_for(std::chrono::seconds(

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -132,8 +132,8 @@ TEST_P(GlobalStateAccessorTest, TestJobTable) {
     auto job_id = JobID::FromInt(index);
     auto job_table_data = Mocker::GenJobTableData(job_id);
     std::promise<bool> promise;
-    RAY_CHECK_OK(gcs_client_->Jobs().AsyncAdd(
-        job_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
+    gcs_client_->Jobs().AsyncAdd(
+        job_table_data, [&promise](Status status) { promise.set_value(status.ok()); });
     promise.get_future().get();
   }
   ASSERT_EQ(global_state_->GetAllJobInfo().size(), job_count);
@@ -152,8 +152,8 @@ TEST_P(GlobalStateAccessorTest, TestJobTableWithSubmissionId) {
           std::to_string(index);
     }
     std::promise<bool> promise;
-    RAY_CHECK_OK(gcs_client_->Jobs().AsyncAdd(
-        job_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
+    gcs_client_->Jobs().AsyncAdd(
+        job_table_data, [&promise](Status status) { promise.set_value(status.ok()); });
     promise.get_future().get();
   }
   ASSERT_EQ(global_state_->GetAllJobInfo().size(), job_count);
@@ -169,8 +169,8 @@ TEST_P(GlobalStateAccessorTest, TestNodeTable) {
                             std::string("127.0.0.") + std::to_string(index),
                             "Mocker_node_" + std::to_string(index * 10));
     std::promise<bool> promise;
-    RAY_CHECK_OK(gcs_client_->Nodes().AsyncRegister(
-        *node_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
+    gcs_client_->Nodes().AsyncRegister(
+        *node_table_data, [&promise](Status status) { promise.set_value(status.ok()); });
     WaitReady(promise.get_future(), timeout_ms_);
   }
   auto node_table = global_state_->GetAllNodeInfo();
@@ -195,8 +195,8 @@ TEST_P(GlobalStateAccessorTest, TestGetAllTotalResources) {
   node_table_data->mutable_resources_total()->insert({"GPU", 10});
 
   std::promise<bool> promise;
-  RAY_CHECK_OK(gcs_client_->Nodes().AsyncRegister(
-      *node_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
+  gcs_client_->Nodes().AsyncRegister(
+      *node_table_data, [&promise](Status status) { promise.set_value(status.ok()); });
   WaitReady(promise.get_future(), timeout_ms_);
   ASSERT_EQ(global_state_->GetAllNodeInfo().size(), 1);
 
@@ -224,8 +224,8 @@ TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
   node_table_data->mutable_resources_total()->insert({"CPU", 1});
 
   std::promise<bool> promise;
-  RAY_CHECK_OK(gcs_client_->Nodes().AsyncRegister(
-      *node_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
+  gcs_client_->Nodes().AsyncRegister(
+      *node_table_data, [&promise](Status status) { promise.set_value(status.ok()); });
   WaitReady(promise.get_future(), timeout_ms_);
   auto node_table = global_state_->GetAllNodeInfo();
   ASSERT_EQ(node_table.size(), 1);

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -467,18 +467,15 @@ struct GcsServerMocker {
       return node_info;
     }
 
-    Status AsyncRegister(const rpc::GcsNodeInfo &node_info,
-                         const gcs::StatusCallback &callback) override {
-      return Status::NotImplemented("");
-    }
+    void AsyncRegister(const rpc::GcsNodeInfo &node_info,
+                       const gcs::StatusCallback &callback) override {}
 
-    Status AsyncGetAll(const gcs::MultiItemCallback<rpc::GcsNodeInfo> &callback,
-                       int64_t timeout_ms,
-                       std::optional<NodeID> node_id = std::nullopt) override {
+    void AsyncGetAll(const gcs::MultiItemCallback<rpc::GcsNodeInfo> &callback,
+                     int64_t timeout_ms,
+                     std::optional<NodeID> node_id = std::nullopt) override {
       if (callback) {
         callback(Status::OK(), {});
       }
-      return Status::OK();
     }
 
     Status AsyncSubscribeToNodeChange(

--- a/src/ray/object_manager/test/ownership_object_directory_test.cc
+++ b/src/ray/object_manager/test/ownership_object_directory_test.cc
@@ -29,10 +29,6 @@
 #include "ray/gcs/gcs_client/accessor.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 
-// clang-format off
-#include "mock/ray/gcs/gcs_client/accessor.h"
-// clang-format on
-
 namespace ray {
 
 using ::testing::_;
@@ -95,12 +91,17 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
   int batch_sent = 0;
 };
 
+class MockGcsClientNodeAccessor : public gcs::NodeInfoAccessor {
+ public:
+  bool IsRemoved(const NodeID &node_id) const override { return false; }
+};
+
 class MockGcsClient : public gcs::GcsClient {
  public:
   MockGcsClient(gcs::GcsClientOptions options,
-                gcs::MockNodeInfoAccessor *node_info_accessor)
+                std::unique_ptr<MockGcsClientNodeAccessor> node_info_accessor)
       : gcs::GcsClient(options) {
-    node_accessor_.reset(node_info_accessor);
+    node_accessor_ = std::move(node_info_accessor);
   }
 
   gcs::NodeInfoAccessor &Nodes() {
@@ -108,9 +109,11 @@ class MockGcsClient : public gcs::GcsClient {
     return *node_accessor_;
   }
 
-  MOCK_METHOD2(Connect, Status(instrumented_io_context &io_service, int64_t timeout_ms));
+  Status Connect(instrumented_io_context &io_service, int64_t timeout_ms) {
+    return Status::OK();
+  }
 
-  MOCK_METHOD0(Disconnect, void());
+  void Disconnect() {}
 };
 
 class OwnershipBasedObjectDirectoryTest : public ::testing::Test {
@@ -121,8 +124,8 @@ class OwnershipBasedObjectDirectoryTest : public ::testing::Test {
                  ClusterID::Nil(),
                  /*allow_cluster_id_nil=*/true,
                  /*fetch_cluster_id_if_nil=*/false),
-        node_info_accessor_(new gcs::MockNodeInfoAccessor()),
-        gcs_client_mock_(new MockGcsClient(options_, node_info_accessor_)),
+        gcs_client_mock_(
+            new MockGcsClient(options_, std::make_unique<MockGcsClientNodeAccessor>())),
         subscriber_(std::make_shared<pubsub::MockSubscriber>()),
         owner_client(std::make_shared<MockWorkerClient>()),
         client_pool([&](const rpc::Address &addr) { return owner_client; }) {
@@ -195,7 +198,6 @@ class OwnershipBasedObjectDirectoryTest : public ::testing::Test {
   int64_t max_batch_size = 20;
   instrumented_io_context io_service_;
   gcs::GcsClientOptions options_;
-  gcs::MockNodeInfoAccessor *node_info_accessor_;
   std::shared_ptr<gcs::GcsClient> gcs_client_mock_;
   std::shared_ptr<pubsub::MockSubscriber> subscriber_;
   std::shared_ptr<MockWorkerClient> owner_client;

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -355,489 +355,482 @@ int main(int argc, char *argv[]) {
 
   ray::NodeID raylet_node_id = ray::NodeID::FromHex(node_id);
 
-  RAY_CHECK_OK(gcs_client->InternalKV().AsyncGetInternalConfig(
-      [&](::ray::Status status, const std::optional<std::string> &stored_raylet_config) {
-        RAY_CHECK_OK(status);
-        RAY_CHECK(stored_raylet_config.has_value());
-        RayConfig::instance().initialize(*stored_raylet_config);
-        ray::asio::testing::Init();
-        ray::rpc::testing::Init();
+  gcs_client->InternalKV().AsyncGetInternalConfig([&](::ray::Status status,
+                                                      const std::optional<std::string>
+                                                          &stored_raylet_config) {
+    RAY_CHECK_OK(status);
+    RAY_CHECK(stored_raylet_config.has_value());
+    RayConfig::instance().initialize(*stored_raylet_config);
+    ray::asio::testing::Init();
+    ray::rpc::testing::Init();
 
-        // Core worker tries to kill child processes when it exits. But they can't do
-        // it perfectly: if the core worker is killed by SIGKILL, the child processes
-        // leak. So in raylet we also kill child processes via Linux subreaper.
-        // Only works on Linux >= 3.4.
-        if (RayConfig::instance()
-                .kill_child_processes_on_worker_exit_with_raylet_subreaper()) {
-          enable_subreaper();
-        } else {
-          RAY_LOG(INFO) << "Raylet is not set to kill unknown children.";
-          ray::SetSigchldIgnore();
-        }
+    // Core worker tries to kill child processes when it exits. But they can't do
+    // it perfectly: if the core worker is killed by SIGKILL, the child processes
+    // leak. So in raylet we also kill child processes via Linux subreaper.
+    // Only works on Linux >= 3.4.
+    if (RayConfig::instance()
+            .kill_child_processes_on_worker_exit_with_raylet_subreaper()) {
+      enable_subreaper();
+    } else {
+      RAY_LOG(INFO) << "Raylet is not set to kill unknown children.";
+      ray::SetSigchldIgnore();
+    }
 
-        // Parse the worker port list.
-        std::istringstream worker_port_list_string(worker_port_list);
-        std::string worker_port;
-        std::vector<int> worker_ports;
+    // Parse the worker port list.
+    std::istringstream worker_port_list_string(worker_port_list);
+    std::string worker_port;
+    std::vector<int> worker_ports;
 
-        while (std::getline(worker_port_list_string, worker_port, ',')) {
-          worker_ports.push_back(std::stoi(worker_port));
-        }
+    while (std::getline(worker_port_list_string, worker_port, ',')) {
+      worker_ports.push_back(std::stoi(worker_port));
+    }
 
-        // Parse the resource list.
-        std::istringstream resource_string(static_resource_list);
-        std::string resource_name;
-        std::string resource_quantity;
+    // Parse the resource list.
+    std::istringstream resource_string(static_resource_list);
+    std::string resource_name;
+    std::string resource_quantity;
 
-        while (std::getline(resource_string, resource_name, ',')) {
-          RAY_CHECK(std::getline(resource_string, resource_quantity, ','));
-          static_resource_conf[resource_name] = std::stod(resource_quantity);
-        }
-        auto num_cpus_it = static_resource_conf.find("CPU");
-        int num_cpus = num_cpus_it != static_resource_conf.end()
-                           ? static_cast<int>(num_cpus_it->second)
-                           : 0;
+    while (std::getline(resource_string, resource_name, ',')) {
+      RAY_CHECK(std::getline(resource_string, resource_quantity, ','));
+      static_resource_conf[resource_name] = std::stod(resource_quantity);
+    }
+    auto num_cpus_it = static_resource_conf.find("CPU");
+    int num_cpus = num_cpus_it != static_resource_conf.end()
+                       ? static_cast<int>(num_cpus_it->second)
+                       : 0;
 
-        node_manager_config.raylet_config = *stored_raylet_config;
-        node_manager_config.resource_config = ray::ResourceSet(static_resource_conf);
-        RAY_LOG(DEBUG) << "Starting raylet with static resource configuration: "
-                       << node_manager_config.resource_config.DebugString();
-        node_manager_config.node_manager_address = node_ip_address;
-        node_manager_config.node_manager_port = node_manager_port;
-        node_manager_config.num_workers_soft_limit =
-            RayConfig::instance().num_workers_soft_limit();
-        node_manager_config.num_prestart_python_workers = num_prestart_python_workers;
-        node_manager_config.maximum_startup_concurrency = maximum_startup_concurrency;
-        node_manager_config.runtime_env_agent_port = runtime_env_agent_port;
-        node_manager_config.min_worker_port = min_worker_port;
-        node_manager_config.max_worker_port = max_worker_port;
-        node_manager_config.worker_ports = worker_ports;
-        node_manager_config.labels = parse_node_labels(labels_json_str);
+    node_manager_config.raylet_config = *stored_raylet_config;
+    node_manager_config.resource_config = ray::ResourceSet(static_resource_conf);
+    RAY_LOG(DEBUG) << "Starting raylet with static resource configuration: "
+                   << node_manager_config.resource_config.DebugString();
+    node_manager_config.node_manager_address = node_ip_address;
+    node_manager_config.node_manager_port = node_manager_port;
+    node_manager_config.num_workers_soft_limit =
+        RayConfig::instance().num_workers_soft_limit();
+    node_manager_config.num_prestart_python_workers = num_prestart_python_workers;
+    node_manager_config.maximum_startup_concurrency = maximum_startup_concurrency;
+    node_manager_config.runtime_env_agent_port = runtime_env_agent_port;
+    node_manager_config.min_worker_port = min_worker_port;
+    node_manager_config.max_worker_port = max_worker_port;
+    node_manager_config.worker_ports = worker_ports;
+    node_manager_config.labels = parse_node_labels(labels_json_str);
 
-        if (!python_worker_command.empty()) {
-          node_manager_config.worker_commands.emplace(
-              make_pair(ray::Language::PYTHON, ParseCommandLine(python_worker_command)));
-        }
-        if (!java_worker_command.empty()) {
-          node_manager_config.worker_commands.emplace(
-              make_pair(ray::Language::JAVA, ParseCommandLine(java_worker_command)));
-        }
-        if (!cpp_worker_command.empty()) {
-          node_manager_config.worker_commands.emplace(
-              make_pair(ray::Language::CPP, ParseCommandLine(cpp_worker_command)));
-        }
-        node_manager_config.native_library_path = native_library_path;
-        if (python_worker_command.empty() && java_worker_command.empty() &&
-            cpp_worker_command.empty()) {
-          RAY_LOG(FATAL) << "At least one of Python/Java/CPP worker command "
-                         << "should be provided";
-        }
-        if (dashboard_agent_command.empty()) {
-          RAY_LOG(FATAL) << "Dashboard agent command must be non empty";
-        }
-        node_manager_config.dashboard_agent_command = dashboard_agent_command;
+    if (!python_worker_command.empty()) {
+      node_manager_config.worker_commands.emplace(
+          make_pair(ray::Language::PYTHON, ParseCommandLine(python_worker_command)));
+    }
+    if (!java_worker_command.empty()) {
+      node_manager_config.worker_commands.emplace(
+          make_pair(ray::Language::JAVA, ParseCommandLine(java_worker_command)));
+    }
+    if (!cpp_worker_command.empty()) {
+      node_manager_config.worker_commands.emplace(
+          make_pair(ray::Language::CPP, ParseCommandLine(cpp_worker_command)));
+    }
+    node_manager_config.native_library_path = native_library_path;
+    if (python_worker_command.empty() && java_worker_command.empty() &&
+        cpp_worker_command.empty()) {
+      RAY_LOG(FATAL) << "At least one of Python/Java/CPP worker command "
+                     << "should be provided";
+    }
+    if (dashboard_agent_command.empty()) {
+      RAY_LOG(FATAL) << "Dashboard agent command must be non empty";
+    }
+    node_manager_config.dashboard_agent_command = dashboard_agent_command;
 
-        if (runtime_env_agent_command.empty()) {
-          RAY_LOG(FATAL) << "Runtime env agent command must be non empty";
-        }
-        node_manager_config.runtime_env_agent_command = runtime_env_agent_command;
+    if (runtime_env_agent_command.empty()) {
+      RAY_LOG(FATAL) << "Runtime env agent command must be non empty";
+    }
+    node_manager_config.runtime_env_agent_command = runtime_env_agent_command;
 
-        node_manager_config.report_resources_period_ms =
-            RayConfig::instance().raylet_report_resources_period_milliseconds();
-        node_manager_config.record_metrics_period_ms =
-            RayConfig::instance().metrics_report_interval_ms() / 2;
-        node_manager_config.store_socket_name = store_socket_name;
-        node_manager_config.log_dir = log_dir;
-        node_manager_config.session_dir = session_dir;
-        node_manager_config.resource_dir = resource_dir;
-        node_manager_config.ray_debugger_external = ray_debugger_external;
-        node_manager_config.max_io_workers = RayConfig::instance().max_io_workers();
+    node_manager_config.report_resources_period_ms =
+        RayConfig::instance().raylet_report_resources_period_milliseconds();
+    node_manager_config.record_metrics_period_ms =
+        RayConfig::instance().metrics_report_interval_ms() / 2;
+    node_manager_config.store_socket_name = store_socket_name;
+    node_manager_config.log_dir = log_dir;
+    node_manager_config.session_dir = session_dir;
+    node_manager_config.resource_dir = resource_dir;
+    node_manager_config.ray_debugger_external = ray_debugger_external;
+    node_manager_config.max_io_workers = RayConfig::instance().max_io_workers();
 
-        // Configuration for the object manager.
-        ray::ObjectManagerConfig object_manager_config;
-        object_manager_config.object_manager_address = node_ip_address;
-        object_manager_config.object_manager_port = object_manager_port;
-        object_manager_config.store_socket_name = store_socket_name;
+    // Configuration for the object manager.
+    ray::ObjectManagerConfig object_manager_config;
+    object_manager_config.object_manager_address = node_ip_address;
+    object_manager_config.object_manager_port = object_manager_port;
+    object_manager_config.store_socket_name = store_socket_name;
 
-        object_manager_config.timer_freq_ms =
-            RayConfig::instance().object_manager_timer_freq_ms();
-        object_manager_config.pull_timeout_ms =
-            RayConfig::instance().object_manager_pull_timeout_ms();
-        object_manager_config.push_timeout_ms =
-            RayConfig::instance().object_manager_push_timeout_ms();
-        if (object_store_memory <= 0) {
-          RAY_LOG(FATAL) << "Object store memory should be set.";
-        }
-        object_manager_config.object_store_memory = object_store_memory;
-        object_manager_config.max_bytes_in_flight =
-            RayConfig::instance().object_manager_max_bytes_in_flight();
-        object_manager_config.plasma_directory = plasma_directory;
-        object_manager_config.fallback_directory = fallback_directory;
-        object_manager_config.huge_pages = huge_pages;
+    object_manager_config.timer_freq_ms =
+        RayConfig::instance().object_manager_timer_freq_ms();
+    object_manager_config.pull_timeout_ms =
+        RayConfig::instance().object_manager_pull_timeout_ms();
+    object_manager_config.push_timeout_ms =
+        RayConfig::instance().object_manager_push_timeout_ms();
+    if (object_store_memory <= 0) {
+      RAY_LOG(FATAL) << "Object store memory should be set.";
+    }
+    object_manager_config.object_store_memory = object_store_memory;
+    object_manager_config.max_bytes_in_flight =
+        RayConfig::instance().object_manager_max_bytes_in_flight();
+    object_manager_config.plasma_directory = plasma_directory;
+    object_manager_config.fallback_directory = fallback_directory;
+    object_manager_config.huge_pages = huge_pages;
 
-        object_manager_config.rpc_service_threads_number =
-            std::min(std::max(2, num_cpus / 4), 8);
-        if (RayConfig::instance().object_manager_rpc_threads_num() != 0) {
-          object_manager_config.rpc_service_threads_number =
-              RayConfig::instance().object_manager_rpc_threads_num();
-        }
-        object_manager_config.object_chunk_size =
-            RayConfig::instance().object_manager_default_chunk_size();
+    object_manager_config.rpc_service_threads_number =
+        std::min(std::max(2, num_cpus / 4), 8);
+    if (RayConfig::instance().object_manager_rpc_threads_num() != 0) {
+      object_manager_config.rpc_service_threads_number =
+          RayConfig::instance().object_manager_rpc_threads_num();
+    }
+    object_manager_config.object_chunk_size =
+        RayConfig::instance().object_manager_default_chunk_size();
 
-        RAY_LOG(DEBUG) << "Starting object manager with configuration: \n"
-                       << "rpc_service_threads_number = "
-                       << object_manager_config.rpc_service_threads_number
-                       << ", object_chunk_size = "
-                       << object_manager_config.object_chunk_size;
-        // Initialize stats.
-        const ray::stats::TagsType global_tags = {
-            {ray::stats::ComponentKey, "raylet"},
-            {ray::stats::WorkerIdKey, ""},
-            {ray::stats::VersionKey, kRayVersion},
-            {ray::stats::NodeAddressKey, node_ip_address},
-            {ray::stats::SessionNameKey, session_name}};
-        ray::stats::Init(global_tags, metrics_agent_port, WorkerID::Nil());
+    RAY_LOG(DEBUG) << "Starting object manager with configuration: \n"
+                   << "rpc_service_threads_number = "
+                   << object_manager_config.rpc_service_threads_number
+                   << ", object_chunk_size = " << object_manager_config.object_chunk_size;
+    // Initialize stats.
+    const ray::stats::TagsType global_tags = {
+        {ray::stats::ComponentKey, "raylet"},
+        {ray::stats::WorkerIdKey, ""},
+        {ray::stats::VersionKey, kRayVersion},
+        {ray::stats::NodeAddressKey, node_ip_address},
+        {ray::stats::SessionNameKey, session_name}};
+    ray::stats::Init(global_tags, metrics_agent_port, WorkerID::Nil());
 
-        RAY_LOG(INFO).WithField(raylet_node_id) << "Setting node ID";
+    RAY_LOG(INFO).WithField(raylet_node_id) << "Setting node ID";
 
-        node_manager_config.AddDefaultLabels(raylet_node_id.Hex());
+    node_manager_config.AddDefaultLabels(raylet_node_id.Hex());
 
-        worker_pool = std::make_unique<ray::raylet::WorkerPool>(
-            main_service,
-            raylet_node_id,
-            node_manager_config.node_manager_address,
-            [&]() {
-              // Callback to determine the maximum number of idle workers to
-              // keep around.
-              if (node_manager_config.num_workers_soft_limit >= 0) {
-                return node_manager_config.num_workers_soft_limit;
-              }
-              // If no limit is provided, use the available number of CPUs,
-              // assuming that each incoming task will likely require 1 CPU.
-              // We floor the available CPUs to the nearest integer to avoid
-              // starting too many workers when there is less than 1 CPU left.
-              // Otherwise, we could end up repeatedly starting the worker, then
-              // killing it because it idles for too long. The downside is that
-              // we will be slower to schedule tasks that could use a fraction
-              // of a CPU.
-              return static_cast<int64_t>(
-                  cluster_resource_scheduler->GetLocalResourceManager()
-                      .GetLocalAvailableCpus());
-            },
-            node_manager_config.num_prestart_python_workers,
-            node_manager_config.maximum_startup_concurrency,
-            node_manager_config.min_worker_port,
-            node_manager_config.max_worker_port,
-            node_manager_config.worker_ports,
-            *gcs_client,
-            node_manager_config.worker_commands,
-            node_manager_config.native_library_path,
-            /*starting_worker_timeout_callback=*/
-            [&] { cluster_task_manager->ScheduleAndDispatchTasks(); },
-            node_manager_config.ray_debugger_external,
-            /*get_time=*/[]() { return absl::Now(); },
-            node_manager_config.enable_resource_isolation);
-
-        client_call_manager = std::make_unique<ray::rpc::ClientCallManager>(
-            main_service, /*record_stats=*/true);
-
-        worker_rpc_pool = std::make_unique<ray::rpc::CoreWorkerClientPool>(
-            [&](const ray::rpc::Address &addr) {
-              return std::make_shared<ray::rpc::CoreWorkerClient>(
-                  addr,
-                  *client_call_manager,
-                  ray::rpc::CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback(
-                      gcs_client.get(),
-                      worker_rpc_pool.get(),
-                      [&](const std::string &node_manager_address, int32_t port) {
-                        return std::make_shared<ray::raylet::RayletClient>(
-                            ray::rpc::NodeManagerWorkerClient::make(
-                                node_manager_address, port, *client_call_manager));
-                      },
-                      addr));
-            });
-
-        core_worker_subscriber = std::make_unique<ray::pubsub::Subscriber>(
-            raylet_node_id,
-            /*channels=*/
-            std::vector<ray::rpc::ChannelType>{
-                ray::rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                ray::rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL,
-                ray::rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL},
-            RayConfig::instance().max_command_batch_size(),
-            /*get_client=*/
-            [&](const ray::rpc::Address &address) {
-              return worker_rpc_pool->GetOrConnect(address);
-            },
-            &main_service);
-
-        object_directory = std::make_unique<ray::OwnershipBasedObjectDirectory>(
-            main_service,
-            *gcs_client,
-            core_worker_subscriber.get(),
-            worker_rpc_pool.get(),
-            [&](const ObjectID &obj_id, const ray::rpc::ErrorType &error_type) {
-              ray::rpc::ObjectReference ref;
-              ref.set_object_id(obj_id.Binary());
-              node_manager->MarkObjectsAsFailed(error_type, {ref}, JobID::Nil());
-            });
-
-        object_manager = std::make_unique<ray::ObjectManager>(
-            main_service,
-            raylet_node_id,
-            object_manager_config,
-            *gcs_client,
-            object_directory.get(),
-            /*restore_spilled_object=*/
-            [&](const ObjectID &object_id,
-                int64_t object_size,
-                const std::string &object_url,
-                std::function<void(const ray::Status &)> callback) {
-              local_object_manager->AsyncRestoreSpilledObject(
-                  object_id, object_size, object_url, std::move(callback));
-            },
-            /*get_spilled_object_url=*/
-            [&](const ObjectID &object_id) {
-              return local_object_manager->GetLocalSpilledObjectURL(object_id);
-            },
-            /*spill_objects_callback=*/
-            [&]() {
-              // This callback is called from the plasma store thread.
-              // NOTE: It means the local object manager should be thread-safe.
-              main_service.post(
-                  [&]() { local_object_manager->SpillObjectUptoMaxThroughput(); },
-                  "NodeManager.SpillObjects");
-              return local_object_manager->IsSpillingInProgress();
-            },
-            /*object_store_full_callback=*/
-            [&]() {
-              // Post on the node manager's event loop since this
-              // callback is called from the plasma store thread.
-              // This will help keep node manager lock-less.
-              main_service.post([&]() { node_manager->TriggerGlobalGC(); },
-                                "NodeManager.GlobalGC");
-            },
-            /*add_object_callback=*/
-            [&](const ray::ObjectInfo &object_info) {
-              node_manager->HandleObjectLocal(object_info);
-            },
-            /*delete_object_callback=*/
-            [&](const ObjectID &object_id) {
-              node_manager->HandleObjectMissing(object_id);
-            },
-            /*pin_object=*/
-            [&](const ObjectID &object_id) {
-              std::vector<ObjectID> object_ids = {object_id};
-              std::vector<std::unique_ptr<ray::RayObject>> results;
-              std::unique_ptr<ray::RayObject> result;
-              if (node_manager->GetObjectsFromPlasma(object_ids, &results) &&
-                  results.size() > 0) {
-                result = std::move(results[0]);
-              }
-              return result;
-            },
-            /*fail_pull_request=*/
-            [&](const ObjectID &object_id, ray::rpc::ErrorType error_type) {
-              ray::rpc::ObjectReference ref;
-              ref.set_object_id(object_id.Binary());
-              node_manager->MarkObjectsAsFailed(error_type, {ref}, JobID::Nil());
-            });
-
-        local_object_manager = std::make_unique<ray::raylet::LocalObjectManager>(
-            raylet_node_id,
-            node_manager_config.node_manager_address,
-            node_manager_config.node_manager_port,
-            main_service,
-            RayConfig::instance().free_objects_batch_size(),
-            RayConfig::instance().free_objects_period_milliseconds(),
-            *worker_pool,
-            *worker_rpc_pool,
-            /*max_io_workers*/ node_manager_config.max_io_workers,
-            /*is_external_storage_type_fs*/
-            RayConfig::instance().is_external_storage_type_fs(),
-            /*max_fused_object_count*/ RayConfig::instance().max_fused_object_count(),
-            /*on_objects_freed*/
-            [&](const std::vector<ObjectID> &object_ids) {
-              object_manager->FreeObjects(object_ids,
-                                          /*local_only=*/false);
-            },
-            /*is_plasma_object_spillable*/
-            [&](const ObjectID &object_id) {
-              return object_manager->IsPlasmaObjectSpillable(object_id);
-            },
-            /*core_worker_subscriber_=*/core_worker_subscriber.get(),
-            object_directory.get());
-
-        dependency_manager =
-            std::make_unique<ray::raylet::DependencyManager>(*object_manager);
-
-        cluster_resource_scheduler = std::make_unique<ray::ClusterResourceScheduler>(
-            main_service,
-            ray::scheduling::NodeID(raylet_node_id.Binary()),
-            node_manager_config.resource_config.GetResourceMap(),
-            /*is_node_available_fn*/
-            [&](ray::scheduling::NodeID node_id) {
-              return gcs_client->Nodes().Get(NodeID::FromBinary(node_id.Binary())) !=
-                     nullptr;
-            },
-            /*get_used_object_store_memory*/
-            [&]() {
-              if (RayConfig::instance().scheduler_report_pinned_bytes_only()) {
-                // Get the current bytes used by local primary object copies.  This
-                // is used to help node scale down decisions. A node can only be
-                // safely drained when this function reports zero.
-                int64_t bytes_used = local_object_manager->GetPrimaryBytes();
-                // Report nonzero if we have objects spilled to the local filesystem.
-                if (bytes_used == 0 && local_object_manager->HasLocallySpilledObjects()) {
-                  bytes_used = 1;
-                }
-                return bytes_used;
-              }
-              return object_manager->GetUsedMemory();
-            },
-            /*get_pull_manager_at_capacity*/
-            [&]() { return object_manager->PullManagerHasPullsQueued(); },
-            shutdown_raylet_gracefully,
-            /*labels*/
-            node_manager_config.labels);
-
-        auto get_node_info_func = [&](const NodeID &node_id) {
-          return gcs_client->Nodes().Get(node_id);
-        };
-        auto announce_infeasible_task = [](const ray::RayTask &task) {
-          /// Publish the infeasible task error to GCS so that drivers can subscribe to it
-          /// and print.
-          bool suppress_warning = false;
-
-          if (!task.GetTaskSpecification().PlacementGroupBundleId().first.IsNil()) {
-            // If the task is part of a placement group, do nothing. If necessary, the
-            // infeasible warning should come from the placement group scheduling, not the
-            // task scheduling.
-            suppress_warning = true;
+    worker_pool = std::make_unique<ray::raylet::WorkerPool>(
+        main_service,
+        raylet_node_id,
+        node_manager_config.node_manager_address,
+        [&]() {
+          // Callback to determine the maximum number of idle workers to
+          // keep around.
+          if (node_manager_config.num_workers_soft_limit >= 0) {
+            return node_manager_config.num_workers_soft_limit;
           }
+          // If no limit is provided, use the available number of CPUs,
+          // assuming that each incoming task will likely require 1 CPU.
+          // We floor the available CPUs to the nearest integer to avoid
+          // starting too many workers when there is less than 1 CPU left.
+          // Otherwise, we could end up repeatedly starting the worker, then
+          // killing it because it idles for too long. The downside is that
+          // we will be slower to schedule tasks that could use a fraction
+          // of a CPU.
+          return static_cast<int64_t>(
+              cluster_resource_scheduler->GetLocalResourceManager()
+                  .GetLocalAvailableCpus());
+        },
+        node_manager_config.num_prestart_python_workers,
+        node_manager_config.maximum_startup_concurrency,
+        node_manager_config.min_worker_port,
+        node_manager_config.max_worker_port,
+        node_manager_config.worker_ports,
+        *gcs_client,
+        node_manager_config.worker_commands,
+        node_manager_config.native_library_path,
+        /*starting_worker_timeout_callback=*/
+        [&] { cluster_task_manager->ScheduleAndDispatchTasks(); },
+        node_manager_config.ray_debugger_external,
+        /*get_time=*/[]() { return absl::Now(); },
+        node_manager_config.enable_resource_isolation);
 
-          // Push a warning to the task's driver that this task is currently infeasible.
-          if (!suppress_warning) {
-            std::ostringstream error_message;
-            error_message
-                << "The actor or task with ID " << task.GetTaskSpecification().TaskId()
-                << " cannot be scheduled right now. It requires "
-                << task.GetTaskSpecification()
-                       .GetRequiredPlacementResources()
-                       .DebugString()
-                << " for placement, however the cluster currently cannot provide the "
-                   "requested "
-                   "resources. The required resources may be added as autoscaling takes "
-                   "place "
-                   "or placement groups are scheduled. Otherwise, consider reducing the "
-                   "resource requirements of the task.";
-            std::string error_message_str = error_message.str();
-            RAY_LOG(WARNING) << error_message_str;
+    client_call_manager = std::make_unique<ray::rpc::ClientCallManager>(
+        main_service, /*record_stats=*/true);
+
+    worker_rpc_pool = std::make_unique<ray::rpc::CoreWorkerClientPool>(
+        [&](const ray::rpc::Address &addr) {
+          return std::make_shared<ray::rpc::CoreWorkerClient>(
+              addr,
+              *client_call_manager,
+              ray::rpc::CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback(
+                  gcs_client.get(),
+                  worker_rpc_pool.get(),
+                  [&](const std::string &node_manager_address, int32_t port) {
+                    return std::make_shared<ray::raylet::RayletClient>(
+                        ray::rpc::NodeManagerWorkerClient::make(
+                            node_manager_address, port, *client_call_manager));
+                  },
+                  addr));
+        });
+
+    core_worker_subscriber = std::make_unique<ray::pubsub::Subscriber>(
+        raylet_node_id,
+        /*channels=*/
+        std::vector<ray::rpc::ChannelType>{
+            ray::rpc::ChannelType::WORKER_OBJECT_EVICTION,
+            ray::rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL,
+            ray::rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL},
+        RayConfig::instance().max_command_batch_size(),
+        /*get_client=*/
+        [&](const ray::rpc::Address &address) {
+          return worker_rpc_pool->GetOrConnect(address);
+        },
+        &main_service);
+
+    object_directory = std::make_unique<ray::OwnershipBasedObjectDirectory>(
+        main_service,
+        *gcs_client,
+        core_worker_subscriber.get(),
+        worker_rpc_pool.get(),
+        [&](const ObjectID &obj_id, const ray::rpc::ErrorType &error_type) {
+          ray::rpc::ObjectReference ref;
+          ref.set_object_id(obj_id.Binary());
+          node_manager->MarkObjectsAsFailed(error_type, {ref}, JobID::Nil());
+        });
+
+    object_manager = std::make_unique<ray::ObjectManager>(
+        main_service,
+        raylet_node_id,
+        object_manager_config,
+        *gcs_client,
+        object_directory.get(),
+        /*restore_spilled_object=*/
+        [&](const ObjectID &object_id,
+            int64_t object_size,
+            const std::string &object_url,
+            std::function<void(const ray::Status &)> callback) {
+          local_object_manager->AsyncRestoreSpilledObject(
+              object_id, object_size, object_url, std::move(callback));
+        },
+        /*get_spilled_object_url=*/
+        [&](const ObjectID &object_id) {
+          return local_object_manager->GetLocalSpilledObjectURL(object_id);
+        },
+        /*spill_objects_callback=*/
+        [&]() {
+          // This callback is called from the plasma store thread.
+          // NOTE: It means the local object manager should be thread-safe.
+          main_service.post(
+              [&]() { local_object_manager->SpillObjectUptoMaxThroughput(); },
+              "NodeManager.SpillObjects");
+          return local_object_manager->IsSpillingInProgress();
+        },
+        /*object_store_full_callback=*/
+        [&]() {
+          // Post on the node manager's event loop since this
+          // callback is called from the plasma store thread.
+          // This will help keep node manager lock-less.
+          main_service.post([&]() { node_manager->TriggerGlobalGC(); },
+                            "NodeManager.GlobalGC");
+        },
+        /*add_object_callback=*/
+        [&](const ray::ObjectInfo &object_info) {
+          node_manager->HandleObjectLocal(object_info);
+        },
+        /*delete_object_callback=*/
+        [&](const ObjectID &object_id) { node_manager->HandleObjectMissing(object_id); },
+        /*pin_object=*/
+        [&](const ObjectID &object_id) {
+          std::vector<ObjectID> object_ids = {object_id};
+          std::vector<std::unique_ptr<ray::RayObject>> results;
+          std::unique_ptr<ray::RayObject> result;
+          if (node_manager->GetObjectsFromPlasma(object_ids, &results) &&
+              results.size() > 0) {
+            result = std::move(results[0]);
           }
-        };
+          return result;
+        },
+        /*fail_pull_request=*/
+        [&](const ObjectID &object_id, ray::rpc::ErrorType error_type) {
+          ray::rpc::ObjectReference ref;
+          ref.set_object_id(object_id.Binary());
+          node_manager->MarkObjectsAsFailed(error_type, {ref}, JobID::Nil());
+        });
 
-        RAY_CHECK(RayConfig::instance().max_task_args_memory_fraction() > 0 &&
-                  RayConfig::instance().max_task_args_memory_fraction() <= 1)
-            << "max_task_args_memory_fraction must be a nonzero fraction.";
-        auto max_task_args_memory =
-            static_cast<int64_t>(static_cast<float>(object_manager->GetMemoryCapacity()) *
-                                 RayConfig::instance().max_task_args_memory_fraction());
-        if (max_task_args_memory <= 0) {
-          RAY_LOG(WARNING)
-              << "Max task args should be a fraction of the object store capacity, but "
-                 "object "
-                 "store capacity is zero or negative. Allowing task args to use 100% of "
-                 "the "
-                 "local object store. This can cause ObjectStoreFullErrors if the tasks' "
-                 "return values are greater than the remaining capacity.";
-          max_task_args_memory = 0;
-        }
+    local_object_manager = std::make_unique<ray::raylet::LocalObjectManager>(
+        raylet_node_id,
+        node_manager_config.node_manager_address,
+        node_manager_config.node_manager_port,
+        main_service,
+        RayConfig::instance().free_objects_batch_size(),
+        RayConfig::instance().free_objects_period_milliseconds(),
+        *worker_pool,
+        *worker_rpc_pool,
+        /*max_io_workers*/ node_manager_config.max_io_workers,
+        /*is_external_storage_type_fs*/
+        RayConfig::instance().is_external_storage_type_fs(),
+        /*max_fused_object_count*/ RayConfig::instance().max_fused_object_count(),
+        /*on_objects_freed*/
+        [&](const std::vector<ObjectID> &object_ids) {
+          object_manager->FreeObjects(object_ids,
+                                      /*local_only=*/false);
+        },
+        /*is_plasma_object_spillable*/
+        [&](const ObjectID &object_id) {
+          return object_manager->IsPlasmaObjectSpillable(object_id);
+        },
+        /*core_worker_subscriber_=*/core_worker_subscriber.get(),
+        object_directory.get());
 
-        local_task_manager = std::make_unique<ray::raylet::LocalTaskManager>(
-            raylet_node_id,
-            *cluster_resource_scheduler,
-            *dependency_manager,
-            get_node_info_func,
-            *worker_pool,
-            leased_workers,
-            [&](const std::vector<ObjectID> &object_ids,
-                std::vector<std::unique_ptr<ray::RayObject>> *results) {
-              return node_manager->GetObjectsFromPlasma(object_ids, results);
-            },
-            max_task_args_memory);
+    dependency_manager =
+        std::make_unique<ray::raylet::DependencyManager>(*object_manager);
 
-        cluster_task_manager =
-            std::make_unique<ray::raylet::ClusterTaskManager>(raylet_node_id,
-                                                              *cluster_resource_scheduler,
-                                                              get_node_info_func,
-                                                              announce_infeasible_task,
-                                                              *local_task_manager);
+    cluster_resource_scheduler = std::make_unique<ray::ClusterResourceScheduler>(
+        main_service,
+        ray::scheduling::NodeID(raylet_node_id.Binary()),
+        node_manager_config.resource_config.GetResourceMap(),
+        /*is_node_available_fn*/
+        [&](ray::scheduling::NodeID node_id) {
+          return gcs_client->Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+        },
+        /*get_used_object_store_memory*/
+        [&]() {
+          if (RayConfig::instance().scheduler_report_pinned_bytes_only()) {
+            // Get the current bytes used by local primary object copies.  This
+            // is used to help node scale down decisions. A node can only be
+            // safely drained when this function reports zero.
+            int64_t bytes_used = local_object_manager->GetPrimaryBytes();
+            // Report nonzero if we have objects spilled to the local filesystem.
+            if (bytes_used == 0 && local_object_manager->HasLocallySpilledObjects()) {
+              bytes_used = 1;
+            }
+            return bytes_used;
+          }
+          return object_manager->GetUsedMemory();
+        },
+        /*get_pull_manager_at_capacity*/
+        [&]() { return object_manager->PullManagerHasPullsQueued(); },
+        shutdown_raylet_gracefully,
+        /*labels*/
+        node_manager_config.labels);
 
-        auto raylet_client_factory =
-            [&](const NodeID &node_id, ray::rpc::ClientCallManager &client_call_manager) {
-              const ray::rpc::GcsNodeInfo *node_info = gcs_client->Nodes().Get(node_id);
-              RAY_CHECK(node_info) << "No GCS info for node " << node_id;
-              std::shared_ptr<ray::rpc::NodeManagerWorkerClient> raylet_client =
-                  ray::rpc::NodeManagerWorkerClient::make(
-                      node_info->node_manager_address(),
-                      node_info->node_manager_port(),
-                      client_call_manager);
-              return std::make_shared<ray::raylet::RayletClient>(
-                  std::move(raylet_client));
-            };
+    auto get_node_info_func = [&](const NodeID &node_id) {
+      return gcs_client->Nodes().Get(node_id);
+    };
+    auto announce_infeasible_task = [](const ray::RayTask &task) {
+      /// Publish the infeasible task error to GCS so that drivers can subscribe to it
+      /// and print.
+      bool suppress_warning = false;
 
-        plasma_client = std::make_unique<plasma::PlasmaClient>();
-        node_manager = std::make_unique<ray::raylet::NodeManager>(
-            main_service,
-            raylet_node_id,
-            node_name,
-            node_manager_config,
-            *gcs_client,
-            *client_call_manager,
-            *worker_rpc_pool,
-            *core_worker_subscriber,
-            *cluster_resource_scheduler,
-            *local_task_manager,
-            *cluster_task_manager,
-            *object_directory,
-            *object_manager,
-            *local_object_manager,
-            *dependency_manager,
-            *worker_pool,
-            leased_workers,
+      if (!task.GetTaskSpecification().PlacementGroupBundleId().first.IsNil()) {
+        // If the task is part of a placement group, do nothing. If necessary, the
+        // infeasible warning should come from the placement group scheduling, not the
+        // task scheduling.
+        suppress_warning = true;
+      }
+
+      // Push a warning to the task's driver that this task is currently infeasible.
+      if (!suppress_warning) {
+        std::ostringstream error_message;
+        error_message
+            << "The actor or task with ID " << task.GetTaskSpecification().TaskId()
+            << " cannot be scheduled right now. It requires "
+            << task.GetTaskSpecification().GetRequiredPlacementResources().DebugString()
+            << " for placement, however the cluster currently cannot provide the "
+               "requested "
+               "resources. The required resources may be added as autoscaling takes "
+               "place "
+               "or placement groups are scheduled. Otherwise, consider reducing the "
+               "resource requirements of the task.";
+        std::string error_message_str = error_message.str();
+        RAY_LOG(WARNING) << error_message_str;
+      }
+    };
+
+    RAY_CHECK(RayConfig::instance().max_task_args_memory_fraction() > 0 &&
+              RayConfig::instance().max_task_args_memory_fraction() <= 1)
+        << "max_task_args_memory_fraction must be a nonzero fraction.";
+    auto max_task_args_memory =
+        static_cast<int64_t>(static_cast<float>(object_manager->GetMemoryCapacity()) *
+                             RayConfig::instance().max_task_args_memory_fraction());
+    if (max_task_args_memory <= 0) {
+      RAY_LOG(WARNING)
+          << "Max task args should be a fraction of the object store capacity, but "
+             "object "
+             "store capacity is zero or negative. Allowing task args to use 100% of "
+             "the "
+             "local object store. This can cause ObjectStoreFullErrors if the tasks' "
+             "return values are greater than the remaining capacity.";
+      max_task_args_memory = 0;
+    }
+
+    local_task_manager = std::make_unique<ray::raylet::LocalTaskManager>(
+        raylet_node_id,
+        *cluster_resource_scheduler,
+        *dependency_manager,
+        get_node_info_func,
+        *worker_pool,
+        leased_workers,
+        [&](const std::vector<ObjectID> &object_ids,
+            std::vector<std::unique_ptr<ray::RayObject>> *results) {
+          return node_manager->GetObjectsFromPlasma(object_ids, results);
+        },
+        max_task_args_memory);
+
+    cluster_task_manager =
+        std::make_unique<ray::raylet::ClusterTaskManager>(raylet_node_id,
+                                                          *cluster_resource_scheduler,
+                                                          get_node_info_func,
+                                                          announce_infeasible_task,
+                                                          *local_task_manager);
+
+    auto raylet_client_factory = [&](const NodeID &node_id,
+                                     ray::rpc::ClientCallManager &client_call_manager) {
+      const ray::rpc::GcsNodeInfo *node_info = gcs_client->Nodes().Get(node_id);
+      RAY_CHECK(node_info) << "No GCS info for node " << node_id;
+      std::shared_ptr<ray::rpc::NodeManagerWorkerClient> raylet_client =
+          ray::rpc::NodeManagerWorkerClient::make(node_info->node_manager_address(),
+                                                  node_info->node_manager_port(),
+                                                  client_call_manager);
+      return std::make_shared<ray::raylet::RayletClient>(std::move(raylet_client));
+    };
+
+    plasma_client = std::make_unique<plasma::PlasmaClient>();
+    node_manager = std::make_unique<ray::raylet::NodeManager>(
+        main_service,
+        raylet_node_id,
+        node_name,
+        node_manager_config,
+        *gcs_client,
+        *client_call_manager,
+        *worker_rpc_pool,
+        *core_worker_subscriber,
+        *cluster_resource_scheduler,
+        *local_task_manager,
+        *cluster_task_manager,
+        *object_directory,
+        *object_manager,
+        *local_object_manager,
+        *dependency_manager,
+        *worker_pool,
+        leased_workers,
+        *plasma_client,
+        std::make_unique<ray::core::experimental::MutableObjectProvider>(
             *plasma_client,
-            std::make_unique<ray::core::experimental::MutableObjectProvider>(
-                *plasma_client,
-                std::move(raylet_client_factory),
-                /*check_signals=*/nullptr),
-            shutdown_raylet_gracefully);
+            std::move(raylet_client_factory),
+            /*check_signals=*/nullptr),
+        shutdown_raylet_gracefully);
 
-        // Initialize the node manager.
-        raylet = std::make_unique<ray::raylet::Raylet>(main_service,
-                                                       raylet_node_id,
-                                                       raylet_socket_name,
-                                                       node_ip_address,
-                                                       node_name,
-                                                       node_manager_config,
-                                                       object_manager_config,
-                                                       *gcs_client,
-                                                       metrics_export_port,
-                                                       is_head_node,
-                                                       *node_manager);
+    // Initialize the node manager.
+    raylet = std::make_unique<ray::raylet::Raylet>(main_service,
+                                                   raylet_node_id,
+                                                   raylet_socket_name,
+                                                   node_ip_address,
+                                                   node_name,
+                                                   node_manager_config,
+                                                   object_manager_config,
+                                                   *gcs_client,
+                                                   metrics_export_port,
+                                                   is_head_node,
+                                                   *node_manager);
 
-        // Initialize event framework.
-        if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {
-          const std::vector<ray::SourceTypeVariant> source_types = {
-              ray::rpc::Event_SourceType::Event_SourceType_RAYLET};
-          ray::RayEventInit(source_types,
-                            {{"node_id", raylet->GetNodeId().Hex()}},
-                            log_dir,
-                            RayConfig::instance().event_level(),
-                            RayConfig::instance().emit_event_to_log_file());
-        };
+    // Initialize event framework.
+    if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {
+      const std::vector<ray::SourceTypeVariant> source_types = {
+          ray::rpc::Event_SourceType::Event_SourceType_RAYLET};
+      ray::RayEventInit(source_types,
+                        {{"node_id", raylet->GetNodeId().Hex()}},
+                        log_dir,
+                        RayConfig::instance().event_level(),
+                        RayConfig::instance().emit_event_to_log_file());
+    };
 
-        raylet->Start();
-      }));
+    raylet->Start();
+  });
 
   auto signal_handler = [&raylet, shutdown_raylet_gracefully_internal](
                             const boost::system::error_code &error, int signal_number) {

--- a/src/ray/raylet/test/node_manager_test.cc
+++ b/src/ray/raylet/test/node_manager_test.cc
@@ -544,10 +544,7 @@ TEST_F(NodeManagerTest, TestRegisterGcsAndCheckSelfAlive) {
       .WillRepeatedly(Return(false));
   std::promise<void> promise;
   EXPECT_CALL(*mock_gcs_client_->mock_node_accessor, AsyncCheckSelfAlive(_, _))
-      .WillOnce([&promise](const auto &, const auto &) {
-        promise.set_value();
-        return Status::OK();
-      });
+      .WillOnce([&promise](const auto &, const auto &) { promise.set_value(); });
   RAY_CHECK_OK(node_manager_->RegisterGcs());
   std::thread thread{[this] {
     // Run the io_service in a separate thread to avoid blocking the main thread.
@@ -565,8 +562,6 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
       .WillOnce(Return(Status::OK()));
   EXPECT_CALL(*mock_gcs_client_->mock_job_accessor, AsyncSubscribeAll(_, _))
       .WillOnce(Return(Status::OK()));
-  EXPECT_CALL(*mock_gcs_client_->mock_node_accessor, AsyncCheckSelfAlive(_, _))
-      .WillRepeatedly(Return(Status::OK()));
   EXPECT_CALL(mock_worker_pool_, GetAllRegisteredWorkers(_, _))
       .WillRepeatedly(Return(std::vector<std::shared_ptr<WorkerInterface>>{}));
   EXPECT_CALL(mock_worker_pool_, GetAllRegisteredDrivers(_))
@@ -646,8 +641,6 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
       .WillOnce(Return(Status::OK()));
   EXPECT_CALL(*mock_gcs_client_->mock_job_accessor, AsyncSubscribeAll(_, _))
       .WillOnce(Return(Status::OK()));
-  EXPECT_CALL(*mock_gcs_client_->mock_node_accessor, AsyncCheckSelfAlive(_, _))
-      .WillRepeatedly(Return(Status::OK()));
   EXPECT_CALL(mock_worker_pool_, GetAllRegisteredWorkers(_, _))
       .WillRepeatedly(Return(std::vector<std::shared_ptr<WorkerInterface>>{}));
   EXPECT_CALL(mock_worker_pool_, GetAllRegisteredDrivers(_))

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1719,7 +1719,7 @@ void WorkerPool::WarnAboutSize() {
 
       auto error_data_ptr = gcs::CreateErrorTableData(
           "worker_pool_large", warning_message_str, get_time_());
-      RAY_CHECK_OK(gcs_client_.Errors().AsyncReportJobError(error_data_ptr, nullptr));
+      gcs_client_.Errors().AsyncReportJobError(error_data_ptr, nullptr);
     }
   }
 }


### PR DESCRIPTION
## Why are these changes needed?
The gcs client accessor often returned out a Status for async functions even though the Status was always ok. Changing those to just return void. Also makes the necessary downstream changes in actor_creator which now also can return void instead of Status. Also removing AsyncListNamedActors which was unused. Also updating ownership_object_directory_test to use fakes instead of mocks so it doesn't need the weird clang-format off on to get around header madness.