### PR TITLE
[Core] [Windows] Ray cluster commands (up, attach, status, etc) updates to work on Windows

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -927,10 +927,15 @@ def get_or_create_head_node(
         cli_logger.newline()
 
     # Clean up temporary config file if it was created
-    if not no_monitor_on_head and "remote_config_file" in locals():
+    # Clean up temporary config file if it was created on Windows
+    if (
+        sys.platform == "win32"
+        and not no_monitor_on_head
+        and "remote_config_file" in locals()
+    ):
         try:
             os.remove(remote_config_file.name)
-        except Exception:
+        except OSError:
             pass  # Ignore cleanup errors
 
 
@@ -1032,14 +1037,14 @@ def _set_up_config_for_head_node(
     remote_config = provider.prepare_for_head_node(remote_config)
 
     # Now inject the rewritten config and SSH key into the head node
-    # On Windows, use delete=False because delete=True locks the file
-    # handle which prevents rsync/scp from being able to copy it the head node.
+    is_windows = sys.platform == "win32"
     remote_config_file = tempfile.NamedTemporaryFile(
-        "w", prefix="ray-bootstrap-", delete=False
+        "w", prefix="ray-bootstrap-", delete=not is_windows
     )
     remote_config_file.write(json.dumps(remote_config))
     remote_config_file.flush()
-    remote_config_file.close()  # Close the file handle to ensure it's accessible
+    if is_windows:
+        remote_config_file.close()  # Close the file handle to ensure it's accessible
     config["file_mounts"].update(
         {"~/ray_bootstrap_config.yaml": remote_config_file.name}
     )

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import os
+import sys
 import threading
 from dataclasses import dataclass
 from datetime import datetime
@@ -192,6 +193,12 @@ def validate_config(config: Dict[str, Any]) -> None:
                 "The specified global `max_workers` is smaller than the "
                 "sum of `min_workers` of all the available node types."
             )
+
+    if sys.platform == "win32" and config.get("file_mounts_sync_continuously", False):
+        raise ValueError(
+            "`file_mounts_sync_continuously` is not supported on Windows. "
+            "Please set this to False when running on Windows."
+        )
 
 
 def check_legacy_fields(config: Dict[str, Any]) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Commands like `ray up` do not work from a Windows machine

<!-- Please give a short summary of the change and the problem this solves. -->

This PR fixes a few issues related to provisioning and managers ray clusters from a Windows machine

This PR fixes the following issues:
- Disables SSH control path usage on Windows (which causes socket errors)
- Updates `command_runner.py` to use `scp -r` on windows to copy files from the local machine to head nodes
- Cleans paths on Windows and converts them to Unix-style (uses '/') before running remote commands
- Fixes an issue where temporary config files with exclusive read permissions and could not be accessed by other programs (like scp) 

## For Discussion:

### rsync vs scp

Windows doesn't have a native rsync client but we can get similar functionality by using SCP.
IF we decide to just support SCP I can update the docs and also display a warning/error if `file_mounts_sync_continuously` is set to `True` in the cluster config since SCP won't do continuous file syncing.

Alternatively, we can explore using something like https://github.com/your-tools/rusync if that would be more desirable from project maintainers.

**Outcome**

We have decided to use `scp` and add checks to ensure `file_mounts_sync_continuously` is not set to True on Windows.
`scp` is installed on Windows by default so there is less of the tool no longer becoming maintained in the future and it also requires less setup from users. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
