### PR TITLE
[depset] remove unsafe treatment for grpcio-tools

### DIFF
--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -16,7 +16,6 @@ DEFAULT_UV_FLAGS = """
     --emit-index-url
     --emit-find-links
     --unsafe-package ray
-    --unsafe-package grpcio-tools
     --unsafe-package setuptools
     --index-url https://pypi.org/simple
     --extra-index-url https://download.pytorch.org/whl/cpu

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -298,8 +298,6 @@ class TestCli(unittest.TestCase):
         expected_flags.remove("--unsafe-package")
         expected_flags.remove("ray")
         expected_flags.remove("--unsafe-package")
-        expected_flags.remove("grpcio-tools")
-        expected_flags.remove("--unsafe-package")
         expected_flags.remove("setuptools")
         expected_flags.extend(["--unsafe-package", "dummy"])
         assert (


### PR DESCRIPTION
not required any more. `grpcio-tools` are now resolving.