### PR TITLE
[core] Miscellaneous cleanup around storing task outputs

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2380,11 +2380,7 @@ cdef CRayStatus task_execution_handler(
                     traceback_str = str(e)
                     logger.error("Exception raised "
                                  f"in creation task: {traceback_str}")
-                    # Cython's bug that doesn't allow reference assignment,
-                    # this is a workaroud.
-                    # See https://github.com/cython/cython/issues/1863
-                    (&creation_task_exception_pb_bytes)[0] = (
-                        ray_error_to_memory_buf(e))
+                    creation_task_exception_pb_bytes = ray_error_to_memory_buf(e)
                     sys_exit.is_creation_task_error = True
                     sys_exit.init_error_message = (
                         "Exception raised from an actor init method. "
@@ -4411,18 +4407,27 @@ cdef class CoreWorker:
                 serialized_object.contained_object_refs)
 
             if not self.store_task_output(
-                    serialized_object, return_id,
+                    serialized_object,
+                    return_id,
                     c_ref_generator_id,
-                    data_size, metadata, contained_id, caller_address,
-                    &task_output_inlined_bytes, return_ptr):
+                    data_size,
+                    metadata,
+                    contained_id,
+                    caller_address,
+                    &task_output_inlined_bytes,
+                    return_ptr):
                 # If the object already exists, but we fail to pin the copy, it
                 # means the existing copy might've gotten evicted. Try to
                 # create another copy.
                 self.store_task_output(
-                        serialized_object, return_id,
+                        serialized_object,
+                        return_id,
                         c_ref_generator_id,
-                        data_size, metadata,
-                        contained_id, caller_address, &task_output_inlined_bytes,
+                        data_size,
+                        metadata,
+                        contained_id,
+                        caller_address,
+                        &task_output_inlined_bytes,
                         return_ptr)
             num_outputs_stored += 1
 

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -125,7 +125,6 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
         c_bool IsTimedOut()
         c_bool IsInvalidArgument()
         c_bool IsInterrupted()
-        c_bool ShouldExitWorker()
         c_bool IsObjectNotFound()
         c_bool IsNotFound()
         c_bool IsObjectUnknownOwner()

--- a/src/mock/ray/object_manager/plasma/client.h
+++ b/src/mock/ray/object_manager/plasma/client.h
@@ -46,11 +46,6 @@ class MockPlasmaClient : public PlasmaClientInterface {
               (override));
 
   MOCK_METHOD(Status,
-              ExperimentalMutableObjectRegisterWriter,
-              (const ObjectID &object_id),
-              (override));
-
-  MOCK_METHOD(Status,
               GetExperimentalMutableObject,
               (const ObjectID &object_id, std::unique_ptr<MutableObject> *mutable_object),
               (override));

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -274,11 +274,6 @@ class RAY_EXPORT Status {
   bool IsRedisError() const { return code() == StatusCode::RedisError; }
   bool IsTimedOut() const { return code() == StatusCode::TimedOut; }
   bool IsInterrupted() const { return code() == StatusCode::Interrupted; }
-  bool ShouldExitWorker() const {
-    return code() == StatusCode::IntentionalSystemExit ||
-           code() == StatusCode::UnexpectedSystemExit ||
-           code() == StatusCode::CreationTaskError;
-  }
   bool IsIntentionalSystemExit() const {
     return code() == StatusCode::IntentionalSystemExit;
   }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3414,8 +3414,8 @@ Status CoreWorker::ExecuteTask(
     Exit(rpc::WorkerExitType::SYSTEM_ERROR,
          absl::StrCat("Worker exits unexpectedly. ", status.message()),
          creation_task_exception_pb_bytes);
-  } else if (!status.ok()) {
-    RAY_LOG(FATAL) << "Unexpected task status type : " << status;
+  } else {
+    RAY_CHECK_OK(status) << "Unexpected task status type : " << status;
   }
   return status;
 }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2200,7 +2200,7 @@ void CoreWorker::TriggerGlobalGC() {
 Status CoreWorker::GetPlasmaUsage(std::string &output) {
   StatusOr<std::string> response = plasma_store_provider_->GetMemoryUsage();
   if (response.ok()) {
-    output = response.value();
+    output = std::move(response.value());
   }
   return response.status();
 }
@@ -3192,7 +3192,7 @@ Status CoreWorker::AllocateReturnObject(const ObjectID &object_id,
                                        owner_address,
                                        &data_buffer,
                                        /*created_by_worker=*/true));
-      object_already_exists = !data_buffer;
+      object_already_exists = data_buffer == nullptr;
     }
   }
   // Leave the return object as a nullptr if the object already exists.
