### PR TITLE
[ci] raydepsets: storing build arg set name in depset

### DIFF
--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -462,9 +462,7 @@ depsets:
             )
             depset = manager.get_depset("build_args_test_depset_py311")
             assert depset.name == "build_args_test_depset_py311"
-            assert depset.build_arg_set.name == "py311_cpu"
-            assert depset.build_arg_set.build_args["PYTHON_VERSION"] == "py311"
-            assert depset.build_arg_set.build_args["CUDA_VERSION"] == "cpu"
+            assert depset.build_arg_set_name == "py311_cpu"
 
     def test_get_depset_without_build_arg_set(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -475,7 +473,7 @@ depsets:
             )
             depset = manager.get_depset("ray_base_test_depset")
             assert depset.name == "ray_base_test_depset"
-            assert depset.build_arg_set is None
+            assert depset.build_arg_set_name is None
 
 
 if __name__ == "__main__":

--- a/ci/raydepsets/workspace.py
+++ b/ci/raydepsets/workspace.py
@@ -23,7 +23,7 @@ class Depset:
     append_flags: List[str]
     source_depset: Optional[str] = None
     depsets: Optional[List[str]] = None
-    build_arg_set: Optional[BuildArgSet] = None
+    build_arg_set_name: Optional[str] = None
 
 
 def _substitute_build_args(obj: Any, build_arg_set: BuildArgSet):
@@ -40,9 +40,7 @@ def _substitute_build_args(obj: Any, build_arg_set: BuildArgSet):
         return obj
 
 
-def _dict_to_depset(
-    depset: dict, build_arg_set: Optional[BuildArgSet] = None
-) -> Depset:
+def _dict_to_depset(depset: dict, build_arg_set_name: Optional[str] = None) -> Depset:
     return Depset(
         name=depset.get("name"),
         requirements=depset.get("requirements", []),
@@ -51,7 +49,7 @@ def _dict_to_depset(
         output=depset.get("output"),
         source_depset=depset.get("source_depset"),
         depsets=depset.get("depsets", []),
-        build_arg_set=build_arg_set,
+        build_arg_set_name=build_arg_set_name,
         override_flags=depset.get("override_flags", []),
         append_flags=depset.get("append_flags", []),
     )
@@ -82,7 +80,7 @@ class Config:
                     if build_arg_set is None:
                         raise KeyError(f"Build arg set {build_arg_set_name} not found")
                     depset_yaml = _substitute_build_args(depset, build_arg_set)
-                    depsets.append(_dict_to_depset(depset_yaml, build_arg_set))
+                    depsets.append(_dict_to_depset(depset_yaml, build_arg_set_name))
             else:
                 depsets.append(_dict_to_depset(depset=depset))
         return Config(depsets=depsets, build_arg_sets=build_arg_sets)


### PR DESCRIPTION
instead of storing an entire build arg set object in a depset, only store the name for reference

