### PR TITLE
[core][oneevent/1bis] rename 'Event' to 'RayEvent' across gcs server

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -735,7 +735,7 @@ void GcsServer::InitGcsTaskManager() {
   rpc_server_.RegisterService(
       std::make_unique<rpc::TaskInfoGrpcService>(io_context, *gcs_task_manager_));
   rpc_server_.RegisterService(
-      std::make_unique<rpc::EventExportGrpcService>(io_context, *gcs_task_manager_));
+      std::make_unique<rpc::RayEventExportGrpcService>(io_context, *gcs_task_manager_));
 }
 
 void GcsServer::InstallEventListeners() {

--- a/src/ray/gcs/gcs_server/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.h
@@ -91,7 +91,7 @@ class FinishedTaskActorTaskGcPolicy : public TaskEventsGcPolicyInterface {
 ///
 /// This class has its own io_context and io_thread, that's separate from other GCS
 /// services. All handling of all rpc should be posted to the single thread it owns.
-class GcsTaskManager : public rpc::TaskInfoHandler, public rpc::EventExportHandler {
+class GcsTaskManager : public rpc::TaskInfoHandler, public rpc::RayEventExportHandler {
  public:
   /// Create a GcsTaskManager.
   explicit GcsTaskManager(instrumented_io_context &io_service);

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -867,7 +867,7 @@ service TaskInfoGcsService {
 }
 
 // Service for recording the unified ray events.
-service EventExportGcsService {
+service RayEventExportGcsService {
   // Add OneEvent task data to GCS.
   rpc AddEvent(events.AddEventRequest) returns (events.AddEventReply);
 }

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -177,8 +177,9 @@ class GcsRpcClient {
         channel_, client_call_manager);
     task_info_grpc_client_ =
         std::make_shared<GrpcClient<TaskInfoGcsService>>(channel_, client_call_manager);
-    event_export_grpc_client_ = std::make_shared<GrpcClient<EventExportGcsService>>(
-        channel_, client_call_manager);
+    ray_event_export_grpc_client_ =
+        std::make_shared<GrpcClient<RayEventExportGcsService>>(channel_,
+                                                               client_call_manager);
     autoscaler_state_grpc_client_ =
         std::make_shared<GrpcClient<autoscaler::AutoscalerStateService>>(
             channel_, client_call_manager);
@@ -396,9 +397,9 @@ class GcsRpcClient {
   /// Add one event data to GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc,
                                   ray::rpc::events,
-                                  EventExportGcsService,
+                                  RayEventExportGcsService,
                                   AddEvent,
-                                  event_export_grpc_client_,
+                                  ray_event_export_grpc_client_,
                                   /*method_timeout_ms*/ -1,
                                   /*handle_payload_status=*/true, )
 
@@ -603,7 +604,7 @@ class GcsRpcClient {
   std::shared_ptr<GrpcClient<InternalKVGcsService>> internal_kv_grpc_client_;
   std::shared_ptr<GrpcClient<InternalPubSubGcsService>> internal_pubsub_grpc_client_;
   std::shared_ptr<GrpcClient<TaskInfoGcsService>> task_info_grpc_client_;
-  std::shared_ptr<GrpcClient<EventExportGcsService>> event_export_grpc_client_;
+  std::shared_ptr<GrpcClient<RayEventExportGcsService>> ray_event_export_grpc_client_;
   std::shared_ptr<GrpcClient<RuntimeEnvGcsService>> runtime_env_grpc_client_;
   std::shared_ptr<GrpcClient<autoscaler::AutoscalerStateService>>
       autoscaler_state_grpc_client_;

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -132,9 +132,9 @@ namespace rpc {
                       HANDLER,                 \
                       RayConfig::instance().gcs_max_active_rpcs_per_handler())
 
-#define EVENT_EXPORT_SERVICE_RPC_HANDLER(HANDLER) \
-  RPC_SERVICE_HANDLER(EventExportGcsService,      \
-                      HANDLER,                    \
+#define RAY_EVENT_EXPORT_SERVICE_RPC_HANDLER(HANDLER) \
+  RPC_SERVICE_HANDLER(RayEventExportGcsService,       \
+                      HANDLER,                        \
                       RayConfig::instance().gcs_max_active_rpcs_per_handler())
 
 #define NODE_RESOURCE_INFO_SERVICE_RPC_HANDLER(HANDLER) \
@@ -690,19 +690,19 @@ class TaskInfoGrpcService : public GrpcService {
   TaskInfoGcsServiceHandler &service_handler_;
 };
 
-class EventExportGcsServiceHandler {
+class RayEventExportGcsServiceHandler {
  public:
-  virtual ~EventExportGcsServiceHandler() = default;
+  virtual ~RayEventExportGcsServiceHandler() = default;
   virtual void HandleAddEvent(AddEventRequest request,
                               AddEventReply *reply,
                               SendReplyCallback send_reply_callback) = 0;
 };
 
-/// The `GrpcService` for `EventExportGcsService`.
-class EventExportGrpcService : public GrpcService {
+/// The `GrpcService` for `RayEventExportGcsService`.
+class RayEventExportGrpcService : public GrpcService {
  public:
-  explicit EventExportGrpcService(instrumented_io_context &io_service,
-                                  EventExportGcsServiceHandler &handler)
+  explicit RayEventExportGrpcService(instrumented_io_context &io_service,
+                                     RayEventExportGcsServiceHandler &handler)
       : GrpcService(io_service), service_handler_(handler) {}
 
  protected:
@@ -711,14 +711,14 @@ class EventExportGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
       const ClusterID &cluster_id) override {
-    EVENT_EXPORT_SERVICE_RPC_HANDLER(AddEvent);
+    RAY_EVENT_EXPORT_SERVICE_RPC_HANDLER(AddEvent);
   }
 
  private:
   /// The grpc async service object.
-  EventExportGcsService::AsyncService service_;
+  RayEventExportGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  EventExportGcsServiceHandler &service_handler_;
+  RayEventExportGcsServiceHandler &service_handler_;
 };
 
 class InternalPubSubGcsServiceHandler {
@@ -775,7 +775,7 @@ using InternalKVHandler = InternalKVGcsServiceHandler;
 using InternalPubSubHandler = InternalPubSubGcsServiceHandler;
 using RuntimeEnvHandler = RuntimeEnvGcsServiceHandler;
 using TaskInfoHandler = TaskInfoGcsServiceHandler;
-using EventExportHandler = EventExportGcsServiceHandler;
+using RayEventExportHandler = RayEventExportGcsServiceHandler;
 
 }  // namespace rpc
 }  // namespace ray


### PR DESCRIPTION
Prefix the GCS grpc endpoint/server with `RayEvent`, as requested by @MengjinYan. This prefix will also give us a convenient way to code-name the whole stack (instead of just using a broad word event).

Test:
- CI