### PR TITLE
[metrics][gcs] Make CPU metric on gcs more reliable

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -989,7 +989,9 @@ class ReporterAgent(
         if self._gcs_pid:
             gcs_proc = psutil.Process(self._gcs_pid)
             if gcs_proc:
-                return gcs_proc.as_dict(attrs=PSUTIL_PROCESS_ATTRS)
+                dictionary = gcs_proc.as_dict(attrs=PSUTIL_PROCESS_ATTRS)
+                dictionary["cpu_percent"] = gcs_proc.cpu_percent(interval=1)
+                return dictionary
         return {}
 
     def _get_raylet(self):


### PR DESCRIPTION
## Why are these changes needed?

gcs cpu metric consistenly reports zero.

This is because psutil.as_dict() seems to return zero very frequently.  cpu_percent() takes an interval argument which mitigates this, but psutil provides no utility for providing this argument in the as_dict() call. This is a 'minimal effort' patch to mitigate this behavior, but it remains somewhat of a mystery for why the other processes are unaffected by this the same way gcs metrics are.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
