### PR TITLE
[Data] Deprecate `with_columns` API in favor of `with_column`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -789,6 +789,7 @@ class Dataset:
         Examples:
 
             >>> import ray
+            >>> from ray.data.expressions import col
             >>> ds = ray.data.range(100)
             >>> ds.with_column("id_2", (col("id") * 2)).schema()
             Column    Type

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -792,10 +792,10 @@ class Dataset:
             >>> from ray.data.expressions import col
             >>> ds = ray.data.range(100)
             >>> ds.with_column("id_2", (col("id") * 2)).schema()
-            Column    Type
-            ------    ----
-            id        int64
-            id_2      int64
+            Column  Type
+            ------  ----
+            id      int64
+            id_2    int64
 
         Args:
             column_name: The name of the new column.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -782,6 +782,44 @@ class Dataset:
         return Dataset(plan, logical_plan)
 
     @PublicAPI(api_group=EXPRESSION_API_GROUP, stability="alpha")
+    def with_column(self, column_name: str, expr: Expr, **ray_remote_args) -> "Dataset":
+        """
+        Add a new column to the dataset via an expression.
+
+        Examples:
+
+            >>> import ray
+            >>> ds = ray.data.range(100)
+            >>> ds.with_column("id_2", (col("id") * 2)).schema()
+            Column    Type
+            ------    ----
+            id        int64
+            id_2      int64
+
+        Args:
+            column_name: The name of the new column.
+            expr: An expression that defines the new column values.
+            ray_remote_args: Additional resource requirements to request from
+                Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
+                :func:`ray.remote` for details.
+
+        Returns:
+            A new dataset with the added column evaluated via the expression.
+        """
+        from ray.data._internal.logical.operators.map_operator import Project
+
+        plan = self._plan.copy()
+        project_op = Project(
+            self._logical_plan.dag,
+            cols=None,
+            cols_rename=None,
+            exprs={column_name: expr},
+            ray_remote_args=ray_remote_args,
+        )
+        logical_plan = LogicalPlan(project_op, self.context)
+        return Dataset(plan, logical_plan)
+
+    @PublicAPI(api_group=EXPRESSION_API_GROUP, stability="alpha")
     def with_columns(self, exprs: Dict[str, Expr]) -> "Dataset":
         """
         Add new columns to the dataset.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -819,44 +819,6 @@ class Dataset:
         logical_plan = LogicalPlan(project_op, self.context)
         return Dataset(plan, logical_plan)
 
-    @PublicAPI(api_group=EXPRESSION_API_GROUP, stability="alpha")
-    def with_columns(self, exprs: Dict[str, Expr]) -> "Dataset":
-        """
-        Add new columns to the dataset.
-
-        Examples:
-
-            >>> import ray
-            >>> from ray.data.expressions import col
-            >>> ds = ray.data.range(100)
-            >>> ds.with_columns({"new_id": col("id") * 2, "new_id_2": col("id") * 3}).schema()
-            Column    Type
-            ------    ----
-            id        int64
-            new_id    int64
-            new_id_2  int64
-
-        Args:
-            exprs: A dictionary mapping column names to expressions that define the new column values.
-
-        Returns:
-            A new dataset with the added columns evaluated via expressions.
-        """
-        if not exprs:
-            raise ValueError("at least one expression is required")
-
-        from ray.data._internal.logical.operators.map_operator import Project
-
-        plan = self._plan.copy()
-        project_op = Project(
-            self._logical_plan.dag,
-            cols=None,
-            cols_rename=None,
-            exprs=exprs,
-        )
-        logical_plan = LogicalPlan(project_op, self.context)
-        return Dataset(plan, logical_plan)
-
     @PublicAPI(api_group=BT_API_GROUP)
     def add_column(
         self,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -800,7 +800,7 @@ class Dataset:
         Args:
             column_name: The name of the new column.
             expr: An expression that defines the new column values.
-            ray_remote_args: Additional resource requirements to request from
+            **ray_remote_args: Additional resource requirements to request from
                 Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
                 :func:`ray.remote` for details.
 

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -3,151 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Union
-import inspect
-import functools
+from typing import Any
 
 from ray.util.annotations import DeveloperAPI, PublicAPI
-
-
-# Import the DataType class
-from pydantic import BaseModel, field_validator
-import pyarrow as pa
-import numpy as np
-
-
-class DataType(BaseModel):
-    """A simplified Ray Data DataType supporting Arrow, NumPy, and Python types."""
-
-    _internal_type: Union[pa.DataType, np.dtype, type]
-
-    class Config:
-        arbitrary_types_allowed = True
-
-    @field_validator("_internal_type")
-    def validate_type(cls, v):
-        if not isinstance(v, (pa.DataType, np.dtype, type)):
-            raise TypeError(
-                "DataType supports only PyArrow DataType, NumPy dtype, or Python type."
-            )
-        return v
-
-    # Type checking methods
-    def is_arrow_type(self) -> bool:
-        return isinstance(self._internal_type, pa.DataType)
-
-    def is_numpy_type(self) -> bool:
-        return isinstance(self._internal_type, np.dtype)
-
-    def is_python_type(self) -> bool:
-        return isinstance(self._internal_type, type)
-
-    # Conversion methods
-    def to_arrow_dtype(self) -> pa.DataType:
-        if self.is_arrow_type():
-            return self._internal_type
-        elif self.is_numpy_type():
-            return pa.from_numpy_dtype(self._internal_type)
-        else:
-            return pa.string()
-
-    def to_numpy_dtype(self) -> np.dtype:
-        if self.is_numpy_type():
-            return self._internal_type
-        elif self.is_arrow_type():
-            return self._internal_type.to_pandas_dtype()
-        else:
-            return np.dtype("object")
-
-    def to_python_type(self) -> type:
-        if self.is_python_type():
-            return self._internal_type
-        else:
-            raise ValueError(f"DataType {self} is not a Python type")
-
-    # Factory methods for Arrow types
-    @classmethod
-    def int8(cls) -> "DataType":
-        return cls(_internal_type=pa.int8())
-
-    @classmethod
-    def int16(cls) -> "DataType":
-        return cls(_internal_type=pa.int16())
-
-    @classmethod
-    def int32(cls) -> "DataType":
-        return cls(_internal_type=pa.int32())
-
-    @classmethod
-    def int64(cls) -> "DataType":
-        return cls(_internal_type=pa.int64())
-
-    @classmethod
-    def uint8(cls) -> "DataType":
-        return cls(_internal_type=pa.uint8())
-
-    @classmethod
-    def uint16(cls) -> "DataType":
-        return cls(_internal_type=pa.uint16())
-
-    @classmethod
-    def uint32(cls) -> "DataType":
-        return cls(_internal_type=pa.uint32())
-
-    @classmethod
-    def uint64(cls) -> "DataType":
-        return cls(_internal_type=pa.uint64())
-
-    @classmethod
-    def float32(cls) -> "DataType":
-        return cls(_internal_type=pa.float32())
-
-    @classmethod
-    def float64(cls) -> "DataType":
-        return cls(_internal_type=pa.float64())
-
-    @classmethod
-    def string(cls) -> "DataType":
-        return cls(_internal_type=pa.string())
-
-    @classmethod
-    def bool(cls) -> "DataType":
-        return cls(_internal_type=pa.bool_())
-
-    @classmethod
-    def binary(cls) -> "DataType":
-        return cls(_internal_type=pa.binary())
-
-    # Factory methods from external systems
-    @classmethod
-    def from_arrow(cls, arrow_type: pa.DataType) -> "DataType":
-        return cls(_internal_type=arrow_type)
-
-    @classmethod
-    def from_numpy(cls, numpy_dtype: Union[np.dtype, str]) -> "DataType":
-        if isinstance(numpy_dtype, str):
-            numpy_dtype = np.dtype(numpy_dtype)
-        return cls(_internal_type=numpy_dtype)
-
-    @classmethod
-    def from_python(cls, python_type: type) -> "DataType":
-        return cls(_internal_type=python_type)
-
-    def __repr__(self) -> str:
-        if self.is_arrow_type():
-            return f"DataType(arrow:{self._internal_type})"
-        elif self.is_numpy_type():
-            return f"DataType(numpy:{self._internal_type})"
-        else:
-            return f"DataType(python:{self._internal_type.__name__})"
-
-    def __eq__(self, other) -> bool:
-        if not isinstance(other, DataType):
-            return False
-        return self._internal_type == other._internal_type
-
-    def __hash__(self) -> int:
-        return hash(str(self._internal_type))
 
 
 @DeveloperAPI(stability="alpha")
@@ -381,54 +239,6 @@ class BinaryExpr(Expr):
         )
 
 
-@DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
-class UDFExpr(Expr):
-    """Expression that represents a user-defined function call.
-
-    This expression type wraps a UDF with schema inference capabilities,
-    allowing UDFs to be used seamlessly within the expression system.
-
-    Args:
-        fn: The user-defined function to call
-        args: List of argument expressions (positional arguments)
-        kwargs: Dictionary of keyword argument expressions
-        return_dtype: Optional return data type for schema inference
-        function_name: Optional name for the function (for debugging)
-
-    Example:
-        >>> from ray.data.expressions import col, udf
-        >>>
-        >>> @udf
-        >>> def add_one(x: int) -> int:
-        ...     return x + 1
-        >>>
-        >>> # Use in expressions
-        >>> expr = add_one(col("value"))
-    """
-
-    fn: Callable
-    args: List[Expr]
-    kwargs: Dict[str, Expr]
-    return_dtype: Optional[DataType] = None
-    function_name: Optional[str] = None
-
-    def structurally_equals(self, other: Any) -> bool:
-        return (
-            isinstance(other, UDFExpr)
-            and self.fn == other.fn
-            and len(self.args) == len(other.args)
-            and all(a.structurally_equals(b) for a, b in zip(self.args, other.args))
-            and self.kwargs.keys() == other.kwargs.keys()
-            and all(
-                self.kwargs[k].structurally_equals(other.kwargs[k])
-                for k in self.kwargs.keys()
-            )
-            and self.return_dtype == other.return_dtype
-            and self.function_name == other.function_name
-        )
-
-
 @PublicAPI(stability="beta")
 def col(name: str) -> ColumnExpr:
     """
