### PR TITLE
Upgrade commons-lang3 to fix CVE-2025-48924

### DIFF
--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -18,7 +18,7 @@ def gen_java_deps():
             "de.ruedigermoeller:fst:2.57",
             "javax.xml.bind:jaxb-api:2.3.0",
             "javax.activation:activation:1.1.1",
-            "org.apache.commons:commons-lang3:3.13.0",
+            "org.apache.commons:commons-lang3:3.18.0",
             "org.msgpack:msgpack-core:0.8.20",
             "org.ow2.asm:asm:6.0",
             "org.apache.logging.log4j:log4j-api:2.17.1",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes [CVE-2025-48924](https://nvd.nist.gov/vuln/detail/CVE-2025-48924) by upgrading the `commons-lang3` dependency.
Vulnerabilities such as this one, even if not severe, can block deployments of ray within certain enterprise environments.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #55068

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
