### PR TITLE
[Core] Only fetch alive nodes for usage stats report

### DIFF
--- a/python/ray/_common/tests/test_usage_stats.py
+++ b/python/ray/_common/tests/test_usage_stats.py
@@ -876,13 +876,15 @@ def test_usage_lib_get_total_num_running_jobs_to_report(
     ray.shutdown()
 
 
-def test_usage_lib_get_total_num_nodes_to_report(ray_start_cluster, reset_usage_stats):
+def test_usage_lib_get_total_num_alive_nodes_to_report(
+    ray_start_cluster, reset_usage_stats
+):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=1)
     ray.init(address=cluster.address)
     worker_node = cluster.add_node(num_cpus=2)
     assert (
-        ray_usage_lib.get_total_num_nodes_to_report(
+        ray_usage_lib.get_total_num_alive_nodes_to_report(
             ray.experimental.internal_kv.internal_kv_get_gcs_client()
         )
         == 2
@@ -890,7 +892,7 @@ def test_usage_lib_get_total_num_nodes_to_report(ray_start_cluster, reset_usage_
     cluster.remove_node(worker_node)
     # Make sure only alive nodes are counted
     assert (
-        ray_usage_lib.get_total_num_nodes_to_report(
+        ray_usage_lib.get_total_num_alive_nodes_to_report(
             ray.experimental.internal_kv.internal_kv_get_gcs_client()
         )
         == 1
@@ -1460,7 +1462,7 @@ def test_usage_stats_gcs_query_failure(
 
         ray.init(address=cluster.address)
         assert (
-            ray_usage_lib.get_total_num_nodes_to_report(
+            ray_usage_lib.get_total_num_alive_nodes_to_report(
                 ray.experimental.internal_kv.internal_kv_get_gcs_client(), timeout=1
             )
             is None

--- a/python/ray/_common/usage/usage_lib.py
+++ b/python/ray/_common/usage/usage_lib.py
@@ -561,15 +561,13 @@ def get_total_num_running_jobs_to_report(gcs_client) -> Optional[int]:
         return None
 
 
-def get_total_num_nodes_to_report(gcs_client, timeout=None) -> Optional[int]:
+def get_total_num_alive_nodes_to_report(gcs_client, timeout=None) -> Optional[int]:
     """Return the total number of alive nodes in the cluster"""
     try:
-        result = gcs_client.get_all_node_info(timeout=timeout)
-        total_num_nodes = 0
-        for node_id, node_info in result.items():
-            if node_info.state == gcs_pb2.GcsNodeInfo.GcsNodeState.ALIVE:
-                total_num_nodes += 1
-        return total_num_nodes
+        result = gcs_client.get_all_node_info(
+            timeout=timeout, state_filter=gcs_pb2.GcsNodeInfo.GcsNodeState.ALIVE
+        )
+        return len(result.items())
     except Exception as e:
         logger.info(f"Failed to query number of nodes in the cluster: {e}")
         return None
@@ -940,7 +938,7 @@ def generate_report_data(
         total_object_store_memory_gb=cluster_status_to_report.total_object_store_memory_gb,  # noqa: E501
         library_usages=get_library_usages_to_report(gcs_client),
         extra_usage_tags=get_extra_usage_tags_to_report(gcs_client),
-        total_num_nodes=get_total_num_nodes_to_report(gcs_client),
+        total_num_nodes=get_total_num_alive_nodes_to_report(gcs_client),
         total_num_running_jobs=get_total_num_running_jobs_to_report(gcs_client),
         libc_version=cluster_metadata.get("libc_version"),
         hardware_usages=get_hardware_usages_to_report(gcs_client),

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -147,6 +147,11 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
     cdef CRayStatus RayStatus_Invalid "Status::Invalid"()
     cdef CRayStatus RayStatus_NotImplemented "Status::NotImplemented"()
 
+cdef extern from "ray/common/status_or.h" namespace "ray" nogil:
+    cdef cppclass CStatusOr "ray::StatusOr"[T]:
+        c_bool ok()
+        const CRayStatus &status() const
+        T &value()
 
 cdef extern from "ray/common/id.h" namespace "ray" nogil:
     const CTaskID GenerateTaskId(const CJobID &job_id,
@@ -448,9 +453,10 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             int64_t timeout_ms,
             c_vector[c_string] &drained_node_ids)
 
-        CRayStatus GetAllNoCache(
+        CStatusOr[c_vector[CGcsNodeInfo]] GetAllNoCache(
             int64_t timeout_ms,
-            c_vector[CGcsNodeInfo] &result)
+            optional[CGcsNodeState] state_filter,
+            optional[CNodeSelector] node_selector)
 
         void AsyncGetAll(
             const MultiItemPyCallback[CGcsNodeInfo] &callback,
@@ -702,6 +708,9 @@ cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
 
     cdef enum CGcsNodeState "ray::rpc::GcsNodeInfo_GcsNodeState":
         ALIVE "ray::rpc::GcsNodeInfo_GcsNodeState_ALIVE",
+
+    cdef cppclass CNodeSelector "ray::rpc::GetAllNodeInfoRequest::NodeSelector":
+        pass
 
     cdef cppclass CJobTableData "ray::rpc::JobTableData":
         c_string job_id() const

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -29,6 +29,10 @@ from ray.includes.common cimport (
     OptionalItemPyCallback,
     StatusPyCallback,
     CGetClusterStatusReply,
+    CStatusOr,
+    CGcsNodeState,
+    CNodeSelector,
+    CGcsNodeInfo,
 )
 from ray.includes.optional cimport optional, make_optional
 from ray.core.generated import gcs_pb2, autoscaler_pb2
@@ -323,13 +327,23 @@ cdef class InnerGcsClient:
         return raise_or_return(convert_multi_str(status, move(results)))
 
     def get_all_node_info(
-        self, timeout: Optional[int | float] = None
+        self, timeout: Optional[int | float] = None,
+        state_filter: Optional[int] = None,
     ) -> Dict[NodeID, gcs_pb2.GcsNodeInfo]:
-        cdef int64_t timeout_ms = round(1000 * timeout) if timeout else -1
-        cdef c_vector[CGcsNodeInfo] reply
-        cdef CRayStatus status
+        cdef:
+            int64_t timeout_ms = round(1000 * timeout) if timeout else -1
+            c_vector[CGcsNodeInfo] reply
+            CRayStatus status
+            optional[CStatusOr[c_vector[CGcsNodeInfo]]] status_or
+            optional[CGcsNodeState] c_state_filter = nullopt
+            optional[CNodeSelector] c_node_selector = nullopt
+        if state_filter is not None:
+            c_state_filter.emplace(<CGcsNodeState>state_filter)
         with nogil:
-            status = self.inner.get().Nodes().GetAllNoCache(timeout_ms, reply)
+            status_or = self.inner.get().Nodes().GetAllNoCache(timeout_ms, c_state_filter, c_node_selector)
+        status = status_or.value().status()
+        if status_or.value().ok():
+            reply = status_or.value().value()
         return raise_or_return(convert_get_all_node_info(status, move(reply)))
 
     def async_get_all_node_info(

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -343,7 +343,7 @@ cdef class InnerGcsClient:
             status_or = self.inner.get().Nodes().GetAllNoCache(timeout_ms, c_state_filter, c_node_selector)
         status = status_or.value().status()
         if status_or.value().ok():
-            reply = status_or.value().value()
+            reply = move(status_or.value().value())
         return raise_or_return(convert_get_all_node_info(status, move(reply)))
 
     def async_get_all_node_info(

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -385,18 +385,14 @@ class NodeInfoAccessor {
   /// \return All nodes in cache.
   virtual const absl::flat_hash_map<NodeID, rpc::GcsNodeInfo> &GetAll() const;
 
-  /// Get information of all nodes from an RPC to GCS synchronously.
-  ///
-  /// \return All nodes from gcs without cache.
-  virtual Status GetAllNoCache(int64_t timeout_ms, std::vector<rpc::GcsNodeInfo> &nodes);
-
-  /// Get information of all nodes from an RPC to GCS synchronously with filters.
+  /// Get information of all nodes from an RPC to GCS synchronously with optional filters.
   ///
   /// \return All nodes that match the given filters from the gcs without the cache.
-  virtual StatusOr<std::vector<rpc::GcsNodeInfo>> GetAllNoCacheWithFilters(
+  virtual StatusOr<std::vector<rpc::GcsNodeInfo>> GetAllNoCache(
       int64_t timeout_ms,
-      rpc::GcsNodeInfo::GcsNodeState state_filter,
-      rpc::GetAllNodeInfoRequest::NodeSelector node_selector);
+      std::optional<rpc::GcsNodeInfo::GcsNodeState> state_filter = std::nullopt,
+      std::optional<rpc::GetAllNodeInfoRequest::NodeSelector> node_selector =
+          std::nullopt);
 
   /// Send a check alive request to GCS for the liveness of some nodes.
   ///

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -415,7 +415,7 @@ ray::Status GlobalStateAccessor::GetNode(const std::string &node_id_hex_str,
       auto timeout_ms =
           std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
       RAY_ASSIGN_OR_RETURN(node_infos,
-                           gcs_client_->Nodes().GetAllNoCacheWithFilters(
+                           gcs_client_->Nodes().GetAllNoCache(
                                timeout_ms, rpc::GcsNodeInfo::ALIVE, std::move(selector)));
     }
     if (!node_infos.empty()) {
@@ -449,7 +449,7 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
       auto timeout_ms =
           std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
       RAY_ASSIGN_OR_RETURN(node_infos,
-                           gcs_client_->Nodes().GetAllNoCacheWithFilters(
+                           gcs_client_->Nodes().GetAllNoCache(
                                timeout_ms, rpc::GcsNodeInfo::ALIVE, selector));
     }
     if (!node_infos.empty()) {
@@ -468,7 +468,7 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
       absl::ReaderMutexLock lock(&mutex_);
       auto timeout_ms = end_time_point - current_time_ms();
       RAY_ASSIGN_OR_RETURN(node_infos,
-                           gcs_client_->Nodes().GetAllNoCacheWithFilters(
+                           gcs_client_->Nodes().GetAllNoCache(
                                timeout_ms, rpc::GcsNodeInfo::ALIVE, selector));
     }
     if (node_infos.empty() && node_ip_address == gcs_address) {
@@ -478,7 +478,7 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
         auto timeout_ms =
             std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
         RAY_ASSIGN_OR_RETURN(node_infos,
-                             gcs_client_->Nodes().GetAllNoCacheWithFilters(
+                             gcs_client_->Nodes().GetAllNoCache(
                                  timeout_ms, rpc::GcsNodeInfo::ALIVE, selector));
       }
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently usage stats report number of alive nodes by fetching all nodes and filter out dead ones. The GetAllNodeInfo RPC supports filtering on the GCS side so we should do that.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
