### PR TITLE
[core][gpu-objects] Always write to GPUObjectStore to avoid `_get_tensor_meta()` from hanging indefinitely.

### DIFF
--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -648,13 +648,13 @@ class SerializationContext:
             self._torch_custom_serializer_registered = True
 
         serialized_val, tensors = self._serialize_and_retrieve_tensors(value)
-        if tensors:
-            obj_id = obj_id.decode("ascii")
-            worker = ray._private.worker.global_worker
-            gpu_object_manager = worker.gpu_object_manager
-            gpu_object_manager.gpu_object_store.add_object(
-                obj_id, tensors, is_primary=True
-            )
+        # Regardless of whether `tensors` is empty, we always store the GPU object
+        # in the GPU object store. This ensures that `_get_tensor_meta` is not
+        # blocked indefinitely.
+        obj_id = obj_id.decode("ascii")
+        worker = ray._private.worker.global_worker
+        gpu_object_manager = worker.gpu_object_manager
+        gpu_object_manager.gpu_object_store.add_object(obj_id, tensors, is_primary=True)
 
         return serialized_val
 

--- a/python/ray/tests/test_gpu_objects_gloo.py
+++ b/python/ray/tests/test_gpu_objects_gloo.py
@@ -203,6 +203,20 @@ def test_p2p(ray_start_regular):
     assert ray.get(result) == pytest.approx(medium_tensor * 2)
 
 
+def test_p2p_with_cpu_data(ray_start_regular):
+    world_size = 2
+    actors = [GPUTestActor.remote() for _ in range(world_size)]
+    create_collective_group(actors, backend="torch_gloo")
+
+    sender = actors[0]
+    receiver = actors[1]
+
+    cpu_data = 123
+    ref = sender.echo.remote(cpu_data)
+    result = receiver.double.remote(ref)
+    assert ray.get(result) == cpu_data * 2
+
+
 def test_send_same_ref_to_same_actor_task_multiple_times(ray_start_regular):
     world_size = 2
     actors = [GPUTestActor.remote() for _ in range(world_size)]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when the sender actor serializes the value of a task output, it only updates the GPU object store if `tensors` is not empty [1]. However, if `value` doesn't include tensors, `_get_tensor_meta` will hang [2].

[1]
https://github.com/ray-project/ray/blob/ba775da115f97e8fe0f9287360aa3aa110b6749b/python/ray/_private/serialization.py#L651-L657

[2]
https://github.com/ray-project/ray/blob/ba775da115f97e8fe0f9287360aa3aa110b6749b/python/ray/experimental/gpu_object_manager/gpu_object_store.py#L94

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
