### PR TITLE
[Core] Only listen to localhost and head node ip from proxy and client server

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -2355,9 +2355,7 @@ def start_ray_client_server(
         root_ray_dir, "_private", "workers", ray_constants.SETUP_WORKER_FILENAME
     )
 
-    ray_client_server_host = (
-        "127.0.0.1" if ray_client_server_ip == "127.0.0.1" else "0.0.0.0"
-    )
+    ray_client_server_host = ray_client_server_ip
     command = [
         sys.executable,
         setup_worker_path,

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -848,7 +848,7 @@ def call_ray_start_with_external_redis(request):
 def init_and_serve():
     import ray.util.client.server.server as ray_client_server
 
-    server_handle, _ = ray_client_server.init_and_serve("localhost:50051")
+    server_handle, _ = ray_client_server.init_and_serve("localhost", 50051)
     yield server_handle
     ray_client_server.shutdown_with_server(server_handle.grpc_server)
     time.sleep(2)

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -651,7 +651,7 @@ def test_startup_retry(call_ray_start_shared):
     thread = threading.Thread(target=run_client, daemon=True)
     thread.start()
     time.sleep(3)
-    server = ray_client_server.serve("localhost:50051")
+    server = ray_client_server.serve("localhost", 50051)
     thread.join()
     server.stop(0)
     ray_client._inside_client_test = False
@@ -671,7 +671,7 @@ def test_dataclient_server_drop(call_ray_start_shared):
         time.sleep(2)
         server.stop(0)
 
-    server = ray_client_server.serve("localhost:50051")
+    server = ray_client_server.serve("localhost", 50051)
     ray_client.connect("localhost:50051")
     thread = threading.Thread(target=stop_server, args=(server,))
     thread.start()

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -362,7 +362,7 @@ def test_client_deprecation_warn():
     )
     ray.shutdown()
 
-    server = ray_client_server.serve("localhost:50055")
+    server = ray_client_server.serve("localhost", 50055)
 
     # Test warning when namespace and runtime env aren't specified
     with warnings.catch_warnings(record=True) as w:

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -53,7 +53,7 @@ def init_and_serve_lazy(ray_start_cluster):
     def connect(job_config=None, **ray_init_kwargs):
         ray.init(address=address, job_config=job_config, **ray_init_kwargs)
 
