### PR TITLE
[CI] Add placeholder commit to reproduce Java test failures on macOS ARM64

### DIFF
--- a/.buildkite/macos/macos.rayci.yml
+++ b/.buildkite/macos/macos.rayci.yml
@@ -103,7 +103,15 @@ steps:
     job_env: MACOS
     instance_type: macos-arm64
     commands:
-      - RAY_INSTALL_JAVA=1 ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_and_java
+      - |
+        if ! /usr/bin/pgrep oahd >/dev/null 2>&1; then
+          echo "Installing Rosetta..."
+          sudo /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+        else
+          echo "Rosetta already installed."
+        fi
+      - arch -x86_64 uname -m  # Debug log: should print i386 or x86_64
+      - RAY_INSTALL_JAVA=1 arch -x86_64 ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_and_java
 
   - label: ":ray: core: :mac: flaky tests"
     key: macos_flaky_tests

--- a/.buildkite/macos/macos.rayci.yml
+++ b/.buildkite/macos/macos.rayci.yml
@@ -101,7 +101,7 @@ steps:
       - macos_wheels
       - oss
     job_env: MACOS
-    instance_type: macos
+    instance_type: macos-arm64
     commands:
       - RAY_INSTALL_JAVA=1 ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_and_java
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR adds an empty commit to trigger the `postmerge-macos` Buildkite pipeline with the `macos-arm64` label and `RAYCI_SELECT=g0_s8` environment variable.  
The goal is to reproduce and investigate the Java test failures occurring on Apple Silicon.

## Context

Java tests are currently failing on `macos-arm64`. Initial indications suggest the issue may stem from mismatched architectures (e.g., x86_64 binaries being used on ARM64), but this needs confirmation via CI reproduction.

## Purpose

- Reproduce Java test failure on Apple Silicon (`macos-arm64`)

## Notes

- No functional code changes are introduced.
- CPP tests are known to pass and will be split out in a separate PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
