### PR TITLE
[core] deflake test_actors::test_kill_actor_gcs

### DIFF
--- a/python/ray/dashboard/modules/reporter/tests/test_actors.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_actors.py
@@ -90,7 +90,9 @@ def test_kill_actor_gcs(ray_start_with_dashboard, enable_concurrency_group):
     # Try to kill the actor, it should not die since a task is running
     resp = _kill_actor_using_dashboard_gcs(webui_url, actor_id, OK, force_kill=False)
     assert "It will exit once running tasks complete" in resp["msg"]
-    with pytest.raises(RuntimeError, match="The condition wasn't met before the timeout expired."):
+    with pytest.raises(
+        RuntimeError, match="The condition wasn't met before the timeout expired."
+    ):
         wait_for_condition(lambda: _actor_killed(worker_pid), 1)
 
     # Force kill the actor

--- a/python/ray/dashboard/modules/reporter/tests/test_actors.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_actors.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 
+import psutil
 import pytest
 import requests
 

--- a/python/ray/dashboard/modules/reporter/tests/test_actors.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_actors.py
@@ -22,6 +22,7 @@ def _actor_killed(pid: str) -> bool:
     """Check if a process with given pid is running."""
     return not psutil.pid_exists(int(pid))
 
+
 def _kill_actor_using_dashboard_gcs(
     webui_url: str, actor_id: str, expected_status_code: int, force_kill=False
 ):
@@ -75,7 +76,7 @@ def test_kill_actor_gcs(ray_start_with_dashboard, enable_concurrency_group):
     # Kill the actor
     resp = _kill_actor_using_dashboard_gcs(webui_url, actor_id, OK, force_kill=False)
     assert "It will exit once running tasks complete" in resp["msg"]
-    wait_for_condition(lambda: _actor_killed(worker_pid),5)
+    wait_for_condition(lambda: _actor_killed(worker_pid), 5)
 
     # Create an actor and have it loop
     a = Actor.remote()
@@ -101,7 +102,7 @@ def test_kill_actor_gcs(ray_start_with_dashboard, enable_concurrency_group):
     # Force kill the actor
     resp = _kill_actor_using_dashboard_gcs(webui_url, actor_id, OK, force_kill=True)
     assert "Force killed actor with id" in resp["msg"]