@@ -3216,8 +3216,11 @@ Status CoreWorker::ExecuteTask(
     std::string *application_error) {
   RAY_LOG(DEBUG) << "Executing task, task info = " << task_spec.DebugString();
 
-  // If the worker is exited via Exit API, we shouldn't execute
-  // tasks anymore.
+  for (size_t i = 0; i < task_spec.NumReturns(); i++) {
+    return_objects->emplace_back(task_spec.ReturnId(i), nullptr);
+  }
+
+  // If the worker is exited via Exit API, we shouldn't execute tasks anymore.
   if (IsExiting()) {
     absl::MutexLock lock(&mutex_);
     return Status::IntentionalSystemExit(
@@ -3272,12 +3275,10 @@ Status CoreWorker::ExecuteTask(
   std::vector<ObjectID> borrowed_ids;
   RAY_CHECK_OK(GetAndPinArgsForExecutor(task_spec, &args, &arg_refs, &borrowed_ids));
 
-  for (size_t i = 0; i < task_spec.NumReturns(); i++) {
-    return_objects->emplace_back(task_spec.ReturnId(i), nullptr);
-  }
   // For dynamic tasks, pass the return IDs that were dynamically generated on
   // the first execution.
   if (!task_spec.ReturnsDynamic()) {
+    RAY_LOG(ERROR) << "ReturnsDynamic is false";
     dynamic_return_objects = nullptr;
   } else if (task_spec.AttemptNumber() > 0) {
     for (const auto &dynamic_return_id : task_spec.DynamicReturnIds()) {
@@ -3295,7 +3296,6 @@ Status CoreWorker::ExecuteTask(
     }
   }
 
-  Status status;
   TaskType task_type = TaskType::NORMAL_TASK;
   if (task_spec.IsActorCreationTask()) {
     task_type = TaskType::ACTOR_CREATION_TASK;
@@ -3327,7 +3327,7 @@ Status CoreWorker::ExecuteTask(
     name_of_concurrency_group_to_execute = task_spec.ConcurrencyGroupName();
   }
 
-  status = options_.task_execution_callback(
+  Status status = options_.task_execution_callback(
       task_spec.CallerAddress(),
       task_type,
       task_spec.GetName(),

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -128,10 +128,9 @@ Status CoreWorkerPlasmaStoreProvider::Create(const std::shared_ptr<Buffer> &meta
                                              std::shared_ptr<Buffer> *data,
                                              bool created_by_worker,
                                              bool is_mutable) {
-  auto source = plasma::flatbuf::ObjectSource::CreatedByWorker;
-  if (!created_by_worker) {
-    source = plasma::flatbuf::ObjectSource::RestoredFromStorage;
-  }
+  const auto source = created_by_worker
+                          ? plasma::flatbuf::ObjectSource::CreatedByWorker
+                          : plasma::flatbuf::ObjectSource::RestoredFromStorage;
   Status status =
       store_client_->CreateAndSpillIfNeeded(object_id,
                                             owner_address,
@@ -164,8 +163,6 @@ Status CoreWorkerPlasmaStoreProvider::Create(const std::shared_ptr<Buffer> &meta
     RAY_LOG_EVERY_MS(WARNING, 5000)
         << "Trying to put an object that already existed in plasma: " << object_id << ".";
     status = Status::OK();
-  } else {
-    RAY_RETURN_NOT_OK(status);
   }
   return status;
 }

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -176,10 +176,7 @@ void TaskReceiver::HandleTask(rpc::PushTaskRequest request,
       }
     } else {
       RAY_CHECK(objects_valid);
-      // This is a product of status being too large of an enum. If this was constrained
-      // to just the 3 possible errors we wouldn't need this ray check to check our work
-      // and the type system would be enforcing for us.
-      RAY_CHECK(status.ok());
+      RAY_CHECK_OK(status);
       send_reply_callback(Status::OK(), nullptr, nullptr);
     }
   };

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -175,8 +175,8 @@ void TaskReceiver::HandleTask(rpc::PushTaskRequest request,
         send_reply_callback(status, nullptr, nullptr);
       }
     } else {
-      RAY_CHECK(objects_valid);
       RAY_CHECK_OK(status);
+      RAY_CHECK(objects_valid);
       send_reply_callback(Status::OK(), nullptr, nullptr);
     }
   };

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -268,7 +268,7 @@ uint8_t *PlasmaClient::Impl::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val,
 // process before.
 uint8_t *PlasmaClient::Impl::LookupMmappedFile(MEMFD_TYPE store_fd_val) const {
   auto entry = mmap_table_.find(store_fd_val);
-  RAY_CHECK_NE(entry, mmap_table_.end());
+  RAY_CHECK(entry != mmap_table_.end());
   return entry->second->pointer();
 }
 
@@ -299,7 +299,7 @@ void PlasmaClient::Impl::IncrementObjectCount(const ObjectID &object_id) {
   // Increment the count of the object to track the fact that it is being used.
   // The corresponding decrement should happen in PlasmaClient::Release.
   auto object_entry = objects_in_use_.find(object_id);
-  RAY_CHECK_NE(object_entry, objects_in_use_.end());
+  RAY_CHECK(object_entry != objects_in_use_.end());
   object_entry->second->count += 1;
   RAY_LOG(DEBUG) << "IncrementObjectCount " << object_id
                  << " count is now: " << object_entry->second->count;
@@ -377,7 +377,7 @@ Status PlasmaClient::Impl::HandleCreateReply(const ObjectID &object_id,
 
   // Create IPC was successful.
   auto object_entry = objects_in_use_.find(object_id);
-  RAY_CHECK_NE(object_entry, objects_in_use_.end());
+  RAY_CHECK(object_entry != objects_in_use_.end());
   auto &entry = object_entry->second;
   RAY_CHECK(!entry->is_sealed);
 
@@ -641,7 +641,7 @@ Status PlasmaClient::Impl::Get(const std::vector<ObjectID> &object_ids,
 
 Status PlasmaClient::Impl::MarkObjectUnused(const ObjectID &object_id) {
   auto object_entry = objects_in_use_.find(object_id);
-  RAY_CHECK_NE(object_entry, objects_in_use_.end());
+  RAY_CHECK(object_entry != objects_in_use_.end());
   RAY_CHECK_EQ(object_entry->second->count, 0);
 
   // Remove the entry from the hash table of objects currently in use.
@@ -657,7 +657,7 @@ Status PlasmaClient::Impl::Release(const ObjectID &object_id) {
     return Status::OK();
   }
   const auto object_entry = objects_in_use_.find(object_id);
-  RAY_CHECK_NE(object_entry, objects_in_use_.end());
+  RAY_CHECK(object_entry != objects_in_use_.end());
 
   object_entry->second->count -= 1;
   RAY_LOG(DEBUG) << "Decrement object count " << object_id << " count is now "
@@ -766,7 +766,7 @@ Status PlasmaClient::Impl::Seal(const ObjectID &object_id) {
 Status PlasmaClient::Impl::Abort(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
   auto object_entry = objects_in_use_.find(object_id);
-  RAY_CHECK_NE(object_entry, objects_in_use_.end())
+  RAY_CHECK(object_entry != objects_in_use_.end())
       << "Plasma client called abort on an object without a reference to it";
   RAY_CHECK(!object_entry->second->is_sealed)
       << "Plasma client called abort on a sealed object";

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -333,7 +333,7 @@ Status PlasmaClient::Impl::HandleCreateReply(const ObjectID &object_id,
     uint64_t unused = 0;
     RAY_RETURN_NOT_OK(ReadCreateReply(
         buffer.data(), buffer.size(), &id, &unused, object.get(), &store_fd, &mmap_size));
-    RAY_CHECK_EQ(unused, 0);
+    RAY_CHECK_EQ(unused, 0ul);
   }
 
   // If the CreateReply included an error, then the store will not send a file

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -302,21 +302,6 @@ class PlasmaClient : public PlasmaClientInterface {
   int64_t store_capacity();
 
  private:
-  /// Retry a previous create call using the returned request ID.
-  ///
-  /// \param object_id The ID to use for the newly created object.
-  /// \param request_id The request ID returned by the previous Create call.
-  /// \param metadata The object's metadata. If there is no metadata, this
-  /// pointer should be NULL.
-  /// \param retry_with_request_id If the request is not yet fulfilled, this
-  ///        will be set to a unique ID with which the client should retry.
-  /// \param data The address of the newly created object will be written here.
-  Status RetryCreate(const ObjectID &object_id,
-                     uint64_t request_id,
-                     const uint8_t *metadata,
-                     uint64_t *retry_with_request_id,
-                     std::shared_ptr<Buffer> *data);
-
   friend class PlasmaBuffer;
   friend class PlasmaMutableBuffer;
   bool IsInUse(const ObjectID &object_id);

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -127,13 +127,6 @@ class PlasmaClientInterface {
                      std::vector<ObjectBuffer> *object_buffers,
                      bool is_from_worker) = 0;
 
-  /// Register an experimental mutable object writer. The writer is on a different node
-  /// and wants to write to this node.
-  ///
-  /// \param[in] object_id The ID of the object.
-  /// \return The return status.
-  virtual Status ExperimentalMutableObjectRegisterWriter(const ObjectID &object_id) = 0;
-
   /// Get an experimental mutable object.
   ///
   /// \param[in] object_id The ID of the object.
@@ -273,8 +266,6 @@ class PlasmaClient : public PlasmaClientInterface {
              int64_t timeout_ms,
              std::vector<ObjectBuffer> *object_buffers,
              bool is_from_worker) override;
-
-  Status ExperimentalMutableObjectRegisterWriter(const ObjectID &object_id) override;
 
   Status GetExperimentalMutableObject(
       const ObjectID &object_id, std::unique_ptr<MutableObject> *mutable_object) override;

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -32,8 +32,8 @@ uint64_t CreateRequestQueue::AddRequest(const ObjectID &object_id,
                                         size_t object_size) {
   auto req_id = next_req_id_++;
   fulfilled_requests_[req_id] = nullptr;
-  queue_.emplace_back(
-      new CreateRequest(object_id, req_id, client, create_callback, object_size));
+  queue_.emplace_back(std::make_unique<CreateRequest>(
+      object_id, req_id, client, create_callback, object_size));
   num_bytes_pending_ += object_size;
   return req_id;
 }

--- a/src/ray/object_manager/plasma/get_request_queue.cc
+++ b/src/ray/object_manager/plasma/get_request_queue.cc
@@ -65,7 +65,7 @@ void GetRequestQueue::AddRequest(const std::shared_ptr<ClientInterface> &client,
     // Check if this object is already present locally. If so, record that the object is
     // being used and mark it as accounted for.
     auto entry = object_lifecycle_mgr_.GetObject(object_id);
-    if (entry && entry->Sealed()) {
+    if (entry != nullptr && entry->Sealed()) {
       // Update the get request to take into account the present object.
       auto *plasma_object = &get_request->objects[object_id];
       entry->ToPlasmaObject(plasma_object, /* checksealed */ true);

--- a/src/ray/object_manager/plasma/get_request_queue.cc
+++ b/src/ray/object_manager/plasma/get_request_queue.cc
@@ -62,8 +62,8 @@ void GetRequestQueue::AddRequest(const std::shared_ptr<ClientInterface> &client,
   auto get_request = std::make_shared<GetRequest>(
       io_context_, client, object_ids, is_from_worker, unique_ids.size());
   for (const auto &object_id : unique_ids) {
-    // Check if this object is already present
-    // locally. If so, record that the object is being used and mark it as accounted for.
+    // Check if this object is already present locally. If so, record that the object is
+    // being used and mark it as accounted for.
     auto entry = object_lifecycle_mgr_.GetObject(object_id);
     if (entry && entry->Sealed()) {
       // Update the get request to take into account the present object.

--- a/src/ray/object_manager/plasma/obj_lifecycle_mgr.cc
+++ b/src/ray/object_manager/plasma/obj_lifecycle_mgr.cc
@@ -36,7 +36,6 @@ ObjectLifecycleManager::ObjectLifecycleManager(
     : object_store_(std::make_unique<ObjectStore>(allocator)),
       eviction_policy_(std::make_unique<EvictionPolicy>(*object_store_, allocator)),
       delete_object_callback_(std::move(delete_object_callback)),
-      earger_deletion_objects_(),
       stats_collector_(std::make_unique<ObjectStatsCollector>()) {}
 
 std::pair<const LocalObject *, flatbuf::PlasmaError> ObjectLifecycleManager::CreateObject(

--- a/src/ray/object_manager/plasma/object_store.cc
+++ b/src/ray/object_manager/plasma/object_store.cc
@@ -22,15 +22,14 @@
 
 namespace plasma {
 
-ObjectStore::ObjectStore(IAllocator &allocator)
-    : allocator_(allocator), object_table_() {}
+ObjectStore::ObjectStore(IAllocator &allocator) : allocator_(allocator) {}
 
 const LocalObject *ObjectStore::CreateObject(const ray::ObjectInfo &object_info,
                                              plasma::flatbuf::ObjectSource source,
                                              bool fallback_allocate) {
   RAY_LOG(DEBUG) << "attempting to create object " << object_info.object_id << " size "
                  << object_info.data_size;
-  RAY_CHECK(object_table_.count(object_info.object_id) == 0)
+  RAY_CHECK(!object_table_.contains(object_info.object_id))
       << object_info.object_id << " already exists!";
   auto object_size = object_info.GetObjectSize();
   auto allocation = fallback_allocate ? allocator_.FallbackAllocate(object_size)
@@ -81,10 +80,9 @@ const LocalObject *ObjectStore::SealObject(const ObjectID &object_id) {
 
 bool ObjectStore::DeleteObject(const ObjectID &object_id) {
   auto entry = GetMutableObject(object_id);
-  if (!entry) {
+  if (entry == nullptr) {
     return false;
   }
-
   allocator_.Free(std::move(entry->allocation));
   object_table_.erase(object_id);
   return true;

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -658,13 +658,13 @@ Status SendGetReply(const std::shared_ptr<Client> &client,
   return PlasmaSend(client, MessageType::PlasmaGetReply, &fbb, message);
 }
 
-Status ReadGetReply(uint8_t *data,
-                    size_t size,
-                    ObjectID object_ids[],
-                    PlasmaObject plasma_objects[],
-                    int64_t num_objects,
-                    std::vector<MEMFD_TYPE> &store_fds,
-                    std::vector<int64_t> &mmap_sizes) {
+void ReadGetReply(uint8_t *data,
+                  size_t size,
+                  ObjectID object_ids[],
+                  PlasmaObject plasma_objects[],
+                  int64_t num_objects,
+                  std::vector<MEMFD_TYPE> &store_fds,
+                  std::vector<int64_t> &mmap_sizes) {
   RAY_DCHECK(data);
   auto message = flatbuffers::GetRoot<fb::PlasmaGetReply>(data);
   RAY_DCHECK(VerifyFlatbuffer(message, data, size));
@@ -692,7 +692,6 @@ Status ReadGetReply(uint8_t *data,
         {INT2FD(message->store_fds()->Get(i)), message->unique_fd_ids()->Get(i)});
     mmap_sizes.push_back(message->mmap_sizes()->Get(i));
   }
-  return Status::OK();
 }
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -163,13 +163,13 @@ Status SendGetReply(const std::shared_ptr<Client> &client,
                     const std::vector<MEMFD_TYPE> &store_fds,
                     const std::vector<int64_t> &mmap_sizes);
 
-Status ReadGetReply(uint8_t *data,
-                    size_t size,
-                    ObjectID object_ids[],
-                    PlasmaObject plasma_objects[],
-                    int64_t num_objects,
-                    std::vector<MEMFD_TYPE> &store_fds,
-                    std::vector<int64_t> &mmap_sizes);
+void ReadGetReply(uint8_t *data,
+                  size_t size,
+                  ObjectID object_ids[],
+                  PlasmaObject plasma_objects[],
+                  int64_t num_objects,
+                  std::vector<MEMFD_TYPE> &store_fds,
+                  std::vector<int64_t> &mmap_sizes);
 
 /* Plasma Release message functions. */
 

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -490,6 +490,7 @@ service NodeManagerService {
       returns (RegisterMutableObjectReply);
   // Failure: TODO: Handle network failure for cgraphs.
   rpc PushMutableObject(PushMutableObjectRequest) returns (PushMutableObjectReply);
-  // Failure: Uses retryable grpc client for retries.
+  // Failure: Is currently only used when grpc channel is unavailable for retryable core
+  // worker clients. The unavailable callback will eventually be retried so if this fails.
   rpc IsLocalWorkerDead(IsLocalWorkerDeadRequest) returns (IsLocalWorkerDeadReply);
 }

--- a/src/ray/raylet/test/node_manager_test.cc
+++ b/src/ray/raylet/test/node_manager_test.cc
@@ -143,10 +143,6 @@ class FakePlasmaClient : public plasma::PlasmaClientInterface {
     return Status::OK();
   }
 
-  Status ExperimentalMutableObjectRegisterWriter(const ObjectID &object_id) override {
-    return Status::OK();
-  }
-
   Status GetExperimentalMutableObject(
       const ObjectID &object_id,
       std::unique_ptr<plasma::MutableObject> *mutable_object) override {


### PR DESCRIPTION
## Why are these changes needed?
Just some cleaning up some code that annoyed me while I was looking through code for https://github.com/ray-project/ray/pull/54904. There's no actual functional changes here.

Some of the bigger changes are:
- Adding a RAY_CHECK_OK in task_receiver, based on the code, the return status can only be ok or one of those 3 in the if or ok. Enforcing this here makes life easier people who are reading this code in the future. It was already enforced in CoreWorker::ExecuteTask which is where the task_receiver gets this status from anyways. In **_my ideal world_**, we would be returning a more constrained enum and not ray status so this check wouldn't even be necessary.
- inlining `RetryCreate` and deleting it
- inlining the statuses that `ShouldExitWorker` is checking for to make it clearer