### PR TITLE
[Data] Removed `target_shuffle_max_block_size` config

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -818,7 +818,7 @@ py_test(
 
 py_test(
     name = "test_dynamic_block_split",
-    size = "medium",
+    size = "large",
     srcs = ["tests/test_dynamic_block_split.py"],
     tags = [
         "data_non_parallel",

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -88,8 +88,6 @@ class TaskPoolMapOperator(MapOperator):
             target_max_block_size=self.actual_target_max_block_size,
         )
 
-        print(f">>> TPMO._add_bundled_input: {self.actual_target_max_block_size=}")
-
         dynamic_ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)
         dynamic_ray_remote_args["name"] = self.name
 

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -88,6 +88,8 @@ class TaskPoolMapOperator(MapOperator):
             target_max_block_size=self.actual_target_max_block_size,
         )
 
+        print(f">>> TPMO._add_bundled_input: {self.actual_target_max_block_size=}")
+
         dynamic_ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)
         dynamic_ray_remote_args["name"] = self.name
 

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -85,8 +85,6 @@ def plan_all_to_all_op(
     assert len(physical_children) == 1
     input_physical_dag = physical_children[0]
 
-    target_max_block_size = None
-
     if isinstance(op, RandomizeBlocks):
         fn = generate_randomize_blocks_fn(op)
         # Randomize block order does not actually compute anything, so we
@@ -103,7 +101,6 @@ def plan_all_to_all_op(
             op._ray_remote_args,
             debug_limit_shuffle_execution_to_num_blocks,
         )
-        target_max_block_size = data_context.target_shuffle_max_block_size
 
     elif isinstance(op, Repartition):
         if op._keys:
@@ -119,7 +116,6 @@ def plan_all_to_all_op(
                 )
 
         elif op._shuffle:
-            target_max_block_size = data_context.target_shuffle_max_block_size
             debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
                 "debug_limit_shuffle_execution_to_num_blocks", None
             )
@@ -143,7 +139,6 @@ def plan_all_to_all_op(
             data_context,
             debug_limit_shuffle_execution_to_num_blocks,
         )
-        target_max_block_size = data_context.target_shuffle_max_block_size
 
     elif isinstance(op, Aggregate):
         if data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE:
@@ -159,7 +154,6 @@ def plan_all_to_all_op(
             data_context,
             debug_limit_shuffle_execution_to_num_blocks,
         )
-        target_max_block_size = data_context.target_shuffle_max_block_size
     else:
         raise ValueError(f"Found unknown logical operator during planning: {op}")
 
@@ -167,7 +161,6 @@ def plan_all_to_all_op(
         fn,
         input_physical_dag,
         data_context,
-        target_max_block_size=target_max_block_size,
         num_outputs=op._num_outputs,
         sub_progress_bar_names=op._sub_progress_bar_names,
         name=op.name,

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -161,6 +161,7 @@ def plan_all_to_all_op(
         fn,
         input_physical_dag,
         data_context,
+        target_max_block_size=None,
         num_outputs=op._num_outputs,
         sub_progress_bar_names=op._sub_progress_bar_names,
         name=op.name,

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -573,7 +573,9 @@ class DataContext:
             )
 
         elif name == "target_shuffle_max_block_size":
-            warnings.warn("`target_shuffle_max_block_size` is deprecated! Configure `target_max_block_size` instead.`")
+            warnings.warn(
+                "`target_shuffle_max_block_size` is deprecated! Configure `target_max_block_size` instead.`"
+            )
 
             self.target_max_block_size = value
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -574,7 +574,7 @@ class DataContext:
 
         elif name == "target_shuffle_max_block_size":
             warnings.warn(
-                "`target_shuffle_max_block_size` is deprecated! Configure `target_max_block_size` instead.`"
+                "`target_shuffle_max_block_size` is deprecated! Configure `target_max_block_size` instead."
             )
 
             self.target_max_block_size = value

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -302,8 +302,6 @@ class DataContext:
     Args:
         target_max_block_size: The max target block size in bytes for reads and
             transformations. If `None`, this means the block size is infinite.
-        target_shuffle_max_block_size: The max target block size in bytes for shuffle
-            ops like ``random_shuffle``, ``sort``, and ``repartition``.
         target_min_block_size: Ray Data avoids creating blocks smaller than this
             size in bytes on read. This takes precedence over
             ``read_op_min_num_blocks``.
@@ -400,7 +398,6 @@ class DataContext:
 
     # `None` means the block size is infinite.
     target_max_block_size: Optional[int] = DEFAULT_TARGET_MAX_BLOCK_SIZE
-    target_shuffle_max_block_size: int = DEFAULT_SHUFFLE_TARGET_MAX_BLOCK_SIZE
     target_min_block_size: int = DEFAULT_TARGET_MIN_BLOCK_SIZE
     streaming_read_buffer_size: int = DEFAULT_STREAMING_READ_BUFFER_SIZE
     enable_pandas_block: bool = DEFAULT_ENABLE_PANDAS_BLOCK
@@ -563,16 +560,22 @@ class DataContext:
             and value != DEFAULT_WRITE_FILE_RETRY_ON_ERRORS
         ):
             warnings.warn(
-                "`write_file_retry_on_errors` is deprecated. Configure "
+                "`write_file_retry_on_errors` is deprecated! Configure "
                 "`retried_io_errors` instead.",
                 DeprecationWarning,
             )
