### PR TITLE
[Windows] Adding support for running formatting script on Windows

### DIFF
--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -97,7 +97,7 @@ fi
 if command -v java >/dev/null; then
   if [ ! -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
     echo "Java code format tool google-java-format.jar is not installed, start to install it."
-    wget https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar -O "$GOOGLE_JAVA_FORMAT_JAR"
+    curl -L https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar -o "$GOOGLE_JAVA_FORMAT_JAR"
   fi
 else
     echo "WARNING:java is not installed, skip format java files!"

--- a/scripts/format.ps1
+++ b/scripts/format.ps1
@@ -1,0 +1,168 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Runs the Ray lint/format script in a bash environment with conda activation on Windows.
+
+.DESCRIPTION
+    This script detects the current conda environment and runs the Ray format script
+    (ci/lint/format.sh) in a bash session with the conda environment properly activated.
+    
+    Assumptions:
+    - Conda is the Python environment manager
+    - Git Bash is installed to either the default location or is available from $Env:PATH
+    
+    The script will:
+    1. Check if conda is available by looking for $Env:_CONDA_EXE environment variable
+    2. Detect the current conda environment name from $Env:CONDA_DEFAULT_ENV
+    3. Start a bash session that activates the conda environment
+    4. Run the Ray format script within that environment
+
+.EXAMPLE
+    .\scripts\format.ps1
+#>
+
+# Set error action preference to stop on errors
+$ErrorActionPreference = "Stop"
+
+Write-Host "Ray Format Script - PowerShell Wrapper" -ForegroundColor Green
+Write-Host "=======================================" -ForegroundColor Green
+
+# Check if conda is available
+Write-Host "Checking for conda installation..." -ForegroundColor Yellow
+
+if (-not $env:_CONDA_EXE) {
+    Write-Error @"
+ERROR: Conda is not available or not properly initialized.
+
+Please run this powershell script from a terminal from which 
+the desired conda environment has been activated.
+
+Current environment variables:
+_CONDA_EXE: $env:_CONDA_EXE
+CONDA_DEFAULT_ENV: $env:CONDA_DEFAULT_ENV
+"@
+    exit 1
+}
+
+Write-Host "[OK] Conda found at: $env:_CONDA_EXE" -ForegroundColor Green
+
+# Check for current conda environment
+if (-not $env:CONDA_DEFAULT_ENV) {
+    Write-Warning "No conda environment is currently active (CONDA_DEFAULT_ENV is not set)."
+    Write-Host "Available conda environments:" -ForegroundColor Yellow
+    & conda env list
+    Write-Error @"
+ERROR: No conda environment is active.
+
+Please activate a conda environment before running this script:
+    conda activate your-environment-name
+"@
+    exit 1
+}
+
+$condaEnv = $env:CONDA_DEFAULT_ENV
+Write-Host "[OK] Current conda environment: $condaEnv" -ForegroundColor Green
+
+# Find bash executable
+$bashPath = $null
+$possibleBashPaths = @(
+    "C:\Program Files\Git\bin\bash.exe",
+    "C:\Program Files (x86)\Git\bin\bash.exe",
+    "bash.exe"
+)
+
+foreach ($path in $possibleBashPaths) {
+    $foundCommand = Get-Command $path -ErrorAction SilentlyContinue
+    if ($foundCommand) {
+        $bashPath = $foundCommand.Source
+        break
+    }
+}
+
+if (-not $bashPath) {
+    Write-Error @"
+ERROR: Bash executable not found.
+"@
+    exit 1
+}
+
+Write-Host "[OK] Bash found at: $bashPath" -ForegroundColor Green
+
+# Find Git repository root and verify format script exists
+try {
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    if (-not $gitRoot) {
+        throw "Not in a Git repository"
+    }
+    
+    # Convert Unix-style path to Windows path if needed
+    $repoRoot = $gitRoot -replace '/', '\'
+    $formatScriptPath = Join-Path $repoRoot "ci\lint\format.sh"
+    
+    if (-not (Test-Path $formatScriptPath)) {
+        Write-Error @"
+ERROR: Ray format script not found at expected location.
+
+Repository root: $repoRoot
+Expected script path: $formatScriptPath
+
+This script must be run from within the Ray repository.
+"@
+        exit 1
+    }
+    
+    Write-Host "[OK] Foundformat script at: $formatScriptPath" -ForegroundColor Green
+    
+} catch {
+    Write-Error @"
+ERROR: Could not locate Ray repository or format script.
+
+This script must be run from within the Ray Git repository.
+Current directory: $(Get-Location)
+
+Error details: $($_.Exception.Message)
+"@
+    exit 1
+}
+
+# Prepare the bash command
+# Create the bash command that will:
+# 1. Source conda initialization
+# 2. Activate the conda environment  
+# 3. Change to repository root
+# 4. Run the format script (default behavior - changed files only)
+$bashCommand = @"
+# Initialize conda for bash
+eval "`$(conda shell.bash hook)"
+
+# Activate the conda environment
+echo "Activating conda environment: $condaEnv"
+conda activate $condaEnv
+
+# Verify environment is active
+echo "Verifying active conda environment: `$CONDA_DEFAULT_ENV"
+echo "Python location: `$(which python)"
+
+# Change to repository root and run the format script
+cd "$($gitRoot)"
+echo "Running format script on changed files..."
+./ci/lint/format.sh
+"@
+
+Write-Host "`nStarting bash session with conda environment activation..." -ForegroundColor Yellow
+
+# Execute the bash command
+try {
+    & $bashPath -c $bashCommand
+    $exitCode = $LASTEXITCODE
+    
+    if ($exitCode -eq 0) {
+        Write-Host "`n[SUCCESS] Format script completed successfully!" -ForegroundColor Green
+    } else {
+        Write-Host "`n[ERROR] Format script failed with exit code: $exitCode" -ForegroundColor Red
+        exit $exitCode
+    }
+} catch {
+    Write-Error "Failed to execute bash command: $_"
+    exit 1
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adding the ability to run linting/formatting operations from a Windows development environment will make it much easier to develop on a Windows machine.

Without this users would need to develop/test their changes in a Windows environment but then use a Linux environment to verify formatting which can be tedious to do, or risk introducing formatting issues into the codebase. 
## Related issue number


Here is the output from when `.\scripts\format.ps1` is run on a Windows machine

```powershell
(ray-dev) PS C:\src\github.com\marosset\ray> .\scripts\format.ps1
Ray Format Script - PowerShell Wrapper
=======================================
Checking for conda installation...
[OK] Conda found at: C:\Users\marosset\AppData\Local\miniconda3\Scripts\conda.exe
[OK] Current conda environment: ray-dev
[OK] Bash found at: C:\Program Files\Git\bin\bash.exe
[OK] Foundformat script at: C:\src\github.com\marosset\ray\ci\lint\format.sh

Starting bash session with conda environment activation...
Activating conda environment: ray-dev
Verifying active conda environment: ray-dev
Python location: /c/Users/marosset/AppData/Local/miniconda3/envs/ray-dev/python
Running format script on changed files...
INFO: Ray uses shellcheck for shell scripts, which is not installed. You may install shellcheck=0.7.1 with your system package manager.
WARNING: clang-format is not installed!
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (7/7), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 8 (delta 3), reused 3 (delta 3), pack-reused 1 (from 1)
Unpacking objects: 100% (8/8), 12.25 KiB | 358.00 KiB/s, done.
From https://github.com/ray-project/ray
 * branch                  master     -> FETCH_HEAD
   9cb253851d..07650d61b9  master     -> upstream/master
reformatted python\ray\autoscaler\_private\_azure\config.py

All done! ✨ 🍰 ✨
1 file reformatted.
Checking docstyle...

[SUCCESS] Format script completed successfully!
```

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :( - it was, just manually :-/
