### PR TITLE
Example fix for autoscaler issue with node-ip-address param set to DNS address

### DIFF
--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -119,7 +119,7 @@ class LoadMetrics:
         pending_placement_groups: List[PlacementGroupTableData] = None,
         cluster_full_of_actors_detected: bool = False,
     ):
-        if not ip_regex.match(ip):
+        if not ip_regex.fullmatch(ip):
             ip = self.dns_resolve_non_ip_address(ip)
         
         self.static_resources_by_ip[ip] = static_resources

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -61,3 +61,4 @@ py-spy>=0.2.0; python_version < '3.12'
 py-spy>=0.4.0; python_version >= '3.12'
 memray; sys_platform != "win32" # memray is not supported on Windows
 pyOpenSSL
+dnspython==2.4.2


### PR DESCRIPTION
## Why are these changes needed?
This is an example fix to demonstrate the root cause of an issue -- likely needs to be iterated on before a real fix can be merged.

Perform a DNS lookup of non-ip-address-shaped node IP addresses from GCS and convert them into IP addresses in `LoadMetrics::update`. This allows `LoadMetrics` to reconcile incongruity between GCS-supplied "IP Addresses" that are actually DNS addresses and the actual worker IP addresses

## Related issue number

Closes #55302

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
