### PR TITLE
[Train] Add ControllerError for the errors thrown from the controller

### DIFF
--- a/python/ray/train/v2/api/exceptions.py
+++ b/python/ray/train/v2/api/exceptions.py
@@ -6,7 +6,13 @@ from ray.util.annotations import PublicAPI
 
 @PublicAPI(stability="alpha")
 class TrainingFailedError(RayTrainError):
-    """Exception raised by `<Framework>Trainer.fit()` when training fails."""
+    """Exception raised from the training workers.
+
+    Args:
+        error_message: A human-readable error message describing the training worker failures.
+        worker_failures: A mapping from worker rank to the exception that
+            occurred on that worker during training.
+    """
 
     def __init__(self, error_message: str, worker_failures: Dict[int, Exception]):
         super().__init__("Training failed due to worker errors:\n" + error_message)
@@ -15,3 +21,21 @@ class TrainingFailedError(RayTrainError):
 
     def __reduce__(self):
         return (self.__class__, (self._error_message, self.worker_failures))
+
+
+@PublicAPI(stability="alpha")
+class ControllerError(RayTrainError):
+    """Exception raised when training fails due to a controller error.
+
+    Args:
+        controller_failure: The exception that occurred on the controller.
+    """
+
+    def __init__(self, controller_failure: Exception):
+        super().__init__(
+            "Training failed due to controller error:\n" + str(controller_failure)
+        )
+        self.controller_failure = controller_failure
+
+    def __reduce__(self):
+        return (self.__class__, (self.controller_failure,))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The controller can raise a variety of errors. We distinguish these through two subclasses of `RayTrainError`:
* `TrainingFailedError` captures Train worker failures. If any of the workers failed, then this error is populated with a dict mapping worker rank to the error.
* `ControllerError` captures Train driver errors (the `TrainController`). For example, if there are too many worker group startup attempts that fail (see https://github.com/ray-project/ray/pull/54257), then the controller can error out.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
