### PR TITLE
[data] make hash shuffling resource usage calculation faster

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -587,8 +587,10 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
 
             def _on_partitioning_done(cur_shuffle_task_idx: int):
                 task = self._shuffling_tasks[input_index].pop(cur_shuffle_task_idx)
-                self._running_resource_usage -= ExecutionResources(
-                    cpu=task.get_requested_resource_bundle().cpu, gpu=0
+                self._running_resource_usage = self._running_resource_usage.subtract(
+                    ExecutionResources(
+                        cpu=task.get_requested_resource_bundle().cpu, gpu=0
+                    )
                 )
                 # Fetch input block and resulting partition shards block metadata and
                 # handle obtained metadata
@@ -631,8 +633,8 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
                     shuffle_task_resource_bundle
                 ),
             )
-            self._running_resource_usage += ExecutionResources(
-                cpu=task.get_requested_resource_bundle().cpu, gpu=0
+            self._running_resource_usage = self._running_resource_usage.add(
+                ExecutionResources(cpu=task.get_requested_resource_bundle().cpu, gpu=0)
             )
 
             #  Update Shuffle Metrics on task submission

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -470,7 +470,8 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
         )
 
         # We track the running usage total because iterating
-        # and summing over all shuffling tasks can be expensive.
+        # and summing over all shuffling tasks can be expensive
+        # if the # of shuffling tasks is large
         self._shuffling_resource_usage = ExecutionResources.zero()
 
         self._input_block_transformer = input_block_transformer

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -866,7 +866,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
         running_usage = self._running_resource_usage
 
         # TODO add memory to resources being tracked
-        return base_usage + running_usage
+        return base_usage.add(running_usage)
 
     @property
     def base_resource_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -469,6 +469,8 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
             data_context=data_context,
         )
 
+        self._running_resource_usage = ExecutionResources.zero()
+
         self._input_block_transformer = input_block_transformer
 
         self._next_shuffle_tasks_idx: int = 0
@@ -585,6 +587,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
 
             def _on_partitioning_done(cur_shuffle_task_idx: int):
                 task = self._shuffling_tasks[input_index].pop(cur_shuffle_task_idx)
+                self.shuffling_cpu_resources -= task.get_requested_resource_bundle().cpu
                 # Fetch input block and resulting partition shards block metadata and
                 # handle obtained metadata
                 #
@@ -614,15 +617,19 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
                 self.shuffle_bar.update(i=input_block_metadata.num_rows)
 
             # TODO update metrics
+            task_resource_bundle = ExecutionResources.from_resource_dict(
+                shuffle_task_resource_bundle
+            )
             self._shuffling_tasks[input_index][cur_shuffle_task_idx] = MetadataOpTask(
                 task_index=cur_shuffle_task_idx,
                 object_ref=input_block_partition_shards_metadata_tuple_ref,
                 task_done_callback=functools.partial(
                     _on_partitioning_done, cur_shuffle_task_idx
                 ),
-                task_resource_bundle=(
-                    ExecutionResources.from_resource_dict(shuffle_task_resource_bundle)
-                ),
+                task_resource_bundle=task_resource_bundle,
+            )
+            self._running_resource_usage += ExecutionResources(
+                cpu=task_resource_bundle.cpu, gpu=0
             )
 
             #  Update Shuffle Metrics on task submission
@@ -850,19 +857,13 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
         #     `base_resource_usage` method)
         #   - Active shuffling tasks
         #   - Active finalizing tasks (actor tasks)
-        base_usage = self.base_resource_usage()
-
-        shuffling_tasks = self._get_active_shuffling_tasks()
-        shuffling_tasks_cpus_used = sum(
-            [t.get_requested_resource_bundle().cpu for t in shuffling_tasks]
-        )
+        base_usage = self.base_resource_usage
+        running_usage = self._running_resource_usage
 
         # TODO add memory to resources being tracked
-        return ExecutionResources(
-            cpu=base_usage.cpu + shuffling_tasks_cpus_used,
-            gpu=0,
-        )
+        return base_usage + running_usage
 
+    @property
     def base_resource_usage(self) -> ExecutionResources:
         # TODO add memory to resources being tracked
         return ExecutionResources(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, we use sum(shuffle_task.cpu_usage for all shuffling tasks). This can be very slow for large number of shuffling tasks.

We can mitigate this by calculating the usage on every task submission
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
