### PR TITLE
[llm][ci] Run llm gpu tests less

### DIFF
--- a/.buildkite/llm.rayci.yml
+++ b/.buildkite/llm.rayci.yml
@@ -37,7 +37,6 @@ steps:
   - label: "llm gpu tests"
     key: "llm-gpu-tests"
     tags:
-      - python
       - llm
       - gpu
     instance_type: g6-large


### PR DESCRIPTION
## Why are these changes needed?
Currently these llm gpu tests run on premerge for all changes that trigger the python ci tag. e.g. these tests will run on premerge for every core pr because any change in src/ triggers the python ci tag + the tests are flaky sometimes so it can make the problem worse
https://github.com/ray-project/ray/blob/98f0732ea703e14596369a7383fdc4b801943c47/ci/pipeline/test_rules.txt#L217-L219

This changes it so only changes that trigger the llm or gpu tags will trigger these tests.