### PR TITLE
[core] give `should_fetch_cluster_id_` an init value

### DIFF
--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -87,7 +87,7 @@ class GcsClientOptions {
   std::string gcs_address_;
   int gcs_port_ = 0;
   ClusterID cluster_id_;
-  bool should_fetch_cluster_id_;
+  bool should_fetch_cluster_id_ = false;
 };
 
 /// \class GcsClient


### PR DESCRIPTION
fixes core worker's ubsan test, makes sure it is a bool value. `CoreWorkOptions` contains a `GcsClientOptions` which is initialized with default constructor.
