### PR TITLE
[wheel] convert `:ray_pkg` references to `:gen_ray_pkg`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -96,7 +96,7 @@ refresh_compile_commands(
     # Specify the targets of interest.
     # For example, specify a dict of targets and any flags required to build.
     targets = {
-        "//:ray_pkg": "",
+        "//:ray_pkg_zip": "",
     },
     # No need to add flags already in .bazelrc. They're automatically picked up.
 )
@@ -105,7 +105,7 @@ refresh_compile_commands(
 refresh_compile_commands(
     name = "refresh_compile_commands_external_sources",
     targets = {
-        "//:ray_pkg": "",
+        "//:ray_pkg_zip": "",
     },
 )
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -211,11 +211,11 @@ _bazel_build_before_install() {
   # NOTE: Do not add build flags here. Use .bazelrc and --config instead.
 
   if [[ -z "${RAY_DEBUG_BUILD:-}" ]]; then
-    bazel build //:ray_pkg
+    bazel run //:gen_ray_pkg
   elif [[ "${RAY_DEBUG_BUILD}" == "asan" ]]; then
     echo "No need to build anything before install"
   elif [[ "${RAY_DEBUG_BUILD}" == "debug" ]]; then
-    bazel build --config debug //:ray_pkg
+    bazel run --config debug //:gen_ray_pkg
   else
     echo "Invalid config given"
     exit 1

--- a/ci/env/install-llvm-binaries.sh
+++ b/ci/env/install-llvm-binaries.sh
@@ -4,7 +4,7 @@
 # with this location. Example usage:
 #
 # (Repository root) $ ci/env/install-llvm-binaries.sh <optional URL to LLVM> <optional target directory>
-# (Repository root) $ bazel build --config=llvm //:ray_pkg
+# (Repository root) $ bazel run --config=llvm //:gen_ray_pkg
 #
 # If the arguments are unspecified, the default ${LLVM_URL} and ${TARGET_DIR} are used. They are set to be
 # suitable for CI, but may not be suitable under other environments.

--- a/ci/lint/check-git-clang-tidy-output.sh
+++ b/ci/lint/check-git-clang-tidy-output.sh
@@ -28,15 +28,15 @@ printInfo "Generating compilation database ..."
 case "${OSTYPE}" in
   linux*)
     printInfo "Running on Linux, using clang to build C++ targets. Please make sure it is installed with install-llvm-binaries.sh"
-    bazel build //ci/lint/generate_compile_commands:extract_compile_command //:ray_pkg --config=llvm \
+    bazel build //ci/lint/generate_compile_commands:extract_compile_command //:ray_pkg_zip --config=llvm \
         --experimental_action_listener=//ci/lint/generate_compile_commands:compile_command_listener;;
   darwin*)
     printInfo "Running on MacOS, assuming default C++ compiler is clang."
-    bazel build //ci/lint/generate_compile_commands:extract_compile_command //:ray_pkg \
+    bazel build //ci/lint/generate_compile_commands:extract_compile_command //:ray_pkg_zip \
         --experimental_action_listener=//ci/lint/generate_compile_commands:compile_command_listener;;
   msys*)
     printInfo "Running on Windows, using clang-cl to build C++ targets. Please make sure it is installed."
-    CC=clang-cl bazel build //ci/lint/generate_compile_commands:extract_compile_command //:ray_pkg \
+    CC=clang-cl bazel build //ci/lint/generate_compile_commands:extract_compile_command //:ray_pkg_zip \
         --experimental_action_listener=//ci/lint/generate_compile_commands:compile_command_listener;;
 esac
 

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -64,7 +64,7 @@ if [[ "$BUILD_TYPE" == "debug" ]]; then
   RAY_DEBUG_BUILD=debug pip install -v -e python/
 elif [[ "$BUILD_TYPE" == "asan" ]]; then
   pip install -v -e python/
-  bazel build $(./ci/run/bazel_export_options) --no//:jemalloc_flag //:ray_pkg
+  bazel run $(./ci/run/bazel_export_options) --no//:jemalloc_flag //:gen_ray_pkg
 elif [[ "$BUILD_TYPE" == "java" ]]; then
   bash java/build-jar-multiplatform.sh linux
   RAY_INSTALL_JAVA=1 pip install -v -e python/

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -367,11 +367,11 @@ run the following (via ``-c`` ``fastbuild``/``dbg``/``opt``, respectively):
 
 .. code-block:: shell
 
- bazel build -c fastbuild //:ray_pkg
+ bazel run -c fastbuild //:gen_ray_pkg
 
 This will rebuild Ray with the appropriate options (which may take a while).
-If you need to build all targets, you can use ``"//:all"`` instead of
-``//:ray_pkg``.
+If you need to build all targets, you can use ``bazel build //:all`` instead of
+``bazel run //:gen_ray_pkg``.
 
 To make this change permanent, you can add an option such as the following
 line to your user-level ``~/.bazelrc`` file (not to be confused with the

--- a/python/ray/_private/ray_experimental_perf.py
+++ b/python/ray/_private/ray_experimental_perf.py
@@ -32,7 +32,7 @@ def check_optimized_build():
         msg = (
             "WARNING: Unoptimized build! "
             "To benchmark an optimized build, try:\n"
-            "\tbazel build -c opt //:ray_pkg\n"
+            "\tbazel run -c opt //:gen_ray_pkg\n"
             "You can also make this permanent by adding\n"
             "\tbuild --compilation_mode=opt\n"
             "to your user-wide ~/.bazelrc file. "

--- a/python/ray/_private/ray_perf.py
+++ b/python/ray/_private/ray_perf.py
@@ -83,7 +83,7 @@ def check_optimized_build():
         msg = (
             "WARNING: Unoptimized build! "
             "To benchmark an optimized build, try:\n"
-            "\tbazel build -c opt //:ray_pkg\n"
+            "\tbazel run -c opt //:gen_ray_pkg\n"
             "You can also make this permanent by adding\n"
             "\tbuild --compilation_mode=opt\n"
             "to your user-wide ~/.bazelrc file. "


### PR DESCRIPTION
getting closer to deleting `:ray_pkg` rule from code base
