### PR TITLE
[serve.llm] fix llm server test logic after refactor

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -41,7 +41,6 @@ from ray.llm._internal.serve.observability.usage_telemetry.usage import (
 )
 from ray.llm._internal.serve.utils.lora_serve_utils import (
     LoraModelLoader,
-    get_lora_mirror_config,
 )
 
 if TYPE_CHECKING:
@@ -221,12 +220,9 @@ class LLMServer(_LLMServerBase):
             )
 
             async def _load_model(lora_model_id: str) -> DiskMultiplexConfig:
-                lora_mirror_config = await get_lora_mirror_config(
-                    lora_model_id, self._llm_config
-                )
-                return await model_downloader.load_model(
+                return await model_downloader.load_model_from_config(
                     lora_model_id=lora_model_id,
-                    lora_mirror_config=lora_mirror_config,
+                    llm_config=self._llm_config,
                 )
 
             self._load_model = serve.multiplexed(

--- a/python/ray/llm/_internal/serve/utils/lora_serve_utils.py
+++ b/python/ray/llm/_internal/serve/utils/lora_serve_utils.py
@@ -152,6 +152,13 @@ class LoraModelLoader:
             raise ValueError(f"max_tries must be >=1, got {max_tries}")
         self.max_tries = max_tries
 
+    async def load_model_from_config(
+        self, lora_model_id: str, llm_config
+    ) -> DiskMultiplexConfig:
+        """Load a LoRA model by first fetching its mirror config from S3."""
+        lora_mirror_config = await get_lora_mirror_config(lora_model_id, llm_config)
+        return await self.load_model(lora_model_id, lora_mirror_config)
+
     async def load_model(
         self, lora_model_id: str, lora_mirror_config: LoraMirrorConfig
     ) -> DiskMultiplexConfig:

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -37,11 +37,13 @@ def multiplexed_serve_handle(mock_llm_config, stream_batching_interval_ms=0):
     mock_llm_config.experimental_configs = {
         "stream_batching_interval_ms": stream_batching_interval_ms,
     }
+    # Set minimal lora_config to enable multiplexing but avoid telemetry S3 calls
     mock_llm_config.lora_config = LoraConfig(
-        dynamic_lora_loading_path="s3://my/s3/path_here",
+        dynamic_lora_loading_path=None,  # No S3 path = no telemetry S3 calls
         download_timeout_s=60,
         max_download_tries=3,
     )
+
     app = serve.deployment(LLMServer).bind(
         mock_llm_config,
         engine_cls=MockVLLMEngine,

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -4,6 +4,7 @@ import random
 from random import randint
 from typing import AsyncGenerator, Dict, Union
 
+from ray.llm._internal.common.utils.cloud_utils import LoraMirrorConfig
 from ray.llm._internal.serve.configs.openai_api_models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -263,15 +264,26 @@ class MockVLLMEngine(LLMEngine):
 
 
 class FakeLoraModelLoader(LoraModelLoader):
-    """Fake LoRA model loader for testing."""
+    """Fake LoRA model loader for testing that bypasses S3 entirely."""
+
+    async def load_model_from_config(
+        self, lora_model_id: str, llm_config
+    ) -> DiskMultiplexConfig:
+        """Load a fake LoRA model without any S3 access."""
+        return DiskMultiplexConfig(
+            model_id=lora_model_id,
+            max_total_tokens=llm_config.max_request_context_length,
+            local_path="/fake/local/path",
+            lora_assigned_int_id=random.randint(1, 100),
+        )
 
     async def load_model(
-        self, lora_model_id: str, llm_config: LLMConfig
+        self, lora_model_id: str, lora_mirror_config: LoraMirrorConfig
     ) -> DiskMultiplexConfig:
         """Load a fake LoRA model."""
         return DiskMultiplexConfig(
             model_id=lora_model_id,
-            max_total_tokens=llm_config.max_request_context_length,
+            max_total_tokens=lora_mirror_config.max_total_tokens,
             local_path="/fake/local/path",
             lora_assigned_int_id=random.randint(1, 100),
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

[Rayturbo](https://buildkite.com/anyscale/rayturbo/builds/4604/steps?jid=019857b7-c608-493b-b6f6-9050dd86883b#/185-1094) and [upstream](https://buildkite.com/ray-project/postmerge/builds/11807#019856ef-f13b-4dcb-a5b5-8ecc24ad7a58/176-1144) tests were failing for all versions of `TestLLMServer::test_multiplexed_request_handling` with the failure 

```
fastapi.exceptions.HTTPException: 404: Unable to find LoRA adapter config file "adapter_config.json" in folder s3://my/s3/path_here. Check that the file exists and that you have read permissions.
```

This was caused by a [previous refactor](https://github.com/ray-project/ray/pull/54946) which consolidated / refactored LoRa downloading functionality. 

1. **Problem:** Original LoRA downloading refactor moved S3 metadata fetching (get_lora_mirror_config) from the model downloader into LLMServer._load_model as a mandatory + blocking step. This broke the assumption where LoraModelLoader was responsible for its own loading logic.
2. **Why the tests failed:** Tests use FakeLoraModelLoader to mock model loading without S3 access, but now LLMServer was directly calling get_lora_mirror_config with the fake s3 test path before the fake loader could intercept it. Telemetry was also  making separate S3 calls during server startup which was causing failure noise (in the logs - even when tests were passing)
3. **Fix:** LLMServer delegates to LoraModelLoader.load_model_from_config(). The base LoraModelLoader calls get_lora_mirror_config internally, while FakeLoraModelLoader overrides it to bypass S3 entirely (fixing test failures). Also set dynamic_lora_loading_path=None in test fixtures to prevent telemetry S3 calls. This way, production codepath / flow remains identical, and there's no test leakage. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
