### PR TITLE
[core] Fixing windows build error

### DIFF
--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -375,6 +375,8 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
             "CoreWorker.HandleException");
       });
 
+  std::shared_ptr<experimental::MutableObjectProvider> experimental_mutable_object_provider;
+
 #if defined(__APPLE__) || defined(__linux__)
   auto raylet_channel_client_factory = [this](const NodeID &node_id) {
     auto core_worker = GetCoreWorker();

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -375,7 +375,8 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
             "CoreWorker.HandleException");
       });
 
-  std::shared_ptr<experimental::MutableObjectProvider> experimental_mutable_object_provider;
+  std::shared_ptr<experimental::MutableObjectProvider>
+      experimental_mutable_object_provider;
 
 #if defined(__APPLE__) || defined(__linux__)
   auto raylet_channel_client_factory = [this](const NodeID &node_id) {
@@ -389,7 +390,7 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
     return core_worker->raylet_client_pool_->GetOrConnectByAddress(addr);
   };
 
-  auto experimental_mutable_object_provider =
+  experimental_mutable_object_provider =
       std::make_shared<experimental::MutableObjectProvider>(
           *plasma_store_provider->store_client(),
           raylet_channel_client_factory,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Introduced a windows build error in https://github.com/ray-project/ray/pull/54759 since experimental_mutable_object_provider is not defined for windows. Updating the initialization of the experimental_mutable_object_provider pointer to be outside of the guards for linux/apple.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
