### PR TITLE
[core] Fix flaky test_cleanup_on_driver_exit

### DIFF
--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -78,19 +78,10 @@ print("success")
     def all_workers_exited():
         result = True
         print("list of idle workers:")
-        for proc in psutil.process_iter():
-            try:
-                if ray_constants.WORKER_PROCESS_TYPE_IDLE_WORKER in proc.name():
-                    print(f"{proc}")
-                    result = False
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                # Between the time psutil.process_iter() returns a process
-                # and when we call proc.name(), the process can terminate.
-                # The test would crash with psutil.NoSuchProcess when processes
-                # terminated during iteration -- see https://github.com/ray-project/ray/issues/55292.
-                # We can safely ignore these cases because worker cleanup is expected but
-                # timing could be too aggressive in CI environments.
-                pass
+        for proc in psutil.process_iter(attrs=["name"], ad_value=None):
+            if proc.info["name"] and ray_constants.WORKER_PROCESS_TYPE_IDLE_WORKER in proc.info["name"]:
+                print(f"{proc}")
+                result = False
         return result
 
     # Check that workers are eventually cleaned up.

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -79,7 +79,10 @@ print("success")
         result = True
         print("list of idle workers:")
         for proc in psutil.process_iter(attrs=["name"], ad_value=None):
-            if proc.info["name"] and ray_constants.WORKER_PROCESS_TYPE_IDLE_WORKER in proc.info["name"]:
+            if (
+                proc.info["name"]
+                and ray_constants.WORKER_PROCESS_TYPE_IDLE_WORKER in proc.info["name"]
+            ):
                 print(f"{proc}")
                 result = False
         return result


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `test_cleanup_on_driver_exit` test has been flaking in CI with `psutil.NoSuchProcess` exceptions. The test fails during worker cleanup verification when checking if idle workers have exited.
Example failure from [CI logs](https://buildkite.com/ray-project/postmerge-macos/builds/7162#01987f0b-3872-4031-a057-406c38641c46):
```
RuntimeError: The condition wasn't met before the timeout expired. Last exception: 
Traceback (most recent call last):
  File "/opt/homebrew/opt/miniforge/lib/python3.9/site-packages/psutil/_psosx.py", line 346, in wrapper
    return fun(self, *args, **kwargs)
  File "/opt/homebrew/opt/miniforge/lib/python3.9/site-packages/psutil/_psosx.py", line 402, in cmdline
    return cext.proc_cmdline(self.pid)
ProcessLookupError: [Errno 3] assume no such process (originated from sysctl(KERN_PROCARGS2) -> EINVAL)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "python/ray/tests/test_multi_node.py", line 82, in all_workers_exited
    if ray_constants.WORKER_PROCESS_TYPE_IDLE_WORKER in proc.name():
  File "/opt/homebrew/opt/miniforge/lib/python3.9/site-packages/psutil/__init__.py", line 644, in name
    cmdline = self.cmdline()
psutil.NoSuchProcess: process no longer exists (pid=640)
```

The flakiness is caused by a race condition in the worker cleanup check:
1. `psutil.process_iter()` returns a process handle (e.g., PID 640 in CI logs)
2. The worker process terminates between the iterator call and `proc.name()` access.
3. `proc.name()` tries to access the terminated process and raises `psutil.NoSuchProcess`.

This race condition became more frequent after commit 792a2eb, and it's not very apparent how that commit can cause this issue. My guess is that the change added metrics overhead that slowed worker cleanup timing, making the race condition more likely to occur. The CI logs show the test repeatedly printing "list of idle workers:" for 15+ seconds before timing out, indicating that worker cleanup is happening but taking longer than the original 15-second timeout anticipated. But, I still don't know why this flakes only on Darwin. Anyway, the fix should unblock CI and hence release.

## Related issue number

Closes https://github.com/ray-project/ray/issues/55292