### PR TITLE
Disable gemini code review summary

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,10 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+ignore_patterns: []

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,3 +108,5 @@
 /.github/ISSUE_TEMPLATE/ @aslonnie
 
 /.github/workflows/ @ray-project/ray-ci
+
+.gemini/ @edoakes @aslonnie

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,4 +109,4 @@
 
 /.github/workflows/ @ray-project/ray-ci
 
-.gemini/ @edoakes @aslonnie
+/.gemini/ @edoakes @aslonnie


### PR DESCRIPTION
Copied [default config](https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#default-configuration), but disabled summary (not useful).