### PR TITLE
[ci] do not clear user's `.bazelrc` file

### DIFF
--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -95,10 +95,10 @@ fi
 
 bazel --version
 
-# clear bazelrc
-echo > ~/.bazelrc
+if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then
+  # clear bazelrc
+  echo > ~/.bazelrc
 
-if [[ "${CI-}" == "true" ]]; then
   # Ask bazel to anounounce the config it finds in bazelrcs, which makes
   # understanding how to reproduce bazel easier.
   echo "build --announce_rc" >> ~/.bazelrc


### PR DESCRIPTION
unless it is on CI systems. tempering with config files under user home directory is way too intrusive..
