### PR TITLE
[core][GPU Objects] Move the registration of torch_custom_serializer to a more general path

### DIFF
--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -131,6 +131,11 @@ class SerializationContext:
     def __init__(self, worker):
         self.worker = worker
         self._thread_local = threading.local()
+        # This flag is to mark whether the custom serializer for torch.Tensor has
+        # been registered. If the method is decorated with
+        # `@ray.method(tensor_transport="xxx")`, it will use external transport
+        # (e.g. gloo, nccl, etc.) for tensor communication between actors,
+        # instead of the normal serialize -> object store -> deserialize codepath.
         self._torch_custom_serializer_registered = False
 
         def actor_handle_reducer(obj):

--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -131,6 +131,7 @@ class SerializationContext:
     def __init__(self, worker):
         self.worker = worker
         self._thread_local = threading.local()
+        self._torch_custom_serializer_registered = False
 
         def actor_handle_reducer(obj):
             ray._private.worker.global_worker.check_connected()
@@ -622,6 +623,17 @@ class SerializationContext:
         assert (
             obj_id is not None
         ), "`obj_id` is required, and it is the key to retrieve corresponding tensors from the GPU object store."
+        if not self._torch_custom_serializer_registered:
+            # Register a custom serializer for torch.Tensor. If the method is
+            # decorated with `@ray.method(tensor_transport="xxx")`, it will
+            # use external transport (e.g. gloo, nccl, etc.) for tensor
+            # communication between actors, instead of the normal serialize ->
+            # object store -> deserialize codepath.
+            from ray.experimental.channel.torch_tensor_type import TorchTensorType
+
+            TorchTensorType().register_custom_serializer()
+            self._torch_custom_serializer_registered = True
+
         serialized_val, tensors = self._serialize_and_retrieve_tensors(value)
         if tensors:
             obj_id = obj_id.decode("ascii")

--- a/python/ray/experimental/collective/collective.py
+++ b/python/ray/experimental/collective/collective.py
@@ -3,7 +3,6 @@ import threading
 import uuid
 
 import ray
-from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.experimental.collective.communicator import CommunicatorHandle
 from ray.experimental.collective.util import get_address_and_port
 import ray.experimental.internal_kv as internal_kv
@@ -77,10 +76,6 @@ def _do_init_collective_group(
     ray.util.collective.init_collective_group(
         world_size, rank, backend, group_name=name
     )
-    # Register a custom serializer for torch.Tensor. This allows torch.Tensors
-    # to use the created collective for communication between actors, instead of
-    # the normal serialize -> object store -> deserialize codepath.
-    TorchTensorType().register_custom_serializer()
 
 
 def _do_destroy_collective_group(self, name):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, the registration of torch_custom_serializer is in `do_init_collective_group`, which is called by nccl, gloo, etc. But it's not suitable for nixl, which doesn't need to call `init_collective_group` before using. This pr aims to move the registration of torch_custom_serializer to a more general path.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
