### PR TITLE
[image] add cuda 12.6 into the cuda image matrix

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -26,6 +26,7 @@ steps:
           - "12.3.2-cudnn9"
           - "12.4.1-cudnn"
           - "12.5.1-cudnn"
+          - "12.6.3-cudnn"
           - "12.8.1-cudnn"
     env:
       PYTHON_VERSION: "{{matrix.python}}"

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -67,7 +67,8 @@ steps:
         --platform cu11.7.1-cudnn8 --platform cu11.8.0-cudnn8
         --platform cu12.1.1-cudnn8 --platform cu12.3.2-cudnn9
         --platform cu12.4.1-cudnn --platform cu12.5.1-cudnn
-        --platform cu12.8.1-cudnn --platform cpu
+        --platform cu12.6.3-cudnn --platform cu12.8.1-cudnn
+        --platform cpu
         --image-type ray --upload
     depends_on:
       - manylinux

--- a/ci/ray_ci/docker_container.py
+++ b/ci/ray_ci/docker_container.py
@@ -15,6 +15,7 @@ PLATFORMS_RAY = [
     "cu12.3.2-cudnn9",
     "cu12.4.1-cudnn",
     "cu12.5.1-cudnn",
+    "cu12.6.3-cudnn",
     "cu12.8.1-cudnn",
 ]
 PLATFORMS_RAY_ML = [

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -399,6 +399,9 @@ class TestRayDockerContainer(RayCITestBase):
         container = RayDockerContainer(v, "cu12.5.1-cudnn", "ray")
         assert container.get_platform_tag() == "-cu125"
 
+        container = RayDockerContainer(v, "cu12.6.3-cudnn", "ray")
+        assert container.get_platform_tag() == "-cu126"
+
         container = RayDockerContainer(v, "cu12.8.1-cudnn", "ray")
         assert container.get_platform_tag() == "-cu128"
 


### PR DESCRIPTION
there is no cuda 12.7 on nvidia repo's image listing, so the list is complete now.
