### PR TITLE
Fix test_deepseek_model release test

### DIFF
--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -147,6 +147,7 @@ def test_deepseek_model(model_name):
             enable_chunked_prefill=True,
             enable_prefix_caching=True,
             enforce_eager=True,
+            trust_remote_code=True,
         ),
     )
     app = build_openai_app({"llm_configs": [llm_config]})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `transformers` downgrade PR https://github.com/ray-project/ray/pull/55295 failed its release test:
```
[36m(ServeController pid=10040)[0m INFO 2025-08-06 22:44:02,999 controller 10040 -- Deploying new version of Deployment(name='LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite', app='default') (initial target replicas: 1).
[36m(ServeController pid=10040)[0m INFO 2025-08-06 22:44:03,000 controller 10040 -- Deploying new version of Deployment(name='LLMRouter', app='default') (initial target replicas: 2).
[36m(ProxyActor pid=10151)[0m INFO 2025-08-06 22:44:03,030 proxy 10.0.213.0 -- Got updated endpoints: {Deployment(name='LLMRouter', app='default'): EndpointInfo(route='/', app_is_cross_language=False)}.
[36m(ProxyActor pid=10151)[0m INFO 2025-08-06 22:44:03,037 proxy 10.0.213.0 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x785e580a9350>.
[36m(ServeController pid=10040)[0m INFO 2025-08-06 22:44:03,132 controller 10040 -- Adding 1 replica to Deployment(name='LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite', app='default').
[36m(ServeController pid=10040)[0m INFO 2025-08-06 22:44:03,133 controller 10040 -- Adding 2 replicas to Deployment(name='LLMRouter', app='default').
[36m(ServeReplica:default:LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite pid=10269)[0m INFO 08-06 22:44:07 [__init__.py:235] Automatically detected platform cuda.
[36m(ServeReplica:default:LLMRouter pid=10271)[0m INFO 08-06 22:44:08 [__init__.py:235] Automatically detected platform cuda.
[36m(ServeReplica:default:LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite pid=10269)[0m INFO 2025-08-06 22:44:09,556 default_LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite oevs2gp7 -- Running tasks to download model files on worker nodes
[36m(download_model_files pid=10558)[0m No cloud storage mirror configured
[36m(download_model_files pid=10558)[0m INFO 08-06 22:44:14 [__init__.py:235] Automatically detected platform cuda.[32m [repeated 2x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)[0m
[36m(_get_vllm_engine_config pid=10558)[0m INFO 2025-08-06 22:44:15,442 serve 10558 -- Disabling request logging by default. To enable, set to False in engine_kwargs.
[36m(_get_vllm_engine_config pid=10558)[0m The original cause of the RayTaskError (<class 'pydantic_core._pydantic_core.ValidationError'>) isn't serializable: cannot pickle 'pydantic_core._pydantic_core.ArgsKwargs' object. Overwriting the cause to a RayError.
[36m(ServeController pid=10040)[0m ERROR 2025-08-06 22:44:15,930 controller 10040 -- Exception in Replica(id='oevs2gp7', deployment='LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite', app='default'), the replica will be stopped.
[36m(ServeController pid=10040)[0m Traceback (most recent call last):
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/deployment_state.py", line 730, in check_ready
[36m(ServeController pid=10040)[0m     ) = ray.get(self._ready_obj_ref)
[36m(ServeController pid=10040)[0m         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
[36m(ServeController pid=10040)[0m     return fn(*args, **kwargs)
[36m(ServeController pid=10040)[0m            ^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
[36m(ServeController pid=10040)[0m     return func(*args, **kwargs)
[36m(ServeController pid=10040)[0m            ^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 2867, in get
[36m(ServeController pid=10040)[0m     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
[36m(ServeController pid=10040)[0m                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 966, in get_objects
[36m(ServeController pid=10040)[0m     raise value.as_instanceof_cause()
[36m(ServeController pid=10040)[0m ray.exceptions.RayTaskError(RuntimeError): [36mray::ServeReplica:default:LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite.initialize_and_get_metadata()[39m (pid=10269, ip=10.0.213.0, actor_id=b152e39659cbf417dc6d3c8c02000000, repr=<ray.serve._private.replica.ServeReplica:default:LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite object at 0x7bbc93ee7710>)
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 449, in result
[36m(ServeController pid=10040)[0m     return self.__get_result()
[36m(ServeController pid=10040)[0m            ^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
[36m(ServeController pid=10040)[0m     raise self._exception
[36m(ServeController pid=10040)[0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 997, in initialize_and_get_metadata
[36m(ServeController pid=10040)[0m     await self._replica_impl.initialize(deployment_config)
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 714, in initialize
[36m(ServeController pid=10040)[0m     raise RuntimeError(traceback.format_exc()) from None
[36m(ServeController pid=10040)[0m RuntimeError: Traceback (most recent call last):
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 692, in initialize
[36m(ServeController pid=10040)[0m     await self._user_callable_wrapper.initialize_callable()
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1413, in initialize_callable
[36m(ServeController pid=10040)[0m     await self._call_func_or_gen(
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1359, in _call_func_or_gen
[36m(ServeController pid=10040)[0m     result = await result
[36m(ServeController pid=10040)[0m              ^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 160, in __init__
[36m(ServeController pid=10040)[0m     await self.start()
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 206, in start
[36m(ServeController pid=10040)[0m     await asyncio.wait_for(self._start_engine(), timeout=ENGINE_START_TIMEOUT_S)
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/asyncio/tasks.py", line 489, in wait_for
[36m(ServeController pid=10040)[0m     return fut.result()
[36m(ServeController pid=10040)[0m            ^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 252, in _start_engine
[36m(ServeController pid=10040)[0m     await self.engine.start()
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 185, in start
[36m(ServeController pid=10040)[0m     ) = self._prepare_engine_config(node_initialization)
[36m(ServeController pid=10040)[0m         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 291, in _prepare_engine_config
[36m(ServeController pid=10040)[0m     vllm_engine_args, vllm_engine_config = ray.get(ref)
[36m(ServeController pid=10040)[0m                                            ^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m            ^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m            ^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m ray.exceptions.RayTaskError: [36mray::_get_vllm_engine_config()[39m (pid=10558, ip=10.0.213.0)
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 61, in _get_vllm_engine_config
[36m(ServeController pid=10040)[0m     vllm_engine_config = async_engine_args.create_engine_config(
[36m(ServeController pid=10040)[0m                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/engine/arg_utils.py", line 1004, in create_engine_config
[36m(ServeController pid=10040)[0m     model_config = self.create_model_config()
[36m(ServeController pid=10040)[0m                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/engine/arg_utils.py", line 872, in create_model_config
[36m(ServeController pid=10040)[0m     return ModelConfig(
[36m(ServeController pid=10040)[0m            ^^^^^^^^^^^^
[36m(ServeController pid=10040)[0m   File "/home/ray/anaconda3/lib/python3.11/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
[36m(ServeController pid=10040)[0m     s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
[36m(ServeController pid=10040)[0m pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
[36m(ServeController pid=10040)[0m   Value error, The repository deepseek-ai/DeepSeek-V2-Lite contains custom code which must be executed to correctly load the model. You can inspect the repository content at https://hf.co/deepseek-ai/DeepSeek-V2-Lite .
[36m(ServeController pid=10040)[0m  You can inspect the repository content at https://hf.co/deepseek-ai/DeepSeek-V2-Lite.
[36m(ServeController pid=10040)[0m Please pass the argument `trust_remote_code=True` to allow custom code to be run. [type=value_error, input_value=ArgsKwargs((), {'model': ...attention_dtype': None}), input_type=ArgsKwargs]
[36m(ServeController pid=10040)[0m     For further information visit https://errors.pydantic.dev/2.10/v/value_error
[36m(ServeController pid=10040)[0m INFO 2025-08-06 22:44:15,935 controller 10040 -- Adding 1 replica to Deployment(name='LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite', app='default').
[36m(ServeController pid=10040)[0m INFO 2025-08-06 22:44:16,099 controller 10040 -- Replica(id='oevs2gp7', deployment='LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite', app='default') is stopped.
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
