### PR TITLE
[LLM] Update ray-llm image to include EP deps

### DIFF
--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -35,7 +35,8 @@ $HOME/anaconda3/bin/pip freeze > /home/ray/pip-freeze.txt
 
 mkdir -p "${ROOT_DIR}"
 
-CUDA_HOME=`dirname $(dirname $(which nvcc))`
+CUDACXX=$(which nvcc)
+CUDA_HOME=$(dirname $(dirname $CUDACXX))
 
 TEMP_DIR="nixl_installer"
 mkdir -p "${TEMP_DIR}"
@@ -120,6 +121,62 @@ NIXL_VERSION="0.3.1"
     pip install --no-cache-dir "nixl==${NIXL_VERSION}"
 )
 sudo rm -rf "${TEMP_DIR}"
+
+EP_TEMP_DIR="ep_temp_dir"
+mkdir -p "${EP_TEMP_DIR}"
+
+NVSHMEM_VERSION="3.2.5-1"
+(
+    echo "Installing NVSHMEM ${NVSHMEM_VERSION}"
+
+    # install dependencies if not installed
+    pip3 install cmake torch ninja
+
+    cd "${EP_TEMP_DIR}"
+    mkdir -p nvshmem_src
+    wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.2.5/source/nvshmem_src_3.2.5-1.txz
+    tar -xvf nvshmem_src_3.2.5-1.txz -C nvshmem_src --strip-components=1
+    cd nvshmem_src
+    wget https://github.com/deepseek-ai/DeepEP/raw/main/third-party/nvshmem.patch
+    git init
+    git apply -vvv nvshmem.patch
+    wget https://github.com/vllm-project/vllm/raw/main/tools/ep_kernels/elastic_ep/eep_nvshmem.patch
+    git apply --reject --whitespace=fix eep_nvshmem.patch
+
+    # disable all features except IBGDA
+    export NVSHMEM_IBGDA_SUPPORT=1
+    export NVSHMEM_SHMEM_SUPPORT=0
+    export NVSHMEM_UCX_SUPPORT=0
+    export NVSHMEM_USE_NCCL=0
+    export NVSHMEM_PMIX_SUPPORT=0
+    export NVSHMEM_TIMEOUT_DEVICE_POLLING=0
+    export NVSHMEM_USE_GDRCOPY=0
+    export NVSHMEM_IBRC_SUPPORT=0
+    export NVSHMEM_BUILD_TESTS=0
+    export NVSHMEM_BUILD_EXAMPLES=0
+    export NVSHMEM_MPI_SUPPORT=0
+    export NVSHMEM_BUILD_HYDRA_LAUNCHER=0
+    export NVSHMEM_BUILD_TXZ_PACKAGE=0
+
+    cmake -G Ninja -S . -B nvshmem_build/ -DCMAKE_INSTALL_PREFIX=nvshmem_install
+    cmake --build nvshmem_build/ --target install
+)
+
+# Install PPLX Kernels
+(
+    echo "Installing PPLX Kernels"
+
+    cd "${EP_TEMP_DIR}"
+
+    export CMAKE_PREFIX_PATH=nvshmem_install:$CMAKE_PREFIX_PATH
+
+    # build and install pplx, require pytorch installed
+    git clone https://github.com/ppl-ai/pplx-kernels
+    cd pplx-kernels
+    # see https://github.com/pypa/pip/issues/9955#issuecomment-838065925
+    # PIP_NO_BUILD_ISOLATION=0 disables build isolation
+    PIP_NO_BUILD_ISOLATION=0 TORCH_CUDA_ARCH_LIST=9.0a+PTX pip install . --no-deps -v
+)
 
 EOF
 

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -181,10 +181,11 @@ NVSHMEM_VERSION="3.2.5-1"
     export CMAKE_PREFIX_PATH="${EP_TEMP_DIR}/nvshmem_install"
 
     # build and install pplx, require pytorch installed
+    git clone https://github.com/ppl-ai/pplx-kernels
+    cd pplx-kernels
     # using a specific commit to make the build deterministic:
     # https://github.com/ppl-ai/pplx-kernels/commit/1d76f488d794f01dc0e895cd746b235392379757
