### PR TITLE
[core] fix the mixed-type arithmetic on max_restarts, num_restarts, and preemptions

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1447,9 +1447,8 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
     remaining_restarts = -1;
   } else {
     // Restarts due to node preemption do not count towards max_restarts.
-    int64_t remaining =
-        max_restarts -
-        static_cast<int64_t>(num_restarts - num_restarts_due_to_node_preemption);
+    const auto effective_restarts = num_restarts - num_restarts_due_to_node_preemption;
+    int64_t remaining = max_restarts - static_cast<int64_t>(effective_restarts);
     remaining_restarts = std::max(remaining, static_cast<int64_t>(0));
   }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1447,7 +1447,9 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
     remaining_restarts = -1;
   } else {
     // Restarts due to node preemption do not count towards max_restarts.
-    int64_t remaining = max_restarts - num_restarts + num_restarts_due_to_node_preemption;
+    int64_t remaining =
+        max_restarts -
+        static_cast<int64_t>(num_restarts - num_restarts_due_to_node_preemption);
     remaining_restarts = std::max(remaining, static_cast<int64_t>(0));
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR replaces the implicit mixed-type arithmetic:
```cpp
int64_t remaining = max_restarts - num_restarts + num_restarts_due_to_node_preemption;
```
where `max_restarts` is int32 but `num_restarts` and `num_restarts_due_to_node_preemption` are uint64 in protobuf (thus `max_restarts` will be converted to uint64 for arithmetic automatically),

to explicit
```cpp
int64_t remaining = max_restarts - static_cast<int64_t>(num_restarts - num_restarts_due_to_node_preemption);
```
to avoid an unexpected wrap-around when converting the whole result back to `int64_t remaining`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
