### PR TITLE
[core][raycheck/01] Fix "it != submissible_tasks_.end()"

### DIFF
--- a/python/ray/tests/test_actor_cancel.py
+++ b/python/ray/tests/test_actor_cancel.py
@@ -228,16 +228,15 @@ def test_async_actor_cancel_restart(ray_start_cluster, monkeypatch):
         cluster.remove_node(node)
         r, ur = ray.wait([ref])
         # When cancel is called, the task won't be retried anymore.
-        # Since an actor is dead, in this case, it will raise
-        # RayActorError.
-        with pytest.raises(ray.exceptions.RayActorError):
+        # It will raise TaskCancelledError.
+        with pytest.raises(ray.exceptions.TaskCancelledError):
             ray.get(ref)
 
         # This will restart actor, but task won't be retried.
         cluster.add_node(num_cpus=1)
         # Verify actor is restarted. f should be retried
         ray.get(a.__ray_ready__.remote())
-        with pytest.raises(ray.exceptions.RayActorError):
+        with pytest.raises(ray.exceptions.TaskCancelledError):
             ray.get(ref)
 
 

--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -233,7 +233,7 @@ ray.shutdown()
         assert type == "INTENDED_USER_EXIT" and "ray.cancel" in detail
         return verify_failed_task(
             name="cancel-f",
-            error_type="WORKER_DIED",  # Since it's a force cancel through kill signal.
+            error_type="TASK_CANCELLED",
         )
 
     wait_for_condition(verify_exit_by_ray_cancel)

--- a/python/ray/tests/test_streaming_generator_3.py
+++ b/python/ray/tests/test_streaming_generator_3.py
@@ -8,7 +8,7 @@ from collections import Counter
 
 import ray
 from ray._raylet import ObjectRefGenerator
-from ray.exceptions import WorkerCrashedError
+from ray.exceptions import TaskCancelledError
 
 
 def test_threaded_actor_generator(shutdown_only):
@@ -290,9 +290,9 @@ def test_completed_next_ready_is_finished(shutdown_only):
     # The last exception is not taken yet.
     assert gen.next_ready()
     assert not gen.is_finished()
-    with pytest.raises(WorkerCrashedError):
+    with pytest.raises(TaskCancelledError):
         ray.get(gen.completed())
-    with pytest.raises(WorkerCrashedError):
+    with pytest.raises(TaskCancelledError):
         ray.get(next(gen))
     assert not gen.next_ready()
     assert gen.is_finished()

--- a/src/mock/ray/core_worker/task_manager_interface.h
+++ b/src/mock/ray/core_worker/task_manager_interface.h
@@ -61,6 +61,7 @@ class MockTaskManagerInterface : public TaskManagerInterface {
                const std::vector<ObjectID> &contained_ids),
               (override));
   MOCK_METHOD(void, MarkTaskCanceled, (const TaskID &task_id), (override));
