### PR TITLE
[core] Add Subprocess Error Logging and Extend Timeout in test_node_labels

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -787,11 +787,18 @@ def call_ray_start_context(request):
         parameter = parameter.get("cmd", default_cmd)
 
     command_args = parameter.split(" ")
-
     try:
         out = ray._common.utils.decode(
             subprocess.check_output(command_args, stderr=subprocess.STDOUT, env=env)
         )
+    # If the exit code is non-zero subprocess.check_output raises a CalledProcessError
+    except subprocess.CalledProcessError as e:
+        print("Ray start cmd failed!")
+        print(f"Command: {' '.join(e.cmd)}")
+        print(f"Exit code: {e.returncode}")
+        if e.output:
+            print(f"Output:\n{e.output}")
+        raise
     except Exception as e:
         print(type(e), e)
         raise

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -797,7 +797,7 @@ def call_ray_start_context(request):
         print(f"Command: {' '.join(e.cmd)}")
         print(f"Exit code: {e.returncode}")
         if e.output:
-            print(f"Output:\n{e.output}")
+            print(f"Output:\n{e.output.decode()}")
         raise
     except Exception as e:
         print(type(e), e)

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -133,7 +133,7 @@ def test_autoscaler_set_node_labels(autoscaler_v2, shutdown_only):
     try:
         cluster.start()
         ray.init()
-        wait_for_condition(lambda: len(ray.nodes()) == 2)
+        wait_for_condition(lambda: len(ray.nodes()) == 2, timeout=20)
 
         for node in ray.nodes():
             if node["Resources"].get("CPU", 0) == 1:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`test_node_labels` has been flaky, the changes in this pr helps debug the issue by improving logging. 

issues seen in previous flaky runs:
example 1:
build: https://buildkite.com/ray-project/postmerge/builds/11787#019851c8-a4e5-424f-9189-7ae433d06d4d
test: `test_ray_start_set_empty_node_labels`
error:`subprocess.CalledProcessError: Command '['ray', 'start', '--head', '--labels={}']' returned non-zero exit status 1.`
Fix: Now catching the exception and logging the exit status and output to assist with root cause analysis.

example 2:
build: https://buildkite.com/ray-project/postmerge/builds/11765#01984520-48b0-47a7-b6bd-dd919a9f7e7c
test: `test_autoscaler_set_node_labels`
error: RuntimeError: The condition wasn't met before the timeout expired.
Fix: Timeout increased to 20 seconds to accommodate potential delays in node provisioning.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
