### PR TITLE
[Serve] Never sleep at first routing attempt

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -344,7 +344,7 @@ RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S = float(
 
 # Backoff seconds when choosing router failed, backoff time is calculated as
 # initial_backoff_s * backoff_multiplier ** attempt.
-# The default backoff time is [0.025, 0.05, 0.1, 0.2, 0.4, 0.5, 0.5 ... ].
+# The default backoff time is [0, 0.025, 0.05, 0.1, 0.2, 0.4, 0.5, 0.5 ... ].
 RAY_SERVE_ROUTER_RETRY_INITIAL_BACKOFF_S = float(
     os.environ.get("RAY_SERVE_ROUTER_RETRY_INITIAL_BACKOFF_S", 0.025)
 )

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -943,18 +943,14 @@ class RequestRouter(ABC):
                     self.num_routing_tasks_in_backoff_gauge.set(
                         self.num_routing_tasks_in_backoff
                     )
-
-                backoff_s = (
-                    min(
-                        self.initial_backoff_s
-                        * self.backoff_multiplier ** (attempt - 1),
+                else:
+                    # Only backoff after the first retry.
+                    backoff_s = min(
+                        self.initial_backoff_s * self.backoff_multiplier**attempt,
                         self.max_backoff_s,
                     )
-                    if attempt > 0
-                    else 0
-                )
-                await asyncio.sleep(backoff_s)
-                attempt += 1
+                    await asyncio.sleep(backoff_s)
+                    attempt += 1
         finally:
             if entered_backoff:
                 self.num_routing_tasks_in_backoff -= 1

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -944,9 +944,14 @@ class RequestRouter(ABC):
                         self.num_routing_tasks_in_backoff
                     )
 
-                backoff_s = min(
-                    self.initial_backoff_s * self.backoff_multiplier**attempt,
-                    self.max_backoff_s,
+                backoff_s = (
+                    min(
+                        self.initial_backoff_s
+                        * self.backoff_multiplier ** (attempt - 1),
+                        self.max_backoff_s,
+                    )
+                    if attempt > 0
+                    else 0
                 )
                 await asyncio.sleep(backoff_s)
                 attempt += 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
The first routing attempt should never wait.
## Related issue number
Fix issue: https://github.com/ray-project/ray/issues/54800

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
