### PR TITLE
Set VLLM_DISABLE_COMPILE_CACHE=1 to work around compile cache issue

### DIFF
--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import logging
 
 import pytest
@@ -168,13 +167,8 @@ def test_vllm_llama_lora():
 
 @pytest.fixture
 def vllm_disable_compile_cache_env(monkeypatch):
-    old_val = os.environ.get("VLLM_DISABLE_COMPILE_CACHE")
     monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-    yield
-    if old_val is not None:
-        monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", old_val)
-    else:
-        monkeypatch.delenv("VLLM_DISABLE_COMPILE_CACHE", raising=False)
+    yield True
 
 
 @pytest.mark.parametrize(

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 import os
 import logging
@@ -167,16 +166,15 @@ def test_vllm_llama_lora():
     assert all("resp" in out for out in outs)
 
 
-@ray.remote(num_gpus=1)
-def delete_torch_compile_cache_on_worker():
-    """Delete torch compile cache on worker.
-    Avoids AssertionError due to torch compile cache corruption
-    TODO(seiji): check if this is still needed after https://github.com/vllm-project/vllm/issues/18851 is fixed
-    """
-    torch_compile_cache_path = os.path.expanduser("~/.cache/vllm/torch_compile_cache")
-    if os.path.exists(torch_compile_cache_path):
-        shutil.rmtree(torch_compile_cache_path)
-        logger.warning(f"Deleted torch compile cache at {torch_compile_cache_path}")
+@pytest.fixture
+def vllm_disable_compile_cache_env(monkeypatch):
+    old_val = os.environ.get("VLLM_DISABLE_COMPILE_CACHE")
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    yield
+    if old_val is not None:
+        monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", old_val)
+    else:
+        monkeypatch.delenv("VLLM_DISABLE_COMPILE_CACHE", raising=False)
 
 
 @pytest.mark.parametrize(
@@ -189,16 +187,21 @@ def delete_torch_compile_cache_on_worker():
     ],
 )
 def test_vllm_vision_language_models(
-    model_source, tp_size, pp_size, concurrency, sample_size
+    model_source,
+    tp_size,
+    pp_size,
+    concurrency,
+    sample_size,
+    vllm_disable_compile_cache_env,
 ):
     """Test vLLM with vision language models using different configurations."""
 
-    # todo(seiji): Commenting out due to https://github.com/ray-project/ray/issues/53824
+    # todo(seiji): Commenting out due to https://github.com/vllm-project/vllm/issues/18851
     # Need to follow up once torch_compile_cache issue is fixed or PyTorch 2.8
-    if model_source == "mistral-community/pixtral-12b":
-        pytest.skip("Skipping test due to torch_compile_cache issue")
-
-    ray.get(delete_torch_compile_cache_on_worker.remote())
+    if vllm_disable_compile_cache_env:
+        pytest.warning(
+            "Disabling torch compile cache due to https://github.com/vllm-project/vllm/issues/18851"
+        )
 
     # vLLM v1 does not support decoupled tokenizer,
     # but since the tokenizer is in a separate process,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Test is failing/flakey with the following signature. The issue should be fixed in PyTorch 2.8. For now, trying a workaround.
```
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/executor/multiproc_executor.py", line 517, in worker_busy_loop
    output = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/worker/gpu_worker.py", line 210, in determine_available_memory
    self.model_runner.profile_run()
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/worker/gpu_model_runner.py", line 2274, in profile_run
    = self._dummy_run(self.max_num_tokens, is_profile=True)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/worker/gpu_model_runner.py", line 2057, in _dummy_run
    outputs = model(
              ^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/model_executor/models/llama.py", line 581, in forward
    model_output = self.model(input_ids, positions, intermediate_tensors,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/compilation/decorators.py", line 239, in __call__
    output = self.compiled_callable(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/_dynamo/eval_frame.py", line 663, in _fn
    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/_dynamo/output_graph.py", line 1544, in _call_user_compiler
    raise BackendCompilerFailed(
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/_dynamo/output_graph.py", line 1519, in _call_user_compiler
    compiled_fn = compiler_fn(gm, self.example_inputs())
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/_dynamo/repro/after_dynamo.py", line 150, in __call__
    compiled_gm = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/__init__.py", line 2392, in __call__
    return self.compiler_fn(model_, inputs_, **self.kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/compilation/backends.py", line 548, in __call__
    PiecewiseCompileInterpreter(self.split_gm, submod_names_to_compile,
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/compilation/backends.py", line 296, in run
    return super().run(*fake_args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/fx/interpreter.py", line 171, in run
    self.env[node] = self.run_node(node)
                     ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/fx/interpreter.py", line 240, in run_node
    return getattr(self, n.op)(n.target, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/compilation/backends.py", line 312, in call_module
    compiler_manager.compile(
    ^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/compilation/backends.py", line 168, in compile
    compiled_graph, handle = self.compiler.compile(
                              ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/compilation/compiler_interface.py", line 440, in compile
    raise RuntimeError(

torch._dynamo.exc.BackendCompilerFailed: backend='<vllm.compilation.backends.VllmBackend object at 0x7927404d8ed0>' raised:

RuntimeError: vLLM failed to compile the model. The most likely reason for this is that a previous compilation failed, leading to a corrupted compilation artifact. We recommend trying to remove ~/.cache/vllm/torch_compile_cache and try again to see the real issue.
```

## Related issue number

https://github.com/vllm-project/vllm/issues/18851

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
