### PR TITLE
[Data] Fixing `StatsManager` to properly handle `StatsActor` being killed on disconnect

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -759,7 +759,7 @@ class _StatsManager:
         per_node_metrics = self._aggregate_per_node_metrics(op_metrics)
         args = (dataset_tag, op_metrics_dicts, operator_tags, state, per_node_metrics)
         if force_update:
-            self._get_stats_actor().update_execution_metrics.remote(*args)
+            self._get_or_create_stats_actor().update_execution_metrics.remote(*args)
         else:
             with self._stats_lock:
                 self._last_execution_stats[dataset_tag] = args

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -633,24 +633,41 @@ class _StatsManager:
         self._update_thread: Optional[threading.Thread] = None
         self._update_thread_lock: threading.Lock = threading.Lock()
 
-    def _stats_actor(self, create_if_not_exists=True) -> Optional[ActorHandle]:
+    def _get_stats_actor(self, skip_cache: bool = False) -> Optional[ActorHandle]:
         if ray._private.worker._global_node is None:
-            raise RuntimeError("Global node is not initialized.")
+            raise RuntimeError("Global node is not initialized. Driver might be not connected to Ray.")
+
         current_cluster_id = ray._private.worker._global_node.cluster_id
+
         if (
             self._stats_actor_handle is None
             or self._stats_actor_cluster_id != current_cluster_id
+            or skip_cache
         ):
-            if create_if_not_exists:
-                self._stats_actor_handle = _get_or_create_stats_actor()
-            else:
-                try:
-                    self._stats_actor_handle = ray.get_actor(
-                        name=STATS_ACTOR_NAME, namespace=STATS_ACTOR_NAMESPACE
-                    )
-                except ValueError:
-                    return None
+            try:
+                self._stats_actor_handle = ray.get_actor(
+                    name=STATS_ACTOR_NAME, namespace=STATS_ACTOR_NAMESPACE
+                )
+            except ValueError:
+                return None
             self._stats_actor_cluster_id = current_cluster_id
+
+        return self._stats_actor_handle
+
+    def _get_or_create_stats_actor(self) -> Optional[ActorHandle]:
+        if ray._private.worker._global_node is None:
+            raise RuntimeError("Global node is not initialized. Driver might be not connected to Ray.")
+
+        # NOTE: In some cases (for ex, when registering dataset) actor might be gone
+        #       (for ex, when prior driver disconnects) and therefore to avoid using
+        #       stale handle we force looking up the actor with Ray to determine if
+        #       we should create a new one.
+        actor = self._get_stats_actor(skip_cache=True)
+
+        if actor is None:
+            self._stats_actor_handle = _get_or_create_stats_actor()
+            self._stats_actor_cluster_id = ray._private.worker._global_node.cluster_id
+
         return self._stats_actor_handle
 
     def _start_thread_if_not_running(self):
@@ -667,9 +684,7 @@ class _StatsManager:
                                 # this thread can be running even after the cluster is
                                 # shutdown. Creating an actor will automatically start
                                 # a new cluster.