@@ -449,10 +259,10 @@ def col(name: str) -> ColumnExpr:
         >>> # Reference columns in an expression
         >>> expr = col("price") * col("quantity")
         >>>
-        >>> # Use with Dataset.with_columns()
+        >>> # Use with Dataset.with_column()
         >>> import ray
         >>> ds = ray.data.from_items([{"price": 10, "quantity": 2}])
-        >>> ds = ds.with_columns({"total": col("price") * col("quantity")})
+        >>> ds = ds.with_column("total", col("price") * col("quantity"))
     """
     return ColumnExpr(name)
 
@@ -483,125 +293,12 @@ def lit(value: Any) -> LiteralExpr:
         >>> # Use in expressions
         >>> expr = col("age") + lit(1) # Add 1 to age column
         >>>
-        >>> # Use with Dataset.with_columns()
+        >>> # Use with Dataset.with_column()
         >>> import ray
         >>> ds = ray.data.from_items([{"age": 25}, {"age": 30}])
-        >>> ds = ds.with_columns({"age_plus_one": col("age") + lit(1)})
+        >>> ds = ds.with_column("age_plus_one", col("age") + lit(1))
     """
     return LiteralExpr(value)
-
-
-def _infer_return_dtype_from_annotation(fn: Callable) -> Optional[DataType]:
-    """Infer the return DataType from function type annotations."""
-    sig = inspect.signature(fn)
-    if sig.return_annotation != inspect.Signature.empty:
-        return_annotation = sig.return_annotation
-
-        # Convert common Python types to DataType
-        if isinstance(return_annotation, int):
-            return DataType.from_python(int)
-        elif isinstance(return_annotation, float):
-            return DataType.from_python(float)
-        elif isinstance(return_annotation, str):
-            return DataType.from_python(str)
-        elif isinstance(return_annotation, bool):
-            return DataType.from_python(bool)
-        elif isinstance(return_annotation, type):
-            return DataType.from_python(return_annotation)
-
-    return None
-
-
-def _create_udf_callable(fn: Callable, return_dtype: Optional[DataType] = None):
-    """Create a callable that generates UDFExpr when called with expressions."""
-
-    def udf_callable(*args, **kwargs):
-        # Convert arguments to expressions if they aren't already
-        expr_args = []
-        for arg in args:
-            if isinstance(arg, Expr):
-                expr_args.append(arg)
-            else:
-                expr_args.append(LiteralExpr(arg))
-
-        expr_kwargs = {}
-        for k, v in kwargs.items():
-            if isinstance(v, Expr):
-                expr_kwargs[k] = v
-            else:
-                expr_kwargs[k] = LiteralExpr(v)
-
-        return UDFExpr(
-            fn=fn,
-            args=expr_args,
-            kwargs=expr_kwargs,
-            return_dtype=return_dtype,
-            function_name=getattr(fn, "__name__", None),
-        )
-
-    # Preserve original function metadata
-    functools.update_wrapper(udf_callable, fn)
-
-    # Store the original function for access if needed
-    udf_callable._original_fn = fn
-    udf_callable._return_dtype = return_dtype
-
-    return udf_callable
-
-
-@PublicAPI(stability="alpha")
-def udf(fn: Optional[Callable] = None, *, return_dtype: Optional[DataType] = None):
-    """
-    Decorator to convert a UDF into an expression-compatible function.
-
-    This decorator allows UDFs to be used seamlessly within the expression system,
-    enabling schema inference and integration with other expressions.
-
-    Args:
-        fn: The function to decorate (when used as @udf)
-        return_dtype: Optional explicit return data type for schema inference.
-                     If not provided, will attempt to infer from type annotations.
-
-    Returns:
-        A callable that creates UDFExpr instances when called with expressions
-
-    Example:
-        >>> from ray.data.expressions import col, udf, DataType
-        >>> import ray
-        >>>
-        >>> @udf
-        >>> def add_one(x: int) -> int:
-        ...     return x + 1
-        >>>
-        >>> @udf(return_dtype=DataType.string())
-        >>> def format_name(first: str, last: str) -> str:
-        ...     return f"{first} {last}"
-        >>>
-        >>> # Use in dataset operations
-        >>> ds = ray.data.from_items([{"value": 5, "first": "John", "last": "Doe"}])
-        >>>
-        >>> # Single column transformation
-        >>> ds_incremented = ds.with_column("value_plus_one", add_one(col("value")))
-        >>>
-        >>> # Multi-column transformation
-        >>> ds_formatted = ds.with_column("full_name", format_name(col("first"), col("last")))
-        >>>
-        >>> # Can also be used in complex expressions
-        >>> ds_complex = ds.with_column("doubled_plus_one", add_one(col("value")) * 2)
-    """
-
-    def decorator(func: Callable):
-        # Try to infer return dtype from annotations if not explicitly provided
-        inferred_return_dtype = return_dtype or _infer_return_dtype_from_annotation(
-            func
-        )
-        return _create_udf_callable(func, inferred_return_dtype)
-
-    # Handle both @udf and @udf(...) syntax
-    if fn is not None:
-        return decorator(fn)
-    else:
-        return decorator
 
 
 # ──────────────────────────────────────
