### PR TITLE
[ci] raydepsets: moving uv binary invocation to depset manager

### DIFF
--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -52,6 +52,7 @@ class DependencySetManager:
         self.config = self.workspace.load_config(config_path)
         self.build_graph = DiGraph()
         self._build()
+        self._uv_binary = _uv_binary()
 
     def _build(self):
         for depset in self.config.depsets:
@@ -85,7 +86,7 @@ class DependencySetManager:
         raise KeyError(f"Dependency set {name} not found")
 
     def exec_uv_cmd(self, cmd: str, args: List[str]) -> str:
-        cmd = [uv_binary(), "pip", cmd, *args]
+        cmd = [self._uv_binary, "pip", cmd, *args]
         click.echo(f"Executing command: {cmd}")
         status = subprocess.run(cmd, cwd=self.workspace.dir)
         if status.returncode != 0:
@@ -239,7 +240,7 @@ def _append_uv_flags(flags: List[str], args: List[str]) -> List[str]:
     return args
 
 
-def uv_binary():
+def _uv_binary():
     r = runfiles.Create()
     system = platform.system()
     if system != "Linux" or platform.processor() != "x86_64":

--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -52,7 +52,10 @@ class DependencySetManager:
         self.config = self.workspace.load_config(config_path)
         self.build_graph = DiGraph()
         self._build()
-        self._uv_binary = _uv_binary()
+        try:
+            self._uv_binary = _uv_binary()
+        except Exception as e:
+            raise RuntimeError(f"Failed to initialize uv binary: {e}") from e
 
     def _build(self):
         for depset in self.config.depsets:

--- a/ci/raydepsets/test_cli.py
+++ b/ci/raydepsets/test_cli.py
@@ -8,7 +8,6 @@ import runfiles
 from ci.raydepsets.cli import (
     load,
     DependencySetManager,
-    uv_binary,
     _override_uv_flags,
     _append_uv_flags,
     _flatten_flags,
@@ -71,14 +70,26 @@ class TestCli(unittest.TestCase):
                 manager.get_depset("fake_depset")
 
     def test_uv_binary_exists(self):
-        assert uv_binary() is not None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _copy_data_to_tmpdir(tmpdir)
+            manager = DependencySetManager(
+                config_path="test.depsets.yaml",
+                workspace_dir=tmpdir,
+            )
+        assert manager._uv_binary is not None
 
     def test_uv_version(self):
-        result = subprocess.run(
-            [uv_binary(), "--version"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _copy_data_to_tmpdir(tmpdir)
+            manager = DependencySetManager(
+                config_path="test.depsets.yaml",
+                workspace_dir=tmpdir,
+            )
+            result = subprocess.run(
+                [manager._uv_binary, "--version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
         assert result.returncode == 0
         assert "uv 0.7.20" in result.stdout.decode("utf-8")
         assert result.stderr.decode("utf-8") == ""


### PR DESCRIPTION
Currently every time uv is called a new runfiles instance is created
Moving uv binary invocation to depset manager
Called once when the depset manager is initialized
