### PR TITLE
change default batch timeout

### DIFF
--- a/doc/source/serve/advanced-guides/dyn-req-batch.md
+++ b/doc/source/serve/advanced-guides/dyn-req-batch.md
@@ -31,9 +31,9 @@ emphasize-lines: 11-12
 ```
 
 You can supply 3 optional parameters to the decorators.
-- `batch_wait_timeout_s` controls how long Serve should wait for a batch once the first request arrives.
-- `max_batch_size` controls the size of the batch.
-- `max_concurrent_batches` maximum number of batches that can run concurrently.
+- `batch_wait_timeout_s` controls how long Serve should wait for a batch once the first request arrives. The default value is 0.01 (10 milliseconds).
+- `max_batch_size` controls the size of the batch. The default value is 10.
+- `max_concurrent_batches` maximum number of batches that can run concurrently. The default value is 1.
 
 Once the first request arrives, the batching decorator waits for a full batch (up to `max_batch_size`) until `batch_wait_timeout_s` is reached. If the timeout is reached, the Serve sends the batch to the model regardless the batch size.
 

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -588,7 +588,7 @@ def batch(
     _func: Optional[Callable] = None,
     /,
     max_batch_size: int = 10,
-    batch_wait_timeout_s: float = 0.0,
+    batch_wait_timeout_s: float = 0.01,
     max_concurrent_batches: int = 1,
 ) -> Callable:
     """Converts a function to asynchronously handle batches.

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -551,7 +551,7 @@ def batch(
     _: Literal[None] = None,
     /,
     max_batch_size: int = 10,
-    batch_wait_timeout_s: float = 0.0,
+    batch_wait_timeout_s: float = 0.01,
     max_concurrent_batches: int = 1,
 ) -> "_BatchDecorator":
     ...


### PR DESCRIPTION
- increasing the batch default timeout from 0.0 to 0.01(10 milliseconds)

`batch_wait_timeout=0.0` is a weird default and effectively disables batching, hence changing it to 10 milliseconds as the default
