### PR TITLE
[Data] Consider budget when making actor autoscaling decisions

### DIFF
--- a/python/ray/data/_internal/execution/autoscaler/util.py
+++ b/python/ray/data/_internal/execution/autoscaler/util.py
@@ -9,8 +9,7 @@ def get_max_scale_up(
     actor_pool: AutoscalingActorPool,
     budget: Optional[ExecutionResources],
 ) -> Optional[int]:
-    """
-    Get the maximum number of actors that can be scaled up.
+    """Get the maximum number of actors that can be scaled up.
 
     Args:
         actor_pool: The actor pool to scale up.

--- a/python/ray/data/_internal/execution/autoscaler/util.py
+++ b/python/ray/data/_internal/execution/autoscaler/util.py
@@ -1,0 +1,49 @@
+import math
+from typing import Optional
+
+from .autoscaling_actor_pool import AutoscalingActorPool
+from ray.data._internal.execution.interfaces import ExecutionResources
+
+
+def get_max_scale_up(
+    actor_pool: AutoscalingActorPool,
+    budget: Optional[ExecutionResources],
+) -> Optional[int]:
+    """
+    Get the maximum number of actors that can be scaled up.
+
+    Args:
+        actor_pool: The actor pool to scale up.
+        budget: The budget to scale up.
+
+    Returns:
+        The maximum number of actors that can be scaled up, or `None` if you can
+        scale up infinitely.
+    """
+    if budget is None:
+        return None
+
+    assert budget.cpu >= 0 and budget.gpu >= 0
+
+    num_cpus_per_actor = actor_pool.per_actor_resource_usage().cpu
+    num_gpus_per_actor = actor_pool.per_actor_resource_usage().gpu
+    assert num_cpus_per_actor >= 0 and num_gpus_per_actor >= 0
+
+    max_cpu_scale_up: float = float("inf")
+    if num_cpus_per_actor > 0 and not math.isinf(budget.cpu):
+        max_cpu_scale_up = budget.cpu // num_cpus_per_actor
+
+    max_gpu_scale_up: float = float("inf")
+    if num_gpus_per_actor > 0 and not math.isinf(budget.gpu):
+        max_gpu_scale_up = budget.gpu // num_gpus_per_actor
+
+    max_scale_up = min(max_cpu_scale_up, max_gpu_scale_up)
+    if math.isinf(max_scale_up):
+        return None
+    else:
+        assert not math.isnan(max_scale_up), (
+            budget,
+            num_cpus_per_actor,
+            num_gpus_per_actor,
+        )
+        return int(max_scale_up)

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -16,6 +16,7 @@ from ray.data._internal.execution.operators.actor_pool_map_operator import _Acto
 from ray.data._internal.execution.operators.base_physical_operator import (
     InternalQueueOperatorMixin,
 )
+from ray.data._internal.execution.resource_manager import ResourceManager
 from ray.data._internal.execution.streaming_executor_state import OpState
 from ray.data.context import (
     AutoscalingConfig,
@@ -25,8 +26,6 @@ from ray.data.context import (
 def test_actor_pool_scaling():
     """Test `_actor_pool_should_scale_up` and `_actor_pool_should_scale_down`
     in `DefaultAutoscaler`"""
-
-    from ray.data._internal.execution.resource_manager import ResourceManager
 
     resource_manager = MagicMock(
         spec=ResourceManager, get_budget=MagicMock(return_value=None)

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -26,9 +26,14 @@ def test_actor_pool_scaling():
     """Test `_actor_pool_should_scale_up` and `_actor_pool_should_scale_down`
     in `DefaultAutoscaler`"""
 
+    from ray.data._internal.execution.resource_manager import ResourceManager
+
+    resource_manager = MagicMock(
+        spec=ResourceManager, get_budget=MagicMock(return_value=None)
+    )
     autoscaler = DefaultAutoscaler(
         topology=MagicMock(),
-        resource_manager=MagicMock(),
+        resource_manager=resource_manager,
         execution_id="execution_id",
         config=AutoscalingConfig(
             actor_pool_util_upscaling_threshold=1.0,
@@ -47,6 +52,7 @@ def test_actor_pool_scaling():
         num_pending_actors=MagicMock(return_value=0),
         num_free_task_slots=MagicMock(return_value=5),
         num_tasks_in_flight=MagicMock(return_value=15),
+        per_actor_resource_usage=MagicMock(return_value=ExecutionResources(cpu=1)),
         _max_actor_concurrency=1,
         get_pool_util=MagicMock(
             # NOTE: Unittest mocking library doesn't support proxying to actual
@@ -188,6 +194,13 @@ def test_actor_pool_scaling():
         assert_autoscaling_action(
             delta=-1,
             expected_reason="pool exceeding max size",
+        )
+
+    # Should no-op because the op has no budget.
+    with patch(resource_manager, "get_budget", ExecutionResources.zero()):
+        assert_autoscaling_action(
+            delta=0,
+            expected_reason="exceeded resource limits",
         )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you don't consider budget when scaling up actor pools, then actors can occupy all of the logical resources and starve other operators.

To fix this issue, this PR updates the autoscaler to consider the budget as well.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
