### PR TITLE
[train][tests] Reduce test flakiness by removing randomness

### DIFF
--- a/python/ray/train/examples/pytorch/torch_fashion_mnist_example.py
+++ b/python/ray/train/examples/pytorch/torch_fashion_mnist_example.py
@@ -65,6 +65,8 @@ class NeuralNetwork(nn.Module):
 
 
 def train_func_per_worker(config: Dict):
+    ray.train.torch.enable_reproducibility()
+
     lr = config["lr"]
     epochs = config["epochs"]
     batch_size = config["batch_size_per_worker"]


### PR DESCRIPTION
[test_gpu_examples](https://github.com/ray-project/ray/blob/master/python/ray/train/tests/test_gpu_examples.py#L105) has a 45% flake rate in our CI - this PR attempts to make it consistent with [this](https://docs.ray.io/en/latest/train/user-guides/reproducibility.html). If it still doesn't work I can try loosening the loss decrease requirement. 