### PR TITLE
[wheel] do not depend on `:ray_pkg` from java

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -776,7 +776,7 @@ pkg_zip(
         "//conditions:default": [],
     }),
     out = "ray_pkg.zip",
-    visibility = ["//visibility:private"],
+    visibility = ["//java:__pkg__"],
 )
 
 genrule(

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -195,6 +195,17 @@ java_library(
     ],
 )
 
+# This is a local java test rule. It needs generated files to be copied into
+# the source tree before running. To build and generate ray core (gcs and
+# raylet), run `bazelisk run //:gen_ray_pkg` first.
+#
+# This rule used to depend on local genrules, which are deprecated. Reason
+# being that local genrules are build rules and do not capture changes in
+# source tree, and hence cannot be cached by bazel remote cache. Using local
+# genrule forces bazel to effectively disable caching globally to have a
+# correct build.
+#
+# TODO(ray-ci): covert java tests to non-local, hermetic tests.
 java_test(
     name = "all_tests",
     testonly = True,
@@ -202,7 +213,7 @@ java_test(
     data = [
         "testng.xml",
         ":ray_java_pkg",
-        "//:ray_pkg",
+        "//:ray_pkg_zip",
     ],
     main_class = "org.testng.TestNG",
     resources = [
@@ -216,15 +227,16 @@ java_test(
 )
 
 # 0. `cp testng_custom_template.xml testng_custom.xml`
-# 1. Specify test class/method in `testng_custom.xml`
-# 2. `bazel test //java:custom_test --test_output=streamed`
+# 1. `bazel run //:gen_ray_pkg`
+# 2. Specify test class/method in `testng_custom.xml`
+# 3. `bazel test //java:custom_test --test_output=streamed`
 java_test(
     name = "custom_test",
     args = ["java/testng_custom.xml"],
     data = [
         "testng_custom.xml",
         ":ray_java_pkg",
-        "//:ray_pkg",
+        "//:ray_pkg_zip",
     ],
     main_class = "org.testng.TestNG",
     tags = ["local"],

--- a/java/test.sh
+++ b/java/test.sh
@@ -68,6 +68,9 @@ bazel build //java:copy_pom_files
 bazel build //java:cp_java_generated
 bazel build //java:gen_maven_deps
 
+echo "Build ray core."
+bazel run //:gen_ray_pkg
+
 echo "Build test jar."
 bazel build //java:all_tests_shaded.jar
 


### PR DESCRIPTION
depends on `//:ray_pkg_zip` instead, with comment asking user to manually run `//:gen_ray_pkg`

the java test rules are not conventional, hermetic ones, but "local" ones that run in the source code directory. the ray core rules are all converted to non-local, hermetic build rules, and we are deprecating the local `ray_pkg` one. as a result, for the java rules to run, one has to manually run the `bazel run //:gen_ray_pkg` to copy the ray core bits back to the source directory.