### PR TITLE
[core] combine python protobuf compiles rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1013,31 +1013,15 @@ alias(
 )
 
 filegroup(
-    name = "all_py_proto",
-    srcs = [
-        "//src/ray/protobuf:autoscaler_py_proto",
-        "//src/ray/protobuf:common_py_proto",
-        "//src/ray/protobuf:core_worker_py_proto",
-        "//src/ray/protobuf:event_py_proto",
-        "//src/ray/protobuf:events_event_aggregator_service_py_proto",
-        "//src/ray/protobuf:export_event_py_proto",
-        "//src/ray/protobuf:gcs_py_proto",
-        "//src/ray/protobuf:gcs_service_py_proto",
-        "//src/ray/protobuf:instance_manager_py_proto",
-        "//src/ray/protobuf:node_manager_py_proto",
-        "//src/ray/protobuf:ray_client_py_proto",
-        "//src/ray/protobuf:reporter_py_proto",
-        "//src/ray/protobuf:runtime_env_agent_py_proto",
-        "//src/ray/protobuf:runtime_env_common_py_proto",
-        "//src/ray/protobuf:usage_py_proto",
-    ],
+    name = "core_py_proto",
+    srcs = ["//src/ray/protobuf:core_py_proto"],
+    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "serve_py_proto",
-    srcs = [
-        "//src/ray/protobuf:serve_py_proto",
-    ],
+    srcs = ["//src/ray/protobuf:serve_py_proto"],
+    visibility = ["//visibility:private"],
 )
 
 # This is a dummy test dependency that causes the python tests to be
@@ -1058,8 +1042,8 @@ copy_to_workspace(
 )
 
 copy_to_workspace(
-    name = "cp_all_py_proto",
-    srcs = [":all_py_proto"],
+    name = "cp_core_py_proto",
+    srcs = [":core_py_proto"],
     dstdir = "python/ray/core/generated",
 )
 
