### PR TITLE
[serve.llm] Allow setting `num_gpu < 1` in `LLMConfig.resources_per_bundle`

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -273,7 +273,7 @@ class VLLMEngine(LLMEngine):
             ref = (
                 ray.remote(
                     num_cpus=0,
-                    num_gpus=1,
+                    num_gpus=0.001,
                     accelerator_type=self.llm_config.accelerator_type,
                 )(_get_vllm_engine_config)
                 .options(

--- a/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
+++ b/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
@@ -89,6 +89,7 @@ async def initialize_node(llm_config: LLMConfig) -> InitializeNodeOutput:
     extra_init_kwargs = {}
 
     engine_config = llm_config.get_engine_config()
+    assert engine_config is not None
     pg = engine_config.get_or_create_pg()
     runtime_env = engine_config.get_runtime_env_with_local_env_vars()
 

--- a/python/ray/llm/tests/serve/gpu/deployments/llm/vllm/test_vllm_engine_gpu.py
+++ b/python/ray/llm/tests/serve/gpu/deployments/llm/vllm/test_vllm_engine_gpu.py
@@ -1,15 +1,13 @@
-
-import asyncio
 import pytest
 
-from ray.serve.llm import LLMConfig, ModelLoadingConfig
 from ray.llm._internal.serve.deployments.llm.vllm.vllm_engine import VLLMEngine
+from ray.serve.llm import LLMConfig, ModelLoadingConfig
 
 
 @pytest.mark.asyncio
 async def test_vllm_engine_start_with_custom_resource_bundle(
     # defined in conftest.py
-    model_smolvlm_256m
+    model_smolvlm_256m,
 ):
     """vLLM engine starts with custom resource bundle."""
     llm_config = LLMConfig(

--- a/python/ray/llm/tests/serve/gpu/deployments/llm/vllm/test_vllm_engine_gpu.py
+++ b/python/ray/llm/tests/serve/gpu/deployments/llm/vllm/test_vllm_engine_gpu.py
@@ -7,11 +7,11 @@ from ray.llm._internal.serve.deployments.llm.vllm.vllm_engine import VLLMEngine
 
 
 @pytest.mark.asyncio
-def test_vllm_engine_start_with_custom_resource_bundle(
+async def test_vllm_engine_start_with_custom_resource_bundle(
     # defined in conftest.py
     model_smolvlm_256m
 ):
-    """Test vLLM engine start with custom resource bundle."""
+    """vLLM engine starts with custom resource bundle."""
     llm_config = LLMConfig(
         model_loading_config=ModelLoadingConfig(
             model_id="smolvlm-256m",
@@ -32,6 +32,6 @@ def test_vllm_engine_start_with_custom_resource_bundle(
     )
 
     engine = VLLMEngine(llm_config)
-    asyncio.run(engine.start())
-    asyncio.run(engine.check_health())
+    await engine.start()
+    await engine.check_health()
     engine.shutdown()

--- a/python/ray/llm/tests/serve/gpu/deployments/llm/vllm/test_vllm_engine_gpu.py
+++ b/python/ray/llm/tests/serve/gpu/deployments/llm/vllm/test_vllm_engine_gpu.py
@@ -1,0 +1,37 @@
+
+import asyncio
+import pytest
+
+from ray.serve.llm import LLMConfig, ModelLoadingConfig
+from ray.llm._internal.serve.deployments.llm.vllm.vllm_engine import VLLMEngine
+
+
+@pytest.mark.asyncio
+def test_vllm_engine_start_with_custom_resource_bundle(
+    # defined in conftest.py
+    model_smolvlm_256m
+):
+    """Test vLLM engine start with custom resource bundle."""
+    llm_config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(
+            model_id="smolvlm-256m",
+            model_source=model_smolvlm_256m,
+        ),
+        engine_kwargs=dict(
+            gpu_memory_utilization=0.4,
+            use_tqdm_on_load=False,
+            enforce_eager=True,
+        ),
+        resources_per_bundle=dict(GPU=0.49),
+        runtime_env=dict(
+            env_vars={
+                "VLLM_RAY_PER_WORKER_GPUS": "0.49",
+                "VLLM_DISABLE_COMPILE_CACHE": "1",
+            },
+        ),
+    )
+
+    engine = VLLMEngine(llm_config)
+    asyncio.run(engine.start())
+    asyncio.run(engine.check_health())
+    engine.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is documented feature to allow custom `resources_per_bundle`. We used to set `num_gpus=1` which might raise exception if user provide `GPU < 1` in the config.

`num_gpus < 1` can be useful if we want to use only partial of the GPU

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
