### PR TITLE
[data] Add in async updating for progress bar

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -239,7 +239,7 @@ class StreamingExecutor(Executor, threading.Thread):
                         f"{WARN_PREFIX} Dataset {self._dataset_id} execution failed"
                     )
                 logger.info(prog_bar_msg)
-                self._global_info.set_description(prog_bar_msg)
+                self._global_info.set_description(prog_bar_msg, flush=True)
                 self._global_info.close()
 
             timer = Timer()
@@ -598,10 +598,10 @@ class _ClosingIterator(OutputIterator):
             op, state = self._executor._output_node
             bundle = state.get_output_blocking(output_split_idx)
 
-            # Update progress-bars
+            # Update progress-bars (flush=True for final state accuracy)
             if self._executor._global_info:
                 self._executor._global_info.update(
-                    bundle.num_rows(), op.num_output_rows_total()
+                    bundle.num_rows(), op.num_output_rows_total(), flush=True
                 )
 
             return bundle

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -73,18 +73,7 @@ class AsyncProgressUpdater:
 
     def _worker_loop(self):
         while not self._shutdown:
-            # Get snapshot of pending calls and clear them
-            with self._lock:
-                calls_to_process = self._pending_calls.copy()
-                self._pending_calls.clear()
-
-            # Execute all pending calls
-            for call_id, (func, args, kwargs) in calls_to_process.items():
-                try:
-                    func(*args, **kwargs)
-                except Exception as e:
-                    logger.debug(f"Progress bar call failed for {call_id}: {e}")
-
+            self.flush_pending()
             time.sleep(self._update_interval)
 
     def shutdown(self):

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -947,7 +947,7 @@ def test_async_progress_updater_non_blocking():
             # If we reach this point, the async progress updater worked for both
             # execution and cleanup
             assert len(result) == 100
-            assert result == list(range(100))
+            assert result == [{"id": i} for i in range(100)]
 
     except ImportError:
         # Skip test if tqdm not available

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -921,6 +921,39 @@ def test_create_topology_metadata_with_sub_stages():
     assert sub_stage2.id.endswith("_sub_1")
 
 
+@pytest.mark.timeout(5)
+def test_async_progress_updater_non_blocking():
+    """Test that slow tqdm updates don't block the streaming executor.
+
+    If tqdm.update or tqdm.close blocks indefinitely, this test will timeout after 5 seconds.
+    If the async progress updater works (including cleanup), the test completes quickly.
+    """
+    import time
+    from unittest.mock import patch
+
+    def blocking_tqdm_operation(self, *args, **kwargs):
+        """Simulate completely blocked terminal I/O"""
+        time.sleep(999)  # Sleep indefinitely to simulate blocked terminal
+
+    try:
+        import tqdm
+
+        # Mock update to block indefinitely
+        with patch.object(tqdm.tqdm, "update", blocking_tqdm_operation):
+            # Create and process a dataset that will trigger progress updates
+            ds = ray.data.range(100, override_num_blocks=10)
+            result = ds.map_batches(lambda batch: batch).take_all()
+
+            # If we reach this point, the async progress updater worked for both
+            # execution and cleanup
+            assert len(result) == 100
+            assert result == list(range(100))
+
+    except ImportError:
+        # Skip test if tqdm not available
+        pytest.skip("tqdm not available")
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?
Currently the scheduling loop is blocking on updating the tqdm progress bars. This decouples the execution from the progress bar updating by introducing an async background updater. This should allow the execution to continue even if the tqdm updates block (due to a closed or inactive terminal).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
