### PR TITLE
[LLM] support custom s3 endpoint when downloading models from remote

### DIFF
--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -148,7 +148,13 @@ class CloudFileSystem:
                 object_uri = f"{scheme}://{parts[1]}"
 
         if object_uri.startswith("s3://"):
-            fs = pa_fs.S3FileSystem(anonymous=anonymous)
+            endpoint = os.getenv("AWS_ENDPOINT_URL_S3", None)
+            virtual_hosted_style = os.getenv("AWS_S3_ADDRESSING_STYLE", None)
+            fs = pa_fs.S3FileSystem(
+                anonymous=anonymous,
+                endpoint_override=endpoint,
+                force_virtual_addressing=(virtual_hosted_style == "virtual"),
+            )
             path = object_uri[5:]  # Remove "s3://"
         elif object_uri.startswith("gs://"):
             fs = pa_fs.GcsFileSystem(anonymous=anonymous)


### PR DESCRIPTION
## Why are these changes needed?
Arrow doesn't pickup endpoint_url from ~/.aws/config or env variables. If using a service compatible with AWS S3, it will not work.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
