### PR TITLE
[Data] Remove `ray.get` call from `_MapWorker` constructor

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -504,10 +504,8 @@ class _MapWorker:
         # Initialize state for this actor.
         self._map_transformer.init()
         self._logical_actor_id = logical_actor_id
-        ray.get(
-            actor_location_tracker.update_actor_location.remote(
-                self._logical_actor_id, ray.get_runtime_context().get_node_id()
-            )
+        actor_location_tracker.update_actor_location.remote(
+            self._logical_actor_id, ray.get_runtime_context().get_node_id()
         )
 
     def get_location(self) -> NodeIdStr:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In the `_MapWorker` constructor, the worker submits a task to `ActorLocationTracker` to register its location. It currently uses `ray.get` to wait for the task to complete, which blocks the actor startup. This can slow down autoscaling, since each actor blocks on a single server. This PR removes the unnecessary `ray.get` to avoid the blocking and improve scaling speed.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
