### PR TITLE
[ci] shorten test name of `concurrency_group_manager_test`

### DIFF
--- a/src/ray/core_worker/task_execution/test/BUILD.bazel
+++ b/src/ray/core_worker/task_execution/test/BUILD.bazel
@@ -23,8 +23,9 @@ ray_cc_test(
     ],
 )
 
+# Test name is shortened for running on Windows.
 ray_cc_test(
-    name = "concurrency_group_manager_test",
+    name = "concurrency_grp_mgr_test",
     srcs = ["concurrency_group_manager_test.cc"],
     tags = ["team:core"],
     deps = [


### PR DESCRIPTION
fixes #55441
