### PR TITLE
[core] Fallback unserializable exceptions to their string representation

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -51,12 +51,12 @@ class RayError(Exception):
             except Exception as e:
                 msg = "Failed to unpickle serialized exception"
                 # Include a fallback string/stacktrace to aid debugging.
-                try:
-                    formatted = ray_exception.formatted_exception_string
-                except Exception:
-                    formatted = "No formatted exception string available."
-                if formatted:
-                    msg += f"\nOriginal exception (string repr):\n{formatted}"
+                formatted = getattr(
+                    ray_exception,
+                    "formatted_exception_string",
+                    "No formatted exception string available.",
+                )
+                msg += f"\nOriginal exception (string repr):\n{formatted}"
                 raise RuntimeError(msg) from e
         else:
             return CrossLanguageError(ray_exception)

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -50,6 +50,13 @@ class RayError(Exception):
                 return pickle.loads(ray_exception.serialized_exception)
             except Exception as e:
                 msg = "Failed to unpickle serialized exception"
+                # Include a fallback string/stacktrace to aid debugging.
+                try:
+                    formatted = ray_exception.formatted_exception_string
+                except Exception:
+                    formatted = "No formatted exception string available."
+                if formatted:
+                    msg += f"\nOriginal exception (string repr):\n{formatted}"
                 raise RuntimeError(msg) from e
         else:
             return CrossLanguageError(ray_exception)

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -51,6 +51,9 @@ class RayError(Exception):
             except Exception as e:
                 msg = "Failed to unpickle serialized exception"
                 # Include a fallback string/stacktrace to aid debugging.
+                #  formatted_exception_string is set in to_bytes() above by calling
+                # traceback.format_exception() on the original exception. It contains
+                # the string representation and stack trace of the original error.
                 formatted = getattr(
                     ray_exception,
                     "formatted_exception_string",

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -295,6 +295,15 @@ def test_actor_repr_in_traceback(ray_start_regular):
 
 def test_unpickleable_stacktrace(shutdown_only):
     expected_output = """System error: Failed to unpickle serialized exception
+Original exception (string repr):
+ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
+    exc_info=True)
+  File "FILE", line ZZ, in f
+    return g(c)
+  File "FILE", line ZZ, in g
+    raise NoPickleError("FILE")
+test_traceback.NoPickleError
+
 traceback: Traceback (most recent call last):
   File "FILE", line ZZ, in from_ray_exception
     return pickle.loads(ray_exception.serialized_exception)
@@ -311,7 +320,15 @@ Traceback (most recent call last):
     return RayError.from_ray_exception(ray_exception)
   File "FILE", line ZZ, in from_ray_exception
     raise RuntimeError(msg) from e
-RuntimeError: Failed to unpickle serialized exception"""
+RuntimeError: Failed to unpickle serialized exception
+Original exception (string repr):
+ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
+    exc_info=True)
+  File "FILE", line ZZ, in f
+    return g(c)
+  File "FILE", line ZZ, in g
+    raise NoPickleError("FILE")
+test_traceback.NoPickleError"""
 
     class NoPickleError(OSError):
         def __init__(self, arg):
@@ -331,9 +348,10 @@ RuntimeError: Failed to unpickle serialized exception"""
         ray.get(f.remote())
     except Exception as ex:
         python310_extra_exc_msg = "test_unpickleable_stacktrace.<locals>.NoPickleError."
