### PR TITLE
[core] Delete extra actor name duplication check

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1545,24 +1545,6 @@ class ActorClass(Generic[T]):
 
             usage_lib.record_library_usage("core")
 
-        # Check whether the name is already taken.
-        # TODO(edoakes): this check has a race condition because two drivers
-        # could pass the check and then create the same named actor. We should
-        # instead check this when we create the actor, but that's currently an
-        # async call.
-        if name is not None:
-            try:
-                ray.get_actor(name, namespace=namespace)
-            except ValueError:  # Name is not taken.
-                pass
-            else:
-                raise ValueError(
-                    f"The name {name} (namespace={namespace}) is already "
-                    "taken. Please use "
-                    "a different name or get the existing actor using "
-                    f"ray.get_actor('{name}', namespace='{namespace}')"
-                )
-
         if lifetime is None:
             detached = None
         elif lifetime == "detached":


### PR DESCRIPTION
## Why are these changes needed?
We make do some extra work and may even make an extra unnecessary sync request to the GCS to check if an actor with the same name already exists when creating one with a name. We don't actually need to do this though because when trying to create the actor, we'll make a sync gcs request to register the actor and if the GCS fails we'll propogate up the status.
https://github.com/ray-project/ray/blob/f9190c0b7971fdf468f42cf8da53ec183908ee86/src/ray/core_worker/core_worker.cc#L2685-L2691

The GCS will return AlreadyExists if an actor with the same name exists in the same namespace.
https://github.com/ray-project/ray/blob/f9190c0b7971fdf468f42cf8da53ec183908ee86/src/ray/gcs/gcs_server/gcs_actor_manager.cc#L810-L813

AlreadyExists translates to the expected ValueError.