### PR TITLE
[core] Use passed report interval in Raylet instead of `RayConfig`

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -251,7 +251,7 @@ void NodeManager::RegisterGcs() {
         /* reporter */ &cluster_resource_scheduler_.GetLocalResourceManager(),
         /* receiver */ this,
         /* pull_from_reporter_interval_ms */
-        RayConfig::instance().raylet_report_resources_period_milliseconds());
+        report_resources_period_ms_);
 
     // Register a commands channel.
     // It's only used for GC right now.


### PR DESCRIPTION
We were [passing the interval into the constructor](https://github.com/ray-project/ray/blob/1895aa1c4329f18a803e9a4386d50e8b1a4f1f1e/src/ray/raylet/node_manager.cc#L149) but then still pulling the value from `RayConfig`.