### PR TITLE
[Data] make autoscaler respect budget

### DIFF
--- a/python/ray/data/_internal/execution/autoscaler/autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/autoscaler.py
@@ -1,6 +1,10 @@
+import math
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
+from ray.data._internal.execution.autoscaler.autoscaling_actor_pool import (
+    AutoscalingActorPool,
+)
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
@@ -44,3 +48,32 @@ class Autoscaler(ABC):
     def get_total_resources(self) -> "ExecutionResources":
         """Get the total resources that are available to this data execution."""
         ...
+
+    def _get_max_scale_up_wrt_budget(
+        self,
+        actor_pool: AutoscalingActorPool,
+        budget: "ExecutionResources",
+    ) -> Optional[int]:
+        assert budget.cpu >= 0 and budget.gpu >= 0
+
+        num_cpus_per_actor = actor_pool.per_actor_resource_usage().cpu
+        num_gpus_per_actor = actor_pool.per_actor_resource_usage().gpu
+        assert num_cpus_per_actor >= 0 and num_gpus_per_actor >= 0
+
+        max_cpu_scale_up: float = float("inf")
+        if num_cpus_per_actor > 0 and not math.isinf(budget.cpu):
+            max_cpu_scale_up = budget.cpu // num_cpus_per_actor
+
+        max_gpu_scale_up: float = float("inf")
+        if num_gpus_per_actor > 0 and not math.isinf(budget.gpu):
+            max_gpu_scale_up = budget.gpu // num_gpus_per_actor
+
+        max_scale_up = min(max_cpu_scale_up, max_gpu_scale_up)
+        if math.isinf(max_scale_up):
+            return None
+        assert not math.isnan(max_scale_up), (
+            budget,
+            num_cpus_per_actor,
+            num_gpus_per_actor,
+        )
+        return int(max_scale_up)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current autoscaler will scale up per op, even if budget is not enough
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
