### PR TITLE
[Data] Add chaos variant of new image embedding release test

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1293,7 +1293,7 @@ class ResourceKillerActor:
         head_node_id,
         kill_interval_s: float = 60,
         kill_delay_s: float = 0,
-        max_to_kill: int = 2,
+        max_to_kill: Optional[int] = 2,
         batch_size_to_kill: int = 1,
         kill_filter_fn: Optional[Callable] = None,
     ):
@@ -1332,7 +1332,7 @@ class ResourceKillerActor:
 
             for to_kill in to_kills:
                 self._kill_resource(*to_kill)
-            if len(self.killed) >= self.max_to_kill:
+            if self.max_to_kill is not None and len(self.killed) >= self.max_to_kill:
                 break
             await asyncio.sleep(self.kill_interval_s - sleep_interval)
 

--- a/release/nightly_tests/dataset/batch_inference_hetero/main.py
+++ b/release/nightly_tests/dataset/batch_inference_hetero/main.py
@@ -45,7 +45,10 @@ def parse_args():
     parser.add_argument(
         "--chaos",
         action="store_true",
-        help="Whether to enable chaos.",
+        help=(
+            "Whether to enable chaos. If set, this script terminates one worker node "
+            "every minute with a grace period."
+        ),
     )
     return parser.parse_args()
 

--- a/release/nightly_tests/dataset/batch_inference_hetero/main.py
+++ b/release/nightly_tests/dataset/batch_inference_hetero/main.py
@@ -10,6 +10,8 @@ from transformers import ViTImageProcessor, ViTForImageClassification
 from PIL import Image
 from pybase64 import b64decode
 
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from ray._private.test_utils import EC2InstanceTerminatorWithGracePeriod
 from benchmark import Benchmark
 
 
@@ -40,11 +42,19 @@ def parse_args():
         required=True,
         help="The minimum and maximum concurrency for the inference operator.",
     )
+    parser.add_argument(
+        "--chaos",
+        action="store_true",
+        help="Whether to enable chaos.",
+    )
     return parser.parse_args()
 
 
 def main(args: argparse.Namespace):
     benchmark = Benchmark()
+
+    if args.chaos:
+        start_chaos()
 
     def benchmark_fn():
         (
@@ -62,6 +72,22 @@ def main(args: argparse.Namespace):
 
     benchmark.run_fn("main", benchmark_fn)
     benchmark.write_result()
+
+
+def start_chaos():
+    assert ray.is_initialized()
+
+    head_node_id = ray.get_runtime_context().get_node_id()
+    scheduling_strategy = NodeAffinitySchedulingStrategy(
+        node_id=head_node_id, soft=False
+    )
+    resource_killer = EC2InstanceTerminatorWithGracePeriod.options(
+        scheduling_strategy=scheduling_strategy
+    ).remote(head_node_id, max_to_kill=None)
+
+    ray.get(resource_killer.ready.remote())
+
+    resource_killer.run.remote()
 
 
 def decode(row: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -547,9 +547,9 @@
 
   matrix:
     setup:
-      case:
-      cluster_type:
-      args:
+      case: []
+      cluster_type: []
+      args: []
     adjustments:
       - with:
           case: fixed_size
@@ -560,7 +560,7 @@
           cluster_type: autoscaling
           args: --inference-concurrency 1 40
       - with:
-          case: chaos
+          case: fixed_size_chaos
           cluster_type: fixed_size
           args: --inference-concurrency 40 40 --chaos
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -564,15 +564,13 @@
           cluster_type: fixed_size
           args: --inference-concurrency 40 40 --chaos
 
-  run:
-    timeout: 3600
-
   cluster:
     cluster_compute: batch_inference_hetero/{{cluster_type}}_cluster_compute.yaml
     byod:
       post_build_script: byod_install_pybase64.sh
 
   run:
+    timeout: 3600
     script: python batch_inference_hetero/main.py {{args}}
 
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -542,28 +542,38 @@
           python setup_chaos.py --chaos TerminateEC2InstanceWithGracePeriod
           --batch-size-to-kill 10 --max-to-kill 100 --kill-delay 120
 
-- name: batch_inference_hetero
+- name: batch_inference_hetero_{{case}}
   frequency: manual
+
+  matrix:
+    setup:
+      case:
+      cluster_type:
+      args:
+    adjustments:
+      - with:
+          case: fixed_size
+          cluster_type: fixed_size
+          args: --inference-concurrency 40 40
+      - with:
+          case: autoscaling
+          cluster_type: autoscaling
+          args: --inference-concurrency 1 40
+      - with:
+          case: chaos
+          cluster_type: fixed_size
+          args: --inference-concurrency 40 40 --chaos
 
   run:
     timeout: 3600
 
-  variations:
-    - __suffix__: fixed_size
-      cluster:
-        cluster_compute: batch_inference_hetero/fixed_size_cluster_compute.yaml
-        byod:
-          post_build_script: byod_install_pybase64.sh
-      run:
-        script: python batch_inference_hetero/main.py --inference-concurrency 40 40
+  cluster:
+    cluster_compute: batch_inference_hetero/{{cluster_type}}_cluster_compute.yaml
+    byod:
+      post_build_script: byod_install_pybase64.sh
 
-    - __suffix__: autoscaling
-      cluster:
-        cluster_compute: batch_inference_hetero/autoscaling_cluster_compute.yaml
-        byod:
-          post_build_script: byod_install_pybase64.sh
-      run:
-        script: python batch_inference_hetero/main.py --inference-concurrency 1 40
+  run:
+    script: python batch_inference_hetero/main.py {{args}}
 
 
 ##############


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We want to make sure Ray Data is fault tolerant. To measure our progress, this PR adds a chaos variant of the image embedding release test added by https://github.com/ray-project/ray/pull/54806

This PR also extends to `ResourceKillerActor` to allow it to run indefinitely (i.e., not stopping it after a number of resources have been killed).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
