### PR TITLE
[Core][Bug Fix] Fix: ray.cancel actor task may cause RAY_CHECK failed: it->second.submitted_task_ref_count > 0

### DIFF
--- a/src/ray/core_worker/transport/actor_task_submitter.h
+++ b/src/ray/core_worker/transport/actor_task_submitter.h
@@ -449,6 +449,15 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
 
   std::shared_ptr<ReferenceCounterInterface> reference_counter_;
 
+  /// Used to resolve the issue where FailOrRetryPendingTask is
+  /// called before ResolveDependencies due to ray.cancel or disconnect.
+  /// details: https://github.com/ray-project/ray/issues/55131
+  mutable absl::Mutex mu_pending_resolve_;
+
+  /// The IDs of tasks that are pending dependency resolution.
+  absl::flat_hash_set<TaskID> pending_dependency_resolution_tasks_
+      ABSL_GUARDED_BY(mu_pending_resolve_);
+
   friend class CoreWorkerTest;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixed the issue where the submitted_task_ref_count of an object ref was decremented twice on a certain task：

1. Caused by ray.cancel, when marking the task as failed.
2. When the object ref is converted from an in-plasma ref to an inlined one.

By designing a new mutex to make the processes of ResolveDependencies and FailOrRetryPendingTask atomic operations, and adding pending_resolve_dependence_tasks_ to cancel ResolveDependencies that have not yet been executed.


## Related issue number

Closes #55131

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
