### PR TITLE
introduce same event loop router in serve

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -75,7 +75,6 @@ steps:
         --except-tags post_wheel_build,gpu,ha_integration,serve_tracing
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name servebuild --test-env=EXPECTED_PYTHON_VERSION=3.9 --test-env=RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD=0
-        --test-env=RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP=0
     depends_on: "servebuild"
 
   - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -75,6 +75,7 @@ steps:
         --except-tags post_wheel_build,gpu,ha_integration,serve_tracing
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name servebuild --test-env=EXPECTED_PYTHON_VERSION=3.9 --test-env=RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD=0
+        --test-env=RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP=0
     depends_on: "servebuild"
 
   - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -80,14 +80,16 @@ class ServeControllerClient:
     def __reduce__(self):
         raise RayServeException(("Ray Serve client cannot be serialized."))
 
-    def shutdown_cached_handles(self):
+    def shutdown_cached_handles(self, _skip_asyncio_check: bool = False):
         """Shuts down all cached handles.
 
         Remove the reference to the cached handles so that they can be
         garbage collected.
         """
         for cache_key in list(self.handle_cache):
-            self.handle_cache[cache_key].shutdown()
+            self.handle_cache[cache_key].shutdown(
+                _skip_asyncio_check=_skip_asyncio_check
+            )
             del self.handle_cache[cache_key]
 
     def shutdown(self, timeout_s: float = 30.0) -> None:

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -471,6 +471,13 @@ RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD = (
     os.environ.get("RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD", "1") == "1"
 )
 
