### PR TITLE
[llm] disable failing gpu test

### DIFF
--- a/python/ray/llm/tests/BUILD
+++ b/python/ray/llm/tests/BUILD
@@ -41,7 +41,11 @@ py_test_module_list(
     env = {
         "VLLM_FLASH_ATTN_VERSION": "2",
     },
-    files = glob(["batch/gpu/**/test_*.py"]),
+    files = glob(
+        ["batch/gpu/**/test_*.py"],
+        # TODO(ray-llm): fix this test: https://github.com/ray-project/ray/issues/52074
+        exclude = ["batch/gpu/processor/test_vllm_engine_proc.py"],
+    ),
     tags = [
         "exclusive",
         "gpu",


### PR DESCRIPTION
the test starts failing, likely due to vllm upgrade.