### PR TITLE
[Core] Add the Default Option in the LabelSelectorOperator enum

### DIFF
--- a/src/ray/common/scheduling/label_selector.h
+++ b/src/ray/common/scheduling/label_selector.h
@@ -24,10 +24,11 @@
 namespace ray {
 
 enum class LabelSelectorOperator {
+  LABEL_OPERATOR_UNSPECIFIED = 0,
   // This is to support equality or in semantics.
-  LABEL_IN = 0,
+  LABEL_IN = 1,
   // This is to support not equal or not in semantics.
-  LABEL_NOT_IN = 1
+  LABEL_NOT_IN = 2
 };
 
 // Defines requirements for a label key and value.

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -1028,10 +1028,11 @@ enum PlacementStrategy {
 
 // The type of operator to use for the label constraint.
 enum LabelSelectorOperator {
+  LABEL_OPERATOR_UNSPECIFIED = 0;
   // This is to support equality or in semantics.
-  LABEL_OPERATOR_IN = 0;
+  LABEL_OPERATOR_IN = 1;
   // This is to support not equal or not in semantics.
-  LABEL_OPERATOR_NOT_IN = 1;
+  LABEL_OPERATOR_NOT_IN = 2;
 }
 
 // A node label constraint with a key, one or a list of values and an operator.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When implementing the logic to send the cluster load to the autoscaler, we moved the label related to protobuf definition from `autoscaler.proto` to `common.proto`. And during the move, we accidentally remove the default option in the `LabelSelectorOperator` enum. 

This PR adds back the default option so that it won't break the implementation on the product side and this is also the best practices recommended by [here](https://protobuf.dev/best-practices/dos-donts/#unspecified-enum)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#51564

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
