### PR TITLE
[Data] Fixed sorting release test to produce 1Gb blocks

### DIFF
--- a/release/nightly_tests/dataset/sort_benchmark.py
+++ b/release/nightly_tests/dataset/sort_benchmark.py
@@ -9,7 +9,7 @@ import psutil
 from benchmark import Benchmark
 import ray
 from ray._private.internal_api import memory_summary
-from ray.data._internal.util import _check_pyarrow_version
+from ray.data._internal.util import _check_pyarrow_version, GiB
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import DataContext
 from ray.data.datasource import Datasource, ReadTask
@@ -120,11 +120,14 @@ if __name__ == "__main__":
     partition_size = int(float(args.partition_size))
     print(
         f"Dataset size: {num_partitions} partitions, "
-        f"{partition_size / 1e9}GB partition size, "
-        f"{num_partitions * partition_size / 1e9}GB total"
+        f"{partition_size / GiB}GB partition size, "
+        f"{num_partitions * partition_size / GiB}GB total"
     )
 
     def run_benchmark(args):
+        # Override target max-block size to avoid creating too many blocks
+        DataContext.get_current().target_max_block_size = 1 * GiB
+
         source = RandomIntRowDatasource()
         # Each row has an int64 key.
         num_rows_per_partition = partition_size // (8 + args.row_size_bytes)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After recent removal of `DataContext.target_shuffle_max_block_size` we now need to override `target_max_block_size` instead.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
