### PR TITLE
[release] Move logic to check whether to build custom BYOD image

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -30,13 +30,11 @@ REQUIREMENTS_LLM_BYOD = "requirements_llm_byod"
 REQUIREMENTS_ML_BYOD = "requirements_ml_byod"
 
 
-def build_anyscale_custom_byod_image(test: Test) -> None:
-    if not test.require_custom_byod_image():
-        logger.info(f"Test {test.get_name()} does not require a custom byod image")
-        return
-    byod_image = test.get_anyscale_byod_image()
-    if _image_exist(byod_image):
-        logger.info(f"Image {byod_image} already exists")
+def build_anyscale_custom_byod_image(
+    image: str, base_image: str, post_build_script: str
+) -> None:
+    if _image_exist(image):
+        logger.info(f"Image {image} already exists")
         return
 
     env = os.environ.copy()
@@ -47,11 +45,11 @@ def build_anyscale_custom_byod_image(test: Test) -> None:
             "build",
             "--progress=plain",
             "--build-arg",
-            f"BASE_IMAGE={test.get_anyscale_base_byod_image()}",
+            f"BASE_IMAGE={base_image}",
             "--build-arg",
-            f"POST_BUILD_SCRIPT={test.get_byod_post_build_script()}",
+            f"POST_BUILD_SCRIPT={post_build_script}",
             "-t",
-            byod_image,
+            image,
             "-f",
             os.path.join(RELEASE_BYOD_DIR, "byod.custom.Dockerfile"),
             RELEASE_BYOD_DIR,
@@ -59,7 +57,7 @@ def build_anyscale_custom_byod_image(test: Test) -> None:
         stdout=sys.stderr,
         env=env,
     )
-    _validate_and_push(byod_image)
+    _validate_and_push(image)
 
 
 def build_anyscale_base_byod_images(tests: List[Test]) -> None:

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -127,7 +127,12 @@ def main(
     build_anyscale_base_byod_images(tests)
     logger.info("Build anyscale custom BYOD images")
     for test in tests:
-        build_anyscale_custom_byod_image(test)
+        if test.require_custom_byod_image():
+            build_anyscale_custom_byod_image(
+                test.get_anyscale_byod_image(),
+                test.get_anyscale_base_byod_image(),
+                test.get_byod_post_build_script(),
+            )
     grouped_tests = group_tests(filtered_tests)
 
     group_str = ""

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -178,7 +178,12 @@ def _trigger_test_run(
 ) -> None:
     os.environ["COMMIT_TO_TEST"] = commit
     build_anyscale_base_byod_images([test])
-    build_anyscale_custom_byod_image(test)
+    if test.require_custom_byod_image():
+        build_anyscale_custom_byod_image(
+            test.get_anyscale_byod_image(),
+            test.get_anyscale_base_byod_image(),
+            test.get_byod_post_build_script(),
+        )
     for run in range(run_per_commit):
         step = get_step(
             copy.deepcopy(test),  # avoid mutating the original test

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -68,7 +68,11 @@ def test_build_anyscale_custom_byod_image() -> None:
             name="name",
             cluster={"byod": {"post_build_script": "foo.sh"}},
         )
-        build_anyscale_custom_byod_image(test)
+        build_anyscale_custom_byod_image(
+            test.get_anyscale_byod_image(),
+            test.get_anyscale_base_byod_image(),
+            test.get_byod_post_build_script(),
+        )
         assert "docker build --build-arg BASE_IMAGE=029272617770.dkr.ecr.us-west-2."
         "amazonaws.com/anyscale/ray:abc123-py37 -t 029272617770.dkr.ecr.us-west-2."
         "amazonaws.com/anyscale/ray:abc123-py37-c3fc5fc6d84cea4d7ab885c6cdc966542e"


### PR DESCRIPTION
The logic should be outside of this function. This PR:
- Moves the logic to outside of the func for every place that calls it.
- Turns the arg to be 3 separate ones so they can be called without a Test object (in order to do things like https://github.com/ray-project/ray/pull/55398 where Test object doesn't exist)
- Change the logic in another spot that calls `build_anyscale_custom_byod_image` that was missed last time in https://github.com/ray-project/ray/pull/55397 which caused release test pipeline to fail