### PR TITLE
[release test] fix broken release test configs

### DIFF
--- a/ci/pipeline/test_conditional_testing.py
+++ b/ci/pipeline/test_conditional_testing.py
@@ -61,6 +61,7 @@ doc/tutorial.rst: lint doc
 ci/docker/doctest.build.Dockerfile: lint
 release/requirements.txt: lint release_tests
 release/requirements_buildkite.txt: lint tools
+release/release_tests.yaml: lint tools
 ci/lint/lint.sh: lint tools
 .buildkite/lint.rayci.yml: lint tools
 .buildkite/macos.rayci.yml: lint macos_wheels

--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -146,12 +146,9 @@ ci/docker/doctest.build.wanda.yaml
 
 release/ray_release/
 release/requirements_buildkite.*
-@ tools
-;
-
 release/*.md
 release/*.yaml
-# Do not run on config changes
+@ tools
 ;
 
 release/

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2664,7 +2664,7 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_compute: 4gpu_64cpus.yaml
+    cluster_compute: 4gpus_64cpus.yaml
 
   run:
     timeout: 36000  # 10h
@@ -2678,7 +2678,7 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_compute: 4gpu_64cpus_gce.yaml
+        cluster_compute: 4gpus_64cpus_gce.yaml
 
 # --------------------------
 # IMPALA


### PR DESCRIPTION
introduced by rllib release teste changes

also run ci tools tests when release test configs are changed. this makes sure that release test configs are sanity checked on CI tests.