@@ -1099,7 +1083,7 @@ copy_to_workspace(
 genrule(
     name = "install_py_proto",
     srcs = [
-        ":cp_all_py_proto",
+        ":cp_core_py_proto",
         ":cp_serve_py_proto",
     ],
     outs = ["install_py_proto.out"],

--- a/src/ray/protobuf/BUILD
+++ b/src/ray/protobuf/BUILD
@@ -18,11 +18,6 @@ cc_proto_library(
     deps = [":common_proto"],
 )
 
-python_grpc_compile(
-    name = "common_py_proto",
-    deps = [":common_proto"],
-)
-
 proto_library(
     name = "gcs_proto",
     srcs = ["gcs.proto"],
@@ -36,11 +31,6 @@ proto_library(
 proto_library(
     name = "instance_manager_proto",
     srcs = ["instance_manager.proto"],
-)
-
-python_grpc_compile(
-    name = "instance_manager_py_proto",
-    deps = [":instance_manager_proto"],
 )
 
 cc_proto_library(
@@ -69,18 +59,8 @@ cc_proto_library(
     deps = [":runtime_env_common_proto"],
 )
 
-python_grpc_compile(
-    name = "runtime_env_common_py_proto",
-    deps = [":runtime_env_common_proto"],
-)
-
 cc_proto_library(
     name = "gcs_cc_proto",
-    deps = [":gcs_proto"],
-)
-
-python_grpc_compile(
-    name = "gcs_py_proto",
     deps = [":gcs_proto"],
 )
 
@@ -88,11 +68,6 @@ python_grpc_compile(
 proto_library(
     name = "dependency_proto",
     srcs = ["dependency.proto"],
-)
-
-python_grpc_compile(
-    name = "dependency_py_proto",
-    deps = [":dependency_proto"],
 )
 
 # Text logging.
@@ -103,11 +78,6 @@ proto_library(
 
 cc_proto_library(
     name = "logging_cc_proto",
-    deps = [":logging_proto"],
-)
-
-python_grpc_compile(
-    name = "logging_py_proto",
     deps = [":logging_proto"],
 )
 
@@ -127,11 +97,6 @@ cc_proto_library(
     deps = [":node_manager_proto"],
 )
 
-python_grpc_compile(
-    name = "node_manager_py_proto",
-    deps = [":node_manager_proto"],
-)
-
 proto_library(
     name = "reporter_proto",
     srcs = ["reporter.proto"],
@@ -143,11 +108,6 @@ proto_library(
 
 cc_proto_library(
     name = "reporter_cc_proto",
-    deps = [":reporter_proto"],
-)
-
-python_grpc_compile(
-    name = "reporter_py_proto",
     deps = [":reporter_proto"],
 )
 
@@ -167,11 +127,6 @@ cc_proto_library(
     deps = [":gcs_service_proto"],
 )
 
-python_grpc_compile(
-    name = "gcs_service_py_proto",
-    deps = [":gcs_service_proto"],
-)
-
 proto_library(
     name = "test_service_proto",
     srcs = ["test_service.proto"],
@@ -183,11 +138,6 @@ proto_library(
 
 cc_proto_library(
     name = "test_service_cc_proto",
-    deps = [":test_service_proto"],
-)
-
-python_grpc_compile(
-    name = "test_service_py_proto",
     deps = [":test_service_proto"],
 )
 
@@ -210,11 +160,6 @@ proto_library(
         ":gcs_service_proto",
         ":pubsub_proto",
     ],
-)
-
-python_grpc_compile(
-    name = "core_worker_py_proto",
-    deps = [":core_worker_proto"],
 )
 
 cc_proto_library(
@@ -242,11 +187,6 @@ cc_proto_library(
     deps = [":event_proto"],
 )
 
-python_grpc_compile(
-    name = "event_py_proto",
-    deps = [":event_proto"],
-)
-
 proto_library(
     name = "export_event_proto",
     srcs = ["export_event.proto"],
@@ -266,11 +206,6 @@ cc_proto_library(
     deps = [":export_event_proto"],
 )
 
-python_grpc_compile(
-    name = "export_event_py_proto",
-    deps = [":export_event_proto"],
-)
-
 proto_library(
     name = "export_task_event_proto",
     srcs = ["export_task_event.proto"],
@@ -285,11 +220,6 @@ cc_proto_library(
     deps = [":export_task_event_proto"],
 )
 
-python_grpc_compile(
-    name = "export_task_event_py_proto",
-    deps = [":export_task_event_proto"],
-)
-
 proto_library(
     name = "export_runtime_env_proto",
     srcs = ["export_runtime_env.proto"],
@@ -297,11 +227,6 @@ proto_library(
 
 cc_proto_library(
     name = "export_runtime_env_cc_proto",
-    deps = [":export_runtime_env_proto"],
-)
-
-python_grpc_compile(
-    name = "export_runtime_env_py_proto",
     deps = [":export_runtime_env_proto"],
 )
 
@@ -315,11 +240,6 @@ cc_proto_library(
     deps = [":export_node_event_proto"],
 )
 
-python_grpc_compile(
-    name = "export_node_event_py_proto",
-    deps = [":export_node_event_proto"],
-)
-
 proto_library(
     name = "export_actor_event_proto",
     srcs = ["export_actor_data.proto"],
@@ -328,11 +248,6 @@ proto_library(
 
 cc_proto_library(
     name = "export_actor_event_cc_proto",
-    deps = [":export_actor_event_proto"],
-)
-
-python_grpc_compile(
-    name = "export_actor_event_py_proto",
     deps = [":export_actor_event_proto"],
 )
 
@@ -350,11 +265,6 @@ cc_proto_library(
     deps = [":export_driver_job_event_proto"],
 )
 
-python_grpc_compile(
-    name = "export_driver_job_event_py_proto",
-    deps = [":export_driver_job_event_proto"],
-)
-
 proto_library(
     name = "export_submission_job_event_proto",
     srcs = ["export_submission_job_event.proto"],
@@ -365,11 +275,6 @@ cc_proto_library(
     deps = [":export_submission_job_event_proto"],
 )
 
-python_grpc_compile(
-    name = "export_submission_job_event_py_proto",
-    deps = [":export_submission_job_event_proto"],
-)
-
 proto_library(
     name = "export_train_state_proto",
     srcs = ["export_train_state.proto"],
@@ -377,11 +282,6 @@ proto_library(
 
 cc_proto_library(
     name = "export_train_state_cc_proto",
-    deps = [":export_train_state_proto"],
-)
-
-python_grpc_compile(
-    name = "export_train_state_py_proto",
     deps = [":export_train_state_proto"],
 )
 
@@ -398,21 +298,11 @@ cc_proto_library(
     deps = [":export_dataset_metadata_proto"],
 )
 
-python_grpc_compile(
-    name = "export_dataset_metadata_py_proto",
-    deps = [":export_dataset_metadata_proto"],
-)
-
 # Ray Client gRPC lib
 proto_library(
     name = "ray_client_proto",
     srcs = ["ray_client.proto"],
     deps = [":common_proto"],
-)
-
-python_grpc_compile(
-    name = "ray_client_py_proto",
-    deps = [":ray_client_proto"],
 )
 
 # Pubsub
@@ -443,35 +333,14 @@ proto_library(
     ],
 )
 
-python_grpc_compile(
-    name = "runtime_env_agent_py_proto",
-    deps = [":runtime_env_agent_proto"],
-)
-
 cc_proto_library(
     name = "runtime_env_agent_cc_proto",
     deps = [":runtime_env_agent_proto"],
 )
 
 proto_library(
-    name = "serve_proto",
-    srcs = ["serve.proto"],
-    visibility = ["//java:__subpackages__"],
-)
-
-python_grpc_compile(
-    name = "serve_py_proto",
-    deps = [":serve_proto"],
-)
-
-proto_library(
     name = "usage_proto",
     srcs = ["usage.proto"],
-)
-
-python_grpc_compile(
-    name = "usage_py_proto",
-    deps = [":usage_proto"],
 )
 
 cc_proto_library(
@@ -482,11 +351,6 @@ cc_proto_library(
 proto_library(
     name = "autoscaler_proto",
     srcs = ["autoscaler.proto"],
-)
-
-python_grpc_compile(
-    name = "autoscaler_py_proto",
-    deps = [":autoscaler_proto"],
 )
 
 cc_proto_library(
@@ -508,11 +372,6 @@ cc_proto_library(
     deps = [":events_actor_task_definition_event_proto"],
 )
 
-python_grpc_compile(
-    name = "events_actor_task_definition_event_py_proto",
-    deps = [":events_actor_task_definition_event_proto"],
-)
-
 proto_library(
     name = "events_actor_task_execution_event_proto",
     srcs = ["events_actor_task_execution_event.proto"],
@@ -524,11 +383,6 @@ proto_library(
 
 cc_proto_library(
     name = "events_actor_task_execution_event_cc_proto",
-    deps = [":events_actor_task_execution_event_proto"],
-)
-
-python_grpc_compile(
-    name = "events_actor_task_execution_event_py_proto",
     deps = [":events_actor_task_execution_event_proto"],
 )
 
@@ -546,11 +400,6 @@ cc_proto_library(
     deps = [":events_task_definition_event_proto"],
 )
 
-python_grpc_compile(
-    name = "events_task_definition_event_py_proto",
-    deps = [":events_task_definition_event_proto"],
-)
-
 proto_library(
     name = "events_task_execution_event_proto",
     srcs = ["events_task_execution_event.proto"],
@@ -562,11 +411,6 @@ proto_library(
 
 cc_proto_library(
     name = "events_task_execution_event_cc_proto",
-    deps = [":events_task_execution_event_proto"],
-)
-
-python_grpc_compile(
-    name = "events_task_execution_event_py_proto",
     deps = [":events_task_execution_event_proto"],
 )
 
@@ -587,11 +431,6 @@ cc_proto_library(
     deps = [":events_base_event_proto"],
 )
 
-python_grpc_compile(
-    name = "events_base_event_py_proto",
-    deps = [":events_base_event_proto"],
-)
-
 proto_library(
     name = "events_event_aggregator_service_proto",
     srcs = ["events_event_aggregator_service.proto"],
@@ -606,7 +445,41 @@ cc_proto_library(
     deps = [":events_event_aggregator_service_proto"],
 )
 
+# All core python protos are compiled in this single rule.
+# They will be copied into ray/core/generated directory
+# on ray wheel building.
 python_grpc_compile(
-    name = "events_event_aggregator_service_py_proto",
-    deps = [":events_event_aggregator_service_proto"],
+    name = "core_py_proto",
+    deps = [
+        ":autoscaler_proto",
+        ":common_proto",
+        ":core_worker_proto",
+        ":event_proto",
+        ":events_event_aggregator_service_proto",
+        ":export_event_proto",
+        ":gcs_proto",
+        ":gcs_service_proto",
+        ":instance_manager_proto",
+        ":node_manager_proto",
+        ":ray_client_proto",
+        ":reporter_proto",
+        ":runtime_env_agent_proto",
+        ":runtime_env_common_proto",
+        ":usage_proto",
+    ],
+)
+
+# Below is the serve proto
+
+proto_library(
+    name = "serve_proto",
+    srcs = ["serve.proto"],
+    visibility = ["//java:__subpackages__"],
+)
+
+# These files will be copied into ray/serve/generated directory.
+# on ray wheel building.
+python_grpc_compile(
+    name = "serve_py_proto",
+    deps = [":serve_proto"],
 )


### PR DESCRIPTION
just use serve and core; stop pretending that we have separate packages.

removes all unused python compile rules