+# By default, we run the router in a separate event loop.
+# This flag can be set to 0 to run the router in the same event loop as the
+# replica's main event loop.
+RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP = (
+    os.environ.get("RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP", "1") == "1"
+)
+
 # The default buffer size for request path logs. Setting to 1 will ensure
 # logs are flushed to file handler immediately, otherwise it will be buffered
 # and flushed to file handler when the buffer is full or when there is a log

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -170,7 +170,7 @@ def create_router(
         except RuntimeError:
             raise RuntimeError(
                 "No event loop running. You cannot use a handle initialized with "
-                "`_run_router_in_separate_loop=True` when not inside an asyncio event "
+                "`_run_router_in_separate_loop=False` when not inside an asyncio event "
                 "loop."
             )
 

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -150,6 +150,10 @@ def create_router(
     handle_options: InitHandleOptions,
     request_router_class: Optional[Callable] = None,
 ) -> Router:
+    import asyncio
+
+    from ray.serve._private.router import CurrentLoopRouter
+
     # NOTE(edoakes): this is lazy due to a nasty circular import that should be fixed.
     from ray.serve.context import _get_global_client
 
@@ -158,7 +162,21 @@ def create_router(
     controller_handle = _get_global_client()._controller
     is_inside_ray_client_context = inside_ray_client_context()
 
-    return SingletonThreadRouter(
+    if handle_options._run_router_in_separate_loop:
+        router_wrapper_cls = SingletonThreadRouter
+    else:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            raise RuntimeError(
+                "No event loop running. You cannot use a handle initialized with "
+                "`_run_router_in_separate_loop=True` when not inside an asyncio event "
+                "loop."
+            )
+
+        router_wrapper_cls = CurrentLoopRouter
+
+    return router_wrapper_cls(
         controller_handle=controller_handle,
         deployment_id=deployment_id,
         handle_id=handle_id,
@@ -182,6 +200,7 @@ def add_grpc_address(grpc_server: gRPCGenericServer, server_address: str):
 def get_proxy_handle(endpoint: DeploymentID, info: EndpointInfo):
     # NOTE(zcin): needs to be lazy import due to a circular dependency.
     # We should not be importing from application_state in context.
+    from ray.serve._private.constants import RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP
     from ray.serve.context import _get_global_client
 
     client = _get_global_client()
@@ -197,6 +216,7 @@ def get_proxy_handle(endpoint: DeploymentID, info: EndpointInfo):
         handle._init(
             _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
             _source=DeploymentHandleSource.PROXY,
+            _run_router_in_separate_loop=RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
         )
 
     return handle.options(stream=not info.app_is_cross_language)

--- a/python/ray/serve/_private/handle_options.py
+++ b/python/ray/serve/_private/handle_options.py
@@ -17,6 +17,7 @@ class InitHandleOptionsBase(ABC):
 
     _prefer_local_routing: bool = False
     _source: DeploymentHandleSource = DeploymentHandleSource.UNKNOWN
+    _run_router_in_separate_loop: bool = RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP
 
     @classmethod
     @abstractmethod
@@ -26,8 +27,6 @@ class InitHandleOptionsBase(ABC):
 
 @dataclass(frozen=True)
 class InitHandleOptions(InitHandleOptionsBase):
-    _run_router_in_separate_loop: bool = RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP
-
     @classmethod
     def create(cls, **kwargs) -> "InitHandleOptions":
         for k in list(kwargs.keys()):

--- a/python/ray/serve/_private/handle_options.py
+++ b/python/ray/serve/_private/handle_options.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, fields
 
 import ray
 from ray.serve._private.common import DeploymentHandleSource
+from ray.serve._private.constants import RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP
 from ray.serve._private.utils import DEFAULT
 
 
@@ -25,6 +26,8 @@ class InitHandleOptionsBase(ABC):
 
 @dataclass(frozen=True)
 class InitHandleOptions(InitHandleOptionsBase):
+    _run_router_in_separate_loop: bool = RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP
+
     @classmethod
     def create(cls, **kwargs) -> "InitHandleOptions":
         for k in list(kwargs.keys()):

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -954,3 +954,40 @@ class SharedRouterLongPollClient:
             for deployment_id in self.routers.keys()
         }
         self.long_poll_client.add_key_listeners(key_listeners)
+
+
+class CurrentLoopRouter(Router):
+    """Wrapper class that runs an AsyncioRouter on the current asyncio loop.
+    Note that this class is NOT THREAD-SAFE, and all methods are expected to be
+    invoked from a single asyncio event loop.
+    """
+
+    def __init__(self, **passthrough_kwargs):
+        assert (
+            "event_loop" not in passthrough_kwargs
+        ), "CurrentLoopRouter uses the current event loop."
+
+        self._asyncio_loop = asyncio.get_running_loop()
+        self._asyncio_router = AsyncioRouter(
+            event_loop=self._asyncio_loop,
+            _request_router_initialized_event=asyncio.Event(),
+            **passthrough_kwargs,
+        )
+
+    def running_replicas_populated(self) -> bool:
+        return self._asyncio_router.running_replicas_populated()
+
+    def assign_request(
+        self,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> asyncio.Future[ReplicaResult]:
+        return self._asyncio_loop.create_task(
+            self._asyncio_router.assign_request(
+                request_meta, *request_args, **request_kwargs
+            ),
+        )
+
+    def shutdown(self) -> asyncio.Future:
+        return self._asyncio_loop.create_task(self._asyncio_router.shutdown())

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -278,20 +278,20 @@ class _DeploymentResponseBase:
         """
 
         if self._replica_result is None:
-            if self._is_router_running_in_separate_loop:
-                try:
-                    self._replica_result = self._replica_result_future.result(
-                        timeout=_timeout_s
-                    )
-                except concurrent.futures.TimeoutError:
-                    raise TimeoutError("Timed out resolving to ObjectRef.") from None
-                except concurrent.futures.CancelledError:
-                    raise RequestCancelledError(self.request_id) from None
-            else:
+            if not self._is_router_running_in_separate_loop:
                 raise RuntimeError(
                     "Sync methods should not be called from within an `asyncio` event "
                     "loop. Use `await response` instead."
                 )
+            try:
+                self._replica_result = self._replica_result_future.result(
+                    timeout=_timeout_s
+                )
+
+            except concurrent.futures.TimeoutError:
+                raise TimeoutError("Timed out resolving to ObjectRef.") from None
+            except concurrent.futures.CancelledError:
+                raise RequestCancelledError(self.request_id) from None
 
         return self._replica_result
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -157,6 +157,9 @@ class _DeploymentHandleBase:
         ):
             ServeUsageTag.DEPLOYMENT_HANDLE_API_USED.record("1")
 
+    def _is_router_running_in_separate_loop(self) -> bool:
+        return self.init_options._run_router_in_separate_loop
+
     def _options(self, _prefer_local_routing=DEFAULT.VALUE, **kwargs):
         if kwargs.get("stream") is True and inside_ray_client_context():
             raise RuntimeError(
@@ -215,8 +218,13 @@ class _DeploymentHandleBase:
 
     async def shutdown_async(self):
         if self._router:
-            shutdown_future = self._router.shutdown()
-            await asyncio.wrap_future(shutdown_future)
+            shutdown_future: Union[
+                asyncio.Future, concurrent.futures.Future
+            ] = self._router.shutdown()
+            if self._is_router_running_in_separate_loop:
+                await asyncio.wrap_future(shutdown_future)
+            else:
+                await shutdown_future
 
     def __repr__(self):
         return f"{self.__class__.__name__}" f"(deployment='{self.deployment_name}')"
@@ -238,13 +246,17 @@ class _DeploymentHandleBase:
 class _DeploymentResponseBase:
     def __init__(
         self,
-        replica_result_future: concurrent.futures.Future[ReplicaResult],
+        replica_result_future: Union[
+            concurrent.futures.Future[ReplicaResult], asyncio.Future[ReplicaResult]
+        ],
         request_metadata: RequestMetadata,
+        _is_router_running_in_separate_loop: bool = True,
     ):
         self._cancelled = False
         self._replica_result_future = replica_result_future
         self._replica_result: Optional[ReplicaResult] = None
         self._request_metadata: RequestMetadata = request_metadata
+        self._is_router_running_in_separate_loop = _is_router_running_in_separate_loop
 
     @property
     def request_id(self) -> str:
@@ -259,14 +271,20 @@ class _DeploymentResponseBase:
         """
 
         if self._replica_result is None:
-            try:
-                self._replica_result = self._replica_result_future.result(
-                    timeout=_timeout_s
+            if self._is_router_running_in_separate_loop:
+                try:
+                    self._replica_result = self._replica_result_future.result(
+                        timeout=_timeout_s
+                    )
+                except concurrent.futures.TimeoutError:
+                    raise TimeoutError("Timed out resolving to ObjectRef.") from None
+                except concurrent.futures.CancelledError:
+                    raise RequestCancelledError(self.request_id) from None
+            else:
+                raise RuntimeError(
+                    "Sync methods should not be called from within an `asyncio` event "
+                    "loop. Use `await response` instead."
                 )
-            except concurrent.futures.TimeoutError:
-                raise TimeoutError("Timed out resolving to ObjectRef.") from None
-            except concurrent.futures.CancelledError:
-                raise RequestCancelledError(self.request_id) from None
 
         return self._replica_result
 
@@ -277,11 +295,16 @@ class _DeploymentResponseBase:
         """
 
         if self._replica_result is None:
-            # Use `asyncio.wrap_future` so `self._replica_result_future` can be awaited
-            # safely from any asyncio loop.
-            self._replica_result = await asyncio.wrap_future(
-                self._replica_result_future
-            )
+            if self._is_router_running_in_separate_loop:
+                # Use `asyncio.wrap_future` so `self._replica_result_future` can be awaited
+                # safely from any asyncio loop.
+                # self._replica_result_future is a object of type concurrent.futures.Future
+                self._replica_result = await asyncio.wrap_future(
+                    self._replica_result_future
+                )
+            else:
+                # self._replica_result_future is a object of type asyncio.Future
+                self._replica_result = await self._replica_result_future
 
         return self._replica_result
 
@@ -310,6 +333,12 @@ class _DeploymentResponseBase:
 
         self._cancelled = True
         self._replica_result_future.cancel()
+        if not self._is_router_running_in_separate_loop:
+            # Given that there is a event loop running, we can't call sync methods.
+            # Hence optimistically cancel the replica result future and replica result.
+            if self._replica_result:
+                self._replica_result.cancel()
+            return
         try:
             # try to fetch the results synchronously. if it succeeds,
             # we will explicitly cancel the replica result. if it fails,
@@ -749,4 +778,8 @@ class DeploymentHandle(_DeploymentHandleBase):
         else:
             response_cls = DeploymentResponse
 
-        return response_cls(future, request_metadata)
+        return response_cls(
+            future,
+            request_metadata,
+            _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+        )

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -211,10 +211,17 @@ class _DeploymentHandleBase:
     def __getattr__(self, name):
         return self.options(method_name=name)
 
-    def shutdown(self):
+    def shutdown(self, _skip_asyncio_check: bool = False):
         if self._router:
             shutdown_future = self._router.shutdown()
-            shutdown_future.result()
+            if self._is_router_running_in_separate_loop():
+                shutdown_future.result()
+            else:
+                if not _skip_asyncio_check:
+                    raise RuntimeError(
+                        "Sync methods should not be called from within an `asyncio` event "
+                        "loop. Use `await handle.shutdown_async()` instead."
+                    )
 
     async def shutdown_async(self):
         if self._router:

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -445,7 +445,7 @@ py_test_module_list(
 )
 
 py_test_module_list(
-    size = "small",
+    size = "medium",
     env = {"RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP": "0"},
     files = [
         "test_handle_same_loop.py",

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -443,3 +443,22 @@ py_test_module_list(
         "//python/ray/serve:serve_lib",
     ],
 )
+
+py_test_module_list(
+    size = "small",
+    env = {"RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP": "0"},
+    files = [
+        "test_handle_same_loop.py",
+    ],
+    name_suffix = "_with_router_in_same_loop",
+    tags = [
+        "exclusive",
+        "no_windows",
+        "team:serve",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -449,6 +449,7 @@ py_test_module_list(
     env = {"RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP": "0"},
     files = [
         "test_handle_same_loop.py",
+        "test_proxy.py",
     ],
     name_suffix = "_with_router_in_same_loop",
     tags = [

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -158,7 +158,7 @@ def serve_instance(_shared_serve_instance):
     # Clear all state for 2.x applications and deployments.
     _shared_serve_instance.delete_all_apps()
     # Clear the ServeHandle cache between tests to avoid them piling up.
-    _shared_serve_instance.shutdown_cached_handles()
+    _shared_serve_instance.shutdown_cached_handles(_skip_asyncio_check=True)
 
 
 @pytest.fixture

--- a/python/ray/serve/tests/test_handle_same_loop.py
+++ b/python/ray/serve/tests/test_handle_same_loop.py
@@ -1,0 +1,222 @@
+import asyncio
+import sys
+
+import httpx
+import pytest
+
+from ray import serve
+from ray._common.test_utils import SignalActor, async_wait_for_condition
+from ray.serve._private.constants import (
+    RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,
+)
+from ray.serve._private.test_utils import get_application_url
+from ray.serve.exceptions import RequestCancelledError
+from ray.serve.handle import (
+    DeploymentHandle,
+)
+
+
+@pytest.fixture
+def _skip_test_if_router_running_in_separate_loop():
+    if RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP:
+        pytest.skip("Router is running in a separate loop.")
+
+
+@pytest.mark.asyncio
+async def test_deployment_handle_works_with_await_when_router_in_same_loop(
+    serve_instance, _skip_test_if_router_running_in_separate_loop
+):
+    @serve.deployment
+    class F:
+        async def __call__(self):
+            return "hi"
+
+    h = serve.run(F.bind())
+    assert await h.remote() == "hi"
+
+
+def test_deployment_handle_result_fails_when_driver_not_in_async_loop(
+    serve_instance, _skip_test_if_router_running_in_separate_loop
+):
+    @serve.deployment
+    class F:
+        def __call__(self):
+            return "hi"
+
+    h = serve.run(F.bind())
+    with pytest.raises(RuntimeError):
+        h.remote().result()
+
+
+@pytest.mark.asyncio
+async def test_deployment_handle_result_fails_in_async_context_but_await_succeeds(
+    serve_instance, _skip_test_if_router_running_in_separate_loop
+):
+    @serve.deployment
+    class F:
+        def __call__(self):
+            return "hi"
+
+    h = serve.run(F.bind())
+    with pytest.raises(RuntimeError):
+        h.remote().result()
+
+    assert await h.remote() == "hi"
+
+
+def test_http_proxy_requests_work_when_router_in_same_loop(
+    serve_instance, _skip_test_if_router_running_in_separate_loop
+):
+    @serve.deployment
+    class F:
+        def __call__(self):
+            return "hi"
+
+    serve.run(F.bind())
+    url = "http://localhost:8000/"
+
+    resp = httpx.get(url)
+    assert resp.status_code == 200
+    assert resp.text == "hi"
+
+
+@pytest.mark.asyncio
+async def test_deployment_handle_configured_for_same_loop_via_init(serve_instance):
+    @serve.deployment
+    class F:
+        def __call__(self):
+            return "hi"
+
+    h = serve.run(F.bind())
+    h._init(_run_router_in_separate_loop=False)
+    assert await h.remote() == "hi"
+
+    with pytest.raises(RuntimeError):
+        h.remote().result()
+
+
+def test_child_deployment_handle_configured_for_same_loop_communication(serve_instance):
+    @serve.deployment
+    class Child:
+        def __call__(self):
+            return "hi"
+
+    @serve.deployment
+    class Parent:
+        def __init__(self, child_handle: DeploymentHandle):
+            self.child_handle = child_handle
+            self.child_handle._init(_run_router_in_separate_loop=False)
+
+        async def __call__(self):
+            return await self.child_handle.remote()
+
+    serve.run(Parent.bind(Child.bind()))
+    url = get_application_url("HTTP")
+    resp = httpx.get(url)
+    assert resp.status_code == 200
+    assert resp.text == "hi"
+
+
+@pytest.mark.asyncio
+async def test_deployment_handle_exception_propagation_in_same_loop(
+    serve_instance, _skip_test_if_router_running_in_separate_loop
+):
+    """Test that exceptions are properly propagated when router runs in same loop."""
+
+    @serve.deployment
+    class FailingDeployment:
+        def __call__(self):
+            raise ValueError("Intentional test error")
+
+    h = serve.run(FailingDeployment.bind())
+
+    with pytest.raises(ValueError, match="Intentional test error"):
+        await h.remote()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_generator_in_same_loop(
+    serve_instance, _skip_test_if_router_running_in_separate_loop
+):
+    """Test that streaming responses work correctly when router runs in same loop."""
+
+    @serve.deployment
+    class StreamingDeployment:
+        def generate_numbers(self, limit: int):
+            for i in range(limit):
+                yield i
+
+    h = serve.run(StreamingDeployment.bind())
+    streaming_handle = h.options(stream=True)
+
+    gen = streaming_handle.generate_numbers.remote(5)
+    results = []
+    async for value in gen:
+        results.append(value)
+
+    assert results == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_in_same_loop(
+    serve_instance, _skip_test_if_router_running_in_separate_loop
+):
+    """Test that multiple concurrent requests work correctly in same loop mode."""
+
+    @serve.deployment
+    class ConcurrentDeployment:
+        async def slow_operation(self, delay: float, value: str):
+            await asyncio.sleep(delay)
+            return f"result-{value}"
+
+    h = serve.run(ConcurrentDeployment.bind())
+
+    # Launch multiple concurrent requests
+    tasks = [
+        h.slow_operation.remote(0.1, "a"),
+        h.slow_operation.remote(0.1, "b"),
+        h.slow_operation.remote(0.1, "c"),
+    ]
+
+    # All should complete successfully
+    results = await asyncio.gather(*tasks)
+    assert set(results) == {"result-a", "result-b", "result-c"}
+
+
+@pytest.mark.asyncio
+async def test_request_cancellation_in_same_loop(
+    serve_instance, _skip_test_if_router_running_in_separate_loop
+):
+    """Test that request cancellation works correctly when router runs in same loop."""
+    signal_actor = SignalActor.remote()
+
+    @serve.deployment
+    class SlowDeployment:
+        async def slow_operation(self):
+            await signal_actor.wait.remote()
+            return "should_not_reach_here"
+
+    h = serve.run(SlowDeployment.bind())
+
+    response = h.slow_operation.remote()
+
+    async def check_num_waiters():
+        assert await signal_actor.cur_num_waiters.remote() == 1
+        return True
+
+    # its important that we use async_wait_for_condition here because
+    # if we block the event loop then router wont be able to function
+    async_wait_for_condition(check_num_waiters, timeout=10)
+
+    # Cancel the request
+    response.cancel()
+
+    # Should raise CancelledError
+    with pytest.raises(RequestCancelledError):
+        await response
+
+    await signal_actor.send.remote(clear=True)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
```
from ray import serve



@serve.deployment(max_ongoing_requests=10000)
class MyDeployment:
    async def __call__(self):
        return "Hello, world!"


app = MyDeployment.bind()

```

`ab -n 2000 -c 100 "http://localhost:8000/"`

`RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP=0 serve run app:app`

Requests per second:    483.46 [#/sec] (mean)
Time per request:       206.843 [ms] (mean)


`RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP=1 serve run app:app`

Requests per second:    412.05 [#/sec] (mean)
Time per request:       242.688 [ms] (mean)

~17% improvement in performance with running router in the same event loop as proxy