### PR TITLE
[train] implement JaxTrainer

### DIFF
--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -353,5 +353,26 @@ def test_get_current_node_tpu_topology_from_metadata():
         assert topology == "2x2x4"
 
 
+@pytest.mark.parametrize(
+    "topology, accelerator_type, expected_pod_type",
+    [
+        ("2x4", "TPU-V6E", "v6e-8"),
+        ("2x2x2", "TPU-V4", "v4-8"),
+        ("2x4x4", "TPU-V3", "v3-32"),
+        ("4x4", "TPU-V5P", "v5p-16"),
+        ("8x16", "TPU-V6E", "v6e-128"),
+        ("", "TPU-V3", None),
+        ("4x", "TPU-V3", None),
+    ],
+)
+def test_infer_tpu_pod_type_from_topology(
+    topology, accelerator_type, expected_pod_type
+):
+    assert (
+        tpu.infer_tpu_pod_type_from_topology(topology, accelerator_type)
+        == expected_pod_type
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/train/v2/_internal/callbacks/accelerators.py
+++ b/python/ray/train/v2/_internal/callbacks/accelerators.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from collections import defaultdict
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import ray
 import ray._private.ray_constants as ray_constants
@@ -19,10 +19,7 @@ from ray.train.constants import (
 from ray.train.v2._internal.execution.callback import WorkerGroupCallback
 from ray.train.v2._internal.execution.worker_group import ActorMetadata, WorkerGroup
 from ray.train.v2._internal.util import ray_get_safe
-from ray.train.v2.api.config import RunConfig, ScalingConfig
-from ray.util.placement_group import (
-    PlacementGroup,
-)
+from ray.train.v2.api.config import ScalingConfig
 
 logger = logging.getLogger(__name__)
 
@@ -163,35 +160,26 @@ def _get_visible_accelerator_ids_per_worker(
     return visible_accelerator_ids_per_worker
 
 
-def create_placement_group_with_spmd(
-    num_workers: int,
-    resources_per_worker: dict,
-    backend_config: BackendConfig,
-    run_config: RunConfig,
-) -> Optional[List[Tuple[PlacementGroup, range]]]:
-    """Creates SPMD-aware heterogeneous placement groups. This currently only
-    supports TPU with JaxTrainer.
-
-    This creates one head PG (for index 0) and one slice PG (for index 1..N-1)
-    by reserving the head node of a multi-host slice, retrieving unique slice
-    information, and atomically scheduling the remaining workers to that slice.
+# TODO: Move this to TPU utils.
+def reserve_tpu_slice(
+    scaling_config: ScalingConfig,
+) -> Optional[str]:
+    """Retrieves the TPU slice name from the placement group.
 
     Args:
-        num_workers: Total number of workers to launch (must be >= 1).
-        resources_per_worker: Resource requirements per bundle (e.g., {"CPU": 4}).
-        backend_config: BackendConfig instance, expected to have TPU fields
+        scaling_config: ScalingConfig instance, expected to have TPU fields
             like `use_tpu`, `topology`, and `accelerator_type`.
-        run_config: RunConfig instance that may include runtime env overrides
-            such as `worker_runtime_env`.
 
     Returns:
-        List of (PlacementGroup, worker_index_range) tuples.
+        TPU slice name.
     """
-    if not getattr(backend_config, "use_tpu", False):
+
+    # TODO: Change this to not use ScalingConfig and just take TPU args.
+    if not getattr(scaling_config, "use_tpu", False):
         return None
 
-    topology = getattr(backend_config, "topology", None)
-    accelerator_type = getattr(backend_config, "accelerator_type", None)
+    topology = getattr(scaling_config, "topology", None)
+    accelerator_type = getattr(scaling_config, "accelerator_type", None)
 
     if not (topology and accelerator_type):
         return None
@@ -200,6 +188,8 @@ def create_placement_group_with_spmd(
     if pod_type is None:
         return None
 
+    topology_id = "TODO"
+    tpu_head = f"TPU-{topology_id}-head"
     # Reserve a slice by creating a placement group on the
     # TPU head.
     head_label_selector = {
@@ -207,8 +197,7 @@ def create_placement_group_with_spmd(
         "ray.io/tpu-pod-type": pod_type,
     }
     head_placement_group = ray.util.placement_group(
-        bundles=[resources_per_worker],
-        strategy="STRICT_PACK",
+        bundles=[{tpu_head: 1}],
         bundle_label_selector=[head_label_selector],
     )
 
@@ -225,55 +214,12 @@ def create_placement_group_with_spmd(
             )
         )
 
-    if num_workers == 1:
-        logger.debug("Reserved single-host TPU placement group.")
-        return (head_placement_group, range(0, 1))
-
-    # If specified, set runtime env vars on reserved multi-host nodes.
-    worker_runtime_env = getattr(run_config, "worker_runtime_env", None)
-    env_vars = worker_runtime_env.get("env_vars", None)
-
     # Retrieve the unique slice ID.
-    slice_name = fetch_tpu_slice_name_from_pg(head_placement_group, env_vars)
+    slice_name = fetch_tpu_slice_name_from_pg(head_placement_group)
     if slice_name is None:
         raise RuntimeError(
             "Failed to retrieve TPU slice name after reserving head placement group. "
             "Ensure that TPU slice metadata is available and correctly configured on multi-host nodes."
         )
-    slice_label_selector = {
-        "ray.io/tpu-slice-name": slice_name,
-    }
-    slice_bundle_label_selector = [
-        slice_label_selector.copy() for _ in range(num_workers - 1)
-    ]
 
-    # Schedule the remaining multi-host workers together with the head bundle.
-    slice_placement_group = ray.util.placement_group(
-        bundles=[resources_per_worker] * (num_workers - 1),
-        strategy="STRICT_SPREAD",
-        bundle_label_selector=slice_bundle_label_selector,
-    )
-    logger.debug("Waiting for multi-host slice placement group to start.")
-    timeout = env_integer(TRAIN_PLACEMENT_GROUP_TIMEOUT_S_ENV, 100)
-    ready, _ = ray.wait([slice_placement_group.ready()], timeout=timeout)
-
-    if ready:
-        logger.debug("SPMD placement groups have started.")
-    else:
-        raise TimeoutError(
-            "SPMD Placement group creation timed out. Make sure your "
-            "cluster either has enough resources or use an "
-            "autoscaling cluster. Ensure your cluster has multi-host nodes "
-            "available for SPMD scheduling."
-            "Current resources available: {}, resources requested by the "
-            "placement groups: {} with labels {}".format(
-                ray.available_resources(),
-                [resources_per_worker] * num_workers,
-                slice_label_selector,
-            )
-        )
-
-    return [
-        (head_placement_group, range(0, 1)),  # TPU head (rank 0)
-        (slice_placement_group, range(1, num_workers)),  # 1...N-1 multi-host workers
-    ]
+    return slice_name

--- a/python/ray/train/v2/_internal/callbacks/accelerators.py
+++ b/python/ray/train/v2/_internal/callbacks/accelerators.py
@@ -1,17 +1,28 @@
 import logging
 import os
 from collections import defaultdict
-from typing import List
+from typing import List, Optional, Tuple
 
+import ray
 import ray._private.ray_constants as ray_constants
 from ray._private.accelerators.nvidia_gpu import CUDA_VISIBLE_DEVICES_ENV_VAR
-from ray._private.ray_constants import env_bool
+from ray._private.accelerators.tpu import (
+    fetch_tpu_slice_name_from_pg,
+    infer_tpu_pod_type_from_topology,
+)
+from ray._private.ray_constants import env_bool, env_integer
 from ray.train import BackendConfig
-from ray.train.constants import ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV
+from ray.train.constants import (
+    ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV,
+    TRAIN_PLACEMENT_GROUP_TIMEOUT_S_ENV,
+)
 from ray.train.v2._internal.execution.callback import WorkerGroupCallback
 from ray.train.v2._internal.execution.worker_group import ActorMetadata, WorkerGroup
 from ray.train.v2._internal.util import ray_get_safe
 from ray.train.v2.api.config import ScalingConfig
+from ray.util.placement_group import (
+    PlacementGroup,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -150,3 +161,94 @@ def _get_visible_accelerator_ids_per_worker(
         visible_accelerator_ids_per_worker.append(all_resource_ids)
 
     return visible_accelerator_ids_per_worker
+
+
+def create_placement_group_with_spmd(
+    num_workers: int,
+    resources_per_worker: dict,
+    backend_config: BackendConfig,
+) -> Optional[List[Tuple[PlacementGroup, range]]]:
+    """Creates SPMD-aware heterogeneous placement groups. This currently only
+    supports TPU with JaxTrainer.
+
+    This creates one head PG (for index 0) and one slice PG (for index 1..N-1)
+    by reserving the head node of a multi-host slice, retrieving unique slice
+    information, and atomically scheduling the remaining workers to that slice.
+
+    Returns:
+        List of (PlacementGroup, worker_index_range) tuples.
+    """
+    if not getattr(backend_config, "use_tpu", False):
+        return None
+
+    topology = getattr(backend_config, "topology", None)
+    accelerator_type = getattr(backend_config, "accelerator_type", None)
+
+    if not (topology and accelerator_type):
+        return None
+
+    pod_type = infer_tpu_pod_type_from_topology(topology, accelerator_type)
+    if pod_type is None:
+        return None
+
+    # Reserve a slice by creating a placement group on the
+    # TPU head.
+    head_label_selector = {
+        "ray.io/tpu-worker-id": "0",
+        "ray.io/tpu-pod-type": pod_type,
+    }
+    head_placement_group = ray.util.placement_group(
+        bundles=[resources_per_worker],
+        strategy="STRICT_PACK",
+        bundle_label_selector=[head_label_selector],
+    )
+
+    logger.debug("Waiting to reserve multi-host slice head.")
+    timeout = env_integer(TRAIN_PLACEMENT_GROUP_TIMEOUT_S_ENV, 100)
+    ready, _ = ray.wait([head_placement_group.ready()], timeout=timeout)
+
+    if not ready:
+        raise TimeoutError(
+            f"Failed to reserve TPU head for slice with shape: {pod_type}."
+            "Ensure your cluster has sufficient resources. Current "
+            "resources: {}".format(ray.available_resources())
+        )
+
+    if num_workers == 1:
+        logger.debug("Reserved single-host TPU placement group.")
+        return (head_placement_group, range(0, 1))
+
+    # Retrieve the unique slice ID.
+    slice_name = fetch_tpu_slice_name_from_pg(head_placement_group)
+    slice_label_selector = {
+        "ray.io/tpu-slice-name": slice_name,
+    }
+
+    # Schedule the remaining multi-host workers together with the head bundle.
+    slice_placement_group = ray.util.placement_group(
+        bundles=[resources_per_worker] * (num_workers - 1),
+        strategy="STRICT_SPREAD",
+        bundle_label_selector=[slice_label_selector] * (num_workers - 1),
+    )
+    logger.debug("Waiting for multi-host slice placement group to start.")
+    timeout = env_integer(TRAIN_PLACEMENT_GROUP_TIMEOUT_S_ENV, 100)
+    ready, _ = ray.wait([slice_placement_group.ready()], timeout=timeout)
+
+    if ready:
+        logger.debug("SPMD placement groups have started.")
+    else:
+        raise TimeoutError(
+            "SPMD Placement group creation timed out. Make sure your "
+            "cluster either has enough resources or use an "
+            "autoscaling cluster. Ensure your cluster has multi-host nodes "
+            "available for SPMD scheduling."
+            "Current resources available: {}, resources requested by the "
+            "placement groups: {}".format(
+                ray.available_resources(), [resources_per_worker] * num_workers
+            )
+        )
+
+    return [
+        (head_placement_group, range(0, 1)),  # TPU head (rank 0)
+        (slice_placement_group, range(1, num_workers)),  # 1...N-1 multi-host workers
+    ]

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -285,19 +285,13 @@ class TrainController:
         placement_strategy = self._scaling_policy.scaling_config.placement_strategy
         scaling_config = self._train_run_context.scaling_config
 
-        slice_name = None
         bundle_label_selector = None
-
         if getattr(scaling_config, "use_tpu", False):
             try:
-                slice_name = reserve_tpu_slice(
-                    scaling_config=scaling_config,
-                )
-                bundle_label_selector = {
-                    "ray.io/tpu-slice-name": slice_name,
-                }
-                if slice_name is None:
+                slice_name = reserve_tpu_slice(scaling_config=scaling_config)
+                if not slice_name:
                     raise RuntimeError("Failed to reserve TPU slice.")
+                bundle_label_selector = {"ray.io/tpu-slice-name": slice_name}
             except Exception as e:
                 return ControllerError(e)
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -9,7 +9,9 @@ import pandas as pd
 
 import ray
 import ray._private.ray_constants as ray_constants
-from ray.train.v2._internal.callbacks import create_placement_group_with_spmd
+from ray.train.v2._internal.callbacks.accelerators import (
+    create_placement_group_with_spmd,
+)
 from ray.train.v2._internal.constants import (
     DEFAULT_ENABLE_CONTROLLER_LOGGING,
     DEFAULT_HEALTH_CHECK_INTERVAL_S,
@@ -283,6 +285,7 @@ class TrainController:
         placement_strategy = self._scaling_policy.scaling_config.placement_strategy
         placement_group_specs = None
         backend_config = self._train_run_context.backend_config
+        run_config = self._train_run_context.run_config
 
         if getattr(backend_config, "use_tpu", False):
             try:
@@ -290,6 +293,7 @@ class TrainController:
                     num_workers=num_workers,
                     resources_per_worker=resources_per_worker,
                     backend_config=backend_config,
+                    run_config=run_config,
                 )
                 if placement_group_specs is None:
                     raise RuntimeError("Failed to create placement group specs.")

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -10,7 +10,7 @@ import pandas as pd
 import ray
 import ray._private.ray_constants as ray_constants
 from ray.train.v2._internal.callbacks.accelerators import (
-    create_placement_group_with_spmd,
+    reserve_tpu_slice,
 )
 from ray.train.v2._internal.constants import (
     DEFAULT_ENABLE_CONTROLLER_LOGGING,
@@ -283,20 +283,21 @@ class TrainController:
             ControllerError if the worker group failed to start.
         """
         placement_strategy = self._scaling_policy.scaling_config.placement_strategy
-        placement_group_specs = None
-        backend_config = self._train_run_context.backend_config
-        run_config = self._train_run_context.run_config
+        scaling_config = self._train_run_context.scaling_config
 
-        if getattr(backend_config, "use_tpu", False):
+        slice_name = None
+        bundle_label_selector = None
+
+        if getattr(scaling_config, "use_tpu", False):
             try:
-                placement_group_specs = create_placement_group_with_spmd(
-                    num_workers=num_workers,
-                    resources_per_worker=resources_per_worker,
-                    backend_config=backend_config,
-                    run_config=run_config,
+                slice_name = reserve_tpu_slice(
+                    scaling_config=scaling_config,
                 )
-                if placement_group_specs is None:
-                    raise RuntimeError("Failed to create placement group specs.")
+                bundle_label_selector = {
+                    "ray.io/tpu-slice-name": slice_name,
+                }
+                if slice_name is None:
+                    raise RuntimeError("Failed to reserve TPU slice.")
             except Exception as e:
                 return ControllerError(e)
 
@@ -306,7 +307,7 @@ class TrainController:
             num_workers=num_workers,
             resources_per_worker=resources_per_worker,
             placement_strategy=placement_strategy,
-            placement_group_specs=placement_group_specs,
+            bundle_label_selector=bundle_label_selector,
         )
         try:
             self._worker_group = self.worker_group_cls.create(

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -269,13 +269,15 @@ class WorkerGroup:
             for callback in self._callbacks:
                 callback.before_worker_group_start(worker_group_context)
 
-            bundle_label_selector = [
-                worker_group_context.bundle_label_selector.copy()
-                for _ in range(worker_group_context.num_workers)
-            ]
+            bundle_label_selector = (
+                [worker_group_context.bundle_label_selector.copy()]
+                * worker_group_context.num_workers
+                if worker_group_context.bundle_label_selector
+                else None
+            )
 
             pg = placement_group(
-                bundles=[{worker_group_context.resources_per_worker: 1}]
+                bundles=[worker_group_context.resources_per_worker]
                 * worker_group_context.num_workers,
                 strategy=worker_group_context.placement_strategy,
                 bundle_label_selector=bundle_label_selector,

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import pyarrow.fs
 
@@ -21,7 +21,9 @@ from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
     from ray.train import UserCallback
+    from ray.tune.search.sample import Domain
 
+SampleRange = Union["Domain", Dict[str, List]]
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +83,8 @@ class ScalingConfig(ScalingConfigV1):
     """
 
     trainer_resources: Optional[dict] = None
+    use_tpu: Union[bool, SampleRange] = False
+    topology: Optional[str] = None
 
     def __post_init__(self):
         if self.trainer_resources is not None:
@@ -115,7 +119,7 @@ class ScalingConfig(ScalingConfigV1):
             if self.use_tpu:
                 return {"TPU": 1}
 
-        super()._resources_per_worker_not_none()
+        return super()._resources_per_worker_not_none
 
     @property
     def _trainer_resources_not_none(self):

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -52,6 +52,14 @@ class ScalingConfig(ScalingConfigV1):
             See :ref:`the available accelerator types <accelerator_types>`.
             Ensure that your cluster has instances with the specified accelerator type
             or is able to autoscale to fulfill the request.
+        use_tpu: [Experimental] If True, training will be done on TPUs (1 TPU VM
+            per worker). Defaults to False. The number of TPUs reserved by each
+            worker can be overridden with the ``resources_per_worker``
+            argument. This arg enables SPMD execution of the training workload.
+        topology: [Experimental] If specified, Ray Train will launch the training
+            coordinator and workers on nodes with the specified topology. Topology is
+            auto-detected for TPUs and added as Ray node labels. This arg enables
+            SPMD execution of the training workload.
 
     Example:
 
@@ -78,11 +86,45 @@ class ScalingConfig(ScalingConfigV1):
         if self.trainer_resources is not None:
             raise DeprecationWarning(TRAINER_RESOURCES_DEPRECATION_MESSAGE)
 
+        if self.resources_per_worker:
+            if self.use_gpu and self.use_tpu:
+                raise ValueError(
+                    "Cannot specify both `use_gpu=True` and `use_tpu=True`."
+                )
+
+        if not self.use_tpu and self.num_tpus_per_worker > 0:
+            raise ValueError(
+                "`use_tpu` is False but `TPU` was found in "
+                "`resources_per_worker`. Either set `use_tpu` to True or "
+                "remove `TPU` from `resources_per_worker."
+            )
+
+        if self.use_tpu and self.num_tpus_per_worker == 0:
+            raise ValueError(
+                "`use_tpu` is True but `TPU` is set to 0 in "
+                "`resources_per_worker`. Either set `use_tpu` to False or "
+                "request a positive number of `TPU` in "
+                "`resources_per_worker."
+            )
+
         super().__post_init__()
+
+    @property
+    def _resources_per_worker_not_none(self):
+        if self.resources_per_worker is None:
+            if self.use_tpu:
+                return {"TPU": 1}
+
+        super()._resources_per_worker_not_none()
 
     @property
     def _trainer_resources_not_none(self):
         return {}
+
+    @property
+    def num_tpus_per_worker(self):
+        """The number of TPUs to set per worker."""
+        return self._resources_per_worker_not_none.get("TPU", 0)
 
 
 @dataclass

--- a/python/ray/train/v2/jax/__init__.py
+++ b/python/ray/train/v2/jax/__init__.py
@@ -1,0 +1,15 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    try:
+        import jax  # noqa: F401
+    except ModuleNotFoundError as exception:
+        raise ModuleNotFoundError(
+            "Jax isn't installed. To install Jax, please check"
+            " `https://github.com/google/jax#installation` for the instructions."
+        ) from exception
+
+from ray.train.v2.jax.config import JaxConfig
+from ray.train.v2.jax.jax_trainer import JaxTrainer
+
+__all__ = ["JaxConfig", "JaxTrainer"]

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -1,0 +1,49 @@
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import ray
+from ray.train._internal.worker_group import WorkerGroup
+from ray.train.backend import Backend, BackendConfig
+from ray.util import PublicAPI
+
+logger = logging.getLogger(__name__)
+
+
+@PublicAPI(stability="alpha")
+@dataclass
+class JaxConfig(BackendConfig):
+    use_tpu: bool = False
+    topology: Optional[str] = None
+    accelerator_type: Optional[str] = None
+
+    @property
+    def backend_cls(self):
+        return _JaxBackend
+
+
+def _setup_jax_tpu_environment():
+    """Set up distributed Jax training information.
+
+    This function should be called on each worker.
+    """
+    import jax
+
+    # coordinator_address, num_processes, process_id are
+    # auto-detected in TPU environments
+    jax.distributed.initialize()
+
+
+class _JaxBackend(Backend):
+    def on_start(self, worker_group: WorkerGroup, backend_config: JaxConfig):
+        if backend_config.use_tpu:
+            # Get setup tasks in order to throw errors on failure.
+            setup_futures = []
+            for i in range(len(worker_group)):
+                setup_futures.append(
+                    worker_group.execute_single_async(
+                        i,
+                        _setup_jax_tpu_environment,
+                    )
+                )
+            ray.get(setup_futures)

--- a/python/ray/train/v2/jax/jax_trainer.py
+++ b/python/ray/train/v2/jax/jax_trainer.py
@@ -1,0 +1,117 @@
+import logging
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Union
+
+from ray.air._internal.config import ensure_only_allowed_dataclass_keys_updated
+from ray.air.checkpoint import Checkpoint
+from ray.air.config import DatasetConfig, RunConfig, ScalingConfig
+from ray.train.data_parallel_trainer import DataParallelTrainer
+from ray.train.jax.config import JaxConfig
+from ray.train.trainer import GenDataset
+from ray.util import PublicAPI
+
+if TYPE_CHECKING:
+    from ray.data.preprocessor import Preprocessor
+
+logger = logging.getLogger(__name__)
+
+
+@PublicAPI(stability="alpha")
+class JaxTrainer(DataParallelTrainer):
+    """A Trainer for data parallel Jax training on TPUs only.
+
+    This Trainer runs the function ``train_loop_per_worker`` on multiple Ray
+    Actors. These actors are expected to be scheduled on TPU VMs with
+    properly configured interconnects. The ``train_loop_per_worker`` function
+    is expected to take in either 0 or 1 arguments:
+
+    .. code-block:: python
+
+        def train_loop_per_worker():
+            ...
+
+        def train_loop_per_worker(config: Dict):
+            ...
+
+    If ``train_loop_per_worker`` accepts an argument, then
+    ``train_loop_config`` will be passed in as the argument.
+
+    If the ``datasets`` dict contains a training dataset (denoted by
+    the "train" key), then it will be split into multiple dataset
+    shards that can then be accessed by ``session.get_dataset_shard("train")``.
+
+    Note:
+        * Only TPU-based distributed training is supported.
+        * Each worker must be assigned one TPU device via
+          ``resources_per_worker={"TPU": 1}``.
+        * Placement strategy is automatically set to ``SPREAD`` to ensure
+          TPU workers are placed on separate VMs.
+        * Importing `jax` should occur within `train_loop_per_worker` to
+          avoid driver-side TPU lock issues.
+
+    Args:
+        train_loop_per_worker: The training function to execute.
+        train_loop_config: Configurations to pass into
+            ``train_loop_per_worker`` if it accepts an argument.
+        jax_config: Configuration for setting up the JAX backend.
+        scaling_config: Configuration for how to scale data parallel training
+            with SPMD.
+        dataset_config: Optional configuration for datasets.
+        run_config: Configuration for the execution of the training run.
+        datasets: Any Datasets to use for training. Use
+            the key "train" to denote which dataset is the training dataset.
+        preprocessor: Optional preprocessor to apply to datasets.
+        resume_from_checkpoint: A checkpoint to resume training from.
+    """
+
+    def __init__(
+        self,
+        train_loop_per_worker: Union[Callable[[], None], Callable[[Dict], None]],
+        *,
+        train_loop_config: Optional[Dict] = None,
+        jax_config: Optional[JaxConfig] = None,
+        scaling_config: Optional[ScalingConfig] = None,
+        dataset_config: Optional[Dict[str, DatasetConfig]] = None,
+        run_config: Optional[RunConfig] = None,
+        datasets: Optional[Dict[str, GenDataset]] = None,
+        preprocessor: Optional["Preprocessor"] = None,
+        resume_from_checkpoint: Optional[Checkpoint] = None,
+    ):
+        if not jax_config:
+            jax_config = JaxConfig(
+                use_tpu=scaling_config.use_tpu,
+                topology=scaling_config.topology,
+                accelerator_type=scaling_config.accelerator_type,
+            )
+        super(JaxTrainer, self).__init__(
+            train_loop_per_worker=train_loop_per_worker,
+            train_loop_config=train_loop_config,
+            backend_config=jax_config,
+            scaling_config=scaling_config,
+            dataset_config=dataset_config,
+            run_config=run_config,
+            datasets=datasets,
+            preprocessor=preprocessor,
+            resume_from_checkpoint=resume_from_checkpoint,
+        )
+
+    @classmethod
+    def _validate_scaling_config(cls, scaling_config: ScalingConfig) -> ScalingConfig:
+        """Return scaling config dataclass after validating updated keys."""
+        ensure_only_allowed_dataclass_keys_updated(
+            dataclass=scaling_config,
+            allowed_keys=cls._scaling_config_allowed_keys,
+        )
+
+        use_tpu = (
+            scaling_config.resources_per_worker
+            and scaling_config.resources_per_worker.get("TPU", 0) > 0
+        )
+
+        if use_tpu and "PACK" in scaling_config.placement_strategy:
+            scaling_config.placement_strategy = "STRICT_SPREAD"
+            logger.warning(
+                "In JaxTrainer with TPU, `placement_strategy` must be `STRICT_SPREAD`. "
+                "Overriding `placement_strategy` to `STRICT_SPREAD`."
+            )
+
+        return scaling_config


### PR DESCRIPTION

1. Expose a `reserve_tpu_slice` utility for reserving a TPU slice.
    1.  Assumes that there is a `f"TPU-{topology_id}-head"` resource that can be scheduled
    2.  Currently takes in a `ScalingConfig` but should just take the topology/accelerator.
    3.  This is currently in `train` but can be moved to `core` as it is generic.
2. When scheduling, Ray Train will call `reserve_tpu_slice` to identify the slice, and perform gang scheduling by creating a single PlacementGroup for all workers with the correct `bundle_label_selector` set.