### PR TITLE
[wheel] hermetic wheel building

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,7 @@ load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_python//python:defs.bzl", "py_library", "py_runtime", "py_runtime_pair")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_runtime", "py_runtime_pair")
 load("//bazel:ray.bzl", "COPTS", "FLATC_ARGS", "PYX_COPTS", "PYX_SRCS", "ray_cc_binary", "ray_cc_library", "ray_cc_test")
 
 package(
@@ -1214,4 +1214,17 @@ genrule(
         echo "$${PWD}" > $@
     """,
     local = 1,
+)
+
+py_binary(
+    name = "gen_ray_pkg",
+    srcs = ["gen_ray_pkg.py"],
+    data = [
+        ":ray_pkg_zip",
+        ":ray_py_proto_zip",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//bazel:gen_extract",
+    ],
 )

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@py_deps_buildkite//:requirements.bzl", ci_require = "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 exports_files([
     "pytest_wrapper.py",
@@ -8,5 +9,14 @@ exports_files([
 py_binary(
     name = "pyzip",
     srcs = ["pyzip.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "gen_extract",
+    srcs = ["gen_extract.py"],
+    deps = [
+        ci_require("bazel-runfiles"),
+    ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/gen_extract.py
+++ b/bazel/gen_extract.py
@@ -1,0 +1,28 @@
+from typing import List, Optional
+import os
+import shutil
+import subprocess
+
+import runfiles
+
+
+def gen_extract(zip_files: List[str], clear_dir_first: Optional[List[str]] = None):
+    r = runfiles.Create()
+    _repo_name = "com_github_ray_project_ray"
+
+    root_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+    if not root_dir:
+        raise ValueError("BUILD_WORKSPACE_DIRECTORY not set")
+    python_dir = os.path.join(root_dir, "python")
+
+    if clear_dir_first:
+        for d in clear_dir_first:
+            shutil.rmtree(os.path.join(python_dir, d), ignore_errors=True)
+
+    for zip_file in zip_files:
+        zip_path = r.Rlocation(_repo_name + "/" + zip_file)
+        if not zip_path:
+            raise ValueError(f"Zip file {zip_file} not found")
+
+        # Uses unzip; python zipfile does not restore the file permissions correctly.
+        subprocess.check_call(["unzip", "-q", "-o", zip_path, "-d", python_dir])

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -4,7 +4,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("//bazel:python.bzl", "py_test_module_list")
 load("//bazel:ray.bzl", "COPTS")
 
@@ -211,6 +211,18 @@ genrule(
     """,
     local = 1,
     visibility = ["//visibility:private"],
+)
+
+py_binary(
+    name = "gen_ray_cpp_pkg",
+    srcs = ["gen_ray_cpp_pkg.py"],
+    data = [
+        ":ray_cpp_pkg.zip",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//bazel:gen_extract",
+    ],
 )
 
 # test

--- a/cpp/gen_ray_cpp_pkg.py
+++ b/cpp/gen_ray_cpp_pkg.py
@@ -1,0 +1,11 @@
+from bazel.gen_extract import gen_extract
+
+if __name__ == "__main__":
+    gen_extract(
+        [
+            "cpp/ray_cpp_pkg.zip",
+        ],
+        clear_dir_first=[
+            "ray/cpp",
+        ],
+    )

--- a/gen_ray_pkg.py
+++ b/gen_ray_pkg.py
@@ -1,0 +1,13 @@
+from bazel.gen_extract import gen_extract
+
+if __name__ == "__main__":
+    gen_extract(
+        [
+            "ray_pkg.zip",
+            "ray_py_proto.zip",
+        ],
+        clear_dir_first=[
+            "ray/core/generated",
+            "ray/serve/generated",
+        ],
+    )

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -9,6 +9,7 @@ load("@rules_java//java:java_test.bzl", "java_test")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_proto_grpc//java:defs.bzl", "java_proto_compile")
+load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel:ray.bzl", "define_java_module", "native_java_library")
 
 exports_files([
@@ -498,4 +499,16 @@ genrule(
     local = 1,
     tags = ["no-cache"],
     visibility = ["//visibility:private"],
+)
+
+py_binary(
+    name = "gen_ray_java_pkg",
+    srcs = ["gen_ray_java_pkg.py"],
+    data = [
+        ":ray_java_pkg.zip",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//bazel:gen_extract",
+    ],
 )

--- a/java/gen_ray_java_pkg.py
+++ b/java/gen_ray_java_pkg.py
@@ -1,0 +1,11 @@
+from bazel.gen_extract import gen_extract
+
+if __name__ == "__main__":
+    gen_extract(
+        [
+            "java/ray_java_pkg.zip",
+        ],
+        clear_dir_first=[
+            "ray/jars",
+        ],
+    )

--- a/java/test.sh
+++ b/java/test.sh
@@ -8,14 +8,6 @@ set -x
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 java -version
 
-pushd "$ROOT_DIR"
-  echo "Check java code format."
-  # check google java style
-  mvn -T16 spotless:check
-  # check naming and others
-  mvn -T16 checkstyle:check
-popd
-
 run_testng() {
     local pid
     local exit_code
@@ -78,6 +70,15 @@ bazel build //java:gen_maven_deps
 
 echo "Build test jar."
 bazel build //java:all_tests_shaded.jar
+
+(
+  cd "$ROOT_DIR"
+  echo "Check java code format."
+  # check google java style
+  mvn -T16 spotless:check
+  # check naming and others
+  mvn -T16 checkstyle:check
+)
 
 java/generate_jni_header_files.sh
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -629,13 +629,12 @@ def build(build_python, build_java, build_cpp):
         #
         # And we put it here so that does not change behavior of
         # conda-forge build.
-        if sys.platform != "darwin":  # TODO(aslonnie): does not work on macOS..
-            bazel_flags.append("--incompatible_strict_action_env")
+        bazel_flags.append("--incompatible_strict_action_env")
 
     bazel_targets = []
-    bazel_targets += ["//:ray_pkg"] if build_python else []
-    bazel_targets += ["//cpp:ray_cpp_pkg"] if build_cpp else []
-    bazel_targets += ["//java:ray_java_pkg"] if build_java else []
+    bazel_targets += ["//:gen_ray_pkg"] if build_python else []
+    bazel_targets += ["//cpp:gen_ray_cpp_pkg"] if build_cpp else []
+    bazel_targets += ["//java:gen_ray_java_pkg"] if build_java else []
 
     if setup_spec.build_type == BuildType.DEBUG:
         bazel_flags.append("--config=debug")
@@ -645,6 +644,7 @@ def build(build_python, build_java, build_cpp):
         bazel_flags.append("--config=tsan")
 
     bazel_bin = _find_bazel_bin()
+    # Build all things first.
     subprocess.check_call(
         [bazel_bin]
         + bazel_precmd_flags
@@ -654,6 +654,12 @@ def build(build_python, build_java, build_cpp):
         + bazel_targets,
         env=bazel_env,
     )
+    # Then run the actions.
+    for action in bazel_targets:
+        subprocess.check_call(
+            [bazel_bin] + bazel_precmd_flags + ["run"] + bazel_flags + [action],
+            env=bazel_env,
+        )
 
 
 def _walk_thirdparty_dir(directory):


### PR DESCRIPTION
use bazel run on binary rules to copy output files back to the source directory, this allows bazel to properly calculate the cache hitting on all the genrules.