### PR TITLE
Revert "[wheel] use minimal remote download"

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -630,7 +630,6 @@ def build(build_python, build_java, build_cpp):
         # And we put it here so that does not change behavior of
         # conda-forge build.
         bazel_flags.append("--incompatible_strict_action_env")
-        bazel_flags.append("--remote_download_minimal")
 
     bazel_targets = []
     bazel_targets += ["//:gen_ray_pkg"] if build_python else []


### PR DESCRIPTION
Reverts ray-project/ray#55116

seems to trigger a lot of remote cache misses.