### PR TITLE
[serve] Add concurrencies option to serve microbenchmarks

### DIFF
--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -413,6 +413,10 @@ def main(
     throughput_max_ongoing_requests: List[int],
     concurrencies: List[int],
 ):
+    assert len(throughput_max_ongoing_requests) == len(
+        concurrencies
+    ), "Must have the same number of --throughput-max-ongoing-requests and --concurrencies"
+
     # If none of the flags are set, default to run all
     if not (
         run_http

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -391,7 +391,7 @@ async def _main(
     multiple=True,
     type=int,
     default=[5, 100, 800],
-    help="Max ongoing requests for throughput benchmarks. Must be in the same order as --concurrency. Default: [5, 100, 800]",
+    help="Max ongoing requests for throughput benchmarks. Must be in the same order as --concurrencies. Default: [5, 100, 800]",
 )
 @click.option(
     "--concurrencies",

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -133,6 +133,7 @@ async def _main(
     run_throughput: bool,
     run_streaming: bool,
     throughput_max_ongoing_requests: List[int],
+    concurrencies: List[int],
 ):
     perf_metrics = []
     payload_1mb = generate_payload(1000000)
@@ -157,14 +158,16 @@ async def _main(
 
         if run_throughput:
             # Microbenchmark: HTTP throughput
-            for max_ongoing_requests in throughput_max_ongoing_requests:
+            for max_ongoing_requests, concurrency in zip(
+                throughput_max_ongoing_requests, concurrencies
+            ):
                 serve.run(
                     Noop.options(max_ongoing_requests=max_ongoing_requests).bind()
                 )
                 url = get_application_url(use_localhost=True)
                 mean, std, _ = await run_throughput_benchmark(
-                    fn=partial(do_single_http_batch, batch_size=BATCH_SIZE, url=url),
-                    multiplier=BATCH_SIZE,
+                    fn=partial(do_single_http_batch, batch_size=concurrency, url=url),
+                    multiplier=concurrency,
                     num_trials=NUM_TRIALS,
                     trial_runtime=TRIAL_RUNTIME_S,
                 )
@@ -279,7 +282,9 @@ async def _main(
 
         if run_throughput:
             # Microbenchmark: GRPC throughput
-            for max_ongoing_requests in throughput_max_ongoing_requests:
+            for max_ongoing_requests, concurrency in zip(
+                throughput_max_ongoing_requests, concurrencies
+            ):
                 serve.start(grpc_options=serve_grpc_options)
                 serve.run(
                     GrpcDeployment.options(
@@ -291,9 +296,9 @@ async def _main(
                 )
                 mean, std, _ = await run_throughput_benchmark(
                     fn=partial(
-                        do_single_grpc_batch, batch_size=BATCH_SIZE, target=target
+                        do_single_grpc_batch, batch_size=concurrency, target=target
                     ),
-                    multiplier=BATCH_SIZE,
+                    multiplier=concurrency,
                     num_trials=NUM_TRIALS,
                     trial_runtime=TRIAL_RUNTIME_S,
                 )
@@ -320,14 +325,16 @@ async def _main(
 
         if run_throughput:
             # Microbenchmark: Handle throughput
-            for max_ongoing_requests in throughput_max_ongoing_requests:
+            for max_ongoing_requests, concurrency in zip(
+                throughput_max_ongoing_requests, concurrencies
+            ):
                 h: DeploymentHandle = serve.run(
                     Benchmarker.options(max_ongoing_requests=max_ongoing_requests).bind(
                         Noop.options(max_ongoing_requests=max_ongoing_requests).bind()
                     )
                 )
                 mean, std, _ = await h.run_throughput_benchmark.remote(
-                    batch_size=BATCH_SIZE,
+                    batch_size=concurrency,
                     num_trials=NUM_TRIALS,
                     trial_runtime=TRIAL_RUNTIME_S,
                 )
@@ -383,8 +390,16 @@ async def _main(
     "-t",
     multiple=True,
     type=int,
-    default=[5, 100],
-    help="Max ongoing requests for throughput benchmarks. Default: [5, 100]",
+    default=[5, 100, 800],
+    help="Max ongoing requests for throughput benchmarks. Must be in the same order as --concurrency. Default: [5, 100, 800]",
+)
+@click.option(
+    "--concurrencies",
+    "-c",
+    multiple=True,
+    type=int,
+    default=[100, 100, 800],
+    help="User concurrency for throughput benchmarks. Must be in the same order as --throughput-max-ongoing-requests. Default: [100, 100, 800]",
 )
 def main(
     output_path: Optional[str],
@@ -396,6 +411,7 @@ def main(
     run_throughput: bool,
     run_streaming: bool,
     throughput_max_ongoing_requests: List[int],
+    concurrencies: List[int],
 ):
     # If none of the flags are set, default to run all
     if not (
@@ -426,6 +442,7 @@ def main(
             run_throughput,
             run_streaming,
             throughput_max_ongoing_requests,
+            concurrencies,
         )
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Perf can differ at various concurrencies. This makes it easy to configure / run at various concurrencies + max_ongoing_request combinations

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
