### PR TITLE
[core][raycheck/01] Fix "it != submissible_tasks_.end()"

### DIFF
--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -363,6 +363,10 @@ class NormalTaskSubmitter {
   // Keeps track of where currently executing tasks are being run.
   absl::flat_hash_map<TaskID, rpc::Address> executing_tasks_ ABSL_GUARDED_BY(mu_);
 
+  // Tasks that have failed but we are waiting for their error cause to decide if they
+  // should be retried or permanently failed.
+  absl::flat_hash_set<TaskID> failed_tasks_pending_failure_cause_ ABSL_GUARDED_BY(mu_);
+
   // Generators that are currently running and need to be resubmitted.
   absl::flat_hash_set<TaskID> generators_to_resubmit_ ABSL_GUARDED_BY(mu_);
 


### PR DESCRIPTION
## Problems

This PR fixes the `RAY_CHECK failure:
it != submissible_tasks_.end() Tried to retry task that was not pending`.

This failure occurs when a task cancellation ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L702)) races with the callback from PushNormalTask ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L546)).

Currently, there's a map called `executing_tasks_` that is intended to prevent this race, but it fails to do so. The crash happens via the following sequence:
- The `PushNormalTask` callback removes the task ID from `executing_tasks_` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L583)).
- This causes the task cancellation to enter the following condition ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L750)), which eventually invokes `TaskManager::FailPendingTask` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L753)).
- `TaskManager` always removes the task from the `submissible_tasks_ `map when it ends a pending task’s lifecycle (via `FailPendingTask` and others).
- After that, the `PushNormalTask` callback invokes `HandleGetTaskFailureCause` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L605)), which attempts to retrieve the task’s failure cause. This function asks `TaskManager` to retry the task ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L694)), but it fails because the task has already been removed from the `submissible_tasks_` map.

## Solutions
This PR introduces a `failed_tasks_pending_failure_cause_` map represent a critical session where the tasks that have failed but we are waiting for their error cause to decide if they should be retried or permanently failed.

If task cancellation comes into this critical session; we will resubmit cancellation again via the ioservice.

## Limitations
This makes `ray.cancel` an async cancellation rather than sync cancellation, because of the retries. However, it seems that the current implementation is already async since the actual cancellation logic is async (https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L770). The main difference here is how long that async period takes.

## Test
- CI
- A test that crashes without this fix and passes with this fix
- Also update normal_task_submitter_test to represent its real implementation