### PR TITLE
[Core][Bug Fix] Fix: ray.cancel actor task may cause RAY_CHECK failed: it->second.submitted_task_ref_count > 0 

### DIFF
--- a/src/mock/ray/core_worker/task_manager_interface.h
+++ b/src/mock/ray/core_worker/task_manager_interface.h
@@ -57,7 +57,8 @@ class MockTaskManagerInterface : public TaskManagerInterface {
               (override));
   MOCK_METHOD(void,
               OnTaskDependenciesInlined,
-              (const std::vector<ObjectID> &inlined_dependency_ids,
+              (const TaskID &task_id,
+               const std::vector<ObjectID> &inlined_dependency_ids,
                const std::vector<ObjectID> &contained_ids),
               (override));
   MOCK_METHOD(void, MarkTaskCanceled, (const TaskID &task_id), (override));

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1286,6 +1286,8 @@ void TaskManager::OnTaskDependenciesInlined(
   auto it = submissible_tasks_.find(task_id);
   if (it == submissible_tasks_.end() || !it->second.IsPending()) return;
   std::vector<ObjectID> deleted;
+  // This process must be locked to prevent TaskManager::FailPendingTask in ray.cancel
+  // from executing concurrently with the current function.
   reference_counter_.UpdateSubmittedTaskReferences(
       /*return_ids=*/{},
       /*argument_ids_to_add=*/contained_ids,

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1279,8 +1279,12 @@ void TaskManager::ShutdownIfNeeded() {
 }
 
 void TaskManager::OnTaskDependenciesInlined(
+    const TaskID &task_id,
     const std::vector<ObjectID> &inlined_dependency_ids,
     const std::vector<ObjectID> &contained_ids) {
+  absl::MutexLock lock(&mu_);
+  auto it = submissible_tasks_.find(task_id);
+  if (it == submissible_tasks_.end() || !it->second.IsPending()) return;
   std::vector<ObjectID> deleted;
   reference_counter_.UpdateSubmittedTaskReferences(
       /*return_ids=*/{},

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -427,7 +427,8 @@ class TaskManager : public TaskManagerInterface {
       const rpc::RayErrorInfo *ray_error_info,
       const absl::flat_hash_set<ObjectID> &store_in_plasma_ids) ABSL_LOCKS_EXCLUDED(mu_);
 
-  void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
+  void OnTaskDependenciesInlined(const TaskID &task_id,
+                                 const std::vector<ObjectID> &inlined_dependency_ids,
                                  const std::vector<ObjectID> &contained_ids) override;
 
   void MarkTaskNoRetry(const TaskID &task_id) override;

--- a/src/ray/core_worker/task_manager_interface.h
+++ b/src/ray/core_worker/task_manager_interface.h
@@ -136,12 +136,14 @@ class TaskManagerInterface {
   /// the ref count for the dependency IDs. If the dependencies contained other
   /// ObjectIDs, then the ref count for these object IDs will be incremented.
   ///
+  /// \param[in] task_id The task id of the pending task spec.
   /// \param[in] inlined_dependency_ids The args that were originally passed by
   /// reference into the task, but have now been inlined.
   /// \param[in] contained_ids Any ObjectIDs that were newly inlined in the
   /// task spec, because a serialized copy of the ID was contained in one of
   /// the inlined dependencies.
   virtual void OnTaskDependenciesInlined(
+      const TaskID &task_id,
       const std::vector<ObjectID> &inlined_dependency_ids,
       const std::vector<ObjectID> &contained_ids) = 0;
 

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -104,7 +104,8 @@ class MockTaskManager : public MockTaskManagerInterface {
     return true;
   }
 
-  void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
+  void OnTaskDependenciesInlined(const TaskID &task_id,
+                                 const std::vector<ObjectID> &inlined_dependency_ids,
                                  const std::vector<ObjectID> &contained_ids) override {
     num_inlined_dependencies += inlined_dependency_ids.size();
     num_contained_ids += contained_ids.size();

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -187,7 +187,8 @@ class MockTaskManager : public MockTaskManagerInterface {
     return true;
   }
 
-  void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
+  void OnTaskDependenciesInlined(const TaskID &task_id,
+                                 const std::vector<ObjectID> &inlined_dependency_ids,
                                  const std::vector<ObjectID> &contained_ids) override {
     num_inlined_dependencies += inlined_dependency_ids.size();
     num_contained_ids += contained_ids.size();

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -202,6 +202,7 @@ Status ActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
           // the callback may get called in the same call stack.
           auto actor_id = task_spec.ActorId();
           auto task_id = task_spec.TaskId();
+          std::this_thread::sleep_for(std::chrono::milliseconds(10000));
           resolver_.ResolveDependencies(
               task_spec, [this, send_pos, actor_id, task_id](Status status) {
                 task_manager_.MarkDependenciesResolved(task_id);

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -202,7 +202,6 @@ Status ActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
           // the callback may get called in the same call stack.
           auto actor_id = task_spec.ActorId();
           auto task_id = task_spec.TaskId();
-          std::this_thread::sleep_for(std::chrono::milliseconds(10000));
           resolver_.ResolveDependencies(
               task_spec, [this, send_pos, actor_id, task_id](Status status) {
                 task_manager_.MarkDependenciesResolved(task_id);

--- a/src/ray/core_worker/transport/dependency_resolver.cc
+++ b/src/ray/core_worker/transport/dependency_resolver.cc
@@ -161,7 +161,8 @@ void LocalDependencyResolver::ResolveDependencies(
           }
 
           if (!inlined_dependency_ids.empty()) {
-            task_manager_.OnTaskDependenciesInlined(inlined_dependency_ids,
+            task_manager_.OnTaskDependenciesInlined(task_id,
+                                                    inlined_dependency_ids,
                                                     contained_ids);
           }
           if (resolved_task_state) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixed the issue where the submitted_task_ref_count of an object ref was decremented twice on a certain task：
1. Caused by ray.cancel, when marking the task as failed.
2. When the object ref is converted from an in-plasma ref to an inlined one.

The fix is to check whether the current task is still in the submission queue when OnTaskDependenciesInlined is called.

## Related issue number

Closes #55131

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