-    server_handle = ray_client_server.serve("localhost:50051", connect)
+    server_handle = ray_client_server.serve("localhost", 50051, connect)
     yield server_handle
     ray_client_server.shutdown_with_server(server_handle.grpc_server)
 

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -182,7 +182,8 @@ def test_delay_in_rewriting_environment(shutdown_only):
     """
     ray_instance = ray.init()
     server = proxier.serve_proxier(
-        "localhost:25010",
+        "localhost",
+        25010,
         ray_instance["address"],
         session_dir=ray_instance["session_dir"],
     )
@@ -220,7 +221,8 @@ def test_startup_error_yields_clean_result(shutdown_only):
     """
     ray_instance = ray.init()
     server = proxier.serve_proxier(
-        "localhost:25030",
+        "localhost",
+        25030,
         ray_instance["address"],
         session_dir=ray_instance["session_dir"],
     )

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -170,7 +170,7 @@ class _ClientContext:
         import ray.util.client.server.server as ray_client_server
 
         server_handle, address_info = ray_client_server.init_and_serve(
-            "127.0.0.1:50051", *args, **kwargs
+            "127.0.0.1", 50051, *args, **kwargs
         )
         self._server = server_handle.grpc_server
         self.connect("127.0.0.1:50051")

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -43,7 +43,7 @@ def ray_start_client_server_pair(metadata=None, ray_connect_handler=None, **kwar
     with disable_client_hook():
         assert not ray.is_initialized()
     server = ray_client_server.serve(
-        "127.0.0.1:50051", ray_connect_handler=ray_connect_handler
+        "127.0.0.1", 50051, ray_connect_handler=ray_connect_handler
     )
     ray.connect("127.0.0.1:50051", metadata=metadata, **kwargs)
     try:
@@ -71,7 +71,7 @@ def ray_start_cluster_client_server_pair(address):
         real_ray.init(address=address)
 
     server = ray_client_server.serve(
-        "127.0.0.1:50051", ray_connect_handler=ray_connect_handler
+        "127.0.0.1", 50051, ray_connect_handler=ray_connect_handler
     )
     ray.connect("127.0.0.1:50051")
     try:

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -858,6 +858,9 @@ def serve_proxier(
     ray_client_pb2_grpc.add_RayletDriverServicer_to_server(task_servicer, server)
     ray_client_pb2_grpc.add_RayletDataStreamerServicer_to_server(data_servicer, server)
     ray_client_pb2_grpc.add_RayletLogStreamerServicer_to_server(logs_servicer, server)
+    host, port = connection_str.rsplit(":", 1)
+    if host != "127.0.0.1":
+        add_port_to_grpc_server(server, f"127.0.0.1:{port}")
     add_port_to_grpc_server(server, connection_str)
     server.start()
     return ClientServerHandle(

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -825,7 +825,8 @@ class LogstreamServicerProxy(ray_client_pb2_grpc.RayletLogStreamerServicer):
 
 
 def serve_proxier(
-    connection_str: str,
+    host: str,
+    port: int,
     address: Optional[str],
     *,
     redis_username: Optional[str] = None,
@@ -858,10 +859,9 @@ def serve_proxier(
     ray_client_pb2_grpc.add_RayletDriverServicer_to_server(task_servicer, server)
     ray_client_pb2_grpc.add_RayletDataStreamerServicer_to_server(data_servicer, server)
     ray_client_pb2_grpc.add_RayletLogStreamerServicer_to_server(logs_servicer, server)
-    host, port = connection_str.rsplit(":", 1)
     if host != "127.0.0.1":
         add_port_to_grpc_server(server, f"127.0.0.1:{port}")
-    add_port_to_grpc_server(server, connection_str)
+    add_port_to_grpc_server(server, f"{host}:{port}")
     server.start()
     return ClientServerHandle(
         task_servicer=task_servicer,

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -786,6 +786,9 @@ def serve(connection_str, ray_connect_handler=None):
     ray_client_pb2_grpc.add_RayletDriverServicer_to_server(task_servicer, server)
     ray_client_pb2_grpc.add_RayletDataStreamerServicer_to_server(data_servicer, server)
     ray_client_pb2_grpc.add_RayletLogStreamerServicer_to_server(logs_servicer, server)
+    host, port = connection_str.rsplit(":", 1)
+    if host != "127.0.0.1":
+        add_port_to_grpc_server(server, f"127.0.0.1:{port}")
     add_port_to_grpc_server(server, connection_str)
     current_handle = ClientServerHandle(
         task_servicer=task_servicer,

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -764,7 +764,7 @@ def decode_options(options: ray_client_pb2.TaskOptions) -> Optional[Dict[str, An
     return opts
 
 
-def serve(connection_str, ray_connect_handler=None):
+def serve(host: str, port: int, ray_connect_handler=None):
     def default_connect_handler(
         job_config: JobConfig = None, **ray_init_kwargs: Dict[str, Any]
     ):
@@ -786,10 +786,9 @@ def serve(connection_str, ray_connect_handler=None):
     ray_client_pb2_grpc.add_RayletDriverServicer_to_server(task_servicer, server)
     ray_client_pb2_grpc.add_RayletDataStreamerServicer_to_server(data_servicer, server)
     ray_client_pb2_grpc.add_RayletLogStreamerServicer_to_server(logs_servicer, server)
-    host, port = connection_str.rsplit(":", 1)
     if host != "127.0.0.1":
         add_port_to_grpc_server(server, f"127.0.0.1:{port}")
-    add_port_to_grpc_server(server, connection_str)
+    add_port_to_grpc_server(server, f"{host}:{port}")
     current_handle = ClientServerHandle(
         task_servicer=task_servicer,
         data_servicer=data_servicer,
@@ -800,7 +799,7 @@ def serve(connection_str, ray_connect_handler=None):
     return current_handle
 
 
-def init_and_serve(connection_str, *args, **kwargs):
+def init_and_serve(host: str, port: int, *args, **kwargs):
     with disable_client_hook():
         # Disable client mode inside the worker's environment
         info = ray.init(*args, **kwargs)
@@ -813,7 +812,7 @@ def init_and_serve(connection_str, *args, **kwargs):
         else:
             return ray.init(job_config=job_config, *args, **kwargs)
 
-    server_handle = serve(connection_str, ray_connect_handler=ray_connect_handler)
+    server_handle = serve(host, port, ray_connect_handler=ray_connect_handler)
     return (server_handle, info)
 
 
@@ -901,14 +900,15 @@ def main():
     logger.info(f"Starting Ray Client server on {hostport}, args {args_str}")
     if args.mode == "proxy":
         server = serve_proxier(
-            hostport,
+            args.host,
+            args.port,
             args.address,
             redis_username=args.redis_username,
             redis_password=args.redis_password,
             runtime_env_agent_address=args.runtime_env_agent_address,
         )
     else:
-        server = serve(hostport, ray_connect_handler)
+        server = serve(args.host, args.port, ray_connect_handler)
 
     try:
         idle_checks_remaining = TIMEOUT_FOR_SPECIFIC_SERVER_S

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -786,7 +786,7 @@ def serve(host: str, port: int, ray_connect_handler=None):
     ray_client_pb2_grpc.add_RayletDriverServicer_to_server(task_servicer, server)
     ray_client_pb2_grpc.add_RayletDataStreamerServicer_to_server(data_servicer, server)
     ray_client_pb2_grpc.add_RayletLogStreamerServicer_to_server(logs_servicer, server)
-    if host != "127.0.0.1":
+    if host != "127.0.0.1" and host != "localhost":
         add_port_to_grpc_server(server, f"127.0.0.1:{port}")
     add_port_to_grpc_server(server, f"{host}:{port}")
     current_handle = ClientServerHandle(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We want to have better security regarding what addresses the client server can connect to. This means that we want to migrate away from usages of accepting connections on the "0.0.0.0" network interface but only accepting connections on localhost and the head node ip specified by the user.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
