### PR TITLE
[Core] Install uv from test-requirements.txt

### DIFF
--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -64,7 +64,7 @@ smart_open[s3]==6.2.0
 tqdm==4.67.1
 trustme==0.9.0
 testfixtures==7.0.0
-uv==0.5.27
+uv==0.8.9
 uvicorn==0.22.0
 vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0
 werkzeug==2.3.8

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -64,6 +64,7 @@ smart_open[s3]==6.2.0
 tqdm==4.67.1
 trustme==0.9.0
 testfixtures==7.0.0
+uv==0.5.27
 uvicorn==0.22.0
 vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0
 werkzeug==2.3.8

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -2405,7 +2405,7 @@ urllib3==1.26.19
     #   sentry-sdk
 utilsforecast==0.2.0
     # via statsforecast
-uv==0.5.27
+uv==0.8.9
     # via -r python/requirements/test-requirements.txt
 uvicorn==0.22.0
     # via

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -2405,6 +2405,8 @@ urllib3==1.26.19
     #   sentry-sdk
 utilsforecast==0.2.0
     # via statsforecast
+uv==0.5.27
+    # via -r python/requirements/test-requirements.txt
 uvicorn==0.22.0
     # via
     #   -r python/requirements.txt


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removes the manual download and installation of uv within the test_runtime_env_uv_run.py test file.

Instead, uv is now added as a dependency in `python/requirements/test-requirements.txt`. The tests have been updated to use the uv executable directly, assuming it's installed in the environment.

Redo #53685
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