+
         elif name == "use_push_based_shuffle":
             warnings.warn(
-                "`use_push_based_shuffle` is deprecated, please configure "
+                "`use_push_based_shuffle` is deprecated! Configure "
                 "`shuffle_strategy` instead.",
                 DeprecationWarning,
             )
+
+        elif name == "target_shuffle_max_block_size":
+            warnings.warn("`target_shuffle_max_block_size` is deprecated! Configure `target_max_block_size` instead.`")
+
+            self.target_max_block_size = value
 
         elif name == "use_polars":
             warnings.warn(

--- a/python/ray/data/tests/test_block_sizing.py
+++ b/python/ray/data/tests/test_block_sizing.py
@@ -164,12 +164,17 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         <= ds._plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
+
+    def _estimate_intermediate_blocks(fusion_supported: bool, num_blocks_expected: int):
+        return num_blocks_expected ** 2 + num_blocks_expected * (
+            2 if fusion_supported else 4
+        )
+
     # map * reduce intermediate blocks + 1 metadata ref per map/reduce task.
     # If fusion is not supported, the un-fused map stage produces 1 data and 1
     # metadata per task.
-    num_intermediate_blocks = num_blocks_expected**2 + num_blocks_expected * (
-        2 if fusion_supported else 4
-    )
+    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
+                                                            num_blocks_expected)
 
     print(f">>> Asserting {num_intermediate_blocks} blocks are in plasma")
 
@@ -191,9 +196,8 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         <= ds._plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
-    num_intermediate_blocks = num_blocks_expected**2 + num_blocks_expected * (
-        2 if fusion_supported else 4
-    )
+    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
+                                                            num_blocks_expected)
     last_snapshot = assert_blocks_expected_in_plasma(
         last_snapshot,
         # Dataset.sort produces some empty intermediate blocks because the
@@ -211,9 +215,8 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         <= ds._plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
-    num_intermediate_blocks = num_blocks_expected**2 + num_blocks_expected * (
-        2 if fusion_supported else 4
-    )
+    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
+                                                            num_blocks_expected)
     last_snapshot = assert_blocks_expected_in_plasma(
         last_snapshot,
         num_intermediate_blocks,
@@ -228,9 +231,8 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         <= ds._plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
-    num_intermediate_blocks = num_blocks_expected**2 + num_blocks_expected * (
-        2 if fusion_supported else 4
-    )
+    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
+                                                            num_blocks_expected)
     last_snapshot = assert_blocks_expected_in_plasma(
         last_snapshot,
         num_intermediate_blocks,
@@ -239,12 +241,17 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
     # Setting target max block size does not affect map ops when there is a
     # shuffle downstream.
     ctx.target_max_block_size = ctx.target_max_block_size * 2
+    num_blocks_expected //= 2
+
     ds = shuffle_fn(ray.data.range(N).map(lambda x: x), **kwargs).materialize()
     assert (
         num_blocks_expected
         <= ds._plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
+
+    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
+                                                            num_blocks_expected)
 
     assert_blocks_expected_in_plasma(
         last_snapshot,

--- a/python/ray/data/tests/test_block_sizing.py
+++ b/python/ray/data/tests/test_block_sizing.py
@@ -170,15 +170,16 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
     )
 
     def _estimate_intermediate_blocks(fusion_supported: bool, num_blocks_expected: int):
-        return num_blocks_expected ** 2 + num_blocks_expected * (
+        return num_blocks_expected**2 + num_blocks_expected * (
             2 if fusion_supported else 4
         )
 
     # map * reduce intermediate blocks + 1 metadata ref per map/reduce task.
     # If fusion is not supported, the un-fused map stage produces 1 data and 1
     # metadata per task.
-    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
-                                                            num_blocks_expected)
+    num_intermediate_blocks = _estimate_intermediate_blocks(
+        fusion_supported, num_blocks_expected
+    )
 
     print(f">>> Asserting {num_intermediate_blocks} blocks are in plasma")
 
@@ -200,8 +201,9 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         <= ds._plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
-    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
-                                                            num_blocks_expected)
+    num_intermediate_blocks = _estimate_intermediate_blocks(
+        fusion_supported, num_blocks_expected
+    )
     last_snapshot = assert_blocks_expected_in_plasma(
         last_snapshot,
         # Dataset.sort produces some empty intermediate blocks because the
@@ -219,8 +221,9 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         <= ds._plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
-    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
-                                                            num_blocks_expected)
+    num_intermediate_blocks = _estimate_intermediate_blocks(
+        fusion_supported, num_blocks_expected
+    )
     last_snapshot = assert_blocks_expected_in_plasma(
         last_snapshot,
         num_intermediate_blocks,
@@ -235,8 +238,9 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         <= ds._plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
-    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
-                                                            num_blocks_expected)
+    num_intermediate_blocks = _estimate_intermediate_blocks(
+        fusion_supported, num_blocks_expected
+    )
     last_snapshot = assert_blocks_expected_in_plasma(
         last_snapshot,
         num_intermediate_blocks,
@@ -254,8 +258,9 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         <= num_blocks_expected * 1.5
     )
 
