### PR TITLE
[ci] raydepsets: refactor depsets - using depset map

### DIFF
--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -95,12 +95,12 @@ class DependencySetManager:
             self.execute_single(depset)
 
     def get_depset_by_id(self, depset_id: Tuple[str, str]) -> Depset:
-        depset = self.depset_map[depset_id]
-        if not depset:
+        try:
+            return self.depset_map[depset_id]
+        except KeyError:
             raise KeyError(
                 f"Dependency set {depset_id[0]} with build arg set {depset_id[1]} not found"
             )
-        return depset
 
     def exec_uv_cmd(self, cmd: str, args: List[str]) -> str:
         cmd = [self._uv_binary, "pip", cmd, *args]

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -66,20 +66,31 @@ class TestCli(unittest.TestCase):
             manager = _create_test_manager(tmpdir)
             assert manager is not None
             assert manager.workspace.dir == tmpdir
-            assert manager.config.depsets[0].name == "ray_base_test_depset"
-            assert manager.config.depsets[0].operation == "compile"
-            assert manager.config.depsets[0].requirements == ["requirements_test.txt"]
-            assert manager.config.depsets[0].constraints == [
+            assert (
+                manager.depset_map[("ray_base_test_depset", None)].name
+                == "ray_base_test_depset"
+            )
+            assert (
+                manager.depset_map[("ray_base_test_depset", None)].operation
+                == "compile"
+            )
+            assert manager.depset_map[("ray_base_test_depset", None)].requirements == [
+                "requirements_test.txt"
+            ]
+            assert manager.depset_map[("ray_base_test_depset", None)].constraints == [
                 "requirement_constraints_test.txt"
             ]
-            assert manager.config.depsets[0].output == "requirements_compiled.txt"
+            assert (
+                manager.depset_map[("ray_base_test_depset", None)].output
+                == "requirements_compiled.txt"
+            )
 
     def test_dependency_set_manager_get_depset(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             manager = _create_test_manager(tmpdir)
             with self.assertRaises(KeyError):
-                manager.get_depset("fake_depset")
+                manager.get_depset_by_id(depset_id=("fake_depset", None))
 
     def test_uv_binary_exists(self):
         assert _uv_binary() is not None
@@ -334,20 +345,23 @@ class TestCli(unittest.TestCase):
             assert len(manager.build_graph.nodes()) == 6
             assert len(manager.build_graph.edges()) == 3
             # assert that the compile depsets are first
-            assert manager.build_graph.nodes["general_depset"]["operation"] == "compile"
             assert (
-                manager.build_graph.nodes["subset_general_depset"]["operation"]
+                manager.build_graph.nodes[("general_depset", None)]["operation"]
+                == "compile"
+            )
+            assert (
+                manager.build_graph.nodes[("subset_general_depset", None)]["operation"]
                 == "subset"
             )
             assert (
-                manager.build_graph.nodes["expand_general_depset"]["operation"]
+                manager.build_graph.nodes[("expand_general_depset", None)]["operation"]
                 == "expand"
             )
             sorted_nodes = list(topological_sort(manager.build_graph))
             # assert that the root nodes are the compile depsets
-            assert "ray_base_test_depset" in sorted_nodes[:3]
-            assert "general_depset" in sorted_nodes[:3]
-            assert "build_args_test_depset_py311" in sorted_nodes[:3]
+            assert ("ray_base_test_depset", None) in sorted_nodes[:3]
+            assert ("general_depset", None) in sorted_nodes[:3]
+            assert ("build_args_test_depset_py311", "py311_cpu") in sorted_nodes[:3]
 
     def test_build_graph_bad_operation(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -458,7 +472,9 @@ depsets:
                 config_path="test.depsets.yaml",
                 workspace_dir=tmpdir,
             )
-            depset = manager.get_depset("build_args_test_depset_py311")
+            depset = manager.get_depset_by_id(
+                depset_id=("build_args_test_depset_py311", "py311_cpu")
+            )
             assert depset.name == "build_args_test_depset_py311"
             assert depset.build_arg_set_name == "py311_cpu"
 
@@ -469,7 +485,7 @@ depsets:
                 config_path="test.depsets.yaml",
                 workspace_dir=tmpdir,
             )
-            depset = manager.get_depset("ray_base_test_depset")
+            depset = manager.get_depset_by_id(depset_id=("ray_base_test_depset", None))
             assert depset.name == "ray_base_test_depset"
             assert depset.build_arg_set_name is None
 

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -465,7 +465,7 @@ depsets:
             output_text_valid = output_file_valid.read_text()
             assert output_text == output_text_valid
 
-    def test_get_depset_with_build_arg_set(self):
+    def test_get_depset_by_id_with_build_arg_set(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             manager = DependencySetManager(
@@ -478,7 +478,7 @@ depsets:
             assert depset.name == "build_args_test_depset_py311"
             assert depset.build_arg_set_name == "py311_cpu"
 
-    def test_get_depset_without_build_arg_set(self):
+    def test_get_depset_by_id_without_build_arg_set(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             manager = DependencySetManager(
@@ -488,6 +488,16 @@ depsets:
             depset = manager.get_depset_by_id(depset_id=("ray_base_test_depset", None))
             assert depset.name == "ray_base_test_depset"
             assert depset.build_arg_set_name is None
+
+    def test_get_depset_by_id_bad_depset_id(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = DependencySetManager(
+                config_path="test.depsets.yaml",
+                workspace_dir=tmpdir,
+            )
+            with self.assertRaises(KeyError):
+                manager.get_depset_by_id(depset_id=("fake_depset", "py311_cpu"))
 
 
 if __name__ == "__main__":

--- a/ci/raydepsets/tests/test_workspace.py
+++ b/ci/raydepsets/tests/test_workspace.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import pytest
 
 from ci.raydepsets.tests.utils import copy_data_to_tmpdir
-from ci.raydepsets.workspace import BuildArgSet, Workspace, _substitute_build_args
+from ci.raydepsets.workspace import (
+    BuildArgSet,
+    Workspace,
+    _substitute_build_args,
+    _expand_depsets_per_build_arg_set,
+)
 
 
 def test_workspace_init():
@@ -18,26 +23,17 @@ def test_parse_build_arg_sets():
     with tempfile.TemporaryDirectory() as tmpdir:
         copy_data_to_tmpdir(tmpdir)
         workspace = Workspace(dir=tmpdir)
-        config = workspace.load_config(path=Path(tmpdir) / "test.depsets.yaml")
-        assert config.build_arg_sets[0].name == "py311_cpu"
-        assert config.build_arg_sets[0].build_args == {
+        workspace.build_depset_map(path=Path(tmpdir) / "test.depsets.yaml")
+        assert workspace.build_arg_sets[0].name == "py311_cpu"
+        assert workspace.build_arg_sets[0].build_args == {
             "CUDA_VERSION": "cpu",
             "PYTHON_VERSION": "py311",
         }
-        assert config.build_arg_sets[1].name == "py311_cuda128"
-        assert config.build_arg_sets[1].build_args == {
+        assert workspace.build_arg_sets[1].name == "py311_cuda128"
+        assert workspace.build_arg_sets[1].build_args == {
             "CUDA_VERSION": 128,
             "PYTHON_VERSION": "py311",
         }
-
-
-def test_from_dict_build_arg_set_matrix():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        copy_data_to_tmpdir(tmpdir)
-        workspace = Workspace(dir=tmpdir)
-        config = workspace.load_config(path=Path(tmpdir) / "test.depsets.yaml")
-        config.build_arg_sets[0].build_args["PYTHON_VERSION"] = "py312"
-        config.build_arg_sets[0].build_args["CUDA_VERSION"] = "cu128"
 
 
 def test_substitute_build_args():
@@ -57,6 +53,52 @@ def test_substitute_build_args():
     substituted_depset = _substitute_build_args(depset_dict, build_arg_set)
     assert substituted_depset["output"] == "requirements_compiled_test_py311_cu128.txt"
     assert substituted_depset["name"] == "test_depset_py311_cu128"
+
+
+def test_expand_depsets_per_build_arg_set():
+    depset = {
+        "name": "test_depset_${PYTHON_VERSION}_${CUDA_VERSION}",
+        "operation": "compile",
+        "requirements": ["requirements_test.txt"],
+        "output": "requirements_compiled_test_${PYTHON_VERSION}_${CUDA_VERSION}.txt",
+    }
+    build_arg_set_matrix = ["py311_cpu", "py311_cuda128"]
+    build_arg_sets = [
+        BuildArgSet(
+            name="py311_cpu",
+            build_args={"PYTHON_VERSION": "py311", "CUDA_VERSION": "cpu"},
+        ),
+        BuildArgSet(
+            name="py311_cuda128",
+            build_args={"PYTHON_VERSION": "py311", "CUDA_VERSION": 128},
+        ),
+    ]
+    expanded_depsets = _expand_depsets_per_build_arg_set(
+        depset, build_arg_set_matrix, build_arg_sets
+    )
+    assert len(expanded_depsets) == 2
+    assert expanded_depsets[0].name == "test_depset_py311_cpu"
+    assert expanded_depsets[0].output == "requirements_compiled_test_py311_cpu.txt"
+    assert expanded_depsets[1].name == "test_depset_py311_128"
+    assert expanded_depsets[1].output == "requirements_compiled_test_py311_128.txt"
+
+
+def test_expand_depsets_per_build_arg_set_bad_build_arg_set():
+    depset = {
+        "name": "test_depset_${PYTHON_VERSION}_${CUDA_VERSION}",
+        "operation": "compile",
+        "requirements": ["requirements_test.txt"],
+        "output": "requirements_compiled_test_${PYTHON_VERSION}_${CUDA_VERSION}.txt",
+    }
+    build_arg_set_matrix = ["py311_cpu", "py311_cuda128"]
+    build_arg_sets = [
+        BuildArgSet(
+            name="py311_cpu",
+            build_args={"PYTHON_VERSION": "py311", "CUDA_VERSION": "cpu"},
+        ),
+    ]
+    with pytest.raises(KeyError):
+        _expand_depsets_per_build_arg_set(depset, build_arg_set_matrix, build_arg_sets)
 
 
 if __name__ == "__main__":

--- a/ci/raydepsets/workspace.py
+++ b/ci/raydepsets/workspace.py
@@ -6,11 +6,13 @@ from typing import Any, Dict, List, Optional, Tuple
 import yaml
 
 
+@dataclass
 class BuildArgSet:
     name: str
     build_args: Dict[str, str]
 
 
+@dataclass
 class Depset:
     name: str
     operation: str

--- a/ci/raydepsets/workspace.py
+++ b/ci/raydepsets/workspace.py
@@ -6,13 +6,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import yaml
 
 
-@dataclass
 class BuildArgSet:
     name: str
     build_args: Dict[str, str]
 
 
-@dataclass
 class Depset:
     name: str
     operation: str
@@ -97,9 +95,11 @@ class Config:
 
 
 def _expand_depsets_per_build_arg_set(
-    depset: dict, build_arg_set_matrix: List[str], build_arg_sets: List[BuildArgSet]
+    depset: dict,
+    build_arg_set_matrix: List[str],
+    build_arg_sets: Dict[str, BuildArgSet],
 ) -> List[Depset]:
-    """returns a list of depsets with the build arg set name appended to the name"""
+    """returns a list of depsets expanded per build arg set"""
     expanded_depsets = []
     for build_arg_set_name in build_arg_set_matrix:
         build_arg_set = next(

--- a/ci/raydepsets/workspace.py
+++ b/ci/raydepsets/workspace.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass, field
 from string import Template
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
@@ -49,41 +49,41 @@ def _dict_to_depset(depset: dict, build_arg_set_name: Optional[str] = None) -> D
         output=depset.get("output"),
         source_depset=depset.get("source_depset"),
         depsets=depset.get("depsets", []),
-        build_arg_set_name=build_arg_set_name,
         override_flags=depset.get("override_flags", []),
         append_flags=depset.get("append_flags", []),
+        build_arg_set_name=build_arg_set_name,
     )
 
 
 @dataclass
 class Config:
-    depsets: List[Depset] = field(default_factory=list)
-    build_arg_sets: List[BuildArgSet] = field(default_factory=list)
-
     @staticmethod
-    def from_dict(data: dict) -> "Config":
-        build_arg_sets = Config.parse_build_arg_sets(data.get("build_arg_sets", []))
+    def to_depset_map(
+        data: dict, build_arg_sets: List[BuildArgSet]
+    ) -> Dict[Tuple[str, str], Depset]:
+        """
+        Convert a config dict to a depset map.
+        The depset map is a dictionary of tuples of (depset_name, build_arg_set_name) to Depset objects.
+        """
         raw_depsets = data.get("depsets", [])
-        depsets = []
+        depset_map = {}
         for depset in raw_depsets:
+            # check if the depset has a build_arg_sets field
             build_arg_set_matrix = depset.get("build_arg_sets", [])
             if build_arg_set_matrix:
-                for build_arg_set_name in build_arg_set_matrix:
-                    build_arg_set = next(
-                        (
-                            build_arg_set
-                            for build_arg_set in build_arg_sets
-                            if build_arg_set.name == build_arg_set_name
-                        ),
-                        None,
+                expanded_depsets = _expand_depsets_per_build_arg_set(
+                    depset, build_arg_set_matrix, build_arg_sets
+                )
+                for expanded_depset in expanded_depsets:
+                    depset_id = (
+                        expanded_depset.name,
+                        expanded_depset.build_arg_set_name,
                     )
-                    if build_arg_set is None:
-                        raise KeyError(f"Build arg set {build_arg_set_name} not found")
-                    depset_yaml = _substitute_build_args(depset, build_arg_set)
-                    depsets.append(_dict_to_depset(depset_yaml, build_arg_set_name))
+                    depset_map[depset_id] = expanded_depset
             else:
-                depsets.append(_dict_to_depset(depset=depset))
-        return Config(depsets=depsets, build_arg_sets=build_arg_sets)
+                depset_id = (depset["name"], None)
+                depset_map[depset_id] = _dict_to_depset(depset=depset)
+        return depset_map
 
     @staticmethod
     def parse_build_arg_sets(build_arg_sets: List[dict]) -> List[BuildArgSet]:
@@ -96,7 +96,30 @@ class Config:
         ]
 
 
+def _expand_depsets_per_build_arg_set(
+    depset: dict, build_arg_set_matrix: List[str], build_arg_sets: List[BuildArgSet]
+) -> List[Depset]:
+    """returns a list of depsets with the build arg set name appended to the name"""
+    expanded_depsets = []
+    for build_arg_set_name in build_arg_set_matrix:
+        build_arg_set = next(
+            (
+                build_arg_set
+                for build_arg_set in build_arg_sets
+                if build_arg_set.name == build_arg_set_name
+            ),
+            None,
+        )
+        if build_arg_set is None:
+            raise KeyError(f"Build arg set {build_arg_set_name} not found")
+        depset_yaml = _substitute_build_args(depset, build_arg_set)
+        expanded_depsets.append(_dict_to_depset(depset_yaml, build_arg_set_name))
+    return expanded_depsets
+
+
 class Workspace:
+    build_arg_sets: List[BuildArgSet] = field(default_factory=list)
+
     def __init__(self, dir: str = None):
         self.dir = (
             dir if dir is not None else os.getenv("BUILD_WORKSPACE_DIRECTORY", None)
@@ -104,7 +127,10 @@ class Workspace:
         if self.dir is None:
             raise RuntimeError("BUILD_WORKSPACE_DIRECTORY is not set")
 
-    def load_config(self, path: str) -> Config:
+    def build_depset_map(self, path: str) -> Dict[Tuple[str, str], Depset]:
         with open(os.path.join(self.dir, path), "r") as f:
             data = yaml.safe_load(f)
-            return Config.from_dict(data)
+            self.build_arg_sets = Config.parse_build_arg_sets(
+                data.get("build_arg_sets", [])
+            )
+            return Config.to_depset_map(data, self.build_arg_sets)


### PR DESCRIPTION
- remove depsets from the config
- move build arg sets to the workspace (config is pure utility)
- replace get depset with get depset by id
- using a depset map to fetch and retrieve the depset and build arg combination (Using a tuple of both as the id)