### PR TITLE
Quiet podman run when creating a runtime_env

### DIFF
--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -15,6 +15,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
     pull_image_cmd = [
         "podman",
         "run",
+        "--quiet",
         "--rm",
         image_uri,
         "python",


### PR DESCRIPTION
## Why are these changes needed?

Using the "Run Multiple Applications in Different Containers" pattern, when Ray creates the new runtime_env, it executes a command that causes Podman to pull the image, run a container and execute a particular command. That particular command has the aim of establishing the image's entrypoint, that will be used as `override_worker_entrypoint` of the runtime_env.

The `override_worker_entrypoint` contains the whole log of Podman instead of just the command's output. This issue is solved by setting `--quiet` flag when executing `podman run` command.


## Related issue number

Closes https://github.com/ray-project/ray/issues/54965

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
