### PR TITLE
[Core] Fix `test_resource_and_label_spec` on macOS

### DIFF
--- a/python/ray/tests/unit/test_resource_and_label_spec.py
+++ b/python/ray/tests/unit/test_resource_and_label_spec.py
@@ -106,10 +106,14 @@ def test_resource_and_label_spec_resolves_auto_detect(monkeypatch):
     assert HEAD_NODE_RESOURCE_NAME in spec.resources
     assert any(key.startswith(NODE_ID_PREFIX) for key in spec.resources.keys())
 
-    # object_store_memory = 8GB * DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
-    expected_object_store = int(
-        8 * 1024**3 * ray_constants.DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
-    )
+    if sys.platform == "darwin":
+        # Object store memory is capped at 2GB on macOS.
+        expected_object_store = 2 * 1024**3
+    else:
+        # object_store_memory = 8GB * DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
+        expected_object_store = int(
+            8 * 1024**3 * ray_constants.DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
+        )
     assert spec.object_store_memory == expected_object_store
 
     # memory is total available memory - object_store_memory


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a failing test on macOS:
```
=================================== FAILURES ===================================
______________ test_resource_and_label_spec_resolves_auto_detect _______________
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1038c8b20>
    def test_resource_and_label_spec_resolves_auto_detect(monkeypatch):
        """Validate that ResourceAndLabelSpec resolve() fills out defaults detected from
        system when Params not passed."""
        monkeypatch.setattr("ray._private.utils.get_num_cpus", lambda: 4)  # 4 cpus
        monkeypatch.setattr(
            "ray._common.utils.get_system_memory", lambda: 16 * 1024**3
        )  # 16GB
        monkeypatch.setattr(
            "ray._private.utils.estimate_available_memory", lambda: 8 * 1024**3
        )  # 8GB
        monkeypatch.setattr(
            "ray._private.utils.get_shared_memory_bytes", lambda: 4 * 1024**3
        )  # 4GB
        spec = ResourceAndLabelSpec()
        spec.resolve(is_head=True)
        assert spec.resolved()
        # Validate all fields are set based on defaults or calls to system.
        assert spec.num_cpus == 4
        assert spec.num_gpus == 0
        assert isinstance(spec.labels, dict)
        assert HEAD_NODE_RESOURCE_NAME in spec.resources
        assert any(key.startswith(NODE_ID_PREFIX) for key in spec.resources.keys())
        # object_store_memory = 8GB * DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
        expected_object_store = int(
            8 * 1024**3 * ray_constants.DEFAULT_OBJECT_STORE_MEMORY_PROPORTION
        )
>       assert spec.object_store_memory == expected_object_store
E       assert 2147483648 == 2576980377
E        +  where 2147483648 = <ray._private.resource_and_label_spec.ResourceAndLabelSpec object at 0x1038c8eb0>.object_store_memory
```

by accounting for this code path:
```
# Set the object_store_memory size to 2GB on Mac
# to avoid degraded performance.
# (https://github.com/ray-project/ray/issues/20388)
if sys.platform == "darwin":
  object_store_memory = min(
    object_store_memory, ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT
  )
```

## Related issue number

https://github.com/ray-project/ray/issues/51564

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