-                                stats_actor = self._stats_actor(
-                                    create_if_not_exists=False
-                                )
+                                stats_actor = self._get_stats_actor()
                                 if stats_actor is None:
                                     continue
                                 stats_actor.update_metrics.remote(
@@ -740,7 +755,7 @@ class _StatsManager:
         per_node_metrics = self._aggregate_per_node_metrics(op_metrics)
         args = (dataset_tag, op_metrics_dicts, operator_tags, state, per_node_metrics)
         if force_update:
-            self._stats_actor().update_execution_metrics.remote(*args)
+            self._get_stats_actor().update_execution_metrics.remote(*args)
         else:
             with self._stats_lock:
                 self._last_execution_stats[dataset_tag] = args
@@ -787,7 +802,7 @@ class _StatsManager:
             topology: Optional Topology representing the DAG structure to export
             data_context: The DataContext attached to the dataset
         """
-        self._stats_actor().register_dataset.remote(
+        self._get_or_create_stats_actor().register_dataset.remote(
             ray.get_runtime_context().get_job_id(),
             dataset_tag,
             operator_tags,
@@ -797,7 +812,7 @@ class _StatsManager:
 
     def get_dataset_id_from_stats_actor(self) -> str:
         try:
-            return ray.get(self._stats_actor().get_dataset_id.remote())
+            return ray.get(self._get_or_create_stats_actor().get_dataset_id.remote())
         except Exception:
             # Getting dataset id from _StatsActor may fail, in this case
             # fall back to uuid4

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -635,7 +635,9 @@ class _StatsManager:
 
     def _get_stats_actor(self, skip_cache: bool = False) -> Optional[ActorHandle]:
         if ray._private.worker._global_node is None:
-            raise RuntimeError("Global node is not initialized. Driver might be not connected to Ray.")
+            raise RuntimeError(
+                "Global node is not initialized. Driver might be not connected to Ray."
+            )
 
         current_cluster_id = ray._private.worker._global_node.cluster_id
 
@@ -656,7 +658,9 @@ class _StatsManager:
 
     def _get_or_create_stats_actor(self) -> Optional[ActorHandle]:
         if ray._private.worker._global_node is None:
-            raise RuntimeError("Global node is not initialized. Driver might be not connected to Ray.")
+            raise RuntimeError(
+                "Global node is not initialized. Driver might be not connected to Ray."
+            )
 
         # NOTE: In some cases (for ex, when registering dataset) actor might be gone
         #       (for ex, when prior driver disconnects) and therefore to avoid using

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1470,7 +1470,9 @@ def test_per_node_metrics_basic(ray_start_regular_shared, restore_data_context):
                 sum_metrics[metric] += value
         return sum_metrics
 
-    with patch("ray.data._internal.stats.StatsManager._stats_actor") as mock_get_actor:
+    with patch(
+        "ray.data._internal.stats.StatsManager._get_or_create_stats_actor"
+    ) as mock_get_actor:
         mock_actor_handle = MagicMock()
         mock_get_actor.return_value = mock_actor_handle
 
@@ -1516,7 +1518,9 @@ def test_per_node_metrics_toggle(
     ctx = DataContext.get_current()
     ctx.enable_per_node_metrics = enable_metrics
 
-    with patch("ray.data._internal.stats.StatsManager._stats_actor") as mock_get_actor:
+    with patch(
+        "ray.data._internal.stats.StatsManager._get_stats_actor"
+    ) as mock_get_actor:
         mock_actor_handle = MagicMock()
         mock_get_actor.return_value = mock_actor_handle
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1902,14 +1902,22 @@ def test_stats_manager_stale_actor_handle(ray_start_cluster):
     # First driver run
     ray.init(ignore_reinit_error=True)
 
-    ray.data.range(1000).map_batches(F, concurrency=(1, 4), num_cpus=1,).take_all()
+    ray.data.range(1000).map_batches(
+        F,
+        concurrency=(1, 4),
+        num_cpus=1,
+    ).take_all()
 
     ray.shutdown()
 
     # Second driver run
     ray.init(ignore_reinit_error=True)
 
-    ray.data.range(1000).map_batches(F, concurrency=(1, 4), num_cpus=1,).take_all()
+    ray.data.range(1000).map_batches(
+        F,
+        concurrency=(1, 4),
+        num_cpus=1,
+    ).take_all()
 
     ray.shutdown()
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1886,6 +1886,34 @@ def test_stats_manager(shutdown_only):
     wait_for_condition(lambda: not StatsManager._update_thread.is_alive())
 
 
+def test_stats_manager_stale_actor_handle(ray_start_cluster):
+    """
+    This test asserts that StatsManager is able to handle appropriately
+    cases of StatsActor being killed upon driver disconnecting from running
+    Ray cluster
+
+    See https://github.com/ray-project/ray/issues/54841 for more details
+    """
+
+    class F:
+        def __call__(self, x):
+            return x
+
+    # First driver run
+    ray.init(ignore_reinit_error=True)
+
+    ray.data.range(1000).map_batches(F, concurrency=(1, 4), num_cpus=1,).take_all()
+
+    ray.shutdown()
+
+    # Second driver run
+    ray.init(ignore_reinit_error=True)
+
+    ray.data.range(1000).map_batches(F, concurrency=(1, 4), num_cpus=1,).take_all()
+
+    ray.shutdown()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1519,7 +1519,7 @@ def test_per_node_metrics_toggle(
     ctx.enable_per_node_metrics = enable_metrics
 
     with patch(
-        "ray.data._internal.stats.StatsManager._get_stats_actor"
+        "ray.data._internal.stats.StatsManager._get_or_create_stats_actor"
     ) as mock_get_actor:
         mock_actor_handle = MagicMock()
         mock_get_actor.return_value = mock_actor_handle


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addresses https://github.com/ray-project/ray/issues/54841

Right now, `StatsManager` is overly reliant on the cached `ActorHandle` for `StatsActor`. Even though there's a corresponding check verifying that we're connected to the right cluster, it doesn't verify however whether `StatsActor` is still alive which could result in failures as highlighted in the linked ticket.

To address this issue:

1. `_stats_actor` method is split into `_get_stats_actor` and `_get_or_create_stats_actor`
2. `_get_or_create_stats_actor` always skips the cache forcing actor lookup every time 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
