### PR TITLE
[core] improve the robustness of raylet metric reporting

### DIFF
--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -260,7 +260,6 @@ int main(int argc, char *argv[]) {
   std::unique_ptr<ray::raylet::NodeManager> node_manager;
   std::unique_ptr<ray::rpc::ClientCallManager> client_call_manager;
   std::unique_ptr<ray::rpc::CoreWorkerClientPool> worker_rpc_pool;
-  std::unique_ptr<ray::rpc::RayletClientPool> raylet_client_pool;
   std::unique_ptr<ray::raylet::WorkerPoolInterface> worker_pool;
   /// Manages all local objects that are pinned (primary
   /// copies), freed, and/or spilled.
@@ -490,15 +489,6 @@ int main(int argc, char *argv[]) {
                    << "rpc_service_threads_number = "
                    << object_manager_config.rpc_service_threads_number
                    << ", object_chunk_size = " << object_manager_config.object_chunk_size;
-    // Initialize stats.
-    const ray::stats::TagsType global_tags = {
-        {ray::stats::ComponentKey, "raylet"},
-        {ray::stats::WorkerIdKey, ""},
-        {ray::stats::VersionKey, kRayVersion},
-        {ray::stats::NodeAddressKey, node_ip_address},
-        {ray::stats::SessionNameKey, session_name}};
-    ray::stats::Init(global_tags, metrics_agent_port, WorkerID::Nil());
-
     RAY_LOG(INFO).WithField(raylet_node_id) << "Setting node ID";
 
     node_manager_config.AddDefaultLabels(raylet_node_id.Hex());
@@ -550,13 +540,11 @@ int main(int argc, char *argv[]) {
               ray::rpc::CoreWorkerClientPool::GetDefaultUnavailableTimeoutCallback(
                   gcs_client.get(),
                   worker_rpc_pool.get(),
-                  raylet_client_pool.get(),
+                  [&](const std::string &node_manager_address, int32_t port) {
+                    return std::make_shared<ray::raylet::RayletClient>(
+                        node_manager_address, port, *client_call_manager);
+                  },
                   addr));
-        });
-
-    raylet_client_pool =
-        std::make_unique<ray::rpc::RayletClientPool>([&](const ray::rpc::Address &addr) {
-          return std::make_shared<ray::raylet::RayletClient>(addr, *client_call_manager);
         });
 
     core_worker_subscriber = std::make_unique<ray::pubsub::Subscriber>(
@@ -770,12 +758,14 @@ int main(int argc, char *argv[]) {
                                                           announce_infeasible_task,
                                                           *local_task_manager);
 
-    auto raylet_client_factory = [&](const NodeID &node_id) {
+    auto raylet_client_factory = [&](const NodeID &node_id,
+                                     ray::rpc::ClientCallManager &client_call_manager) {
       const ray::rpc::GcsNodeInfo *node_info = gcs_client->Nodes().Get(node_id);
       RAY_CHECK(node_info) << "No GCS info for node " << node_id;
-      auto addr = ray::rpc::RayletClientPool::GenerateRayletAddress(
-          node_id, node_info->node_manager_address(), node_info->node_manager_port());
-      return raylet_client_pool->GetOrConnectByAddress(std::move(addr));
+      return std::make_shared<ray::raylet::RayletClient>(
+          node_info->node_manager_address(),
+          node_info->node_manager_port(),
+          client_call_manager);
     };
 
     plasma_client = std::make_unique<plasma::PlasmaClient>();
@@ -787,7 +777,6 @@ int main(int argc, char *argv[]) {
         *gcs_client,
         *client_call_manager,
         *worker_rpc_pool,
-        *raylet_client_pool,
         *core_worker_subscriber,
         *cluster_resource_scheduler,
         *local_task_manager,
@@ -817,6 +806,15 @@ int main(int argc, char *argv[]) {
                                                    metrics_export_port,
                                                    is_head_node,
                                                    *node_manager);
+
+    // Initialize stats.
+    const ray::stats::TagsType global_tags = {
+        {ray::stats::ComponentKey, "raylet"},
+        {ray::stats::WorkerIdKey, ""},
+        {ray::stats::VersionKey, kRayVersion},
+        {ray::stats::NodeAddressKey, node_ip_address},
+        {ray::stats::SessionNameKey, session_name}};
+    ray::stats::Init(global_tags, metrics_agent_port, WorkerID::Nil());
 
     // Initialize event framework.
     if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {


### PR DESCRIPTION
Context
This PR is related to the Ray metrics infrastructure. In Ray, each node runs a centralized process called the DashboardAgent, which acts as a gRPC server. Other processes on the same node send their per-process metrics to this server. The DashboardAgent then aggregates these metrics and exports them to Prometheus.
The DashboardAgent is spawned by the raylet.

Problem
Currently, raylet server also depends on the DashboardAgent to export its internal metrics. However, the DashboardAgent (part of the NodeManager) is initialized **after** raylet sends over metrics.

Solution
To address this, this PR moves stats::Init to after the DashboardAgent is already initialized.

Test:
- CI
- test_metrics_agent.py is a comprehensive test that provides confidence everything is working properly. Run this test locally and check that errors are no longer observed inside raylet logs.