### PR TITLE
[cpp] hermetic build rules for all cpp files in the wheel

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -2,6 +2,8 @@
 # C/C++ documentation: https://docs.bazel.build/versions/master/be/c-cpp.html
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_test")
 load("//bazel:python.bzl", "py_test_module_list")
 load("//bazel:ray.bzl", "COPTS")
@@ -120,75 +122,92 @@ filegroup(
     visibility = ["//visibility:private"],
 )
 
-filegroup(
+pkg_files(
     name = "ray_cpp_hdrs",
     srcs = ["include/ray/api.h"] + glob([
         "include/ray/api/*.h",
     ]),
+    prefix = "ray/cpp/include/",
+    strip_prefix = "include",
     visibility = ["//visibility:private"],
 )
 
-filegroup(
+pkg_files(
     name = "example_files",
-    srcs = glob(["example/**"]),
+    srcs = glob(["example/*"]),
+    prefix = "ray/cpp/example/",
+    renames = {
+        "example/_WORKSPACE": "WORKSPACE",
+        "example/_BUILD.bazel": "BUILD.bazel",
+        "example/_.bazelrc": ".bazelrc",
+    },
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "msgpack_hdrs_files",
+    srcs = ["@msgpack//:msgpack_hdrs"],
+    prefix = "ray/cpp/include/",
+    strip_prefix = "include",
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "nlohmann_json_hdrs_files",
+    srcs = ["@nlohmann_json//:nlohmann_json_hdrs"],
+    prefix = "ray/cpp/include/",
+    strip_prefix = "single_include",
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "boost_ray_hdrs_files",
+    srcs = ["@boost//:boost_ray_hdrs"],
+    prefix = "ray/cpp/include/boost/",
+    strip_prefix = "boost",
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "default_worker_files",
+    srcs = ["default_worker"],
+    attributes = pkg_attributes(mode = "755"),
+    prefix = "ray/cpp/",
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "libray_api_files",
+    srcs = ["libray_api.so"],
+    attributes = pkg_attributes(mode = "755"),
+    prefix = "ray/cpp/lib/",
+    visibility = ["//visibility:private"],
+)
+
+pkg_zip(
+    name = "ray_cpp_pkg_zip",
+    srcs = [
+        ":boost_ray_hdrs_files",
+        ":default_worker_files",
+        ":example_files",
+        ":libray_api_files",
+        ":msgpack_hdrs_files",
+        ":nlohmann_json_hdrs_files",
+        ":ray_cpp_hdrs",
+    ],
+    out = "ray_cpp_pkg.zip",
     visibility = ["//visibility:private"],
 )
 
 genrule(
     name = "ray_cpp_pkg",
-    srcs = [
-        ":ray_cpp_hdrs",
-        ":example_files",
-        "default_worker",
-        "libray_api.so",
-        "@msgpack//:msgpack_hdrs",
-        "@nlohmann_json//:nlohmann_json_hdrs",
-        "@boost//:boost_ray_hdrs",
-    ],
+    srcs = ["ray_cpp_pkg.zip"],
     outs = ["ray_cpp_pkg.out"],
     cmd = """
         WORK_DIR="$$(pwd)" &&
-        PY_CPP_DIR="$$WORK_DIR/python/ray/cpp" &&
-        rm -rf $$PY_CPP_DIR &&
-        BOOST_DIR="$$PY_CPP_DIR/include/boost/" &&
-        mkdir -p "$$BOOST_DIR" &&
-        mkdir -p "$$PY_CPP_DIR/lib/" &&
-        cp -f $(location default_worker) "$$PY_CPP_DIR/" &&
-        cp -f -r $$WORK_DIR/external/msgpack/include/* "$$PY_CPP_DIR/include" &&
-        cp -f -r $$WORK_DIR/external/nlohmann_json/single_include/* "$$PY_CPP_DIR/include" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/archive" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/assert" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/bind" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/callable_traits" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/concept" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/config" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/container" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/container_hash" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/core" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/detail" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/dll" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/exception" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/filesystem" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/functional" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/io" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/iterator" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/lexical_cast" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/move" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/mpl" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/optional" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/parameter" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/preprocessor" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/system" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/type_traits" "$$BOOST_DIR" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/utility" "$$BOOST_DIR" &&
-        cp -f -r $$WORK_DIR/external/boost/boost/*.hpp "$$BOOST_DIR" &&
-        cp -f $(locations libray_api.so) "$$PY_CPP_DIR/lib/" &&
-        cp -f -r "$$WORK_DIR/cpp/include/ray" "$$PY_CPP_DIR/include" &&
-        cp -f -r "$$WORK_DIR/cpp/example" "$$PY_CPP_DIR" &&
-        mv "$$PY_CPP_DIR/example/_WORKSPACE" "$$PY_CPP_DIR/example/WORKSPACE" &&
-        mv "$$PY_CPP_DIR/example/_BUILD.bazel" "$$PY_CPP_DIR/example/BUILD.bazel" &&
-        mv "$$PY_CPP_DIR/example/_.bazelrc" "$$PY_CPP_DIR/example/.bazelrc" &&
-        echo "$$WORK_DIR" > $@
+        rm -rf "$$WORK_DIR/python/ray/cpp" &&
+        unzip -q $(location ray_cpp_pkg.zip) -d "$$WORK_DIR/python" &&
+        if [[ "$$OSTYPE" =~ ^darwin ]]; then shasum $< > $@ ; else sha1sum $< > $@ ; fi
     """,
     local = 1,
     visibility = ["//visibility:private"],


### PR DESCRIPTION
this change makes it another step closer to having hermetic, cacheable wheel building. it builds a `//cpp:ray_cpp_pkg_zip` file that is ready to be extracted under the wheel's root directory (`python/`) for wheel building
