### PR TITLE
[core] Deprecate internal.free

### DIFF
--- a/python/ray/_private/internal_api.py
+++ b/python/ray/_private/internal_api.py
@@ -216,9 +216,8 @@ def free(object_refs: list, local_only: bool = False):
             object store or all object stores.
     """
     warnings.warn(
-        "DeprecationWarning: `free` is a deprecated API and will be "
-        "removed in a future version of Ray. If you have a use case "
-        " for this API, please open an issue on GitHub.",
+        "`free` is a deprecated API and will be removed in a future version of Ray. "
+        "If you have a use case for this API, please open an issue on GitHub.",
         DeprecationWarning,
     )
     worker = ray._private.worker.global_worker

--- a/python/ray/_private/internal_api.py
+++ b/python/ray/_private/internal_api.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List, Tuple
 
 import ray
@@ -178,7 +179,12 @@ def store_stats_summary(reply):
 
 
 def free(object_refs: list, local_only: bool = False):
-    """Free a list of IDs from the in-process and plasma object stores.
+    """
+    DeprecationWarning: `free` is a deprecated API and will be
+    removed in a future version of Ray. If you have a use case
+    for this API, please open an issue on GitHub.
+
+    Free a list of IDs from the in-process and plasma object stores.
 
     This function is a low-level API which should be used in restricted
     scenarios.
@@ -209,6 +215,12 @@ def free(object_refs: list, local_only: bool = False):
         local_only: Whether only deleting the list of objects in local
             object store or all object stores.
     """
+    warnings.warn(
+        "DeprecationWarning: `free` is a deprecated API and will be "
+        "removed in a future version of Ray. If you have a use case "
+        " for this API, please open an issue on GitHub.",
+        DeprecationWarning,
+    )
     worker = ray._private.worker.global_worker
 
     if isinstance(object_refs, ray.ObjectRef):


### PR DESCRIPTION
## Why are these changes needed?
We're choosing to deprecate the internal.free API and plan to remove it very soon. It was only used by Ray Data before, and Ray Data is now moving away from the API. It adds unnecessary complexity and introduces issues to the reference counting protocol.