### PR TITLE
[core][otel/11] turn on open telemetry for performance tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2827,7 +2827,10 @@
 
   team: core
   cluster:
-    byod: {}
+    byod:
+      runtime_env:
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: stress_tests/placement_group_tests_compute.yaml
 
   run:
@@ -2899,7 +2902,10 @@
   working_dir: microbenchmark
 
   cluster:
-    byod: {}
+    byod:
+      runtime_env:
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: tpl_64.yaml
 
   run:
@@ -3144,7 +3150,10 @@
   frequency: nightly
   team: core
   cluster:
-    byod: {}
+    byod:
+      runtime_env:
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
@@ -3184,7 +3193,10 @@
   frequency: nightly
   team: core
   cluster:
-    byod: {}
+    byod:
+      runtime_env:
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
@@ -3316,7 +3328,10 @@
   team: core
   env: aws_perf
   cluster:
-    byod: {}
+    byod:
+      runtime_env:
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: stress_tests/stress_tests_single_node_oom_compute.yaml
 
   run:
@@ -3480,6 +3495,8 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: single_node.yaml
 
   run:
@@ -3507,6 +3524,8 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: object_store.yaml
 
   run:
@@ -3535,6 +3554,8 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: object_store/small_objects.yaml
 
   run:
@@ -3558,6 +3579,8 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: object_store/large_objects.yaml
 
   run:
@@ -3581,6 +3604,8 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: distributed.yaml
 
   run:
@@ -3629,6 +3654,8 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: distributed.yaml
 
   run:
@@ -3657,6 +3684,8 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: distributed.yaml
 
   run:
@@ -3706,6 +3735,8 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        - RAY_experimental_enable_open_telemetry_on_agent=1
+        - RAY_experimental_enable_open_telemetry_on_core=1
     cluster_compute: many_nodes.yaml
 
   run:


### PR DESCRIPTION
Turn on the full open telemetry stack for all release performance tests (those that are using the aws_perf environment). I already sanity check `microbenchmark` and `stress_test_many_tasks` and they look good. For the rest of the tests, I'll defer to go/cd after this PR is merged for sanity check.

Test:
- CI