### PR TITLE
[serve.llm] Serialize ChatCompletionRequest tool_calls ValidatorIterator object

### DIFF
--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -148,8 +148,20 @@ class TestRouter:
             stream=stream,
             max_tokens=200,
         )
-        assert response.choices[0].message.content is not None
-        print(response.choices[0].message)
+
+        if stream:
+            text = ""
+            role = None
+            for chunk in response:
+                if chunk.choices[0].delta.role is not None and role is None:
+                    role = chunk.choices[0].delta.role
+                if chunk.choices[0].delta.content:
+                    text += chunk.choices[0].delta.content
+        else:
+            text = response.choices[0].message.content
+            role = response.choices[0].message.role
+
+        assert text
 
     def test_router_with_num_router_replicas_config(self):
         """Test the router with num_router_replicas config."""

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -115,6 +115,42 @@ class TestRouter:
         expected_text = " ".join([f"test_{i}" for i in range(n_tokens)])
         assert text.strip() == expected_text
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stream", [True, False])
+    async def test_tool_call(self, client, stream):
+        response = client.chat.completions.create(
+            model="llm_model_id",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Can you tell me what the temperate will be in Dallas, in fahrenheit?",
+                },
+                {
+                    "content": None,
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "RBS92VTjJ",
+                            "function": {
+                                "arguments": '{"city": "Dallas", "state": "TX", "unit": "fahrenheit"}',
+                                "name": "get_current_weather",
+                            },
+                            "type": "function",
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": "The weather in Dallas, TX is 85 degrees fahrenheit. It is partly cloudly, with highs in the 90's.",
+                    "tool_call_id": "n3OMUpydP",
+                },
+            ],
+            stream=stream,
+            max_tokens=200,
+        )
+        assert response.choices[0].message.content is not None
+        print(response.choices[0].message)
+
     def test_router_with_num_router_replicas_config(self):
         """Test the router with num_router_replicas config."""
         # Test with no num_router_replicas config.

--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -149,33 +149,34 @@ async def test_tool_calls_serialization():
 
     # Query with multi-turn tool call
     client = OpenAI(base_url="http://localhost:8000/v1", api_key="FAKE_KEY")
-    messages = [{"role": "user", "content": "What's 2+2 ?"}]
-    response = client.chat.completions.create(
-        model="qwen",
-        messages=messages,
-        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
-    )
-
-    messages.append(
+    messages = [
         {
-            "content": "2 + 2 equals 4.",
-            "refusal": None,
+            "role": "user",
+            "content": "Can you tell me what the temperate will be in Dallas, in fahrenheit?",
+        },
+        {
+            "content": None,
             "role": "assistant",
-            "annotations": None,
-            "audio": None,
-            "function_call": None,
-            "tool_calls": [],
-            "reasoning_content": None,
-        }
-    )
-
-    response = client.chat.completions.create(
-        model="qwen",
-        messages=messages,
-        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
-    )
-
-    print(response.choices[0].message)
+            "tool_calls": [
+                {
+                    "id": "RBS92VTjJ",
+                    "function": {
+                        "arguments": '{"city": "Dallas", "state": "TX", "unit": "fahrenheit"}',
+                        "name": "get_current_weather",
+                    },
+                    "type": "function",
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "The weather in Dallas, TX is 85 degrees fahrenheit. It is partly cloudly, with highs in the 90's.",
+            "tool_call_id": "n3OMUpydP",
+        },
+    ]
+    chat_completion = client.chat.completions.create(messages=messages, model="qwen")
+    assert chat_completion.choices[0].message.content is not None
+    print(chat_completion.choices[0].message)
     serve.shutdown()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This addresses a known Pydantic bug where `tool_calls` fields become `ValidatorIterator` objects that cannot be pickled for Ray remote calls.

References:
  - vLLM PR that introduces the workaround: https://github.com/vllm-project/vllm/pull/9951
  - Pydantic Issue: https://github.com/pydantic/pydantic/issues/9467
  - Related Issue: https://github.com/pydantic/pydantic/issues/9541
  - Official Workaround: https://github.com/pydantic/pydantic/issues/9467#issuecomment-2442097291

We can remove when we update to Pydantic v2.11+ with the fix.

## Related issue number

Closes https://github.com/ray-project/ray/issues/55046
Closes https://github.com/ray-project/ray/issues/55294

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
