### PR TITLE
[scripts] Fix bazel file path in bazel format script

### DIFF
--- a/ci/lint/bazel-format.sh
+++ b/ci/lint/bazel-format.sh
@@ -50,7 +50,7 @@ BAZEL_FILES=(
   BUILD.bazel
   java/BUILD.bazel
   cpp/BUILD.bazel
-  cpp/example/BUILD.bazel
+  cpp/example/_BUILD.bazel
   WORKSPACE
 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It seems the name of the bezel file targeted in this script has changed.  This in turn causes the script to error out when it runs.  Updated the path so the script now executes succssfully

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