-    wait_for_condition(lambda: _actor_killed(worker_pid),5)
+    wait_for_condition(lambda: _actor_killed(worker_pid), 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
to deflake test_actors::test_kill_actor_gcs

flaky run 1: https://buildkite.com/ray-project/postmerge/builds/12059#01988549-8598-44c3-a3c7-25bacc05bdd5
```
[2025-08-07T16:30:40Z] python/ray/dashboard/modules/reporter/tests/test_actors.py::test_kill_actor_gcs[False] FAILED [ 50%]
[2025-08-07T16:30:40Z] python/ray/dashboard/modules/reporter/tests/test_actors.py::test_kill_actor_gcs[True] FAILED [100%]
[2025-08-07T16:30:40Z] 
[2025-08-07T16:30:40Z] =================================== FAILURES ===================================
[2025-08-07T16:30:40Z] __________________________ test_kill_actor_gcs[False] __________________________
[2025-08-07T16:30:40Z] 
[2025-08-07T16:30:40Z] ray_start_with_dashboard = RayContext(dashboard_url='127.0.0.1:8265', python_version='3.9.23', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}')
[2025-08-07T16:30:40Z] enable_concurrency_group = False
[2025-08-07T16:30:40Z] 
[2025-08-07T16:30:40Z]     @pytest.mark.parametrize("enable_concurrency_group", [False, True])
[2025-08-07T16:30:40Z]     def test_kill_actor_gcs(ray_start_with_dashboard, enable_concurrency_group):
[2025-08-07T16:30:40Z]         # Start the dashboard
[2025-08-07T16:30:40Z]         webui_url = ray_start_with_dashboard["webui_url"]
[2025-08-07T16:30:40Z]         assert wait_until_server_available(webui_url)
[2025-08-07T16:30:40Z]         webui_url = format_web_url(webui_url)
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]         concurrency_groups = {"io": 1} if enable_concurrency_group else None
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]         @ray.remote(concurrency_groups=concurrency_groups)
[2025-08-07T16:30:40Z]         class Actor:
[2025-08-07T16:30:40Z]             def f(self):
[2025-08-07T16:30:40Z]                 ray._private.worker.show_in_dashboard("test")
[2025-08-07T16:30:40Z]                 return os.getpid()
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]             def loop(self):
[2025-08-07T16:30:40Z]                 while True:
[2025-08-07T16:30:40Z]                     time.sleep(1)
[2025-08-07T16:30:40Z]                     print("Looping...")
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]         # Create an actor
[2025-08-07T16:30:40Z]         a = Actor.remote()
[2025-08-07T16:30:40Z]         worker_pid = ray.get(a.f.remote())  # noqa
[2025-08-07T16:30:40Z]         actor_id = a._ray_actor_id.hex()
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]         OK = 200
[2025-08-07T16:30:40Z]         NOT_FOUND = 404
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]         # Kill an non-existent actor
[2025-08-07T16:30:40Z]         resp = _kill_actor_using_dashboard_gcs(
[2025-08-07T16:30:40Z]             webui_url, "non-existent-actor-id", NOT_FOUND
[2025-08-07T16:30:40Z]         )
[2025-08-07T16:30:40Z]         assert "not found" in resp["msg"]
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]         # Kill the actor
[2025-08-07T16:30:40Z]         resp = _kill_actor_using_dashboard_gcs(webui_url, actor_id, OK, force_kill=False)
[2025-08-07T16:30:40Z]         assert "It will exit once running tasks complete" in resp["msg"]
[2025-08-07T16:30:40Z]         assert _actor_killed_loop(worker_pid)
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]         # Create an actor and have it loop
[2025-08-07T16:30:40Z]         a = Actor.remote()
[2025-08-07T16:30:40Z]         worker_pid = ray.get(a.f.remote())  # noqa
[2025-08-07T16:30:40Z]         actor_id = a._ray_actor_id.hex()
[2025-08-07T16:30:40Z]         a.loop.remote()
[2025-08-07T16:30:40Z]     
[2025-08-07T16:30:40Z]         # Try to kill the actor, it should not die since a task is running
[2025-08-07T16:30:40Z]         resp = _kill_actor_using_dashboard_gcs(webui_url, actor_id, OK, force_kill=False)
[2025-08-07T16:30:40Z]         assert "It will exit once running tasks complete" in resp["msg"]
[2025-08-07T16:30:40Z] >       assert not _actor_killed_loop(worker_pid, timeout_secs=1)
[2025-08-07T16:30:40Z] E       assert not True
[2025-08-07T16:30:40Z] E        +  where True = _actor_killed_loop(3896, timeout_secs=1)
[2025-08-07T16:30:40Z] 
[2025-08-07T16:30:40Z] python/ray/dashboard/modules/reporter/tests/test_actors.py:101: AssertionError
```

based on this failure log, my hunch is that there was a race condition between submitting actor.loop() call and the kill actor call.
fix: added a short wait after calling `loop()` before killing the actor

flaky run 2: https://buildkite.com/ray-project/postmerge/builds/12059#01988549-8598-44c3-a3c7-25bacc05bdd5
```
_bk;t=1754801477362python/ray/dashboard/modules/reporter/tests/test_actors.py::test_kill_actor_gcs[False] PASSED [ 50%]
_bk;t=1754801477362python/ray/dashboard/modules/reporter/tests/test_actors.py::test_kill_actor_gcs[True] -- Test timed out at 2025-08-10 04:50:59 UTC --
```
not really enough logs to figure out why the test may have timed out. 
fix: increased `_actor_killed_loop` default timeout from 3 -> 5seconds. also added a timeout to the http call so that it does not block indefinitely (we can consider adding retries here as well)
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
NA
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
