### PR TITLE
[KubeRay] Add instructions to run distributed Ray Debugger in KubeRay by Code Server

### DIFF
--- a/doc/source/ray-observability/ray-distributed-debugger.rst
+++ b/doc/source/ray-observability/ray-distributed-debugger.rst
@@ -81,31 +81,35 @@ Start a Ray cluster
 
     Follow the instructions in :doc:`the RayCluster quickstart <../cluster/kubernetes/getting-started/raycluster-quick-start>` to set up a cluster.
     
-    A simpler approach is to run a browser-based VSCode (Code Server) as a sidecar container in the Ray head pod. This eliminates network connectivity issues by placing VS Code inside the kubernetes cluster.
+    A simpler approach is to run a browser-based VS Code (Code Server) as a sidecar container in the Ray head pod. This eliminates network connectivity issues by placing VS Code inside the Kubernetes cluster.
 
-    Add the following to your Ray head pod configuration:
-
+    Add a sidecar container to the Ray head pod and configure a shared volume. Modify your Ray head pod template with the following additions:
+    
     .. code-block:: yaml
 
+        # In your RayCluster YAML, under spec.headGroupSpec.template.spec
         containers:
-        - name: ray-head
-          # ... existing ray-head configuration ...
-          volumeMounts:
-            - mountPath: /tmp/ray
-              name: shared-ray-volume
-        - name: vscode-debugger
-          image: docker.io/onesizefitsquorum/code-server-with-ray-distributed-debugger:latest
-          ports:
-            - containerPort: 8443
-          volumeMounts:
-            - mountPath: /tmp/ray
-              name: shared-ray-volume
-          env:
-            - name: DEFAULT_WORKSPACE
-              value: "/tmp/ray/session_latest/runtime_resources"
+          - name: ray-head
+            # ... your existing ray-head configuration ...
+            # Add this volumeMount:
+            volumeMounts:
+              - mountPath: /tmp/ray
+                name: shared-ray-volume
+          # Add this sidecar container:
+          - name: vscode-debugger
+            image: docker.io/onesizefitsquorum/code-server-with-ray-distributed-debugger:4.101.2
+            ports:
+              - containerPort: 8443
+            volumeMounts:
+              - mountPath: /tmp/ray
+                name: shared-ray-volume
+            env:
+              - name: DEFAULT_WORKSPACE
+                value: "/tmp/ray/session_latest/runtime_resources"
+        # Add this volume at the same level as `containers`:
         volumes:
-        - name: shared-ray-volume
-          emptyDir: {}
+          - name: shared-ray-volume
+            emptyDir: {}
 
     After the Ray cluster is running, forward the Code Server port:
 

--- a/doc/source/ray-observability/ray-distributed-debugger.rst
+++ b/doc/source/ray-observability/ray-distributed-debugger.rst
@@ -77,7 +77,7 @@ Start a Ray cluster
     After checking that `ssh -p 2222 ray@localhost` works, set up VS Code as described in the
     `VS Code SSH documentation <https://code.visualstudio.com/docs/remote/ssh>`_.
 
-  .. tab-item:: KubeRay (Code Server)
+  .. tab-item:: KubeRay (Code Server, Community Maintained)
 
     Follow the instructions in :doc:`the RayCluster quickstart <../cluster/kubernetes/getting-started/raycluster-quick-start>` to set up a cluster.
     
@@ -104,6 +104,7 @@ Start a Ray cluster
               - mountPath: /tmp/ray
                 name: shared-ray-volume
             env:
+              # Specifies the default directory that opens when VSCode Web starts, pointing to the workspace containing the Ray runtime resources.
               - name: DEFAULT_WORKSPACE
                 value: "/tmp/ray/session_latest/runtime_resources"
         # Add this volume at the same level as `containers`:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We found a method to use Ray Distributed Debugger in the Kuberay environment. This solution uses Code Server as an intermediate layer to solve connection problems caused by Kubernetes network isolation.

## Related issue number

Closes https://github.com/ray-project/ray/issues/45541

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
