### PR TITLE
[ci] remove clang installation on mac java/cpp tests

### DIFF
--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -86,9 +86,7 @@ run_core_dashboard_test() {
 }
 
 run_ray_cpp_and_java() {
-  # clang-format is needed by java/test.sh
   # 42 is the universal rayci exit code for test failures
-  pip install clang-format==12.0.1
   export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home
   ./java/test.sh || exit 42
   ./ci/ci.sh test_cpp || exit 42


### PR DESCRIPTION
it is not used; the comment was old and wrong.
