### PR TITLE
[Serve.llm] refactor LLMServer to sync init

### DIFF
--- a/ci/raydepsets/BUILD.bazel
+++ b/ci/raydepsets/BUILD.bazel
@@ -27,10 +27,10 @@ py_test(
     srcs = ["test_cli.py"],
     data = [
         "test_data/requirement_constraints_test.txt",
-        "test_data/requirements_test.txt",
-        "test_data/test.config.yaml",
         "test_data/requirements_compiled_test.txt",
         "test_data/requirements_compiled_test_update.txt",
+        "test_data/requirements_test.txt",
+        "test_data/test.config.yaml",
     ],
     exec_compatible_with = ["//:hermetic_python"],
     tags = [

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -121,7 +121,7 @@ class LLMServer(_LLMServerBase):
     3. Batching in case of streaming (only for chat and completions).
     4. Telemetry reporting.
 
-    Usage Patterns (Ed's Pattern):
+    Usage Patterns:
 
     1. Basic pattern (for testing):
         server = LLMServer.sync_init(llm_config)  # Sync constructor, unstarted
@@ -181,7 +181,7 @@ class LLMServer(_LLMServerBase):
     ) -> "LLMServer":
         """Synchronous constructor that returns an unstarted instance.
 
-        This is used for testing Edward's pattern where initialization
+        This is used for testing the new pattern where initialization
         and starting are explicitly separated.
 
         Args:
@@ -310,9 +310,9 @@ class LLMServer(_LLMServerBase):
         Returns:
             An AsyncGenerator of the response. If stream is True and batching is enabled, then the generator will yield a list of streaming responses (strings of the format data: {response_json}\n\n). Otherwise, it will yield the non-streaming response from engine directly.
         """
-        if self._llm_config.multiplex_config is not None:
-            await self._maybe_add_request_id_to_request(request)
-            await self._maybe_resolve_lora_from_multiplex()
+
+        await self._maybe_add_request_id_to_request(request)
+        await self._maybe_resolve_lora_from_multiplex()
 
         is_stream = hasattr(request, "stream") and request.stream
         if is_stream and batch_output_stream:

--- a/python/ray/llm/_internal/serve/deployments/prefill_decode_disagg/prefill_decode_disagg.py
+++ b/python/ray/llm/_internal/serve/deployments/prefill_decode_disagg/prefill_decode_disagg.py
@@ -20,7 +20,6 @@ from ray.llm._internal.serve.configs.openai_api_models import (
 from ray.llm._internal.serve.configs.server_models import (
     parse_args as parse_llm_configs,
 )
-from ray.llm._internal.serve.deployments.llm.llm_server import _LLMServerBase
 from ray.serve.deployment import Application
 from ray.serve.handle import DeploymentHandle
 from ray.serve.llm import (
@@ -82,7 +81,7 @@ class PDProxyServer(LLMServer):
         decode_server: The decode server deployment handle.
     """
 
-    def __init__(
+    async def __init__(
         self,
         llm_config: LLMConfig,
         prefill_server: DeploymentHandle,
@@ -92,13 +91,9 @@ class PDProxyServer(LLMServer):
         # endpoint can work correctly.
         # TODO(lk-chen): refactor LLMRouter <-> LLMServer such that router query model_id through
         # API, instead of passing it in as an argument.
-
-        # Use sync initialization since PDProxyServer has no engine to start
-        # (it's just a proxy between prefill and decode servers)
-
-        # Initialize like LLMServer.sync_init but without returning
-        _LLMServerBase.__init__(self)
-        self._init_shared(llm_config, engine_cls=None, model_downloader=None)
+        await super().__init__(
+            llm_config,
+        )
 
         self.prefill_server = prefill_server.options(stream=True)
         self.decode_server = decode_server.options(stream=True)

--- a/python/ray/llm/_internal/serve/deployments/prefill_decode_disagg/prefill_decode_disagg.py
+++ b/python/ray/llm/_internal/serve/deployments/prefill_decode_disagg/prefill_decode_disagg.py
@@ -81,7 +81,7 @@ class PDProxyServer(LLMServer):
         decode_server: The decode server deployment handle.
     """
 
-    async def __init__(
+    def __init__(
         self,
         llm_config: LLMConfig,
         prefill_server: DeploymentHandle,
@@ -92,7 +92,7 @@ class PDProxyServer(LLMServer):
         # endpoint can work correctly.
         # TODO(lk-chen): refactor LLMRouter <-> LLMServer such that router query model_id through
         # API, instead of passing it in as an argument.
-        await super().__init__(
+        super().__init__(
             llm_config,
         )
 

--- a/python/ray/llm/_internal/serve/deployments/prefill_decode_disagg/prefill_decode_disagg.py
+++ b/python/ray/llm/_internal/serve/deployments/prefill_decode_disagg/prefill_decode_disagg.py
@@ -81,8 +81,9 @@ class PDProxyServer(LLMServer):
         decode_server: The decode server deployment handle.
     """
 
-    def __init__(
-        self,
+    @classmethod
+    def sync_init(
+        cls,
         llm_config: LLMConfig,
         prefill_server: DeploymentHandle,
         decode_server: DeploymentHandle,
@@ -92,12 +93,13 @@ class PDProxyServer(LLMServer):
         # endpoint can work correctly.
         # TODO(lk-chen): refactor LLMRouter <-> LLMServer such that router query model_id through
         # API, instead of passing it in as an argument.
-        super().__init__(
+        instance = super().sync_init(
             llm_config,
         )
 
-        self.prefill_server = prefill_server.options(stream=True)
-        self.decode_server = decode_server.options(stream=True)
+        instance.prefill_server = prefill_server.options(stream=True)
+        instance.decode_server = decode_server.options(stream=True)
+        return instance
 
     async def embeddings(
         self, request: EmbeddingRequest

--- a/python/ray/llm/tests/serve/conftest.py
+++ b/python/ray/llm/tests/serve/conftest.py
@@ -182,7 +182,7 @@ def create_server():
     """Create an LLMServer instance."""
 
     def creator(*args, **kwargs):
-        # Now __init__ is sync, so we can create normally
+        # Use regular constructor
         return LLMServer(*args, **kwargs)
 
     return creator

--- a/python/ray/llm/tests/serve/conftest.py
+++ b/python/ray/llm/tests/serve/conftest.py
@@ -179,13 +179,10 @@ def testing_model_no_accelerator(shutdown_ray_and_serve, disable_placement_bundl
 
 @pytest.fixture
 def create_server():
-    """Asynchronously create an LLMServer instance."""
+    """Create an LLMServer instance."""
 
-    async def creator(*args, **kwargs):
-        # _ = LLMServer(...) will raise TypeError("__init__() should return None")
-        # so we do __new__ then __init__
-        server = LLMServer.__new__(LLMServer)
-        await server.__init__(*args, **kwargs)
-        return server
+    def creator(*args, **kwargs):
+        # Now __init__ is sync, so we can create normally
+        return LLMServer(*args, **kwargs)
 
     return creator

--- a/python/ray/llm/tests/serve/conftest.py
+++ b/python/ray/llm/tests/serve/conftest.py
@@ -21,7 +21,6 @@ from ray.llm._internal.serve.deployments.llm.vllm.vllm_models import (
 )
 from ray.serve.llm import (
     LLMConfig,
-    LLMServer,
     LLMServingArgs,
     ModelLoadingConfig,
     build_openai_app,
@@ -175,15 +174,3 @@ def testing_model_no_accelerator(shutdown_ray_and_serve, disable_placement_bundl
 
     with get_rayllm_testing_model(test_model_path) as (client, model_id):
         yield client, model_id
-
-
-@pytest.fixture
-def create_server():
-    """Create an LLMServer instance."""
-
-    def creator(*args, **kwargs):
-        # Use sync init and manually start (outside of this fixture) for Ed's pattern
-        server = LLMServer.sync_init(*args, **kwargs)
-        return server
-
-    return creator

--- a/python/ray/llm/tests/serve/conftest.py
+++ b/python/ray/llm/tests/serve/conftest.py
@@ -182,7 +182,8 @@ def create_server():
     """Create an LLMServer instance."""
 
     def creator(*args, **kwargs):
-        # Use regular constructor
-        return LLMServer(*args, **kwargs)
+        # Use sync init and manually start (outside of this fixture) for Ed's pattern
+        server = LLMServer.sync_init(*args, **kwargs)
+        return server
 
     return creator

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -137,7 +137,7 @@ class TestLLMServer:
         LLMResponseValidator.validate_embedding_response(chunks[0], dimensions)
 
     @pytest.mark.asyncio
-    async def test_check_health(self, create_server, mock_llm_config):
+    async def test_check_health(self, mock_llm_config):
         """Test health check functionality."""
 
         # Mock the engine's check_health method
@@ -150,7 +150,7 @@ class TestLLMServer:
                 self.check_health_called = True
 
         # Create a server with a mocked engine
-        server = create_server(mock_llm_config, engine_cls=LocalMockEngine)
+        server = LLMServer.sync_init(mock_llm_config, engine_cls=LocalMockEngine)
         await server.start()
 
         # Perform the health check, no exceptions should be raised
@@ -160,9 +160,9 @@ class TestLLMServer:
         assert server.engine.check_health_called
 
     @pytest.mark.asyncio
-    async def test_llm_config_property(self, create_server, mock_llm_config):
+    async def test_llm_config_property(self, mock_llm_config):
         """Test the llm_config property."""
-        server = create_server(mock_llm_config, engine_cls=MockVLLMEngine)
+        server = LLMServer.sync_init(mock_llm_config, engine_cls=MockVLLMEngine)
         await server.start()
         llm_config = await server.llm_config()
         assert isinstance(llm_config, type(mock_llm_config))
@@ -257,12 +257,12 @@ class TestLLMServer:
             )
 
     @pytest.mark.asyncio
-    async def test_push_telemetry(self, create_server, mock_llm_config):
+    async def test_push_telemetry(self, mock_llm_config):
         """Test that the telemetry push is called properly."""
         with patch(
             "ray.llm._internal.serve.deployments.llm.llm_server.push_telemetry_report_for_all_models"
         ) as mock_push_telemetry:
-            server = create_server(mock_llm_config, engine_cls=MockVLLMEngine)
+            server = LLMServer.sync_init(mock_llm_config, engine_cls=MockVLLMEngine)
             await server.start()
             mock_push_telemetry.assert_called_once()
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -150,7 +150,7 @@ class TestLLMServer:
                 self.check_health_called = True
 
         # Create a server with a mocked engine
-        server = await create_server(mock_llm_config, engine_cls=LocalMockEngine)
+        server = create_server(mock_llm_config, engine_cls=LocalMockEngine)
 
         # Perform the health check, no exceptions should be raised
         await server.check_health()
@@ -161,7 +161,7 @@ class TestLLMServer:
     @pytest.mark.asyncio
     async def test_llm_config_property(self, create_server, mock_llm_config):
         """Test the llm_config property."""
-        server = await create_server(mock_llm_config, engine_cls=MockVLLMEngine)
+        server = create_server(mock_llm_config, engine_cls=MockVLLMEngine)
         llm_config = await server.llm_config()
         assert isinstance(llm_config, type(mock_llm_config))
 
@@ -260,7 +260,7 @@ class TestLLMServer:
         with patch(
             "ray.llm._internal.serve.deployments.llm.llm_server.push_telemetry_report_for_all_models"
         ) as mock_push_telemetry:
-            await create_server(mock_llm_config, engine_cls=MockVLLMEngine)
+            create_server(mock_llm_config, engine_cls=MockVLLMEngine)
             mock_push_telemetry.assert_called_once()
 
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -151,6 +151,7 @@ class TestLLMServer:
 
         # Create a server with a mocked engine
         server = create_server(mock_llm_config, engine_cls=LocalMockEngine)
+        await server.start()
 
         # Perform the health check, no exceptions should be raised
         await server.check_health()
@@ -162,6 +163,7 @@ class TestLLMServer:
     async def test_llm_config_property(self, create_server, mock_llm_config):
         """Test the llm_config property."""
         server = create_server(mock_llm_config, engine_cls=MockVLLMEngine)
+        await server.start()
         llm_config = await server.llm_config()
         assert isinstance(llm_config, type(mock_llm_config))
 
@@ -260,7 +262,8 @@ class TestLLMServer:
         with patch(
             "ray.llm._internal.serve.deployments.llm.llm_server.push_telemetry_report_for_all_models"
         ) as mock_push_telemetry:
-            create_server(mock_llm_config, engine_cls=MockVLLMEngine)
+            server = create_server(mock_llm_config, engine_cls=MockVLLMEngine)
+            await server.start()
             mock_push_telemetry.assert_called_once()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Refactor LLMServer to separate out sync and async constructors.

- Keep async init functionality (default constructor for Ray Serve)
- Add LLMServer.sync_init class method for testing Edward's pattern  
- Update test fixtures to use sync_init + explicit await start()

Example:
```python
# Before (bad):
cls = LLMServer.__new__(LLMServer)
server = await cls.__init__(config)

# After (natural):
server = await LLMServer(config)
# or
server = LLMServer.sync_init(config)
await server.start()
```

This eliminates the need for lazy initialization since Ray Serve can now 
use the async constructor directly while tests follow Edward's pattern 
of sync construction + explicit async start.

More information + prev approach in [Investigation Doc](https://docs.google.com/document/d/1obIrFZr4ZlyLCuUsYdRIC-troySB6XE2eExxRS0m1KE/edit?usp=sharing)
[Previous PR](https://github.com/ray-project/ray/pull/53719) (closed)

## Related issue number
Closes [LLM-2107](https://anyscale1.atlassian.net/browse/LLM-2107) / address TODO
Related (Serve investigation): [SERVE-990](https://anyscale1.atlassian.net/browse/SERVE-990)
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests (LLMServer test suite passes)
   - [x] Release tests  - to re-run PD release tests
   - [ ] This PR is not tested :(

**Change overview:**
- `_LLMServerBase`: sync `__init__` + abstract async `start()` method
- `LLMServer`: sync `__init__` + `asyncio.run(self.start())` with event loop fallback
- `PDProxyServer`: updated to sync `__init__` 
- Test fixtures: simplified to work with sync constructors
- Event loop handling: graceful fallback for test envs - asyncio was unhappy being called within the pytest async framework (`RuntimeError: asyncio.run() cannot be called from a running event loop`) - so we use `future.result()` from `ThreadPoolExecutor` which blocks until completion, and lets us maintain sync __init__ semantics.
