### PR TITLE
[Core] [Azure] Adding ability to specify availability zones for ray cluster node pools on Azure

### DIFF
--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -127,6 +127,7 @@ Provider
 
             :ref:`type <cluster-configuration-type>`: str
             :ref:`location <cluster-configuration-location>`: str
+            :ref:`availability_zone <cluster-configuration-availability-zone>`: str
             :ref:`resource_group <cluster-configuration-resource-group>`: str
             :ref:`subscription_id <cluster-configuration-subscription-id>`: str
             :ref:`msi_name <cluster-configuration-msi-name>`: str
@@ -953,11 +954,26 @@ The user that Ray will authenticate with when launching new nodes.
 
     .. tab-item:: Azure
 
-        For Azure, the avability zone avability depends on each specific VM size / location combination.
-        Each ``available_node_types.<>node_type_name>.node_config.azure_arm_parameters`` configuration can specify
-        which availability zones should be used when creating new VMs.
+        A string specifying a comma-separated list of availability zone(s) that nodes may be launched in.
+        This can be specified at the provider level to set defaults for all node types, or at the node level
+        to override the provider setting for specific node types.
 
-        See The following example Azure cluster config for more details:
+        For Azure, availability zone availability depends on each specific VM size / location combination.
+        Node-level configuration in ``available_node_types.<node_type_name>.node_config.azure_arm_parameters.availability_zone``
+        takes precedence over provider-level configuration.
+
+        * **Required:** No
+        * **Importance:** Low
+        * **Type:** String
+        * **Default:** "" (let Azure automatically pick zones)
+        * **Example values:**
+          
+          * ``"1,2,3"`` - Use zones 1, 2, and 3
+          * ``"1"`` - Use only zone 1
+          * ``"none"`` - Explicitly disable zones
+          * ``""`` or omit - Let Azure automatically pick zones
+
+        See the following example Azure cluster config for more details:
 
         .. literalinclude:: ../../../../../python/ray/autoscaler/azure/example-availability-zones.yaml
             :language: yaml

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -953,7 +953,14 @@ The user that Ray will authenticate with when launching new nodes.
 
     .. tab-item:: Azure
 
-        Not available.
+        For Azure, the avability zone avability depends on each specific VM size / location combination.
+        Each ``available_node_types.<>node_type_name>.node_config.azure_arm_parameters`` configuration can specify
+        which availability zones should be used when creating new VMs.
+
+        See The following example Azure cluster config for more details:
+
+        .. literalinclude:: ../../../../../python/ray/autoscaler/azure/example-availability-zones.yaml
+            :language: yaml
 
     .. tab-item:: GCP
 

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -965,13 +965,13 @@ The user that Ray will authenticate with when launching new nodes.
         * **Required:** No
         * **Importance:** Low
         * **Type:** String
-        * **Default:** "" (let Azure automatically pick zones)
+        * **Default:** "auto" (let Azure automatically pick zones)
         * **Example values:**
           
           * ``"1,2,3"`` - Use zones 1, 2, and 3
           * ``"1"`` - Use only zone 1
           * ``"none"`` - Explicitly disable zones
-          * ``""`` or omit - Let Azure automatically pick zones
+          * ``"auto"`` or omit - Let Azure automatically pick zones
 
         See the following example Azure cluster config for more details:
 

--- a/python/ray/autoscaler/_private/_azure/azure-vm-template.json
+++ b/python/ray/autoscaler/_private/_azure/azure-vm-template.json
@@ -132,10 +132,18 @@
             "metadata": {
                 "descriptions": "Whether to enable accelerated networking."
             }
+        },
+        "zones": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Availability zones for the virtual machine. If empty, no zones will be specified."
+            }
         }
     },
     "variables": {
         "location": "[resourceGroup().location]",
+        "useZones": "[greater(length(parameters('zones')), 0)]",
         "networkInterfaceNamePrivate": "[concat(parameters('vmName'), '-nic')]",
         "networkInterfaceNamePublic": "[concat(parameters('vmName'), '-nic-public')]",
         "networkInterfaceName": "[if(parameters('provisionPublicIp'), variables('networkInterfaceNamePublic'), variables('networkInterfaceNamePrivate'))]",
@@ -219,8 +227,9 @@
                 "name": "PublicIpCopy",
                 "count": "[parameters('vmCount')]"
             },
