### PR TITLE
[core] stop using the generated opentelemetry proto files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1032,7 +1032,6 @@ filegroup(
         "//src/ray/protobuf:gcs_py_proto",
         "//src/ray/protobuf:gcs_service_py_proto",
         "//src/ray/protobuf:instance_manager_py_proto",
-        "//src/ray/protobuf:metrics_service_py_proto",
         "//src/ray/protobuf:node_manager_py_proto",
         "//src/ray/protobuf:ray_client_py_proto",
         "//src/ray/protobuf:reporter_py_proto",

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -14,7 +14,10 @@ from typing import List, Optional, Tuple, TypedDict, Union
 from opencensus.stats import stats as stats_module
 from prometheus_client.core import REGISTRY
 from prometheus_client.parser import text_string_to_metric_families
-from opentelemetry.proto.collector.metrics.v1 import metrics_service_pb2
+from opentelemetry.proto.collector.metrics.v1 import (
+    metrics_service_pb2,
+    metrics_service_pb2_grpc,
+)
 from grpc.aio import ServicerContext
 
 
@@ -39,7 +42,7 @@ from ray._private.telemetry.open_telemetry_metric_recorder import (
     OpenTelemetryMetricRecorder,
 )
 from ray._raylet import GCS_PID_KEY, WorkerID
-from ray.core.generated import metrics_service_pb2_grpc, reporter_pb2, reporter_pb2_grpc
+from ray.core.generated import reporter_pb2, reporter_pb2_grpc
 from ray.dashboard import k8s_utils
 from ray.dashboard.consts import (
     CLUSTER_TAG_KEYS,

--- a/src/ray/protobuf/BUILD
+++ b/src/ray/protobuf/BUILD
@@ -141,11 +141,6 @@ proto_library(
     ],
 )
 
-python_grpc_compile(
-    name = "metrics_service_py_proto",
-    deps = ["@com_github_opentelemetry_proto//:metrics_service_proto"],
-)
-
 cc_proto_library(
     name = "reporter_cc_proto",
     deps = [":reporter_proto"],
@@ -430,7 +425,6 @@ proto_library(
         ":gcs_proto",
         ":logging_proto",
         ":reporter_proto",
-        "@com_github_opentelemetry_proto//:metrics_service_proto",
     ],
 )
 


### PR DESCRIPTION
the generated files are importing `opentelemetry.proto.*` anyways, generating those protobuf files and using them only introduces risks of using a version that is not compatible.

opentelemetry proto is already declared as part of the python dependencies, there is no need to generate those protobuf python files
