### PR TITLE
[Core] [Azure] set user agent with ray version for Azure calls

### DIFF
--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -9,6 +9,7 @@ from azure.common.credentials import get_cli_profile
 from azure.identity import AzureCliCredential
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.resources.models import DeploymentMode
+import ray  # Import ray to get the version
 
 UNIQUE_ID_LEN = 4
 
@@ -47,7 +48,11 @@ def _configure_resource_group(config):
     subscription_id = config["provider"].get("subscription_id")
     if subscription_id is None:
         subscription_id = get_cli_profile().get_subscription_id()
-    resource_client = ResourceManagementClient(AzureCliCredential(), subscription_id)
+    ray_user_agent = f"ray/{ray.__version__}"
+    resource_client = ResourceManagementClient(
+        AzureCliCredential(), subscription_id, user_agent=ray_user_agent
+    )
+
     config["provider"]["subscription_id"] = subscription_id
     logger.info("Using subscription id: %s", subscription_id)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change adds a custom user-agent that includes the Ray version to Azure SDK calls.
This information can help identify Ray API usage for each version of Ray which can be helpful for identifying when APIs will be deprecated, when code should be updated to use newer APIs, etc

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( - Tested manually I plan to work on Azure test coverage soon 
