### PR TITLE
[core][ci] Upgrade redis version and remove from base-deps image

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -95,7 +95,6 @@ PIP_PKGS=(
 )
 if [[ "$AUTOSCALER" == "autoscaler" ]]; then
     PIP_PKGS+=(
-        redis
         six
         boto3
         pyopenssl

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -58,7 +58,7 @@ pytest-timeout==2.1.0
 pytest-virtualenv==1.8.1; python_version < "3.12"
 pytest-sphinx @ git+https://github.com/ray-project/pytest-sphinx
 pytest-mock==3.14.0
-redis==4.4.2
+redis==4.5.4
 scikit-learn==1.3.2
 smart_open[s3]==6.2.0
 tqdm==4.67.1

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -58,7 +58,7 @@ pytest-timeout==2.1.0
 pytest-virtualenv==1.8.1; python_version < "3.12"
 pytest-sphinx @ git+https://github.com/ray-project/pytest-sphinx
 pytest-mock==3.14.0
-redis==4.5.4
+redis
 scikit-learn==1.3.2
 smart_open[s3]==6.2.0
 tqdm==4.67.1

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1807,7 +1807,7 @@ qpd==0.4.4
     # via fugue
 raydp==1.7.0b20250423.dev0
     # via -r python/requirements/ml/data-test-requirements.txt
-redis==4.4.2
+redis==4.5.4
     # via -r python/requirements/test-requirements.txt
 referencing==0.36.2
     # via


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Upgrading redis to address some security concerns. Also removing it from the base-deps image because it's not needed for the autoscaler.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/53915
<!-- For example: "Closes #1234" -->
