### PR TITLE
[CI] Split macOS Java and C++ tests into separate Buildkite jobs

### DIFF
--- a/.buildkite/macos/macos.rayci.yml
+++ b/.buildkite/macos/macos.rayci.yml
@@ -93,17 +93,27 @@ steps:
     commands:
       - ./ci/ray_ci/macos/macos_ci.sh run_core_dashboard_test
 
-  - label: ":ray: core: :mac: core c++ and java tests"
+  - label: ":ray: core: :mac: Java tests"
     if: build.env("BUILDKITE_PIPELINE_ID") != "0189e759-8c96-4302-b6b5-b4274406bf89"
     tags:
-      - cpp
       - java
       - macos_wheels
       - oss
     job_env: MACOS
     instance_type: macos
     commands:
-      - RAY_INSTALL_JAVA=1 ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_and_java
+      - RAY_INSTALL_JAVA=1 ./ci/ray_ci/macos/macos_ci.sh run_ray_java_tests
+
+  - label: ":ray: core: :mac: C++ tests"
+    if: build.env("BUILDKITE_PIPELINE_ID") != "0189e759-8c96-4302-b6b5-b4274406bf89"
+    tags:
+      - cpp
+      - macos_wheels
+      - oss
+    job_env: MACOS
+    instance_type: macos
+    commands:
+      - ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_tests
 
   - label: ":ray: core: :mac: flaky tests"
     key: macos_flaky_tests

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -98,11 +98,6 @@ run_ray_cpp_tests() {
   ./ci/ci.sh test_cpp || exit 42
 }
 
-run_ray_cpp_and_java() {
-  run_ray_java_tests
-  run_ray_cpp_tests
-}
-
 bisect() {
   bazel run //ci/ray_ci/bisect:bisect_test -- "$@"
 }

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -85,13 +85,22 @@ run_core_dashboard_test() {
     //:all python/ray/dashboard/... -python/ray/serve/... -rllib/...) || exit 42
 }
 
-run_ray_cpp_and_java() {
+run_ray_java_tests() {
   # clang-format is needed by java/test.sh
   # 42 is the universal rayci exit code for test failures
   pip install clang-format==12.0.1
   export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home
   ./java/test.sh || exit 42
+}
+
+run_ray_cpp_tests() {
+  # 42 is the universal rayci exit code for test failures
   ./ci/ci.sh test_cpp || exit 42
+}
+
+run_ray_cpp_and_java() {
+  run_ray_java_tests
+  run_ray_cpp_tests
 }
 
 bisect() {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Summary

This PR splits the existing combined macOS job (`run_ray_cpp_and_java`) into two separate Buildkite jobs:

- `:mac: Java tests` — runs only the Java test suite
- `:mac: C++ tests` — runs only the C++ test suite

This change makes it easier to manage test failures independently and enables selective debugging or rollout of Java/C++ pipelines, especially for macOS ARM64 environments.

## Motivation

Java tests are currently failing on Apple Silicon (`macos-arm64`) due to architecture-related issues. C++ tests, however, are passing.  
Splitting the test jobs allows us to:
- Land and verify the working C++ pipeline independently
- Isolate and debug Java-specific issues separately

## Changes

- Added `run_ray_java_tests` and `run_ray_cpp_tests` bash functions in place of `run_ray_cpp_and_java`
- Updated `macos_ci.sh` logic to support split function execution
- Created two new Buildkite jobs for Java and C++ tests respectively

## Notes

- No changes to test logic or functionality
- CI-only refactor; no effect on source code or runtime behavior

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
