### PR TITLE
[Fix] Fix the pylint scanning defects in Ray Data

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -847,11 +847,7 @@ class Dataset:
 
                 # The index of the column must be set
                 # to align with the index of the batch.
-                if (
-                    isinstance(column, pd.Series)
-                    or isinstance(column, pd.DataFrame)
-                    or isinstance(column, pd.Index)
-                ):
+                if isinstance(column, (pd.DataFrame, pd.Index, pd.Series)):
                     column.index = batch.index
                 batch.loc[:, col] = column
                 return batch
@@ -872,8 +868,7 @@ class Dataset:
                 column_idx = batch.schema.get_field_index(col)
                 if column_idx == -1:
                     return batch.append_column(col, column)
-                else:
-                    return batch.set_column(column_idx, col, column)
+                return batch.set_column(column_idx, col, column)
 
             else:
                 # batch format is assumed to be numpy since we checked at the

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -273,8 +273,7 @@ class FileBasedDatasource(Datasource):
                     num_threads = 0
 
                 if num_threads > 0:
-                    if len(read_paths) < num_threads:
-                        num_threads = len(read_paths)
+                    num_threads = min(num_threads, len(read_paths))
 
                     logger.debug(
                         f"Reading {len(read_paths)} files with {num_threads} threads."

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3324,7 +3324,7 @@ def from_huggingface(
         hf_ds_arrow = dataset.with_format("arrow")
         ray_ds = from_arrow(hf_ds_arrow[:], override_num_blocks=override_num_blocks)
         return ray_ds
-    elif isinstance(dataset, (datasets.DatasetDict, datasets.IterableDatasetDict)):
+    if isinstance(dataset, (datasets.DatasetDict, datasets.IterableDatasetDict)):
         available_keys = list(dataset.keys())
         raise DeprecationWarning(
             "You provided a Hugging Face DatasetDict or IterableDatasetDict, "
@@ -3335,10 +3335,9 @@ def from_huggingface(
             f"['{available_keys[0]}'])`. "
             f"Available splits are {available_keys}."
         )
-    else:
-        raise TypeError(
-            f"`dataset` must be a `datasets.Dataset`, but got {type(dataset)}"
-        )
+    raise TypeError(
+        f"`dataset` must be a `datasets.Dataset`, but got {type(dataset)}"
+    )
 
 
 @PublicAPI


### PR DESCRIPTION
I have fixed the defect in the Python code of the data module scanned by the PyLint tool. The issue address is [no.53881](https://github.com/ray-project/ray/issues/53881)

The modifications in PR do not affect the logic and functionality of the code, nor do they affect existing unit test cases. The aim is to reduce code complexity and redundant code by scanning the code through the PyLint tool.



