### PR TITLE
[Core] Add default TPU Ray node labels

### DIFF
--- a/python/ray/_private/accelerators/accelerator.py
+++ b/python/ray/_private/accelerators/accelerator.py
@@ -136,3 +136,12 @@ class AcceleratorManager(ABC):
             Return None if it's unknown.
         """
         return None
+
+    @staticmethod
+    def get_current_node_accelerator_labels() -> Optional[Dict[str, str]]:
+        """Get accelerator related Ray node labels of the curent node.
+
+        Returns:
+            A dictionary mapping accelerator related label keys to values.
+        """
+        return None

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -458,7 +458,17 @@ class TPUAcceleratorManager(AcceleratorManager):
 
     @staticmethod
     def get_current_node_accelerator_labels() -> Dict[str, str]:
-        """Return default TPU-specific node labels for this host."""
+        """Get default TPU-specific Ray node labels for the current node.
+
+        For TPUs, these labels include:
+        - ray.io/tpu-slice-name: the name of the TPU Pod or slice
+        - ray.io/tpu-worker-id: the integer worker ID within the slice
+        - ray.io/tpu-topology: the TPU topology (e.g. 4x4)
+        - ray.io/tpu-head: set to "TPU-<tpu_pod_type>-head" only on worker 0
+
+        Returns:
+            A dictionary of TPU label keys and resolved values.
+        """
         tpu_labels = {}
 
         tpu_name = TPUAcceleratorManager.get_current_node_tpu_name()

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -466,7 +466,7 @@ class TPUAcceleratorManager(AcceleratorManager):
         - ray.io/tpu-slice-name: the name of the TPU Pod or slice
         - ray.io/tpu-worker-id: the integer worker ID within the slice
         - ray.io/tpu-topology: the TPU topology (e.g. 4x4)
-        - ray.io/tpu-head: set to "TPU-<tpu_pod_type>-head" only on worker 0
+        - ray.io/tpu-pod-type: the TPU pod type (e.g. v4-8)
 
         Returns:
             A dictionary of TPU label keys and resolved values.
@@ -486,7 +486,7 @@ class TPUAcceleratorManager(AcceleratorManager):
             tpu_labels[ray._raylet.RAY_NODE_TPU_TOPOLOGY_KEY] = tpu_topology
 
         pod_type = TPUAcceleratorManager.get_current_node_tpu_pod_type()
-        if worker_id == 0 and pod_type:
-            tpu_labels[ray._raylet.RAY_NODE_TPU_HEAD_KEY] = f"TPU-{pod_type}-head"
+        if pod_type:
+            tpu_labels[ray._raylet.RAY_NODE_TPU_POD_TYPE_KEY] = pod_type
 
         return tpu_labels

--- a/python/ray/_private/resource_and_label_spec.py
+++ b/python/ray/_private/resource_and_label_spec.py
@@ -294,40 +294,10 @@ class ResourceAndLabelSpec:
 
             # Set TPU specific default labels to enable SPMD scheduling.
             if isinstance(accelerator_manager, TPUAcceleratorManager):
-                ResourceAndLabelSpec._add_tpu_default_labels(
-                    default_labels, accelerator_manager, accelerator_type
-                )
+                tpu_labels = accelerator_manager.get_current_node_accelerator_labels()
+                default_labels.update(tpu_labels)
 
         return default_labels
-
-    @staticmethod
-    def _add_tpu_default_labels(
-        default_labels: Dict[str, str],
-        accelerator_manager: TPUAcceleratorManager,
-        accelerator_type: Optional[str],
-    ) -> None:
-        """Add TPU-specific default labels.
-
-        Args:
-            default_labels: Dict to append labels to.
-            accelerator_manager: Active TPUAcceleratorManager.
-            accelerator_type: The detected TPU accelerator type (e.g. "TPU-V6E").
-        """
-        tpu_name = TPUAcceleratorManager.get_current_node_tpu_name()
-        if tpu_name:
-            default_labels[ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY] = tpu_name
-
-        worker_id = TPUAcceleratorManager._get_current_node_tpu_worker_id()
-        if worker_id is not None:
-            default_labels[ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY] = str(worker_id)
-
-        tpu_topology = TPUAcceleratorManager.get_current_node_tpu_topology()
-        if tpu_topology:
-            default_labels[ray._raylet.RAY_NODE_TPU_TOPOLOGY_KEY] = tpu_topology
-
-        pod_type = TPUAcceleratorManager._get_current_node_tpu_pod_type()
-        if worker_id == 0 and pod_type:
-            default_labels[ray._raylet.RAY_NODE_TPU_HEAD_KEY] = f"TPU-{pod_type}-Head"
 
     def _resolve_labels(
         self, accelerator_manager: Optional[AcceleratorManager]

--- a/python/ray/_private/resource_and_label_spec.py
+++ b/python/ray/_private/resource_and_label_spec.py
@@ -10,6 +10,7 @@ from ray._common.constants import HEAD_NODE_RESOURCE_NAME, NODE_ID_PREFIX
 from ray._common.utils import RESOURCE_CONSTRAINT_PREFIX
 from ray._private import accelerators
 from ray._private.accelerators import AcceleratorManager
+from ray._private.accelerators.tpu import TPUAcceleratorManager
 
 logger = logging.getLogger(__name__)
 
@@ -291,7 +292,42 @@ class ResourceAndLabelSpec:
                     ray._raylet.RAY_NODE_ACCELERATOR_TYPE_KEY
                 ] = accelerator_type
 
+            # Set TPU specific default labels to enable SPMD scheduling.
+            if isinstance(accelerator_manager, TPUAcceleratorManager):
+                ResourceAndLabelSpec._add_tpu_default_labels(
+                    default_labels, accelerator_manager, accelerator_type
+                )
+
         return default_labels
+
+    @staticmethod
+    def _add_tpu_default_labels(
+        default_labels: Dict[str, str],
+        accelerator_manager: TPUAcceleratorManager,
+        accelerator_type: Optional[str],
+    ) -> None:
+        """Add TPU-specific default labels.
+
+        Args:
+            default_labels: Dict to append labels to.
+            accelerator_manager: Active TPUAcceleratorManager.
+            accelerator_type: The detected TPU accelerator type (e.g. "TPU-V6E").
+        """
+        tpu_name = TPUAcceleratorManager.get_current_node_tpu_name()
+        if tpu_name:
+            default_labels[ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY] = tpu_name
+
+        worker_id = TPUAcceleratorManager._get_current_node_tpu_worker_id()
+        if worker_id is not None:
+            default_labels[ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY] = str(worker_id)
+
+        tpu_topology = TPUAcceleratorManager.get_current_node_tpu_topology()
+        if tpu_topology:
+            default_labels[ray._raylet.RAY_NODE_TPU_TOPOLOGY_KEY] = tpu_topology
+
+        pod_type = TPUAcceleratorManager._get_current_node_tpu_pod_type()
+        if worker_id == 0 and pod_type:
+            default_labels[ray._raylet.RAY_NODE_TPU_HEAD_KEY] = f"TPU-{pod_type}-Head"
 
     def _resolve_labels(
         self, accelerator_manager: Optional[AcceleratorManager]

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -783,3 +783,7 @@ cdef extern from "ray/common/constants.h" nogil:
     cdef const char[] kLabelKeyNodeRegion
     cdef const char[] kLabelKeyNodeZone
     cdef const char[] kLabelKeyNodeGroup
+    cdef const char[] kLabelKeyTpuTopology
+    cdef const char[] kLabelKeyTpuSliceName
+    cdef const char[] kLabelKeyTpuWorkerId
+    cdef const char[] kLabelKeyTpuHead

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -786,4 +786,4 @@ cdef extern from "ray/common/constants.h" nogil:
     cdef const char[] kLabelKeyTpuTopology
     cdef const char[] kLabelKeyTpuSliceName
     cdef const char[] kLabelKeyTpuWorkerId
-    cdef const char[] kLabelKeyTpuHead
+    cdef const char[] kLabelKeyTpuPodType

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -26,7 +26,7 @@ from ray.includes.common cimport (
     kLabelKeyTpuTopology,
     kLabelKeyTpuSliceName,
     kLabelKeyTpuWorkerId,
-    kLabelKeyTpuHead,
+    kLabelKeyTpuPodType,
 )
 
 from ray.exceptions import (
@@ -158,4 +158,4 @@ RAY_NODE_GROUP_KEY = kLabelKeyNodeGroup.decode()
 RAY_NODE_TPU_TOPOLOGY_KEY = kLabelKeyTpuTopology.decode()
 RAY_NODE_TPU_SLICE_NAME_KEY = kLabelKeyTpuSliceName.decode()
 RAY_NODE_TPU_WORKER_ID_KEY = kLabelKeyTpuWorkerId.decode()
-RAY_NODE_TPU_HEAD_KEY = kLabelKeyTpuHead.decode()
+RAY_NODE_TPU_POD_TYPE_KEY = kLabelKeyTpuPodType.decode()

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -23,6 +23,10 @@ from ray.includes.common cimport (
     kLabelKeyNodeRegion,
     kLabelKeyNodeZone,
     kLabelKeyNodeGroup,
+    kLabelKeyTpuTopology,
+    kLabelKeyTpuSliceName,
+    kLabelKeyTpuWorkerId,
+    kLabelKeyTpuHead,
 )
 
 from ray.exceptions import (
@@ -138,7 +142,7 @@ GCS_AUTOSCALER_V2_ENABLED_KEY = kGcsAutoscalerV2EnabledKey.decode()
 GCS_AUTOSCALER_CLUSTER_CONFIG_KEY = kGcsAutoscalerClusterConfigKey.decode()
 GCS_PID_KEY = kGcsPidKey.decode()
 
-# Ray node label related constants form src/ray/common/constants.h
+# Ray node label related constants from src/ray/common/constants.h
 NODE_TYPE_NAME_ENV = kNodeTypeNameEnv.decode()
 NODE_MARKET_TYPE_ENV = kNodeMarketTypeEnv.decode()
 NODE_REGION_ENV = kNodeRegionEnv.decode()
@@ -149,3 +153,9 @@ RAY_NODE_MARKET_TYPE_KEY = kLabelKeyNodeMarketType.decode()
 RAY_NODE_REGION_KEY = kLabelKeyNodeRegion.decode()
 RAY_NODE_ZONE_KEY = kLabelKeyNodeZone.decode()
 RAY_NODE_GROUP_KEY = kLabelKeyNodeGroup.decode()
+
+# TPU specifc Ray node label related constants
+RAY_NODE_TPU_TOPOLOGY_KEY = kLabelKeyTpuTopology.decode()
+RAY_NODE_TPU_SLICE_NAME_KEY = kLabelKeyTpuSliceName.decode()
+RAY_NODE_TPU_WORKER_ID_KEY = kLabelKeyTpuWorkerId.decode()
+RAY_NODE_TPU_HEAD_KEY = kLabelKeyTpuHead.decode()

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -328,5 +328,20 @@ def test_num_tpu_chips(mock_glob):
     assert num_tpu_chips == 4
 
 
+def test_get_current_node_labels_env_only(monkeypatch):
+    # Simulate GKE TPU environment variables
+    monkeypatch.setenv("TPU_NAME", "tpu-worker-group-2")
+    monkeypatch.setenv("TPU_WORKER_ID", "0")
+    monkeypatch.setenv("TPU_ACCELERATOR_TYPE", "v6e-16")
+    monkeypatch.setenv("TPU_TOPOLOGY", "4x4")
+
+    tpu_labels = TPUAcceleratorManager.get_current_node_accelerator_labels()
+
+    assert tpu_labels["ray.io/tpu-slice-name"] == "tpu-worker-group-2"
+    assert tpu_labels["ray.io/tpu-worker-id"] == "0"
+    assert tpu_labels["ray.io/tpu-topology"] == "4x4"
+    assert tpu_labels["ray.io/tpu-head"] == "TPU-v6e-16-head"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -99,7 +99,7 @@ def test_get_current_node_tpu_worker_id(mock_os, mock_request, test_case):
         mock_os.return_value = None
     else:
         mock_os.return_value = worker_id
-    assert TPUAcceleratorManager._get_current_node_tpu_worker_id() == expected_value
+    assert TPUAcceleratorManager.get_current_node_tpu_worker_id() == expected_value
 
 
 @pytest.mark.parametrize(
@@ -246,12 +246,12 @@ def test_tpu_pod_detect_and_configure_worker(test_config):
     ):
         with patch(
             "ray._private.accelerators.tpu.TPUAcceleratorManager."
-            "_get_current_node_tpu_pod_type",
+            "get_current_node_tpu_pod_type",
             return_value="v4-16",
         ):
             with patch(
                 "ray._private.accelerators.tpu.TPUAcceleratorManager"
-                "._get_current_node_tpu_worker_id",
+                ".get_current_node_tpu_worker_id",
                 return_value=worker_id,
             ):
                 final_resources = (
@@ -307,7 +307,7 @@ def test_worker_count(mock_glob, test_case):
 
     with patch(
         "ray._private.accelerators.tpu.TPUAcceleratorManager."
-        "_get_current_node_tpu_pod_type",
+        "get_current_node_tpu_pod_type",
         return_value=accelerator_type,
     ):
         worker_count = ray.util.accelerators.tpu.get_current_pod_worker_count()

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -340,7 +340,7 @@ def test_get_current_node_labels_env_only(monkeypatch):
     assert tpu_labels["ray.io/tpu-slice-name"] == "tpu-worker-group-2"
     assert tpu_labels["ray.io/tpu-worker-id"] == "0"
     assert tpu_labels["ray.io/tpu-topology"] == "4x4"
-    assert tpu_labels["ray.io/tpu-head"] == "TPU-v6e-16-head"
+    assert tpu_labels["ray.io/tpu-pod-type"] == "v6e-16"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -343,5 +343,15 @@ def test_get_current_node_labels_env_only(monkeypatch):
     assert tpu_labels["ray.io/tpu-pod-type"] == "v6e-16"
 
 
+def test_get_current_node_tpu_topology_from_metadata():
+    tpu_env_string = "TPU_ACCELERATOR:v6e.\nTOPOLOGY: '2x2x4'\nTPU_HOST_BOUNDS:0,1,1,2"
+
+    with patch(
+        "ray._private.accelerators.tpu._get_tpu_metadata", return_value=tpu_env_string
+    ):
+        topology = TPUAcceleratorManager.get_current_node_tpu_topology()
+        assert topology == "2x2x4"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -207,7 +207,7 @@ def test_get_default_tpu_labels(shutdown_only, monkeypatch):
     assert labels.get("ray.io/tpu-slice-name") == "slice-0"
     assert labels.get("ray.io/tpu-worker-id") == "0"
     assert labels.get("ray.io/tpu-topology") == "4x8"
-    assert labels.get("ray.io/tpu-head") == "TPU-v6e-32-head"
+    assert labels.get("ray.io/tpu-pod-type") == "v6e-32"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -3,6 +3,8 @@ import sys
 import pytest
 import subprocess
 import tempfile
+from unittest.mock import patch
+from ray._private.accelerators.tpu import TPUAcceleratorManager
 
 import ray
 from ray.cluster_utils import AutoscalingCluster
@@ -179,6 +181,33 @@ def test_get_default_ray_node_labels(shutdown_only, monkeypatch):
     assert labels.get("ray.io/availability-region") == "us-central2"
     assert labels.get("ray.io/availability-zone") == "us-central2-b"
     assert labels.get("ray.io/accelerator-type") == "TPU-V4"
+
+
+def test_get_default_tpu_labels(shutdown_only, monkeypatch):
+    # Set env vars for this test
+    monkeypatch.setenv("TPU_NAME", "slice-0")
+    monkeypatch.setenv("TPU_WORKER_ID", "0")
+    monkeypatch.setenv("TPU_ACCELERATOR_TYPE", "v6e-32")
+    monkeypatch.setenv("TPU_TOPOLOGY", "4x8")
+
+    with patch(
+        "ray._private.accelerators.get_all_accelerator_resource_names",
+        return_value=["TPU"],
+    ), patch(
+        "ray._private.accelerators.get_accelerator_manager_for_resource",
+        return_value=TPUAcceleratorManager(),
+    ):
+        ray.init(resources={"TPU": 4})
+        node_info = ray.nodes()[0]
+        labels = node_info["Labels"]
+
+    assert labels.get("ray.io/accelerator-type") == "TPU-V6E"
+
+    # TPU specific labels for SPMD
+    assert labels.get("ray.io/tpu-slice-name") == "slice-0"
+    assert labels.get("ray.io/tpu-worker-id") == "0"
+    assert labels.get("ray.io/tpu-topology") == "4x8"
+    assert labels.get("ray.io/tpu-head") == "TPU-v6e-32-Head"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -207,7 +207,7 @@ def test_get_default_tpu_labels(shutdown_only, monkeypatch):
     assert labels.get("ray.io/tpu-slice-name") == "slice-0"
     assert labels.get("ray.io/tpu-worker-id") == "0"
     assert labels.get("ray.io/tpu-topology") == "4x8"
-    assert labels.get("ray.io/tpu-head") == "TPU-v6e-32-Head"
+    assert labels.get("ray.io/tpu-head") == "TPU-v6e-32-head"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/unit/test_resource_and_label_spec.py
+++ b/python/ray/tests/unit/test_resource_and_label_spec.py
@@ -117,35 +117,6 @@ def test_resource_and_label_spec_resolves_auto_detect(monkeypatch):
     assert spec.memory == expected_memory
 
 
-def test_resolve_tpu_labels(monkeypatch):
-    from ray._private.accelerators.tpu import TPUAcceleratorManager
-
-    # Simulate a v4-16 2-host TPU pod with defaults
-    monkeypatch.setenv("TPU_NAME", "tpu-worker-group-1")
-    monkeypatch.setenv("TPU_WORKER_ID", "0")
-    monkeypatch.setenv("TPU_ACCELERATOR_TYPE", "v4-16")
-
-    with patch(
-        "ray._private.accelerators.get_accelerator_manager_for_resource",
-        return_value=TPUAcceleratorManager(),
-    ), patch(
-        "ray._private.accelerators.get_all_accelerator_resource_names",
-        return_value=["TPU"],
-    ), patch.object(
-        TPUAcceleratorManager,
-        "get_current_node_num_accelerators",
-        return_value=4,  # Simulate 4 chips per host
-    ):
-        spec = ResourceAndLabelSpec()
-        spec.resolve(is_head=False)
-
-    assert spec.labels["ray.io/accelerator-type"] == "TPU-V4"
-    assert spec.labels["ray.io/tpu-slice-name"] == "tpu-worker-group-1"
-    assert spec.labels["ray.io/tpu-worker-id"] == "0"
-    assert spec.labels["ray.io/tpu-topology"] == "2x2x2"
-    assert spec.labels["ray.io/tpu-head"] == "TPU-v4-16-Head"
-
-
 def test_env_resource_overrides_with_conflict(monkeypatch):
     """Validate that RESOURCES_ENVIRONMENT_VARIABLE overrides Ray Param resources."""
     # Prepare environment overrides

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -135,9 +135,8 @@ constexpr char kLabelKeyTpuSliceName[] = RAY_LABEL_KEY_PREFIX "tpu-slice-name";
 // it's scheduled on. Valid values are 0 to N-1 where N is the number of TPU hosts.
 constexpr char kLabelKeyTpuWorkerId[] = RAY_LABEL_KEY_PREFIX "tpu-worker-id";
 
-// A label applied to the TPU "head" (worker 0) on a multi-host slice. The value
-// is a string of the form "TPU-{ACCELERATOR_TYPE}-head".
-constexpr char kLabelKeyTpuHead[] = RAY_LABEL_KEY_PREFIX "tpu-head";
+// A string representing the current TPU pod type, e.g. v6e-32.
+constexpr char kLabelKeyTpuPodType[] = RAY_LABEL_KEY_PREFIX "tpu-pod-type";
 
 #undef RAY_LABEL_KEY_PREFIX
 

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -122,6 +122,23 @@ constexpr char kLabelKeyNodeZone[] = RAY_LABEL_KEY_PREFIX "availability-zone";
 // The name of the head or worker group this Ray node is a part of.
 constexpr char kLabelKeyNodeGroup[] = RAY_LABEL_KEY_PREFIX "node-group";
 
+/// TPU specific default labels. Used for multi-host TPU workload scheduling.
+
+// The physical chip topology of the TPU accelerator of this Ray node.
+constexpr char kLabelKeyTpuTopology[] = RAY_LABEL_KEY_PREFIX "tpu-topology";
+
+// A unique identifier within the RayCluster for the TPU slice this Ray
+// node is scheduled on.
+constexpr char kLabelKeyTpuSliceName[] = RAY_LABEL_KEY_PREFIX "tpu-slice-name";
+
+// A unique integer ID for a Ray node with TPU resources within the TPU slice
+// it's scheduled on. Valid values are 0 to N-1 where N is the number of TPU hosts.
+constexpr char kLabelKeyTpuWorkerId[] = RAY_LABEL_KEY_PREFIX "tpu-worker-id";
+
+// A label applied to the TPU "head" (worker 0) on a multi-host slice. THe value
+// is a string of the form "TPU-{ACCELERATOR_TYPE}-Head".
+constexpr char kLabelKeyTpuHead[] = RAY_LABEL_KEY_PREFIX "tpu-head";
+
 #undef RAY_LABEL_KEY_PREFIX
 
 /// All nodes implicitly have resources with this prefix and the quantity is 1.

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -135,8 +135,8 @@ constexpr char kLabelKeyTpuSliceName[] = RAY_LABEL_KEY_PREFIX "tpu-slice-name";
 // it's scheduled on. Valid values are 0 to N-1 where N is the number of TPU hosts.
 constexpr char kLabelKeyTpuWorkerId[] = RAY_LABEL_KEY_PREFIX "tpu-worker-id";
 
-// A label applied to the TPU "head" (worker 0) on a multi-host slice. THe value
-// is a string of the form "TPU-{ACCELERATOR_TYPE}-Head".
+// A label applied to the TPU "head" (worker 0) on a multi-host slice. The value
+// is a string of the form "TPU-{ACCELERATOR_TYPE}-head".
 constexpr char kLabelKeyTpuHead[] = RAY_LABEL_KEY_PREFIX "tpu-head";
 
 #undef RAY_LABEL_KEY_PREFIX


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds useful TPU accelerator information to the node labels of a Ray node when TPU resources are detected. These labels will enable fine-grained control over scheduling on TPU devices and support for SPMD workloads. This information is currently added to the resource configuration of Ray nodes as additional custom resources, but this workaround will be deprecated in favor of using the `label_selector` API.

I added `get_current_node_accelerator_labels` as a function to the `AcceleratorManager` abstract class so that we can extend this to other accelerators in the future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
