### PR TITLE
[Serve.llm][logging] Set disable_log_requests: True by default

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -136,6 +136,12 @@ class VLLMEngineConfig(BaseModelExtended):
         else:
             engine_kwargs["distributed_executor_backend"] = "ray"
 
+        if "disable_log_requests" not in engine_kwargs:
+            logger.info(
+                "Disabling request logging by default. To enable, set to False in engine_kwargs."
+            )
+            engine_kwargs["disable_log_requests"] = True
+
         return engine_kwargs
 
     def get_runtime_env_with_local_env_vars(self) -> dict:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow up to https://github.com/ray-project/ray/pull/54719, since `disable_log_requests != disable_log_stats` we can just disable the prompt logging which is the extremely verbose one.

In vLLM, Prometheus stat logging is enabled by default, so this won't affect that:
```
# vllm/v1/engine/async_llm.py

class AsyncLLM:
...

    @classmethod
    def from_vllm_config(
...
        disable_log_requests: bool = False,
        disable_log_stats: bool = False,
```

Output with this change:
```
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 2025-07-18 10:04:50,421 default_LLMDeploymentdeepseek hfvapdwg 5d8961c9-75e2-4af4-b90e-abcae057ff9e -- CALL llm_config OK 1.6ms
INFO 2025-07-18 10:04:51,320 serve 48895 -- Application 'default' is ready at http://127.0.0.1:8000/.
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 07-18 10:05:17 [chat_utils.py:444] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 07-18 10:05:17 [async_llm.py:270] Added request chatcmpl-eb683d58-832a-41b4-b820-d6721f454721.
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 07-18 10:05:17 [ray_distributed_executor.py:569] RAY_CGRAPH_get_timeout is set to 300
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 07-18 10:05:17 [ray_distributed_executor.py:571] VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE = auto
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 07-18 10:05:17 [ray_distributed_executor.py:573] VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM = False
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) 2025-07-18 10:05:17,730 INFO torch_tensor_accelerator_channel.py:807 -- Creating communicator group 141d0c4a-86c7-4389-a894-149da5dd9e19 on actors: [Actor(RayWorkerWrapper, fa376c7909d5b29f5e0309a105000000), Actor(RayWorkerWrapper, dbc2af5bb40fdfcd81f9e25805000000), Actor(RayWorkerWrapper, 79ce270b3bd4f4960df8e61805000000), Actor(RayWorkerWrapper, 4d3f9ebf2e3d22cb13766ef205000000)]
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) 2025-07-18 10:05:18,105 INFO torch_tensor_accelerator_channel.py:833 -- Communicator group initialized.
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 2025-07-18 10:05:18,596 default_LLMDeploymentdeepseek hfvapdwg eb683d58-832a-41b4-b820-d6721f454721 -- CALL /v1/chat/completions OK 3104.7ms
(ServeReplica:default:LLMRouter pid=49152) INFO 2025-07-18 10:05:18,599 default_LLMRouter vn8nze6o eb683d58-832a-41b4-b820-d6721f454721 -- POST /v1/chat/completions 200 3147.5ms
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 07-18 10:05:18 [async_llm.py:270] Added request chatcmpl-e7e6ad9f-e10c-4f83-a067-2e825a0241da.
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 2025-07-18 10:05:19,130 default_LLMDeploymentdeepseek hfvapdwg e7e6ad9f-e10c-4f83-a067-2e825a0241da -- CALL /v1/chat/completions OK 481.4ms
(ServeReplica:default:LLMDeploymentdeepseek pid=49151) INFO 07-18 10:05:19 [async_llm.py:270] Added request chatcmpl-58be2d18-e095-467c-b0a4-8fc7193b6f60.
```

Output without this change:
```
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 2025-07-18 09:58:20,002 default_LLMDeploymentdeepseek xwbqmpbj d015bf14-74e9-49e0-8abe-db6b1d79df0a -- CALL llm_config OK 2.7ms
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 2025-07-18 09:58:20,003 default_LLMDeploymentdeepseek xwbqmpbj 5ef2218a-1769-47ae-af0c-64f804113793 -- CALL llm_config OK 2.5ms
INFO 2025-07-18 09:58:20,617 serve 42382 -- Application 'default' is ready at http://127.0.0.1:8000/.
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 07-18 10:00:24 [chat_utils.py:444] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 07-18 10:00:24 [logger.py:43] Received request chatcmpl-e7a7de3c-532e-4a4f-bf3b-670fad52ee33: prompt: '<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nHello!<|im_end|>\n<|im_start|>assistant\n', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.05, temperature=0.7, top_p=0.8, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=16353, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, prompt_embeds shape: None, lora_request: None, prompt_adapter_request: None.
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 07-18 10:00:24 [async_llm.py:270] Added request chatcmpl-e7a7de3c-532e-4a4f-bf3b-670fad52ee33.
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 07-18 10:00:24 [ray_distributed_executor.py:569] RAY_CGRAPH_get_timeout is set to 300
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 07-18 10:00:24 [ray_distributed_executor.py:571] VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE = auto
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 07-18 10:00:24 [ray_distributed_executor.py:573] VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM = False
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) 2025-07-18 10:00:25,440  INFO torch_tensor_accelerator_channel.py:807 -- Creating communicator group 7833e406-d893-411f-ba16-4a25300cfcdb on actors: [Actor(RayWorkerWrapper, 8ceec7229cc8b6c3d2f47b3a03000000), Actor(RayWorkerWrapper, 093d767e7412e71f348ce27503000000), Actor(RayWorkerWrapper, 6a938c246dc233c15ca4280b03000000), Actor(RayWorkerWrapper, 7482ddad9a7d68186576afe603000000)]
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) 2025-07-18 10:00:25,887  INFO torch_tensor_accelerator_channel.py:833 -- Communicator group initialized.
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 07-18 10:00:26 [logger.py:43] Received request chatcmpl-99a11c81-8918-4228-91b2-d3c46235253a: prompt: '<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nHello!<|im_end|>\n<|im_start|>assistant\n', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.05, temperature=0.7, top_p=0.8, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=16353, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, prompt_embeds shape: None, lora_request: None, prompt_adapter_request: None.
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 07-18 10:00:26 [async_llm.py:270] Added request chatcmpl-99a11c81-8918-4228-91b2-d3c46235253a.
(ServeReplica:default:LLMRouter pid=42954) INFO 2025-07-18 10:00:26,430 default_LLMRouter hilhb9rv e7a7de3c-532e-4a4f-bf3b-670fad52ee33 -- POST /v1/chat/completions 200 3566.4ms
(ServeReplica:default:LLMDeploymentdeepseek pid=42953) INFO 2025-07-18 10:00:26,427 default_LLMDeploymentdeepseek xwbqmpbj e7a7de3c-532e-4a4f-bf3b-670fad52ee33 -- CALL /v1/chat/completions OK 3522.7ms
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manual testing