-        assert clean_noqa(expected_output) == scrub_traceback(str(ex)).replace(
+        cleaned = scrub_traceback(str(ex)).replace(
             f"TypeError: {python310_extra_exc_msg}", "TypeError: "
         )
+        assert clean_noqa(expected_output) == cleaned
 
 
 def test_serialization_error_message(shutdown_only):

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -297,7 +297,6 @@ def test_unpickleable_stacktrace(shutdown_only):
     expected_output = """System error: Failed to unpickle serialized exception
 Original exception (string repr):
 ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
-    exc_info=True)
   File "FILE", line ZZ, in f
     return g(c)
   File "FILE", line ZZ, in g
@@ -323,7 +322,6 @@ Traceback (most recent call last):
 RuntimeError: Failed to unpickle serialized exception
 Original exception (string repr):
 ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
-    exc_info=True)
   File "FILE", line ZZ, in f
     return g(c)
   File "FILE", line ZZ, in g


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Falls back to printing the user exception's string representation instead of simply throwing a generic (non debugable) ray internal exception when the user's exception is not serializable.

eg for:
```python
import openai
import ray
from openai import AuthenticationError


def call_openai_and_error_out():
    client = openai.OpenAI(
        base_url="https://api.endpoints.anyscale.com/v1",
        api_key="test",
    )
    try:
        client.chat.completions.create(
            model="gpt-3.5-turbo",
            messages=[
                {"role": "system", "content": "You are a chatbot."},
                {"role": "user", "content": "What is the capital of France?"},
            ],
        )
    except AuthenticationError as e:
        print("Errored as expected given API key is invalid.")
        raise e

remote_fn = ray.remote(call_openai_and_error_out)
ray.get(remote_fn.remote())
```

we previously threw

```
2025-08-02 14:19:36,726 ERROR serialization.py:462 -- Failed to unpickle serialized exception
Traceback (most recent call last):
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/exceptions.py", line 51, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
TypeError: APIStatusError.__init__() missing 2 required keyword-only arguments: 'response' and 'body'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/_private/serialization.py", line 460, in deserialize_objects
    obj = self._deserialize_object(data, metadata, object_ref)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/_private/serialization.py", line 342, in _deserialize_object
    return RayError.from_bytes(obj)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/exceptions.py", line 45, in from_bytes
    return RayError.from_ray_exception(ray_exception)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/exceptions.py", line 54, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception
Traceback (most recent call last):
  File "/Users/rliaw/dev/proteins/_test.py", line 31, in <module>
    ray.get(remote_fn.remote())
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/_private/worker.py", line 2782, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/_private/worker.py", line 931, in get_objects
    raise value
ray.exceptions.RaySystemError: System error: Failed to unpickle serialized exception
traceback: Traceback (most recent call last):
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/exceptions.py", line 51, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
TypeError: APIStatusError.__init__() missing 2 required keyword-only arguments: 'response' and 'body'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/_private/serialization.py", line 460, in deserialize_objects
    obj = self._deserialize_object(data, metadata, object_ref)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/_private/serialization.py", line 342, in _deserialize_object
    return RayError.from_bytes(obj)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/exceptions.py", line 45, in from_bytes
    return RayError.from_ray_exception(ray_exception)
  File "/Users/rliaw/miniconda3/lib/python3.10/site-packages/ray/exceptions.py", line 54, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception
```

but with this change we instead throw:

```
2025-08-12 09:04:59,591 ERROR serialization.py:539 -- Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=2563971, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>
Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 50, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
TypeError: __init__() missing 2 required keyword-only arguments: 'response' and 'body'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 532, in deserialize_objects
    obj = self._deserialize_object(
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 396, in _deserialize_object
    return RayError.from_bytes(obj)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 44, in from_bytes
    return RayError.from_ray_exception(ray_exception)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 63, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=2563971, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>

Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/test.py", line 24, in <module>
    ray.get(remote_fn.remote())
  File "/home/ubuntu/clone/ray/python/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/home/ubuntu/clone/ray/python/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/clone/ray/python/ray/_private/worker.py", line 2869, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File "/home/ubuntu/clone/ray/python/ray/_private/worker.py", line 970, in get_objects
    raise value
ray.exceptions.RaySystemError: System error: Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=2563971, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>

traceback: Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 50, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
TypeError: __init__() missing 2 required keyword-only arguments: 'response' and 'body'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 532, in deserialize_objects
    obj = self._deserialize_object(
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 396, in _deserialize_object
    return RayError.from_bytes(obj)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 44, in from_bytes
    return RayError.from_ray_exception(ray_exception)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 63, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=2563971, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/55171
Closes https://github.com/ray-project/ray/issues/43428
Closes https://github.com/ray-project/ray/issues/50138
Closes https://github.com/ray-project/ray/issues/49885
Closes https://github.com/ray-project/ray/issues/49970
Closes https://github.com/ray-project/ray/issues/54341
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
