### PR TITLE
[1/n] IPv6 support: address <-> host:port conversion for Python Part

### DIFF
--- a/doc/source/ray-core/examples/lm/ray_train.py
+++ b/doc/source/ray-core/examples/lm/ray_train.py
@@ -11,6 +11,7 @@ from fairseq import options
 from fairseq_cli.train import main
 
 import ray
+from ray._common.network_utils import build_address
 
 _original_save_checkpoint = fairseq.checkpoint_utils.save_checkpoint
 
@@ -112,7 +113,7 @@ def run_fault_tolerant_loop():
         # fairseq distributed training.
         ip = ray.get(workers[0].get_node_ip.remote())
         port = ray.get(workers[0].find_free_port.remote())
-        address = "tcp://{ip}:{port}".format(ip=ip, port=port)
+        address = f"tcp://{build_address(ip, port)}"
 
         # Start the remote processes, and check whether their are any process
         # fails. If so, restart all the processes.

--- a/doc/source/train/user-guides/persistent-storage.rst
+++ b/doc/source/train/user-guides/persistent-storage.rst
@@ -73,7 +73,7 @@ Use by specifying the shared storage path as the :class:`RunConfig(storage_path)
         run_config=train.RunConfig(
             storage_path="/mnt/cluster_storage",
             # HDFS example:
-            # storage_path=f"hdfs://{build_address(hostname, port)}/subpath",
+            # storage_path=f"hdfs://{hostname}:{port}/subpath",
             name="experiment_name",
         )
     )

--- a/doc/source/train/user-guides/persistent-storage.rst
+++ b/doc/source/train/user-guides/persistent-storage.rst
@@ -73,7 +73,7 @@ Use by specifying the shared storage path as the :class:`RunConfig(storage_path)
         run_config=train.RunConfig(
             storage_path="/mnt/cluster_storage",
             # HDFS example:
-            # storage_path=f"hdfs://{hostname}:{port}/subpath",
+            # storage_path=f"hdfs://{build_address(hostname, port)}/subpath",
             name="experiment_name",
         )
     )

--- a/python/ray/_common/network_utils.py
+++ b/python/ray/_common/network_utils.py
@@ -1,0 +1,44 @@
+from typing import Optional, Tuple, Union
+
+
+def parse_address(address: str) -> Optional[Tuple[str, str]]:
+    """Parse a network address string into host and port.
+
+    Args:
+        address: The address string to parse (e.g., "localhost:8000", "[::1]:8000").
+
+    Returns:
+        Tuple with (host, port) if port found, None if no colon separator.
+    """
+    pos = address.rfind(":")
+    if pos == -1:
+        return None
+
+    host = address[:pos]
+    port = address[pos + 1 :]
+
+    if ":" in host:
+        if host.startswith("[") and host.endswith("]"):
+            host = host[1:-1]
+        else:
+            # Invalid IPv6 (missing brackets) or colon is part of the address, not a host:port split.
+            return None
+
+    return (host, port)
+
+
+def build_address(host: str, port: Union[int, str]) -> str:
+    """Build a network address string from host and port.
+
+    Args:
+        host: The hostname or IP address.
+        port: The port number (int or string).
+
+    Returns:
+        Formatted address string (e.g., "localhost:8000" or "[::1]:8000").
+    """
+    if host is not None and ":" in host:
+        # IPv6 address
+        return f"[{host}]:{port}"
+    # IPv4 address or hostname
+    return f"{host}:{port}"

--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -18,6 +18,7 @@ from enum import Enum
 
 
 import ray
+from ray._common.network_utils import build_address
 import ray._private.utils
 import ray._common.usage.usage_lib as ray_usage_lib
 
