### PR TITLE
[serve] Add a function with a Warning to migrate constants that use `or` expression.

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -4,7 +4,7 @@ from ray.serve._private.constants_utils import (
     get_env_bool,
     get_env_float,
     get_env_float_non_negative,
-    get_env_float_warning_till_2_50,
+    get_env_float_warning,
     get_env_int,
     get_env_int_positive,
     get_env_str,
@@ -132,14 +132,14 @@ DEFAULT_MAX_ONGOING_REQUESTS = 5
 DEFAULT_TARGET_ONGOING_REQUESTS = 2
 
 # HTTP Proxy health check configs
-PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_warning_till_2_50(
+PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_warning(
     "RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S", 10.0
 )
 
-PROXY_HEALTH_CHECK_PERIOD_S = get_env_float_warning_till_2_50(
+PROXY_HEALTH_CHECK_PERIOD_S = get_env_float_warning(
     "RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S", 10.0
 )
-PROXY_READY_CHECK_TIMEOUT_S = get_env_float_warning_till_2_50(
+PROXY_READY_CHECK_TIMEOUT_S = get_env_float_warning(
     "RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S", 5.0
 )
 
@@ -148,7 +148,7 @@ PROXY_READY_CHECK_TIMEOUT_S = get_env_float_warning_till_2_50(
 PROXY_HEALTH_CHECK_UNHEALTHY_THRESHOLD = 3
 
 # The minimum drain period for a HTTP proxy.
-PROXY_MIN_DRAINING_PERIOD_S = get_env_float_warning_till_2_50(
+PROXY_MIN_DRAINING_PERIOD_S = get_env_float_warning(
     "RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", 30.0
 )
 # The time in seconds that the http proxy state waits before
@@ -167,7 +167,7 @@ CLIENT_POLLING_INTERVAL_S = 1.0
 CLIENT_CHECK_CREATION_POLLING_INTERVAL_S = 0.1
 
 # Timeout for GCS internal KV service
-RAY_SERVE_KV_TIMEOUT_S = get_env_float_warning_till_2_50("RAY_SERVE_KV_TIMEOUT_S", None)
+RAY_SERVE_KV_TIMEOUT_S = get_env_float_warning("RAY_SERVE_KV_TIMEOUT_S", None)
 
 # Timeout for GCS RPC request
 RAY_GCS_RPC_TIMEOUT_S = 3.0

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -4,7 +4,7 @@ from ray.serve._private.constants_utils import (
     get_env_bool,
     get_env_float,
     get_env_float_non_negative,
-    get_env_float_warning,
+    get_env_float_non_zero_with_warning,
     get_env_int,
     get_env_int_positive,
     get_env_str,
@@ -132,14 +132,14 @@ DEFAULT_MAX_ONGOING_REQUESTS = 5
 DEFAULT_TARGET_ONGOING_REQUESTS = 2
 
 # HTTP Proxy health check configs
-PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_warning(
+PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_non_zero_with_warning(
     "RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S", 10.0
 )
 
-PROXY_HEALTH_CHECK_PERIOD_S = get_env_float_warning(
+PROXY_HEALTH_CHECK_PERIOD_S = get_env_float_non_zero_with_warning(
     "RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S", 10.0
 )
-PROXY_READY_CHECK_TIMEOUT_S = get_env_float_warning(
+PROXY_READY_CHECK_TIMEOUT_S = get_env_float_non_zero_with_warning(
     "RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S", 5.0
 )
 
@@ -148,7 +148,7 @@ PROXY_READY_CHECK_TIMEOUT_S = get_env_float_warning(
 PROXY_HEALTH_CHECK_UNHEALTHY_THRESHOLD = 3
 
 # The minimum drain period for a HTTP proxy.
-PROXY_MIN_DRAINING_PERIOD_S = get_env_float_warning(
+PROXY_MIN_DRAINING_PERIOD_S = get_env_float_non_zero_with_warning(
     "RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", 30.0
 )
 # The time in seconds that the http proxy state waits before
@@ -167,7 +167,9 @@ CLIENT_POLLING_INTERVAL_S = 1.0
 CLIENT_CHECK_CREATION_POLLING_INTERVAL_S = 0.1
 
 # Timeout for GCS internal KV service
-RAY_SERVE_KV_TIMEOUT_S = get_env_float_warning("RAY_SERVE_KV_TIMEOUT_S", None)
+RAY_SERVE_KV_TIMEOUT_S = get_env_float_non_zero_with_warning(
+    "RAY_SERVE_KV_TIMEOUT_S", None
+)
 
 # Timeout for GCS RPC request
 RAY_GCS_RPC_TIMEOUT_S = 3.0

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -4,7 +4,7 @@ from ray.serve._private.constants_utils import (
     get_env_bool,
     get_env_float,
     get_env_float_non_negative,
-    get_env_float_positive,
+    get_env_float_warning_till_2_50,
     get_env_int,
     get_env_int_positive,
     get_env_str,
@@ -132,14 +132,14 @@ DEFAULT_MAX_ONGOING_REQUESTS = 5
 DEFAULT_TARGET_ONGOING_REQUESTS = 2
 
 # HTTP Proxy health check configs
-PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_positive(
+PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_warning_till_2_50(
     "RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S", 10.0
 )
 
-PROXY_HEALTH_CHECK_PERIOD_S = get_env_float_positive(
+PROXY_HEALTH_CHECK_PERIOD_S = get_env_float_warning_till_2_50(
     "RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S", 10.0
 )
-PROXY_READY_CHECK_TIMEOUT_S = get_env_float_positive(
+PROXY_READY_CHECK_TIMEOUT_S = get_env_float_warning_till_2_50(
     "RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S", 5.0
 )
 
@@ -148,7 +148,7 @@ PROXY_READY_CHECK_TIMEOUT_S = get_env_float_positive(
 PROXY_HEALTH_CHECK_UNHEALTHY_THRESHOLD = 3
 
 # The minimum drain period for a HTTP proxy.
-PROXY_MIN_DRAINING_PERIOD_S = get_env_float_positive(
+PROXY_MIN_DRAINING_PERIOD_S = get_env_float_warning_till_2_50(
     "RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", 30.0
 )
 # The time in seconds that the http proxy state waits before
@@ -167,7 +167,7 @@ CLIENT_POLLING_INTERVAL_S = 1.0
 CLIENT_CHECK_CREATION_POLLING_INTERVAL_S = 0.1
 
 # Timeout for GCS internal KV service
-RAY_SERVE_KV_TIMEOUT_S = get_env_float_positive("RAY_SERVE_KV_TIMEOUT_S", None)
+RAY_SERVE_KV_TIMEOUT_S = get_env_float_warning_till_2_50("RAY_SERVE_KV_TIMEOUT_S", None)
 
 # Timeout for GCS RPC request
 RAY_GCS_RPC_TIMEOUT_S = 3.0

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -4,6 +4,7 @@ from ray.serve._private.constants_utils import (
     get_env_bool,
     get_env_float,
     get_env_float_non_negative,
+    get_env_float_positive,
     get_env_int,
     get_env_int_positive,
     get_env_str,
@@ -131,15 +132,15 @@ DEFAULT_MAX_ONGOING_REQUESTS = 5
 DEFAULT_TARGET_ONGOING_REQUESTS = 2
 
 # HTTP Proxy health check configs
-PROXY_HEALTH_CHECK_TIMEOUT_S = (
-    get_env_float("RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S", 10.0) or 10.0
+PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_positive(
+    "RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S", 10.0
 )
 
-PROXY_HEALTH_CHECK_PERIOD_S = (
-    get_env_float("RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S", 10.0) or 10.0
+PROXY_HEALTH_CHECK_PERIOD_S = get_env_float_positive(
+    "RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S", 10.0
 )
-PROXY_READY_CHECK_TIMEOUT_S = (
-    get_env_float("RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S", 5.0) or 5.0
+PROXY_READY_CHECK_TIMEOUT_S = get_env_float_positive(
+    "RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S", 5.0
 )
 
 # Number of times in a row that a HTTP proxy must fail the health check before
@@ -147,8 +148,8 @@ PROXY_READY_CHECK_TIMEOUT_S = (
 PROXY_HEALTH_CHECK_UNHEALTHY_THRESHOLD = 3
 
 # The minimum drain period for a HTTP proxy.
-PROXY_MIN_DRAINING_PERIOD_S = (
-    get_env_float("RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", 30.0) or 30.0
+PROXY_MIN_DRAINING_PERIOD_S = get_env_float_positive(
+    "RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S", 30.0
 )
 # The time in seconds that the http proxy state waits before
 # rechecking whether the proxy actor is drained or not.
@@ -166,7 +167,7 @@ CLIENT_POLLING_INTERVAL_S = 1.0
 CLIENT_CHECK_CREATION_POLLING_INTERVAL_S = 0.1
 
 # Timeout for GCS internal KV service
-RAY_SERVE_KV_TIMEOUT_S = get_env_float("RAY_SERVE_KV_TIMEOUT_S", 0.0) or None
+RAY_SERVE_KV_TIMEOUT_S = get_env_float_positive("RAY_SERVE_KV_TIMEOUT_S", None)
 
 # Timeout for GCS RPC request
 RAY_GCS_RPC_TIMEOUT_S = 3.0

--- a/python/ray/serve/_private/constants_utils.py
+++ b/python/ray/serve/_private/constants_utils.py
@@ -249,9 +249,9 @@ def get_env_float_warning_till_2_50(
             # warning message if unexpected value
             warnings.warn(
                 f"Got unexpected value `{env_value}` for `{name}` environment variable! "
-                f"Starting from version {removal_version}, the environment variable `{name}` will require a positive value. "
+                f"Starting from version `{removal_version}`, the environment variable `{name}` will require a positive value. "
                 f"Either set a positive value or remove this variable to use the default value `{default}`. "
-                f"Your current Ray version is {current_version}.",
+                f"Your current Ray version is `{current_version}`.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/python/ray/serve/_private/constants_utils.py
+++ b/python/ray/serve/_private/constants_utils.py
@@ -53,7 +53,7 @@ def _get_env_value(
     default: Optional[T],
     value_type: Type[T],
     validation_func: Optional[Callable[[T], bool]] = None,
-    failed_validation_req_str: str = None,
+    expected_value_description: str = None,
 ) -> Optional[T]:
     """Get environment variable with type conversion and validation.
 
@@ -67,7 +67,7 @@ def _get_env_value(
         value_type: Type to convert the environment variable value to (e.g., int, float, str).
         validation_func: Optional function that takes the converted value and returns
                        a boolean indicating whether the value is valid.
-        failed_validation_req_str: Description of the expected value characteristics
+        expected_value_description: Description of the expected value characteristics
                                  (e.g., "positive", "non negative") used in error messages.
 
     Returns:
@@ -92,7 +92,7 @@ def _get_env_value(
     if validation_func and not validation_func(value):
         raise ValueError(
             f"Got unexpected value `{value}` for `{name}` environment variable! "
-            f"Expected {failed_validation_req_str} `{value_type.__name__}`."
+            f"Expected {expected_value_description} `{value_type.__name__}`."
         )
 
     return value
@@ -222,7 +222,9 @@ def get_env_bool(name: str, default: Optional[str]) -> bool:
     return os.environ.get(name, default) == "1"
 
 
-def get_env_float_warning(name: str, default: Optional[float]) -> Optional[float]:
+def get_env_float_non_zero_with_warning(
+    name: str, default: Optional[float]
+) -> Optional[float]:
     """Introduced for backward compatibility for constants:
 
     PROXY_HEALTH_CHECK_TIMEOUT_S
@@ -231,7 +233,7 @@ def get_env_float_warning(name: str, default: Optional[float]) -> Optional[float
     PROXY_MIN_DRAINING_PERIOD_S
     RAY_SERVE_KV_TIMEOUT_S
 
-    todo: remove the function after 2.49.0 release - use get_env_float_positive instead
+    todo: replace this function with 'get_env_float_positive' for the '2.50.0' release.
     """
     removal_version = "2.50.0"
 
@@ -242,8 +244,8 @@ def get_env_float_warning(name: str, default: Optional[float]) -> Optional[float
         # warning message if unexpected value
         warnings.warn(
             f"Got unexpected value `{env_value}` for `{name}` environment variable! "
-            f"Starting from version `{removal_version}`, the environment variable `{name}` will require a positive value. "
-            f"Be aware that the value that is used from the variable is `{backward_compatible_result}`. ",
+            f"Starting from version `{removal_version}`, the environment variable will require a positive value. "
+            f"Setting `{name}` to `{backward_compatible_result}`. ",
             FutureWarning,
             stacklevel=2,
         )

--- a/python/ray/serve/_private/constants_utils.py
+++ b/python/ray/serve/_private/constants_utils.py
@@ -57,21 +57,25 @@ def _get_env_value(
     default: Optional[T],
     value_type: Type[T],
     validation_func: Optional[Callable[[T], bool]] = None,
-    requirement_in_error: str = None,
+    failed_validation_req_str: str = None,
 ) -> Optional[T]:
     """Get environment variable with type conversion and validation.
+
+    This function retrieves an environment variable, converts it to the specified type,
+    and optionally validates the converted value.
 
     Args:
         name: The name of the environment variable.
         default: Default value to use if the environment variable is not set.
-        value_type: Type to convert the environment variable value to.
-        validation_func: Optional validation function that takes the converted
-            value and returns a boolean indicating if the value is valid.
-        requirement_in_error: Error message to use if type conversion fails
-            or validation check fails.
+               If None, the function will return None without validation.
+        value_type: Type to convert the environment variable value to (e.g., int, float, str).
+        validation_func: Optional function that takes the converted value and returns
+                       a boolean indicating whether the value is valid.
+        failed_validation_req_str: Description of the expected value characteristics
+                                 (e.g., "positive", "non negative") used in error messages.
 
     Returns:
-        The converted and validated environment variable,
+        The environment variable value converted to the specified type and validated,
         or the default value if the environment variable is not set.
 
     Raises:
@@ -92,7 +96,7 @@ def _get_env_value(
     if validation_func and not validation_func(value):
         raise ValueError(
             f"Got unexpected value `{value}` for `{name}` environment variable! "
-            f"Expected {requirement_in_error} `{value_type.__name__}`."
+            f"Expected {failed_validation_req_str} `{value_type.__name__}`."
         )
 
     return value
@@ -233,7 +237,7 @@ def get_env_float_warning_till_2_50(
     PROXY_MIN_DRAINING_PERIOD_S
     RAY_SERVE_KV_TIMEOUT_S
 
-    todo: after the 2.49.0 release - delete this function and use get_env_float_positive instead
+    todo: remove the function after 2.49.0 release - use get_env_float_positive instead
     """
     current_version = packaging_version.parse(ray.__version__)
     removal_version = packaging_version.parse("2.50.0")

--- a/python/ray/serve/tests/unit/test_constants_utils.py
+++ b/python/ray/serve/tests/unit/test_constants_utils.py
@@ -8,8 +8,8 @@ from ray.serve._private.constants_utils import (
     get_env_bool,
     get_env_float,
     get_env_float_non_negative,
+    get_env_float_non_zero_with_warning,
     get_env_float_positive,
-    get_env_float_warning,
     get_env_int,
     get_env_int_non_negative,
     get_env_int_positive,
@@ -221,7 +221,7 @@ class TestDeprecationFunctions:
         env_name = "TEST_POSITIVE_FLOAT"
         mock_environ[env_name] = "5.5"
 
-        result = get_env_float_warning(env_name, 10.0)
+        result = get_env_float_non_zero_with_warning(env_name, 10.0)
 
         assert result == 5.5
 
@@ -231,7 +231,7 @@ class TestDeprecationFunctions:
         mock_environ[env_name] = "-2.5"
 
         with pytest.warns(FutureWarning) as record:
-            result = get_env_float_warning(env_name, 10.0)
+            result = get_env_float_non_zero_with_warning(env_name, 10.0)
 
         assert result == -2.5
         assert len(record) == 1
@@ -243,7 +243,7 @@ class TestDeprecationFunctions:
         mock_environ[env_name] = "0.0"
 
         with pytest.warns(FutureWarning) as record:
-            result = get_env_float_warning(env_name, 10.0)
+            result = get_env_float_non_zero_with_warning(env_name, 10.0)
 
         assert result == 10.0
         assert len(record) == 1
@@ -254,7 +254,7 @@ class TestDeprecationFunctions:
         env_name = "TEST_MISSING_FLOAT"
         # Don't set environment variable
 
-        result = get_env_float_warning(env_name, 1.0)
+        result = get_env_float_non_zero_with_warning(env_name, 1.0)
 
         assert result == 1.0
 
@@ -263,26 +263,26 @@ class TestDeprecationFunctions:
         env_name = "TEST_FLOAT"
         mock_environ[env_name] = "2.0"
 
-        assert get_env_float_warning(env_name, 1.0) == 2.0
+        assert get_env_float_non_zero_with_warning(env_name, 1.0) == 2.0
 
         mock_environ["TEST_VAR"] = "-1.2"
-        assert get_env_float_warning("TEST_VAR", 5.0) == -1.2
+        assert get_env_float_non_zero_with_warning("TEST_VAR", 5.0) == -1.2
 
         mock_environ["TEST_VAR"] = "0.0"
-        assert get_env_float_warning("TEST_VAR", 5.0) == 5.0
+        assert get_env_float_non_zero_with_warning("TEST_VAR", 5.0) == 5.0
 
     @mock.patch("ray.__version__", "2.51.0")  # Version after 2.50.0
     def test_remain_the_same_behavior_after_2_50(self, mock_environ):
         env_name = "TEST_FLOAT"
         mock_environ[env_name] = "2.0"
 
-        assert get_env_float_warning(env_name, 1.0) == 2.0
+        assert get_env_float_non_zero_with_warning(env_name, 1.0) == 2.0
 
         mock_environ["TEST_VAR"] = "-1.2"
-        assert get_env_float_warning("TEST_VAR", 5.0) == -1.2
+        assert get_env_float_non_zero_with_warning("TEST_VAR", 5.0) == -1.2
 
         mock_environ["TEST_VAR"] = "0.0"
-        assert get_env_float_warning("TEST_VAR", 5.0) == 5.0
+        assert get_env_float_non_zero_with_warning("TEST_VAR", 5.0) == 5.0
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_constants_utils.py
+++ b/python/ray/serve/tests/unit/test_constants_utils.py
@@ -130,12 +130,12 @@ class TestEnvValueFunctions:
         mock_environ["TEST_VAR"] = "42"
         assert get_env_int_non_negative("TEST_VAR", 0) == 42
 
-        with pytest.raises(ValueError, match=".*unexpected default value `-1`.*"):
-            get_env_int_non_negative("TEST_VAR", -1)
-
         mock_environ["TEST_VAR"] = "-1"
         with pytest.raises(ValueError, match=".*Expected non negative `int`.*"):
             get_env_int_non_negative("TEST_VAR", 5)
+
+        with pytest.raises(ValueError, match=".*Expected non negative `int`.*"):
+            get_env_int_non_negative("TEST_VAR_FROM_DEFAULT", -1)
 
     def test_get_env_float(self, mock_environ):
         assert get_env_float("TEST_VAR", 0.0) == 0.0
@@ -159,12 +159,15 @@ class TestEnvValueFunctions:
         mock_environ["TEST_VAR"] = "42.5"
         assert get_env_float_positive("TEST_VAR", 1.0) == 42.5
 
-        with pytest.raises(ValueError, match=".*unexpected default value `0.0`.*"):
-            get_env_float_positive("TEST_VAR", 0.0)
-
         mock_environ["TEST_VAR"] = "-1.2"
         with pytest.raises(ValueError, match=".*Expected positive `float`.*"):
             get_env_float_positive("TEST_VAR", 5.0)
+
+        with pytest.raises(ValueError, match=".*Expected positive `float`.*"):
+            get_env_float_positive("TEST_VAR_FROM_DEFAULT", 0.0)
+
+        with pytest.raises(ValueError, match=".*Expected positive `float`.*"):
+            get_env_float_positive("TEST_VAR_FROM_DEFAULT", -1)
 
     def test_get_env_float_non_negative(self, mock_environ):
         assert get_env_float_non_negative("TEST_VAR", 0.0) == 0.0

--- a/python/ray/serve/tests/unit/test_constants_utils.py
+++ b/python/ray/serve/tests/unit/test_constants_utils.py
@@ -9,7 +9,7 @@ from ray.serve._private.constants_utils import (
     get_env_float,
     get_env_float_non_negative,
     get_env_float_positive,
-    get_env_float_warning_till_2_50,
+    get_env_float_warning,
     get_env_int,
     get_env_int_non_negative,
     get_env_int_positive,
@@ -221,7 +221,7 @@ class TestDeprecationFunctions:
         env_name = "TEST_POSITIVE_FLOAT"
         mock_environ[env_name] = "5.5"
 
-        result = get_env_float_warning_till_2_50(env_name, 10.0)
+        result = get_env_float_warning(env_name, 10.0)
 
         assert result == 5.5
 
@@ -231,7 +231,7 @@ class TestDeprecationFunctions:
         mock_environ[env_name] = "-2.5"
 
         with pytest.warns(FutureWarning) as record:
-            result = get_env_float_warning_till_2_50(env_name, 10.0)
+            result = get_env_float_warning(env_name, 10.0)
 
         assert result == -2.5
         assert len(record) == 1
@@ -243,7 +243,7 @@ class TestDeprecationFunctions:
         mock_environ[env_name] = "0.0"
 
         with pytest.warns(FutureWarning) as record:
-            result = get_env_float_warning_till_2_50(env_name, 10.0)
+            result = get_env_float_warning(env_name, 10.0)
 
         assert result == 10.0
         assert len(record) == 1
@@ -254,39 +254,35 @@ class TestDeprecationFunctions:
         env_name = "TEST_MISSING_FLOAT"
         # Don't set environment variable
 
-        result = get_env_float_warning_till_2_50(env_name, 1.0)
+        result = get_env_float_warning(env_name, 1.0)
 
         assert result == 1.0
 
     @mock.patch("ray.__version__", "2.50.0")  # Version at 2.50.0
-    def test_delegates_to_positive_at_250(self, mock_environ):
+    def test_remain_the_same_behavior_at_2_50(self, mock_environ):
         env_name = "TEST_FLOAT"
         mock_environ[env_name] = "2.0"
 
-        assert get_env_float_warning_till_2_50(env_name, 1.0) == 2.0
+        assert get_env_float_warning(env_name, 1.0) == 2.0
 
         mock_environ["TEST_VAR"] = "-1.2"
-        with pytest.raises(ValueError, match=".*Expected positive `float`.*"):
-            get_env_float_warning_till_2_50("TEST_VAR", 5.0)
+        assert get_env_float_warning("TEST_VAR", 5.0) == -1.2
 
         mock_environ["TEST_VAR"] = "0.0"
-        with pytest.raises(ValueError, match=".*Expected positive `float`.*"):
-            get_env_float_warning_till_2_50("TEST_VAR", 5.0)
+        assert get_env_float_warning("TEST_VAR", 5.0) == 5.0
 
     @mock.patch("ray.__version__", "2.51.0")  # Version after 2.50.0
-    def test_delegates_to_positive_after_250(self, mock_environ):
+    def test_remain_the_same_behavior_after_2_50(self, mock_environ):
         env_name = "TEST_FLOAT"
         mock_environ[env_name] = "2.0"
 
-        assert get_env_float_warning_till_2_50(env_name, 1.0) == 2.0
+        assert get_env_float_warning(env_name, 1.0) == 2.0
 
         mock_environ["TEST_VAR"] = "-1.2"
-        with pytest.raises(ValueError, match=".*Expected positive `float`.*"):
-            get_env_float_warning_till_2_50("TEST_VAR", 5.0)
+        assert get_env_float_warning("TEST_VAR", 5.0) == -1.2
 
         mock_environ["TEST_VAR"] = "0.0"
-        with pytest.raises(ValueError, match=".*Expected positive `float`.*"):
-            get_env_float_warning_till_2_50("TEST_VAR", 5.0)
+        assert get_env_float_warning("TEST_VAR", 5.0) == 5.0
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_constants_utils.py
+++ b/python/ray/serve/tests/unit/test_constants_utils.py
@@ -95,13 +95,13 @@ def mock_environ():
 
 class TestEnvValueFunctions:
     def test_get_env_int(self, mock_environ):
-        assert 0 == get_env_int("TEST_VAR", 0)
+        assert get_env_int("TEST_VAR", 0) == 0
 
         mock_environ["TEST_VAR"] = "42"
-        assert 42 == get_env_int("TEST_VAR", 0)
+        assert get_env_int("TEST_VAR", 0) == 42
 
         mock_environ["TEST_VAR"] = "-1"
-        assert -1 == get_env_int("TEST_VAR", 0)
+        assert get_env_int("TEST_VAR", 0) == -1
 
         mock_environ["TEST_VAR"] = "0.1"
         with pytest.raises(ValueError, match=".*`0.1` cannot be converted to `int`!*"):
@@ -112,34 +112,37 @@ class TestEnvValueFunctions:
             get_env_int_positive("TEST_VAR", 5)
 
     def test_get_env_int_positive(self, mock_environ):
-        assert 1 == get_env_int_positive("TEST_VAR", 1)
+        assert get_env_int_positive("TEST_VAR", 1) == 1
 
         mock_environ["TEST_VAR"] = "42"
-        assert 42 == get_env_int_positive("TEST_VAR", 0)
+        assert get_env_int_positive("TEST_VAR", 1) == 42
 
         mock_environ["TEST_VAR"] = "-1"
         with pytest.raises(ValueError, match=".*Expected positive `int`.*"):
             get_env_int_positive("TEST_VAR", 5)
 
     def test_get_env_int_non_negative(self, mock_environ):
-        assert 0 == get_env_int_non_negative("TEST_VAR", 0)
-        assert 1 == get_env_int_non_negative("TEST_VAR", 1)
+        assert get_env_int_non_negative("TEST_VAR", 0) == 0
+        assert get_env_int_non_negative("TEST_VAR", 1) == 1
 
         mock_environ["TEST_VAR"] = "42"
-        assert 42 == get_env_int_non_negative("TEST_VAR", 0)
+        assert get_env_int_non_negative("TEST_VAR", 0) == 42
+
+        with pytest.raises(ValueError, match=".*unexpected default value `-1`.*"):
+            get_env_int_non_negative("TEST_VAR", -1)
 
         mock_environ["TEST_VAR"] = "-1"
         with pytest.raises(ValueError, match=".*Expected non negative `int`.*"):
             get_env_int_non_negative("TEST_VAR", 5)
 
     def test_get_env_float(self, mock_environ):
-        assert 0.0 == get_env_float("TEST_VAR", 0.0)
+        assert get_env_float("TEST_VAR", 0.0) == 0.0
 
         mock_environ["TEST_VAR"] = "3.14"
-        assert 3.14 == get_env_float("TEST_VAR", 0.0)
+        assert get_env_float("TEST_VAR", 0.0) == 3.14
 
         mock_environ["TEST_VAR"] = "-2.5"
-        assert -2.5 == get_env_float("TEST_VAR", 0.0)
+        assert get_env_float("TEST_VAR", 0.0) == -2.5
 
         mock_environ["TEST_VAR"] = "abc"
         with pytest.raises(
@@ -148,21 +151,25 @@ class TestEnvValueFunctions:
             get_env_float("TEST_VAR", 0.0)
 
     def test_get_env_float_positive(self, mock_environ):
-        assert 1.5 == get_env_float_positive("TEST_VAR", 1.5)
+        assert get_env_float_positive("TEST_VAR", 1.5) == 1.5
+        assert get_env_float_positive("TEST_VAR", None) is None
 
         mock_environ["TEST_VAR"] = "42.5"
-        assert 42.5 == get_env_float_positive("TEST_VAR", 0.0)
+        assert get_env_float_positive("TEST_VAR", 1.0) == 42.5
+
+        with pytest.raises(ValueError, match=".*unexpected default value `0.0`.*"):
+            get_env_float_positive("TEST_VAR", 0.0)
 
         mock_environ["TEST_VAR"] = "-1.2"
         with pytest.raises(ValueError, match=".*Expected positive `float`.*"):
             get_env_float_positive("TEST_VAR", 5.0)
 
     def test_get_env_float_non_negative(self, mock_environ):
-        assert 0.0 == get_env_float_non_negative("TEST_VAR", 0.0)
-        assert 1.5 == get_env_float_non_negative("TEST_VAR", 1.5)
+        assert get_env_float_non_negative("TEST_VAR", 0.0) == 0.0
+        assert get_env_float_non_negative("TEST_VAR", 1.5) == 1.5
 
         mock_environ["TEST_VAR"] = "42.5"
-        assert 42.5 == get_env_float_non_negative("TEST_VAR", 0.0)
+        assert get_env_float_non_negative("TEST_VAR", 0.0) == 42.5
 
         mock_environ["TEST_VAR"] = "-1.2"
         with pytest.raises(ValueError, match=".*Expected non negative `float`.*"):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the `serve` package some of the constants which are initialized from environment variables are silently replaced empty  values as `0` with their default values even if a user set them to `0` explicitly. In addition, they are also can be set to negative values which is likely not expected. 

The list of the constants:
```
PROXY_HEALTH_CHECK_TIMEOUT_S
PROXY_HEALTH_CHECK_PERIOD_S
PROXY_READY_CHECK_TIMEOUT_S
PROXY_MIN_DRAINING_PERIOD_S
--
RAY_SERVE_KV_TIMEOUT_S
```

It happens because of the `or value` structure.

This PR introduces:
- temporary function `get_env_float_non_zero_with_warning` with `FutureWarning`. The function is showing a warning in the following format in case of unexpected value:
```
FutureWarning: Got unexpected value `0.0` for `RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S` environment variable! Starting from version `2.50.0`, the environment variable will require a positive value. Setting `RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S` to `10.0`. 
  PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_non_zero_with_warning(
-- or
FutureWarning: Got unexpected value `-1.0` for `RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S` environment variable! Starting from version `2.50.0`, the environment variable will require a positive value. Setting `RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S` to `-1.0`. 
  PROXY_HEALTH_CHECK_TIMEOUT_S = get_env_float_non_zero_with_warning(
-- or
FutureWarning: Got unexpected value `0.0` for `RAY_SERVE_KV_TIMEOUT_S` environment variable! Starting from version `2.50.0`, the environment variable will require a positive value. Setting `RAY_SERVE_KV_TIMEOUT_S` to `None`. 
  RAY_SERVE_KV_TIMEOUT_S = get_env_float_non_zero_with_warning(
```
If the input value is positive, no warning will be emit.

- `None` default value support for env variables (introduced for the `RAY_SERVE_KV_TIMEOUT_S`)
- `todo` comment for removing the function: `todo: replace this function with 'get_env_float_positive' for the '2.50.0' release.`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #55454

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
