### PR TITLE
[data] truncate dataset export

### DIFF
--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 UNKNOWN = "unknown"
 
+# Number of characters to truncate to when
+# exporting dataset operator arguments
+DEFAULT_TRUNCATION_LENGTH = 100
+
 # NOTE: These dataclasses need to be updated in sync with the protobuf definitions in
 # src/ray/protobuf/export_api/export_dataset_metadata.proto
 @dataclass
@@ -138,17 +142,19 @@ class DatasetMetadata:
     data_context: DataContext
 
 
-def sanitize_for_struct(obj):
+def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
     if isinstance(obj, Mapping):
         return {k: sanitize_for_struct(v) for k, v in obj.items()}
-    elif isinstance(obj, (str, int, float, bool)) or obj is None:
+    elif isinstance(obj, (int, float, bool)) or obj is None:
         return obj
+    elif isinstance(obj, str):
+        return obj[:truncate_length]
     elif isinstance(obj, Sequence):
         return [sanitize_for_struct(v) for v in obj]
     else:
         # Convert unhandled types to string
         try:
-            return json.dumps(obj)
+            return json.dumps(obj)[:truncate_length]
         except (TypeError, OverflowError):
             try:
                 return str(obj)

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -157,7 +157,7 @@ def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
             return json.dumps(obj)[:truncate_length]
         except (TypeError, OverflowError):
             try:
-                return str(obj)
+                return str(obj)[:truncate_length]
             except Exception:
                 return UNKNOWN
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, dataset metadata exports can be large because we include operator args for each operator. The size(args) is unbounded. Instead, we can truncate the length of arguments to a default 100 characters. 

This should mitigate any unexpectedly large arguments, but won't affect the # of Operators or the # of args per Operator that are exported. That's ok(for now), because we shouldn't have too many.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
