### PR TITLE
[release test] remove release image build step from postmerge

### DIFF
--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -1,7 +1,8 @@
 group: release build
+tags:
+  - oss
 steps:
   - label: ":tapioca: build: anyscale py{{matrix.python}}-{{matrix.platform}} docker"
-    tags: skip-on-premerge
     key: anyscalebuild
     instance_type: release-medium
     commands:
@@ -26,7 +27,6 @@ steps:
           - cpu
 
   - label: ":tapioca: build: anyscale-llm py{{matrix}} docker"
-    tags: skip-on-premerge
     key: anyscalellmbuild
     instance_type: release-medium
     commands:
@@ -40,7 +40,6 @@ steps:
       - "3.11"
 
   - label: ":tapioca: build: anyscale-ml py{{matrix}} docker"
-    tags: skip-on-premerge
     key: anyscalemlbuild
     instance_type: release-medium
     commands:

--- a/.buildkite/releasebuild.rayci.yml
+++ b/.buildkite/releasebuild.rayci.yml
@@ -1,1 +1,0 @@
-release/build.rayci.yml


### PR DESCRIPTION
they should be always building from release test pipeline directly

we used to run release tests on postmerge; we are no longer doing it any more.

also add oss tag for those steps.
