### PR TITLE
[cpp] add a bazel rule that exports boost headers

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -172,6 +172,10 @@ def ray_deps_setup():
         # If you update the Boost version, remember to update the 'boost' rule.
         url = "https://github.com/nelhage/rules_boost/archive/57c99395e15720e287471d79178d36a85b64d6f6.tar.gz",
         sha256 = "490d11425393eed068966a4990ead1ff07c658f823fd982fddac67006ccc44ab",
+        patches = [
+            "//thirdparty/patches:boost-headers.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     http_archive(

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -143,6 +143,7 @@ genrule(
         "libray_api.so",
         "@msgpack//:msgpack_hdrs",
         "@nlohmann_json//:nlohmann_json_hdrs",
+        "@boost//:boost_ray_hdrs",
     ],
     outs = ["ray_cpp_pkg.out"],
     cmd = """

--- a/thirdparty/patches/boost-headers.patch
+++ b/thirdparty/patches/boost-headers.patch
@@ -1,0 +1,42 @@
+diff --git BUILD.boost BUILD.boost
+--- a/BUILD.boost
++++ b/BUILD.boost
+@@ -2736,3 +2736,38 @@
+         ":variant2",
+     ],
+ )
++
++filegroup(
++    name = "boost_ray_hdrs",
++    srcs = glob([
++        "boost/%s/**/*" % lib
++        for lib in [
++            "archive",
++            "assert",
++            "bind",
++            "callable_traits",
++            "concept",
++            "config",
++            "container",
++            "container_hash",
++            "core",
++            "detail",
++            "dll",
++            "exception",
++            "filesystem",
++            "functional",
++            "io",
++            "iterator",
++            "lexical_cast",
++            "move",
++            "mpl",
++            "optional",
++            "parameter",
++            "preprocessor",
++            "system",
++            "type_traits",
++            "utility",
++        ]
++    ] + ["boost/*.hpp"]),
++    visibility = ["//visibility:public"],
++)


### PR DESCRIPTION
so that they can be used for building the cpp ray package, without using local genrules
