### PR TITLE
Add GKE GPU operator compat paths to ray-llm image PATH, LD_LIBRARY_PATH

### DIFF
--- a/ci/docker/base.cu128.wanda.yaml
+++ b/ci/docker/base.cu128.wanda.yaml
@@ -1,5 +1,5 @@
 name: "oss-ci-base_cu128-py$PYTHON"
-froms: ["nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04"]
+froms: ["nvidia/cuda:12.8.1-cudnn-devel-ubuntu20.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
@@ -12,6 +12,6 @@ srcs:
 build_args:
   - REMOTE_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
-  - BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+  - BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu20.04
 tags:
   - cr.ray.io/rayproject/oss-ci-base_cu128-py$PYTHON

--- a/ci/docker/base.cu128.wanda.yaml
+++ b/ci/docker/base.cu128.wanda.yaml
@@ -1,5 +1,5 @@
 name: "oss-ci-base_cu128-py$PYTHON"
-froms: ["nvidia/cuda:12.8.1-cudnn-devel-ubuntu20.04"]
+froms: ["nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
@@ -12,6 +12,6 @@ srcs:
 build_args:
   - REMOTE_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
-  - BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu20.04
+  - BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
 tags:
   - cr.ray.io/rayproject/oss-ci-base_cu128-py$PYTHON

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -188,6 +188,6 @@ rm -rf "${EP_TEMP_DIR}"
 
 EOF
 
-ENV PATH="${UCX_HOME}/bin:${NIXL_HOME}/bin:${PATH}"
-ENV LD_LIBRARY_PATH="${UCX_HOME}/lib:${NIXL_HOME}/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
+ENV PATH="${PATH}:${UCX_HOME}/bin:${NIXL_HOME}/bin:/usr/local/nvidia/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${UCX_HOME}/lib:${NIXL_HOME}/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64"
 ENV NIXL_PLUGIN_DIR="${NIXL_HOME}/lib/x86_64-linux-gnu/plugins/"

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -188,6 +188,16 @@ rm -rf "${EP_TEMP_DIR}"
 
 EOF
 
+# Q: Why add paths that don't exist in the base image, like /usr/local/nvidia/lib64
+# and /usr/local/nvidia/bin?
+# A: The NVIDIA GPU operator version used by GKE injects these into the container
+# after it's mounted to a pod.
+# Issue is tracked here:
+# https://github.com/GoogleCloudPlatform/compute-gpu-installation/issues/46
+# More context here:
+# https://github.com/NVIDIA/nvidia-container-toolkit/issues/275
+# and here:
+# https://gitlab.com/nvidia/container-images/cuda/-/issues/27
 ENV PATH="${PATH}:${UCX_HOME}/bin:${NIXL_HOME}/bin:/usr/local/nvidia/bin"
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${UCX_HOME}/lib:${NIXL_HOME}/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64"
 ENV NIXL_PLUGIN_DIR="${NIXL_HOME}/lib/x86_64-linux-gnu/plugins/"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `ray-llm` base image, [nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04](https://hub.docker.com/layers/nvidia/cuda/12.8.1-cudnn-devel-ubuntu22.04/images/sha256-61f6c08f2b59036cb935e56d1e31a6b64e3ae2c7ddb86d33fa0b044c7917b719) no longer includes the GPU operator compatibility paths included in the [runtime image]( https://hub.docker.com/layers/nvidia/cuda/12.8.0-runtime-ubuntu22.04/images/sha256-80c946064fc2db73957af8fa6a7a8bec3e3fd3241d130fb668cad6a62510aeda).

Additional context on those compatibility paths: https://gitlab.com/nvidia/container-images/cuda/-/issues/47

Test image: `029272617770.dkr.ecr.us-west-2.amazonaws.com/anyscale/ray-llm:pr-55206.016061-py311-cu128`

## Related issue number

- Closes https://github.com/ray-project/ray/issues/54551
- Workaround for https://github.com/GoogleCloudPlatform/compute-gpu-installation/issues/46

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
