### PR TITLE
[data] Handle unhashable types in OneHotEncoding

### DIFF
--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -278,13 +278,13 @@ class OneHotEncoder(Preprocessor):
             num_categories = len(stats)
             one_hot = np.zeros((len(df), num_categories), dtype=int)
 
-            def safe_get(v, m):
+            def safe_get(v):
                 try:
-                    return m.get(v, -1)
+                    return stats.get(v, -1)
                 except TypeError:
                     return -1  # Unhashable type treated as a missing category
 
-            codes = df[column].apply(lambda v, m=stats: safe_get(v, m)).to_numpy()
+            codes = df[column].apply(safe_get).to_numpy()
             valid_rows = codes != -1
             one_hot[np.nonzero(valid_rows)[0], codes[valid_rows].astype(int)] = 1
             df[output_column] = one_hot.tolist()

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -268,6 +268,15 @@ class OneHotEncoder(Preprocessor):
 
     def _transform_pandas(self, df: pd.DataFrame):
         _validate_df(df, *self.columns)
+        from typing import Any
+
+        def safe_get(v: Any, stats: Dict[str, int]):
+            from collections.abc import Hashable
+
+            if isinstance(v, Hashable):
+                return stats.get(v, -1)
+            else:
+                return -1  # Unhashable type treated as a missing category
 
         # Compute new one-hot encoded columns
         for column, output_column in zip(self.columns, self.output_columns):
@@ -277,14 +286,7 @@ class OneHotEncoder(Preprocessor):
             stats = self.stats_[f"unique_values({column})"]
             num_categories = len(stats)
             one_hot = np.zeros((len(df), num_categories), dtype=int)
-
-            def safe_get(v):
-                try:
-                    return stats.get(v, -1)
-                except TypeError:
-                    return -1  # Unhashable type treated as a missing category
-
-            codes = df[column].apply(safe_get).to_numpy()
+            codes = df[column].apply(lambda v: safe_get(v, stats)).to_numpy()
             valid_rows = codes != -1
             one_hot[np.nonzero(valid_rows)[0], codes[valid_rows].astype(int)] = 1
             df[output_column] = one_hot.tolist()

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -278,7 +278,13 @@ class OneHotEncoder(Preprocessor):
             num_categories = len(stats)
             one_hot = np.zeros((len(df), num_categories), dtype=int)
 
-            codes = df[column].apply(lambda v, m=stats: m.get(v, -1)).to_numpy()
+            def safe_get(v, m):
+                try:
+                    return m.get(v, -1)
+                except TypeError:
+                    return -1  # Unhashable type treated as a missing category
+
+            codes = df[column].apply(lambda v, m=stats: safe_get(v, m)).to_numpy()
             valid_rows = codes != -1
             one_hot[np.nonzero(valid_rows)[0], codes[valid_rows].astype(int)] = 1
             df[output_column] = one_hot.tolist()

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -390,6 +390,27 @@ def test_one_hot_encoder_with_max_categories():
     pd.testing.assert_frame_equal(df_out, expected_df, check_like=True)
 
 
+def test_one_hot_encoder_mixed_data_types():
+    """Tests OneHotEncoder functionality with mixed data types (strings and lists)."""
+
+    from ray.data.preprocessors.encoder import OneHotEncoder
+
+    test_inputs = {"category": ["1", [1]]}
+    test_pd_df = pd.DataFrame(test_inputs)
+    test_data_for_fitting = {"category": ["1", "[1]", "a", "[]", "True"]}
+    test_ray_dataset_for_fitting = ray.data.from_pandas(
+        pd.DataFrame(test_data_for_fitting)
+    )
+
+    encoder = OneHotEncoder(columns=["category"])
+    encoder.fit(test_ray_dataset_for_fitting)
+
+    pandas_output = encoder.transform_batch(test_pd_df)
+    expected_output = pd.DataFrame({"category": [[1, 0, 0, 0, 0], [0, 0, 0, 0, 0]]})
+
+    pd.testing.assert_frame_equal(pandas_output, expected_output)
+
+
 def test_multi_hot_encoder():
     """Tests basic MultiHotEncoder functionality."""
     col_a = ["red", "green", "blue", "red"]

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -393,8 +393,6 @@ def test_one_hot_encoder_with_max_categories():
 def test_one_hot_encoder_mixed_data_types():
     """Tests OneHotEncoder functionality with mixed data types (strings and lists)."""
 
-    from ray.data.preprocessors.encoder import OneHotEncoder
-
     test_inputs = {"category": ["1", [1]]}
     test_pd_df = pd.DataFrame(test_inputs)
     test_data_for_fitting = {"category": ["1", "[1]", "a", "[]", "True"]}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Handles the case that a column has mixed types whereby some of the types are unhashable.

## Related issue number

Closes #[54823](https://github.com/ray-project/ray/issues/54823)

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
