### PR TITLE
[core][obsclean/04] move metric registration to constructor

### DIFF
--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -114,20 +114,6 @@ void Metric::Record(double value, TagsType tags) {
   }
 
   if (::RayConfig::instance().enable_open_telemetry()) {
-    // Register the metric if it hasn't been registered yet; otherwise, this is a no-op.
-    // We defer metric registration until the first time it's recorded, rather than during
-    // construction, to avoid issues with static initialization order. Specifically, our
-    // internal Metric objects (see metric_defs.h) are declared as static, and
-    // constructing another static object within their constructor can lead to crashes at
-    // program exit due to unpredictable destruction order.
-    //
-    // Once these internal Metric objects are migrated to use DEFINE_stats, we can
-    // safely move the registration logic to the constructor. See
-    // https://github.com/ray-project/ray/issues/54538 for the backlog of Ray metric infra
-    // improvements.
-    //
-    // This function is thread-safe.
-    RegisterOpenTelemetryMetric();
     // Collect tags from both the metric-specific tags and the global tags.
     absl::flat_hash_map<std::string, std::string> open_telemetry_tags;
     std::unordered_set<std::string> tag_keys_set;

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -163,7 +163,11 @@ class Gauge : public Metric {
         const std::string &description,
         const std::string &unit,
         const std::vector<std::string> &tag_keys = {})
-      : Metric(name, description, unit, tag_keys) {}
+      : Metric(name, description, unit, tag_keys) {
+    if (::RayConfig::instance().enable_open_telemetry()) {
+      RegisterOpenTelemetryMetric();
+    }
+  }
 
  private:
   void RegisterView() override;
@@ -178,7 +182,11 @@ class Histogram : public Metric {
             const std::string &unit,
             const std::vector<double> &boundaries,
             const std::vector<std::string> &tag_keys = {})
-      : Metric(name, description, unit, tag_keys), boundaries_(boundaries) {}
+      : Metric(name, description, unit, tag_keys), boundaries_(boundaries) {
+    if (::RayConfig::instance().enable_open_telemetry()) {
+      RegisterOpenTelemetryMetric();
+    }
+  }
 
  private:
   void RegisterView() override;
@@ -195,7 +203,11 @@ class Count : public Metric {
         const std::string &description,
         const std::string &unit,
         const std::vector<std::string> &tag_keys = {})
-      : Metric(name, description, unit, tag_keys) {}
+      : Metric(name, description, unit, tag_keys) {
+    if (::RayConfig::instance().enable_open_telemetry()) {
+      RegisterOpenTelemetryMetric();
+    }
+  }
 
  private:
   void RegisterView() override;
@@ -209,7 +221,11 @@ class Sum : public Metric {
       const std::string &description,
       const std::string &unit,
       const std::vector<std::string> &tag_keys = {})
-      : Metric(name, description, unit, tag_keys) {}
+      : Metric(name, description, unit, tag_keys) {
+    if (::RayConfig::instance().enable_open_telemetry()) {
+      RegisterOpenTelemetryMetric();
+    }
+  }
 
  private:
   void RegisterView() override;


### PR DESCRIPTION
Currently, the `Metric` class registers the metric name each time it records a new value, due to the [C++ static initialization order fiasco](https://en.cppreference.com/w/cpp/language/siof.html). The base of this PR move all static metrics to runtime initialization, allowing us to safely perform metric registration in the constructor.

Note that I'm only doing this for the open-telemetry stack. The opencensus has a complex registration sequence using view+measure and I have hard time make it to work so I don't bother fixing it.

Test:
- CI