### PR TITLE
[Core] Fixed the bug where the head was unable to submit tasks after redis is turned on in Ray 2.44.0 .

### DIFF
--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -72,6 +72,8 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
         # The time it takes until the head node is registered. None means
         # head node hasn't been registered.
         self._head_node_registration_time_s = None
+        # The node ID of the current head node
+        self._registered_head_node_id = None
         # Queue of dead nodes to be removed, up to MAX_DEAD_NODES_TO_CACHE
         self._dead_node_queue = deque()
 
@@ -156,7 +158,19 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
 
     async def _update_node(self, node: dict):
         node_id = node["nodeId"]  # hex
-        if node["isHeadNode"] and not self._head_node_registration_time_s:
+        if (
+            node["isHeadNode"]
+            and node["state"] == "ALIVE"
+            and self._registered_head_node_id != node_id
+        ):
+            if self._registered_head_node_id is not None:
+                logger.warning(
+                    "A new head node has become ALIVE. New head node ID: %s, old head node ID: %s, internal states: %s",
+                    node_id,
+                    self._registered_head_node_id,
+                    self.get_internal_states(),
+                )
+            self._registered_head_node_id = node_id
             self._head_node_registration_time_s = time.time() - self._module_start_time
             # Put head node ID in the internal KV to be read by JobAgent.
             # TODO(architkulkarni): Remove once State API exposes which


### PR DESCRIPTION
## Why are these changes needed?

To fix https://github.com/ray-project/ray/issues/54241 . When updating the head node, we should not only verify the isHeadNode flag but also confirm that node["state"] == "ALIVE". Additionally, record the updated node ID using _registered_head_node_id to log warnings when the head node changes.

## Related issue number

issue #54241


Below is a detailed analysis of the issue and verification of its resolution.

## Issue Analysis

### Environment Configuration

Ray 2.44.0 + Redis

```yaml
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: raycluster-with-redis
  namespace: zenap
  annotations:
    ray.io/ft-enabled: "true" # enable Ray GCS FT
    ray.io/external-storage-namespace: raycluster-with-redis
spec:
  rayVersion: '2.44.0'
  enableInTreeAutoscaling: true
  HeadGroupSpec:
    rayStartParams:
      dashboard-host: '0.0.0.0'
      num-cpus: "4"
      num-gpus: "0"
      redis-password: "password"
      disable-usage-stats: "true"
    template:
      spec:
        enableServiceLinks: false
        containers:
          - name: ray
            image: 'rayproject/ray:2.44.0-py311-cpu'
            imagePullPolicy: Always
            resources:
              limits:
                cpu: "12"
                memory: "24G"
              requests:
                cpu: "12"
                memory: "12G"
            env:
            - name: RAY_REDIS_ADDRESS
              value: "redis:6379"
            ports:
              - containerPort: 6379
                name: gcs-server
              - containerPort: 8265
                name: dashboard
              - containerPort: 10001
                name: client
              - containerPort: 8000
                name: serve
```


### Issue phenomenon before applying the patch

Using the configuration above, we start a Ray cluster and submit a job. The job is submitted successfully as shown below:

<img width="930" height="447" alt="image" src="https://github.com/user-attachments/assets/7ddf20d9-4f18-4175-950f-5775ad07de93" />

Subsequently, we delete pod (`kubectl delete pod`) and wait to restart the Head Pod. When listing jobs and resubmitting a job, the logs indicate that `ray list jobs` succeeds, but `ray submit job` fails:

<img width="1459" height="1134" alt="image" src="https://github.com/user-attachments/assets/4a345886-4b9a-4b46-97a0-8158ab87300c" />


### Root Cause of the Issue

In Ray 2.44.0 and earlier versions, we observed that the dashboard process starts earlier than the raylet process:

<img width="1920" height="229" alt="image" src="https://github.com/user-attachments/assets/7d6be191-2b23-4802-b527-64e3610435ba" />

The cause of this problem is that during the Ray startup process, the Dashboard Node Head queries the GCS for the node list when it starts. If the Head node has not yet been registered, the node list returned by GCS only contains information about dead old Head nodes and other worker nodes. Due to the lack of status filtering for Head nodes, the Dashboard Node Head will write an incorrect (dead) Head node ID into `KV_HEAD_NODE_ID_KEY` at this point.

However, in Ray 2.45 and later versions, the dashboard single process was split into multiple processes (see details at https://github.com/ray-project/ray/releases/tag/ray-2.45.0):

The raylet process starts earlier than the dashboard's NodeHead child process, making the issue difficult to reproduce:

<img width="1949" height="411" alt="image" src="https://github.com/user-attachments/assets/aa592295-3f43-49c9-90ae-0bc969894a93" />

In summary, after restarting a Redis-configured Head node, the issue is guaranteed to occur if the Head node's registration with GCS is delayed beyond the NodeHead's query for the node list from GCS.

Additionally, this issue does not occur in Ray clusters without Redis, because the Dashboard Head in such cases can only fetch data from GCS after the raylet is ready; otherwise, GCS returns an empty result.

## Verification of the fix after applying the patch

This PR resolves the aforementioned issue.

We modified the image used by the Head node via `kubectl edit` to use the new image incorporating this PR.

After restarting the Head Pod, we listed jobs and resubmitted a job. The job list matches the one from the issue reproduction, confirming it is the same cluster. Jobs can now be submitted successfully:

<img width="1604" height="692" alt="image" src="https://github.com/user-attachments/assets/9f0e872c-5858-45d9-b499-cf6d27dda284" />

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
