### PR TITLE
[llm] Adapt to vLLM 0.10.0 changes

### DIFF
--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -284,7 +284,7 @@ class vLLMEngineWrapper:
                 guided_decoding=guided_decoding,
             )
         elif self.task_type == vLLMTaskType.EMBED:
-            params = vllm.PoolingParams()
+            params = vllm.PoolingParams(task=self.task_type.value)
         else:
             raise ValueError(f"Unsupported task type: {self.task_type}")
 

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -360,19 +360,9 @@ class VLLMEngine(LLMEngine):
     async def resolve_lora(self, disk_lora_model: DiskMultiplexConfig):
         from vllm.entrypoints.openai.protocol import LoadLoRAAdapterRequest
 
-        # TODO (Kourosh): We should uncomment this logic when
-        # https://github.com/vllm-project/vllm/pull/20636 is
-        # included in our vLLM release.
-        # if disk_lora_model.model_id in self._oai_models.lora_requests:
-        #     # Lora is already loaded, return
-        #     return
-
         self._validate_openai_serving_models()
 
-        if any(
-            lora_request.lora_name == disk_lora_model.model_id
-            for lora_request in self._oai_models.lora_requests  # type: ignore[attr-defined]
-        ):
+        if disk_lora_model.model_id in self._oai_models.lora_requests:
             # Lora is already loaded, return
             return
 

--- a/python/ray/llm/tests/BUILD
+++ b/python/ray/llm/tests/BUILD
@@ -43,8 +43,6 @@ py_test_module_list(
     },
     files = glob(
         ["batch/gpu/**/test_*.py"],
-        # TODO(ray-llm): fix this test: https://github.com/ray-project/ray/issues/52074
-        exclude = ["batch/gpu/processor/test_vllm_engine_proc.py"],
     ),
     tags = [
         "exclusive",

--- a/release/llm_tests/serve/benchmark/benchmark_vllm.py
+++ b/release/llm_tests/serve/benchmark/benchmark_vllm.py
@@ -82,7 +82,7 @@ def get_vllm_cli_args(llm_config):
     # subprocesses are resolved we can remove these constraints
     engine_kwargs.pop("tokenizer_pool_extra_config", None)
     engine_kwargs.pop("tokenizer_pool_size", None)
-    engine_kwargs["tokenizer_pool_type"] = None
+    engine_kwargs.pop("tokenizer_pool_type", None)
 
     cli_args = ["--model", llm_config["model_loading_config"]["model_id"]]
     for key, value in engine_kwargs.items():

--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -124,7 +124,6 @@ def is_default_app_running():
 
 
 @pytest.mark.parametrize("model_name", ["deepseek-ai/DeepSeek-V2-Lite"])
-@pytest.mark.asyncio(scope="function")
 def test_deepseek_model(model_name):
     """
     Test that the deepseek model can be loaded successfully.
@@ -169,6 +168,7 @@ def remote_model_app(request):
 
     base_config = {
         "model_loading_config": dict(
+            model_id="hmellor/Ilama-3.2-1B",
             model_source="hmellor/Ilama-3.2-1B",
         ),
         "runtime_env": dict(env_vars={"VLLM_USE_V1": "1"}),

--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -114,6 +114,47 @@ async def test_engine_metrics_with_spec_decode():
             pass
 
 
+def is_default_app_running():
+    """Check if the default application is running successfully."""
+    try:
+        default_app = serve.status().applications[SERVE_DEFAULT_APP_NAME]
+        return default_app.status == ApplicationStatus.RUNNING
+    except (KeyError, AttributeError):
+        return False
+
+
+@pytest.mark.parametrize("model_name", ["deepseek-ai/DeepSeek-V2-Lite"])
+@pytest.mark.asyncio(scope="function")
+def test_deepseek_model(model_name):
+    """
+    Test that the deepseek model can be loaded successfully.
+    """
+    llm_config = LLMConfig(
+        model_loading_config=dict(
+            model_id=model_name,
+            model_source=model_name,
+        ),
+        runtime_env=dict(env_vars={"VLLM_USE_V1": "1"}),
+        deployment_config=dict(
+            autoscaling_config=dict(min_replicas=1, max_replicas=1),
+        ),
+        engine_kwargs=dict(
+            tensor_parallel_size=2,
+            pipeline_parallel_size=2,
+            gpu_memory_utilization=0.92,
+            dtype="auto",
+            max_num_seqs=40,
+            max_model_len=8192,
+            enable_chunked_prefill=True,
+            enable_prefix_caching=True,
+            enforce_eager=True,
+        ),
+    )
+    app = build_openai_app({"llm_configs": [llm_config]})
+    serve.run(app, blocking=False)
+    wait_for_condition(is_default_app_running, timeout=300)
+
+
 @pytest.mark.asyncio(scope="function")
 @pytest.fixture
 def remote_model_app(request):
@@ -128,24 +169,14 @@ def remote_model_app(request):
 
     base_config = {
         "model_loading_config": dict(
-            model_id="deepseek",
-            model_source="deepseek-ai/DeepSeek-V2-Lite",
+            model_source="hmellor/Ilama-3.2-1B",
         ),
         "runtime_env": dict(env_vars={"VLLM_USE_V1": "1"}),
         "deployment_config": dict(
             autoscaling_config=dict(min_replicas=1, max_replicas=1),
         ),
         "engine_kwargs": dict(
-            tensor_parallel_size=2,
-            pipeline_parallel_size=2,
-            gpu_memory_utilization=0.92,
-            dtype="auto",
-            max_num_seqs=40,
-            max_model_len=8192,
-            enable_chunked_prefill=True,
-            enable_prefix_caching=True,
             trust_remote_code=remote_code,
-            enforce_eager=True,
         ),
     }
 
@@ -160,14 +191,6 @@ def remote_model_app(request):
 
 class TestRemoteCode:
     """Tests for remote code model loading behavior."""
-
-    def _is_default_app_running(self):
-        """Check if the default application is running successfully."""
-        try:
-            default_app = serve.status().applications[SERVE_DEFAULT_APP_NAME]
-            return default_app.status == ApplicationStatus.RUNNING
-        except (KeyError, AttributeError):
-            return False
 
     @pytest.mark.parametrize("remote_model_app", [False], indirect=True)
     def test_remote_code_failure(self, remote_model_app):
@@ -194,7 +217,7 @@ class TestRemoteCode:
             wait_for_condition(check_for_failed_deployment, timeout=120)
         except TimeoutError:
             # If deployment didn't fail, check if it succeeded
-            if self._is_default_app_running():
+            if is_default_app_running():
                 pytest.fail(
                     "App deployed successfully without trust_remote_code=True. "
                     "This model may not actually require remote code. "
@@ -213,7 +236,7 @@ class TestRemoteCode:
         serve.run(app, blocking=False)
 
         # Wait for the application to be running (timeout after 5 minutes)
-        wait_for_condition(self._is_default_app_running, timeout=300)
+        wait_for_condition(is_default_app_running, timeout=300)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/55067 is failing release tests (they had not finished running when the PR was merged)
- `DeepSeek-V2-Lite` no longer requires `trust_remote_code: True`; changing model
- LoRA requests is now a dictionary keyed by the LoRA name, not a list of objects
- `tokenizer_pool_type` is no longer a valid CLI arg in vLLM
- `task` now required in `vllm.PoolingParams`

## Related issue number

Closes https://github.com/ray-project/ray/issues/52074

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