+            "zones": "[if(variables('useZones'), createArray(string(parameters('zones')[mod(copyIndex(), length(parameters('zones')))])), json('null'))]",
             "sku": {
-                "name": "Basic",
+                "name": "[if(variables('useZones'), 'Standard', 'Basic')]",
                 "tier": "Regional"
             },
             "condition": "[parameters('provisionPublicIp')]"
@@ -238,6 +247,7 @@
                 "count": "[parameters('vmCount')]"
             },
             "tags": "[parameters('vmTags')]",
+            "zones": "[if(variables('useZones'), createArray(string(parameters('zones')[mod(copyIndex(), length(parameters('zones')))])), json('null'))]",
             "properties": {
                 "hardwareProfile": {
                     "vmSize": "[parameters('vmSize')]"

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -163,6 +163,55 @@ class AzureNodeProvider(NodeProvider):
 
         return metadata
 
+    def _get_zones_for_vm_size(self, vm_size, location):
+        """Get usable availability zones for a given VM size in a specific location."""
+        try:
+            # Note: Azure ResourceSKUs API filters don't work reliably(?), so we query all SKUs
+            # and filter in code. Each SKU object represents one location for the VM size.
+            skus = self.compute_client.resource_skus.list()
+
+            for sku in skus:
+                if sku.name == vm_size and sku.location_info:
+                    # Each SKU object represents one location, check if it matches our target
+                    for location_info in sku.location_info:
+                        if location_info.location.lower() == location.lower():
+                            zones = location_info.zones if location_info.zones else []
+                            logger.debug(
+                                f"Found {vm_size} in {location} with zones: {zones}"
+                            )
+                            return sorted(zones)
+
+            logger.warning(f"No zones found for {vm_size} in {location}")
+            return []  # No zones available for this VM size
+        except Exception as e:
+            logger.warning(
+                f"Failed to get zones for VM size {vm_size} in location {location}: {str(e)}"
+            )
+            return []
+
+    def _validate_zones_for_node_pool(self, zones, location, vm_size):
+        """Validate that the specified zones are available for the given VM size in the location."""
+        # Special case: zones: ["None"] explicitly disables availability zones
+        if zones and len(zones) == 1 and str(zones[0]).lower() in ["none", "null"]:
+            logger.info(
+                "Zones explicitly disabled with ['None'] - will create VM without an availability zone"
+            )
+            return None  # Special return value to indicate "no zones by choice"
+
+        vm_zones = self._get_zones_for_vm_size(vm_size, location)
+
+        available_zones = set(vm_zones)
+        if not available_zones:
+            logger.warning("No zones available for this VM size and location")
+            return []
+
+        if zones:
+            requested_zones = {str(z) for z in zones}
+            intersection = sorted(available_zones.intersection(requested_zones))
+            return intersection
+
+        return sorted(available_zones)
+
     def stopped_nodes(self, tag_filters):
         """Return a list of stopped node ids filtered by the specified tags dict."""
         nodes = self._get_filtered_nodes(tag_filters=tag_filters)
@@ -253,6 +302,24 @@ class AzureNodeProvider(NodeProvider):
     def _create_node(self, node_config, tags, count):
         """Creates a number of nodes within the namespace."""
         resource_group = self.provider_config["resource_group"]
+        location = self.provider_config["location"]
+        vm_size = node_config["azure_arm_parameters"]["vmSize"]
+        requested_zones = node_config.get("azure_arm_parameters", {}).get("zones", [])
+        logger.info(f"Requested zones from config: {requested_zones}")
+
+        # Get actually available zones for this VM size
+        available_zones = self._validate_zones_for_node_pool(
+            requested_zones, location, vm_size
+        )
+
+        # Handle explicit zone disabling
+        zones_explicitly_disabled = available_zones is None
+
+        if requested_zones and not zones_explicitly_disabled and not available_zones:
+            raise ValueError(
+                f"No available zones for VM size {vm_size} in {location}. "
+                f"Requested: {requested_zones}, but none are available for this VM size."
+            )
 
         # load the template file
         current_path = Path(__file__).parent
@@ -265,14 +332,17 @@ class AzureNodeProvider(NodeProvider):
         config_tags.update(tags)
         config_tags[TAG_RAY_CLUSTER_NAME] = self.cluster_name
 
-        vm_name = "{node}-{unique_id}-{vm_id}".format(
+        deployment_name = "{node}-{unique_id}-{vm_id}".format(
             node=config_tags.get(TAG_RAY_NODE_NAME, "node"),
             unique_id=self.provider_config["unique_id"],
             vm_id=uuid4().hex[:UNIQUE_ID_LEN],
         )[:VM_NAME_MAX_LEN]
 
         template_params = node_config["azure_arm_parameters"].copy()
-        template_params["vmName"] = vm_name
+        # Use deployment_name for the vmName template parameter since
+        # the template will append copyIndex() for each VM that gets created
+        # to guarantee uniqueness.
+        template_params["vmName"] = deployment_name
         # Provision public IP if not using internal IPs or if this is the
         # head node and use_external_head_ip is True
         template_params["provisionPublicIp"] = not self.provider_config.get(
@@ -287,6 +357,24 @@ class AzureNodeProvider(NodeProvider):
         template_params["nsg"] = self.provider_config["nsg"]
         template_params["subnet"] = self.provider_config["subnet"]
 
+        # Add zone information based on availability and requested zones
+        if zones_explicitly_disabled:
+            # User explicitly disabled zones with ["None"]
+            template_params["zones"] = []
+            logger.info(
+                f"Creating {count} VMs with zones explicitly disabled (no availability zone)"
+            )
+        elif available_zones:
+            # Pass the list of available zones to the template
+            template_params["zones"] = available_zones
+            logger.info(
+                f"Creating {count} VMs, distributed across availability zones: {available_zones}"
+            )
+        else:
+            # For non-zonal deployments (no zones available), use empty array
+            template_params["zones"] = []
+            logger.info(f"Creating {count} VMs without specific availability zone")
+
         parameters = {
             "properties": {
                 "mode": DeploymentMode.incremental,
@@ -299,11 +387,12 @@ class AzureNodeProvider(NodeProvider):
 
         # TODO: we could get the private/public ips back directly
         create_or_update = get_azure_sdk_function(
-            client=self.resource_client.deployments, function_name="create_or_update"
+            client=self.resource_client.deployments,
+            function_name="create_or_update",
         )
         create_or_update(
             resource_group_name=resource_group,
-            deployment_name=vm_name,
+            deployment_name=deployment_name,
             parameters=parameters,
         ).wait(timeout=AUTOSCALER_NODE_START_WAIT_S)
 

--- a/python/ray/autoscaler/azure/defaults.yaml
+++ b/python/ray/autoscaler/azure/defaults.yaml
@@ -61,6 +61,7 @@ available_node_types:
                 imageOffer: ubuntu-1804
                 imageSku: 1804-gen2
                 imageVersion: latest
+                zones: ["None"]
 
     ray.worker.default:
         # The minimum number of nodes of this type to launch.
@@ -82,6 +83,8 @@ available_node_types:
                 # set a maximum price for spot instances if desired
                 # billingProfile:
                 #     maxPrice: -1
+                # Nodes will not be assigned availability zones
+                zones: ["None"]
 
 # Specify the node type of the head node (as configured above).
 head_node_type: ray.head.default

--- a/python/ray/autoscaler/azure/defaults.yaml
+++ b/python/ray/autoscaler/azure/defaults.yaml
@@ -32,6 +32,12 @@ provider:
     # set unique id for resources in this cluster
     # if not set a default id will be generated based on the resource group and cluster name
     # unique_id: RAY1
+    # Availability zones for VM placement (comma-separated). Examples:
+    # availability_zone: "1,2,3"  # Use zones 1, 2, and 3
+    # availability_zone: "1"      # Use only zone 1
+    # availability_zone: "none"   # Explicitly disable zones
+    availability_zone: ""       # Let Azure automatically pick zones
+
 
 # How Ray will authenticate with newly launched nodes.
 auth:
@@ -61,7 +67,8 @@ available_node_types:
                 imageOffer: ubuntu-1804
                 imageSku: 1804-gen2
                 imageVersion: latest
-                zones: ["None"]
+                # Head node: explicitly disable availability zones
+                availability_zone: "none"
 
     ray.worker.default:
         # The minimum number of nodes of this type to launch.
@@ -83,8 +90,9 @@ available_node_types:
                 # set a maximum price for spot instances if desired
                 # billingProfile:
                 #     maxPrice: -1
-                # Nodes will not be assigned availability zones
-                zones: ["None"]
+                # Workers: inherit provider availability_zone setting
+                # Options: "1,2,3" for specific zones, "none" to disable zones,
+                # "" (empty) or omit to let Azure pick zones automatically
 
 # Specify the node type of the head node (as configured above).
 head_node_type: ray.head.default

--- a/python/ray/autoscaler/azure/defaults.yaml
+++ b/python/ray/autoscaler/azure/defaults.yaml
@@ -36,7 +36,7 @@ provider:
     # availability_zone: "1,2,3"  # Use zones 1, 2, and 3
     # availability_zone: "1"      # Use only zone 1
     # availability_zone: "none"   # Explicitly disable zones
-    availability_zone: ""       # Let Azure automatically pick zones
+    availability_zone: "auto"    # Let Azure automatically pick zones
 
 
 # How Ray will authenticate with newly launched nodes.
@@ -92,7 +92,7 @@ available_node_types:
                 #     maxPrice: -1
                 # Workers: inherit provider availability_zone setting
                 # Options: "1,2,3" for specific zones, "none" to disable zones,
-                # "" (empty) or omit to let Azure pick zones automatically
+                #  or "auto" to let Azure pick zones automatically
 
 # Specify the node type of the head node (as configured above).
 head_node_type: ray.head.default

--- a/python/ray/autoscaler/azure/example-availability-zones.yaml
+++ b/python/ray/autoscaler/azure/example-availability-zones.yaml
@@ -10,6 +10,9 @@ provider:
   location: westus2
   resource_group: ray-zones
   cache_stopped_nodes: False
+  # Provider-level availability zone configuration (comma-separated)
+  # This will be used as default for all node types unless overridden
+  availability_zone: "1,2,3"
 
 auth:
   ssh_user: ubuntu
@@ -26,8 +29,8 @@ available_node_types:
         imageOffer: ubuntu-2004
         imageSku: 2004-gen2
         imageVersion: latest
-        # Nodes will not be assigned availability zones
-        zones: ["None"]
+        # Head node: explicitly disable availability zones
+        availability_zone: "none"
   ray.worker.default:
     min_workers: 0
     max_workers: 2
@@ -39,9 +42,8 @@ available_node_types:
         imageOffer: ubuntu-2004
         imageSku: 2004-gen2
         imageVersion: latest
-        # Workers will be assigned to availability zones 2 and 3 in a round-robin manner.
-        zones: ["2", "3"]
-  ray.worker.any_zone:
+        # Workers will use provider specified availability zones
+  ray.worker.specific_zone:
     min_workers: 0
     max_workers: 2
     resources: {"CPU": 2}
@@ -52,8 +54,8 @@ available_node_types:
         imageOffer: ubuntu-2004
         imageSku: 2004-gen2
         imageVersion: latest
-        # Workers will be assigned to availability zones by Azure
-        zones: []
+        # Workers will use availability zone 2 only (overrides provider setting)
+        availability_zone: "2"
 
 # Note: The Ubuntu 20.04 dsvm image has a few venvs already configured but
 # they all contain python modules that are not compatible with Ray at the moment.

--- a/python/ray/autoscaler/azure/example-availability-zones.yaml
+++ b/python/ray/autoscaler/azure/example-availability-zones.yaml
@@ -39,7 +39,7 @@ available_node_types:
         imageOffer: ubuntu-2004
         imageSku: 2004-gen2
         imageVersion: latest
-        # Workers will be assigned to avaibility zones 2 and 3 in a round-robin manner.
+        # Workers will be assigned to availability zones 2 and 3 in a round-robin manner.
         zones: ["2", "3"]
   ray.worker.any_zone:
     min_workers: 0
@@ -52,13 +52,14 @@ available_node_types:
         imageOffer: ubuntu-2004
         imageSku: 2004-gen2
         imageVersion: latest
-        # Workers will be assigned to avability zones by Azure
+        # Workers will be assigned to availability zones by Azure
         zones: []
 
 # Note: The Ubuntu 20.04 dsvm image has a few venvs already configured but
 # they all contain python modules that are not compatible with Ray at the moment.
 setup_commands:
     - (which conda && echo 'eval "$(conda shell.bash hook)"' >> ~/.bashrc) || true
+    - conda tos accept
     - conda create -n ray-env python=3.10 -y
     - conda activate ray-env && echo 'conda activate ray-env' >> ~/.bashrc
     - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl"

--- a/python/ray/autoscaler/azure/example-availbility-zones.yaml
+++ b/python/ray/autoscaler/azure/example-availbility-zones.yaml
@@ -1,0 +1,73 @@
+# Unique identifier for the head node and workers of this cluster.
+cluster_name: nightly-cpu-minimal-2
+max_workers: 6
+idle_timeout_minutes: 5
+
+# Cloud-provider specific configuration.
+provider:
+  type: azure
+    # https://azure.microsoft.com/en-us/global-infrastructure/locations
+  location: westus2
+  resource_group: ray-zones
+  cache_stopped_nodes: False
+
+auth:
+  ssh_user: ubuntu
+  ssh_private_key: ~/.ssh/id_rsa
+  ssh_public_key: ~/.ssh/id_rsa.pub
+
+available_node_types:
+  ray.head.default:
+    resources: {"CPU": 2}
+    node_config:
+      azure_arm_parameters:
+        vmSize: Standard_D2s_v3
+        imagePublisher: microsoft-dsvm
+        imageOffer: ubuntu-2004
+        imageSku: 2004-gen2
+        imageVersion: latest
+        # Nodes will not be assigned availability zones
+        zones: ["None"]
+  ray.worker.default:
+    min_workers: 0
+    max_workers: 2
+    resources: {"CPU": 2}
+    node_config:
+      azure_arm_parameters:
+        vmSize: Standard_D2s_v3
+        imagePublisher: microsoft-dsvm
+        imageOffer: ubuntu-2004
+        imageSku: 2004-gen2
+        imageVersion: latest
+        # Workers will be assigned to avaibility zones 2 and 3 in a round-robin manner.
+        zones: ["2", "3"]
+  ray.worker.any_zone:
+    min_workers: 0
+    max_workers: 2
+    resources: {"CPU": 2}
+    node_config:
+      azure_arm_parameters:
+        vmSize: Standard_D2s_v3
+        imagePublisher: microsoft-dsvm
+        imageOffer: ubuntu-2004
+        imageSku: 2004-gen2
+        imageVersion: latest
+        # Workers will be assigned to avability zones by Azure
+        zones: []
+
+# Note: The Ubuntu 20.04 dsvm image has a few venvs already configured but
+# they all contain python modules that are not compatible with Ray at the moment.
+setup_commands:
+    - (which conda && echo 'eval "$(conda shell.bash hook)"' >> ~/.bashrc) || true
+    - conda create -n ray-env python=3.10 -y
+    - conda activate ray-env && echo 'conda activate ray-env' >> ~/.bashrc
+    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl"
+
+file_mounts_sync_continuously: False
+
+file_mounts: {
+    "~/.ssh/id_rsa.pub": "~/.ssh/id_rsa.pub"
+}
+
+head_setup_commands:
+- pip install azure-core==1.35.0 azure-identity==1.23.1 azure-mgmt-compute==35.0.0 azure-mgmt-network==29.0.0 azure-mgmt-resource==24.0.0 azure-common==1.1.28 msrest==0.7.1 msrestazure==0.6.4.post1

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -748,6 +748,7 @@ py_test_module_list(
 py_test_module_list(
     size = "small",
     files = [
+        "test_autoscaler_azure.py",
         "test_autoscaler_gcp.py",
         "test_autoscaler_util.py",
     ],

--- a/python/ray/tests/test_autoscaler_azure.py
+++ b/python/ray/tests/test_autoscaler_azure.py
@@ -1,0 +1,370 @@
+"""Tests for Azure autoscaler availability zone functionality."""
+import copy
+import unittest
+from unittest.mock import Mock, patch
+
+from ray.autoscaler._private._azure.node_provider import AzureNodeProvider
+
+
+class TestAzureAvailabilityZones(unittest.TestCase):
+    """Test cases for Azure autoscaler availability zone support."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.provider_config = {
+            "resource_group": "test-rg",
+            "location": "westus2",
+            "subscription_id": "test-sub-id",
+        }
+        self.cluster_name = "test-cluster"
+
+        # Create a mock provider that doesn't initialize Azure clients
+        with patch.object(
+            AzureNodeProvider,
+            "__init__",
+            lambda self, provider_config, cluster_name: None,
+        ):
+            self.provider = AzureNodeProvider(self.provider_config, self.cluster_name)
+            self.provider.provider_config = self.provider_config
+            self.provider.cluster_name = self.cluster_name
+
+    def test_parse_availability_zones_none_input(self):
+        """Test _parse_availability_zones with None input returns empty list."""
+        result = self.provider._parse_availability_zones(None)
+        self.assertEqual(result, [])
+
+    def test_parse_availability_zones_empty_string(self):
+        """Test _parse_availability_zones with empty string returns empty list."""
+        result = self.provider._parse_availability_zones("")
+        self.assertEqual(result, [])
+
+    def test_parse_availability_zones_whitespace_only(self):
+        """Test _parse_availability_zones with whitespace-only string returns empty list."""
+        result = self.provider._parse_availability_zones("   ")
+        self.assertEqual(result, [])
+
+    def test_parse_availability_zones_single_zone(self):
+        """Test _parse_availability_zones with single zone string."""
+        result = self.provider._parse_availability_zones("1")
+        self.assertEqual(result, ["1"])
+
+    def test_parse_availability_zones_multiple_zones(self):
+        """Test _parse_availability_zones with comma-separated zones."""
+        result = self.provider._parse_availability_zones("1,2,3")
+        self.assertEqual(result, ["1", "2", "3"])
+
+    def test_parse_availability_zones_zones_with_spaces(self):
+        """Test _parse_availability_zones with spaces around zones."""
+        result = self.provider._parse_availability_zones("1, 2, 3")
+        self.assertEqual(result, ["1", "2", "3"])
+
+    def test_parse_availability_zones_zones_with_extra_spaces(self):
+        """Test _parse_availability_zones with extra spaces and tabs."""
+        result = self.provider._parse_availability_zones("  1 ,   2   , 3  ")
+        self.assertEqual(result, ["1", "2", "3"])
+
+    def test_parse_availability_zones_none_disable_case_insensitive(self):
+        """Test _parse_availability_zones with 'none' variations disables zones."""
+        test_cases = ["none", "None", "NONE"]
+        for case in test_cases:
+            with self.subTest(case=case):
+                result = self.provider._parse_availability_zones(case)
+                self.assertIsNone(result)
+
+    def test_parse_availability_zones_null_disable_case_insensitive(self):
+        """Test _parse_availability_zones with 'null' variations disables zones."""
+        test_cases = ["null", "Null", "NULL"]
+        for case in test_cases:
+            with self.subTest(case=case):
+                result = self.provider._parse_availability_zones(case)
+                self.assertIsNone(result)
+
+    def test_parse_availability_zones_invalid_type(self):
+        """Test _parse_availability_zones with invalid input type raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            self.provider._parse_availability_zones(123)
+
+        self.assertIn("availability_zone must be a string", str(context.exception))
+        self.assertIn("got int: 123", str(context.exception))
+
+    def test_parse_availability_zones_list_input_invalid(self):
+        """Test _parse_availability_zones with list input raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            self.provider._parse_availability_zones(["1", "2", "3"])
+
+        self.assertIn("availability_zone must be a string", str(context.exception))
+
+    def test_parse_availability_zones_dict_input_invalid(self):
+        """Test _parse_availability_zones with dict input raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            self.provider._parse_availability_zones({"zones": ["1", "2"]})
+
+        self.assertIn("availability_zone must be a string", str(context.exception))
+
+    def test_parse_availability_zones_numeric_zones(self):
+        """Test _parse_availability_zones with numeric zone strings."""
+        result = self.provider._parse_availability_zones("1,2,3")
+        self.assertEqual(result, ["1", "2", "3"])
+
+    def test_parse_availability_zones_alpha_zones(self):
+        """Test _parse_availability_zones with alphabetic zone strings."""
+        result = self.provider._parse_availability_zones("east,west,central")
+        self.assertEqual(result, ["east", "west", "central"])
+
+    def test_parse_availability_zones_mixed_zones(self):
+        """Test _parse_availability_zones with mixed numeric and alpha zones."""
+        result = self.provider._parse_availability_zones("1,zone-b,3")
+        self.assertEqual(result, ["1", "zone-b", "3"])
+
+
+class TestAzureAvailabilityZonePrecedence(unittest.TestCase):
+    """Test cases for Azure availability zone precedence logic."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.base_provider_config = {
+            "resource_group": "test-rg",
+            "location": "westus2",
+            "subscription_id": "test-sub-id",
+        }
+        self.cluster_name = "test-cluster"
+
+    def _create_mock_provider(self, provider_config=None):
+        """Create a mock Azure provider for testing."""
+        config = copy.deepcopy(self.base_provider_config)
+        if provider_config:
+            config.update(provider_config)
+
+        with patch.object(
+            AzureNodeProvider,
+            "__init__",
+            lambda self, provider_config, cluster_name: None,
+        ):
+            provider = AzureNodeProvider(config, self.cluster_name)
+            provider.provider_config = config
+            provider.cluster_name = self.cluster_name
+
+            # Mock the validation method to avoid Azure API calls
+            provider._validate_zones_for_node_pool = Mock(
+                side_effect=lambda zones, location, vm_size: zones
+            )
+
+            return provider
+
+    def _extract_zone_logic(self, provider, node_config):
+        """Extract zone determination logic similar to _create_node method."""
+        node_availability_zone = node_config.get("azure_arm_parameters", {}).get(
+            "availability_zone"
+        )
+        provider_availability_zone = provider.provider_config.get("availability_zone")
+
+        if node_availability_zone is not None:
+            return (
+                provider._parse_availability_zones(node_availability_zone),
+                "node config availability_zone",
+            )
+        elif provider_availability_zone is not None:
+            return (
+                provider._parse_availability_zones(provider_availability_zone),
+                "provider availability_zone",
+            )
+        else:
+            return ([], "default")
+
+    def test_node_availability_zone_overrides_provider(self):
+        """Test that node-level availability_zone overrides provider-level."""
+        provider = self._create_mock_provider({"availability_zone": "1,2"})
+        node_config = {
+            "azure_arm_parameters": {
+                "vmSize": "Standard_D2s_v3",
+                "availability_zone": "3",
+            }
+        }
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertEqual(zones, ["3"])
+        self.assertEqual(source, "node config availability_zone")
+
+    def test_provider_availability_zone_used_when_no_node_override(self):
+        """Test that provider-level availability_zone is used when no node override."""
+        provider = self._create_mock_provider({"availability_zone": "1,2"})
+        node_config = {"azure_arm_parameters": {"vmSize": "Standard_D2s_v3"}}
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertEqual(zones, ["1", "2"])
+        self.assertEqual(source, "provider availability_zone")
+
+    def test_none_disables_zones_at_node_level(self):
+        """Test that 'none' at node level disables zones even with provider zones."""
+        provider = self._create_mock_provider({"availability_zone": "1,2"})
+        node_config = {
+            "azure_arm_parameters": {
+                "vmSize": "Standard_D2s_v3",
+                "availability_zone": "none",
+            }
+        }
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertIsNone(zones)
+        self.assertEqual(source, "node config availability_zone")
+
+    def test_no_zones_when_neither_provider_nor_node_specify(self):
+        """Test default behavior when neither provider nor node specify zones."""
+        provider = self._create_mock_provider()
+        node_config = {"azure_arm_parameters": {"vmSize": "Standard_D2s_v3"}}
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertEqual(zones, [])
+        self.assertEqual(source, "default")
+
+    def test_node_empty_string_overrides_provider_zones(self):
+        """Test that node empty string overrides provider zones (auto-selection)."""
+        provider = self._create_mock_provider({"availability_zone": "1,2"})
+        node_config = {
+            "azure_arm_parameters": {
+                "vmSize": "Standard_D2s_v3",
+                "availability_zone": "",
+            }
+        }
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertEqual(zones, [])
+        self.assertEqual(source, "node config availability_zone")
+
+    def test_provider_none_disables_zones(self):
+        """Test that provider-level 'none' disables zones."""
+        provider = self._create_mock_provider({"availability_zone": "none"})
+        node_config = {"azure_arm_parameters": {"vmSize": "Standard_D2s_v3"}}
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertIsNone(zones)
+        self.assertEqual(source, "provider availability_zone")
+
+    def test_provider_empty_string_allows_auto_selection(self):
+        """Test that provider-level empty string allows auto-selection."""
+        provider = self._create_mock_provider({"availability_zone": ""})
+        node_config = {"azure_arm_parameters": {"vmSize": "Standard_D2s_v3"}}
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertEqual(zones, [])
+        self.assertEqual(source, "provider availability_zone")
+
+    def test_node_null_overrides_provider_zones(self):
+        """Test that node-level 'null' overrides provider zones."""
+        provider = self._create_mock_provider({"availability_zone": "1,2,3"})
+        node_config = {
+            "azure_arm_parameters": {
+                "vmSize": "Standard_D2s_v3",
+                "availability_zone": "null",
+            }
+        }
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertIsNone(zones)
+        self.assertEqual(source, "node config availability_zone")
+
+    def test_provider_null_disables_zones(self):
+        """Test that provider-level 'null' disables zones."""
+        provider = self._create_mock_provider({"availability_zone": "NULL"})
+        node_config = {"azure_arm_parameters": {"vmSize": "Standard_D2s_v3"}}
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertIsNone(zones)
+        self.assertEqual(source, "provider availability_zone")
+
+    def test_complex_override_scenario(self):
+        """Test complex scenario with multiple node types and different overrides."""
+        provider = self._create_mock_provider({"availability_zone": "1,2,3"})
+
+        # Test different node configurations
+        test_cases = [
+            # Node with specific zone override
+            {
+                "config": {
+                    "azure_arm_parameters": {
+                        "vmSize": "Standard_D2s_v3",
+                        "availability_zone": "2",
+                    }
+                },
+                "expected_zones": ["2"],
+                "expected_source": "node config availability_zone",
+            },
+            # Node with disabled zones
+            {
+                "config": {
+                    "azure_arm_parameters": {
+                        "vmSize": "Standard_D2s_v3",
+                        "availability_zone": "none",
+                    }
+                },
+                "expected_zones": None,
+                "expected_source": "node config availability_zone",
+            },
+            # Node with auto-selection
+            {
+                "config": {
+                    "azure_arm_parameters": {
+                        "vmSize": "Standard_D2s_v3",
+                        "availability_zone": "",
+                    }
+                },
+                "expected_zones": [],
+                "expected_source": "node config availability_zone",
+            },
+            # Node using provider default
+            {
+                "config": {"azure_arm_parameters": {"vmSize": "Standard_D2s_v3"}},
+                "expected_zones": ["1", "2", "3"],
+                "expected_source": "provider availability_zone",
+            },
+        ]
+
+        for i, test_case in enumerate(test_cases):
+            with self.subTest(case=i):
+                zones, source = self._extract_zone_logic(provider, test_case["config"])
+                self.assertEqual(zones, test_case["expected_zones"])
+                self.assertEqual(source, test_case["expected_source"])
+
+    def test_mixed_case_precedence(self):
+        """Test precedence with mixed case 'none' values."""
+        provider = self._create_mock_provider({"availability_zone": "None"})
+        node_config = {
+            "azure_arm_parameters": {
+                "vmSize": "Standard_D2s_v3",
+                "availability_zone": "NONE",
+            }
+        }
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        # Both should be None (disabled), but node should take precedence
+        self.assertIsNone(zones)
+        self.assertEqual(source, "node config availability_zone")
+
+    def test_whitespace_handling_in_precedence(self):
+        """Test that whitespace is properly handled in precedence logic."""
+        provider = self._create_mock_provider({"availability_zone": "  1, 2, 3  "})
+        node_config = {
+            "azure_arm_parameters": {
+                "vmSize": "Standard_D2s_v3",
+                "availability_zone": "  2  ",
+            }
+        }
+
+        zones, source = self._extract_zone_logic(provider, node_config)
+
+        self.assertEqual(zones, ["2"])
+        self.assertEqual(source, "node config availability_zone")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds ability to specify availability zones for each node pool in a ray cluster deployment on Azure.
Sometimes VM quota (especially for GPU VM SKUs) are only given per availability zone so without these changes users might not be able to use GPU enabled VM SKUs

## Related issue number

<!-- For example: "Closes #1234" -->
Fixes: https://github.com/ray-project/ray/issues/39966

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
  
