### PR TITLE
[core] Add return type to ActorClass.options

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1296,7 +1296,8 @@ class ActorClass(Generic[T]):
         """
         return self._remote(args=args, kwargs=kwargs, **self._default_options)
 
-    def options(self, **actor_options):
+
+    def options(self, **actor_options) -> "ActorClass[T]":
         """Configures and overrides the actor instantiation parameters.
 
         The arguments are the same as those that can be passed
@@ -1415,26 +1416,10 @@ class ActorClass(Generic[T]):
                 updated_options["runtime_env"]
             )
 
-        class ActorOptionWrapper:
-            def remote(self, *args, **kwargs):
-                return actor_cls._remote(args=args, kwargs=kwargs, **updated_options)
-
-            @DeveloperAPI
-            def bind(self, *args, **kwargs):
-                """
-                For Ray DAG building that creates static graph from decorated
-                class or functions.
-                """
-                from ray.dag.class_node import ClassNode
-
-                return ClassNode(
-                    actor_cls.__ray_metadata__.modified_class,
-                    args,
-                    kwargs,
-                    updated_options,
-                )
-
-        return ActorOptionWrapper()
+        new_actor_cls = ActorClass.__new__(ActorClass)
+        new_actor_cls.__ray_metadata__ = actor_cls.__ray_metadata__
+        new_actor_cls._default_options = updated_options
+        return new_actor_cls
 
     @wrap_auto_init
     @_tracing_actor_creation

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1296,7 +1296,6 @@ class ActorClass(Generic[T]):
         """
         return self._remote(args=args, kwargs=kwargs, **self._default_options)
 
-
     def options(self, **actor_options) -> "ActorClass[T]":
         """Configures and overrides the actor instantiation parameters.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


Currently the following pattern throws many lint errors as `ActorDemoRay.options(name="demo_ray")` returns an instance of `ActorOptionWrapper` which messes with the IDE's static type checker:

```python
import ray
from ray import ObjectRef
from ray.actor import ActorProxy, ActorClass

class DemoRay:
    def __init__(self, init: int):
        self.init = init

    @ray.method
    def calculate(self, v1: int, v2: int) -> int:
        return self.init + v1 + v2

ActorDemoRay: ActorClass[DemoRay] = ray.remote(DemoRay)

def main():   
    p: ActorProxy[DemoRay] = ActorDemoRay.options(name="demo_ray").remote(1)

    actor: ActorProxy[DemoRay] = ray.get_actor("demo_ray")
    a = actor.calculate.remote(1, 2)

    print(ray.get(a))
    return



if __name__ == "__main__":
    main()
```


This PR changes ActorClass[T].options(...) to return a new instance of ActorClass[T] instead, allow IDEs to correct infer the type of subsequent `.remote(...)` calls
 
## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/54149
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
