### PR TITLE
[core] Wait to register cgraph writer until node cache is populated

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3353,11 +3353,11 @@ cdef class CoreWorker:
             c_remote_reader_nodes.push_back(CNodeID.FromHex(node_id))
 
         with nogil:
-            check_status(CCoreWorkerProcess.GetCoreWorker()
-                         .ExperimentalRegisterMutableObjectWriter(
-                            c_writer_ref,
-                            c_remote_reader_nodes,
-                        ))
+            CCoreWorkerProcess.GetCoreWorker()
+                .ExperimentalRegisterMutableObjectWriter(
+                    c_writer_ref,
+                    c_remote_reader_nodes,
+                )
             check_status(
                     CCoreWorkerProcess.GetCoreWorker()
                     .ExperimentalRegisterMutableObjectReaderRemote(

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3353,11 +3353,10 @@ cdef class CoreWorker:
             c_remote_reader_nodes.push_back(CNodeID.FromHex(node_id))
 
         with nogil:
-            CCoreWorkerProcess.GetCoreWorker()
-                .ExperimentalRegisterMutableObjectWriter(
+            CCoreWorkerProcess.GetCoreWorker().ExperimentalRegisterMutableObjectWriter(
                     c_writer_ref,
                     c_remote_reader_nodes,
-                )
+            )
             check_status(
                     CCoreWorkerProcess.GetCoreWorker()
                     .ExperimentalRegisterMutableObjectReaderRemote(

--- a/python/ray/dag/tests/experimental/test_compiled_graphs.py
+++ b/python/ray/dag/tests/experimental/test_compiled_graphs.py
@@ -75,10 +75,10 @@ def test_two_returns_one_reader(ray_start_regular, single_fetch):
     a = Actor.remote(0)
     b = Actor.remote(0)
     with InputNode() as i:
-        o1, o2 = a.return_two.bind(i)
-        o3 = b.echo.bind(o1)
-        o4 = b.echo.bind(o2)
-        dag = MultiOutputNode([o3, o4])
+        out_1, out_2 = a.return_two.bind(i)
+        out_3 = b.echo.bind(out_1)
+        out_4 = b.echo.bind(out_2)
+        dag = MultiOutputNode([out_3, out_4])
 
     compiled_dag = dag.experimental_compile()
     for _ in range(3):

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -278,7 +278,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                                   const CObjectID &object_id)
         CRayStatus ExperimentalChannelSetError(
                                   const CObjectID &object_id)
-        CRayStatus ExperimentalRegisterMutableObjectWriter(
+        void ExperimentalRegisterMutableObjectWriter(
                 const CObjectID &writer_object_id,
                 const c_vector[CNodeID] &remote_reader_node_ids)
         CRayStatus ExperimentalRegisterMutableObjectReader(const CObjectID &object_id)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -358,6 +358,35 @@ CoreWorker::CoreWorker(
 
   RegisterToGcs(options_.worker_launch_time_ms, options_.worker_launched_time_ms);
 
+  // Register a callback to monitor add/removed nodes.
+  // Note we capture a shared ownership of reference_counter_ and rate_limiter
+  // here to avoid destruction order fiasco between gcs_client and reference_counter_.
+  auto on_node_change = [temp_reference_counter = reference_counter_,
+                         temp_rate_limiter = lease_request_rate_limiter_](
+                            const NodeID &node_id, const rpc::GcsNodeInfo &data) {
+    if (data.state() == rpc::GcsNodeInfo::DEAD) {
+      RAY_LOG(INFO).WithField(node_id)
+          << "Node failure. All objects pinned on that node will be lost if object "
+             "reconstruction is not enabled.";
+      temp_reference_counter->ResetObjectsOnRemovedNode(node_id);
+    }
+    auto cluster_size_based_rate_limiter =
+        dynamic_cast<ClusterSizeBasedLeaseRequestRateLimiter *>(temp_rate_limiter.get());
+    if (cluster_size_based_rate_limiter != nullptr) {
+      cluster_size_based_rate_limiter->OnNodeChanges(data);
+    }
+  };
+  gcs_client->Nodes().AsyncSubscribeToNodeChange(std::move(on_node_change), nullptr);
+
+  gcs_client_->Nodes().AsyncSubscribeToNodeChange(
+      std::move(on_node_change), [this](const Status &) {
+        {
+          std::scoped_lock<std::mutex> lock(gcs_client_node_cache_populated_mutex_);
+          gcs_client_node_cache_populated_ = true;
+        }
+        gcs_client_node_cache_populated_cv_.notify_all();
+      });
+
   // Create an entry for the driver task in the task table. This task is
   // added immediately with status RUNNING. This allows us to push errors
   // related to this driver task back to the driver. For example, if the
@@ -1243,11 +1272,15 @@ Status CoreWorker::SealExisting(const ObjectID &object_id,
   return Status::OK();
 }
 
-Status CoreWorker::ExperimentalRegisterMutableObjectWriter(
+void CoreWorker::ExperimentalRegisterMutableObjectWriter(
     const ObjectID &writer_object_id, const std::vector<NodeID> &remote_reader_node_ids) {
+  std::unique_lock<std::mutex> lock(gcs_client_node_cache_populated_mutex_);
+  if (!gcs_client_node_cache_populated_) {
+    gcs_client_node_cache_populated_cv_.wait(
+        lock, [this]() { return gcs_client_node_cache_populated_; });
+  }
   experimental_mutable_object_provider_->RegisterWriterChannel(writer_object_id,
                                                                remote_reader_node_ids);
-  return Status::OK();
 }
 
 Status CoreWorker::ExperimentalRegisterMutableObjectReaderRemote(

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -376,7 +376,6 @@ CoreWorker::CoreWorker(
       cluster_size_based_rate_limiter->OnNodeChanges(data);
     }
   };
-  gcs_client->Nodes().AsyncSubscribeToNodeChange(std::move(on_node_change), nullptr);
 
   gcs_client_->Nodes().AsyncSubscribeToNodeChange(
       std::move(on_node_change), [this](const Status &) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1274,10 +1274,12 @@ Status CoreWorker::SealExisting(const ObjectID &object_id,
 
 void CoreWorker::ExperimentalRegisterMutableObjectWriter(
     const ObjectID &writer_object_id, const std::vector<NodeID> &remote_reader_node_ids) {
-  std::unique_lock<std::mutex> lock(gcs_client_node_cache_populated_mutex_);
-  if (!gcs_client_node_cache_populated_) {
-    gcs_client_node_cache_populated_cv_.wait(
-        lock, [this]() { return gcs_client_node_cache_populated_; });
+  {
+    std::unique_lock<std::mutex> lock(gcs_client_node_cache_populated_mutex_);
+    if (!gcs_client_node_cache_populated_) {
+      gcs_client_node_cache_populated_cv_.wait(
+          lock, [this]() { return gcs_client_node_cache_populated_; });
+    }
   }
   experimental_mutable_object_provider_->RegisterWriterChannel(writer_object_id,
                                                                remote_reader_node_ids);

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -625,7 +625,7 @@ class CoreWorker {
   ///
   /// \param[in] writer_object_id The ID of the object.
   /// \param[in] remote_reader_node_ids The list of remote reader's node ids.
-  Status ExperimentalRegisterMutableObjectWriter(
+  void ExperimentalRegisterMutableObjectWriter(
       const ObjectID &writer_object_id,
       const std::vector<NodeID> &remote_reader_node_ids);
 
@@ -1926,6 +1926,11 @@ class CoreWorker {
   /// Maps serialized runtime env info to **immutable** deserialized protobuf.
   mutable utils::container::ThreadSafeSharedLruCache<std::string, rpc::RuntimeEnvInfo>
       runtime_env_json_serialization_cache_;
+
+  /// Used to block in certain spots if the GCS node cache is needed.
+  std::mutex gcs_client_node_cache_populated_mutex_;
+  std::condition_variable gcs_client_node_cache_populated_cv_;
+  bool gcs_client_node_cache_populated_ = false;
 };
 
 // Lease request rate-limiter based on cluster node size.


### PR DESCRIPTION
## Why are these changes needed?
When a writer is registered for compiled graphs it needs the addresses of other raylets. If the node subscription cache isn't populated at the time we try to get the addresses the following ray check will likely fail.
https://github.com/ray-project/ray/blob/c041e834490f940621585a25f405e8e889b4c6f0/src/ray/core_worker/core_worker.cc#L608-L611

This is where it's used inside RegisterWriterChannel. So in this pr, we're blocking the registering of the writer channel to wait on the GCS node subscription cache population.
https://github.com/ray-project/ray/blob/c041e834490f940621585a25f405e8e889b4c6f0/src/ray/core_worker/experimental_mutable_object_provider.cc#L77-L78

For context, the `done` callback in `AsyncSubscribeToNodeChange` is called once the initial GetAllNodeInfo request response is processed.

This becomes a bigger problem once we start having workers lazy subscribe to node changes.
https://github.com/ray-project/ray/pull/54220


Also `ExperimentalRegisterMutableObjectWriter` was returning a status, but it would just always be Status::OK so updating that.