### PR TITLE
[wheel] revert back cython build rule hack

### DIFF
--- a/bazel/cython.BUILD
+++ b/bazel/cython.BUILD
@@ -20,9 +20,11 @@ py_library(
 )
 
 # May not be named "cython", since that conflicts with Cython/ on OSX
-filegroup(
+py_binary(
     name="cython_binary",
     srcs=["cython.py"],
+    main="cython.py",
+    srcs_version="PY2AND3",
     visibility=["//visibility:public"],
-    data=["cython_lib"],
+    deps=["cython_lib"],
 )


### PR DESCRIPTION
so that cython is a hermetic `py_binary`

reverts the change from https://github.com/ray-project/ray/pull/4334

this makes the wheel build on all platforms