### PR TITLE
[Data] Prevent negative resource budget when `concurrency` exceeds global limit

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -705,6 +705,11 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             if op.min_max_resource_requirements()[1].gpu > 0:
                 # If an operator needs GPU, we just allocate all GPUs to it.
                 # TODO(hchen): allocate resources across multiple GPU operators.
+
+                # The op_usage can be more than the global limit in the following cases:
+                # 1. The op is setting a minimum concurrency that is larger than
+                #    available num of GPUs.
+                # 2. The cluster scales down, and the global limit decreases.
                 self._op_budgets[op].gpu = max(
                     self._resource_manager.get_global_limits().gpu
                     - self._resource_manager.get_op_usage(op).gpu,

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -705,9 +705,10 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             if op.min_max_resource_requirements()[1].gpu > 0:
                 # If an operator needs GPU, we just allocate all GPUs to it.
                 # TODO(hchen): allocate resources across multiple GPU operators.
-                self._op_budgets[op].gpu = (
+                self._op_budgets[op].gpu = max(
                     self._resource_manager.get_global_limits().gpu
-                    - self._resource_manager.get_op_usage(op).gpu
+                    - self._resource_manager.get_op_usage(op).gpu,
+                    0,
                 )
             else:
                 self._op_budgets[op].gpu = 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If an actor pool operator uses GPUs and concurrency is set higher than the total number of GPUs in the cluster, the resource manager calculates a negative resource budget due to a bug. This PR fixes that issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
