### PR TITLE
[Data] Restore handling of `PyExtensionType` to maintain compatibility w/ previously written datasets

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -85,10 +85,10 @@ try:
     # disabled it's deserialization by default. To ensure that users can load data
     # written with earlier version of Ray Data, we enable auto-loading of serialized
     # tensor extensions.
+    #
+    # NOTE: `PyExtensionType` is deleted from Arrow >= 21.0
     pyarrow_version = get_pyarrow_version()
-    if pyarrow_version is None:
-        # PyArrow is mocked in documentation builds. In this case, we don't need to do
-        # anything.
+    if pyarrow_version is None or pyarrow_version >= parse_version("21.0.0"):
         pass
     else:
         from ray._private.ray_constants import env_bool

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -81,6 +81,12 @@ configure_logging()
 try:
     import pyarrow as pa
 
+    # Import these arrow extension types to ensure that they are registered.
+    from ray.air.util.tensor_extensions.arrow import (  # noqa
+        ArrowTensorType,
+        ArrowVariableShapedTensorType,
+    )
+
     # https://github.com/apache/arrow/pull/38608 deprecated `PyExtensionType`, and
     # disabled it's deserialization by default. To ensure that users can load data
     # written with earlier version of Ray Data, we enable auto-loading of serialized
@@ -102,11 +108,7 @@ try:
             and RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE
         ):
             pa.PyExtensionType.set_auto_load(True)
-        # Import these arrow extension types to ensure that they are registered.
-        from ray.air.util.tensor_extensions.arrow import (  # noqa
-            ArrowTensorType,
-            ArrowVariableShapedTensorType,
-        )
+
 except ModuleNotFoundError:
     pass
 

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,6 +1,9 @@
 # Short term workaround for https://github.com/ray-project/ray/issues/32435
 # Dataset has a hard dependency on pandas, so it doesn't need to be delayed.
 import pandas  # noqa
+from packaging.version import parse as parse_version
+
+from ray._private.arrow_utils import get_pyarrow_version
 
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.datasource.tfrecords_datasource import TFXReadOptions
@@ -74,6 +77,38 @@ from ray.data.read_api import (  # noqa: F401
 _map_actor_context = None
 
 configure_logging()
+
+try:
+    import pyarrow as pa
+
+    # https://github.com/apache/arrow/pull/38608 deprecated `PyExtensionType`, and
+    # disabled it's deserialization by default. To ensure that users can load data
+    # written with earlier version of Ray Data, we enable auto-loading of serialized
+    # tensor extensions.
+    pyarrow_version = get_pyarrow_version()
+    if pyarrow_version is None:
+        # PyArrow is mocked in documentation builds. In this case, we don't need to do
+        # anything.
+        pass
+    else:
+        from ray._private.ray_constants import env_bool
+
+        RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE = env_bool(
+            "RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE", False
+        )
+
+        if (
+            pyarrow_version >= parse_version("14.0.1")
+            and RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE
+        ):
+            pa.PyExtensionType.set_auto_load(True)
+        # Import these arrow extension types to ensure that they are registered.
+        from ray.air.util.tensor_extensions.arrow import (  # noqa
+            ArrowTensorType,
+            ArrowVariableShapedTensorType,
+        )
+except ModuleNotFoundError:
+    pass
 
 
 __all__ = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Batch inference tests started to fail after https://github.com/ray-project/ray/pull/55426 due to us eliminating handling of the auto-loading of `PyExtensionType`

This change restores handling of the auto-loading while also fixing it for Arrow >= 21.0 that deleted PyExtensionType support completely.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
