### PR TITLE
[core][otel/12] clean up gauge metric map at each collection interval

### DIFF
--- a/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
+++ b/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
@@ -45,7 +45,7 @@ class OpenTelemetryMetricRecorder:
             def callback(options):
                 # Take snapshot of current observations.
                 with self._lock:
-                    observations = self._observations_by_name[name].items()
+                    observations = self._observations_by_name.pop(name).items()
                     return [
                         Observation(val, attributes=dict(tag_set))
                         for tag_set, val in observations


### PR DESCRIPTION
We used to turned off the `test_metrics_agent` on mac due to an issue that is now fixed. Turn it on again.

Test:
- CI