### PR TITLE
[core] Fix possible race by checking node cache status instead of just subscription

### DIFF
--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -144,8 +144,8 @@ class MockNodeInfoAccessor : public NodeInfoAccessor {
               (override));
   MOCK_METHOD(void,
               AsyncSubscribeToNodeChange,
-              ((const SubscribeCallback<NodeID, rpc::GcsNodeInfo> &subscribe),
-               const StatusCallback &done),
+              (std::function<void(NodeID, const rpc::GcsNodeInfo &)> subscribe,
+               StatusCallback done),
               (override));
   MOCK_METHOD(const rpc::GcsNodeInfo *,
               Get,

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -142,7 +142,7 @@ class MockNodeInfoAccessor : public NodeInfoAccessor {
                int64_t timeout_ms,
                std::optional<NodeID> node_id),
               (override));
-  MOCK_METHOD(Status,
+  MOCK_METHOD(void,
               AsyncSubscribeToNodeChange,
               ((const SubscribeCallback<NodeID, rpc::GcsNodeInfo> &subscribe),
                const StatusCallback &done),

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -635,7 +635,7 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
       cluster_size_based_rate_limiter->OnNodeChanges(data);
     }
   };
-  RAY_CHECK_OK(gcs_client_->Nodes().AsyncSubscribeToNodeChange(on_node_change, nullptr));
+  gcs_client_->Nodes().AsyncSubscribeToNodeChange(std::move(on_node_change), nullptr);
 
   plasma_store_provider_ = std::make_shared<CoreWorkerPlasmaStoreProvider>(
       options_.store_socket,

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -642,7 +642,6 @@ void NodeInfoAccessor::AsyncSubscribeToNodeChange(
           if (done) {
             done(status);
           }
-          node_subscription_cache_populated_ = true;
         },
         /*timeout_ms=*/-1);
   };

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -624,8 +624,8 @@ void NodeInfoAccessor::AsyncSubscribeToNodeChange(
   1. Subscribe to node info
   2. Once the subscription is made, ask for all node info.
   3. Once all node info is received, call done callback.
-  4. HandleNotification will handle conflicts between the subscription updates and
-     GetAllNodeInfo.
+  4. HandleNotification can handle conflicts between the subscription updates and
+     GetAllNodeInfo because nodes can only go from alive to dead, never back to alive.
   */
 
   RAY_CHECK(node_change_callback_ == nullptr);

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -772,10 +772,12 @@ void NodeInfoAccessor::AsyncResubscribe() {
         /*subscribe=*/[this](rpc::GcsNodeInfo
                                  &&data) { HandleNotification(std::move(data)); },
         /*done=*/
-        [](const Status &) {
-          RAY_LOG(INFO)
-              << "Finished fetching all node information from gcs server after gcs "
-                 "server or pub-sub server is restarted.";
+        [this](const Status &) {
+          fetch_node_data_operation_([](const Status &) {
+            RAY_LOG(INFO)
+                << "Finished fetching all node information from gcs server after gcs "
+                   "server or pub-sub server is restarted.";
+          });
         });
   }
 }

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -626,6 +626,9 @@ void NodeInfoAccessor::AsyncSubscribeToNodeChange(
   3. Once all node info is received, call done callback.
   4. HandleNotification can handle conflicts between the subscription updates and
      GetAllNodeInfo because nodes can only go from alive to dead, never back to alive.
+     Note that this only works because state is the only mutable field, otherwise we'd
+     have to queue subscription updates until the initial population from AsyncGetAll is
+     done.
   */
 
   RAY_CHECK(node_change_callback_ == nullptr);

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -627,8 +627,8 @@ void NodeInfoAccessor::AsyncSubscribeToNodeChange(
   4. HandleNotification can handle conflicts between the subscription updates and
      GetAllNodeInfo because nodes can only go from alive to dead, never back to alive.
      Note that this only works because state is the only mutable field, otherwise we'd
-     have to queue subscription updates until the initial population from AsyncGetAll is
-     done.
+     have to queue processing subscription updates until the initial population from
+     AsyncGetAll is done.
   */
 
   RAY_CHECK(node_change_callback_ == nullptr);

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -766,7 +766,7 @@ void NodeInfoAccessor::HandleNotification(rpc::GcsNodeInfo &&node_info) {
 
 void NodeInfoAccessor::AsyncResubscribe() {
   RAY_LOG(DEBUG) << "Reestablishing subscription for node info.";
-  if (fetch_node_data_operation_ != nullptr) {
+  if (IsSubscribedToNodeChange()) {
     client_impl_->GetGcsSubscriber().SubscribeAllNodeInfo(
         /*subscribe=*/[this](rpc::GcsNodeInfo
                                  &&data) { HandleNotification(std::move(data)); },

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -617,36 +617,41 @@ void NodeInfoAccessor::AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &ca
       timeout_ms);
 }
 
-Status NodeInfoAccessor::AsyncSubscribeToNodeChange(
-    const SubscribeCallback<NodeID, rpc::GcsNodeInfo> &subscribe,
-    const StatusCallback &done) {
-  RAY_CHECK(subscribe != nullptr);
+void NodeInfoAccessor::AsyncSubscribeToNodeChange(
+    std::function<void(NodeID, const rpc::GcsNodeInfo &)> subscribe,
+    StatusCallback done) {
+  /**
+  1. Subscribe to node info
+  2. Once the subscription is made, ask for all node info.
+  3. Once all node info is received, call done callback.
+  4. HandleNotification will handle conflicts between the subscription updates and
+     GetAllNodeInfo.
+  */
+
   RAY_CHECK(node_change_callback_ == nullptr);
-  node_change_callback_ = subscribe;
+  node_change_callback_ = std::move(subscribe);
+  RAY_CHECK(node_change_callback_ != nullptr);
 
   fetch_node_data_operation_ = [this](const StatusCallback &done) {
-    auto callback = [this, done](const Status &status,
-                                 std::vector<rpc::GcsNodeInfo> &&node_info_list) {
-      for (auto &node_info : node_info_list) {
-        HandleNotification(std::move(node_info));
-      }
-      if (done) {
-        done(status);
-      }
-    };
-    AsyncGetAll(callback, /*timeout_ms=*/-1);
+    AsyncGetAll(
+        [this, done](const Status &status,
+                     std::vector<rpc::GcsNodeInfo> &&node_info_list) {
+          for (auto &node_info : node_info_list) {
+            HandleNotification(std::move(node_info));
+          }
+          if (done) {
+            done(status);
+          }
+          node_subscription_cache_populated_ = true;
+        },
+        /*timeout_ms=*/-1);
   };
 
-  subscribe_node_operation_ = [this](const StatusCallback &done) {
-    auto on_subscribe = [this](rpc::GcsNodeInfo &&data) {
-      HandleNotification(std::move(data));
-    };
-    return client_impl_->GetGcsSubscriber().SubscribeAllNodeInfo(on_subscribe, done);
-  };
-
-  return subscribe_node_operation_([this, subscribe, done](const Status &status) {
-    fetch_node_data_operation_(done);
-  });
+  client_impl_->GetGcsSubscriber().SubscribeAllNodeInfo(
+      /*subscribe=*/[this](
+                        rpc::GcsNodeInfo &&data) { HandleNotification(std::move(data)); },
+      /*done=*/[this, done = std::move(done)](
+                   const Status &) { fetch_node_data_operation_(done); });
 }
 
 const rpc::GcsNodeInfo *NodeInfoAccessor::Get(const NodeID &node_id,
@@ -756,11 +761,7 @@ void NodeInfoAccessor::HandleNotification(rpc::GcsNodeInfo &&node_info) {
     } else {
       removed_nodes_.insert(node_id);
     }
-    if (node_change_callback_) {
-      // Copy happens!
-      rpc::GcsNodeInfo cache_data_copied = node_cache_[node_id];
-      node_change_callback_(node_id, std::move(cache_data_copied));
-    }
+    node_change_callback_(node_id, node_cache_[node_id]);
   }
 }
 

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -462,6 +462,8 @@ class NodeInfoAccessor {
   absl::flat_hash_map<NodeID, rpc::GcsNodeInfo> node_cache_;
   /// The set of removed nodes.
   std::unordered_set<NodeID> removed_nodes_;
+
+  FRIEND_TEST(NodeInfoAccessorTest, TestHandleNotification);
 };
 
 /// \class NodeResourceInfoAccessor

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -438,8 +438,8 @@ class NodeInfoAccessor {
   virtual void HandleNotification(rpc::GcsNodeInfo &&node_info);
 
   /// Initial GetAllNodeInfo request is done and has populated the cache.
-  virtual bool IsSubscriptionCachePopulated() const {
-    return node_subscription_cache_populated_;
+  virtual bool IsSubscribedToNodeChange() const {
+    return node_change_callback_ != nullptr;
   }
 
  private:
@@ -454,9 +454,6 @@ class NodeInfoAccessor {
 
   /// The callback to call when a new node is added or a node is removed.
   std::function<void(NodeID, const rpc::GcsNodeInfo &)> node_change_callback_ = nullptr;
-
-  /// Initial GetAllNodeInfo request is done and has populated the cache.
-  bool node_subscription_cache_populated_ = false;
 
   /// A cache for information about all nodes.
   absl::flat_hash_map<NodeID, rpc::GcsNodeInfo> node_cache_;

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -459,6 +459,7 @@ class NodeInfoAccessor {
   /// The set of removed nodes.
   std::unordered_set<NodeID> removed_nodes_;
 
+  // TODO(dayshah): Need to refactor gcs client / accessor to avoid this.
   FRIEND_TEST(NodeInfoAccessorTest, TestHandleNotification);
 };
 

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -443,10 +443,6 @@ class NodeInfoAccessor {
   }
 
  private:
-  /// Save the subscribe operation in this function, so we can call it again when PubSub
-  /// server restarts from a failure.
-  SubscribeOperation subscribe_node_operation_;
-
   /// Save the fetch data operation in this function, so we can call it again when GCS
   /// server restarts from a failure.
   FetchDataOperation fetch_node_data_operation_;

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -460,6 +460,7 @@ class NodeInfoAccessor {
   std::unordered_set<NodeID> removed_nodes_;
 
   // TODO(dayshah): Need to refactor gcs client / accessor to avoid this.
+  // https://github.com/ray-project/ray/issues/54805
   FRIEND_TEST(NodeInfoAccessorTest, TestHandleNotification);
 };
 

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -437,7 +437,6 @@ class NodeInfoAccessor {
   /// Add a node to accessor cache.
   virtual void HandleNotification(rpc::GcsNodeInfo &&node_info);
 
-  /// Initial GetAllNodeInfo request is done and has populated the cache.
   virtual bool IsSubscribedToNodeChange() const {
     return node_change_callback_ != nullptr;
   }

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -317,7 +317,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
   }
 
   bool SubscribeToNodeChange(
-      const gcs::SubscribeCallback<NodeID, rpc::GcsNodeInfo> &subscribe) {
+      std::function<void(NodeID, const rpc::GcsNodeInfo &)> subscribe) {
     std::promise<bool> promise;
     gcs_client_->Nodes().AsyncSubscribeToNodeChange(
         subscribe, [&promise](Status status) { promise.set_value(status.ok()); });

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -319,8 +319,8 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
   bool SubscribeToNodeChange(
       const gcs::SubscribeCallback<NodeID, rpc::GcsNodeInfo> &subscribe) {
     std::promise<bool> promise;
-    RAY_CHECK_OK(gcs_client_->Nodes().AsyncSubscribeToNodeChange(
-        subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
+    gcs_client_->Nodes().AsyncSubscribeToNodeChange(
+        subscribe, [&promise](Status status) { promise.set_value(status.ok()); });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -116,7 +116,7 @@ void GcsNodeManager::HandleRegisterNode(rpc::RegisterNodeRequest request,
       }
     }
 
-    RAY_CHECK_LE(head_nodes.size(), 1);
+    RAY_CHECK_LE(head_nodes.size(), 1UL);
     if (head_nodes.size() == 1) {
       OnNodeFailure(head_nodes[0],
                     [this, request, on_done, node_id](const Status &status) {

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -116,7 +116,7 @@ void GcsNodeManager::HandleRegisterNode(rpc::RegisterNodeRequest request,
       }
     }
 
-    assert(head_nodes.size() <= 1);
+    RAY_CHECK_LE(head_nodes.size(), 1);
     if (head_nodes.size() == 1) {
       OnNodeFailure(head_nodes[0],
                     [this, request, on_done, node_id](const Status &status) {

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -479,8 +479,8 @@ struct GcsServerMocker {
     }
 
     void AsyncSubscribeToNodeChange(
-        const gcs::SubscribeCallback<NodeID, rpc::GcsNodeInfo> &subscribe,
-        const gcs::StatusCallback &done) override {}
+        std::function<void(NodeID, const rpc::GcsNodeInfo &)> subscribe,
+        gcs::StatusCallback done) override {}
 
     const rpc::GcsNodeInfo *Get(const NodeID &node_id,
                                 bool filter_dead_nodes = true) const override {

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -478,11 +478,9 @@ struct GcsServerMocker {
       }
     }
 
-    Status AsyncSubscribeToNodeChange(
+    void AsyncSubscribeToNodeChange(
         const gcs::SubscribeCallback<NodeID, rpc::GcsNodeInfo> &subscribe,
-        const gcs::StatusCallback &done) override {
-      return Status::NotImplemented("");
-    }
+        const gcs::StatusCallback &done) override {}
 
     const rpc::GcsNodeInfo *Get(const NodeID &node_id,
                                 bool filter_dead_nodes = true) const override {

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -480,7 +480,9 @@ struct GcsServerMocker {
 
     void AsyncSubscribeToNodeChange(
         std::function<void(NodeID, const rpc::GcsNodeInfo &)> subscribe,
-        gcs::StatusCallback done) override {}
+        gcs::StatusCallback done) override {
+      RAY_LOG(FATAL) << "Not implemented";
+    }
 
     const rpc::GcsNodeInfo *Get(const NodeID &node_id,
                                 bool filter_dead_nodes = true) const override {

--- a/src/ray/gcs/pubsub/gcs_pub_sub.cc
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.cc
@@ -166,8 +166,8 @@ bool GcsSubscriber::IsActorUnsubscribed(const ActorID &id) {
       rpc::ChannelType::GCS_ACTOR_CHANNEL, gcs_address_, id.Binary());
 }
 
-Status GcsSubscriber::SubscribeAllNodeInfo(
-    const ItemCallback<rpc::GcsNodeInfo> &subscribe, const StatusCallback &done) {
+void GcsSubscriber::SubscribeAllNodeInfo(const ItemCallback<rpc::GcsNodeInfo> &subscribe,
+                                         const StatusCallback &done) {
   // GCS subscriber.
   auto subscribe_item_callback = [subscribe](rpc::PubMessage &&msg) {
     RAY_CHECK(msg.channel_type() == rpc::ChannelType::GCS_NODE_INFO_CHANNEL);
@@ -188,7 +188,6 @@ Status GcsSubscriber::SubscribeAllNodeInfo(
       },
       std::move(subscribe_item_callback),
       std::move(subscription_failure_callback)));
-  return Status::OK();
 }
 
 Status GcsSubscriber::SubscribeAllWorkerFailures(

--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -124,8 +124,8 @@ class GcsSubscriber {
   Status SubscribeAllJobs(const SubscribeCallback<JobID, rpc::JobTableData> &subscribe,
                           const StatusCallback &done);
 
-  Status SubscribeAllNodeInfo(const ItemCallback<rpc::GcsNodeInfo> &subscribe,
-                              const StatusCallback &done);
+  void SubscribeAllNodeInfo(const ItemCallback<rpc::GcsNodeInfo> &subscribe,
+                            const StatusCallback &done);
 
   Status SubscribeAllWorkerFailures(const ItemCallback<rpc::WorkerDeltaData> &subscribe,
                                     const StatusCallback &done);

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -174,9 +174,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                             const uint8_t *message_data);
 
   /// Subscribe to the relevant GCS tables and set up handlers.
-  ///
-  /// \return Status indicating whether this was done successfully or not.
-  ray::Status RegisterGcs();
+  void RegisterGcs();
 
   /// Get initial node manager configuration.
   const NodeManagerConfig &GetInitialConfig() const;

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -113,7 +113,7 @@ Raylet::Raylet(instrumented_io_context &main_service,
 Raylet::~Raylet() {}
 
 void Raylet::Start() {
-  RAY_CHECK_OK(RegisterGcs());
+  RegisterGcs();
 
   // Start listening for clients.
   DoAccept();
@@ -129,7 +129,7 @@ void Raylet::Stop() {
   acceptor_.close();
 }
 
-ray::Status Raylet::RegisterGcs() {
+void Raylet::RegisterGcs() {
   auto register_callback = [this](const Status &status) {
     RAY_CHECK_OK(status);
     RAY_LOG(INFO) << "Raylet of id, " << self_node_id_
@@ -139,11 +139,10 @@ ray::Status Raylet::RegisterGcs() {
                   << " object_manager address: " << self_node_info_.node_manager_address()
                   << ":" << self_node_info_.object_manager_port()
                   << " hostname: " << self_node_info_.node_manager_hostname();
-    RAY_CHECK_OK(node_manager_.RegisterGcs());
+    node_manager_.RegisterGcs();
   };
 
-  RAY_RETURN_NOT_OK(gcs_client_.Nodes().RegisterSelf(self_node_info_, register_callback));
-  return Status::OK();
+  RAY_CHECK_OK(gcs_client_.Nodes().RegisterSelf(self_node_info_, register_callback));
 }
 
 void Raylet::DoAccept() {

--- a/src/ray/raylet/raylet.h
+++ b/src/ray/raylet/raylet.h
@@ -79,7 +79,7 @@ class Raylet {
 
  private:
   /// Register GCS client.
-  ray::Status RegisterGcs();
+  void RegisterGcs();
 
   /// Accept a client connection.
   void DoAccept();

--- a/src/ray/raylet/test/node_manager_test.cc
+++ b/src/ray/raylet/test/node_manager_test.cc
@@ -530,7 +530,7 @@ class NodeManagerTest : public ::testing::Test {
 
 TEST_F(NodeManagerTest, TestRegisterGcsAndCheckSelfAlive) {
   EXPECT_CALL(*mock_gcs_client_->mock_node_accessor, AsyncSubscribeToNodeChange(_, _))
-      .WillOnce(Return(Status::OK()));
+      .Times(1);
   EXPECT_CALL(*mock_gcs_client_->mock_worker_accessor,
               AsyncSubscribeToWorkerFailures(_, _))
       .WillOnce(Return(Status::OK()));
@@ -545,7 +545,7 @@ TEST_F(NodeManagerTest, TestRegisterGcsAndCheckSelfAlive) {
   std::promise<void> promise;
   EXPECT_CALL(*mock_gcs_client_->mock_node_accessor, AsyncCheckSelfAlive(_, _))
       .WillOnce([&promise](const auto &, const auto &) { promise.set_value(); });
-  RAY_CHECK_OK(node_manager_->RegisterGcs());
+  node_manager_->RegisterGcs();
   std::thread thread{[this] {
     // Run the io_service in a separate thread to avoid blocking the main thread.
     auto work_guard = boost::asio::make_work_guard(io_service_);
@@ -559,7 +559,7 @@ TEST_F(NodeManagerTest, TestRegisterGcsAndCheckSelfAlive) {
 
 TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
   EXPECT_CALL(*mock_gcs_client_->mock_node_accessor, AsyncSubscribeToNodeChange(_, _))
-      .WillOnce(Return(Status::OK()));
+      .Times(1);
   EXPECT_CALL(*mock_gcs_client_->mock_job_accessor, AsyncSubscribeAll(_, _))
       .WillOnce(Return(Status::OK()));
   EXPECT_CALL(mock_worker_pool_, GetAllRegisteredWorkers(_, _))
@@ -589,7 +589,7 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
       });
 
   // Invoke RegisterGcs and wait until publish_worker_failure_callback is set.
-  RAY_CHECK_OK(node_manager_->RegisterGcs());
+  node_manager_->RegisterGcs();
   while (!publish_worker_failure_callback) {
     io_service_.run_one();
   }
@@ -664,11 +664,10 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
       .WillOnce([&](const gcs::SubscribeCallback<NodeID, rpc::GcsNodeInfo> &subscribe,
                     const gcs::StatusCallback &done) {
         publish_node_change_callback = subscribe;
-        return Status::OK();
       });
 
   // Invoke RegisterGcs and wait until publish_node_change_callback is set.
-  RAY_CHECK_OK(node_manager_->RegisterGcs());
+  node_manager_->RegisterGcs();
   while (!publish_node_change_callback) {
     io_service_.run_one();
   }

--- a/src/ray/rpc/worker/core_worker_client_pool.cc
+++ b/src/ray/rpc/worker/core_worker_client_pool.cc
@@ -59,7 +59,7 @@ std::function<void()> CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback
           });
     };
 
-    if (gcs_client->Nodes().IsSubscriptionCachePopulated()) {
+    if (gcs_client->Nodes().IsSubscribedToNodeChange()) {
       auto *node_info = gcs_client->Nodes().Get(node_id, /*filter_dead_nodes=*/false);
       if (node_info == nullptr) {
         // Node info hasn't come in yet for this node.

--- a/src/ray/rpc/worker/core_worker_client_pool.cc
+++ b/src/ray/rpc/worker/core_worker_client_pool.cc
@@ -62,7 +62,8 @@ std::function<void()> CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback
     if (gcs_client->Nodes().IsSubscribedToNodeChange()) {
       auto *node_info = gcs_client->Nodes().Get(node_id, /*filter_dead_nodes=*/false);
       if (node_info == nullptr) {
-        // Node info hasn't come in yet for this node.
+        // Node info hasn't come in yet for this node, will try again when unavailable
+        // timeout callback is retried.
         return;
       }
       if (node_info->state() == rpc::GcsNodeInfo::DEAD) {
@@ -88,7 +89,8 @@ std::function<void()> CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback
             return;
           }
           if (nodes.empty()) {
-            // Node info hasn't come in yet for this node.
+            // Node info hasn't come in yet for this node, will try again when unavailable
+            // timeout callback is retried.
             return;
           }
           if (nodes[0].state() != rpc::GcsNodeInfo::ALIVE) {

--- a/src/ray/rpc/worker/core_worker_client_pool.cc
+++ b/src/ray/rpc/worker/core_worker_client_pool.cc
@@ -73,10 +73,13 @@ std::function<void()> CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback
                   return;
                 }
                 if (nodes.empty() || nodes[0].state() != rpc::GcsNodeInfo::ALIVE) {
-                  // The node is dead or the GCS has erased the info for this node. It
-                  // erases based on maximum_gcs_dead_node_cached_count. There's no way
-                  // for the a component to know about a remote node unless the gcs has
-                  // registered it.
+                  // The node is dead or GCS doesn't know about this node.
+                  // There's only two reasons the GCS doesn't know about the node:
+                  // 1. The node isn't registered yet.
+                  // 2. The GCS erased the dead node based on
+                  //    maximum_gcs_dead_node_cached_count.
+                  // In this case, it must be 2 since there's no way for a component to
+                  // know about a remote node id until the gcs has registered it.
                   RAY_LOG(INFO).WithField(worker_id).WithField(node_id)
                       << "Disconnecting core worker client because its node is dead";
                   worker_client_pool->Disconnect(worker_id);

--- a/src/ray/rpc/worker/core_worker_client_pool.cc
+++ b/src/ray/rpc/worker/core_worker_client_pool.cc
@@ -60,7 +60,7 @@ std::function<void()> CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback
     };
 
     if (gcs_client->Nodes().IsSubscribedToNodeChange()) {
-      auto *node_info = gcs_client->Nodes().Get(node_id, /*filter_dead_nodes=*/true);
+      auto *node_info = gcs_client->Nodes().Get(node_id, /*filter_dead_nodes=*/false);
       if (node_info == nullptr) {
         // Node info hasn't come in yet for this node.
         return;

--- a/src/ray/rpc/worker/core_worker_client_pool.cc
+++ b/src/ray/rpc/worker/core_worker_client_pool.cc
@@ -60,7 +60,7 @@ std::function<void()> CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback
     };
 
     if (gcs_client->Nodes().IsSubscribedToNodeChange()) {
-      auto *node_info = gcs_client->Nodes().Get(node_id, /*filter_dead_nodes=*/false);
+      auto *node_info = gcs_client->Nodes().Get(node_id, /*filter_dead_nodes=*/true);
       if (node_info == nullptr) {
         // Node info hasn't come in yet for this node.
         return;

--- a/src/ray/rpc/worker/test/core_worker_client_pool_test.cc
+++ b/src/ray/rpc/worker/test/core_worker_client_pool_test.cc
@@ -82,7 +82,7 @@ class MockGcsClientNodeAccessor : public gcs::NodeInfoAccessor {
  public:
   MockGcsClientNodeAccessor() : gcs::NodeInfoAccessor(nullptr) {}
 
-  bool IsSubscribedToNodeChange() const override { return true; }
+  bool IsSubscriptionCachePopulated() const override { return true; }
 
   MOCK_METHOD(const rpc::GcsNodeInfo *,
               Get,


### PR DESCRIPTION
### Problem:
Before we would check `IsSubscribedToNodeChange` in `GetDefaultUnavailableTimeoutCallback` to make sure we're subscribed and then use the node subscription cache immediately. In reality, it's possible that the cache might've not been ready. When you do a `Get` with `filter_dead_nodes` as True and it returns nullptr, there's two possibilities, the node could be dead or the node info might've not gotten to the cache. The caller currently always thinks in terms of 1, the node is dead. In reality, it's possible that when you do the `Get` (cache check) the GCS might not have persisted the node info or might not have published the node info yet.

### Solution:
Now in `GetDefaultUnavailableTimeoutCallback`, we're doing a `Get` with `filter_dead_nodes` as false. If the node is dead, disconnect the client. If the node is alive, do nothing.

If we get a nullptr, it could mean that the node is dead or the node cache isn't populated yet. Because there's a cap in the GCS for storing info for dead nodes up to 1000 dead nodes, it's possible that the cache never got populated with this dead node. Therefore we have to make an rpc to the GCS, if the GCS responds back saying the node is dead or there's no trace of this node, we can go ahead and disconnect the client. It's ok to assume the node is dead if the rpc to the GCS tells us there's no trace, because the system can only find out about a remote node after the gcs registers it. It's possible to know about a local raylet before, but an RPC to a local raylet should never fail in the first place.

### A little future-proofing:
In the future https://github.com/ray-project/ray/pull/54220, we don't always want to subscribe to node changes to use the core worker client. In that case the `GetDefaultUnavailableTimeoutCallback` should be able to handle there being no subscription. So making that change here to just fire off an rpc to get the node info in that case.

### Note
Note that this issue also exists in other places the subscription cache is used and will try to fix those in a follow-up. Fixing these is also a prereq for https://github.com/ray-project/ray/pull/54220 because that will make it more likely if the subscription doesn't happen at process startup. This will also happen more when the gcs is under load (large clusters) because the event loop will have more queuing time and the request that populates the cache may take seconds to fulfill.

### Immaterial changes:
- Simplifying the actual code for AsyncSubscribeToNodeChange and adding a comment to explain bc it's pretty confusing.
- Making the node subscription cache test better
- Making the actual node change handler take by const ref. The actual handler implementations in node_manager and core_worker were already taking by a const ref, but the accessor subscription logic was making a meaningless copy of each node info object to pass as rvalue ref.
- Not returning a status from AsyncSubscribeToNodeChange because it would always return ok.
- Also not returning a status now from the raylet/node manager's RegisterGCS functions and just doing the RAY_CHECK_OK's inside instead of checking outside.

