### PR TITLE
[core] Move GCSNodeInfo mutations to GcsNodeManager::UpdateAliveNode

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -28,6 +28,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "ray/common/id.h"
+#include "ray/common/ray_syncer/ray_syncer.h"
 #include "ray/gcs/gcs_server/gcs_init_data.h"
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
@@ -170,6 +171,13 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Idempotent.
   /// This is technically not draining a node. It should be just called "kill node".
   virtual void DrainNode(const NodeID &node_id);
+
+  /// Update node state from a resource view sync message if the node is alive.
+  ///
+  /// \param node_id The ID of the node to update.
+  /// \param resource_view_sync_message The sync message containing the new state.
+  void UpdateAliveNode(const NodeID &node_id,
+                       const syncer::ResourceViewSyncMessage &resource_view_sync_message);
 
  private:
   /// Add the dead node to the cache. If the cache is full, the earliest dead node is

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -258,22 +258,7 @@ void GcsResourceManager::UpdateNodeResourceUsage(
     const syncer::ResourceViewSyncMessage &resource_view_sync_message) {
   // Note: This may be inconsistent with autoscaler state, which is
   // not reported as often as a Ray Syncer message.
-  if (auto maybe_node_info = gcs_node_manager_.GetAliveNode(node_id);
-      maybe_node_info != absl::nullopt) {
-    auto snapshot = maybe_node_info.value()->mutable_state_snapshot();
-
-    if (resource_view_sync_message.idle_duration_ms() > 0) {
-      snapshot->set_state(rpc::NodeSnapshot::IDLE);
-      snapshot->set_idle_duration_ms(resource_view_sync_message.idle_duration_ms());
-    } else {
-      snapshot->set_state(rpc::NodeSnapshot::ACTIVE);
-      snapshot->mutable_node_activity()->CopyFrom(
-          resource_view_sync_message.node_activity());
-    }
-    if (resource_view_sync_message.is_draining()) {
-      snapshot->set_state(rpc::NodeSnapshot::DRAINING);
-    }
-  }
+  gcs_node_manager_.UpdateAliveNode(node_id, resource_view_sync_message);
 
   auto iter = node_resource_usages_.find(node_id);
   if (iter == node_resource_usages_.end()) {

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -24,6 +24,7 @@
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
 #include "mock/ray/pubsub/publisher.h"
 #include "ray/common/asio/asio_util.h"
+#include "ray/common/ray_syncer/ray_syncer.h"
 // clang-format on
 
 namespace ray {
@@ -104,6 +105,64 @@ TEST_F(GcsNodeManagerTest, TestListener) {
   ASSERT_TRUE(node_manager.GetAllAliveNodes().empty());
   for (int i = 0; i < node_count; ++i) {
     ASSERT_EQ(added_nodes[i], removed_nodes[i]);
+  }
+}
+
+TEST_F(GcsNodeManagerTest, TestUpdateAliveNode) {
+  gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                   gcs_table_storage_.get(),
+                                   io_context_->GetIoService(),
+                                   client_pool_.get(),
+                                   ClusterID::Nil());
+
+  // Create a test node
+  auto node = Mocker::GenNodeInfo();
+  auto node_id = NodeID::FromBinary(node->node_id());
+
+  // Add the node to the manager
+  node_manager.AddNode(node);
+
+  // Test 1: Update node with idle state
+  {
+    rpc::syncer::ResourceViewSyncMessage sync_message;
+    sync_message.set_idle_duration_ms(5000);
+
+    node_manager.UpdateAliveNode(node_id, sync_message);
+
+    auto updated_node = node_manager.GetAliveNode(node_id);
+    EXPECT_TRUE(updated_node.has_value());
+    EXPECT_EQ(updated_node.value()->state_snapshot().state(), rpc::NodeSnapshot::IDLE);
+    EXPECT_EQ(updated_node.value()->state_snapshot().idle_duration_ms(), 5000);
+  }
+
+  // Test 2: Update node with active state (idle_duration_ms = 0)
+  {
+    rpc::syncer::ResourceViewSyncMessage sync_message;
+    sync_message.set_idle_duration_ms(0);
+    sync_message.add_node_activity("Busy workers on node.");
+
+    node_manager.UpdateAliveNode(node_id, sync_message);
+
+    auto updated_node = node_manager.GetAliveNode(node_id);
+    EXPECT_TRUE(updated_node.has_value());
+    EXPECT_EQ(updated_node.value()->state_snapshot().state(), rpc::NodeSnapshot::ACTIVE);
+    EXPECT_EQ(updated_node.value()->state_snapshot().node_activity_size(), 1);
+    EXPECT_EQ(updated_node.value()->state_snapshot().node_activity(0),
+              "Busy workers on node.");
+  }
+
+  // Test 3: Update node with draining state
+  {
+    rpc::syncer::ResourceViewSyncMessage sync_message;
+    sync_message.set_idle_duration_ms(0);
+    sync_message.set_is_draining(true);
+
+    node_manager.UpdateAliveNode(node_id, sync_message);
+
+    auto updated_node = node_manager.GetAliveNode(node_id);
+    EXPECT_TRUE(updated_node.has_value());
+    EXPECT_EQ(updated_node.value()->state_snapshot().state(),
+              rpc::NodeSnapshot::DRAINING);
   }
 }
 


### PR DESCRIPTION
## Why are these changes needed?

Currently, `GcsResourceManager` directly mutates `GCSNodeInfo`, which is managed by `GcsNodeManager`; however, this mutation should be the responsibility of `GcsNodeManager`.

This PR moves the mutation to the new `GcsNodeManager::UpdateNode` function without any behavioral changes and adds tests for it.



## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