-    git clone --branch 1d76f488d794f01dc0e895cd746b235392379757 --single-branch https://github.com/ppl-ai/pplx-kernels
-    cd pplx-kernels
+    git checkout 1d76f488d794f01dc0e895cd746b235392379757
     # see https://github.com/pypa/pip/issues/9955#issuecomment-838065925
     # PIP_NO_BUILD_ISOLATION=0 disables build isolation
     PIP_NO_BUILD_ISOLATION=0 TORCH_CUDA_ARCH_LIST=9.0a+PTX pip install . --no-deps -v

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -36,7 +36,7 @@ $HOME/anaconda3/bin/pip freeze > /home/ray/pip-freeze.txt
 mkdir -p "${ROOT_DIR}"
 
 CUDACXX=$(which nvcc)
-CUDA_HOME=$(dirname $(dirname $CUDACXX))
+CUDA_HOME=$(dirname $(dirname ${CUDACXX}))
 
 TEMP_DIR="nixl_installer"
 mkdir -p "${TEMP_DIR}"
@@ -134,8 +134,8 @@ NVSHMEM_VERSION="3.2.5-1"
 
     cd "${EP_TEMP_DIR}"
     mkdir -p nvshmem_src
-    wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.2.5/source/nvshmem_src_3.2.5-1.txz
-    tar -xvf nvshmem_src_3.2.5-1.txz -C nvshmem_src --strip-components=1
+    wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.2.5/source/nvshmem_src_${NVSHMEM_VERSION}.txz
+    tar -xvf nvshmem_src_${NVSHMEM_VERSION}.txz -C nvshmem_src --strip-components=1
     cd nvshmem_src
     # using a specific commit to make the build deterministic:
     # https://github.com/deepseek-ai/DeepEP/commit/bdd119f8b249953cab366f4d737ad39d4246fd7e
@@ -173,17 +173,18 @@ NVSHMEM_VERSION="3.2.5-1"
     export CMAKE_PREFIX_PATH="${EP_TEMP_DIR}/nvshmem_install"
 
     # build and install pplx, require pytorch installed
-    git clone https://github.com/ppl-ai/pplx-kernels
+    git clone --depth 1 --no-checkout https://github.com/ppl-ai/pplx-kernels
     cd pplx-kernels
     # using a specific commit to make the build deterministic:
     # https://github.com/ppl-ai/pplx-kernels/commit/1d76f488d794f01dc0e895cd746b235392379757
+    git fetch --depth 1 origin 1d76f488d794f01dc0e895cd746b235392379757
     git checkout 1d76f488d794f01dc0e895cd746b235392379757
     # see https://github.com/pypa/pip/issues/9955#issuecomment-838065925
     # PIP_NO_BUILD_ISOLATION=0 disables build isolation
     PIP_NO_BUILD_ISOLATION=0 TORCH_CUDA_ARCH_LIST=9.0a+PTX pip install . --no-deps -v
 )
 
-sudo rm -rf "${EP_TEMP_DIR}"
+rm -rf "${EP_TEMP_DIR}"
 
 EOF
 

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -139,10 +139,18 @@ NVSHMEM_VERSION="3.2.5-1"
     cd nvshmem_src
     # using a specific commit to make the build deterministic:
     # https://github.com/deepseek-ai/DeepEP/commit/bdd119f8b249953cab366f4d737ad39d4246fd7e
-    wget https://github.com/deepseek-ai/DeepEP/raw/bdd119f8b249953cab366f4d737ad39d4246fd7e/third-party/nvshmem.patch
+    for i in {1..5}; do
+        wget https://github.com/deepseek-ai/DeepEP/raw/bdd119f8b249953cab366f4d737ad39d4246fd7e/third-party/nvshmem.patch && break
+        echo "Download failed, retrying in 5 seconds... (attempt $i/5)"
+        sleep 5
+    done
     git init
     git apply -vvv nvshmem.patch
