### PR TITLE
[SERVE] E2E fix: test_cli.py 

### DIFF
--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -173,7 +173,6 @@ py_test_module_list(
     size = "large",
     data = glob(["test_config_files/**/*"]),
     files = [
-        "test_cli.py",
         "test_cli_2.py",
         "test_cli_3.py",
     ],

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -149,6 +149,26 @@ py_test_module_list(
     ],
 )
 
+# CLI tests need extra time for deployments - test_cli.py gets longer timeout
+py_test_module_list(
+    size = "large",
+    size = "enormous",
+    timeout = "eternal",
+    data = glob(["test_config_files/**/*"]),
+    files = [
+        "test_cli.py",
+    ],
+    tags = [
+        "exclusive",
+        "team:serve",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
 # Large tests requiring `test_config_files/`.
 py_test_module_list(
     size = "large",

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -151,7 +151,6 @@ py_test_module_list(
 
 # CLI tests need extra time for deployments - test_cli.py gets longer timeout
 py_test_module_list(
-    size = "large",
     size = "enormous",
     timeout = "eternal",
     data = glob(["test_config_files/**/*"]),

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -156,14 +156,7 @@ def _shared_serve_instance():
 def serve_instance(_shared_serve_instance):
     yield _shared_serve_instance
     # Clear all state for 2.x applications and deployments.
-    try:
-        _shared_serve_instance.delete_all_apps()
-    except (TimeoutError, SystemExit) as e:
-        if isinstance(e, SystemExit) and e.code == 15:
-            print("Suppressed SystemExit(15) during teardown.")
-        # Some apps might block deletion (like delete_blocked.app),
-        # so we don't fail the test if deletion times out
-        pass
+    _shared_serve_instance.delete_all_apps()
     # Clear the ServeHandle cache between tests to avoid them piling up.
     _shared_serve_instance.shutdown_cached_handles(_skip_asyncio_check=True)
 

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -156,7 +156,14 @@ def _shared_serve_instance():
 def serve_instance(_shared_serve_instance):
     yield _shared_serve_instance
     # Clear all state for 2.x applications and deployments.
-    _shared_serve_instance.delete_all_apps()
+    try:
+        _shared_serve_instance.delete_all_apps()
+    except (TimeoutError, SystemExit) as e:
+        if isinstance(e, SystemExit) and e.code == 15:
+            print("Suppressed SystemExit(15) during teardown.")
+        # Some apps might block deletion (like delete_blocked.app),
+        # so we don't fail the test if deletion times out
+        pass
     # Clear the ServeHandle cache between tests to avoid them piling up.
     _shared_serve_instance.shutdown_cached_handles(_skip_asyncio_check=True)
 

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -536,6 +536,7 @@ def test_status_invalid_runtime_env(serve_instance):
         cli_output = subprocess.check_output(
             ["serve", "status", "-a", "http://localhost:8265/"]
         )
+        cli_output = remove_ansi_escape_sequences(cli_output.decode())
         cli_status = yaml.safe_load(cli_output)["applications"][SERVE_DEFAULT_APP_NAME]
         assert cli_status["status"] == "DEPLOY_FAILED"
         assert "Failed to set up runtime environment" in cli_status["message"]

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -748,6 +748,7 @@ def test_status_multi_app(serve_instance):
         status = yaml.safe_load(remove_ansi_escape_sequences(status_response.decode()))[
             "applications"
         ]
+
         return len(status["app1"]["deployments"]) and len(status["app2"]["deployments"])
 
     wait_for_condition(lambda: num_live_deployments() == 3, timeout=15)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

test_cli.py fails when ansi escape sequence characters are printed causing e2e tests to error out. This PR removes these characters. Also, the test takes approximately 900+ seconds to finish, so updated the target to have more timeout.

`\x1b[...` sequences are ANSI escape codes that aren't visible when displayed in a terminal (they just change colors), but they're present in the raw string data, which breaks string comparisons in tests. So `remove_ansi_escape_sequences` is essential for testing error messages reliably without having to account for terminal color formatting codes.

These color codes are added by bash/zsh/any terminal that has syntax highlighting enabled. Removing ansi color codes help pass the test, which otherwise fail as the `stderr` has to be read to pass the tests. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
