### PR TITLE
Upgrade ml_user_tests to use g6.12xlarge

### DIFF
--- a/release/ml_user_tests/horovod/compute_tpl_aws.yaml
+++ b/release/ml_user_tests/horovod/compute_tpl_aws.yaml
@@ -9,7 +9,7 @@ head_node_type:
 
 worker_node_types:
     - name: worker_node
-      instance_type: g3.8xlarge
+      instance_type: g6.12xlarge
       max_workers: 3
       min_workers: 3
       use_spot: false

--- a/release/ml_user_tests/train/compute_tpl_aws.yaml
+++ b/release/ml_user_tests/train/compute_tpl_aws.yaml
@@ -5,11 +5,11 @@ max_workers: 2
 
 head_node_type:
     name: head_node
-    instance_type: g4dn.8xlarge
+    instance_type: g6.12xlarge
 
 worker_node_types:
     -   name: worker_node
-        instance_type: g4dn.8xlarge
+        instance_type: g6.12xlarge
         min_workers: 2
         max_workers: 2
         use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Previously we change to g4dn machine which has a similar memory as g3 machines but is a newer generation in https://github.com/ray-project/ray/pull/55107.
2. Since g3.8xlarge machine has 2 GPU per node, hence the g4.8xlarge won't fit, this is to use g6.12xlarge, each has 4 GPUs but relatively cheaper compared with A10G.
3. Running release tests in https://buildkite.com/ray-project/release/builds/51805#

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
#55005

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(