### PR TITLE
[core][autoscaler] add release tests on RAY_UP_enable_autoscaler_v2=1

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4006,6 +4006,11 @@
     timeout: 2400
     script: python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10
 
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10
 
 - name: aws_cluster_launcher_nightly_image
   group: cluster-launcher-test
@@ -4021,6 +4026,11 @@
     timeout: 2400
     script: python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override nightly
 
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override nightly
 
 - name: aws_cluster_launcher_latest_image
   group: cluster-launcher-test
@@ -4036,6 +4046,11 @@
     timeout: 2400
     script: python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override latest
 
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override latest
 
 - name: aws_cluster_launcher_release_image
   group: cluster-launcher-test
@@ -4067,6 +4082,12 @@
     timeout: 1200
     script: python launch_and_verify_cluster.py aws/example-minimal.yaml
 
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/example-minimal.yaml
+
 - name: aws_cluster_launcher_full
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -4080,6 +4101,12 @@
   run:
     timeout: 3000
     script: python launch_and_verify_cluster.py aws/example-full.yaml --num-expected-nodes 2 --retries 20 --docker-override latest
+
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/example-full.yaml --num-expected-nodes 2 --retries 20 --docker-override latest
 
 - name: gcp_cluster_launcher_minimal
   group: cluster-launcher-test
@@ -4098,6 +4125,12 @@
     timeout: 1200
     script: python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
 
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
+
 - name: gcp_cluster_launcher_full
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -4114,6 +4147,12 @@
   run:
     timeout: 4800
     script: python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 30
+
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 30 --docker-override latest
 
 - name: gcp_cluster_launcher_latest_image
   group: cluster-launcher-test
@@ -4132,6 +4171,12 @@
     timeout: 3600
     script: python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
 
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
+
 - name: gcp_cluster_launcher_nightly_image
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -4149,6 +4194,11 @@
     timeout: 3600
     script: python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
 
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
 
 - name: gcp_cluster_launcher_release_image
   group: cluster-launcher-test
@@ -4183,6 +4233,12 @@
   run:
     timeout: 1200
     script: python launch_and_verify_cluster.py gcp/example-gpu-docker.yaml
+
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-gpu-docker.yaml
 
 - name: autoscaler_aws
   group: autoscaler-test

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4066,6 +4066,11 @@
     timeout: 2400
     script: python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override commit
 
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override commit
 
 
 - name: aws_cluster_launcher_minimal
@@ -4216,6 +4221,12 @@
   run:
     timeout: 3600
     script: python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override commit
+
+  variations:
+    - __suffix__: v1
+    - __suffix__: v2
+      run:
+        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override commit
 
 - name: gcp_cluster_launcher_gpu_docker
   group: cluster-launcher-test


### PR DESCRIPTION
## Why are these changes needed?

Since ray 2.48.0 has been released, the autoscaler v2 in the `latest` ray image should have cluster launcher support, and thus we can test autoscaler v2 on the cluster launcher in release tests.

This PR adds those tests.

<img width="1684" height="637" alt="image" src="https://github.com/user-attachments/assets/b9032008-fd8b-41ef-839e-10be0692779c" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
