### PR TITLE
[java] convert internal java local genrules to py_binary run rules

### DIFF
--- a/bazel/gen_extract.py
+++ b/bazel/gen_extract.py
@@ -6,18 +6,26 @@ import subprocess
 import runfiles
 
 
-def gen_extract(zip_files: List[str], clear_dir_first: Optional[List[str]] = None):
+def gen_extract(
+    zip_files: List[str],
+    clear_dir_first: Optional[List[str]] = None,
+    sub_dir: str = "python",
+):
     r = runfiles.Create()
     _repo_name = "com_github_ray_project_ray"
 
     root_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
     if not root_dir:
         raise ValueError("BUILD_WORKSPACE_DIRECTORY not set")
-    python_dir = os.path.join(root_dir, "python")
+
+    if sub_dir:
+        extract_dir = os.path.join(root_dir, sub_dir)
+    else:
+        extract_dir = root_dir
 
     if clear_dir_first:
         for d in clear_dir_first:
-            shutil.rmtree(os.path.join(python_dir, d), ignore_errors=True)
+            shutil.rmtree(os.path.join(extract_dir, d), ignore_errors=True)
 
     for zip_file in zip_files:
         zip_path = r.Rlocation(_repo_name + "/" + zip_file)
@@ -25,4 +33,4 @@ def gen_extract(zip_files: List[str], clear_dir_first: Optional[List[str]] = Non
             raise ValueError(f"Zip file {zip_file} not found")
 
         # Uses unzip; python zipfile does not restore the file permissions correctly.
-        subprocess.check_call(["unzip", "-q", "-o", zip_path, "-d", python_dir])
+        subprocess.check_call(["unzip", "-q", "-o", zip_path, "-d", extract_dir])

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -292,7 +292,7 @@ filegroup(
 pkg_files(
     name = "api_pom_files",
     srcs = ["io_ray_ray_api_pom"],
-    prefix = "java/api/",
+    prefix = "api/",
     renames = {
         "io_ray_ray_api_pom.xml": "pom.xml",
     },
@@ -302,7 +302,7 @@ pkg_files(
 pkg_files(
     name = "runtime_pom_files",
     srcs = ["io_ray_ray_runtime_pom"],
-    prefix = "java/runtime/",
+    prefix = "runtime/",
     renames = {
         "io_ray_ray_runtime_pom.xml": "pom.xml",
     },
@@ -312,7 +312,7 @@ pkg_files(
 pkg_files(
     name = "test_pom_files",
     srcs = ["io_ray_ray_test_pom"],
-    prefix = "java/test/",
+    prefix = "test/",
     renames = {
         "io_ray_ray_test_pom.xml": "pom.xml",
     },
@@ -322,7 +322,7 @@ pkg_files(
 pkg_files(
     name = "performance_test_pom_files",
     srcs = ["io_ray_ray_performance_test_pom"],
-    prefix = "java/performance_test/",
+    prefix = "performance_test/",
     renames = {
         "io_ray_ray_performance_test_pom.xml": "pom.xml",
     },
@@ -332,7 +332,7 @@ pkg_files(
 pkg_files(
     name = "serve_pom_files",
     srcs = ["io_ray_ray_serve_pom"],
-    prefix = "java/serve/",
+    prefix = "serve/",
     renames = {
         "io_ray_ray_serve_pom.xml": "pom.xml",
     },
@@ -351,29 +351,22 @@ pkg_zip(
     visibility = ["//visibility:private"],
 )
 
-genrule(
-    name = "copy_pom_files",
-    srcs = [
-        ":pom_files.zip",
-    ],
-    outs = ["copy_pom_files.sum"],
-    cmd = """
-        unzip -q -o $(location :pom_files.zip) -d "$$(pwd)" &&
-        if [[ "$$OSTYPE" =~ ^darwin ]]; then shasum $< > $@ ; else sha1sum $< > $@ ; fi
-    """,
-    local = 1,
-    tags = ["no-cache"],
+py_binary(
+    name = "gen_pom_files",
+    srcs = ["gen_pom_files.py"],
+    data = [":pom_files.zip"],
     visibility = ["//visibility:private"],
+    deps = ["//bazel:gen_extract"],
 )
 
 # Generates the dependencies needed by maven.
 genrule(
-    name = "cp_java_generated_zip",
+    name = "proto_files",
     srcs = [
         ":all_java_proto",
         ":serve_java_proto",
     ],
-    outs = ["cp_java_generated.zip"],
+    outs = ["proto_files.zip"],
     cmd = """
         set -euo pipefail
 
@@ -389,40 +382,28 @@ genrule(
             unzip -q "$$f" -x META-INF/MANIFEST.MF -d "$$tmpdir/java/serve/src/main/java"
         done
 
-        (cd "$$tmpdir"; zip -0 -q -r out.zip "java")
-        mv "$$tmpdir/out.zip" $@
+        (cd "$$tmpdir/java"; zip -0 -q -r out.zip runtime serve)
+        mv "$$tmpdir/java/out.zip" $@
 
         rm -rf "$$tmpdir"
     """,
     visibility = ["//visibility:private"],
 )
 
-genrule(
-    name = "cp_java_generated",
-    srcs = [
-        ":cp_java_generated_zip",
-    ],
-    outs = ["cp_java_generated.out"],
-    cmd = """
-        WORK_DIR="$$(pwd)"
-
-        rm -rf "$$WORK_DIR/java/runtime/src/main/java/io/ray/runtime/generated"
-        rm -rf "$$WORK_DIR/java/serve/src/main/java/io/ray/serve/generated"
-
-        unzip -q -o $(location :cp_java_generated_zip) -d "$$WORK_DIR"
-        if [[ "$$OSTYPE" =~ ^darwin ]]; then shasum $< > $@ ; else sha1sum $< > $@ ; fi
-    """,
-    local = 1,
-    tags = ["no-cache"],
+py_binary(
+    name = "gen_proto_files",
+    srcs = ["gen_proto_files.py"],
+    data = [":proto_files.zip"],
     visibility = ["//visibility:private"],
+    deps = ["//bazel:gen_extract"],
 )
 
 # Generates the dependencies needed by maven.
 genrule(
     name = "gen_maven_deps",
     srcs = [
-        ":copy_pom_files",
-        ":cp_java_generated",
+        ":pom_files.zip",
+        ":proto_files.zip",
         ":java_native_deps",
     ],
     outs = ["gen_maven_deps.out"],

--- a/java/build-jar-multiplatform.sh
+++ b/java/build-jar-multiplatform.sh
@@ -34,8 +34,8 @@ build_jars() {
   mkdir -p "$JAR_DIR"
   for p in "${JAVA_DIRS_PATH[@]}"; do
     cd "$WORKSPACE_DIR/$p"
-    bazel build ":copy_pom_files"
-    bazel build ":cp_java_generated"
+    bazel run ":gen_pom_files"
+    bazel run ":gen_proto_files"
     if [[ $bazel_build == "true" ]]; then
       echo "Starting building java native dependencies for $p"
       bazel build ":gen_maven_deps"

--- a/java/gen_pom_files.py
+++ b/java/gen_pom_files.py
@@ -1,0 +1,4 @@
+from bazel.gen_extract import gen_extract
+
+if __name__ == "__main__":
+    gen_extract(["java/pom_files.zip"], sub_dir="java")

--- a/java/gen_proto_files.py
+++ b/java/gen_proto_files.py
@@ -1,0 +1,11 @@
+from bazel.gen_extract import gen_extract
+
+if __name__ == "__main__":
+    gen_extract(
+        ["java/proto_files.zip"],
+        clear_dir_first=[
+            "runtime/src/main/java/io/ray/runtime/generated",
+            "serve/src/main/java/io/ray/serve/generated",
+        ],
+        sub_dir="java",
+    )

--- a/java/test.sh
+++ b/java/test.sh
@@ -64,8 +64,8 @@ if [[ ! -d ".git" ]]; then
 fi
 
 echo "Build java maven deps."
-bazel build //java:copy_pom_files
-bazel build //java:cp_java_generated
+bazel run //java:gen_pom_files
+bazel run //java:gen_proto_files
 bazel build //java:gen_maven_deps
 
 echo "Build ray core."


### PR DESCRIPTION
so that these rules are idiomatic bazel build rules that do not write back to source tree during build phase