@@ -617,9 +314,6 @@ __all__ = [
     "ColumnExpr",
     "LiteralExpr",
     "BinaryExpr",
-    "UDFExpr",
-    "DataType",
     "col",
     "lit",
-    "udf",
 ]

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -3,9 +3,151 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Callable, Dict, List, Optional, Union
+import inspect
+import functools
 
 from ray.util.annotations import DeveloperAPI, PublicAPI
+
+
+# Import the DataType class
+from pydantic import BaseModel, field_validator
+import pyarrow as pa
+import numpy as np
+
+
+class DataType(BaseModel):
+    """A simplified Ray Data DataType supporting Arrow, NumPy, and Python types."""
+
+    _internal_type: Union[pa.DataType, np.dtype, type]
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @field_validator("_internal_type")
+    def validate_type(cls, v):
+        if not isinstance(v, (pa.DataType, np.dtype, type)):
+            raise TypeError(
+                "DataType supports only PyArrow DataType, NumPy dtype, or Python type."
+            )
+        return v
+
+    # Type checking methods
+    def is_arrow_type(self) -> bool:
+        return isinstance(self._internal_type, pa.DataType)
+
+    def is_numpy_type(self) -> bool:
+        return isinstance(self._internal_type, np.dtype)
+
+    def is_python_type(self) -> bool:
+        return isinstance(self._internal_type, type)
+
+    # Conversion methods
+    def to_arrow_dtype(self) -> pa.DataType:
+        if self.is_arrow_type():
+            return self._internal_type
+        elif self.is_numpy_type():
+            return pa.from_numpy_dtype(self._internal_type)
+        else:
+            return pa.string()
+
+    def to_numpy_dtype(self) -> np.dtype:
+        if self.is_numpy_type():
+            return self._internal_type
+        elif self.is_arrow_type():
+            return self._internal_type.to_pandas_dtype()
+        else:
+            return np.dtype("object")
+
+    def to_python_type(self) -> type:
+        if self.is_python_type():
+            return self._internal_type
+        else:
+            raise ValueError(f"DataType {self} is not a Python type")
+
+    # Factory methods for Arrow types
+    @classmethod
+    def int8(cls) -> "DataType":
+        return cls(_internal_type=pa.int8())
+
+    @classmethod
+    def int16(cls) -> "DataType":
+        return cls(_internal_type=pa.int16())
+
+    @classmethod
+    def int32(cls) -> "DataType":
+        return cls(_internal_type=pa.int32())
+
+    @classmethod
+    def int64(cls) -> "DataType":
+        return cls(_internal_type=pa.int64())
+
+    @classmethod
+    def uint8(cls) -> "DataType":
+        return cls(_internal_type=pa.uint8())
+
+    @classmethod
+    def uint16(cls) -> "DataType":
+        return cls(_internal_type=pa.uint16())
+
+    @classmethod
+    def uint32(cls) -> "DataType":
+        return cls(_internal_type=pa.uint32())
+
+    @classmethod
+    def uint64(cls) -> "DataType":
+        return cls(_internal_type=pa.uint64())
+
+    @classmethod
+    def float32(cls) -> "DataType":
+        return cls(_internal_type=pa.float32())
+
+    @classmethod
+    def float64(cls) -> "DataType":
+        return cls(_internal_type=pa.float64())
+
+    @classmethod
+    def string(cls) -> "DataType":
+        return cls(_internal_type=pa.string())
+
+    @classmethod
+    def bool(cls) -> "DataType":
+        return cls(_internal_type=pa.bool_())
+
+    @classmethod
+    def binary(cls) -> "DataType":
+        return cls(_internal_type=pa.binary())
+
+    # Factory methods from external systems
+    @classmethod
+    def from_arrow(cls, arrow_type: pa.DataType) -> "DataType":
+        return cls(_internal_type=arrow_type)
+
+    @classmethod
+    def from_numpy(cls, numpy_dtype: Union[np.dtype, str]) -> "DataType":
+        if isinstance(numpy_dtype, str):
+            numpy_dtype = np.dtype(numpy_dtype)
+        return cls(_internal_type=numpy_dtype)
+
+    @classmethod
+    def from_python(cls, python_type: type) -> "DataType":
+        return cls(_internal_type=python_type)
+
+    def __repr__(self) -> str:
+        if self.is_arrow_type():
+            return f"DataType(arrow:{self._internal_type})"
+        elif self.is_numpy_type():
+            return f"DataType(numpy:{self._internal_type})"
+        else:
+            return f"DataType(python:{self._internal_type.__name__})"
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, DataType):
+            return False
+        return self._internal_type == other._internal_type
+
+    def __hash__(self) -> int:
+        return hash(str(self._internal_type))
 
 
 @DeveloperAPI(stability="alpha")
