### PR TITLE
 [data] truncate dataset export

### DIFF
--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -142,22 +142,28 @@ class DatasetMetadata:
     data_context: DataContext
 
 
+def _add_ellipsis(s, truncate_length):
+    if len(s) > truncate_length:
+        return s[:truncate_length] + "..."
+    return s
+
+
 def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
     if isinstance(obj, Mapping):
-        return {k: sanitize_for_struct(v) for k, v in obj.items()}
+        return {k: sanitize_for_struct(v, truncate_length) for k, v in obj.items()}
     elif isinstance(obj, (int, float, bool)) or obj is None:
         return obj
     elif isinstance(obj, str):
-        return obj[:truncate_length]
+        return _add_ellipsis(obj, truncate_length)
     elif isinstance(obj, Sequence):
-        return [sanitize_for_struct(v) for v in obj]
+        return [sanitize_for_struct(v, truncate_length) for v in obj]
     else:
         # Convert unhandled types to string
         try:
-            return json.dumps(obj)[:truncate_length]
+            return _add_ellipsis(json.dumps(obj), truncate_length)
         except (TypeError, OverflowError):
             try:
-                return str(obj)[:truncate_length]
+                return _add_ellipsis(str(obj), truncate_length)
             except Exception:
                 return UNKNOWN
 

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 UNKNOWN = "unknown"
 
+# Number of characters to truncate to when
+# exporting dataset operator arguments
+DEFAULT_TRUNCATION_LENGTH = 100
+
 # NOTE: These dataclasses need to be updated in sync with the protobuf definitions in
 # src/ray/protobuf/export_api/export_dataset_metadata.proto
 @dataclass
@@ -138,17 +142,19 @@ class DatasetMetadata:
     data_context: DataContext
 
 
-def sanitize_for_struct(obj):
+def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
     if isinstance(obj, Mapping):
         return {k: sanitize_for_struct(v) for k, v in obj.items()}
-    elif isinstance(obj, (str, int, float, bool)) or obj is None:
+    elif isinstance(obj, (int, float, bool)) or obj is None:
         return obj
+    elif isinstance(obj, str):
+        return obj[:truncate_length]
     elif isinstance(obj, Sequence):
         return [sanitize_for_struct(v) for v in obj]
     else:
         # Convert unhandled types to string
         try:
-            return json.dumps(obj)
+            return json.dumps(obj)[:truncate_length]
         except (TypeError, OverflowError):
             try:
                 return str(obj)

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -157,7 +157,7 @@ def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
             return json.dumps(obj)[:truncate_length]
         except (TypeError, OverflowError):
             try:
-                return str(obj)
+                return str(obj)[:truncate_length]
             except Exception:
                 return UNKNOWN
 

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -312,7 +312,7 @@ class BasicObject:
             100,
         ),
         # Objects that can be converted to string
-        (BasicObject("test"), '"BasicObject(test)"', 100),  # JSON serialized
+        (BasicObject("test"), "BasicObject(test)", 100),  # Falls back to str()
         # Objects that can't be JSON serialized but can be stringified
         ({1, 2, 3}, "{1, 2, 3}", 100),  # Falls back to str()
         # Objects that can't be serialized or stringified

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -6,7 +6,12 @@ import pytest
 
 import ray
 from ray.data import DataContext
-from ray.data._internal.metadata_exporter import Operator, Topology, sanitize_for_struct
+from ray.data._internal.metadata_exporter import (
+    UNKNOWN,
+    Operator,
+    Topology,
+    sanitize_for_struct,
+)
 from ray.data._internal.stats import _get_or_create_stats_actor
 from ray.tests.conftest import _ray_start
 
@@ -257,6 +262,76 @@ def test_export_multiple_datasets(
     )
     assert second_entry["event_data"]["job_id"] == STUB_JOB_ID
     assert second_entry["event_data"]["start_time"] is not None
+
+
+class UnserializableObject:
+    """A test class that can't be JSON serialized or converted to string easily."""
+
+    def __str__(self):
+        raise ValueError("Cannot convert to string")
+
+    def __repr__(self):
+        raise ValueError("Cannot convert to repr")
+
+
+class BasicObject:
+    """A test class that can be converted to string."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return f"BasicObject({self.value})"
+
+
+@pytest.mark.parametrize(
+    "input_obj,expected_output,truncate_length",
+    [
+        # Basic types - should return as-is
+        (42, 42, 100),
+        (3.14, 3.14, 100),
+        (True, True, 100),
+        (False, False, 100),
+        (None, None, 100),
+        # Strings - short strings return as-is
+        ("hello", "hello", 100),
+        # Strings - long strings get truncated
+        ("a" * 150, "a" * 100 + "...", 100),
+        ("hello world", "hello...", 5),
+        # Mappings - should recursively sanitize values
+        ({"key": "value"}, {"key": "value"}, 100),
+        ({"long_key": "a" * 150}, {"long_key": "a" * 100 + "..."}, 100),
+        ({"nested": {"inner": "value"}}, {"nested": {"inner": "value"}}, 100),
+        # Sequences - should recursively sanitize elements
+        ([1, 2, 3], [1, 2, 3], 100),
+        (["short", "a" * 150], ["short", "a" * 100 + "..."], 100),
+        # Complex nested structures
+        (
+            {"list": [1, "a" * 150], "dict": {"key": "a" * 150}},
+            {"list": [1, "a" * 100 + "..."], "dict": {"key": "a" * 100 + "..."}},
+            100,
+        ),
+        # Objects that can be converted to string
+        (BasicObject("test"), '"BasicObject(test)"', 100),  # JSON serialized
+        # Objects that can't be JSON serialized but can be stringified
+        ({1, 2, 3}, "{1, 2, 3}", 100),  # Falls back to str()
+        # Objects that can't be serialized or stringified
+        (UnserializableObject(), UNKNOWN, 100),
+        # Empty containers
+        ({}, {}, 100),
+        ([], [], 100),
+        # Mixed type sequences
+        (
+            [1, "hello", {"key": "value"}, None],
+            [1, "hello", {"key": "value"}, None],
+            100,
+        ),
+    ],
+)
+def test_sanitize_for_struct(input_obj, expected_output, truncate_length):
+    """Test sanitize_for_struct with various input types and truncation lengths."""
+    result = sanitize_for_struct(input_obj, truncate_length)
+    assert result == expected_output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?
Currently, dataset metadata exports can be large because we include operator args for each operator. The size(args) is unbounded. Instead, we can truncate the length of arguments to a default 100 characters.

This should mitigate any unexpectedly large arguments, but won't affect the # of Operators or the # of args per Operator that are exported. That's ok(for now), because we shouldn't have too many.

Clone of #55160, using this to merge this faster since @iamjustinhsu is out.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
