### PR TITLE
[RLlib] - Remove some more old 'enable_new_api_stack' flags.

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2704,7 +2704,7 @@
 
   run:
     timeout: 1800
-    script: python learning_tests/tuned_examples/impala/pong_impala.py --enable-new-api-stack --num-learners=0 --num-env-runners=46 --stop-reward=19.5 --as-release-test
+    script: python learning_tests/tuned_examples/impala/pong_impala.py --num-learners=0 --num-env-runners=46 --stop-reward=19.5 --as-release-test
 
   alert: default
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2603,7 +2603,7 @@
 
   run:
     timeout: 1800
-    script: python learning_tests/tuned_examples/appo/pong_appo.py --enable-new-api-stack --num-learners=0 --num-env-runners=46 --stop-reward=19.5 --as-release-test
+    script: python learning_tests/tuned_examples/appo/pong_appo.py --num-learners=0 --num-env-runners=46 --stop-reward=19.5 --as-release-test
 
   alert: default
 
@@ -2634,7 +2634,7 @@
 
   run:
     timeout: 5400
-    script: python learning_tests/tuned_examples/appo/halfcheetah_appo.py --enable-new-api-stack --num-learners=0 --num-env-runners=31 --stop-reward=1000.0 --as-release-test
+    script: python learning_tests/tuned_examples/appo/halfcheetah_appo.py --num-learners=0 --num-env-runners=31 --stop-reward=1000.0 --as-release-test
 
   alert: default
 
@@ -2738,7 +2738,7 @@
 
   run:
     timeout: 1200
-    script: python learning_tests/tuned_examples/ppo/atari_ppo.py --enable-new-api-stack --env=ale_py:ALE/Pong-v5 --num-learners=4 --num-env-runners=95 --stop-reward=20.0 --as-release-test
+    script: python learning_tests/tuned_examples/ppo/atari_ppo.py --env=ale_py:ALE/Pong-v5 --num-learners=4 --num-env-runners=95 --stop-reward=20.0 --as-release-test
 
   alert: default
 
@@ -2773,7 +2773,7 @@
 
   run:
     timeout: 7200
-    script: python learning_tests/tuned_examples/sac/halfcheetah_sac.py --enable-new-api-stack --num-learners=4 --num-env-runners=8 --stop-reward=1000.0 --as-release-test
+    script: python learning_tests/tuned_examples/sac/halfcheetah_sac.py --num-learners=4 --num-env-runners=8 --stop-reward=1000.0 --as-release-test
 
   alert: default
 

--- a/release/rllib_tests/checkpointing_tests/test_e2e_rl_module_restore.py
+++ b/release/rllib_tests/checkpointing_tests/test_e2e_rl_module_restore.py
@@ -50,7 +50,6 @@ class TestE2ERLModuleLoad(unittest.TestCase):
 
         config = (
             PPOConfig()
-            .experimental(_enable_new_api_stack=True)
             .env_runners(rollout_fragment_length=4)
             .environment(MultiAgentCartPole, env_config={"num_agents": num_agents})
             .training(num_sgd_iter=1, train_batch_size=8, sgd_minibatch_size=8)
@@ -86,7 +85,6 @@ class TestE2ERLModuleLoad(unittest.TestCase):
                 module_specs=module_specs,
                 load_state_path=marl_checkpoint_path,
             )
-            config.experimental(_enable_new_api_stack=True)
             config.rl_module(rl_module_spec=marl_module_spec_from_checkpoint)
 
             # Create the algorithm with multiple nodes and check if the weights
@@ -146,7 +144,6 @@ class TestE2ERLModuleLoad(unittest.TestCase):
                 module_specs=module_specs,
                 load_state_path=marl_checkpoint_path,
             )
-            config.experimental(_enable_new_api_stack=True)
             config.rl_module(rl_module_spec=marl_module_spec_from_checkpoint)
 
             # create the algorithm with multiple nodes and check if the weights
@@ -178,7 +175,6 @@ class TestE2ERLModuleLoad(unittest.TestCase):
 
         config = (
             PPOConfig()
-            .experimental(_enable_new_api_stack=True)
             .env_runners(rollout_fragment_length=4)
             .environment("CartPole-v1")
             .training(num_sgd_iter=1, train_batch_size=8, sgd_minibatch_size=8)
@@ -208,8 +204,6 @@ class TestE2ERLModuleLoad(unittest.TestCase):
                 catalog_class=PPOCatalog,
                 load_state_path=module_ckpt_path,
             )
-
-            config.experimental(_enable_new_api_stack=True)
             config.rl_module(rl_module_spec=module_to_load_spec)
 
             # create the algorithm with multiple nodes and check if the weights
@@ -282,7 +276,6 @@ class TestE2ERLModuleLoad(unittest.TestCase):
                     "policy_0",
                 },
             )
-            config.experimental(_enable_new_api_stack=True)
             config.rl_module(rl_module_spec=marl_module_spec_from_checkpoint)
 
             # create the algorithm with multiple nodes and check if the weights

--- a/rllib/tuned_examples/appo/cartpole_appo.py
+++ b/rllib/tuned_examples/appo/cartpole_appo.py
@@ -24,7 +24,6 @@ config = (
     )
 )
 
-args.no_tune = True
 if __name__ == "__main__":
     from ray.rllib.utils.test_utils import run_rllib_example_script_experiment
 

--- a/rllib/tuned_examples/appo/cartpole_appo.py
+++ b/rllib/tuned_examples/appo/cartpole_appo.py
@@ -24,7 +24,7 @@ config = (
     )
 )
 
-
+args.no_tune = True
 if __name__ == "__main__":
     from ray.rllib.utils.test_utils import run_rllib_example_script_experiment
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There were some CI tests failing b/c of the latest removal of the `--enable-new-api-stack`. This PR removes more such flags to make tests pass.

## Related issue number

Closes #54773 #54772

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
