### PR TITLE
[Data] Add back `from_daft` arrow version checks

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -16,8 +16,10 @@ from typing import (
 )
 
 import numpy as np
+from packaging.version import parse as parse_version
 
 import ray
+from ray._private.arrow_utils import get_pyarrow_version
 from ray._private.auto_init_hook import wrap_auto_init
 from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 from ray.data._internal.datasource.audio_datasource import AudioDatasource
@@ -2652,6 +2654,14 @@ def from_daft(df: "daft.DataFrame") -> Dataset:
     Returns:
         A :class:`~ray.data.Dataset` holding rows read from the DataFrame.
     """
+    pyarrow_version = get_pyarrow_version()
+    assert pyarrow_version is not None
+    if pyarrow_version >= parse_version("14.0.0"):
+        raise RuntimeError(
+            "`from_daft` only works with PyArrow 13 or lower. For more details, see "
+            "https://github.com/ray-project/ray/issues/53278."
+        )
+
     # NOTE: Today this returns a MaterializedDataset. We should also integrate Daft such
     # that we can stream object references into a Ray dataset. Unfortunately this is
     # very tricky today because of the way Ray Datasources are implemented with a fully-

--- a/python/ray/data/tests/test_daft.py
+++ b/python/ray/data/tests/test_daft.py
@@ -1,20 +1,36 @@
-import sys
+import os
 from unittest.mock import patch
 
-import daft
-import numpy as np
-import pandas as pd
 import pyarrow as pa
 import pytest
 from packaging.version import parse as parse_version
 
-import ray
-
 
 @pytest.fixture(scope="module")
 def ray_start(request):
+    """Initialize Ray with proper serialization format."""
+    # TODO: Remove this once Daft issue is fixed to default to Cloudpickle
+    # serialization format.
+    # Force the serialization format to JSON for this test.
+    # Refer Daft issue https://github.com/Eventual-Inc/Daft/issues/4828
+    # and Ray issue https://github.com/ray-project/ray/issues/54837
+    # for more details.
+
+    # Set environment variable before importing ray
+    os.environ["RAY_DATA_ARROW_EXTENSION_SERIALIZATION_LEGACY_JSON_FORMAT"] = "1"
+
+    import ray
+    import ray.air.util.tensor_extensions.arrow as arrow_module
+    from ray.air.util.tensor_extensions.arrow import _SerializationFormat
+
+    # Force the serialization format to JSON after import
+    arrow_module.ARROW_EXTENSION_SERIALIZATION_FORMAT = _SerializationFormat.JSON
+
     try:
-        yield ray.init(num_cpus=16)
+        # Set environment variable for Ray workers
+        yield ray.init(
+            num_cpus=16,
+        )
     finally:
         ray.shutdown()
 
@@ -26,6 +42,10 @@ def test_from_daft_raises_error_on_pyarrow_14(ray_start):
     with patch(
         "ray.data.read_api.get_pyarrow_version", return_value=parse_version("14.0.0")
     ):
+        import daft
+
+        import ray
+
         with pytest.raises(RuntimeError):
             ray.data.from_daft(daft.from_pydict({"col": [0]}))
 
@@ -35,6 +55,12 @@ def test_from_daft_raises_error_on_pyarrow_14(ray_start):
     reason="https://github.com/ray-project/ray/issues/53278",
 )
 def test_daft_round_trip(ray_start):
+    import daft
+    import numpy as np
+    import pandas as pd
+
+    import ray
+
     data = {
         "int_col": list(range(128)),
         "str_col": [str(i) for i in range(128)],

--- a/python/ray/data/tests/test_daft.py
+++ b/python/ray/data/tests/test_daft.py
@@ -1,44 +1,40 @@
-import os
+import sys
+from unittest.mock import patch
 
+import daft
+import numpy as np
+import pandas as pd
+import pyarrow as pa
 import pytest
+from packaging.version import parse as parse_version
+
+import ray
 
 
 @pytest.fixture(scope="module")
 def ray_start(request):
-    """Initialize Ray with proper serialization format."""
-    # TODO: Remove this once Daft issue is fixed to default to Cloudpickle
-    # serialization format.
-    # Force the serialization format to JSON for this test.
-    # Refer Daft issue https://github.com/Eventual-Inc/Daft/issues/4828
-    # and Ray issue https://github.com/ray-project/ray/issues/54837
-    # for more details.
-
-    # Set environment variable before importing ray
-    os.environ["RAY_DATA_ARROW_EXTENSION_SERIALIZATION_LEGACY_JSON_FORMAT"] = "1"
-
-    import ray
-    import ray.air.util.tensor_extensions.arrow as arrow_module
-    from ray.air.util.tensor_extensions.arrow import _SerializationFormat
-
-    # Force the serialization format to JSON after import
-    arrow_module.ARROW_EXTENSION_SERIALIZATION_FORMAT = _SerializationFormat.JSON
-
     try:
-        # Set environment variable for Ray workers
-        yield ray.init(
-            num_cpus=16,
-        )
+        yield ray.init(num_cpus=16)
     finally:
         ray.shutdown()
 
 
+def test_from_daft_raises_error_on_pyarrow_14(ray_start):
+    # This test assumes that `from_daft` calls `get_pyarrow_version` to get the
+    # PyArrow version. We can't mock `__version__` on the module directly because
+    # `get_pyarrow_version` caches the version.
+    with patch(
+        "ray.data.read_api.get_pyarrow_version", return_value=parse_version("14.0.0")
+    ):
+        with pytest.raises(RuntimeError):
+            ray.data.from_daft(daft.from_pydict({"col": [0]}))
+
+
+@pytest.mark.skipif(
+    parse_version(pa.__version__) >= parse_version("14.0.0"),
+    reason="https://github.com/ray-project/ray/issues/53278",
+)
 def test_daft_round_trip(ray_start):
-    import daft
-    import numpy as np
-    import pandas as pd
-
-    import ray
-
     data = {
         "int_col": list(range(128)),
         "str_col": [str(i) for i in range(128)],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Add back `from_daft` arrow version checks for version >= 14.

https://buildkite.com/ray-project/postmerge/builds/11735#01983e3e-fa6e-4866-bdbe-8bacc6a2af81

```
[2025-07-24T21:33:08Z] python/ray/data/tests/test_daft.py::test_daft_round_trip FAILED          [100%]
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z] =================================== FAILURES ===================================
  | [2025-07-24T21:33:08Z] _____________________________ test_daft_round_trip _____________________________
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z] ray_start = RayContext(dashboard_url='127.0.0.1:8265', python_version='3.9.23', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}')
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]     def test_daft_round_trip(ray_start):
  | [2025-07-24T21:33:08Z]         import daft
  | [2025-07-24T21:33:08Z]         import numpy as np
  | [2025-07-24T21:33:08Z]         import pandas as pd
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]         import ray
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]         data = {
  | [2025-07-24T21:33:08Z]             "int_col": list(range(128)),
  | [2025-07-24T21:33:08Z]             "str_col": [str(i) for i in range(128)],
  | [2025-07-24T21:33:08Z]             "nested_list_col": [[i] * 3 for i in range(128)],
  | [2025-07-24T21:33:08Z]             "tensor_col": [np.array([[i] * 3] * 3) for i in range(128)],
  | [2025-07-24T21:33:08Z]         }
  | [2025-07-24T21:33:08Z] >       df = daft.from_pydict(data)
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z] python/ray/data/tests/test_daft.py:48:
  | [2025-07-24T21:33:08Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  | [2025-07-24T21:33:08Z] /opt/miniforge/lib/python3.9/site-packages/daft/convert.py:80: in from_pydict
  | [2025-07-24T21:33:08Z]     return DataFrame._from_pydict(data)
  | [2025-07-24T21:33:08Z] /opt/miniforge/lib/python3.9/site-packages/daft/dataframe/dataframe.py:520: in _from_pydict
  | [2025-07-24T21:33:08Z]     return cls._from_tables(data_micropartition)
  | [2025-07-24T21:33:08Z] /opt/miniforge/lib/python3.9/site-packages/daft/dataframe/dataframe.py:572: in _from_tables
  | [2025-07-24T21:33:08Z]     df._populate_preview()
  | [2025-07-24T21:33:08Z] /opt/miniforge/lib/python3.9/site-packages/daft/dataframe/dataframe.py:473: in _populate_preview
  | [2025-07-24T21:33:08Z]     preview_parts = self._result._get_preview_micropartitions(self._num_preview_rows)
  | [2025-07-24T21:33:08Z] /opt/miniforge/lib/python3.9/site-packages/daft/runners/ray_runner.py:272: in _get_preview_micropartitions
  | [2025-07-24T21:33:08Z]     part: MicroPartition = ray.get(ref)
  | [2025-07-24T21:33:08Z] /rayci/python/ray/_private/auto_init_hook.py:22: in auto_init_wrapper
  | [2025-07-24T21:33:08Z]     return fn(*args, **kwargs)
  | [2025-07-24T21:33:08Z] /rayci/python/ray/_private/auto_init_hook.py:22: in auto_init_wrapper
  | [2025-07-24T21:33:08Z]     return fn(*args, **kwargs)
  | [2025-07-24T21:33:08Z] /rayci/python/ray/_private/client_mode_hook.py:104: in wrapper
  | [2025-07-24T21:33:08Z]     return func(*args, **kwargs)
  | [2025-07-24T21:33:08Z] /rayci/python/ray/_private/worker.py:2847: in get
  | [2025-07-24T21:33:08Z]     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  | [2025-07-24T21:33:08Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z] self = <ray._private.worker.Worker object at 0x7f1fdd2c4580>
  | [2025-07-24T21:33:08Z] object_refs = [ObjectRef(00ffffffffffffffffffffffffffffffffffffff0100000002e1f505)]
  | [2025-07-24T21:33:08Z] timeout = None, return_exceptions = False, skip_deserialization = False
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]     def get_objects(
  | [2025-07-24T21:33:08Z]         self,
  | [2025-07-24T21:33:08Z]         object_refs: list,
  | [2025-07-24T21:33:08Z]         timeout: Optional[float] = None,
  | [2025-07-24T21:33:08Z]         return_exceptions: bool = False,
  | [2025-07-24T21:33:08Z]         skip_deserialization: bool = False,
  | [2025-07-24T21:33:08Z]     ) -> Tuple[List[serialization.SerializedRayObject], bytes]:
  | [2025-07-24T21:33:08Z]         """Get the values in the object store associated with the IDs.
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]         Return the values from the local object store for object_refs. This
  | [2025-07-24T21:33:08Z]         will block until all the values for object_refs have been written to
  | [2025-07-24T21:33:08Z]         the local object store.
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]         Args:
  | [2025-07-24T21:33:08Z]             object_refs: A list of the object refs
  | [2025-07-24T21:33:08Z]                 whose values should be retrieved.
  | [2025-07-24T21:33:08Z]             timeout: The maximum amount of time in
  | [2025-07-24T21:33:08Z]                 seconds to wait before returning.
  | [2025-07-24T21:33:08Z]             return_exceptions: If any of the objects deserialize to an
  | [2025-07-24T21:33:08Z]                 Exception object, whether to return them as values in the
  | [2025-07-24T21:33:08Z]                 returned list. If False, then the first found exception will be
  | [2025-07-24T21:33:08Z]                 raised.
  | [2025-07-24T21:33:08Z]             skip_deserialization: If true, only the buffer will be released and
  | [2025-07-24T21:33:08Z]                 the object associated with the buffer will not be deserialized.
  | [2025-07-24T21:33:08Z]         Returns:
  | [2025-07-24T21:33:08Z]             list: List of deserialized objects or None if skip_deserialization is True.
  | [2025-07-24T21:33:08Z]             bytes: UUID of the debugger breakpoint we should drop
  | [2025-07-24T21:33:08Z]                 into or b"" if there is no breakpoint.
  | [2025-07-24T21:33:08Z]         """
  | [2025-07-24T21:33:08Z]         # Make sure that the values are object refs.
  | [2025-07-24T21:33:08Z]         for object_ref in object_refs:
  | [2025-07-24T21:33:08Z]             if not isinstance(object_ref, ObjectRef):
  | [2025-07-24T21:33:08Z]                 raise TypeError(
  | [2025-07-24T21:33:08Z]                     f"Attempting to call `get` on the value {object_ref}, "
  | [2025-07-24T21:33:08Z]                     "which is not an ray.ObjectRef."
  | [2025-07-24T21:33:08Z]                 )
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]         timeout_ms = (
  | [2025-07-24T21:33:08Z]             int(timeout * 1000) if timeout is not None and timeout != -1 else -1
  | [2025-07-24T21:33:08Z]         )
  | [2025-07-24T21:33:08Z]         serialized_objects: List[
  | [2025-07-24T21:33:08Z]             serialization.SerializedRayObject
  | [2025-07-24T21:33:08Z]         ] = self.core_worker.get_objects(
  | [2025-07-24T21:33:08Z]             object_refs,
  | [2025-07-24T21:33:08Z]             timeout_ms,
  | [2025-07-24T21:33:08Z]         )
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]         debugger_breakpoint = b""
  | [2025-07-24T21:33:08Z]         for data, metadata, _ in serialized_objects:
  | [2025-07-24T21:33:08Z]             if metadata:
  | [2025-07-24T21:33:08Z]                 metadata_fields = metadata.split(b",")
  | [2025-07-24T21:33:08Z]                 if len(metadata_fields) >= 2 and metadata_fields[1].startswith(
  | [2025-07-24T21:33:08Z]                     ray_constants.OBJECT_METADATA_DEBUG_PREFIX
  | [2025-07-24T21:33:08Z]                 ):
  | [2025-07-24T21:33:08Z]                     debugger_breakpoint = metadata_fields[1][
  | [2025-07-24T21:33:08Z]                         len(ray_constants.OBJECT_METADATA_DEBUG_PREFIX) :
  | [2025-07-24T21:33:08Z]                     ]
  | [2025-07-24T21:33:08Z]         if skip_deserialization:
  | [2025-07-24T21:33:08Z]             return None, debugger_breakpoint
  | [2025-07-24T21:33:08Z]
  | [2025-07-24T21:33:08Z]         values = self.deserialize_objects(serialized_objects, object_refs)
  | [2025-07-24T21:33:08Z]         if not return_exceptions:
  | [2025-07-24T21:33:08Z]             # Raise exceptions instead of returning them to the user.
  | [2025-07-24T21:33:08Z]             for i, value in enumerate(values):
  | [2025-07-24T21:33:08Z]                 if isinstance(value, RayError):
  | [2025-07-24T21:33:08Z]                     if isinstance(value, ray.exceptions.ObjectLostError):
  | [2025-07-24T21:33:08Z]                         global_worker.core_worker.log_plasma_usage()
  | [2025-07-24T21:33:08Z]                     if isinstance(value, RayTaskError):
  | [2025-07-24T21:33:08Z]                         raise value.as_instanceof_cause()
  | [2025-07-24T21:33:08Z]                     else:
  | [2025-07-24T21:33:08Z] >                       raise value
  | [2025-07-24T21:33:08Z] E                       ray.exceptions.RaySystemError: System error: module 'pyarrow' has no attribute 'PyExtensionType'
  | [2025-07-24T21:33:08Z] E                       traceback: Traceback (most recent call last):
  | [2025-07-24T21:33:08Z] E                         File "/rayci/python/ray/_private/serialization.py", line 533, in deserialize_objects
  | [2025-07-24T21:33:08Z] E                           obj = self._deserialize_object(
  | [2025-07-24T21:33:08Z] E                         File "/rayci/python/ray/_private/serialization.py", line 384, in _deserialize_object
  | [2025-07-24T21:33:08Z] E                           return self._deserialize_msgpack_data(
  | [2025-07-24T21:33:08Z] E                         File "/rayci/python/ray/_private/serialization.py", line 329, in _deserialize_msgpack_data
  | [2025-07-24T21:33:08Z] E                           python_objects = self._deserialize_pickle5_data(
  | [2025-07-24T21:33:08Z] E                         File "/rayci/python/ray/_private/serialization.py", line 306, in _deserialize_pickle5_data
  | [2025-07-24T21:33:08Z] E                           obj = pickle.loads(in_band, buffers=buffers)
  | [2025-07-24T21:33:08Z] E                         File "/opt/miniforge/lib/python3.9/site-packages/daft/series.py", line 36, in from_arrow
  | [2025-07-24T21:33:08Z] E                           if DataType.from_arrow_type(array.type) == DataType.python():
  | [2025-07-24T21:33:08Z] E                         File "/opt/miniforge/lib/python3.9/site-packages/daft/datatype.py", line 457, in from_arrow_type
  | [2025-07-24T21:33:08Z] E                           elif isinstance(arrow_type, pa.PyExtensionType):
  | [2025-07-24T21:33:08Z] E                         File "/opt/miniforge/lib/python3.9/site-packages/daft/lazy_import.py", line 63, in __getattr__
  | [2025-07-24T21:33:08Z] E                           raise e
  | [2025-07-24T21:33:08Z] E                         File "/opt/miniforge/lib/python3.9/site-packages/daft/lazy_import.py", line 53, in __getattr__
  | [2025-07-24T21:33:08Z] E                           return getattr(self._load_module(), name)
  | [2025-07-24T21:33:08Z] E                       AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'
  | [2025-07-24T21:33:08Z]
  |  

```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
