### PR TITLE
[serve] Deflake test_fastapi by waiting on background task to complete

### DIFF
--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -310,7 +310,10 @@ def test_fastapi_features(serve_instance):
         "db",
         "app.state",
     ]
-    assert open(resp.json()["file_path"]).read() == "hello"
+    wait_for_condition(
+        lambda: open(resp.json()["file_path"]).read() == "hello",
+        timeout=10,
+    )
 
     resp = httpx.request(
         "GET",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test checks if a file contains the string hello which is written by a background task. Sometimes, the background task will run after this check, which causes the test to fail. This PR changes it to wait on the condition to be true with a 10second timeout.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
