### PR TITLE
[serve] Avoid errant cancelation of LongPollClient method

### DIFF
--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import logging
 import os
 import random
@@ -101,7 +102,10 @@ class LongPollClient:
         }
         self.is_running = True
 
-        self._poll_next()
+        # NOTE(edoakes): we schedule the initial _poll_next call with an empty context
+        # so that Ray will not recursively cancel the underlying `listen_for_change`
+        # task. See: https://github.com/ray-project/ray/issues/52476.
+        self.event_loop.call_soon_threadsafe(self._poll_next, context=contextvars.Context())
 
     def stop(self) -> None:
         """Stop the long poll client after the next RPC returns."""

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -105,7 +105,9 @@ class LongPollClient:
         # NOTE(edoakes): we schedule the initial _poll_next call with an empty context
         # so that Ray will not recursively cancel the underlying `listen_for_change`
         # task. See: https://github.com/ray-project/ray/issues/52476.
-        self.event_loop.call_soon_threadsafe(self._poll_next, context=contextvars.Context())
+        self.event_loop.call_soon_threadsafe(
+            self._poll_next, context=contextvars.Context()
+        )
 
     def stop(self) -> None:
         """Stop the long poll client after the next RPC returns."""


### PR DESCRIPTION
Ray will errantly cancel the `LongPollClient.listen_for_change` task if the first task to a replica is canceled prior to `listen_for_change` returning.

This PR works around the issue by initiating the `listen_for_change` from a background asyncio task with an empty `contextvars.Context`.

Closes https://github.com/ray-project/ray/issues/52476