### PR TITLE
[Core] Bind runtime env agent and dashboard agent server to specified ip instead of 0.0.0.0

### DIFF
--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -218,9 +218,7 @@ if __name__ == "__main__":
         check_raylet_task = create_check_raylet_task(
             args.log_dir, gcs_client, parent_dead_callback, loop
         )
-    runtime_env_agent_ip = (
-        "127.0.0.1" if args.node_ip_address == "127.0.0.1" else "0.0.0.0"
-    )
+    runtime_env_agent_ip = args.node_ip_address
     try:
         web.run_app(
             app,

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -218,11 +218,10 @@ if __name__ == "__main__":
         check_raylet_task = create_check_raylet_task(
             args.log_dir, gcs_client, parent_dead_callback, loop
         )
-    runtime_env_agent_ip = args.node_ip_address
     try:
         web.run_app(
             app,
-            host=runtime_env_agent_ip,
+            host=args.node_ip_address,
             port=args.runtime_env_agent_port,
             loop=loop,
         )

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -113,6 +113,10 @@ class DashboardAgent:
             self.grpc_port = add_port_to_grpc_server(
                 self.server, f"{grpc_ip}:{self.dashboard_agent_port}"
             )
+            if grpc_ip != "127.0.0.1" and grpc_ip != "localhost":
+                self.grpc_port = add_port_to_grpc_server(
+                    self.server, f"127.0.0.1:{self.dashboard_agent_port}"
+                )
         except Exception:
             # TODO(SongGuyang): Catch the exception here because there is
             # port conflict issue which brought from static port. We should

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -108,7 +108,7 @@ class DashboardAgent:
                 ),
             )  # noqa
         )
-        grpc_ip = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
+        grpc_ip = self.ip
         try:
             self.grpc_port = add_port_to_grpc_server(
                 self.server, f"{grpc_ip}:{self.dashboard_agent_port}"

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -108,12 +108,11 @@ class DashboardAgent:
                 ),
             )  # noqa
         )
-        grpc_ip = self.ip
         try:
             self.grpc_port = add_port_to_grpc_server(
-                self.server, f"{grpc_ip}:{self.dashboard_agent_port}"
+                self.server, f"{self.ip}:{self.dashboard_agent_port}"
             )
-            if grpc_ip != "127.0.0.1" and grpc_ip != "localhost":
+            if self.ip != "127.0.0.1" and self.ip != "localhost":
                 self.grpc_port = add_port_to_grpc_server(
                     self.server, f"127.0.0.1:{self.dashboard_agent_port}"
                 )
@@ -128,7 +127,7 @@ class DashboardAgent:
             self.server = None
             self.grpc_port = None
         else:
-            logger.info("Dashboard agent grpc address: %s:%s", grpc_ip, self.grpc_port)
+            logger.info("Dashboard agent grpc address: %s:%s", self.ip, self.grpc_port)
 
         # If the agent is not minimal it should start the http server
         # to communicate with the dashboard in a head node.

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -43,7 +43,7 @@ class HttpServerAgent:
             try:
                 site = aiohttp.web.TCPSite(
                     self.runner,
-                    "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0",
+                    self.ip,
                     self.listen_port,
                 )
                 await site.start()

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -43,10 +43,17 @@ class HttpServerAgent:
             try:
                 site = aiohttp.web.TCPSite(
                     self.runner,
-                    "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0",
+                    self.ip,
                     self.listen_port,
                 )
                 await site.start()
+                if self.ip != "127.0.0.1" and self.ip != "localhost":
+                    local_site = aiohttp.web.TCPSite(
+                        self.runner,
+                        "127.0.0.1",
+                        self.listen_port,
+                    )
+                    await local_site.start()
                 if attempt > 0:
                     logger.info(
                         f"Successfully started agent on port {self.listen_port} "
@@ -113,7 +120,9 @@ class HttpServerAgent:
 
         self.http_host, self.http_port, *_ = site._server.sockets[0].getsockname()
         logger.info(
-            "Dashboard agent http address: %s:%s", self.http_host, self.http_port
+            "Dashboard agent http address: %s:%s",
+            self.http_host,
+            self.http_port,
         )
 
         # Dump registered http routes.

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -43,7 +43,7 @@ class HttpServerAgent:
             try:
                 site = aiohttp.web.TCPSite(
                     self.runner,
-                    self.ip,
+                    "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0",
                     self.listen_port,
                 )
                 await site.start()

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -120,9 +120,7 @@ class HttpServerAgent:
 
         self.http_host, self.http_port, *_ = site._server.sockets[0].getsockname()
         logger.info(
-            "Dashboard agent http address: %s:%s",
-            self.http_host,
-            self.http_port,
+            "Dashboard agent http address: %s:%s", self.http_host, self.http_port
         )
 
         # Dump registered http routes.

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -442,7 +442,7 @@ class ReporterAgent(
                     prometheus_exporter.Options(
                         namespace="ray",
                         port=dashboard_agent.metrics_export_port,
-                        address=self._ip,
+                        address="127.0.0.1" if self._ip == "127.0.0.1" else "",
                     )
                 )
             except Exception:

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -442,7 +442,7 @@ class ReporterAgent(
                     prometheus_exporter.Options(
                         namespace="ray",
                         port=dashboard_agent.metrics_export_port,
-                        address="127.0.0.1" if self._ip == "127.0.0.1" else "",
+                        address=self._ip,
                     )
                 )
             except Exception:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

For better security practice, we want to avoid having our servers listening to all interfaces and instead bind to localhost and an external interface if one is passed in.

Changed conditional logic from binding to all interfaces to only the IP that is passed in. If the IP is external, then have servers bind to localhost as well.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
