### PR TITLE
use orjson for json log formatter

### DIFF
--- a/python/ray/_private/ray_logging/formatters.py
+++ b/python/ray/_private/ray_logging/formatters.py
@@ -1,7 +1,8 @@
-import json
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
+
+import orjson
 
 from ray._private.log import INTERNAL_TIMESTAMP_LOG_KEY
 from ray._private.ray_constants import LOGGER_FORMAT
@@ -99,7 +100,7 @@ class JSONFormatter(AbstractFormatter):
         record_format_attrs = self.generate_record_format_attrs(
             record, exclude_default_standard_attrs=False
         )
-        return json.dumps(record_format_attrs)
+        return orjson.dumps(record_format_attrs).decode("utf-8")
 
 
 class TextFormatter(AbstractFormatter):


### PR DESCRIPTION
in serve for high throughput and low latency scenario, this change produces a 4% increase in output RPS

test script
```
from ray import serve


@serve.deployment(max_ongoing_requests=10000)
class ChildDeployment:
    async def __call__(self):
        return "Hello, world!"


@serve.deployment(max_ongoing_requests=10000)
class MyDeployment:
    def __init__(self, child):
        self.child = child
        self.child._init(_run_router_in_separate_loop=False)
    
    async def __call__(self):
        return await self.child.remote()


app = MyDeployment.bind(ChildDeployment.bind())

```

```
# This file was generated using the `serve build` command on Ray v3.0.0.dev0.

proxy_location: EveryNode
http_options:
  host: 0.0.0.0
  port: 8000
grpc_options:
  port: 9000
  grpc_servicer_functions: []

logging_config:
  encoding: JSON
  log_level: INFO
  logs_dir: null
  enable_access_log: true
  additional_log_standard_attrs: []

applications:
- name: app1
  route_prefix: /
  import_path: app:app

  deployments:

  - name: ChildDeployment
    max_ongoing_requests: 1000

  - name: MyDeployment
    max_ongoing_requests: 1000

```

`serve run config.yaml`

Locust with 100 concurrent requests