-    wget https://github.com/vllm-project/vllm/raw/releases/v0.10.0/tools/ep_kernels/elastic_ep/eep_nvshmem.patch
+    for i in {1..5}; do
+        wget https://github.com/vllm-project/vllm/raw/releases/v0.10.0/tools/ep_kernels/elastic_ep/eep_nvshmem.patch && break
+        echo "Download failed, retrying in 5 seconds... (attempt $i/5)"
+        sleep 5
+    done
     git apply --reject --whitespace=fix eep_nvshmem.patch
 
     # disable all features except IBGDA

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -139,18 +139,10 @@ NVSHMEM_VERSION="3.2.5-1"
     cd nvshmem_src
     # using a specific commit to make the build deterministic:
     # https://github.com/deepseek-ai/DeepEP/commit/bdd119f8b249953cab366f4d737ad39d4246fd7e
-    for i in {1..5}; do
-        wget https://github.com/deepseek-ai/DeepEP/raw/bdd119f8b249953cab366f4d737ad39d4246fd7e/third-party/nvshmem.patch && break
-        echo "Download failed, retrying in 5 seconds... (attempt $i/5)"
-        sleep 5
-    done
+    wget https://github.com/deepseek-ai/DeepEP/raw/bdd119f8b249953cab366f4d737ad39d4246fd7e/third-party/nvshmem.patch
     git init
     git apply -vvv nvshmem.patch
-    for i in {1..5}; do
-        wget https://github.com/vllm-project/vllm/raw/releases/v0.10.0/tools/ep_kernels/elastic_ep/eep_nvshmem.patch && break
-        echo "Download failed, retrying in 5 seconds... (attempt $i/5)"
-        sleep 5
-    done
+    wget https://github.com/vllm-project/vllm/raw/releases/v0.10.0/tools/ep_kernels/elastic_ep/eep_nvshmem.patch
     git apply --reject --whitespace=fix eep_nvshmem.patch
 
     # disable all features except IBGDA

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -137,7 +137,9 @@ NVSHMEM_VERSION="3.2.5-1"
     wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.2.5/source/nvshmem_src_3.2.5-1.txz
     tar -xvf nvshmem_src_3.2.5-1.txz -C nvshmem_src --strip-components=1
     cd nvshmem_src
-    wget https://github.com/deepseek-ai/DeepEP/raw/main/third-party/nvshmem.patch
+    # using a specific commit to make the build deterministic:
+    # https://github.com/deepseek-ai/DeepEP/commit/bdd119f8b249953cab366f4d737ad39d4246fd7e
+    wget https://github.com/deepseek-ai/DeepEP/raw/bdd119f8b249953cab366f4d737ad39d4246fd7e/third-party/nvshmem.patch
     git init
     git apply -vvv nvshmem.patch
     wget https://github.com/vllm-project/vllm/raw/releases/v0.10.0/tools/ep_kernels/elastic_ep/eep_nvshmem.patch
@@ -171,7 +173,9 @@ NVSHMEM_VERSION="3.2.5-1"
     export CMAKE_PREFIX_PATH="${EP_TEMP_DIR}/nvshmem_install"
 
     # build and install pplx, require pytorch installed
-    git clone https://github.com/ppl-ai/pplx-kernels
+    # using a specific commit to make the build deterministic:
+    # https://github.com/ppl-ai/pplx-kernels/commit/1d76f488d794f01dc0e895cd746b235392379757
+    git clone --branch 1d76f488d794f01dc0e895cd746b235392379757 --single-branch https://github.com/ppl-ai/pplx-kernels
     cd pplx-kernels
     # see https://github.com/pypa/pip/issues/9955#issuecomment-838065925
     # PIP_NO_BUILD_ISOLATION=0 disables build isolation

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -122,7 +122,7 @@ NIXL_VERSION="0.3.1"
 )
 sudo rm -rf "${TEMP_DIR}"
 
-EP_TEMP_DIR="ep_temp_dir"
+EP_TEMP_DIR=$(pwd)/"ep_temp_dir"
 mkdir -p "${EP_TEMP_DIR}"
 
 NVSHMEM_VERSION="3.2.5-1"
