### PR TITLE
[core][autoscaler][IPPR] PublishNodeInfo to GCS clients when the total resources on a node changed

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -548,6 +548,16 @@ void GcsNodeManager::UpdateAliveNode(
   if (resource_view_sync_message.is_draining()) {
     snapshot->set_state(rpc::NodeSnapshot::DRAINING);
   }
+
+  auto resources_total = maybe_node_info.value()->mutable_resources_total();
+  auto &new_resources = resource_view_sync_message.resources_total();
+  // Check if resources_total has changed
+  if (!MapEqual(*resources_total, new_resources)) {
+    // Update total resources
+    *resources_total = new_resources;
+    // Publish the updated node info to notify subscribers
+    gcs_publisher_->PublishNodeInfo(node_id, *maybe_node_info.value());
+  }
 }
 
 }  // namespace gcs


### PR DESCRIPTION
## Why are these changes needed?

This is part of the Autoscaler <> Kubernetes In-place Pod Resizing integration. After the Autoscaler resizes a Raylet, the update is also sent to GCS (done by https://github.com/ray-project/ray/pull/54807). And this PR:
1. Updates `node_info.resources_total` in the `GcsNodeManager` based on the `ResourceViewSyncMessage`.
2. Publishes the updated `node_info` to GCS clients with `gcs_publisher_->PublishNodeInfo()` if `node_info.resources_total` changed, so that the Ray Dashboard will reflect the updated resources as well.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