-    num_intermediate_blocks = _estimate_intermediate_blocks(fusion_supported,
-                                                            num_blocks_expected)
+    num_intermediate_blocks = _estimate_intermediate_blocks(
+        fusion_supported, num_blocks_expected
+    )
 
     assert_blocks_expected_in_plasma(
         last_snapshot,

--- a/python/ray/data/tests/test_block_sizing.py
+++ b/python/ray/data/tests/test_block_sizing.py
@@ -154,8 +154,8 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
 
     shuffle_fn, kwargs, fusion_supported = shuffle_op
 
-    ctx.target_shuffle_max_block_size = 10_000 * 8
-    num_blocks_expected = mem_size // ctx.target_shuffle_max_block_size
+    ctx.target_max_block_size = 10_000 * 8
+    num_blocks_expected = mem_size // ctx.target_max_block_size
     last_snapshot = get_initial_core_execution_metrics_snapshot()
 
     ds = shuffle_fn(ray.data.range(N), **kwargs).materialize()
@@ -201,9 +201,9 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         num_intermediate_blocks,
     )
 
-    ctx.target_shuffle_max_block_size //= 2
-    num_blocks_expected = mem_size // ctx.target_shuffle_max_block_size
-    block_size_expected = ctx.target_shuffle_max_block_size
+    ctx.target_max_block_size //= 2
+    num_blocks_expected = mem_size // ctx.target_max_block_size
+    block_size_expected = ctx.target_max_block_size
 
     ds = shuffle_fn(ray.data.range(N), **kwargs).materialize()
     assert (
@@ -238,7 +238,7 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
 
     # Setting target max block size does not affect map ops when there is a
     # shuffle downstream.
-    ctx.target_max_block_size = ctx.target_shuffle_max_block_size * 2
+    ctx.target_max_block_size = ctx.target_max_block_size * 2
     ds = shuffle_fn(ray.data.range(N).map(lambda x: x), **kwargs).materialize()
     assert (
         num_blocks_expected

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -458,7 +458,7 @@ def test_random_shuffle_operator(ray_start_regular_shared_2_cpus):
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
     assert (
         physical_op.actual_target_max_block_size
-        == DataContext.get_current().target_shuffle_max_block_size
+        == DataContext.get_current().target_max_block_size
     )
 
     # Check that the linked logical operator is the same the input op.
@@ -495,7 +495,7 @@ def test_repartition_operator(ray_start_regular_shared_2_cpus, shuffle):
     if shuffle:
         assert (
             physical_op.actual_target_max_block_size
-            == DataContext.get_current().target_shuffle_max_block_size
+            == DataContext.get_current().target_max_block_size
         )
     else:
         assert (
@@ -604,7 +604,7 @@ def test_sort_operator(
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
     assert (
         physical_op.actual_target_max_block_size
-        == DataContext.get_current().target_shuffle_max_block_size
+        == DataContext.get_current().target_max_block_size
     )
 
 
@@ -744,7 +744,7 @@ def test_aggregate_operator(ray_start_regular_shared_2_cpus):
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
     assert (
         physical_op.actual_target_max_block_size
-        == DataContext.get_current().target_shuffle_max_block_size
+        == DataContext.get_current().target_max_block_size
     )
 
     # Check that the linked logical operator is the same the input op.

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -101,7 +101,10 @@ def test_map_groups_with_gpus(
     ray.init(num_gpus=1)
 
     rows = (
-        ray.data.range(1).groupby("id").map_groups(lambda x: x, num_gpus=1).take_all()
+        ray.data.range(1, override_num_blocks=1)
+        .groupby("id")
+        .map_groups(lambda x: x, num_gpus=1)
+        .take_all()
     )
 
     assert rows == [{"id": 0}]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This configuration seem to have been introduced in an attempt to address [release test failure](https://github.com/ray-project/ray/pull/40839) and now creates a diverging behavior where `target_max_block_size` isn't respected if either of sort/shuffle/aggregate operations are used.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
