### PR TITLE
[Data] For overwrite mode, map to the right arrow behavior to account for parallel writes

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -22,7 +22,7 @@ WRITE_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
 # Docs: https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html
 EXISTING_DATA_BEHAVIOR_MAP = {
     SaveMode.APPEND: "overwrite_or_ignore",
-    SaveMode.OVERWRITE: "delete_matching",
+    SaveMode.OVERWRITE: "overwrite_or_ignore",  # delete_matching is not a suitable choice for parallel writes.
     SaveMode.IGNORE: "overwrite_or_ignore",
     SaveMode.ERROR: "error",
 }

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -2185,50 +2185,38 @@ def test_read_parquet_with_zero_row_groups(shutdown_only, tmp_path):
     assert dataset.count() == 0
 
 
-def test_parquet_write_parallel_overwrite_no_partitioning(
-    ray_start_regular_shared, tmp_path
+@pytest.mark.parametrize(
+    "partition_info",
+    [
+        {"partition_cols": None, "output_dir": "test_output"},
+        {
+            "partition_cols": ["id_mod"],
+            "output_dir": "test_output_partitioned",
+        },
+    ],
+    ids=["no_partitioning", "with_partitioning"],
+)
+def test_parquet_write_parallel_overwrite(
+    ray_start_regular_shared, tmp_path, partition_info
 ):
-    """Test parallel Parquet write with overwrite mode, no partitioning."""
-    import pandas as pd
+    """Test parallel Parquet write with overwrite mode."""
+
+    partition_cols = partition_info["partition_cols"]
+    output_dir = partition_info["output_dir"]
 
     # Create dataset with 1000 rows
-    df = pd.DataFrame({"id": range(1000), "value": [f"value_{i}" for i in range(1000)]})
+    df_data = {"id": range(1000), "value": [f"value_{i}" for i in range(1000)]}
+    if partition_cols:
+        df_data["id_mod"] = [i % 10 for i in range(1000)]  # 10 partitions
+    df = pd.DataFrame(df_data)
     ds = ray.data.from_pandas(df)
 
     # Repartition to ensure multiple write tasks
     ds = ds.repartition(10)
 
     # Write with overwrite mode
-    path = os.path.join(tmp_path, "test_output")
-    ds.write_parquet(path, mode="overwrite")
-
-    # Read back and verify
-    result = ray.data.read_parquet(path)
-    assert result.count() == 1000
-
-
-def test_parquet_write_parallel_overwrite_with_partitioning(
-    ray_start_regular_shared, tmp_path
-):
-    """Test parallel Parquet write with overwrite mode and partitioning."""
-    import pandas as pd
-
-    # Create dataset with 1000 rows and a partition column
-    df = pd.DataFrame(
-        {
-            "id": range(1000),
-            "value": [f"value_{i}" for i in range(1000)],
-            "id_mod": [i % 10 for i in range(1000)],  # 10 partitions
-        }
-    )
-    ds = ray.data.from_pandas(df)
-
-    # Repartition to ensure multiple write tasks
-    ds = ds.repartition(10)
-
-    # Write with overwrite mode and partitioning
-    path = os.path.join(tmp_path, "test_output_partitioned")
-    ds.write_parquet(path, mode="overwrite", partition_cols=["id_mod"])
+    path = os.path.join(tmp_path, output_dir)
+    ds.write_parquet(path, mode="overwrite", partition_cols=partition_cols)
 
     # Read back and verify
     result = ray.data.read_parquet(path)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The save_mode for `write_parquet` was mapped to pyarrow's `delete_matching` instead of `overwrite_or_ignore` which affected parallel writes.

## Related issue number

Closes #55043 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