@@ -239,6 +381,54 @@ class BinaryExpr(Expr):
         )
 
 
+@DeveloperAPI(stability="alpha")
+@dataclass(frozen=True, eq=False)
+class UDFExpr(Expr):
+    """Expression that represents a user-defined function call.
+
+    This expression type wraps a UDF with schema inference capabilities,
+    allowing UDFs to be used seamlessly within the expression system.
+
+    Args:
+        fn: The user-defined function to call
+        args: List of argument expressions (positional arguments)
+        kwargs: Dictionary of keyword argument expressions
+        return_dtype: Optional return data type for schema inference
+        function_name: Optional name for the function (for debugging)
+
+    Example:
+        >>> from ray.data.expressions import col, udf
+        >>>
+        >>> @udf
+        >>> def add_one(x: int) -> int:
+        ...     return x + 1
+        >>>
+        >>> # Use in expressions
+        >>> expr = add_one(col("value"))
+    """
+
+    fn: Callable
+    args: List[Expr]
+    kwargs: Dict[str, Expr]
+    return_dtype: Optional[DataType] = None
+    function_name: Optional[str] = None
+
+    def structurally_equals(self, other: Any) -> bool:
+        return (
+            isinstance(other, UDFExpr)
+            and self.fn == other.fn
+            and len(self.args) == len(other.args)
+            and all(a.structurally_equals(b) for a, b in zip(self.args, other.args))
+            and self.kwargs.keys() == other.kwargs.keys()
+            and all(
+                self.kwargs[k].structurally_equals(other.kwargs[k])
+                for k in self.kwargs.keys()
+            )
+            and self.return_dtype == other.return_dtype
+            and self.function_name == other.function_name
+        )
+
+
 @PublicAPI(stability="beta")
 def col(name: str) -> ColumnExpr:
     """
@@ -301,6 +491,119 @@ def lit(value: Any) -> LiteralExpr:
     return LiteralExpr(value)
 
 
+def _infer_return_dtype_from_annotation(fn: Callable) -> Optional[DataType]:
+    """Infer the return DataType from function type annotations."""
+    sig = inspect.signature(fn)
+    if sig.return_annotation != inspect.Signature.empty:
+        return_annotation = sig.return_annotation
+
+        # Convert common Python types to DataType
+        if isinstance(return_annotation, int):
+            return DataType.from_python(int)
+        elif isinstance(return_annotation, float):
+            return DataType.from_python(float)
+        elif isinstance(return_annotation, str):
+            return DataType.from_python(str)
+        elif isinstance(return_annotation, bool):
+            return DataType.from_python(bool)
+        elif isinstance(return_annotation, type):
+            return DataType.from_python(return_annotation)
+
+    return None
+
+
+def _create_udf_callable(fn: Callable, return_dtype: Optional[DataType] = None):
+    """Create a callable that generates UDFExpr when called with expressions."""
+
+    def udf_callable(*args, **kwargs):
+        # Convert arguments to expressions if they aren't already
+        expr_args = []
+        for arg in args:
+            if isinstance(arg, Expr):
+                expr_args.append(arg)
+            else:
+                expr_args.append(LiteralExpr(arg))
+
+        expr_kwargs = {}
+        for k, v in kwargs.items():
+            if isinstance(v, Expr):
+                expr_kwargs[k] = v
+            else:
+                expr_kwargs[k] = LiteralExpr(v)
+
+        return UDFExpr(
+            fn=fn,
+            args=expr_args,
+            kwargs=expr_kwargs,
+            return_dtype=return_dtype,
+            function_name=getattr(fn, "__name__", None),
+        )
+
+    # Preserve original function metadata
+    functools.update_wrapper(udf_callable, fn)
+
+    # Store the original function for access if needed
+    udf_callable._original_fn = fn
+    udf_callable._return_dtype = return_dtype
+
+    return udf_callable
+
+
+@PublicAPI(stability="alpha")
+def udf(fn: Optional[Callable] = None, *, return_dtype: Optional[DataType] = None):
+    """
+    Decorator to convert a UDF into an expression-compatible function.
+
+    This decorator allows UDFs to be used seamlessly within the expression system,
+    enabling schema inference and integration with other expressions.
+
+    Args:
+        fn: The function to decorate (when used as @udf)
+        return_dtype: Optional explicit return data type for schema inference.
+                     If not provided, will attempt to infer from type annotations.
+
+    Returns:
+        A callable that creates UDFExpr instances when called with expressions
+
+    Example:
+        >>> from ray.data.expressions import col, udf, DataType
+        >>> import ray
+        >>>
+        >>> @udf
+        >>> def add_one(x: int) -> int:
+        ...     return x + 1
+        >>>
+        >>> @udf(return_dtype=DataType.string())
+        >>> def format_name(first: str, last: str) -> str:
+        ...     return f"{first} {last}"
+        >>>
+        >>> # Use in dataset operations
+        >>> ds = ray.data.from_items([{"value": 5, "first": "John", "last": "Doe"}])
+        >>>
+        >>> # Single column transformation
+        >>> ds_incremented = ds.with_column("value_plus_one", add_one(col("value")))
+        >>>
+        >>> # Multi-column transformation
+        >>> ds_formatted = ds.with_column("full_name", format_name(col("first"), col("last")))
+        >>>
+        >>> # Can also be used in complex expressions
+        >>> ds_complex = ds.with_column("doubled_plus_one", add_one(col("value")) * 2)
+    """
+
+    def decorator(func: Callable):
+        # Try to infer return dtype from annotations if not explicitly provided
+        inferred_return_dtype = return_dtype or _infer_return_dtype_from_annotation(
+            func
+        )
+        return _create_udf_callable(func, inferred_return_dtype)
+
+    # Handle both @udf and @udf(...) syntax
+    if fn is not None:
+        return decorator(fn)
+    else:
+        return decorator
+
+
 # ──────────────────────────────────────
 # Public API for evaluation
 # ──────────────────────────────────────
@@ -314,6 +617,9 @@ __all__ = [
     "ColumnExpr",
     "LiteralExpr",
     "BinaryExpr",
+    "UDFExpr",
+    "DataType",
     "col",
     "lit",
+    "udf",
 ]

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -2339,52 +2339,53 @@ def test_map_names(target_max_block_size_infinite_or_default):
 
 @pytest.mark.skipif(
     get_pyarrow_version() < parse_version("20.0.0"),
-    reason="with_columns requires PyArrow >= 20.0.0",
+    reason="with_column requires PyArrow >= 20.0.0",
 )
 @pytest.mark.parametrize(
-    "exprs, expected_value",
+    "column_name, expr, expected_value",
     [
         # Arithmetic operations
-        ({"result": col("id") + 1}, 1),  # 0 + 1 = 1
-        ({"result": col("id") + 5}, 5),  # 0 + 5 = 5
-        ({"result": col("id") - 1}, -1),  # 0 - 1 = -1
-        ({"result": col("id") * 2}, 0),  # 0 * 2 = 0
-        ({"result": col("id") * 3}, 0),  # 0 * 3 = 0
-        ({"result": col("id") / 2}, 0.0),  # 0 / 2 = 0.0
+        ("result", col("id") + 1, 1),  # 0 + 1 = 1
+        ("result", col("id") + 5, 5),  # 0 + 5 = 5
+        ("result", col("id") - 1, -1),  # 0 - 1 = -1
+        ("result", col("id") * 2, 0),  # 0 * 2 = 0
+        ("result", col("id") * 3, 0),  # 0 * 3 = 0
+        ("result", col("id") / 2, 0.0),  # 0 / 2 = 0.0
         # More complex arithmetic
-        ({"result": (col("id") + 1) * 2}, 2),  # (0 + 1) * 2 = 2
-        ({"result": (col("id") * 2) + 3}, 3),  # 0 * 2 + 3 = 3
+        ("result", (col("id") + 1) * 2, 2),  # (0 + 1) * 2 = 2
+        ("result", (col("id") * 2) + 3, 3),  # 0 * 2 + 3 = 3
         # Comparison operations
-        ({"result": col("id") > 0}, False),  # 0 > 0 = False
-        ({"result": col("id") >= 0}, True),  # 0 >= 0 = True
-        ({"result": col("id") < 1}, True),  # 0 < 1 = True
-        ({"result": col("id") <= 0}, True),  # 0 <= 0 = True
-        ({"result": col("id") == 0}, True),  # 0 == 0 = True
+        ("result", col("id") > 0, False),  # 0 > 0 = False
+        ("result", col("id") >= 0, True),  # 0 >= 0 = True
+        ("result", col("id") < 1, True),  # 0 < 1 = True
+        ("result", col("id") <= 0, True),  # 0 <= 0 = True
+        ("result", col("id") == 0, True),  # 0 == 0 = True
         # Operations with literals
-        ({"result": col("id") + lit(10)}, 10),  # 0 + 10 = 10
-        ({"result": col("id") * lit(5)}, 0),  # 0 * 5 = 0
-        ({"result": lit(2) + col("id")}, 2),  # 2 + 0 = 2
-        ({"result": lit(10) / (col("id") + 1)}, 10.0),  # 10 / (0 + 1) = 10.0
+        ("result", col("id") + lit(10), 10),  # 0 + 10 = 10
+        ("result", col("id") * lit(5), 0),  # 0 * 5 = 0
+        ("result", lit(2) + col("id"), 2),  # 2 + 0 = 2
+        ("result", lit(10) / (col("id") + 1), 10.0),  # 10 / (0 + 1) = 10.0
     ],
 )
-def test_with_columns(
+def test_with_column(
     ray_start_regular_shared,
-    exprs,
+    column_name,
+    expr,
     expected_value,
     target_max_block_size_infinite_or_default,
 ):
-    """Verify that `with_columns` works with various operations."""
-    ds = ray.data.range(5).with_columns(exprs)
+    """Verify that `with_column` works with various operations."""
+    ds = ray.data.range(5).with_column(column_name, expr)
     result = ds.take(1)[0]
     assert result["id"] == 0
-    assert result["result"] == expected_value
+    assert result[column_name] == expected_value
 
 
 @pytest.mark.skipif(
     get_pyarrow_version() < parse_version("20.0.0"),
-    reason="with_columns requires PyArrow >= 20.0.0",
+    reason="with_column requires PyArrow >= 20.0.0",
 )
-def test_with_columns_nonexistent_column(
+def test_with_column_nonexistent_column(
     ray_start_regular_shared, target_max_block_size_infinite_or_default
 ):
     """Verify that referencing a non-existent column with col() raises an exception."""
@@ -2393,26 +2394,22 @@ def test_with_columns_nonexistent_column(
 
     # Try to reference a non-existent column - this should raise an exception
     with pytest.raises(UserCodeException):
-        ds.with_columns({"result": col("nonexistent_column") + 1}).materialize()
+        ds.with_column("result", col("nonexistent_column") + 1).materialize()
 
 
 @pytest.mark.skipif(
     get_pyarrow_version() < parse_version("20.0.0"),
-    reason="with_columns requires PyArrow >= 20.0.0",
+    reason="with_column requires PyArrow >= 20.0.0",
 )
-def test_with_columns_multiple_expressions(
+def test_with_column_multiple_expressions(
     ray_start_regular_shared, target_max_block_size_infinite_or_default
 ):
-    """Verify that `with_columns` correctly handles multiple expressions at once."""
+    """Verify that `with_column` correctly handles multiple expressions at once."""
     ds = ray.data.range(5)
 
-    exprs = {
-        "plus_one": col("id") + 1,
-        "times_two": col("id") * 2,
-        "ten_minus_id": 10 - col("id"),
-    }
-
-    ds = ds.with_columns(exprs)
+    ds = ds.with_column("plus_one", col("id") + 1)
+    ds = ds.with_column("times_two", col("id") * 2)
+    ds = ds.with_column("ten_minus_id", 10 - col("id"))
 
     first_row = ds.take(1)[0]
     assert first_row["id"] == 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`with_column` is an API designed for consuming an expression which can take an arbitrary amount of resources. This is the building block for supporting UDFs as expressions which will be added in subsequent changes.

## Related issue number

DATA-1302
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
