### PR TITLE
[distro] image: drops the AUTOSCALER ARG in the base image

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -8,7 +8,6 @@ FROM ${BASE_IMAGE}
 # FROM directive resets ARG
 ARG BASE_IMAGE
 # If this arg is not "autoscaler" then no autoscaler requirements will be included
-ARG AUTOSCALER="autoscaler"
 ENV TZ=America/Los_Angeles
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
@@ -38,17 +37,15 @@ APT_PKGS=(
     cmake
     g++
     zlib1g-dev
+
+    # For autoscaler
+    tmux
+    screen
+    rsync
+    netbase
+    openssh-client
+    gnupg
 )
-if [[ "$AUTOSCALER" == "autoscaler" ]]; then
-    APT_PKGS+=(
-        tmux
-        screen
-        rsync
-        netbase
-        openssh-client
-        gnupg
-    )
-fi
 
 apt-get install -y "${APT_PKGS[@]}"
 
@@ -92,18 +89,17 @@ PIP_PKGS=(
     cython
     numpy  # Necessary for Dataset to work properly.
     psutil
-    smart_open[s3]
+
+    # For the ease to submit jobs on various cloud providers.
+    "smart_open[s3,gcs,azure,http]"
+
+    six
+    boto3
+    pyopenssl
+    cryptography
+    google-api-python-client
+    google-oauth
 )
-if [[ "$AUTOSCALER" == "autoscaler" ]]; then
-    PIP_PKGS+=(
-        six
-        boto3
-        pyopenssl
-        cryptography
-        google-api-python-client
-        google-oauth
-    )
-fi
 
 # Install uv
 wget -qO- https://astral.sh/uv/install.sh | sudo env UV_UNMANAGED_INSTALL="/usr/local/bin" sh


### PR DESCRIPTION
autoscaler deps are practically always included in the image right now; the arg has not been used for a long time.
