### PR TITLE
make test cli 2 use get application url

### DIFF
--- a/python/ray/dashboard/modules/serve/tests/test_serve_dashboard_2.py
+++ b/python/ray/dashboard/modules/serve/tests/test_serve_dashboard_2.py
@@ -55,7 +55,6 @@ def test_serve_namespace(ray_start_stop):
     )
     print("Deployments are live and reachable over HTTP.\n")
 
-    ray.init(address="auto", namespace="serve")
     my_app_status = serve.status().applications["my_app"]
     assert (
         len(my_app_status.deployments) == 2
@@ -63,8 +62,6 @@ def test_serve_namespace(ray_start_stop):
     )
     print("Successfully retrieved deployment statuses with Python API.")
     print("Shutting down Python API.")
-    serve.shutdown()
-    ray.shutdown()
 
 
 @pytest.mark.parametrize(

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -734,7 +734,7 @@ def get_application_urls(
     Returns:
         The URLs of the application.
     """
-    client = _get_global_client()
+    client = _get_global_client(_health_check_controller=True)
     serve_details = client.get_serve_details()
     if app_name not in serve_details["applications"]:
         return [client.root_url]

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -183,6 +183,7 @@ def check_ray_stop():
 @pytest.fixture(scope="function")
 def ray_start_stop():
     subprocess.check_output(["ray", "stop", "--force"])
+    ray.shutdown()
     wait_for_condition(
         check_ray_stop,
         timeout=15,
@@ -192,7 +193,10 @@ def ray_start_stop():
         lambda: httpx.get("http://localhost:8265/api/ray/version").status_code == 200,
         timeout=15,
     )
+    ray.init("auto")
     yield
+    serve.shutdown()
+    ray.shutdown()
     subprocess.check_output(["ray", "stop", "--force"])
     wait_for_condition(
         check_ray_stop,
@@ -253,6 +257,7 @@ def ray_instance(request):
         },
     )
 
+    serve.shutdown()
     ray.shutdown()
 
     os.environ.clear()


### PR DESCRIPTION
The reason why test_cli_2 starts to fail when using get_application_url is that get_application_url internally initializes a ray cluster separate from the one started from the cli ray start, the state of this new cluster is not cleared across tests cleanly causing the tests to fail with ActorDiedError. Instead of having get_application_url implicitly create the separate cluster, we are explicitly doing that in the test fixture.

