### PR TITLE
[core] Add a `ray sanity-check` CLI

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2646,6 +2646,17 @@ def cpp(show_library_path, generate_bazel_project_template_to):
             )
         )
 
+@cli.command(hidden=True)
+def sanity_check():
+    """Run a sanity check to check that the Ray installation works."""
+    @ray.remote
+    def get_version() -> str:
+        return ray.__version__
+
+    v = ray.get(get_version.remote())
+    assert v == ray.__version__
+    print("Ray version:", v)
+
 
 @click.group(name="metrics")
 def metrics_group():
@@ -2704,6 +2715,7 @@ cli.add_command(enable_usage_stats)
 cli.add_command(metrics_group)
 cli.add_command(drain_node)
 cli.add_command(check_open_ports)
+cli.add_command(sanity_check)
 
 try:
     from ray.util.state.state_cli import (

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2649,7 +2649,10 @@ def cpp(show_library_path, generate_bazel_project_template_to):
 
 @cli.command(hidden=True)
 def sanity_check():
-    """Run a sanity check to check that the Ray installation works."""
+    """Run a sanity check to check that the Ray installation works.
+
+    This is not a public API and is intended to be used by Ray developers only.
+    """
 
     @ray.remote
     def get_version() -> str:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2646,9 +2646,11 @@ def cpp(show_library_path, generate_bazel_project_template_to):
             )
         )
 
+
 @cli.command(hidden=True)
 def sanity_check():
     """Run a sanity check to check that the Ray installation works."""
+
     @ray.remote
     def get_version() -> str:
         return ray.__version__

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2660,7 +2660,7 @@ def sanity_check():
 
     v = ray.get(get_version.remote())
     assert v == ray.__version__
-    print("Ray version:", v)
+    cli_logger.success(f"Success! Ray version: {v}")
 
 
 @click.group(name="metrics")


### PR DESCRIPTION
After I re-build Ray and am manually testing, I often go through the process of writing a trivial Ray script and testing it before running something more complex.

Adding a hidden CLI command to make this more convenient and for others to use as well.