### PR TITLE
[core][obs-clean/01] de-static object_store_available_memory metric

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -767,7 +767,7 @@ void ObjectManager::RecordMetrics() {
   push_manager_->RecordMetrics();
   // used_memory_ includes the fallback allocation, so we should add it again here
   // to calculate the exact available memory.
-  stats::ObjectStoreAvailableMemory().Record(
+  ray_metric_object_store_available_memory_.Record(
       config_.object_store_memory - used_memory_ +
       plasma::plasma_store_runner->GetFallbackAllocated());
   // Subtract fallback allocated memory. It is tracked separately by

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -32,6 +32,7 @@
 #include "ray/object_manager/push_manager.h"
 #include "ray/rpc/object_manager/object_manager_client.h"
 #include "ray/rpc/object_manager/object_manager_server.h"
+#include "ray/stats/metric.h"
 #include "src/ray/protobuf/common.pb.h"
 #include "src/ray/protobuf/node_manager.pb.h"
 
@@ -497,6 +498,12 @@ class ObjectManager : public ObjectManagerInterface,
   /// create the object in plasma. This is usually due to out-of-memory in
   /// plasma.
   size_t num_chunks_received_failed_due_to_plasma_ = 0;
+
+  /// Metrics
+  ray::stats::Gauge ray_metric_object_store_available_memory_{
+      /*name=*/"object_store_available_memory",
+      /*description=*/"Amount of memory currently available in the object store.",
+      /*unit=*/"bytes"};
 };
 
 }  // namespace ray

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -164,11 +164,6 @@ static Gauge LocalTotalResource("local_total_resource",
                                 {kResourceNameKey});
 
 /// Object Manager.
-static Gauge ObjectStoreAvailableMemory(
-    "object_store_available_memory",
-    "Amount of memory currently available in the object store.",
-    "bytes");
-
 static Gauge ObjectStoreUsedMemory(
     "object_store_used_memory",
     "Amount of memory currently occupied in the object store.",


### PR DESCRIPTION
Ray core currently offers two APIs for defining internal metrics: a static object-oriented (OO) API and a template/extern-based API. The OO API is also used for defining custom metrics at the Ray application level, and I personally find it easier to read. This series of PRs aims to unify all metric definitions under the OO API.

----

This PR migrates one metric from static to runtime definition, as part of the effort to eliminate all statically defined metrics. Currently, the OO interface attempts to register a metric at the same time its first value is recorded, due to the [C++ static initialization order fiasco](https://en.cppreference.com/w/cpp/language/siof.html), which is awkward and potentially inefficient. We can fix this by removing all statically defined metrics.

Test:
- CI