### PR TITLE
[doc] disable `automl_for_time_series`

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -57,6 +57,7 @@ py_test(
         "exclusive",
         "team:ml",
         "timeseries_libs",
+        "manual", # TODO(ray-train): fix this doc test.
     ],
 )
 


### PR DESCRIPTION
the s3 bucket of `m5-benchmarks` that save the data is no longer accessible.