+  MOCK_METHOD(void, MarkTaskNoRetry, (const TaskID &task_id), (override));
   MOCK_METHOD(std::optional<TaskSpecification>,
               GetTaskSpec,
               (const TaskID &task_id),

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1159,11 +1159,27 @@ void TaskManager::FailPendingTask(const TaskID &task_id,
   {
     absl::MutexLock lock(&mu_);
     auto it = submissible_tasks_.find(task_id);
-    RAY_CHECK(it != submissible_tasks_.end())
-        << "Tried to fail task that was not pending " << task_id;
+    if (it == submissible_tasks_.end()) {
+      // Failing a pending task can happen through the normal task lifecycle or task
+      // cancellation. Since task cancellation runs concurrently with the normal task
+      // lifecycle, we do expect this state. It is safe to assume the task
+      // has been failed correctly by either the normal task lifecycle or task
+      // cancellation, and we can skip failing it again.
+      RAY_LOG(INFO).WithField("task_id", task_id)
+          << "Task is no longer in the submissible tasks map. It has either completed or "
+             "been cancelled. Skip failing";
+      return;
+    }
     RAY_CHECK(it->second.IsPending())
         << "Tried to fail task that was not pending " << task_id;
     spec = it->second.spec;
+    if (it->second.is_canceled && error_type != rpc::ErrorType::TASK_CANCELLED) {
+      // If the task is marked as cancelled before reaching FailPendingTask (which is
+      // essentially the final state of the task lifecycle), that failure reason takes
+      // precedence.
+      error_type = rpc::ErrorType::TASK_CANCELLED;
+      ray_error_info = nullptr;
+    }
 
     if ((status != nullptr) && status->IsIntentionalSystemExit()) {
       // We don't mark intentional system exit as failures, such as tasks that
@@ -1361,8 +1377,7 @@ int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
   return total_lineage_footprint_bytes_ - total_lineage_footprint_bytes_prev;
 }
 
-void TaskManager::MarkTaskCanceled(const TaskID &task_id) {
-  // Mark the task for cancelation. This will prevent the task from being retried.
+void TaskManager::MarkTaskNoRetryInternal(const TaskID &task_id, bool canceled) {
   ObjectID generator_id = TaskGeneratorId(task_id);
   if (!generator_id.IsNil()) {
     // Pass -1 because the task has been canceled, so we should just end the
@@ -1378,8 +1393,18 @@ void TaskManager::MarkTaskCanceled(const TaskID &task_id) {
   if (it != submissible_tasks_.end()) {
     it->second.num_retries_left = 0;
     it->second.num_oom_retries_left = 0;
-    it->second.is_canceled = true;
+    if (canceled) {
+      it->second.is_canceled = true;
+    }
   }
+}
+
+void TaskManager::MarkTaskCanceled(const TaskID &task_id) {
+  MarkTaskNoRetryInternal(task_id, /*canceled=*/true);
+}
+
+void TaskManager::MarkTaskNoRetry(const TaskID &task_id) {
+  MarkTaskNoRetryInternal(task_id, /*canceled=*/false);
 }
 
 absl::flat_hash_set<ObjectID> TaskManager::GetTaskReturnObjectsToStoreInPlasma(

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -430,6 +430,8 @@ class TaskManager : public TaskManagerInterface {
   void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
                                  const std::vector<ObjectID> &contained_ids) override;
 
+  void MarkTaskNoRetry(const TaskID &task_id) override;
+
   void MarkTaskCanceled(const TaskID &task_id) override;
 
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override;
@@ -595,6 +597,11 @@ class TaskManager : public TaskManagerInterface {
     // Whether this is a task retry due to task failure.
     bool is_retry_ = false;
   };
+
+  /// Set the task retry number to 0. If canceled is true, mark the task as
+  // canceled.
+  void MarkTaskNoRetryInternal(const TaskID &task_id, bool canceled)
+      ABSL_LOCKS_EXCLUDED(mu_);
 
   /// Update nested ref count info and store the in-memory value for a task's
   /// return object. Returns true if the task's return object was returned

--- a/src/ray/core_worker/task_manager_interface.h
+++ b/src/ray/core_worker/task_manager_interface.h
@@ -151,7 +151,18 @@ class TaskManagerInterface {
   /// \param[in] task_id The task that is now scheduled.
   virtual void MarkDependenciesResolved(const TaskID &task_id) = 0;
 
-  /// Set the task state to be canceled. Set the number of retries to zero.
+  /// Sets the task state to no-retry. This is used when Ray overrides the user-specified
+  /// retry count for a task (e.g., a task belonging to a dead actor).
+  /// Unlike `MarkTaskCanceled`, this does not mark the task as canceled—`ray.get()` will
+  /// raise the specific error that caused the retry override (e.g., ACTOR_ERROR).
+  ///
+  /// \param[in] task_id to set no retry.
+  virtual void MarkTaskNoRetry(const TaskID &task_id) = 0;
+
+  /// Marks the task as canceled and sets its retry count to zero. This function
+  /// should only be used for task cancellation. Unlike `MarkTaskNoRetry`, a
+  /// canceled task is not retriable and `ray.get()` will raise a
+  /// `TASK_CANCELLED` error.
   ///
   /// \param[in] task_id to cancel.
   virtual void MarkTaskCanceled(const TaskID &task_id) = 0;

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -112,6 +112,8 @@ class MockTaskManager : public MockTaskManagerInterface {
 
   void MarkTaskCanceled(const TaskID &task_id) override {}
 
+  void MarkTaskNoRetry(const TaskID &task_id) override {}
+
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();
     return task;

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -145,10 +145,13 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
 };
 
 class MockTaskManager : public MockTaskManagerInterface {
+  // TODO(ray-core): Consider adding an integration test between TaskManager and
+  // NormalTaskSubmitter, due to the complexity of the interaction between the two.
+  // https://github.com/ray-project/ray/issues/54922
  public:
   MockTaskManager() {}
 
-  void CompletePendingTask(const TaskID &,
+  void CompletePendingTask(const TaskID &task_id,
                            const rpc::PushTaskReply &,
                            const rpc::Address &actor_addr,
                            bool is_application_error) override {
@@ -176,6 +179,10 @@ class MockTaskManager : public MockTaskManagerInterface {
                               bool mark_task_object_failed = true,
                               bool fail_immediately = false) override {
     num_tasks_failed++;
+    if (!fail_immediately) {
+      RetryTaskIfPossible(task_id,
+                          ray_error_info ? *ray_error_info : rpc::RayErrorInfo());
+    }
     return true;
   }
 
@@ -186,6 +193,8 @@ class MockTaskManager : public MockTaskManagerInterface {
   }
 
   void MarkTaskCanceled(const TaskID &task_id) override {}
+
+  void MarkTaskNoRetry(const TaskID &task_id) override {}
 
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();
@@ -237,9 +246,19 @@ class MockRayletClient : public WorkerLeaseInterface {
       const ray::rpc::ClientCallback<ray::rpc::GetTaskFailureCauseReply> &callback)
       override {
     std::lock_guard<std::mutex> lock(mu_);
-    ray::rpc::GetTaskFailureCauseReply reply;
-    callback(Status::OK(), std::move(reply));
+    get_task_failure_cause_callbacks.push_back(callback);
     num_get_task_failure_causes += 1;
+  }
+
+  bool ReplyGetTaskFailureCause() {
+    if (get_task_failure_cause_callbacks.size() == 0) {
+      return false;
+    }
+    auto callback = std::move(get_task_failure_cause_callbacks.front());
+    get_task_failure_cause_callbacks.pop_front();
+    rpc::GetTaskFailureCauseReply reply;
+    callback(Status::OK(), std::move(reply));
+    return true;
   }
 
   void ReportWorkerBacklog(
@@ -622,6 +641,7 @@ TEST_F(NormalTaskSubmitterTest, TestHandleTaskFailure) {
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
   // Simulate a system failure, i.e., worker died unexpectedly.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("oops")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
@@ -634,6 +654,28 @@ TEST_F(NormalTaskSubmitterTest, TestHandleTaskFailure) {
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
+}
+
+TEST_F(NormalTaskSubmitterTest, TestCancellationWhileHandlingTaskFailure) {
+  // This test is a regression test for a bug where a crash happens when
+  // the task cancellation races between ReplyPushTask and ReplyGetTaskFailureCause.
+  // For an example of a python integration test, see
+  // https://github.com/ray-project/ray/blob/2b6807f4d9c4572e6309f57bc404aa641bc4b185/python/ray/tests/test_cancel.py#L35
+  auto submitter =
+      CreateNormalTaskSubmitter(std::make_shared<StaticLeaseRequestRateLimiter>(1));
+
+  TaskSpecification task = BuildEmptyTaskSpec();
+  ASSERT_TRUE(submitter.SubmitTask(task).ok());
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
+  // Simulate a system failure, i.e., worker died unexpectedly so that
+  // GetTaskFailureCause is called.
+  ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("oops")));
+  // Cancel the task while GetTaskFailureCause has not been completed.
+  ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
+  // Completing the GetTaskFailureCause call. Check that the reply runs without error
+  // and FailPendingTask is not called.
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
+  ASSERT_EQ(task_manager->num_fail_pending_task_calls, 0);
 }
 
 TEST_F(NormalTaskSubmitterTest, TestHandleUnschedulableTask) {
@@ -1217,6 +1259,7 @@ TEST_F(NormalTaskSubmitterTest, TestWorkerNotReusedOnError) {
 
   // Task 1 finishes with failure; the worker is returned.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("worker dead")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
@@ -1638,6 +1681,7 @@ TEST_F(NormalTaskSubmitterTest, TestWorkerLeaseTimeout) {
   // Task 1 finishes with failure; the worker is returned due to the error even though
   // it hasn't timed out.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("worker dead")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
 
@@ -1677,6 +1721,7 @@ TEST_F(NormalTaskSubmitterTest, TestKillExecutingTask) {
   ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(), task.TaskIdBinary());
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("workerdying"), true));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_returned_exiting, 0);

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -144,7 +144,7 @@ Status ActorTaskSubmitter::SubmitActorCreationTask(TaskSpecification task_spec) 
             if (status.IsSchedulingCancelled()) {
               RAY_LOG(DEBUG).WithField(actor_id).WithField(task_id)
                   << "Actor creation cancelled";
-              task_manager_.MarkTaskCanceled(task_id);
+              task_manager_.MarkTaskNoRetry(task_id);
               if (reply.has_death_cause()) {
                 ray_error_info.mutable_actor_died_error()->CopyFrom(reply.death_cause());
               }
@@ -233,7 +233,7 @@ Status ActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
         "ActorTaskSubmitter::SubmitTask");
   } else {
     // Do not hold the lock while calling into task_manager_.
-    task_manager_.MarkTaskCanceled(task_id);
+    task_manager_.MarkTaskNoRetry(task_id);
     rpc::ErrorType error_type;
     rpc::RayErrorInfo error_info;
     {
@@ -441,7 +441,7 @@ void ActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,
     for (auto &task_id : task_ids_to_fail) {
       // No need to increment the number of completed tasks since the actor is
       // dead.
-      task_manager_.MarkTaskCanceled(task_id);
+      task_manager_.MarkTaskNoRetry(task_id);
       // This task may have been waiting for dependency resolution, so cancel
       // this first.
       resolver_.CancelDependencyResolution(task_id);

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -36,17 +36,25 @@ Status NormalTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
     // outside of this closure).
     task_manager_.MarkDependenciesResolved(task_spec.TaskId());
     if (!status.ok()) {
+      // TODO(https://github.com/ray-project/ray/issues/54871): There is a potential
+      // logical race conditions here where the task is cancelled right before the
+      // task is retried. Task cancellation might remove the task from the submissible
+      // task queue, while the task retry here expects that the task must be in the
+      // submissible task queue.
       RAY_LOG(WARNING) << "Resolving task dependencies failed " << status.ToString();
-      RAY_UNUSED(task_manager_.FailOrRetryPendingTask(
-          task_spec.TaskId(), rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED, &status));
+      bool will_retry = task_manager_.FailOrRetryPendingTask(
+          task_spec.TaskId(), rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED, &status);
+      if (!will_retry) {
+        absl::MutexLock lock(&mu_);
+        cancelled_tasks_.erase(task_spec.TaskId());
+      }
       return;
     }
     RAY_LOG(DEBUG) << "Task dependencies resolved " << task_spec.TaskId();
 
     absl::MutexLock lock(&mu_);
-    auto task_iter = cancelled_tasks_.find(task_spec.TaskId());
-    if (task_iter != cancelled_tasks_.end()) {
-      cancelled_tasks_.erase(task_iter);
+    if (cancelled_tasks_.erase(task_spec.TaskId()) > 0) {
+      task_manager_.FailPendingTask(task_spec.TaskId(), rpc::ErrorType::TASK_CANCELLED);
       return;
     }
 
@@ -595,16 +603,27 @@ void NormalTaskSubmitter::PushNormalTask(
           scheduling_key_entry.num_busy_workers--;
 
           if (!status.ok()) {
+            failed_tasks_pending_failure_cause_.insert(task_id);
             RAY_LOG(DEBUG) << "Getting error from raylet for task " << task_id;
             const ray::rpc::ClientCallback<ray::rpc::GetTaskFailureCauseReply> callback =
                 [this, status, task_id, addr](
                     const Status &get_task_failure_cause_reply_status,
                     const rpc::GetTaskFailureCauseReply &get_task_failure_cause_reply) {
-                  HandleGetTaskFailureCause(status,
-                                            task_id,
-                                            addr,
-                                            get_task_failure_cause_reply_status,
-                                            get_task_failure_cause_reply);
+                  bool will_retry =
+                      HandleGetTaskFailureCause(status,
+                                                task_id,
+                                                addr,
+                                                get_task_failure_cause_reply_status,
+                                                get_task_failure_cause_reply);
+                  absl::MutexLock lock(&mu_);
+                  if (!will_retry) {
+                    // Task submission and task cancellation are the only two other code
+                    // paths that clean up the cancelled_tasks_ map. If the task is not
+                    // retried (aka. it will not go through the task submission path),
+                    // we need to remove it from the map here.
+                    cancelled_tasks_.erase(task_id);
+                  }
+                  failed_tasks_pending_failure_cause_.erase(task_id);
                 };
             auto &cur_lease_entry = worker_to_lease_entry_[addr];
             RAY_CHECK(cur_lease_entry.lease_client);
@@ -646,7 +665,7 @@ void NormalTaskSubmitter::PushNormalTask(
       });
 }
 
-void NormalTaskSubmitter::HandleGetTaskFailureCause(
+bool NormalTaskSubmitter::HandleGetTaskFailureCause(
     const Status &task_execution_status,
     const TaskID &task_id,
     const rpc::Address &addr,
@@ -689,12 +708,12 @@ void NormalTaskSubmitter::HandleGetTaskFailureCause(
     error_info->set_error_message(buffer.str());
     error_info->set_error_type(rpc::ErrorType::NODE_DIED);
   }
-  RAY_UNUSED(task_manager_.FailOrRetryPendingTask(task_id,
-                                                  task_error_type,
-                                                  &task_execution_status,
-                                                  error_info.get(),
-                                                  /*mark_task_object_failed*/ true,
-                                                  fail_immediately));
+  return task_manager_.FailOrRetryPendingTask(task_id,
+                                              task_error_type,
+                                              &task_execution_status,
+                                              error_info.get(),
+                                              /*mark_task_object_failed*/ true,
+                                              fail_immediately);
 }
 
 Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
@@ -747,9 +766,14 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
 
     if (rpc_client == executing_tasks_.end()) {
       // This case is reached for tasks that have unresolved dependencies.
-      resolver_.CancelDependencyResolution(task_spec.TaskId());
-      RAY_UNUSED(task_manager_.FailPendingTask(task_spec.TaskId(),
-                                               rpc::ErrorType::TASK_CANCELLED));
+      if (failed_tasks_pending_failure_cause_.contains(task_spec.TaskId())) {
+        // We are waiting for the task failure cause. Do not fail it here; instead,
+        // wait for the cause to come in and then handle it appropriately.
+      } else {
+        resolver_.CancelDependencyResolution(task_spec.TaskId());
+        RAY_UNUSED(task_manager_.FailPendingTask(task_spec.TaskId(),
+                                                 rpc::ErrorType::TASK_CANCELLED));
+      }
       if (scheduling_key_entry.CanDelete()) {
         // We can safely remove the entry keyed by scheduling_key from the
         // scheduling_key_entries_ hashmap.

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -239,7 +239,8 @@ class NormalTaskSubmitter {
                           &assigned_resources);
 
   /// Handles result from GetTaskFailureCause.
-  void HandleGetTaskFailureCause(
+  /// \return true if the task should be retried, false otherwise.
+  bool HandleGetTaskFailureCause(
       const Status &task_execution_status,
       const TaskID &task_id,
       const rpc::Address &addr,
@@ -365,6 +366,10 @@ class NormalTaskSubmitter {
 
   // Generators that are currently running and need to be resubmitted.
   absl::flat_hash_set<TaskID> generators_to_resubmit_ ABSL_GUARDED_BY(mu_);
+
+  // Tasks that have failed but we are waiting for their error cause to decide if they
+  // should be retried or permanently failed.
+  absl::flat_hash_set<TaskID> failed_tasks_pending_failure_cause_ ABSL_GUARDED_BY(mu_);
 
   // Ratelimiter controls the num of pending lease requests.
   std::shared_ptr<LeaseRequestRateLimiter> lease_request_rate_limiter_;


### PR DESCRIPTION
## Problems

This PR fixes the `RAY_CHECK failure:
it != submissible_tasks_.end() Tried to retry task that was not pending`.

This failure occurs when a task cancellation ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L702)) races with the callback from PushNormalTask ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L546)).

Currently, there's a map called `executing_tasks_` that is intended to prevent this race, but it fails to do so. The crash happens via the following sequence:
- The `PushNormalTask` callback removes the task ID from `executing_tasks_` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L583)).
- This causes the task cancellation to enter the following condition ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L750)), which eventually invokes `TaskManager::FailPendingTask` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L753)).
- `TaskManager` always removes the task from the `submissible_tasks_ `map when it ends a pending task’s lifecycle (via `FailPendingTask` and others).
- After that, the `PushNormalTask` callback invokes `HandleGetTaskFailureCause` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L605)), which attempts to retrieve the task’s failure cause. This function asks `TaskManager` to retry the task ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L694)), but it fails because the task has already been removed from the `submissible_tasks_` map.

## Solutions

This PR introduces a `failed_tasks_pending_failure_cause_` map to track tasks that have finished execution but is still pending failure resolution. It ensures that if **cancellation occurs during this period, cancellation will defer the failure resolution to current failure resolution process**. It also:
- Allow `FailPendingTask` to be called multiple times during the window between task cancellation and normal task lifecycle completion. Regardless of who calls it, the CANCELLATION failure reason takes precedence.
- Introduce `MarkTaskNoRetry` to distinguish between genuine and synthetic cancellations, and update all relevant call sites accordingly. For example, the `ActorTaskSubmitter::SubmitActorCreationTask` is using `MarkTaskCancellation` to handle death reasons while it just means to reset the number of retries to 0.

## Test
- CI
- A test that crashes without this fix and passes with this fix
- Also update normal_task_submitter_test to represent its real implementation