### PR TITLE
[wheel] remove zip dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1050,13 +1050,13 @@ pkg_files(
     name = "raylet_so_files",
     srcs = ["python/ray/_raylet.so"],
     attributes = pkg_attributes(mode = "755"),
+    prefix = "ray/",
     renames = select({
         "@platforms//os:windows": {
-            "python/ray/_raylet.so": "python/ray/_raylet.pyd",
+            "python/ray/_raylet.so": "_raylet.pyd",
         },
         "//conditions:default": {},
     }),
-    strip_prefix = "python",
     visibility = ["//visibility:private"],
 )
 
@@ -1170,16 +1170,11 @@ genrule(
         sed -i -E 's/from opencensus.proto.metrics.v1 import/from . import/' "$${files[@]}"
         sed -i -E 's/from opencensus.proto.resource.v1 import/from . import/' "$${files[@]}"
 
-        # Set the modification time to 2025-01-01 00:00:00
-        # This makes the zip file building deterministic and reproducible.
-        touch -t 202501010000 "$${files[@]}"
-        touch -t 202501010000 "$$tmpdir"/ray/ \
-            "$$tmpdir"/ray/core "$$tmpdir"/ray/core/generated \
-            "$$tmpdir"/ray/serve "$$tmpdir"/ray/serve/generated
-
-        (cd "$$tmpdir"; zip -0 -X -r output.zip ray)
-        mv "$$tmpdir/output.zip" $@
+        $(location //bazel:pyzip) "$$tmpdir" $@
     """,
+    tools = [
+        "//bazel:pyzip",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,4 +1,0 @@
-exports_files([
-    "pytest_wrapper.py",
-    "default_doctest_pytest_plugin.py",
-])

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
+exports_files([
+    "pytest_wrapper.py",
+    "default_doctest_pytest_plugin.py",
+])
+
+py_binary(
+    name = "pyzip",
+    srcs = ["pyzip.py"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/pyzip.py
+++ b/bazel/pyzip.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# This script is used to zip a directory into a zip file.
+# It only uses python standard library, so it can be portable and used in bazel.
+
+import os
+import os.path
+import sys
+import zipfile
+
+# Everything in the zip file is stored with this timestamp.
+# This makes the zip file building deterministic and reproducible.
+_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
+
+_UNIX_DIR_BIT = 0o040000
+_MSDOS_DIR_BIT = 0x10
+_DIR_BIT = (_UNIX_DIR_BIT << 16) | _MSDOS_DIR_BIT | (0o755 << 16)
+
+_FILE_BIT = (0o100000 << 16) | (0o644 << 16)
+
+
+def zip_dir(dir_path: str, output_zip_path: str):
+    with zipfile.ZipFile(output_zip_path, "w") as output:
+        for root, _, files in os.walk(dir_path):
+            if root != dir_path:
+                dir_zip_path = os.path.relpath(root, dir_path)
+                dir_zip_info = zipfile.ZipInfo(dir_zip_path + "/", date_time=_TIMESTAMP)
+                dir_zip_info.external_attr |= _DIR_BIT
+                dir_zip_info.flag_bits |= 0x800  # UTF-8 encoded file name.
+                output.writestr(dir_zip_info, "", compress_type=zipfile.ZIP_STORED)
+
+            for f in files:
+                file_path = os.path.join(root, f)
+                zip_path = os.path.relpath(file_path, dir_path)
+                zip_info = zipfile.ZipInfo(zip_path, date_time=_TIMESTAMP)
+                zip_info.flag_bits |= 0x800  # UTF-8 encoded file name.
+                zip_info.external_attr |= _FILE_BIT
+
+                with open(file_path, "rb") as f:
+                    content = f.read()
+                output.writestr(zip_info, content, compress_type=zipfile.ZIP_STORED)
+
+
+if __name__ == "__main__":
+    zip_dir(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
many machines, especially windows ones, do not have zip pre-installed currently. uses python3's builtin library to build the zip instead.

fixes wheel building on windows.