### PR TITLE
[serve.llm] Skip batching logic if `batch_interval_ms` == 0

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -226,13 +226,6 @@ class LLMServer(_LLMServerBase):
     def _batch_output_stream(
         self, generator: AsyncGenerator[T, None]
     ) -> AsyncGenerator[List[T], None]:
-        if self._get_batch_interval_ms() == 0:
-
-            async def _to_list(generator: AsyncGenerator[T, None]) -> List[T]:
-                async for item in generator:
-                    yield [item]
-
-            return _to_list(generator)
         return Batcher(
             generator,
             interval_ms=self._get_batch_interval_ms(),

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -277,7 +277,9 @@ class LLMServer(_LLMServerBase):
             An AsyncGenerator of the response. If stream is True and batching is enabled, then the generator will yield a list of chat streaming responses (strings of the format data: {response_json}\n\n). Otherwise, it will yield the ChatCompletionResponse object directly.
         """
         return await self._run_request(
-            request, engine_method="chat", batch_output_stream=True
+            request,
+            engine_method="chat",
+            batch_output_stream=self._get_batch_interval_ms() > 0,
         )
 
     async def completions(
@@ -294,7 +296,9 @@ class LLMServer(_LLMServerBase):
             An AsyncGenerator of the response. If stream is True and batching is enabled, then the generator will yield a list of completion streaming responses (strings of the format data: {response_json}\n\n). Otherwise, it will yield the CompletionResponse object directly.
         """
         return await self._run_request(
-            request, engine_method="completions", batch_output_stream=True
+            request,
+            engine_method="completions",
+            batch_output_stream=self._get_batch_interval_ms() > 0,
         )
 
     async def embeddings(

--- a/python/ray/llm/_internal/serve/deployments/utils/batcher.py
+++ b/python/ray/llm/_internal/serve/deployments/utils/batcher.py
@@ -36,11 +36,13 @@ class Batcher(Generic[T]):
         else:
             self.interval_s = interval_ms / 1000
 
-        if interval_ms > 0:
-            self.done_event: asyncio.Event = asyncio.Event()
+        if interval_ms == 0:
+            return
 
-            # We are okay with this task getting cancelled (to propagate cancellations)
-            self.read_task = asyncio.create_task(self.read())
+        self.done_event: asyncio.Event = asyncio.Event()
+
+        # We are okay with this task getting cancelled (to propagate cancellations)
+        self.read_task = asyncio.create_task(self.read())
 
     def _merge_results(self, results: List[T]) -> Iterable[T]:
         return results

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -18,7 +18,7 @@ from ray.llm.tests.serve.utils.testing_utils import LLMResponseValidator
 
 
 @pytest.fixture
-def serve_handle(mock_llm_config, stream_batching_interval_ms):
+def serve_handle(mock_llm_config, stream_batching_interval_ms=0):
     mock_llm_config.experimental_configs = {
         "stream_batching_interval_ms": stream_batching_interval_ms,
     }

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -1,7 +1,10 @@
+import asyncio
 import sys
-from typing import Optional
+import time
+from typing import AsyncGenerator, Optional
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from ray import serve
@@ -15,7 +18,7 @@ from ray.llm.tests.serve.utils.testing_utils import LLMResponseValidator
 
 
 @pytest.fixture
-def serve_handle(mock_llm_config, stream_batching_interval_ms=0):
+def serve_handle(mock_llm_config, stream_batching_interval_ms):
     mock_llm_config.experimental_configs = {
         "stream_batching_interval_ms": stream_batching_interval_ms,
     }
@@ -48,6 +51,17 @@ def multiplexed_serve_handle(mock_llm_config, stream_batching_interval_ms=0):
     handle = handle.options(stream=True, multiplexed_model_id="test_model_id")
     yield handle
     serve.shutdown()
+
+
+async def count_tpot_ms_from_stream(stream: AsyncGenerator) -> list[float]:
+    all_tpots_in_ms = []
+    start = None
+    async for _ in stream:
+        now = time.perf_counter()
+        if start is not None:
+            all_tpots_in_ms.append((now - start) * 1e3)
+        start = now
+    return all_tpots_in_ms
 
 
 class TestLLMServer:
@@ -262,6 +276,71 @@ class TestLLMServer:
         ) as mock_push_telemetry:
             await create_server(mock_llm_config, engine_cls=MockVLLMEngine)
             mock_push_telemetry.assert_called_once()
+
+    @pytest.mark.parametrize("api_type", ["chat", "completions"])
+    @pytest.mark.parametrize("stream", [True])
+    @pytest.mark.parametrize("max_tokens", [64])
+    @pytest.mark.parametrize("concurrency", [1, 16])
+    @pytest.mark.parametrize("stream_batching_interval_ms", [0, 8])
+    @pytest.mark.asyncio
+    async def test_stable_streaming_tpot(
+        self,
+        serve_handle,
+        mock_llm_config,
+        mock_chat_request,
+        mock_completion_request,
+        api_type: str,
+        stream: bool,
+        max_tokens: int,
+        concurrency: int,
+        stream_batching_interval_ms: int,
+    ):
+        """Test that the streaming TPOT is stable when batching is disabled."""
+
+        # Create request based on API type
+        if api_type == "chat":
+            request = mock_chat_request
+        elif api_type == "completions":
+            request = mock_completion_request
+        batched_chunks: list[AsyncGenerator] = [
+            getattr(serve_handle, api_type).remote(request) for _ in range(concurrency)
+        ]
+
+        print(
+            f"\n\n_____ {api_type.upper()} ({'STREAMING' if stream else 'NON-STREAMING'}) max_tokens={max_tokens} batching_interval_ms={stream_batching_interval_ms} _____\n\n"
+        )
+
+        # Collect responses from llm_server
+        tpots_ms = await asyncio.gather(
+            *[
+                count_tpot_ms_from_stream(server_stream)
+                for server_stream in batched_chunks
+            ]
+        )
+        mean_llm_server = np.mean(tpots_ms)
+        std_var_llm_server = np.std(tpots_ms)
+
+        # Run same request with vllm engine
+        vllm_engine = MockVLLMEngine(llm_config=mock_llm_config)
+        await vllm_engine.start()
+        engine_streams: list[AsyncGenerator] = [
+            getattr(vllm_engine, api_type)(request) for _ in range(concurrency)
+        ]
+        tpots_ms_engine = await asyncio.gather(
+            *[
+                count_tpot_ms_from_stream(engine_stream)
+                for engine_stream in engine_streams
+            ]
+        )
+        mean_engine = np.mean(tpots_ms_engine)
+        std_var_engine = np.std(tpots_ms_engine)
+
+        assert np.isclose(
+            mean_llm_server, mean_engine, rtol=0.1
+        ), f"{mean_llm_server=}, {mean_engine=}"
+        assert np.isclose(
+            std_var_llm_server, std_var_engine, atol=0.5
+        ), f"{std_var_llm_server=}, {std_var_engine=}"
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -281,7 +281,7 @@ class TestLLMServer:
     @pytest.mark.parametrize("stream", [True])
     @pytest.mark.parametrize("max_tokens", [64])
     @pytest.mark.parametrize("concurrency", [1, 16])
-    @pytest.mark.parametrize("stream_batching_interval_ms", [0, 8])
+    @pytest.mark.parametrize("stream_batching_interval_ms", [0])
     @pytest.mark.asyncio
     async def test_stable_streaming_tpot(
         self,

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -339,7 +339,7 @@ class TestLLMServer:
             mean_llm_server, mean_engine, rtol=0.1
         ), f"{mean_llm_server=}, {mean_engine=}"
         assert np.isclose(
-            std_var_llm_server, std_var_engine, atol=0.5
+            std_var_llm_server, std_var_engine, atol=1.0
         ), f"{std_var_llm_server=}, {std_var_engine=}"
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

With added unit tests, we can reproduce higher std. variance if not skipping `Batcher` logic, i.e. `Batcher` is adding additional jitter to output stream which we want to fully eliminate if `batch_interval_ms==0`

Errors without the change
```
FAILED llm/test_llm_server.py::TestLLMServer::test_stable_streaming_tpot[0-16-64-True-chat] - AssertionError: std_var_llm_server=27.77915118448428, std_var_engine=0.0280409148081092
FAILED llm/test_llm_server.py::TestLLMServer::test_stable_streaming_tpot[0-16-64-True-completions] - AssertionError: std_var_llm_server=15.742387830406825, std_var_engine=0.14092649239505908
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
