### PR TITLE
[core] improve the robustness of metric reporting

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -534,6 +534,17 @@ class ReporterAgent(
             output=output, success=success, warning=warning
         )
 
+    async def HealthCheck(
+        self,
+        _request: reporter_pb2.HealthCheckRequest,
+        _context: ServicerContext,
+    ) -> reporter_pb2.HealthCheckReply:
+        """This is a health check endpoint for the reporter agent.
+
+        It is used to check if the reporter agent is ready to receive requests.
+        """
+        return reporter_pb2.HealthCheckReply()
+
     async def ReportOCMetrics(self, request, context):
         # Do nothing if metrics collection is disabled.
         if self._metrics_collection_disabled:

--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -41,6 +41,7 @@ ray_cc_library(
         "//src/ray/raylet_client:raylet_client_lib",
         "//src/ray/rpc:core_worker_client",
         "//src/ray/rpc:core_worker_server",
+        "//src/ray/rpc:metrics_agent_client",
         "//src/ray/stats:stats_lib",
         "//src/ray/util",
         "//src/ray/util:container_util",

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "ray/core_worker/core_worker_options.h"
+#include "ray/rpc/metrics_agent_client.h"
 #include "ray/util/mutex_protected.h"
 
 namespace ray {
@@ -177,6 +178,9 @@ class CoreWorkerProcessImpl {
 
   /// The proxy service handler that routes the RPC calls to the core worker.
   std::unique_ptr<CoreWorkerServiceHandlerProxy> service_handler_;
+
+  /// The client to export metrics to the metrics agent.
+  std::unique_ptr<ray::rpc::MetricsAgentClient> metrics_agent_client_;
 };
 }  // namespace core
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/BUILD.bazel
@@ -242,6 +242,7 @@ ray_cc_library(
         "//src/ray/raylet_client:raylet_client_lib",
         "//src/ray/rpc:core_worker_client",
         "//src/ray/rpc:gcs_server",
+        "//src/ray/rpc:metrics_agent_client",
         "//src/ray/rpc:node_manager_client",
         "//src/ray/util:counter_map",
         "//src/ray/util:exponential_backoff",

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -41,6 +41,7 @@
 #include "ray/raylet/scheduling/cluster_task_manager.h"
 #include "ray/rpc/client_call.h"
 #include "ray/rpc/gcs/gcs_rpc_server.h"
+#include "ray/rpc/metrics_agent_client.h"
 #include "ray/rpc/node_manager/raylet_client_pool.h"
 #include "ray/rpc/worker/core_worker_client_pool.h"
 #include "ray/util/throttler.h"
@@ -55,6 +56,7 @@ struct GcsServerConfig {
   std::string grpc_server_name = "GcsServer";
   uint16_t grpc_server_port = 0;
   uint16_t grpc_server_thread_num = 1;
+  uint16_t metrics_agent_port = 0;
   std::string redis_username;
   std::string redis_password;
   std::string redis_address;
@@ -294,6 +296,8 @@ class GcsServer {
   int task_pending_schedule_detected_ = 0;
   /// Throttler for global gc
   std::unique_ptr<Throttler> global_gc_throttler_;
+  /// Client to call a metrics agent gRPC server.
+  std::unique_ptr<rpc::MetricsAgentClient> metrics_agent_client_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -155,6 +155,7 @@ int main(int argc, char *argv[]) {
   gcs_server_config.redis_username = redis_username;
   gcs_server_config.retry_redis = retry_redis;
   gcs_server_config.node_ip_address = node_ip_address;
+  gcs_server_config.metrics_agent_port = metrics_agent_port;
   gcs_server_config.log_dir = log_dir;
   gcs_server_config.raylet_config_list = config_list;
   gcs_server_config.session_name = session_name;

--- a/src/ray/protobuf/reporter.proto
+++ b/src/ray/protobuf/reporter.proto
@@ -83,6 +83,10 @@ message ReportOCMetricsRequest {
 
 message ReportOCMetricsReply {}
 
+message HealthCheckRequest {}
+
+message HealthCheckReply {}
+
 // Service for communicating with the reporter agent module on a remote node.
 service ReporterService {
   // Report OpenCensus metrics to the local metrics agent.
@@ -91,6 +95,8 @@ service ReporterService {
   rpc CpuProfiling(CpuProfilingRequest) returns (CpuProfilingReply);
   rpc GpuProfiling(GpuProfilingRequest) returns (GpuProfilingReply);
   rpc MemoryProfiling(MemoryProfilingRequest) returns (MemoryProfilingReply);
+  // Health check to validate whether the service is running
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckReply);
 }
 
 message StreamLogRequest {

--- a/src/ray/raylet/BUILD.bazel
+++ b/src/ray/raylet/BUILD.bazel
@@ -281,6 +281,7 @@ ray_cc_binary(
         "//src/ray/gcs/gcs_client:gcs_client_lib",
         "//src/ray/object_manager:ownership_object_directory",
         "//src/ray/raylet/scheduling:cluster_task_manager",
+        "//src/ray/rpc:metrics_agent_client",
         "//src/ray/stats:stats_lib",
         "//src/ray/util:cmd_line_utils",
         "//src/ray/util:event",

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -283,6 +283,8 @@ int main(int argc, char *argv[]) {
   /// A manager to resolve objects needed by queued tasks and workers that
   /// called `ray.get` or `ray.wait`.
   std::unique_ptr<ray::raylet::DependencyManager> dependency_manager;
+  /// The client to export metrics to the metrics agent.
+  std::unique_ptr<ray::rpc::MetricsAgentClientImpl> metrics_agent_client;
   /// Map of workers leased out to clients.
   absl::flat_hash_map<WorkerID, std::shared_ptr<ray::raylet::WorkerInterface>>
       leased_workers;
@@ -825,6 +827,12 @@ int main(int argc, char *argv[]) {
         {ray::stats::NodeAddressKey, node_ip_address},
         {ray::stats::SessionNameKey, session_name}};
     ray::stats::Init(global_tags, metrics_agent_port, WorkerID::Nil());
+    metrics_agent_client = std::make_unique<ray::rpc::MetricsAgentClientImpl>(
+        "127.0.0.1", metrics_agent_port, main_service, *client_call_manager);
+    metrics_agent_client->WaitForServerReady(
+        [metrics_agent_port](const ray::Status &server_status) {
+          ray::stats::InitOpenTelemetryExporter(metrics_agent_port, server_status);
+        });
 
     // Initialize event framework. This should be done after the node manager is
     // initialized.

--- a/src/ray/rpc/BUILD.bazel
+++ b/src/ray/rpc/BUILD.bazel
@@ -51,6 +51,7 @@ ray_cc_library(
 
 ray_cc_library(
     name = "metrics_agent_client",
+    srcs = ["metrics_agent_client.cc"],
     hdrs = ["metrics_agent_client.h"],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/ray/rpc/metrics_agent_client.cc
+++ b/src/ray/rpc/metrics_agent_client.cc
@@ -1,0 +1,69 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/rpc/metrics_agent_client.h"
+
+#include <chrono>
+#include <functional>
+
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace rpc {
+
+void MetricsAgentClientImpl::WaitForServerReady(
+    std::function<void(const Status &)> init_exporter_fn) {
+  WaitForServerReadyWithRetry(
+      init_exporter_fn, 0, kMetricAgentInitMaxRetries, kMetricAgentInitRetryDelayMs);
+}
+
+void MetricsAgentClientImpl::WaitForServerReadyWithRetry(
+    std::function<void(const Status &)> init_exporter_fn,
+    int retry_count,
+    int max_retry,
+    int retry_interval_ms) {
+  if (exporter_initialized_) {
+    return;
+  }
+
+  RAY_LOG(INFO) << "Initializing exporter ...";
+  HealthCheck(rpc::HealthCheckRequest(),
+              [this, init_exporter_fn](auto &status, auto &&reply) {
+                if (status.ok() && !exporter_initialized_) {
+                  init_exporter_fn(status);
+                  exporter_initialized_ = true;
+                  RAY_LOG(INFO) << "Exporter initialized.";
+                }
+              });
+  if (retry_count >= max_retry) {
+    init_exporter_fn(Status::RpcError("The metrics agent server is not ready.", 14));
+    return;
+  }
+  retry_count++;
+  retry_timer_->expires_after(std::chrono::milliseconds(retry_interval_ms));
+  retry_timer_->async_wait(
+      [this, init_exporter_fn, retry_count, max_retry, retry_interval_ms](
+          const boost::system::error_code &error) {
+        if (!error) {
+          WaitForServerReadyWithRetry(
+              init_exporter_fn, retry_count, max_retry, retry_interval_ms);
+        } else {
+          RAY_LOG(ERROR) << "Failed to initialize exporter. Data will not be exported to "
+                            "the metrics agent.";
+        }
+      });
+}
+
+}  // namespace rpc
+}  // namespace ray

--- a/src/ray/rpc/metrics_agent_client.h
+++ b/src/ray/rpc/metrics_agent_client.h
@@ -30,6 +30,11 @@
 namespace ray {
 namespace rpc {
 
+/// The maximum number of retries to wait for the server to be ready.
+/// This setting allows for 30 seconds of retries.
+constexpr int kMetricAgentInitMaxRetries = 30;
+constexpr int kMetricAgentInitRetryDelayMs = 1000;
+
 /// Client used for communicating with a remote node manager server.
 class MetricsAgentClient {
  public:
@@ -40,6 +45,20 @@ class MetricsAgentClient {
   /// \param[in] request The request message.
   /// \param[in] callback The callback function that handles reply.
   VOID_RPC_CLIENT_VIRTUAL_METHOD_DECL(ReporterService, ReportOCMetrics)
+
+  /// Send a health check request to the metrics agent.
+  ///
+  /// \param[in] request The request message.
+  /// \param[in] callback The callback function that handles reply.
+  VOID_RPC_CLIENT_VIRTUAL_METHOD_DECL(ReporterService, HealthCheck)
+
+  /// Initialize an exporter (e.g. metrics, events exporter).
+  ///
+  /// This function ensures that the server is ready to receive metrics before
+  /// initializing the exporter. If the server is not ready, it will retry for
+  /// a number of times.
+  virtual void WaitForServerReady(
+      std::function<void(const Status &)> init_exporter_fn) = 0;
 };
 
 class MetricsAgentClientImpl : public MetricsAgentClient {
@@ -48,15 +67,17 @@ class MetricsAgentClientImpl : public MetricsAgentClient {
   ///
   /// \param[in] address Address of the metrics agent server.
   /// \param[in] port Port of the metrics agent server.
+  /// \param[in] io_service The `instrumented_io_context` used for managing requests.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
   MetricsAgentClientImpl(const std::string &address,
                          const int port,
-                         instrumented_io_context &io_service)
-      : client_call_manager_(io_service, /*record_stats=*/true) {
+                         instrumented_io_context &io_service,
+                         rpc::ClientCallManager &client_call_manager) {
     RAY_LOG(DEBUG) << "Initiate the metrics client of address:"
                    << BuildAddress(address, port);
-    grpc_client_ = std::make_unique<GrpcClient<ReporterService>>(
-        address, port, client_call_manager_);
+    grpc_client_ =
+        std::make_unique<GrpcClient<ReporterService>>(address, port, client_call_manager);
+    retry_timer_ = std::make_unique<boost::asio::steady_timer>(io_service);
   };
 
   VOID_RPC_CLIENT_METHOD(ReporterService,
@@ -65,11 +86,33 @@ class MetricsAgentClientImpl : public MetricsAgentClient {
                          /*method_timeout_ms*/ -1,
                          override)
 
+  VOID_RPC_CLIENT_METHOD(ReporterService,
+                         HealthCheck,
+                         grpc_client_,
+                         /*method_timeout_ms*/ -1,
+                         override)
+
+  /// Wait for the server to be ready. Invokes the callback with the final readiness
+  /// status of the server.
+  void WaitForServerReady(std::function<void(const Status &)> init_exporter_fn) override;
+
  private:
-  /// Call Manager for gRPC client.
-  rpc::ClientCallManager client_call_manager_;
   /// The RPC client.
   std::unique_ptr<GrpcClient<ReporterService>> grpc_client_;
+  /// Timer for retrying to initialize the OpenTelemetry exporter.
+  std::unique_ptr<boost::asio::steady_timer> retry_timer_;
+  /// Whether the exporter is initialized.
+  bool exporter_initialized_ = false;
+  /// Wait for the server to be ready with a retry count. Invokes the callback
+  /// with the status of the server. This is a helper function for WaitForServerReady.
+  void WaitForServerReadyWithRetry(std::function<void(const Status &)> init_exporter_fn,
+                                   int retry_count,
+                                   int max_retry,
+                                   int retry_interval_ms);
+
+  friend class MetricsAgentClientTest;
+  FRIEND_TEST(MetricsAgentClientTest, WaitForServerReadyWithRetrySuccess);
+  FRIEND_TEST(MetricsAgentClientTest, WaitForServerReadyWithRetryFailure);
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/tests/BUILD.bazel
+++ b/src/ray/rpc/tests/BUILD.bazel
@@ -41,3 +41,16 @@ ray_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+ray_cc_test(
+    name = "metrics_agent_client_test",
+    size = "small",
+    srcs = [
+        "metrics_agent_client_test.cc",
+    ],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/rpc:metrics_agent_client",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/rpc/tests/metrics_agent_client_test.cc
+++ b/src/ray/rpc/tests/metrics_agent_client_test.cc
@@ -1,0 +1,94 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/rpc/metrics_agent_client.h"
+
+#include <memory>
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace ray {
+namespace rpc {
+
+constexpr int kCountToReturnOk = 3;
+constexpr int kRetryIntervalMs = 100;
+
+class TestableMetricsAgentClientImpl : public MetricsAgentClientImpl {
+ public:
+  TestableMetricsAgentClientImpl(const std::string &address,
+                                 const int port,
+                                 instrumented_io_context &io_service,
+                                 rpc::ClientCallManager &client_call_manager,
+                                 int count_to_return_ok)
+      : MetricsAgentClientImpl(address, port, io_service, client_call_manager),
+        count_to_return_ok_(count_to_return_ok) {}
+
+  // HealthCheck is a macro+template method that supposes to invoke the callback upon
+  // the completion of an RPC call. We override it to invoke the callback directly
+  // without the RPC call. Ideally we would create a GrpcClientMock that overrides
+  // the RPC call. However, currently the RPC call is a template method, which cannot
+  // be overridden.
+  void HealthCheck(const HealthCheckRequest &request,
+                   const ClientCallback<HealthCheckReply> &callback) override {
+    health_check_count_++;
+    if (health_check_count_ <= count_to_return_ok_) {
+      callback(Status::RpcError("Failed to connect to the metrics agent server.", 14),
+               HealthCheckReply());
+    } else {
+      callback(Status::OK(), HealthCheckReply());
+    }
+  }
+
+ private:
+  int count_to_return_ok_;
+  int health_check_count_ = 1;
+};
+
+class MetricsAgentClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    client_call_manager_ = std::make_unique<ClientCallManager>(io_service_, true);
+    client_ = std::make_unique<TestableMetricsAgentClientImpl>(
+        "127.0.0.1", 8000, io_service_, *client_call_manager_, kCountToReturnOk);
+  }
+
+  instrumented_io_context io_service_;
+  std::unique_ptr<MetricsAgentClientImpl> client_;
+  std::unique_ptr<ClientCallManager> client_call_manager_;
+};
+
+TEST_F(MetricsAgentClientTest, WaitForServerReadyWithRetrySuccess) {
+  client_->WaitForServerReadyWithRetry(
+      [](const Status &server_status) { ASSERT_TRUE(server_status.ok()); },
+      0,
+      kCountToReturnOk,
+      kRetryIntervalMs);
+  io_service_.run_for(std::chrono::milliseconds(kCountToReturnOk * kRetryIntervalMs));
+  ASSERT_TRUE(client_->exporter_initialized_);
+}
+
+TEST_F(MetricsAgentClientTest, WaitForServerReadyWithRetryFailure) {
+  client_->WaitForServerReadyWithRetry(
+      [](const Status &server_status) { ASSERT_FALSE(server_status.ok()); },
+      0,
+      kCountToReturnOk - 2,
+      kRetryIntervalMs);
+  io_service_.run_for(std::chrono::milliseconds(kCountToReturnOk * kRetryIntervalMs));
+  ASSERT_FALSE(client_->exporter_initialized_);
+}
+
+}  // namespace rpc
+}  // namespace ray

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -106,6 +106,7 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
   /// Lock to protect the client
   mutable absl::Mutex mu_;
   /// Client to call a metrics agent gRPC server.
+  std::unique_ptr<rpc::ClientCallManager> client_call_manager_;
   std::shared_ptr<rpc::MetricsAgentClient> client_ ABSL_GUARDED_BY(&mu_);
   /// The worker ID of the current component.
   WorkerID worker_id_;

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -90,14 +90,6 @@ static inline void Init(
       absl::Milliseconds(std::max(RayConfig::instance().metrics_report_interval_ms() / 2,
                                   static_cast<uint64_t>(500))));
   // Register the metric recorder.
-  if (RayConfig::instance().enable_open_telemetry()) {
-    OpenTelemetryMetricRecorder::GetInstance().RegisterGrpcExporter(
-        BuildAddress("127.0.0.1", metrics_agent_port),
-        std::chrono::milliseconds(
-            absl::ToInt64Milliseconds(StatsConfig::instance().GetReportInterval())),
-        std::chrono::milliseconds(
-            absl::ToInt64Milliseconds(StatsConfig::instance().GetHarvestInterval())));
-  }
   if (should_enable_open_census()) {
     metrics_io_service_pool = std::make_shared<IOServicePool>(1);
     metrics_io_service_pool->Run();
@@ -120,6 +112,27 @@ static inline void Init(
     f();
   }
   StatsConfig::instance().SetIsInitialized(true);
+}
+
+static inline void InitOpenTelemetryExporter(const int metrics_agent_port,
+                                             const Status &metrics_agent_server_status) {
+  if (!RayConfig::instance().enable_open_telemetry()) {
+    return;
+  }
+  if (!metrics_agent_server_status.ok()) {
+    RAY_LOG(ERROR) << "Failed to initialize OpenTelemetry exporter. Data will not be "
+                      "exported to the "
+                   << "metrics agent. Server status: " << metrics_agent_server_status;
+    return;
+  }
+  OpenTelemetryMetricRecorder::GetInstance().RegisterGrpcExporter(
+      /*endpoint=*/std::string("127.0.0.1:") + std::to_string(metrics_agent_port),
+      /*interval=*/
+      std::chrono::milliseconds(
+          absl::ToInt64Milliseconds(StatsConfig::instance().GetReportInterval())),
+      /*timeout=*/
+      std::chrono::milliseconds(
+          absl::ToInt64Milliseconds(StatsConfig::instance().GetHarvestInterval())));
 }
 
 /// Shutdown the initialized stats library.

--- a/src/ray/stats/tests/metric_exporter_grpc_test.cc
+++ b/src/ray/stats/tests/metric_exporter_grpc_test.cc
@@ -57,6 +57,12 @@ class MockMetricsAgentClient : public rpc::MetricsAgentClient {
     callback(Status::OK(), {});
   }
 
+  void HealthCheck(const rpc::HealthCheckRequest &request,
+                   const rpc::ClientCallback<rpc::HealthCheckReply> &callback) override {}
+
+  void WaitForServerReady(std::function<void(const Status &)> init_exporter_fn) override {
+  }
+
   const std::vector<rpc::ReportOCMetricsRequest> &CollectedReportOCMetricsRequests()
       const {
     return reportOCMetricsRequests_;


### PR DESCRIPTION
**Context**
This PR is related to the Ray metrics infrastructure. In Ray, each node runs a centralized process called the DashboardAgent, which acts as a gRPC server. Other processes on the same node send their per-process metrics to this server. The DashboardAgent then aggregates these metrics and exports them to Prometheus.
The DashboardAgent is spawned by the raylet.

**Problem**
Currently, the `GCS` server also depends on the DashboardAgent to export its internal metrics. However, the DashboardAgent is often spawned significantly later than the GCS. This leads to failed RPC requests from GCS to the DashboardAgent, resulting in dropped metrics and noisy error logs in GCS.

The same issue in theory also applies to `raylet` and `core_worker`, even though the initialization gap is not observed during my testing, likely because the gap is small.

**Solution**
To address this, this PR introduces an `InitExporter` function inside the `MetricsAgentClient` that repeatedly retries the connection to the DashboardAgent until it succeeds. Only after a successful connection is established will GCS/raylet/core-worker begin sending metrics.

To check if the gRPC server in DashboardAgent is ready, the implementation creates a new `HealthCheck` endpoint on the server side of the `MetricsAgent`.

I fixed this only for the OpenTelemetry-backed infrastructure. Addressing it for OpenCensus has complication (it doesn't lazily store metrics before init) so I don't bother spend more efforts for something that will be soon deprecated.

Test:
- CI
- `test_metrics_agent.py` is a comprehensive test that provides confidence everything is working properly. Run this test locally and check that errors are no longer observed inside gcs log.