### PR TITLE
[core] Make raylet subreaper interval configurable

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -891,11 +891,10 @@ RAY_CONFIG(bool, kill_child_processes_on_worker_exit, true)
 // the case where the worker crashed and had no chance to clean up its child processes.
 // Only works on Linux>=3.4. On other platforms, this flag is ignored.
 // See https://github.com/ray-project/ray/pull/42992 for more info.
-RAY_CONFIG(bool, kill_child_processes_on_worker_exit_with_raylet_subreaper, false)
+RAY_CONFIG(bool, kill_child_processes_on_worker_exit_with_raylet_subreaper, true)
 
 // The interval for the subreaper to periodically kill unknown children processes.
 RAY_CONFIG(int64_t, subreaper_cleanup_interval_ms, 5000)
-
 
 // If autoscaler v2 is enabled.
 RAY_CONFIG(bool, enable_autoscaler_v2, false)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -893,6 +893,10 @@ RAY_CONFIG(bool, kill_child_processes_on_worker_exit, true)
 // See https://github.com/ray-project/ray/pull/42992 for more info.
 RAY_CONFIG(bool, kill_child_processes_on_worker_exit_with_raylet_subreaper, false)
 
+// The interval for the subreaper to periodically kill unknown children processes.
+RAY_CONFIG(int64_t, subreaper_cleanup_interval_ms, 5000)
+
+
 // If autoscaler v2 is enabled.
 RAY_CONFIG(bool, enable_autoscaler_v2, false)
 

--- a/src/ray/common/test/ray_config_test.cc
+++ b/src/ray/common/test/ray_config_test.cc
@@ -31,4 +31,8 @@ TEST_F(RayConfigTest, ConvertValueTrimsVectorElements) {
   ASSERT_EQ(output, expected_output);
 }
 
+TEST_F(RayConfigTest, TestSubreaperIntervalConfig) {
+  ASSERT_EQ(RayConfig::instance().subreaper_cleanup_interval_ms(), 5000);
+}
+
 }  // namespace ray

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -296,9 +296,10 @@ int main(int argc, char *argv[]) {
       ray::KnownChildrenTracker::instance().Enable();
       ray::SetupSigchldHandlerRemoveKnownChildren(main_service);
       auto runner = ray::PeriodicalRunner::Create(main_service);
-      runner->RunFnPeriodically([runner]() { ray::KillUnknownChildren(); },
-                                /*period_ms=*/10000,
-                                "Raylet.KillUnknownChildren");
+      runner->RunFnPeriodically(
+          [runner]() { ray::KillUnknownChildren(); },
+          RayConfig::instance().subreaper_cleanup_interval_ms(),
+          "Raylet.KillUnknownChildren");
       RAY_LOG(INFO) << "Set this process as subreaper. Will kill unknown children every "
                        "10 seconds.";
     } else {

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -296,10 +296,9 @@ int main(int argc, char *argv[]) {
       ray::KnownChildrenTracker::instance().Enable();
       ray::SetupSigchldHandlerRemoveKnownChildren(main_service);
       auto runner = ray::PeriodicalRunner::Create(main_service);
-      runner->RunFnPeriodically(
-          [runner]() { ray::KillUnknownChildren(); },
-          RayConfig::instance().subreaper_cleanup_interval_ms(),
-          "Raylet.KillUnknownChildren");
+      runner->RunFnPeriodically([runner]() { ray::KillUnknownChildren(); },
+                                RayConfig::instance().subreaper_cleanup_interval_ms(),
+                                "Raylet.KillUnknownChildren");
       RAY_LOG(INFO) << "Set this process as subreaper. Will kill unknown children every "
                        "10 seconds.";
     } else {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->


## Why are these changes needed?

The subreaper based cleanup cycle's periodicity is hard-coded to 10s: https://github.com/ray-project/ray/blob/0ec9ed99d2016c1b63e1f00e2516604192090cc3/src/ray/raylet/main.cc#L298-L301

This PR makes it configurable and brings the default down to 5s.
It also enabled the subreaper by default.
