### PR TITLE
[serve] Call request routed hook only when request is accepted

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -664,8 +664,8 @@ class AsyncioRouter:
             try:
                 result, queue_info = await r.send_request(pr, with_rejection=True)
                 self.request_router.on_new_queue_len_info(r.replica_id, queue_info)
-                self.request_router.on_request_routed(pr, r.replica_id, result)
                 if queue_info.accepted:
+                    self.request_router.on_request_routed(pr, r.replica_id, result)
                     return result, r.replica_id
             except asyncio.CancelledError:
                 # NOTE(edoakes): this is not strictly necessary because there are


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
If the request is rejected, we shouldn't call the `on_request_routed` hook since the request doesn't process on the replica if it's rejected. E.g. in the case of `prefix_aware_router`, we wouldn't want to update the prefix tree if the request was rejected by the replica. https://github.com/ray-project/ray/blob/26770affbdf600cdc518957c50ed58d882a67f5b/python/ray/llm/_internal/serve/request_router/prefix_aware/prefix_aware_router.py#L327-L351

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
