### PR TITLE
[core] Log actor plasma restart warning only once per process

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2240,7 +2240,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       }
     }
     if (actor_restart_warning) {
-      RAY_LOG_ONCE(ERROR)
+      RAY_LOG_ONCE_PER_PROCESS(ERROR)
           << "Actor " << (actor_name.empty() ? "" : (actor_name + " "))
           << "with class name: '" << function.GetFunctionDescriptor()->ClassName()
           << "' and ID: '" << task_spec.ActorCreationId()

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2240,7 +2240,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       }
     }
     if (actor_restart_warning) {
-      RAY_LOG(ERROR)
+      RAY_LOG_ONCE(ERROR)
           << "Actor " << (actor_name.empty() ? "" : (actor_name + " "))
           << "with class name: '" << function.GetFunctionDescriptor()->ClassName()
           << "' and ID: '" << task_spec.ActorCreationId()

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -185,8 +185,8 @@ enum class RayLogLevel {
       RAY_LOG_OCCURRENCES.fetch_add(1) % n == 0)              \
   RAY_LOG_INTERNAL(ray::RayLogLevel::level) << "[" << RAY_LOG_OCCURRENCES << "] "
 
-#define RAY_LOG_ONCE(level)                  \
-  static std::once_flag<bool> once_log_flag; \
+#define RAY_LOG_ONCE(level)                            \
+  static std::once_flag<bool> once_log_flag##__LINE__; \
   std::call_once(once_log_flag, []() { RAY_LOG(level); });
 
 // Occasional logging with DEBUG fallback:

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -185,6 +185,10 @@ enum class RayLogLevel {
       RAY_LOG_OCCURRENCES.fetch_add(1) % n == 0)              \
   RAY_LOG_INTERNAL(ray::RayLogLevel::level) << "[" << RAY_LOG_OCCURRENCES << "] "
 
+#define RAY_LOG_ONCE(level)                  \
+  static std::once_flag<bool> once_log_flag; \
+  std::call_once(once_log_flag, []() { RAY_LOG(level); });
+
 // Occasional logging with DEBUG fallback:
 // If DEBUG is not enabled, log every n'th occurrence of an event.
 // Otherwise, if DEBUG is enabled, always log as DEBUG events.

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -185,9 +185,9 @@ enum class RayLogLevel {
       RAY_LOG_OCCURRENCES.fetch_add(1) % n == 0)              \
   RAY_LOG_INTERNAL(ray::RayLogLevel::level) << "[" << RAY_LOG_OCCURRENCES << "] "
 
-#define RAY_LOG_ONCE(level)                            \
-  static std::once_flag<bool> once_log_flag##__LINE__; \
-  std::call_once(once_log_flag, []() { RAY_LOG(level); });
+#define RAY_LOG_ONCE_PER_PROCESS(level)                   \
+  static std::atomic_bool once_log_flag##__LINE__(false); \
+  if (!once_log_flag##__LINE__.exchange(true)) RAY_LOG(level)
 
 // Occasional logging with DEBUG fallback:
 // If DEBUG is not enabled, log every n'th occurrence of an event.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As noted here the log can get too chatty. https://github.com/ray-project/ray/issues/53727#issuecomment-3145987428

So only logging once per submitter and adding a macro for logging once per process.