### PR TITLE
fix version switcher CSS

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -394,6 +394,12 @@ table.autosummary tr > td:first-child > p > a > code > span {
   overflow-y: scroll;
 }
 
+/* Right align the version switcher dropdown menu to prevent it from going off screen */
+.version-switcher__menu[data-bs-popper] {
+  right: 0;
+  left: unset;
+}
+
 /* Hide the RTD version switcher since we are using PyData theme one */
 readthedocs-flyout {
   display: none !important;


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes issue where the version switcher is overflowing to the right of the screen since the button to the right of it has been removed

Before:
<img width="416" height="759" alt="Screenshot 2025-07-18 at 7 42 49 AM" src="https://github.com/user-attachments/assets/b407e7ad-2d55-43d2-ad7e-4e0b447be212" />

After:
<img width="429" height="804" alt="Screenshot 2025-07-18 at 7 42 29 AM" src="https://github.com/user-attachments/assets/74968e00-b29a-4643-9eea-e2c833462970" />


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
