### PR TITLE
[Doc][KubeRay] fix typo in integration with Apache YuniKorn

### DIFF
--- a/doc/source/cluster/kubernetes/k8s-ecosystem/yunikorn.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/yunikorn.md
@@ -12,7 +12,7 @@ This feature requires KubeRay version 1.2.2 or newer, and it's in alpha testing.
 
 :::
 
-## Step 1: Create a Kubernetes cluster with KinD
+## Step 1: Create a Kubernetes cluster with Kind
 Run the following command in a terminal:
 
 ```shell


### PR DESCRIPTION
## Why are these changes needed?
Docs link: https://anyscale-ray--55233.com.readthedocs.build/en/55233/cluster/kubernetes/k8s-ecosystem/yunikorn.html

change `KinD` to `kind`.

## Related issue number


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
