### PR TITLE
[core] Comment on caller requirements for GetObjectStatus

### DIFF
--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -484,6 +484,8 @@ service CoreWorkerService {
       returns (ActorCallArgWaitCompleteReply);
 
   // A worker asks the object's owner worker about the object's current status.
+  // This RPC assumes the ref won't be removed in the middle of execution and it's the
+  // caller's responsibility to guarantee that.
   // Failure: TODO, Needs better failure behavior, currently assumes owner is dead and
   // object is lost.
   rpc GetObjectStatus(GetObjectStatusRequest) returns (GetObjectStatusReply);


### PR DESCRIPTION
## Why are these changes needed?
See discussion here https://github.com/ray-project/ray/pull/54690#issuecomment-3090189537
The comment exists to make sure the caller is aware of this. Currently this is only called on borrowing so it will stay in scope. Future callers should be aware of this limitation.