@@ -130,17 +130,16 @@ NVSHMEM_VERSION="3.2.5-1"
     echo "Installing NVSHMEM ${NVSHMEM_VERSION}"
 
     # install dependencies if not installed
-    pip3 install cmake torch ninja
+    pip3 install cmake
 
     cd "${EP_TEMP_DIR}"
     mkdir -p nvshmem_src
-    wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.2.5/source/nvshmem_src_3.2.5-1.txz
-    tar -xvf nvshmem_src_3.2.5-1.txz -C nvshmem_src --strip-components=1
+    wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.2.5/source/nvshmem_src_3.2.5-1.txz -O - | tar -xJvf - -C nvshmem_src --strip-components=1
     cd nvshmem_src
     wget https://github.com/deepseek-ai/DeepEP/raw/main/third-party/nvshmem.patch
     git init
     git apply -vvv nvshmem.patch
-    wget https://github.com/vllm-project/vllm/raw/main/tools/ep_kernels/elastic_ep/eep_nvshmem.patch
+    wget https://github.com/vllm-project/vllm/raw/releases/v0.10.0/tools/ep_kernels/elastic_ep/eep_nvshmem.patch
     git apply --reject --whitespace=fix eep_nvshmem.patch
 
     # disable all features except IBGDA
@@ -158,8 +157,8 @@ NVSHMEM_VERSION="3.2.5-1"
     export NVSHMEM_BUILD_HYDRA_LAUNCHER=0
     export NVSHMEM_BUILD_TXZ_PACKAGE=0
 
-    cmake -G Ninja -S . -B nvshmem_build/ -DCMAKE_INSTALL_PREFIX=nvshmem_install
-    cmake --build nvshmem_build/ --target install
+    cmake -G Ninja -S . -B "${EP_TEMP_DIR}/nvshmem_build" -DCMAKE_INSTALL_PREFIX="${EP_TEMP_DIR}/nvshmem_install"
+    cmake --build "${EP_TEMP_DIR}/nvshmem_build" --target install
 )
 
 # Install PPLX Kernels
@@ -168,7 +167,7 @@ NVSHMEM_VERSION="3.2.5-1"
 
     cd "${EP_TEMP_DIR}"
 
-    export CMAKE_PREFIX_PATH=nvshmem_install:$CMAKE_PREFIX_PATH
+    export CMAKE_PREFIX_PATH="${EP_TEMP_DIR}/nvshmem_install"
 
     # build and install pplx, require pytorch installed
     git clone https://github.com/ppl-ai/pplx-kernels
@@ -177,6 +176,8 @@ NVSHMEM_VERSION="3.2.5-1"
     # PIP_NO_BUILD_ISOLATION=0 disables build isolation
     PIP_NO_BUILD_ISOLATION=0 TORCH_CUDA_ARCH_LIST=9.0a+PTX pip install . --no-deps -v
 )
+
+sudo rm -rf "${EP_TEMP_DIR}"
 
 EOF
 

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -134,7 +134,8 @@ NVSHMEM_VERSION="3.2.5-1"
 
     cd "${EP_TEMP_DIR}"
     mkdir -p nvshmem_src
-    wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.2.5/source/nvshmem_src_3.2.5-1.txz -O - | tar -xJvf - -C nvshmem_src --strip-components=1
+    wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.2.5/source/nvshmem_src_3.2.5-1.txz
+    tar -xvf nvshmem_src_3.2.5-1.txz -C nvshmem_src --strip-components=1
     cd nvshmem_src
     wget https://github.com/deepseek-ai/DeepEP/raw/main/third-party/nvshmem.patch
     git init


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Add NVSHMEM and PPLX EP kernel dependencies to ray-llm image. This is needed to enable EP serving.
We will add DeepEP and DeepGEMM deps in future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests: https://buildkite.com/ray-project/release/builds/50627
   - [x] Manual test: `LLM_ALL2ALL_BACKEND=pplx vllm serve Qwen/Qwen3-30B-A3B-FP8` runs OK on 8xH100
   - [ ] This PR is not tested :(
