### PR TITLE
[SERVE] Parameterize app deletion timeout for ray serve

### DIFF
--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -345,17 +345,17 @@ class ServeControllerClient:
         ray.get(self._controller.apply_config.remote(config))
 
         if _blocking:
-            start = time.time()
+            timeout_s = 60
 
-            while time.time() - start < RAY_SERVE_APP_DELETION_TIMEOUT_S:
+            start = time.time()
+            while time.time() - start < timeout_s:
                 curr_status = self.get_serve_status()
                 if curr_status.app_status.status == ApplicationStatus.RUNNING:
                     break
                 time.sleep(CLIENT_POLLING_INTERVAL_S)
             else:
                 raise TimeoutError(
-                    f"Serve application isn't running after "
-                    f"{RAY_SERVE_APP_DELETION_TIMEOUT_S}s."
+                    f"Serve application isn't running after {timeout_s}s."
                 )
 
     @_ensure_connected
@@ -367,7 +367,7 @@ class ServeControllerClient:
         self._controller.delete_apps.remote(names)
         if blocking:
             start = time.time()
-            while time.time() - start < 60:
+            while time.time() - start < RAY_SERVE_APP_DELETION_TIMEOUT_S:
                 curr_statuses_bytes = ray.get(
                     self._controller.get_serve_statuses.remote(names)
                 )

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import random
 import time
 from collections.abc import Sequence
@@ -20,6 +19,7 @@ from ray.serve._private.constants import (
     CLIENT_CHECK_CREATION_POLLING_INTERVAL_S,
     CLIENT_POLLING_INTERVAL_S,
     MAX_CACHED_HANDLES,
+    RAY_SERVE_APP_DELETION_TIMEOUT_S,
     SERVE_DEFAULT_APP_NAME,
     SERVE_LOGGER_NAME,
 )
@@ -345,17 +345,17 @@ class ServeControllerClient:
         ray.get(self._controller.apply_config.remote(config))
 
         if _blocking:
-            timeout_s = float(os.environ.get("RAY_SERVE_APP_DELETION_TIMEOUT_S", "60"))
             start = time.time()
 
-            while time.time() - start < timeout_s:
+            while time.time() - start < RAY_SERVE_APP_DELETION_TIMEOUT_S:
                 curr_status = self.get_serve_status()
                 if curr_status.app_status.status == ApplicationStatus.RUNNING:
                     break
                 time.sleep(CLIENT_POLLING_INTERVAL_S)
             else:
                 raise TimeoutError(
-                    f"Serve application isn't running after {timeout_s}s."
+                    f"Serve application isn't running after "
+                    f"{RAY_SERVE_APP_DELETION_TIMEOUT_S}s."
                 )
 
     @_ensure_connected

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -165,6 +165,11 @@ CLIENT_POLLING_INTERVAL_S = 1.0
 # deployment has been created
 CLIENT_CHECK_CREATION_POLLING_INTERVAL_S = 0.1
 
+# Timeout for application deletion in seconds
+RAY_SERVE_APP_DELETION_TIMEOUT_S = get_env_float(
+    "RAY_SERVE_APP_DELETION_TIMEOUT_S", 60.0
+)
+
 # Timeout for GCS internal KV service
 RAY_SERVE_KV_TIMEOUT_S = get_env_float("RAY_SERVE_KV_TIMEOUT_S", 0.0) or None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. **The problem**: Tests were failing with "applications weren't deleted after 60s" because in certain deployment modes, Ray Serve cannot forcefully kill replicas - it must wait for all requests to complete and honor a mandatory draining period.

2. **Why some modes are different**: When replicas are exposed to external load balancers (AWS ALB, K8s Ingress), the system needs extra time for load balancers to detect unhealthy targets and stop routing traffic, unlike standard proxy mode where replicas can be force-killed.

3. **The solution**: I made the application deletion timeout configurable via the `RAY_SERVE_APP_DELETION_TIMEOUT_S` environment variable, defaulting to 60 seconds to preserve existing behavior.

4. **Enabling different test configuration**: Added this environment variable to the test configurations which can be set  higher than 60 seconds allowing tests to run successfully across different deployment modes and configurations that may require varying cleanup times.

5. **Why this change helps**: This minimal change keeps production code behavior unchanged while allowing tests to specify appropriate timeouts for their execution mode, solving the test failures without affecting normal Ray Serve operations.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
