### PR TITLE
[serve] Update compute type for serve microbenchmarks

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2058,7 +2058,7 @@
 
   cluster:
     byod: {}
-    cluster_compute: compute_tpl_single_node_32_cpu.yaml
+    cluster_compute: compute_tpl_single_node_16_cpu.yaml
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
     project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
 

--- a/release/serve_tests/compute_tpl_single_node_16_cpu.yaml
+++ b/release/serve_tests/compute_tpl_single_node_16_cpu.yaml
@@ -1,0 +1,18 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    # 16 cpus, arm, 64G mem, 12.5Gb NIC
+    instance_type: m7a.4xlarge
+
+worker_node_types: []
+
+advanced_configurations_json:
+  TagSpecifications:
+    - ResourceType: "instance"
+      Tags:
+        - Key: ttl-hours
+          Value: '24'


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We've been using m7a.4xlarge for lots of perf benchmarks. We should update these nightly benchmarks with the same hw type.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
