### PR TITLE
Remove ref to deleted panel in Ray Data metrics

### DIFF
--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -222,10 +222,6 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
         pathParams: "theme=light&panelId=1",
       },
       {
-        title: "Bytes Allocated",
-        pathParams: "theme=light&panelId=2",
-      },
-      {
         title: "Bytes Freed",
         pathParams: "theme=light&panelId=3",
       },


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The "Bytes Allocated" Grafana panel was removed in https://github.com/ray-project/ray/pull/52943. However, the reference to it in the Metrics UI code was not removed, and this leads to a "Panel not found" error showing up on the UI. This PR just cleans up the reference.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
