### PR TITLE
[core] fix test_unpickleable_stacktrace test on windows 

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -51,12 +51,12 @@ class RayError(Exception):
             except Exception as e:
                 msg = "Failed to unpickle serialized exception"
                 # Include a fallback string/stacktrace to aid debugging.
-                try:
-                    formatted = ray_exception.formatted_exception_string
-                except Exception:
-                    formatted = "No formatted exception string available."
-                if formatted:
-                    msg += f"\nOriginal exception (string repr):\n{formatted}"
+                formatted = getattr(
+                    ray_exception,
+                    "formatted_exception_string",
+                    "No formatted exception string available.",
+                )
+                msg += f"\nOriginal exception (string repr):\n{formatted}"
                 raise RuntimeError(msg) from e
         else:
             return CrossLanguageError(ray_exception)

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -50,6 +50,13 @@ class RayError(Exception):
                 return pickle.loads(ray_exception.serialized_exception)
             except Exception as e:
                 msg = "Failed to unpickle serialized exception"
+                # Include a fallback string/stacktrace to aid debugging.
+                try:
+                    formatted = ray_exception.formatted_exception_string
+                except Exception:
+                    formatted = "No formatted exception string available."
+                if formatted:
+                    msg += f"\nOriginal exception (string repr):\n{formatted}"
                 raise RuntimeError(msg) from e
         else:
             return CrossLanguageError(ray_exception)

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -51,6 +51,9 @@ class RayError(Exception):
             except Exception as e:
                 msg = "Failed to unpickle serialized exception"
                 # Include a fallback string/stacktrace to aid debugging.
+                #  formatted_exception_string is set in to_bytes() above by calling
+                # traceback.format_exception() on the original exception. It contains
+                # the string representation and stack trace of the original error.
                 formatted = getattr(
                     ray_exception,
                     "formatted_exception_string",

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -54,6 +54,13 @@ def scrub_traceback(ex):
     )
     # Clean up underscore in stack trace, which is new in python 3.12
     ex = re.sub("^\\s+~*\\^+~*\n", "", ex, flags=re.MULTILINE)
+    # Remove internal Cython frames from ray._raylet that can appear on Windows.
+    ex = re.sub(
+        r"^\s*File \"FILE\", line ZZ, in ray\._raylet\.[^\n]+\n",
+        "",
+        ex,
+        flags=re.MULTILINE,
+    )
     return ex
 
 

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -295,6 +295,15 @@ def test_actor_repr_in_traceback(ray_start_regular):
 
 def test_unpickleable_stacktrace(shutdown_only):
     expected_output = """System error: Failed to unpickle serialized exception
+Original exception (string repr):
+ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
+    exc_info=True)
+  File "FILE", line ZZ, in f
+    return g(c)
+  File "FILE", line ZZ, in g
+    raise NoPickleError("FILE")
+test_traceback.NoPickleError
+
 traceback: Traceback (most recent call last):
   File "FILE", line ZZ, in from_ray_exception
     return pickle.loads(ray_exception.serialized_exception)
@@ -311,7 +320,15 @@ Traceback (most recent call last):
     return RayError.from_ray_exception(ray_exception)
   File "FILE", line ZZ, in from_ray_exception
     raise RuntimeError(msg) from e
-RuntimeError: Failed to unpickle serialized exception"""
+RuntimeError: Failed to unpickle serialized exception
+Original exception (string repr):
+ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
+    exc_info=True)
+  File "FILE", line ZZ, in f
+    return g(c)
+  File "FILE", line ZZ, in g
+    raise NoPickleError("FILE")
+test_traceback.NoPickleError"""
 
     class NoPickleError(OSError):
         def __init__(self, arg):
@@ -331,9 +348,10 @@ RuntimeError: Failed to unpickle serialized exception"""
         ray.get(f.remote())
     except Exception as ex:
         python310_extra_exc_msg = "test_unpickleable_stacktrace.<locals>.NoPickleError."
-        assert clean_noqa(expected_output) == scrub_traceback(str(ex)).replace(
+        cleaned = scrub_traceback(str(ex)).replace(
             f"TypeError: {python310_extra_exc_msg}", "TypeError: "
         )
+        assert clean_noqa(expected_output) == cleaned
 
 
 def test_serialization_error_message(shutdown_only):

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -297,7 +297,6 @@ def test_unpickleable_stacktrace(shutdown_only):
     expected_output = """System error: Failed to unpickle serialized exception
 Original exception (string repr):
 ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
-    exc_info=True)
   File "FILE", line ZZ, in f
     return g(c)
   File "FILE", line ZZ, in g
@@ -323,7 +322,6 @@ Traceback (most recent call last):
 RuntimeError: Failed to unpickle serialized exception
 Original exception (string repr):
 ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
-    exc_info=True)
   File "FILE", line ZZ, in f
     return g(c)
   File "FILE", line ZZ, in g


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
fix `test_traceback::test_unpickleable_stacktrace()` test case on windows by scrubbing logs related to `ray._raylet` before assertion

ci run with failure: https://buildkite.com/ray-project/postmerge/builds/12165#01989bf5-4008-4098-a6ff-1963047047a6/3056-3537
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
NA
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
