### PR TITLE
[core] fix test_aggregator_agent_profile_events_not_exposed test case

### DIFF
--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -361,8 +361,7 @@ def test_aggregator_agent_profile_events_not_exposed(
     )
 
     reply = stub.AddEvents(request)
-    assert reply.status.code == 0
-    assert reply.status.message == "all events received"
+    assert reply is not None
 
     # Wait for exactly one event to be received (the TASK_DEFINITION_EVENT)
     wait_for_condition(lambda: len(httpserver.log) == 1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The status field is no longer included in AddEventsReply. https://github.com/ray-project/ray/pull/55186 updated all existing tests to reflect this change. However, `test_aggregator_agent_profile_events_not_exposed` cases was missed because it was added in a more recent [commit](https://github.com/ray-project/ray/pull/55089) that wasn’t present in the base of that PR.

This PR updates the missed test case to align with the latest AddEventsReply behavior.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
NA
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
