### PR TITLE
make get_current_servable_instance async

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -432,7 +432,7 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
     from fastapi import APIRouter, Depends
     from fastapi.routing import APIRoute, APIWebSocketRoute
 
-    def get_current_servable_instance():
+    async def get_current_servable_instance():
         from ray import serve
 
         return serve.get_replica_context().servable_object


### PR DESCRIPTION
This PR updates the injected dependency used in FastAPI routes to be asynchronous. Specifically, it modifies the implementation of get_current_servable_instance to be an async def so that FastAPI awaits it instead of offloading it to a threadpool. This change avoids unnecessary threadpool overhead and improves request performance.

### Performance Comparison Table (With fix vs Master)

| Metric                   | With fix       | Master         |
|--------------------------|----------------|----------------|
| # Requests               | 22,429         | 12,970         |
| # Fails                  | 0              | 0              |
| Median (ms)              | 250            | 340            |
| 95%ile (ms)              | 310            | 430            |
| 99%ile (ms)              | 350            | 480            |
| Average (ms)             | 248.04         | 338.4          |
| Min (ms)                 | 119            | 156            |
| Max (ms)                 | 392            | 662            |
| Average size (bytes)     | 15             | 15             |
| Current RPS              | 400.2          | 295.7          |
| Current Failures/s       | 0              | 0              |


evidence that fastapi dependency injection is using threadpool

### master

<img width="2560" height="594" alt="image" src="https://github.com/user-attachments/assets/90091fc7-c93d-49b1-bd0a-a2449122f548" />

### after fix

<img width="2050" height="466" alt="image" src="https://github.com/user-attachments/assets/9ca04860-ec0b-4d4a-9e32-efe5afc77d30" />



### app used for benchmark

```python
app = FastAPI()

@serve.deployment(max_ongoing_requests=10000)
@serve.ingress(app)
class MyDeployment:
    @app.get("/")
    async def request(self):
        return "Hello, world!"


app = MyDeployment.bind()
```
run using `serve run app:app`

device used: `m6a.2xlarge`
Concurrency: `100`