### PR TITLE
[image] follow constraint file when installing dependencies

### DIFF
--- a/docker/ray-ml/install-ml-docker-requirements.sh
+++ b/docker/ray-ml/install-ml-docker-requirements.sh
@@ -19,13 +19,11 @@ sudo apt-get update \
         unrar \
         zlib1g-dev
 
-pip --no-cache-dir install -U pip pip-tools
-
 # Install requirements
-pip --no-cache-dir install -U -r requirements.txt
+pip --no-cache-dir install -r requirements.txt -c requirements_compiled.txt
 
 # Install other requirements. Keep pinned requirements bounds as constraints
-pip --no-cache-dir install -U \
+pip --no-cache-dir install \
            -c requirements.txt \
            -c requirements_compiled.txt \
            -r dl-cpu-requirements.txt \


### PR DESCRIPTION
and do not upgrade pip and pip-tools.

otherwise, it is creating inconsistencies between `ray` and `ray-ml` images.