@@ -174,7 +175,7 @@ def simulate_s3_bucket(
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
 
-    s3_server = f"http://localhost:{port}"
+    s3_server = f"http://{build_address('localhost', port)}"
     server = ThreadedMotoServer(port=port)
     server.start()
     url = f"s3://{uuid.uuid4().hex}?region={region}&endpoint_override={s3_server}"

--- a/python/ray/_common/tests/BUILD
+++ b/python/ray/_common/tests/BUILD
@@ -14,6 +14,7 @@ py_library(
 py_test_module_list(
     size = "small",
     files = [
+        "test_network_utils.py",
         "test_ray_option_utils.py",
         "test_signal_semaphore_utils.py",
         "test_signature.py",

--- a/python/ray/_common/tests/test_network_utils.py
+++ b/python/ray/_common/tests/test_network_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 from ray._common.network_utils import parse_address, build_address
 
@@ -64,3 +65,7 @@ class TestParseAddress:
         """Test parsing bare addresses returns None."""
         result = parse_address(address)
         assert result is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/_common/tests/test_network_utils.py
+++ b/python/ray/_common/tests/test_network_utils.py
@@ -1,0 +1,66 @@
+import pytest
+
+from ray._common.network_utils import parse_address, build_address
+
+
+class TestBuildAddress:
+    """Test cases for build_address function, matching C++ tests exactly."""
+
+    @pytest.mark.parametrize(
+        "host,port,expected",
+        [
+            # IPv4
+            ("192.168.1.1", 8080, "192.168.1.1:8080"),
+            ("192.168.1.1", "8080", "192.168.1.1:8080"),
+            # IPv6
+            ("::1", 8080, "[::1]:8080"),
+            ("::1", "8080", "[::1]:8080"),
+            ("2001:db8::1", 8080, "[2001:db8::1]:8080"),
+            ("2001:db8::1", "8080", "[2001:db8::1]:8080"),
+            # Hostname
+            ("localhost", 9000, "localhost:9000"),
+            ("localhost", "9000", "localhost:9000"),
+        ],
+    )
+    def test_build_address(self, host, port, expected):
+        """Test building address strings from host and port."""
+        result = build_address(host, port)
+        assert result == expected
+
+
+class TestParseAddress:
+    """Test cases for parse_address function, matching C++ tests exactly."""
+
+    @pytest.mark.parametrize(
+        "address,expected",
+        [
+            # IPv4
+            ("192.168.1.1:8080", ("192.168.1.1", "8080")),
+            # IPv6:loopback address
+            ("[::1]:8080", ("::1", "8080")),
+            # IPv6
+            ("[2001:db8::1]:8080", ("2001:db8::1", "8080")),
+            # Hostname:Port
+            ("localhost:9000", ("localhost", "9000")),
+        ],
+    )
+    def test_parse_valid_addresses(self, address, expected):
+        """Test parsing valid addresses."""
+        result = parse_address(address)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "address",
+        [
+            # bare IP or hostname
+            # should return None when no port is found
+            "::1",
+            "2001:db8::1",
+            "192.168.1.1",
+            "localhost",
+        ],
+    )
+    def test_parse_bare_addresses(self, address):
+        """Test parsing bare addresses returns None."""
+        result = parse_address(address)
+        assert result is None

--- a/python/ray/_private/internal_api.py
+++ b/python/ray/_private/internal_api.py
@@ -6,6 +6,7 @@ import ray._private.profiling as profiling
 import ray._private.services as services
 import ray._private.utils as utils
 import ray._private.worker
+from ray._common.network_utils import build_address
 from ray._private.state import GlobalState
 from ray._raylet import GcsClientOptions
 from ray.core.generated import common_pb2
@@ -68,11 +69,11 @@ def get_memory_info_reply(state, node_manager_address=None, node_manager_port=No
                 raylet = node
                 break
         assert raylet is not None, "Every raylet is dead"
-        raylet_address = "{}:{}".format(
+        raylet_address = build_address(
             raylet["NodeManagerAddress"], raylet["NodeManagerPort"]
         )
     else:
-        raylet_address = "{}:{}".format(node_manager_address, node_manager_port)
+        raylet_address = build_address(node_manager_address, node_manager_port)
 
     channel = utils.init_grpc_channel(
         raylet_address,
@@ -99,7 +100,7 @@ def node_stats(
 
     # We can ask any Raylet for the global memory info.
     assert node_manager_address is not None and node_manager_port is not None
-    raylet_address = "{}:{}".format(node_manager_address, node_manager_port)
+    raylet_address = build_address(node_manager_address, node_manager_port)
     channel = utils.init_grpc_channel(
         raylet_address,
         options=[

--- a/python/ray/_private/metrics_agent.py
+++ b/python/ray/_private/metrics_agent.py
@@ -34,6 +34,7 @@ from prometheus_client.core import (
 )
 
 import ray
+from ray._common.network_utils import build_address
 from ray._private.ray_constants import env_bool
 from ray._private.telemetry.metric_cardinality import (
     WORKER_ID_TAG_KEY,
@@ -780,7 +781,7 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
         """Return the content for Prometheus service discovery."""
         nodes = ray.nodes()
         metrics_export_addresses = [
-            "{}:{}".format(node["NodeManagerAddress"], node["MetricsExportPort"])
+            build_address(node["NodeManagerAddress"], node["MetricsExportPort"])
             for node in nodes
             if node["alive"] is True
         ]

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -21,6 +21,7 @@ from filelock import FileLock
 # Ray modules
 import ray
 import ray._private.ray_constants as ray_constants
+from ray._common.network_utils import build_address, parse_address
 from ray._private.ray_constants import RAY_NODE_IP_FILENAME
 from ray._private.resource_isolation_config import ResourceIsolationConfig
 from ray._raylet import GcsClient, GcsClientOptions
@@ -262,10 +263,6 @@ class ConsolePopen(subprocess.Popen):
                 kwargs[flags_key] = (kwargs.get(flags_key) or 0) | flags_to_add
             self._use_signals = kwargs[flags_key] & new_pgroup
             super(ConsolePopen, self).__init__(*args, **kwargs)
-
-
-def address(ip_address, port):
-    return ip_address + ":" + str(port)
 
 
 def _find_address_from_flag(flag: str):
@@ -526,12 +523,18 @@ def canonicalize_bootstrap_address(
         addr = get_ray_address_from_environment(addr, temp_dir)
     if addr is None or addr == "local":
         return None
+
+    parsed = parse_address(addr)
+    if parsed is None:
+        raise ValueError(f"Invalid address format: {addr}")
+    host, port = parsed
+
     try:
-        bootstrap_address = resolve_ip_for_localhost(addr)
+        bootstrap_host = resolve_ip_for_localhost(host)
     except Exception:
         logger.exception(f"Failed to convert {addr} to host:port")
         raise
-    return bootstrap_address
+    return build_address(bootstrap_host, port)
 
 
 def canonicalize_bootstrap_address_or_die(
@@ -574,11 +577,12 @@ def canonicalize_bootstrap_address_or_die(
 
 
 def extract_ip_port(bootstrap_address: str):
-    if ":" not in bootstrap_address:
+    ip_port = parse_address(bootstrap_address)
+    if ip_port is None:
         raise ValueError(
             f"Malformed address {bootstrap_address}. " f"Expected '<host>:<port>'."
         )
-    ip, _, port = bootstrap_address.rpartition(":")
+    ip, port = ip_port
     try:
         port = int(port)
     except ValueError:
@@ -591,27 +595,24 @@ def extract_ip_port(bootstrap_address: str):
     return ip, port
 
 
-def resolve_ip_for_localhost(address: str):
-    """Convert to a remotely reachable IP if the address is "localhost"
-            or "127.0.0.1". Otherwise do nothing.
+def resolve_ip_for_localhost(host: str):
+    """Convert to a remotely reachable IP if the host is "localhost",
+            "127.0.0.1", or "::1". Otherwise do nothing.
 
     Args:
-        address: This can be either a string containing a hostname (or an IP
-            address) and a port or it can be just an IP address.
+        host: The hostname or IP address.
 
     Returns:
-        The same address but with the local host replaced by remotely
+        The same host but with the local host replaced by remotely
             reachable IP.
     """
-    if not address:
-        raise ValueError(f"Malformed address: {address}")
-    address_parts = address.split(":")
-    if address_parts[0] == "127.0.0.1" or address_parts[0] == "localhost":
+    if not host:
+        raise ValueError(f"Malformed host: {host}")
+    if host == "127.0.0.1" or host == "::1" or host == "localhost":
         # Make sure localhost isn't resolved to the loopback ip
-        ip_address = get_node_ip_address()
-        return ":".join([ip_address] + address_parts[1:])
+        return get_node_ip_address()
     else:
-        return address
+        return host
 
 
 def node_ip_address_from_perspective(address: str):
@@ -624,7 +625,7 @@ def node_ip_address_from_perspective(address: str):
     Returns:
         The IP address by which the local node can be reached from the address.
     """
-    ip_address, port = address.split(":")
+    ip_address, port = parse_address(address)
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         # This command will raise an exception if there is no internet
@@ -1430,7 +1431,7 @@ def get_address(redis_address):
     parts = redis_address.split("://", 1)
     enable_redis_ssl = False
     if len(parts) == 1:
-        redis_ip_address, redis_port = parts[0].rsplit(":", 1)
+        redis_ip_address, redis_port = parse_address(parts[0])
     else:
         # rediss for SSL
         if len(parts) != 2 or parts[0] not in ("redis", "rediss"):
@@ -1439,7 +1440,7 @@ def get_address(redis_address):
                 "Expected format is ip:port or redis://ip:port, "
                 "or rediss://ip:port for SSL."
             )
-        redis_ip_address, redis_port = parts[1].rsplit(":", 1)
+        redis_ip_address, redis_port = parse_address(parts[1])
         if parts[0] == "rediss":
             enable_redis_ssl = True
     return redis_ip_address, redis_port, enable_redis_ssl

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -30,6 +30,7 @@ import ray._private.memory_monitor as memory_monitor
 import ray._private.services
 import ray._private.services as services
 import ray._private.utils
+from ray._common.network_utils import build_address, parse_address
 from ray._common.test_utils import wait_for_condition
 from ray._common.utils import get_or_create_event_loop
 from ray._private import (
@@ -657,7 +658,7 @@ def get_metric_check_condition(
     node_info = ray.nodes()[0]
     metrics_export_port = node_info["MetricsExportPort"]
     addr = node_info["NodeManagerAddress"]
-    prom_addr = export_addr or f"{addr}:{metrics_export_port}"
+    prom_addr = export_addr or build_address(addr, metrics_export_port)
 
     def f():
         for metric_pattern in metrics_to_check:
@@ -770,9 +771,8 @@ def put_object(obj, use_ray_put):
 
 
 def wait_until_server_available(address, timeout_ms=5000, retry_interval_ms=100):
-    ip_port = address.split(":")
-    ip = ip_port[0]
-    port = int(ip_port[1])
+    ip, port_str = parse_address(address)
+    port = int(port_str)
     time_elapsed = 0
     start = time.time()
     while time_elapsed <= timeout_ms:
@@ -1421,7 +1421,7 @@ class RayletKiller(NodeKillerBase):
 
         from ray.core.generated import node_manager_pb2_grpc
 
-        raylet_address = f"{ip}:{port}"
+        raylet_address = build_address(ip, port)
         channel = grpc.insecure_channel(raylet_address)
         stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
         try:
@@ -1774,7 +1774,9 @@ def get_node_stats(raylet, num_retry=5, timeout=2):
 
     from ray.core.generated import node_manager_pb2_grpc
 
-    raylet_address = f'{raylet["NodeManagerAddress"]}:{raylet["NodeManagerPort"]}'
+    raylet_address = build_address(
+        raylet["NodeManagerAddress"], raylet["NodeManagerPort"]
+    )
     channel = ray._private.utils.init_grpc_channel(raylet_address)
     stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
     for _ in range(num_retry):
@@ -1826,7 +1828,9 @@ def kill_raylet(raylet, graceful=False):
 
     from ray.core.generated import node_manager_pb2_grpc
 
-    raylet_address = f'{raylet["NodeManagerAddress"]}:{raylet["NodeManagerPort"]}'
+    raylet_address = build_address(
+        raylet["NodeManagerAddress"], raylet["NodeManagerPort"]
+    )
     channel = grpc.insecure_channel(raylet_address)
     stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
     try:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -230,6 +230,7 @@ import ray._private.profiling as profiling
 from ray._common.utils import decode
 from ray._private.utils import DeferSigint
 from ray._private.object_ref_generator import DynamicObjectRefGenerator
+from ray._common.network_utils import build_address, parse_address
 from ray.util.annotations import PublicAPI
 from ray._private.custom_types import TensorTransportEnum
 
@@ -2802,7 +2803,7 @@ cdef class _GcsSubscriber:
         # subscriber_id needs to match the binary format of a random
         # SubscriberID / UniqueID, which is 28 (kUniqueIDSize) random bytes.
         subscriber_id = bytes(bytearray(random.getrandbits(8) for _ in range(28)))
-        gcs_address, gcs_port = address.split(":")
+        gcs_address, gcs_port = parse_address(address)
         self.inner.reset(new CPythonGcsSubscriber(
             gcs_address, int(gcs_port), channel, subscriber_id, c_worker_id))
 

--- a/python/ray/air/tests/test_remote_storage_hdfs.py
+++ b/python/ray/air/tests/test_remote_storage_hdfs.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from ray import train
+from ray._common.network_utils import build_address
 from ray.train.base_trainer import TrainingFailedError
 from ray.train.data_parallel_trainer import DataParallelTrainer
 from ray.train.tests.test_new_persistence import (
@@ -44,7 +45,7 @@ def test_hdfs_train_checkpointing(tmp_path, monkeypatch, setup_hdfs):
     no_checkpoint_ranks = [0]
 
     hostname, port = setup_hdfs
-    storage_path = f"hdfs://{hostname}:{port}/results/"
+    storage_path = f"hdfs://{build_address(hostname, port)}/results/"
     storage_filesystem = None
 
     checkpoint_config = train.CheckpointConfig(

--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -18,6 +18,7 @@ import ray
 from ray.actor import ActorHandle
 from ray.air._internal.torch_utils import get_devices
 from ray.train._internal.utils import get_address_and_port
+from ray._common.network_utils import build_address
 
 
 class TorchDistributedWorker(ABC):
@@ -55,7 +56,7 @@ def _init_torch_distributed(
         os.environ["MASTER_PORT"] = str(master_port)
         url = "env://"
     elif init_method == "tcp":
-        url = f"tcp://{master_addr}:{master_port}"
+        url = f"tcp://{build_address(master_addr, master_port)}"
     else:
         raise ValueError(
             f"The provided init_method ("

--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -13,6 +13,7 @@ import yaml
 
 import ray
 import ray._private.ray_constants as ray_constants
+from ray._common.network_utils import build_address
 from ray.autoscaler._private.fake_multi_node.command_runner import (
     FakeDockerCommandRunner,
 )
@@ -359,13 +360,13 @@ class FakeMultiNodeProvider(NodeProvider):
                 object_store_memory=resources.pop("object_store_memory", None),
                 resources=resources,
                 labels=labels,
-                redis_address="{}:6379".format(
-                    ray._private.services.get_node_ip_address()
+                redis_address=build_address(
+                    ray._private.services.get_node_ip_address(), 6379
                 )
                 if not self._gcs_address
                 else self._gcs_address,
-                gcs_address="{}:6379".format(
-                    ray._private.services.get_node_ip_address()
+                gcs_address=build_address(
+                    ray._private.services.get_node_ip_address(), 6379
                 )
                 if not self._gcs_address
                 else self._gcs_address,

--- a/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Optional
 import yaml
 
 import ray
+from ray._common.network_utils import build_address
 from ray._private.dict import deep_update
 from ray.autoscaler._private.fake_multi_node.node_provider import (
     FAKE_DOCKER_DEFAULT_CLIENT_PORT,
@@ -102,10 +103,10 @@ class DockerCluster:
 
         if client:
             port = self.client_port
-            address = f"ray://{host}:{port}"
+            address = f"ray://{build_address(host, port)}"
         else:
             port = self.gcs_port
-            address = f"{host}:{port}"
+            address = build_address(host, port)
 
         timeout_at = time.monotonic() + timeout
         while time.monotonic() < timeout_at:

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -22,6 +22,7 @@ from ray.autoscaler.tags import (
     STATUS_UPDATE_FAILED,
     TAG_RAY_USER_NODE_TYPE,
 )
+from ray._common.network_utils import build_address
 
 # Key for KubeRay label that identifies a Ray pod as head or worker.
 KUBERAY_LABEL_KEY_KIND = "ray.io/node-type"
@@ -51,7 +52,7 @@ KUBERNETES_SERVICE_HOST = os.getenv(
     "KUBERNETES_SERVICE_HOST", "https://kubernetes.default"
 )
 KUBERNETES_SERVICE_PORT = os.getenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
-KUBERNETES_HOST = f"{KUBERNETES_SERVICE_HOST}:{KUBERNETES_SERVICE_PORT}"
+KUBERNETES_HOST = build_address(KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT)
 # Key for GKE label that identifies which multi-host replica a pod belongs to
 REPLICA_INDEX_KEY = "replicaIndex"
 

--- a/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
+++ b/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
@@ -11,6 +11,7 @@ from ray._common.ray_constants import (
 )
 from ray._private.ray_logging import setup_component_logger
 from ray._private.services import get_node_ip_address
+from ray._common.network_utils import build_address
 from ray._common.utils import try_to_create_directory
 from ray._raylet import GcsClient
 from ray.autoscaler._private.kuberay.autoscaling_config import AutoscalingConfigProducer
@@ -34,7 +35,7 @@ def _get_log_dir() -> str:
 def run_kuberay_autoscaler(cluster_name: str, cluster_namespace: str):
     """Wait until the Ray head container is ready. Then start the autoscaler."""
     head_ip = get_node_ip_address()
-    ray_address = f"{head_ip}:6379"
+    ray_address = build_address(head_ip, 6379)
     while True:
         try:
             # Autoscaler Ray version might not exactly match GCS version, so skip the

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -21,6 +21,7 @@ from ray._common.ray_constants import (
 from ray._private.event.event_logger import get_event_logger
 from ray._private.ray_logging import setup_component_logger
 from ray._raylet import GcsClient
+from ray._common.network_utils import parse_address, build_address
 from ray.autoscaler._private.autoscaler import StandardAutoscaler
 from ray.autoscaler._private.commands import teardown_cluster
 from ray.autoscaler._private.constants import (
@@ -152,14 +153,14 @@ class Monitor:
         _initialize_internal_kv(self.gcs_client)
 
         if monitor_ip:
-            monitor_addr = f"{monitor_ip}:{AUTOSCALER_METRIC_PORT}"
+            monitor_addr = build_address(monitor_ip, AUTOSCALER_METRIC_PORT)
             self.gcs_client.internal_kv_put(
                 b"AutoscalerMetricsAddress", monitor_addr.encode(), True, None
             )
         self._session_name = self.get_session_name(self.gcs_client)
         logger.info(f"session_name: {self._session_name}")
         worker.mode = 0
-        head_node_ip = self.gcs_address.split(":")[0]
+        head_node_ip = parse_address(self.gcs_address)[0]
 
         self.load_metrics = LoadMetrics()
         self.last_avail_resources = None

--- a/python/ray/autoscaler/_private/spark/node_provider.py
+++ b/python/ray/autoscaler/_private/spark/node_provider.py
@@ -18,6 +18,7 @@ from ray.autoscaler.tags import (
     TAG_RAY_NODE_STATUS,
     TAG_RAY_USER_NODE_TYPE,
 )
+from ray._common.network_utils import build_address
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,9 @@ class SparkNodeProvider(NodeProvider):
         # to launch spark jobs, ray worker nodes are launched by spark task in
         # spark jobs.
         spark_job_server_port = self.provider_config["spark_job_server_port"]
-        self.spark_job_server_url = f"http://{self.ray_head_ip}:{spark_job_server_port}"
+        self.spark_job_server_url = (
+            f"http://{build_address(self.ray_head_ip, spark_job_server_port)}"
+        )
         self.ray_head_port = self.provider_config["ray_head_port"]
         # The unique id for the Ray on spark cluster.
         self.cluster_id = self.provider_config["cluster_unique_id"]
@@ -190,7 +193,7 @@ class SparkNodeProvider(NodeProvider):
                     "spark_job_group_desc": (
                         "This job group is for spark job which runs the Ray "
                         f"cluster worker node {node_id} connecting to ray "
-                        f"head node {self.ray_head_ip}:{self.ray_head_port}"
+                        f"head node {build_address(self.ray_head_ip, self.ray_head_port)}"
                     ),
                     "using_stage_scheduling": conf["using_stage_scheduling"],
                     "ray_head_ip": self.ray_head_ip,

--- a/python/ray/autoscaler/local/coordinator_server.py
+++ b/python/ray/autoscaler/local/coordinator_server.py
@@ -11,6 +11,7 @@ import socket
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 
 from ray.autoscaler._private.local.node_provider import LocalNodeProvider
+from ray._common.network_utils import build_address
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -76,7 +77,7 @@ class OnPremCoordinatorServer(threading.Thread):
         """Initialize HTTPServer and serve forever by invoking self.run()."""
 
         logger.info(
-            "Running on prem coordinator server on address " + host + ":" + str(port)
+            "Running on prem coordinator server on address " + build_address(host, port)
         )
         threading.Thread.__init__(self)
         self._port = port

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -22,6 +22,7 @@ from ray._private.ray_logging import setup_component_logger
 from ray._common.usage.usage_lib import record_extra_usage_tag
 from ray._private.worker import SCRIPT_MODE
 from ray._raylet import GcsClient
+from ray._common.network_utils import parse_address, build_address
 from ray.autoscaler._private.constants import (
     AUTOSCALER_METRIC_PORT,
     AUTOSCALER_UPDATE_INTERVAL_S,
@@ -79,14 +80,14 @@ class AutoscalerMonitor:
         self.gcs_client = GcsClient(address=self.gcs_address)
 
         if monitor_ip:
-            monitor_addr = f"{monitor_ip}:{AUTOSCALER_METRIC_PORT}"
+            monitor_addr = build_address(monitor_ip, AUTOSCALER_METRIC_PORT)
             self.gcs_client.internal_kv_put(
                 b"AutoscalerMetricsAddress", monitor_addr.encode(), True, None
             )
         self._session_name = self._get_session_name(self.gcs_client)
         logger.info(f"session_name: {self._session_name}")
         worker.set_mode(SCRIPT_MODE)
-        head_node_ip = self.gcs_address.split(":")[0]
+        head_node_ip = parse_address(self.gcs_address)[0]
 
         self.autoscaler = None
         if log_dir:

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -11,6 +11,7 @@ import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
 from ray._private import logging_utils
+from ray._common.network_utils import build_address
 from ray._private.process_watcher import create_check_raylet_task
 from ray._private.ray_constants import AGENT_GRPC_MAX_MESSAGE_LENGTH
 from ray._private.ray_logging import setup_component_logger
@@ -111,7 +112,7 @@ class DashboardAgent:
         grpc_ip = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
         try:
             self.grpc_port = add_port_to_grpc_server(
-                self.server, f"{grpc_ip}:{self.dashboard_agent_port}"
+                self.server, build_address(grpc_ip, self.dashboard_agent_port)
             )
         except Exception:
             # TODO(SongGuyang): Catch the exception here because there is
@@ -124,7 +125,10 @@ class DashboardAgent:
             self.server = None
             self.grpc_port = None
         else:
-            logger.info("Dashboard agent grpc address: %s:%s", grpc_ip, self.grpc_port)
+            logger.info(
+                "Dashboard agent grpc address: %s",
+                build_address(grpc_ip, self.grpc_port),
+            )
 
         # If the agent is not minimal it should start the http server
         # to communicate with the dashboard in a head node.

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -24,6 +24,7 @@ from ray.dashboard.utils import (
     DashboardHeadModuleConfig,
     async_loop_forever,
 )
+from ray._common.network_utils import build_address
 
 import psutil
 
@@ -301,7 +302,7 @@ class DashboardHead:
         # Setup prometheus metrics export server
         assert internal_kv._internal_kv_initialized()
         assert gcs_client is not None
-        address = f"{self.ip}:{DASHBOARD_METRIC_PORT}"
+        address = build_address(self.ip, DASHBOARD_METRIC_PORT)
         await gcs_client.async_internal_kv_put(
             "DashboardMetricsAddress".encode(), address.encode(), True, namespace=None
         )
@@ -436,7 +437,9 @@ class DashboardHead:
                 dashboard_head_modules, subprocess_module_handles
             )
             http_host, http_port = self.http_server.get_address()
-            logger.info(f"http server initialized at {http_host}:{http_port}")
+            logger.info(
+                f"http server initialized at {build_address(http_host, http_port)}"
+            )
         else:
             logger.info("http server disabled.")
 
@@ -455,7 +458,7 @@ class DashboardHead:
         # server address to Ray via stdin / stdout or a pipe.
         self.gcs_client.internal_kv_put(
             ray_constants.DASHBOARD_ADDRESS.encode(),
-            f"{dashboard_http_host}:{http_port}".encode(),
+            build_address(dashboard_http_host, http_port).encode(),
             True,
             namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
         )

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -7,6 +7,7 @@ from packaging.version import Version
 
 import ray.dashboard.optional_utils as dashboard_optional_utils
 from ray._common.utils import get_or_create_event_loop
+from ray._common.network_utils import build_address
 from ray.dashboard.optional_deps import aiohttp, aiohttp_cors, hdrs
 
 logger = logging.getLogger(__name__)
@@ -113,7 +114,8 @@ class HttpServerAgent:
 
         self.http_host, self.http_port, *_ = site._server.sockets[0].getsockname()
         logger.info(
-            "Dashboard agent http address: %s:%s", self.http_host, self.http_port
+            "Dashboard agent http address: %s",
+            build_address(self.http_host, self.http_port),
         )
 
         # Dump registered http routes.

--- a/python/ray/dashboard/http_server_head.py
+++ b/python/ray/dashboard/http_server_head.py
@@ -18,7 +18,9 @@ import ray.dashboard.timezone_utils as timezone_utils
 import ray.dashboard.utils as dashboard_utils
 from ray import ray_constants
 from ray._common.utils import get_or_create_event_loop
+from ray._common.network_utils import build_address
 from ray._common.usage.usage_lib import TagKey, record_extra_usage_tag
+from ray._common.network_utils import parse_address
 from ray.dashboard.dashboard_metrics import DashboardPrometheusMetrics
 from ray.dashboard.head import DashboardHeadModule
 
@@ -89,7 +91,7 @@ class HttpServerDashboardHead:
         self.http_host = http_host
         self.http_port = http_port
         self.http_port_retries = http_port_retries
-        self.head_node_ip = gcs_address.split(":")[0]
+        self.head_node_ip = parse_address(gcs_address)[0]
         self.metrics = metrics
         self._session_name = session_name
 
@@ -288,7 +290,8 @@ class HttpServerDashboardHead:
             else self.http_host
         )
         logger.info(
-            "Dashboard head http address: %s:%s", self.http_host, self.http_port
+            "Dashboard head http address: %s",
+            build_address(self.http_host, self.http_port),
         )
         # Dump registered http routes.
         dump_routes = [r for r in app.router.routes() if r.method != hdrs.METH_HEAD]

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -17,6 +17,7 @@ from ray._private.test_utils import (
     wait_until_server_available,
     find_free_port,
 )
+from ray._common.network_utils import parse_address, build_address
 
 from ray.core.generated.events_event_aggregator_service_pb2_grpc import (
     EventAggregatorServiceStub,
@@ -59,8 +60,8 @@ def get_event_aggregator_grpc_stub(webui_url, gcs_address, head_node_id):
     An helper function to get the gRPC stub for the event aggregator agent.
     Should only be used in tests.
     """
-    ip, port = webui_url.split(":")
-    agent_address = f"{ip}:{ray_constants.DEFAULT_DASHBOARD_AGENT_LISTEN_PORT}"
+    ip, _ = parse_address(webui_url)
+    agent_address = build_address(ip, ray_constants.DEFAULT_DASHBOARD_AGENT_LISTEN_PORT)
     assert wait_until_server_available(agent_address)
 
     gcs_address = gcs_address

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -25,6 +25,7 @@ from ray._private.runtime_env.packaging import (
     pin_runtime_env_uri,
     upload_package_to_gcs,
 )
+from ray._common.network_utils import build_address
 from ray.dashboard.consts import (
     DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX,
     GCS_RPC_TIMEOUT_SECONDS,
@@ -324,7 +325,7 @@ class JobHead(SubprocessModule):
                 # JobAgentSubmissionClient. May raise if the node_id is removed in
                 # InternalKV after the _fetch_all_agent_node_ids, though unlikely.
                 ip, http_port, _ = await self._fetch_agent_info(node_id)
-                agent_http_address = f"http://{ip}:{http_port}"
+                agent_http_address = f"http://{build_address(ip, http_port)}"
                 self._agents[node_id] = JobAgentSubmissionClient(agent_http_address)
 
             return self._agents[node_id]
@@ -339,7 +340,7 @@ class JobHead(SubprocessModule):
 
         if head_node_id not in self._agents:
             ip, http_port, _ = await self._fetch_agent_info(head_node_id)
-            agent_http_address = f"http://{ip}:{http_port}"
+            agent_http_address = f"http://{build_address(ip, http_port)}"
             self._agents[head_node_id] = JobAgentSubmissionClient(agent_http_address)
 
         return self._agents[head_node_id]

--- a/python/ray/dashboard/modules/job/job_supervisor.py
+++ b/python/ray/dashboard/modules/job/job_supervisor.py
@@ -25,6 +25,7 @@ from ray.dashboard.modules.job.common import (
 )
 from ray.dashboard.modules.job.job_log_storage_client import JobLogStorageClient
 from ray.job_submission import JobStatus
+from ray._common.network_utils import build_address
 
 import psutil
 
@@ -336,9 +337,7 @@ class JobSupervisor:
             await _start_signal_actor.wait.remote()
 
         node = ray._private.worker.global_worker.node
-        driver_agent_http_address = (
-            f"http://{node.node_ip_address}:{node.dashboard_agent_listen_port}"
-        )
+        driver_agent_http_address = f"http://{build_address(node.node_ip_address, node.dashboard_agent_listen_port)}"
         driver_node_id = ray.get_runtime_context().get_node_id()
 
         await self._job_info_client.put_status(

--- a/python/ray/dashboard/modules/job/tests/test_job_agent.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_agent.py
@@ -25,6 +25,7 @@ from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
     wait_until_server_available,
 )
+from ray._common.network_utils import parse_address, build_address
 from ray.dashboard.modules.job.common import (
     JOB_ACTOR_NAME_TEMPLATE,
     SUPERVISOR_ACTOR_RAY_NAMESPACE,
@@ -76,8 +77,8 @@ class JobAgentSubmissionBrowserClient(JobAgentSubmissionClient):
 @pytest_asyncio.fixture
 async def job_sdk_client(make_sure_dashboard_http_port_unused):
     with _ray_start(include_dashboard=True, num_cpus=1) as ctx:
-        ip, _ = ctx.address_info["webui_url"].split(":")
-        agent_address = f"{ip}:{DEFAULT_DASHBOARD_AGENT_LISTEN_PORT}"
+        ip, _ = parse_address(ctx.address_info["webui_url"])
+        agent_address = build_address(ip, DEFAULT_DASHBOARD_AGENT_LISTEN_PORT)
         assert wait_until_server_available(agent_address)
         head_address = ctx.address_info["webui_url"]
         assert wait_until_server_available(head_address)
@@ -468,8 +469,8 @@ async def test_job_log_in_multiple_node(
         dashboard_agent_listen_port=DEFAULT_DASHBOARD_AGENT_LISTEN_PORT + 2
     )
 
-    ip, port = cluster.webui_url.split(":")
-    agent_address = f"{ip}:{DEFAULT_DASHBOARD_AGENT_LISTEN_PORT}"
+    ip, _ = parse_address(cluster.webui_url)
+    agent_address = build_address(ip, DEFAULT_DASHBOARD_AGENT_LISTEN_PORT)
     assert wait_until_server_available(agent_address)
     client = JobAgentSubmissionClient(format_web_url(agent_address))
 
@@ -603,9 +604,9 @@ async def test_non_default_dashboard_agent_http_port(tmp_path):
         # We will need to wait for the ray to be started in the subprocess.
         address_info = ray.init("auto", ignore_reinit_error=True).address_info
 
-        ip, _ = address_info["webui_url"].split(":")
+        ip, _ = parse_address(address_info["webui_url"])
         dashboard_agent_listen_port = address_info["dashboard_agent_listen_port"]
-        agent_address = f"{ip}:{dashboard_agent_listen_port}"
+        agent_address = build_address(ip, dashboard_agent_listen_port)
         print("agent address = ", agent_address)
 
         agent_client = JobAgentSubmissionClient(format_web_url(agent_address))

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -17,6 +17,7 @@ from ray._private.ray_constants import (
     KV_NAMESPACE_JOB,
     RAY_ADDRESS_ENVIRONMENT_VARIABLE,
 )
+from ray._common.network_utils import build_address
 from ray._common.test_utils import (
     async_wait_for_condition,
 )
@@ -1187,7 +1188,7 @@ async def test_bootstrap_address(job_manager, monkeypatch):
     ip = ray._private.ray_constants.DEFAULT_DASHBOARD_IP
     port = ray._private.ray_constants.DEFAULT_DASHBOARD_PORT
 
-    monkeypatch.setenv("RAY_ADDRESS", f"http://{ip}:{port}")
+    monkeypatch.setenv("RAY_ADDRESS", f"http://{build_address(ip, port)}")
     print_ray_address_cmd = (
         'python -c"' "import os;" "import ray;" "ray.init();" "print('SUCCESS!');" '"'
     )

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -30,6 +30,7 @@ from ray._common.utils import (
     get_or_create_event_loop,
     get_user_temp_dir,
 )
+from ray._common.network_utils import parse_address
 from ray._private.utils import get_system_memory
 from ray.dashboard.modules.reporter.gpu_providers import (
     GpuMetricProvider,
@@ -417,7 +418,7 @@ class ReporterAgent(
         self._gcs_client = dashboard_agent.gcs_client
         self._ip = dashboard_agent.ip
         self._log_dir = dashboard_agent.log_dir
-        self._is_head_node = self._ip == dashboard_agent.gcs_address.split(":")[0]
+        self._is_head_node = self._ip == parse_address(dashboard_agent.gcs_address)[0]
         self._hostname = socket.gethostname()
         # (pid, created_time) -> psutil.Process
         self._workers = {}

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -13,6 +13,7 @@ import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray import ActorID, NodeID
 from ray._private.metrics_agent import PrometheusServiceDiscoveryWriter
+from ray._common.network_utils import build_address
 from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_ERROR,
     DEBUG_AUTOSCALING_STATUS,
@@ -253,7 +254,7 @@ class ReportHead(SubprocessModule):
                 text=f"Failed to get agent address for node {node_id_hex}"
             )
         node_id, ip, http_port, grpc_port = addrs
-        reporter_stub = self._make_stub(f"{ip}:{grpc_port}")
+        reporter_stub = self._make_stub(build_address(ip, grpc_port))
 
         # Default not using `--native` for profiling
         native = req.query.get("native", False) == "1"
@@ -351,7 +352,7 @@ class ReportHead(SubprocessModule):
                 text=f"Failed to get agent address for node {node_id_hex}"
             )
         node_id, ip, http_port, grpc_port = addrs
-        reporter_stub = self._make_stub(f"{ip}:{grpc_port}")
+        reporter_stub = self._make_stub(build_address(ip, grpc_port))
 
         try:
             (pid, _) = await self.get_worker_details_for_running_task(
@@ -361,7 +362,7 @@ class ReportHead(SubprocessModule):
             raise aiohttp.web.HTTPInternalServerError(text=str(e))
 
         logger.info(
-            f"Sending CPU profiling request to {ip}:{grpc_port}, pid {pid}, for {task_id} with native={native}"
+            f"Sending CPU profiling request to {build_address(ip, grpc_port)}, pid {pid}, for {task_id} with native={native}"
         )
 
         reply = await reporter_stub.CpuProfiling(
@@ -428,11 +429,11 @@ class ReportHead(SubprocessModule):
                 text=f"Failed to get agent address for node at IP {ip}"
             )
         node_id, ip, http_port, grpc_port = addrs
-        reporter_stub = self._make_stub(f"{ip}:{grpc_port}")
+        reporter_stub = self._make_stub(build_address(ip, grpc_port))
         # Default not using `--native` for profiling
         native = req.query.get("native", False) == "1"
         logger.info(
-            f"Sending stack trace request to {ip}:{grpc_port}, pid {pid}, with native={native}"
+            f"Sending stack trace request to {build_address(ip, grpc_port)}, pid {pid}, with native={native}"
         )
         pid = int(pid)
         reply = await reporter_stub.GetTraceback(
@@ -474,7 +475,7 @@ class ReportHead(SubprocessModule):
                 text=f"Failed to get agent address for node at IP {ip}"
             )
         node_id, ip, http_port, grpc_port = addrs
-        reporter_stub = self._make_stub(f"{ip}:{grpc_port}")
+        reporter_stub = self._make_stub(build_address(ip, grpc_port))
 
         pid = int(pid)
         duration_s = int(req.query.get("duration", 5))
@@ -485,7 +486,7 @@ class ReportHead(SubprocessModule):
         # Default not using `--native` for profiling
         native = req.query.get("native", False) == "1"
         logger.info(
-            f"Sending CPU profiling request to {ip}:{grpc_port}, pid {pid}, with native={native}"
+            f"Sending CPU profiling request to {build_address(ip, grpc_port)}, pid {pid}, with native={native}"
         )
         reply = await reporter_stub.CpuProfiling(
             reporter_pb2.CpuProfilingRequest(
@@ -546,13 +547,13 @@ class ReportHead(SubprocessModule):
                 text=f"Failed to get agent address for node at IP {ip}, pid {pid}"
             )
         node_id, ip, http_port, grpc_port = addrs
-        reporter_stub = self._make_stub(f"{ip}:{grpc_port}")
+        reporter_stub = self._make_stub(build_address(ip, grpc_port))
 
         # Profile for num_iterations training steps (calls to optimizer.step())
         num_iterations = int(req.query.get("num_iterations", 4))
 
         logger.info(
-            f"Sending GPU profiling request to {ip}:{grpc_port}, pid {pid}. "
+            f"Sending GPU profiling request to {build_address(ip, grpc_port)}, pid {pid}. "
             f"Profiling for {num_iterations} training steps."
         )
 
@@ -659,7 +660,7 @@ class ReportHead(SubprocessModule):
             _, ip, _, grpc_port = addrs
 
         assert pid is not None
-        ip_port = f"{ip}:{grpc_port}"
+        ip_port = build_address(ip, grpc_port)
 
         duration_s = int(req.query.get("duration", 10))
 
@@ -672,7 +673,7 @@ class ReportHead(SubprocessModule):
         reporter_stub = self._make_stub(ip_port)
 
         logger.info(
-            f"Retrieving memory profiling request to {ip}:{grpc_port}, pid {pid}, with native={native}"
+            f"Retrieving memory profiling request to {build_address(ip, grpc_port)}, pid {pid}, with native={native}"
         )
 
         reply = await reporter_stub.MemoryProfiling(

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -17,6 +17,7 @@ import ray
 import ray._common.usage.usage_lib as ray_usage_lib
 from ray._private import ray_constants
 from ray._private.metrics_agent import fix_grpc_metric
+from ray._common.network_utils import build_address
 from ray._private.test_utils import (
     fetch_prometheus,
     format_web_url,
@@ -217,7 +218,7 @@ def test_prometheus_physical_stats_record(
     addresses = ray.init(include_dashboard=True, num_cpus=1)
     metrics_export_port = addresses["metrics_export_port"]
     addr = addresses["raylet_ip_address"]
-    prom_addresses = [f"{addr}:{metrics_export_port}"]
+    prom_addresses = [build_address(addr, metrics_export_port)]
 
     def test_case_stats_exist():
         _, metric_descriptors, _ = fetch_prometheus(prom_addresses)
@@ -284,7 +285,7 @@ def test_prometheus_export_worker_and_memory_stats(enable_test_module, shutdown_
     addresses = ray.init(include_dashboard=True, num_cpus=1)
     metrics_export_port = addresses["metrics_export_port"]
     addr = addresses["raylet_ip_address"]
-    prom_addresses = [f"{addr}:{metrics_export_port}"]
+    prom_addresses = [build_address(addr, metrics_export_port)]
 
     @ray.remote
     def f():

--- a/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
+++ b/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
@@ -11,6 +11,7 @@ import ray._common.usage.usage_lib as ray_usage_lib
 import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
 from ray.dashboard.utils import async_loop_forever
+from ray._common.network_utils import build_address
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,9 @@ class UsageStatsHead(dashboard_utils.DashboardHeadModule):
         # The seq number of report. It increments whenever a new report is sent.
         self.seq_no = 0
 
-        self._dashboard_url_base = f"http://{self.http_host}:{self.http_port}"
+        self._dashboard_url_base = (
+            f"http://{build_address(self.http_host, self.http_port)}"
+        )
         # We want to record stats for anyone who has run ray with grafana or
         # prometheus at any point in time during a ray session.
         self._grafana_ran_before = False

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -30,6 +30,7 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BYTES,
     LOGGING_ROTATE_BACKUP_COUNT,
 )
+from ray._common.network_utils import build_address, parse_address
 from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_ERROR,
     DEBUG_AUTOSCALING_STATUS_LEGACY,
@@ -330,7 +331,7 @@ def test_agent_report_unexpected_raylet_death_large_file(
 )
 def test_dashboard_address_local(ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
-    webui_ip = webui_url.split(":")[0]
+    webui_ip = parse_address(webui_url)[0]
     assert not ipaddress.ip_address(webui_ip).is_unspecified
     assert webui_ip == "127.0.0.1"
 
@@ -349,7 +350,7 @@ def test_dashboard_address_local(ray_start_with_dashboard):
 )
 def test_dashboard_address_global(ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
-    webui_ip = webui_url.split(":")[0]
+    webui_ip = parse_address(webui_url)[0]
     assert not ipaddress.ip_address(webui_ip).is_unspecified
     assert webui_ip == ray_start_with_dashboard["node_ip_address"]
 
@@ -391,7 +392,7 @@ def test_http_get(enable_test_module, ray_start_with_dashboard):
             node_ip, http_port, _ = json.loads(agent_addr)
 
             response = requests.get(
-                f"http://{node_ip}:{http_port}"
+                f"http://{build_address(node_ip, http_port)}"
                 f"/test/http_get_from_agent?url={quote_plus(target_url)}"
             )
             response.raise_for_status()
@@ -915,7 +916,7 @@ def test_dashboard_port_conflict(ray_start_with_dashboard):
     address_info = ray_start_with_dashboard
     gcs_client = make_gcs_client(address_info)
     ray.experimental.internal_kv._initialize_internal_kv(gcs_client)
-    host, port = address_info["webui_url"].split(":")
+    host, port = parse_address(address_info["webui_url"])
     temp_dir = "/tmp/ray"
     session_dir = "/tmp/ray/session_latest"
     log_dir = "/tmp/ray/session_latest/logs"
@@ -1053,7 +1054,7 @@ def test_agent_does_not_depend_on_serve(shutdown_only):
 
     logger.info("Agent works.")
 
-    agent_url = node.node_ip_address + ":" + str(node.dashboard_agent_listen_port)
+    agent_url = build_address(node.node_ip_address, node.dashboard_agent_listen_port)
 
     # Check that Serve-dependent features fail
     try:
@@ -1315,7 +1316,7 @@ async def test_dashboard_exports_metric_on_event_loop_lag(
 
     # Fetch the metrics from the dashboard.
     addr = ray_context["raylet_ip_address"]
-    prom_addresses = [f"{addr}:{dashboard_consts.DASHBOARD_METRIC_PORT}"]
+    prom_addresses = [build_address(addr, dashboard_consts.DASHBOARD_METRIC_PORT)]
 
     def check_lag_metrics():
         metrics_samples: Dict[str, List[Sample]] = fetch_prometheus_metrics(

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -28,6 +28,7 @@ import ray._private.services as services
 import ray.experimental.internal_kv as internal_kv
 from ray._common.utils import get_or_create_event_loop
 from ray._private.gcs_utils import GcsChannel
+from ray._common.network_utils import parse_address
 from ray._private.utils import (
     get_dashboard_dependency_error,
     split_address,
@@ -345,7 +346,7 @@ def to_posix_time(dt):
 def address_tuple(address):
     if isinstance(address, tuple):
         return address
-    ip, port = address.split(":")
+    ip, port = parse_address(address)
     return ip, int(port)
 
 

--- a/python/ray/data/tests/mock_server.py
+++ b/python/ray/data/tests/mock_server.py
@@ -8,6 +8,8 @@ import time
 import pytest
 import requests
 
+from ray._common.network_utils import build_address
+
 _proxy_bypass = {
     "http": None,
     "https": None,
@@ -25,7 +27,7 @@ def start_service(service_name, host, port):
     process = sp.Popen(
         args, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE
     )  # shell=True
-    url = "http://{host}:{port}".format(host=host, port=port)
+    url = f"http://{build_address(host, port)}"
 
     for i in range(0, 30):
         output = process.poll()
@@ -73,7 +75,7 @@ def stop_process(process):
 def s3_server():
     host = "localhost"
     port = 5002
-    url = "http://{host}:{port}".format(host=host, port=port)
+    url = f"http://{build_address(host, port)}"
     process = start_service("s3", host, port)
     yield url
     stop_process(process)

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -63,8 +63,8 @@ cdef class GcsClientOptions:
             c_cluster_id = CClusterID.FromHex(cluster_id_hex)
         self = GcsClientOptions()
         try:
-            ip, port = gcs_address.split(":", 2)
-            port = int(port)
+            ip, port_str = parse_address(gcs_address)
+            port = int(port_str)
             self.inner.reset(
                 new CGcsClientOptions(
                     ip, port, c_cluster_id, allow_cluster_id_nil, allow_cluster_id_nil))

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -72,7 +72,7 @@ cdef class InnerGcsClient:
         cdef c_pair[c_string, int] pair = self.inner.get().GetGcsServerAddress()
         host = pair.first.decode("utf-8")
         port = pair.second
-        return f"{host}:{port}"
+        return build_address(host, port)
 
     @property
     def cluster_id(self) -> ray.ClusterID:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -35,6 +35,7 @@ from ray._private.utils import (
     get_ray_client_dependency_error,
     parse_resources_json,
 )
+from ray._common.network_utils import parse_address, build_address
 from ray._private.internal_api import memory_summary
 from ray._common.usage import usage_lib
 import ray._common.usage.usage_constants as usage_constant
@@ -196,7 +197,7 @@ def continue_debug_session(live_jobs: Set[str]):
                             key, namespace=ray_constants.KV_NAMESPACE_PDB
                         )
                         return
-                    host, port = session["pdb_address"].split(":")
+                    host, port = parse_address(session["pdb_address"])
                     ray.util.rpdb._connect_pdb_client(host, int(port))
                     ray.experimental.internal_kv._internal_kv_del(
                         key, namespace=ray_constants.KV_NAMESPACE_PDB
@@ -337,7 +338,7 @@ def debug(address: str, verbose: bool):
                     active_sessions[index], namespace=ray_constants.KV_NAMESPACE_PDB
                 )
             )
-            host, port = session["pdb_address"].split(":")
+            host, port = parse_address(session["pdb_address"])
             ray.util.rpdb._connect_pdb_client(host, int(port))
 
 
@@ -920,7 +921,7 @@ def start(
 
         # Fail early when starting a new cluster when one is already running
         if address is None:
-            default_address = f"{ray_params.node_ip_address}:{port}"
+            default_address = build_address(ray_params.node_ip_address, port)
             bootstrap_address = services.find_bootstrap_address(temp_dir)
             if (
                 default_address == bootstrap_address

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -6,6 +6,7 @@ import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import ray
+from ray._common.network_utils import build_address
 from ray._common.utils import run_background_task
 from ray._raylet import GcsClient
 from ray.actor import ActorHandle
@@ -659,7 +660,7 @@ class ServeController:
                 return os.environ[SERVE_ROOT_URL_ENV_KEY]
             else:
                 return (
-                    f"http://{http_config.host}:{http_config.port}"
+                    f"http://{build_address(http_config.host, http_config.port)}"
                     f"{http_config.root_path}"
                 )
         return http_config.root_url

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Set, Tuple, Type
 
 import ray
 from ray import ObjectRef
+from ray._common.network_utils import build_address
 from ray.actor import ActorHandle
 from ray.exceptions import GetTimeoutError, RayActorError
 from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
@@ -159,7 +160,7 @@ class ActorProxyWrapper(ProxyWrapper):
         try:
             proxy = ray.get_actor(name, namespace=SERVE_NAMESPACE)
         except ValueError:
-            addr = f"{http_options.host}:{http_options.port}"
+            addr = build_address(http_options.host, http_options.port)
             logger.info(
                 f"Starting proxy on node '{node_id}' listening on '{addr}'.",
                 extra={"log_to_stderr": False},

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -15,6 +15,7 @@ from starlette.requests import Request
 import ray
 import ray.util.state as state_api
 from ray import serve
+from ray._common.network_utils import build_address
 from ray.actor import ActorHandle
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import (
@@ -763,13 +764,13 @@ def get_application_urls(
             ip = "localhost" if use_localhost else target.ip
             if protocol == RequestProtocol.HTTP:
                 scheme = "ws" if is_websocket else "http"
-                url = f"{scheme}://{ip}:{target.port}{route_prefix}"
+                url = f"{scheme}://{build_address(ip, target.port)}{route_prefix}"
             elif protocol == RequestProtocol.GRPC:
                 if is_websocket:
                     raise ValueError(
                         "is_websocket=True is not supported with gRPC protocol."
                     )
-                url = f"{ip}:{target.port}"
+                url = build_address(ip, target.port)
             else:
                 raise ValueError(f"Unsupported protocol: {protocol}")
             url = url.rstrip("/")

--- a/python/ray/serve/tests/test_api_2.py
+++ b/python/ray/serve/tests/test_api_2.py
@@ -2,6 +2,7 @@ import pytest
 
 import ray
 from ray import serve
+from ray._common.network_utils import build_address
 from ray.serve._private.common import RequestProtocol
 from ray.serve._private.test_utils import get_application_urls
 
@@ -14,13 +15,17 @@ def test_get_application_urls(serve_instance):
     serve.run(f.bind())
     controller_details = ray.get(serve_instance._controller.get_actor_details.remote())
     node_ip = controller_details.node_ip
-    assert get_application_urls(use_localhost=False) == [f"http://{node_ip}:8000"]
-    assert get_application_urls("gRPC", use_localhost=False) == [f"{node_ip}:9000"]
+    assert get_application_urls(use_localhost=False) == [
+        f"http://{build_address(node_ip, 8000)}"
+    ]
+    assert get_application_urls("gRPC", use_localhost=False) == [
+        build_address(node_ip, 9000)
+    ]
     assert get_application_urls(RequestProtocol.HTTP, use_localhost=False) == [
-        f"http://{node_ip}:8000"
+        f"http://{build_address(node_ip, 8000)}"
     ]
     assert get_application_urls(RequestProtocol.GRPC, use_localhost=False) == [
-        f"{node_ip}:9000"
+        build_address(node_ip, 9000)
     ]
 
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -17,6 +17,7 @@ from websockets.sync.client import connect
 import ray
 import ray.util.state as state_api
 from ray import serve
+from ray._common.network_utils import parse_address
 from ray._common.test_utils import SignalActor, wait_for_condition
 from ray._private.test_utils import (
     fetch_prometheus_metrics,
@@ -571,7 +572,7 @@ def test_proxy_disconnect_http_metrics(metrics_start_shutdown):
     # Simulate an HTTP disconnect
     http_url = get_application_url("HTTP", app_name="disconnect")
     ip_port = http_url.replace("http://", "").split("/")[0]  # remove the route prefix
-    ip, port = ip_port.split(":")
+    ip, port = parse_address(ip_port)
     conn = http.client.HTTPConnection(ip, int(port))
     conn.request("GET", "/disconnect")
     wait_for_condition(

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -6,6 +6,7 @@ import pytest
 
 import ray
 from ray import serve
+from ray._common.network_utils import build_address
 from ray._common.test_utils import wait_for_condition
 from ray.actor import ActorHandle
 from ray.serve._private.constants import (
@@ -166,8 +167,12 @@ def test_grpc_proxy_on_draining_nodes(ray_cluster):
     assert len(ray.nodes()) == 2
 
     # Set up gRPC channels.
-    head_node_channel = grpc.insecure_channel(f"localhost:{head_node_grpc_port}")
-    worker_node_channel = grpc.insecure_channel(f"localhost:{worker_node_grpc_port}")
+    head_node_channel = grpc.insecure_channel(
+        build_address("localhost", head_node_grpc_port)
+    )
+    worker_node_channel = grpc.insecure_channel(
+        build_address("localhost", worker_node_grpc_port)
+    )
 
     # Ensures ListApplications method on the head node is succeeding.
     wait_for_condition(

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -24,6 +24,7 @@ import ray
 from ray._common.test_utils import wait_for_condition
 import ray._private.ray_constants as ray_constants
 from ray._private.conftest_utils import set_override_dashboard_url  # noqa: F401
+from ray._common.network_utils import build_address
 from ray._private.runtime_env import virtualenv_utils
 
 from ray._private.test_utils import (
@@ -90,8 +91,8 @@ def wait_for_redis_to_start(
         try:
             # Run some random command and see if it worked.
             logger.debug(
-                "Waiting for redis server at {}:{} to respond...".format(
-                    redis_ip_address, redis_port
+                "Waiting for redis server at {} to respond...".format(
+                    build_address(redis_ip_address, redis_port)
                 )
             )
             redis_client.client_list()
@@ -105,14 +106,14 @@ def wait_for_redis_to_start(
         # redis.AuthenticationError isn't trapped here.
         except redis.AuthenticationError as authEx:
             raise RuntimeError(
-                f"Unable to connect to Redis at {redis_ip_address}:{redis_port}."
+                f"Unable to connect to Redis at {build_address(redis_ip_address, redis_port)}."
             ) from authEx
         except redis.ConnectionError as connEx:
             if i >= num_retries - 1:
                 raise RuntimeError(
-                    f"Unable to connect to Redis at {redis_ip_address}:"
-                    f"{redis_port} after {num_retries} retries. Check that "
-                    f"{redis_ip_address}:{redis_port} is reachable from this "
+                    f"Unable to connect to Redis at {build_address(redis_ip_address, redis_port)} "
+                    f"after {num_retries} retries. Check that "
+                    f"{build_address(redis_ip_address, redis_port)} is reachable from this "
                     "machine. If it is not, your firewall may be blocking "
                     "this port. If the problem is a flaky connection, try "
                     "setting the environment variable "
@@ -830,7 +831,7 @@ def call_ray_start_with_external_redis(request):
     for port in port_list:
         temp_dir = ray._common.utils.get_ray_temp_dir()
         start_redis_instance(temp_dir, int(port), password="123")
-    address_str = ",".join(map(lambda x: "localhost:" + x, port_list))
+    address_str = ",".join(map(lambda x: build_address("localhost", x), port_list))
     cmd = f"ray start --head --address={address_str} --redis-password=123"
     subprocess.call(cmd.split(" "))
 

--- a/python/ray/tests/conftest_docker.py
+++ b/python/ray/tests/conftest_docker.py
@@ -5,6 +5,7 @@ from pytest_docker_tools import wrappers
 import subprocess
 import docker
 from typing import List
+from ray._common.network_utils import build_address
 
 # If you need to debug tests using fixtures in this file,
 # comment in the volume
@@ -126,7 +127,7 @@ def gen_worker_node(envs, num_cpus):
             "ray",
             "start",
             "--address",
-            f"{head_node_container_name}:6379",
+            build_address(head_node_container_name, 6379),
             "--block",
             # Fix the port of raylet to make sure raylet restarts at the same
             # ip:port is treated as a different raylet.

--- a/python/ray/tests/mock_s3_server.py
+++ b/python/ray/tests/mock_s3_server.py
@@ -7,6 +7,8 @@ import signal
 import subprocess as sp
 import time
 
+from ray._common.network_utils import build_address
+
 _proxy_bypass = {
     "http": None,
     "https": None,
@@ -19,7 +21,7 @@ def start_service(service_name, host, port):
     process = sp.Popen(
         args, stdin=sp.PIPE, stdout=sp.DEVNULL, stderr=sp.DEVNULL
     )  # shell=True
-    url = "http://{host}:{port}".format(host=host, port=port)
+    url = f"http://{build_address(host, port)}"
 
     for i in range(0, 30):
         output = process.poll()
@@ -61,7 +63,7 @@ def stop_process(process):
 def dynamodb2_server():
     host = "localhost"
     port = 5001
-    url = "http://{host}:{port}".format(host=host, port=port)
+    url = f"http://{build_address(host, port)}"
     process = start_service("dynamodb2", host, port)
     yield url
     stop_process(process)
@@ -71,7 +73,7 @@ def dynamodb2_server():
 def s3_server():
     host = "localhost"
     port = 5002
-    url = "http://{host}:{port}".format(host=host, port=port)
+    url = f"http://{build_address(host, port)}"
     process = start_service("s3", host, port)
     yield url
     stop_process(process)
@@ -81,7 +83,7 @@ def s3_server():
 def kms_server():
     host = "localhost"
     port = 5003
-    url = "http://{host}:{port}".format(host=host, port=port)
+    url = f"http://{build_address(host, port)}"
     process = start_service("kms", host, port)
 
     yield url

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -15,6 +15,7 @@ from ray._private.test_utils import (
     get_gcs_memory_used,
     run_string_as_driver_nonblocking,
 )
+from ray._common.network_utils import parse_address
 from ray._common.test_utils import Semaphore, wait_for_condition
 from ray.experimental.internal_kv import _internal_kv_list
 from ray.tests.conftest import call_ray_start
@@ -395,7 +396,7 @@ def test_redis_full(ray_start_cluster_head):
 
     gcs_address = ray_start_cluster_head.gcs_address
     redis_addr = os.environ["RAY_REDIS_ADDRESS"]
-    host, port = redis_addr.split(":")
+    host, port = parse_address(redis_addr)
     if os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS", "1") != "1":
         cli = redis.RedisCluster(host, int(port))
     else:

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -5,6 +5,7 @@ import pytest
 
 import ray
 from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
+from ray._common.network_utils import build_address
 from ray._private.test_utils import (
     get_metric_check_condition,
     MetricSamplePattern,
@@ -161,7 +162,7 @@ def test_ray_status_e2e(local_autoscaling_cluster, shutdown_only):
 def test_metrics(local_autoscaling_cluster, shutdown_only):
 
     info = ray.init(address="auto")
-    autoscaler_export_addr = "{}:{}".format(
+    autoscaler_export_addr = build_address(
         info.address_info["node_ip_address"], AUTOSCALER_METRIC_PORT
     )
 

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -48,6 +48,7 @@ import ray._private.ray_constants as ray_constants
 import ray.scripts.scripts as scripts
 import ray._private.utils as utils
 from ray.util.check_open_ports import check_open_ports
+from ray._common.network_utils import build_address, parse_address
 from ray._common.test_utils import wait_for_condition
 from ray.cluster_utils import cluster_not_supported
 from ray.util.state import list_nodes
@@ -1034,7 +1035,7 @@ def start_open_port_check_server():
 
     yield (
         OpenPortCheckServer,
-        f"http://{server.server_address[0]}:{server.server_address[1]}",
+        f"http://{build_address(server.server_address[0], server.server_address[1])}",
     )
 
     server.shutdown()
@@ -1057,7 +1058,7 @@ def test_ray_check_open_ports(shutdown_only, start_open_port_check_server):
     )
     assert result.exit_code == 0
     assert (
-        int(context.address_info["gcs_address"].split(":")[1])
+        int(parse_address(context.address_info["gcs_address"])[1])
         in open_port_check_server.request_ports
     )
     assert "[🟢] No open ports detected" in result.output

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -22,6 +22,7 @@ from ray._private.client_mode_hook import (
     disable_client_hook,
     enable_client_mode,
 )
+from ray._common.network_utils import build_address
 from ray._private.test_utils import run_string_as_driver
 from ray.tests.client_test_utils import (
     create_remote_signal_actor,
@@ -48,7 +49,9 @@ from ray.util.client.ray_client_helpers import (
 
 # Client server port of the shared Ray instance
 SHARED_CLIENT_SERVER_PORT = 25555
-SHARED_CLIENT_SERVER_ADDRESS = f"ray://localhost:{SHARED_CLIENT_SERVER_PORT}"
+SHARED_CLIENT_SERVER_ADDRESS = (
+    f"ray://{build_address('localhost', SHARED_CLIENT_SERVER_PORT)}"
+)
 
 
 @pytest.fixture(scope="module")

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -13,6 +13,7 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
+from ray._common.network_utils import parse_address
 import ray.util.client.server.proxier as proxier
 from ray._private.ray_constants import REDIS_DEFAULT_PASSWORD
 from ray._private.test_utils import run_string_as_driver
@@ -90,7 +91,7 @@ def test_proxy_manager_bad_startup(shutdown_only):
     pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
     client = "client1"
     ctx = ray.init(ignore_reinit_error=True)
-    port_to_conflict = ctx.dashboard_url.split(":")[1]
+    _, port_to_conflict = parse_address(ctx.dashboard_url)
 
     pm.create_specific_server(client)
     # Intentionally bind to the wrong port so that the

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -17,6 +17,7 @@ from ray.autoscaler._private.local.node_provider import (
 from ray.autoscaler._private.local.coordinator_node_provider import (
     CoordinatorSenderNodeProvider,
 )
+from ray._common.network_utils import build_address
 from ray.autoscaler.tags import (
     TAG_RAY_NODE_KIND,
     TAG_RAY_CLUSTER_NAME,
@@ -39,7 +40,7 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
             host=self.host,
             port=self.port,
         )
-        self.coordinator_address = self.host + ":" + str(self.port)
+        self.coordinator_address = build_address(self.host, self.port)
 
     def tearDown(self):
         self.server.shutdown()

--- a/python/ray/tests/test_failure_2.py
+++ b/python/ray/tests/test_failure_2.py
@@ -11,6 +11,7 @@ import ray
 import ray._private.ray_constants as ray_constants
 import ray._private.utils
 from ray._private.ray_constants import DEBUG_AUTOSCALING_ERROR
+from ray._common.network_utils import parse_address
 from ray._private.test_utils import (
     get_error_message,
     get_log_batch,
@@ -361,7 +362,8 @@ def test_list_named_actors_timeout(monkeypatch, shutdown_only):
 
 def test_raylet_node_manager_server_failure(ray_start_cluster_head, log_pubsub):
     cluster = ray_start_cluster_head
-    redis_port = int(cluster.address.split(":")[1])
+    _, redis_port = parse_address(cluster.address)
+    redis_port = int(redis_port)
     # Reuse redis port to make node manager grpc server fail to start.
     with pytest.raises(Exception):
         cluster.add_node(wait=False, node_manager_port=redis_port)

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -21,6 +21,7 @@ from ray._private.test_utils import (
     run_string_as_driver,
     kill_raylet,
 )
+from ray._common.network_utils import build_address
 from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.core.generated import (
     gcs_service_pb2,
@@ -353,10 +354,10 @@ def test_raylet_graceful_shutdown_through_rpc(ray_start_cluster_head, error_pubs
 
     # Kill a raylet gracefully.
     def kill_raylet(ip, port, graceful=True):
-        raylet_address = f"{ip}:{port}"
+        raylet_address = build_address(ip, port)
         channel = grpc.insecure_channel(raylet_address)
         stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
-        print(f"Sending a shutdown request to {ip}:{port}")
+        print(f"Sending a shutdown request to {build_address(ip, port)}")
         try:
             stub.ShutdownRaylet(
                 node_manager_pb2.ShutdownRayletRequest(graceful=graceful)

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -18,6 +18,7 @@ from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 import ray._private.gcs_utils as gcs_utils
 from ray._private import ray_constants
+from ray._common.network_utils import parse_address
 from ray._private.test_utils import (
     convert_actor_state,
     external_redis_test_enabled,
@@ -662,7 +663,7 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
     import redis
 
     redis_addr = os.environ.get("RAY_REDIS_ADDRESS")
-    ip, port = redis_addr.split(":")
+    ip, port = parse_address(redis_addr)
     redis_cli = redis.Redis(ip, port)
 
     def get_connected_nodes():
@@ -678,7 +679,7 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
     leader_cli = None
     follower_cli = []
     for addr in nodes:
-        ip, port = addr.split(":")
+        ip, port = parse_address(addr)
         cli = redis.Redis(ip, port)
         meta = nodes[addr]
         flags = meta["flags"].split(",")
@@ -793,7 +794,7 @@ def test_redis_with_sentinel_failureover(
     import redis
 
     redis_addr = os.environ.get("RAY_REDIS_ADDRESS")
-    ip, port = redis_addr.split(":")
+    ip, port = parse_address(redis_addr)
     redis_cli = redis.Redis(ip, port)
     print(redis_cli.info("sentinel"))
     redis_name = redis_cli.info("sentinel")["master0"]["name"]
@@ -973,7 +974,7 @@ def test_redis_data_loss_no_leak(ray_start_regular_with_external_redis):
     redis_addr = os.environ.get("RAY_REDIS_ADDRESS")
     import redis
 
-    ip, port = redis_addr.split(":")
+    ip, port = parse_address(redis_addr)
     cli = redis.Redis(ip, port)
     cli.flushall()
     raylet_proc = ray._private.worker._global_node.all_processes[

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -17,6 +17,7 @@ from ray._private.test_utils import (
     find_free_port,
     generate_system_config_map,
 )
+from ray._common.network_utils import parse_address
 import ray._private.ray_constants as ray_constants
 
 # Import asyncio timeout depends on python version
@@ -301,7 +302,7 @@ def test_redis_cleanup(redis_replicas, shutdown_only):
     gcs_client.internal_kv_put(b"ABC", b"XYZ", True, None)
     ray.shutdown()
     redis_addr = os.environ["RAY_REDIS_ADDRESS"]
-    host, port = redis_addr.split(":")
+    host, port = parse_address(redis_addr)
     if os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS", "1") != "1":
         cli = redis.RedisCluster(host, int(port))
     else:

--- a/python/ray/tests/test_metric_cardinality.py
+++ b/python/ray/tests/test_metric_cardinality.py
@@ -11,6 +11,7 @@ from ray._private.test_utils import (
     fetch_prometheus_metrics,
     wait_for_assertion,
 )
+from ray._common.network_utils import build_address
 from ray._private.telemetry.metric_cardinality import (
     WORKER_ID_TAG_KEY,
     TASK_OR_ACTOR_NAME_TAG_KEY,
@@ -72,7 +73,9 @@ def _setup_cluster_for_test(request, ray_start_cluster):
     prom_addresses = []
     for node_info in node_info_list:
         prom_addresses.append(
-            f"{node_info['NodeManagerAddress']}:{node_info['MetricsExportPort']}"
+            build_address(
+                node_info["NodeManagerAddress"], node_info["MetricsExportPort"]
+            )
         )
     yield prom_addresses
 

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -12,6 +12,7 @@ from ray._private.test_utils import (
     wait_until_succeeded_without_exception,
     get_node_stats,
 )
+from ray._common.network_utils import build_address
 from ray.core.generated import common_pb2
 
 _WIN32 = os.name == "nt"
@@ -330,7 +331,7 @@ def test_multi_node_metrics_export_port_discovery(ray_start_cluster):
         # Make sure we can ping Prometheus endpoints.
         def test_prometheus_endpoint():
             response = requests.get(
-                "http://localhost:{}".format(metrics_export_port),
+                f"http://{build_address('localhost', metrics_export_port)}",
                 # Fail the request early on if connection timeout
                 timeout=1.0,
             )

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -38,6 +38,7 @@ from ray._private.test_utils import (
     raw_metrics,
     find_free_port,
 )
+from ray._common.network_utils import build_address
 from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
 from ray.dashboard.consts import DASHBOARD_METRIC_PORT
 from ray.util.metrics import Counter, Gauge, Histogram, Metric
@@ -258,11 +259,11 @@ def _setup_cluster_for_test(request, ray_start_cluster):
     for node_info in node_info_list:
         metrics_export_port = node_info["MetricsExportPort"]
         addr = node_info["NodeManagerAddress"]
-        prom_addresses.append(f"{addr}:{metrics_export_port}")
-    autoscaler_export_addr = "{}:{}".format(
+        prom_addresses.append(build_address(addr, metrics_export_port))
+    autoscaler_export_addr = build_address(
         cluster.head_node.node_ip_address, AUTOSCALER_METRIC_PORT
     )
-    dashboard_export_addr = "{}:{}".format(
+    dashboard_export_addr = build_address(
         cluster.head_node.node_ip_address, DASHBOARD_METRIC_PORT
     )
     yield prom_addresses, autoscaler_export_addr, dashboard_export_addr
@@ -420,7 +421,7 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
 def test_metrics_export_node_metrics(shutdown_only):
     # Verify node metrics are available.
     addr = ray.init()
-    dashboard_export_addr = "{}:{}".format(
+    dashboard_export_addr = build_address(
         addr["raylet_ip_address"], DASHBOARD_METRIC_PORT
     )
 
@@ -494,7 +495,7 @@ def test_metrics_export_event_aggregator_agent(
 
     metrics_export_port = cluster.head_node.metrics_export_port
     addr = cluster.head_node.raylet_ip_address
-    prom_addresses = [f"{addr}:{metrics_export_port}"]
+    prom_addresses = [build_address(addr, metrics_export_port)]
 
     def test_case_stats_exist():
         _, metric_descriptors, _ = fetch_prometheus(prom_addresses)
@@ -949,14 +950,14 @@ def test_prometheus_file_based_service_discovery(ray_start_cluster):
 
     def get_metrics_export_address_from_node(nodes):
         node_export_addrs = [
-            "{}:{}".format(node.node_ip_address, node.metrics_export_port)
+            build_address(node.node_ip_address, node.metrics_export_port)
             for node in nodes
         ]
         # monitor should be run on head node for `ray_start_cluster` fixture
-        autoscaler_export_addr = "{}:{}".format(
+        autoscaler_export_addr = build_address(
             cluster.head_node.node_ip_address, AUTOSCALER_METRIC_PORT
         )
-        dashboard_export_addr = "{}:{}".format(
+        dashboard_export_addr = build_address(
             cluster.head_node.node_ip_address, DASHBOARD_METRIC_PORT
         )
         return node_export_addrs + [autoscaler_export_addr, dashboard_export_addr]

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -15,6 +15,7 @@ from ray.util.state import list_actors, list_placement_groups
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.test_utils import fetch_prometheus_metrics
+from ray._common.network_utils import build_address
 import ray.scripts.scripts as scripts
 
 
@@ -516,7 +517,10 @@ def test_remove_placement_group_with_pending_worker_lease_waiting_for_pg_resourc
          is removed successfully.
     """
     context = ray.init(num_cpus=1)
-    prom_address = f"{context.address_info['node_ip_address']}:{context.address_info['metrics_export_port']}"
+    prom_address = build_address(
+        context.address_info["node_ip_address"],
+        context.address_info["metrics_export_port"],
+    )
 
     pg = ray.util.placement_group(
         [{"CPU": 1}],

--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -15,6 +15,7 @@ from ray._private.test_utils import (
     check_spilled_mb,
     fetch_prometheus,
 )
+from ray._common.network_utils import build_address
 
 MB = 1024 * 1024
 
@@ -321,7 +322,7 @@ def test_object_store_memory_metrics_reported_correctly(shutdown_only):
     )
     metrics_export_port = address["metrics_export_port"]
     addr = address["node_ip_address"]
-    prom_addr = f"{addr}:{metrics_export_port}"
+    prom_addr = build_address(addr, metrics_export_port)
 
     x1 = ray.put(np.zeros(400 * MB, dtype=np.uint8))
     # x1 will be spilled.

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -13,6 +13,7 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray._private import ray_constants, services
+from ray._common.network_utils import parse_address
 from ray._private.test_utils import run_string_as_driver
 from ray.cluster_utils import Cluster, cluster_not_supported
 
@@ -56,7 +57,7 @@ def test_ray_debugger_breakpoint(shutdown_only):
             active_sessions[0], namespace=ray_constants.KV_NAMESPACE_PDB
         )
     )
-    host, port = session["pdb_address"].split(":")
+    host, port = parse_address(session["pdb_address"])
     assert host == "localhost"  # Should be private by default.
 
     tn = Telnet(host, int(port))
@@ -283,7 +284,7 @@ def test_ray_debugger_public(shutdown_only, call_ray_stop_only, ray_debugger_ext
         )
     )
 
-    host, port = session["pdb_address"].split(":")
+    host, port = parse_address(session["pdb_address"])
     if ray_debugger_external:
         assert host == services.get_node_ip_address(), host
     else:
@@ -348,13 +349,13 @@ def test_ray_debugger_public_multi_node(shutdown_only, ray_debugger_external):
         )
     )
 
-    host1, port1 = session1["pdb_address"].split(":")
+    host1, port1 = parse_address(session1["pdb_address"])
     if ray_debugger_external:
         assert host1 == services.get_node_ip_address(), host1
     else:
         assert host1 == "localhost", host1
 
-    host2, port2 = session2["pdb_address"].split(":")
+    host2, port2 = parse_address(session2["pdb_address"])
     if ray_debugger_external:
         assert host2 == services.get_node_ip_address(), host2
     else:

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -13,6 +13,7 @@ from ray._common.test_utils import wait_for_condition
 from ray._private.ray_constants import RAY_OVERRIDE_DASHBOARD_URL, DEFAULT_RESOURCES
 import ray._private.services
 from ray._private.services import get_node_ip_address
+from ray._common.network_utils import parse_address
 from ray.dashboard.utils import ray_address_to_api_server_url
 from ray._private.test_utils import (
     get_current_unused_port,
@@ -301,7 +302,7 @@ def test_ray_init_from_workers(ray_start_cluster):
     node2 = cluster.add_node(node_ip_address="127.0.0.3")
     address = cluster.address
     password = cluster.redis_password
-    assert address.split(":")[0] == "127.0.0.2"
+    assert parse_address(address)[0] == "127.0.0.2"
     assert node1.node_manager_port != node2.node_manager_port
     info = ray.init(address, _redis_password=password, _node_ip_address="127.0.0.3")
     assert info["node_ip_address"] == "127.0.0.3"

--- a/python/ray/tests/test_resource_metrics.py
+++ b/python/ray/tests/test_resource_metrics.py
@@ -10,6 +10,7 @@ from ray._private.test_utils import (
     fetch_prometheus_metrics,
     run_string_as_driver_nonblocking,
 )
+from ray._common.network_utils import build_address
 
 
 METRIC_CONFIG = {
@@ -20,7 +21,7 @@ METRIC_CONFIG = {
 
 
 def raw_metrics(info):
-    metrics_page = "localhost:{}".format(info["metrics_export_port"])
+    metrics_page = build_address("localhost", info["metrics_export_port"])
     print("Fetch metrics from", metrics_page)
     res = fetch_prometheus_metrics([metrics_page])
     return res

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -27,6 +27,7 @@ import ray.dashboard.consts as dashboard_consts
 import ray._private.state as global_state
 import ray._private.ray_constants as ray_constants
 from ray._raylet import GcsClient, ActorID, JobID, TaskID
+from ray._common.network_utils import parse_address
 from ray._private.test_utils import (
     run_string_as_driver,
     find_free_port,
@@ -371,7 +372,7 @@ def test_ray_address_to_api_server_url(shutdown_only):
     # explicit head node gcs address
     assert api_server_url == ray_address_to_api_server_url(gcs_address)
     # localhost string
-    gcs_port = gcs_address.split(":")[1]
+    _, gcs_port = parse_address(gcs_address)
     assert api_server_url == ray_address_to_api_server_url(f"localhost:{gcs_port}")
 
 

--- a/python/ray/train/lightgbm/config.py
+++ b/python/ray/train/lightgbm/config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import ray
+from ray._common.network_utils import build_address
 from ray.train._internal.utils import get_address_and_port
 from ray.train._internal.worker_group import WorkerGroup
 from ray.train.backend import Backend, BackendConfig
@@ -76,7 +77,7 @@ class _LightGBMBackend(Backend):
         node_ips_and_ports = worker_group.execute(get_address_and_port)
         ports = [port for _, port in node_ips_and_ports]
         machines = ",".join(
-            [f"{node_ip}:{port}" for node_ip, port in node_ips_and_ports]
+            [build_address(node_ip, port) for node_ip, port in node_ips_and_ports]
         )
         num_machines = len(worker_group)
         ray.get(

--- a/python/ray/train/tensorflow/config.py
+++ b/python/ray/train/tensorflow/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import List
 
 import ray
+from ray._common.network_utils import build_address
 from ray.train._internal.utils import get_address_and_port
 from ray.train._internal.worker_group import WorkerGroup
 from ray.train.backend import Backend, BackendConfig
@@ -42,7 +43,7 @@ class _TensorflowBackend(Backend):
         # Compute URL for initializing distributed setup.
         def get_url():
             address, port = get_address_and_port()
-            return f"{address}:{port}"
+            return build_address(address, port)
 
         urls = worker_group.execute(get_url)
 

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -9,6 +9,7 @@ import torch.distributed as dist
 from packaging.version import Version
 
 import ray
+from ray._common.network_utils import build_address
 from ray.air._internal.device_manager import register_custom_torch_dist_backend
 from ray.train._internal.utils import get_address_and_port
 from ray.train._internal.worker_group import WorkerGroup
@@ -176,7 +177,7 @@ class _TorchBackend(Backend):
                 worker_group.execute(set_env_vars, addr=master_addr, port=master_port)
                 url = "env://"
             elif backend_config.init_method == "tcp":
-                url = f"tcp://{master_addr}:{master_port}"
+                url = f"tcp://{build_address(master_addr, master_port)}"
             else:
                 raise ValueError(
                     f"The provided init_method ("

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -28,6 +28,7 @@ from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.services import ProcessInfo, start_ray_client_server
 from ray._private.tls_utils import add_port_to_grpc_server
 from ray._private.utils import detect_fate_sharing_support
+from ray._common.network_utils import build_address
 from ray.cloudpickle.compat import pickle
 from ray.job_config import JobConfig
 from ray.util.client.common import (
@@ -201,7 +202,7 @@ class ProxyManager:
                 port=port,
                 process_handle_future=futures.Future(),
                 channel=ray._private.utils.init_grpc_channel(
-                    f"127.0.0.1:{port}", options=GRPC_OPTIONS
+                    build_address("127.0.0.1", port), options=GRPC_OPTIONS
                 ),
             )
             self.servers[client_id] = server

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -27,6 +27,7 @@ from ray._private.ray_constants import env_integer
 from ray._private.ray_logging import setup_logger
 from ray._private.services import canonicalize_bootstrap_address_or_die
 from ray._private.tls_utils import add_port_to_grpc_server
+from ray._common.network_utils import build_address
 from ray.job_config import JobConfig
 from ray.util.client.common import (
     CLIENT_SERVER_MAX_THREADS,
@@ -893,7 +894,7 @@ def main():
         args.address, args.redis_password, args.redis_username
     )
 
-    hostport = "%s:%d" % (args.host, args.port)
+    hostport = build_address(args.host, args.port)
     args_str = str(args)
     if args.redis_password:
         args_str = args_str.replace(args.redis_password, "****")

--- a/python/ray/util/collective/collective_group/gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/gloo_collective_group.py
@@ -12,6 +12,7 @@ from ray._private import ray_constants
 from ray.util.collective.collective_group import gloo_util
 from ray.util.collective.collective_group.base_collective_group import BaseGroup
 from ray.util.collective.const import get_store_name
+from ray._common.network_utils import parse_address
 from ray.util.collective.types import (
     AllGatherOptions,
     AllReduceOptions,
@@ -45,7 +46,7 @@ class Rendezvous:
         self._context = context
         redis_address = ray._private.worker._global_node.redis_address
         (self._redis_ip_address, self._redis_port) = (
-            redis_address.split(":") if store_type == "redis" else (None, None)
+            parse_address(redis_address) if store_type == "redis" else (None, None)
         )
         self._process_ip_address = ray.util.get_node_ip_address()
         logger.debug(

--- a/python/ray/util/collective/collective_group/torch_gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/torch_gloo_collective_group.py
@@ -5,6 +5,7 @@ import torch.distributed as dist
 
 import ray.experimental.internal_kv as internal_kv
 from ray.util.collective.collective_group.base_collective_group import BaseGroup
+from ray._common.network_utils import parse_address
 from ray.util.collective.types import (
     AllReduceOptions,
     BarrierOptions,
@@ -52,7 +53,7 @@ class TorchGLOOGroup(BaseGroup):
             )
 
         metadata = metadata.decode()
-        master_addr, master_port = metadata.split(":")
+        master_addr, master_port = parse_address(metadata)
         os.environ["MASTER_ADDR"] = master_addr
         os.environ["MASTER_PORT"] = master_port
 

--- a/python/ray/util/debugpy.py
+++ b/python/ray/util/debugpy.py
@@ -5,6 +5,7 @@ import threading
 import importlib
 
 import ray
+from ray._common.network_utils import build_address
 from ray.util.annotations import DeveloperAPI
 
 log = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ def _ensure_debugger_port_open_thread_safe():
                 (ray._private.worker.global_worker.node_ip_address, 0)
             )
             ray._private.worker.global_worker.set_debugger_port(port)
-            log.info(f"Ray debugger is listening on {host}:{port}")
+            log.info(f"Ray debugger is listening on {build_address(host, port)}")
         else:
             log.info(f"Ray debugger is already open on {debugger_port}")
 

--- a/python/ray/util/rpdb.py
+++ b/python/ray/util/rpdb.py
@@ -3,6 +3,7 @@
 # (BSD 2-Clause "Simplified" License)
 
 import errno
+from ray._common.network_utils import build_address
 import inspect
 import json
 import logging
@@ -110,9 +111,9 @@ class _RemotePdb(Pdb):
     def listen(self):
         if not self._quiet:
             _cry(
-                "RemotePdb session open at %s:%s, "
+                "RemotePdb session open at %s, "
                 "use 'ray debug' to connect..."
-                % (self._ip_address, self._listen_socket.getsockname()[1])
+                % build_address(self._ip_address, self._listen_socket.getsockname()[1])
             )
         self._listen_socket.listen(1)
         connection, address = self._listen_socket.accept()

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -20,6 +20,7 @@ import ray._private.services
 from ray.autoscaler._private.spark.node_provider import HEAD_NODE_ID
 from ray.util.annotations import DeveloperAPI, PublicAPI
 from ray._common.utils import load_class
+from ray._common.network_utils import build_address, parse_address
 
 from .utils import (
     exec_cmd,
@@ -130,7 +131,7 @@ class RayClusterOnSpark:
             ray.init(address=self.address)
 
             if self.ray_dashboard_port is not None and _wait_service_up(
-                self.address.split(":")[0],
+                parse_address(self.address)[0],
                 self.ray_dashboard_port,
                 _RAY_DASHBOARD_STARTUP_TIMEOUT,
             ):
@@ -189,7 +190,7 @@ class RayClusterOnSpark:
                             ) = self.spark_job_server.server_address[:2]
                             response = requests.post(
                                 url=(
-                                    f"http://{job_server_host}:{job_server_port}"
+                                    f"http://{build_address(job_server_host, job_server_port)}"
                                     "/query_last_worker_err"
                                 ),
                                 json={"spark_job_group_id": None},
@@ -691,7 +692,7 @@ def _setup_ray_cluster(
 
     _logger.info("Ray head node started.")
 
-    cluster_address = f"{ray_head_ip}:{ray_head_port}"
+    cluster_address = build_address(ray_head_ip, ray_head_port)
     # Set RAY_ADDRESS environment variable to the cluster address.
     os.environ["RAY_ADDRESS"] = cluster_address
 
@@ -1206,8 +1207,10 @@ def _setup_ray_cluster_internal(
                 pass
             raise RuntimeError("Launch Ray-on-Spark cluster failed") from e
 
-    head_ip = cluster.address.split(":")[0]
-    remote_connection_address = f"ray://{head_ip}:{cluster.ray_client_server_port}"
+    head_ip = parse_address(cluster.address)[0]
+    remote_connection_address = (
+        f"ray://{build_address(head_ip, cluster.ray_client_server_port)}"
+    )
     return cluster.address, remote_connection_address
 
 
@@ -1527,7 +1530,7 @@ def _start_ray_worker_nodes(
             "ray.util.spark.start_ray_node",
             f"--num-cpus={num_cpus_per_node}",
             "--block",
-            f"--address={ray_head_ip}:{ray_head_port}",
+            f"--address={build_address(ray_head_ip, ray_head_port)}",
             f"--memory={heap_memory_per_node}",
             f"--object-store-memory={object_store_memory_per_node}",
             f"--min-worker-port={worker_port_range_begin}",
@@ -1576,7 +1579,7 @@ def _start_ray_worker_nodes(
             # Check node id availability
             response = requests.post(
                 url=(
-                    f"http://{ray_head_ip}:{spark_job_server_port}"
+                    f"http://{build_address(ray_head_ip, spark_job_server_port)}"
                     "/check_node_id_availability"
                 ),
                 json={
@@ -1603,7 +1606,7 @@ def _start_ray_worker_nodes(
             # Notify job server the task has been launched.
             requests.post(
                 url=(
-                    f"http://{ray_head_ip}:{spark_job_server_port}"
+                    f"http://{build_address(ray_head_ip, spark_job_server_port)}"
                     "/notify_task_launched"
                 ),
                 json={

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -9,6 +9,7 @@ import yaml
 
 import ray._private.services as services
 from ray._private.thirdparty.tabulate.tabulate import tabulate
+from ray._common.network_utils import parse_address
 from ray.util.state import (
     StateApiClient,
     get_log,
@@ -807,7 +808,7 @@ def _get_head_node_ip(address: Optional[str] = None):
     """
     try:
         address = services.canonicalize_bootstrap_address_or_die(address)
-        return address.split(":")[0]
+        return parse_address(address)[0]
     except (ConnectionError, ValueError) as e:
         # Hide all the stack trace
         raise click.UsageError(str(e))

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -54,6 +54,7 @@ from ray.util.state.common import (
     SupportedFilterType,
 )
 from ray.util.state.exception import DataSourceUnavailable
+from ray._common.network_utils import build_address
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +147,7 @@ class StateDataSourceClient:
     def get_raylet_stub(self, ip: str, port: int):
         options = _STATE_MANAGER_GRPC_OPTIONS
         channel = ray._private.utils.init_grpc_channel(
-            f"{ip}:{port}", options, asynchronous=True
+            build_address(ip, port), options, asynchronous=True
         )
         return NodeManagerServiceStub(channel)
 
@@ -162,7 +163,7 @@ class StateDataSourceClient:
         ip, http_port, grpc_port = json.loads(agent_addr)
         options = ray_constants.GLOBAL_GRPC_OPTIONS
         channel = ray._private.utils.init_grpc_channel(
-            f"{ip}:{grpc_port}", options=options, asynchronous=True
+            build_address(ip, grpc_port), options=options, asynchronous=True
         )
         return LogServiceStub(channel)
 
@@ -429,7 +430,7 @@ class StateDataSourceClient:
                 f"Expected non empty node ip and runtime env agent port, got {node_ip} and {runtime_env_agent_port}."
             )
         timeout = aiohttp.ClientTimeout(total=timeout)
-        url = f"http://{node_ip}:{runtime_env_agent_port}/get_runtime_envs_info"
+        url = f"http://{build_address(node_ip, runtime_env_agent_port)}/get_runtime_envs_info"
         request = GetRuntimeEnvsInfoRequest(limit=limit)
         data = request.SerializeToString()
         async with self._client_session.post(url, data=data, timeout=timeout) as resp:

--- a/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
@@ -8,6 +8,8 @@ import numpy as np
 import tensorflow as tf
 from typing import List, Tuple
 
+from ray._common.network_utils import build_address
+
 CONFIG = {"lr": 1e-3, "batch_size": 64}
 VANILLA_RESULT_JSON = "/tmp/vanilla_out.json"
 
@@ -185,7 +187,7 @@ def train_tf_vanilla(
     run_fn_on_actors(actors=actors, fn=lambda: os.environ.pop("OMP_NUM_THREADS", None))
 
     ips_ports = get_ip_port_actors(actors=actors)
-    ip_port_list = [f"{ip}:{port}" for ip, port in ips_ports]
+    ip_port_list = [build_address(ip, port) for ip, port in ips_ports]
     ip_port_str = ",".join(ip_port_list)
 
     cmds = [

--- a/release/benchmarks/distributed/many_nodes_tests/dashboard_test.py
+++ b/release/benchmarks/distributed/many_nodes_tests/dashboard_test.py
@@ -11,6 +11,7 @@ import logging
 from collections import defaultdict
 from ray.util.state import list_nodes
 from ray._private.test_utils import fetch_prometheus_metrics
+from ray._common.network_utils import build_address
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from pydantic import BaseModel
 from ray.dashboard.consts import DASHBOARD_METRIC_PORT
@@ -124,7 +125,7 @@ class DashboardTestAtScale:
             return Result(success=False)
 
         # Get the memory usage.
-        dashboard_export_addr = "{}:{}".format(
+        dashboard_export_addr = build_address(
             self.addr["raylet_ip_address"], DASHBOARD_METRIC_PORT
         )
         metrics = fetch_prometheus_metrics([dashboard_export_addr])

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -5,6 +5,7 @@ import ray
 import requests
 from ray._private.test_utils import monitor_memory_usage
 from ray.cluster_utils import Cluster
+from ray._common.network_utils import build_address
 
 from ray import serve
 from ray.serve.config import DeploymentMode
@@ -79,7 +80,8 @@ def warm_up_one_cluster(
     for _ in range(num_warmup_iterations):
         try:
             resp = requests.get(
-                f"http://{http_host}:{http_port}/{endpoint}", timeout=timeout
+                f"http://{build_address(http_host, http_port)}/{endpoint}",
+                timeout=timeout,
             ).text
             logger.info(resp)
         except requests.exceptions.ReadTimeout:

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -13,6 +13,7 @@ from ray.serve.schema import ProxyStatus
 from serve_test_cluster_utils import NUM_CPU_PER_NODE
 from subprocess import PIPE
 from typing import Dict, List, Optional, Union
+from ray._common.network_utils import build_address
 
 logger = logging.getLogger(__file__)
 
@@ -220,7 +221,7 @@ def run_one_wrk_trial(
             "-d",
             trial_length,
             "--latency",
-            f"http://{http_host}:{http_port}/{endpoint}",
+            f"http://{build_address(http_host, http_port)}/{endpoint}",
         ],
         stdout=PIPE,
         stderr=PIPE,

--- a/rllib/env/policy_server_input.py
+++ b/rllib/env/policy_server_input.py
@@ -20,6 +20,7 @@ from ray.rllib.utils.annotations import override, PublicAPI
 from ray.rllib.evaluation.metrics import RolloutMetrics
 from ray.rllib.evaluation.sampler import SamplerInput
 from ray.rllib.utils.typing import SampleBatchType
+from ray._common.network_utils import build_address
 
 logger = logging.getLogger(__name__)
 
@@ -175,14 +176,15 @@ class PolicyServerInput(ThreadingMixIn, HTTPServer, InputReader):
             time.sleep(1)
             HTTPServer.__init__(self, (address, port), handler)
         except OSError:
-            print(f"Creating a PolicyServer on {address}:{port} failed!")
+            print(f"Creating a PolicyServer on {build_address(address, port)} failed!")
             import time
 
             time.sleep(1)
             raise
 
         logger.info(
-            "Starting connector server at " f"{self.server_name}:{self.server_port}"
+            "Starting connector server at "
+            f"{build_address(self.server_name, self.server_port)}"
         )
 
         # Start the serving thread, listening on socket and handling commands.

--- a/rllib/examples/envs/external_envs/cartpole_client.py
+++ b/rllib/examples/envs/external_envs/cartpole_client.py
@@ -44,6 +44,7 @@ import argparse
 import gymnasium as gym
 
 from ray.rllib.env.policy_client import PolicyClient
+from ray._common.network_utils import build_address
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -84,7 +85,8 @@ if __name__ == "__main__":
     # Note that no config is needed in this script as it will be defined
     # on and sent from the server.
     client = PolicyClient(
-        f"http://localhost:{args.port}", inference_mode=args.inference_mode
+        f"http://{build_address('localhost', args.port)}",
+        inference_mode=args.inference_mode,
     )
 
     # In the following, we will use our external environment (the CartPole

--- a/rllib/examples/envs/external_envs/dummy_client_with_two_episodes.py
+++ b/rllib/examples/envs/external_envs/dummy_client_with_two_episodes.py
@@ -18,6 +18,7 @@ import gymnasium as gym
 import ray
 
 from ray.rllib.env.policy_client import PolicyClient
+from ray._common.network_utils import build_address
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -47,7 +48,8 @@ if __name__ == "__main__":
     # of local inference) will contain only a RandomEnv dummy env to step through.
     # The actual env we care about is the above generated CartPole one.
     client = PolicyClient(
-        f"http://localhost:{args.port}", inference_mode=args.inference_mode
+        f"http://{build_address('localhost', args.port)}",
+        inference_mode=args.inference_mode,
     )
 
     # Get a dummy obs

--- a/rllib/examples/envs/external_envs/unity3d_client.py
+++ b/rllib/examples/envs/external_envs/unity3d_client.py
@@ -34,6 +34,7 @@ import argparse
 
 from ray.rllib.env.policy_client import PolicyClient
 from ray.rllib.env.wrappers.unity3d_env import Unity3DEnv
+from ray._common.network_utils import build_address
 
 SERVER_ADDRESS = "localhost"
 SERVER_PORT = 9900
@@ -96,7 +97,7 @@ if __name__ == "__main__":
     # Start the client for sending environment information (e.g. observations,
     # actions) to a policy server (listening on port 9900).
     client = PolicyClient(
-        "http://" + args.server + ":" + str(args.port),
+        f"http://{build_address(args.server, args.port)}",
         inference_mode=args.inference_mode,
         update_interval=args.update_interval_local_mode,
     )

--- a/rllib/examples/envs/external_envs/unity3d_dummy_client.py
+++ b/rllib/examples/envs/external_envs/unity3d_dummy_client.py
@@ -21,6 +21,7 @@ import argparse
 from ray.rllib.env.policy_client import PolicyClient
 from ray.rllib.env.wrappers.unity3d_env import Unity3DEnv
 from ray.rllib.examples.envs.classes.random_env import RandomMultiAgentEnv
+from ray._common.network_utils import build_address
 
 SERVER_ADDRESS = "localhost"
 SERVER_PORT = 9900
@@ -95,7 +96,7 @@ if __name__ == "__main__":
     # Start the client for sending environment information (e.g. observations,
     # actions) to a policy server (listening on port 9900).
     client = PolicyClient(
-        "http://" + args.server + ":" + str(args.port),
+        f"http://{build_address(args.server, args.port)}",
         inference_mode=args.inference_mode,
         update_interval=args.update_interval_local_mode,
     )

--- a/rllib/examples/ray_serve/ray_serve_with_rllib.py
+++ b/rllib/examples/ray_serve/ray_serve_with_rllib.py
@@ -90,6 +90,7 @@ from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
     run_rllib_example_script_experiment,
 )
+from ray._common.network_utils import build_address
 
 parser = add_rllib_example_script_args()
 parser.set_defaults(
@@ -166,7 +167,7 @@ if __name__ == "__main__":
             # print(f"-> Requesting action for obs={obs} ...", end="")
             # Send a request to serve.
             resp = requests.get(
-                f"http://localhost:{args.port}/rllib-rlmodule",
+                f"http://{build_address('localhost', args.port)}/rllib-rlmodule",
                 json={"observation": obs.tolist()},
             )
             response = resp.json()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Provide utilities that supports both ipv4 and ipv6 to combine host and port to address and split address to host and port.

This is a continuation of the work in [#54662 (comment)](https://github.com/ray-project/ray/pull/54662#issuecomment-3130750868) and https://github.com/ray-project/ray/pull/55129. Please refer to the discussion for more context.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
