### PR TITLE
[wheel] fix macos wheel building with strict actions

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -202,6 +202,15 @@ def ray_deps_setup():
         build_file = True,
         url = "https://github.com/cython/cython/archive/refs/tags/3.0.12.tar.gz",
         sha256 = "a156fff948c2013f2c8c398612c018e2b52314fdf0228af8fbdb5585e13699c2",
+        patches = [
+            # Use python3 rather than python. macos does not have python installed
+            # by default, and hermetic strict action does not work as python cannot
+            # be found under /usr/bin or any systeme PATH in bazel sandbox.
+            #
+            # This patch can be removed after the following change is included.
+            # https://github.com/cython/cython/pull/7053
+            "//thirdparty/patches:cython.patch",
+        ],
     )
 
     auto_http_archive(

--- a/thirdparty/patches/cython.patch
+++ b/thirdparty/patches/cython.patch
@@ -1,0 +1,10 @@
+diff --git cython.py cython.py
+index 9283c4d..cae9864 100755
+--- cython.py
++++ cython.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+
+ #
+ #   Cython -- Main Program, generic


### PR DESCRIPTION
macos does not have `python` from the systems by default, but has `python3`. as a result, we need to patch `cpython.py` to use python3.
