### PR TITLE
[Data] Fixing `AutoscalingActorPool` to properly downscale upon completion of the execution

### DIFF
--- a/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
+++ b/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
@@ -10,6 +10,7 @@ from ray.util.annotations import DeveloperAPI
 class ActorPoolScalingRequest:
 
     delta: int
+    force: bool = field(default=False)
     reason: Optional[str] = field(default=None)
 
     @classmethod
@@ -22,9 +23,9 @@ class ActorPoolScalingRequest:
         return ActorPoolScalingRequest(delta=delta, reason=reason)
 
     @classmethod
-    def downscale(cls, *, delta: int, reason: Optional[str] = None):
+    def downscale(cls, *, delta: int, force: bool = False, reason: Optional[str] = None):
         assert delta < 0, "For scale down delta is expected to be negative!"
-        return ActorPoolScalingRequest(delta=delta, reason=reason)
+        return ActorPoolScalingRequest(delta=delta, force=force, reason=reason)
 
 
 @DeveloperAPI

--- a/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
+++ b/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
@@ -23,7 +23,9 @@ class ActorPoolScalingRequest:
         return ActorPoolScalingRequest(delta=delta, reason=reason)
 
     @classmethod
-    def downscale(cls, *, delta: int, force: bool = False, reason: Optional[str] = None):
+    def downscale(
+        cls, *, delta: int, force: bool = False, reason: Optional[str] = None
+    ):
         assert delta < 0, "For scale down delta is expected to be negative!"
         return ActorPoolScalingRequest(delta=delta, force=force, reason=reason)
 

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -64,9 +64,7 @@ class DefaultAutoscaler(Autoscaler):
             op._inputs_complete and op_state.total_enqueued_input_bundles() == 0
         ):
             return ActorPoolScalingRequest.downscale(
-                delta=-1,
-                force=True,
-                reason="consumed all inputs"
+                delta=-1, force=True, reason="consumed all inputs"
             )
 
         if actor_pool.current_size() < actor_pool.min_size():

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -64,7 +64,9 @@ class DefaultAutoscaler(Autoscaler):
             op._inputs_complete and op_state.total_enqueued_input_bundles() == 0
         ):
             return ActorPoolScalingRequest.downscale(
-                delta=-1, reason="consumed all inputs"
+                delta=-1,
+                force=True,
+                reason="consumed all inputs"
             )
 
         if actor_pool.current_size() < actor_pool.min_size():

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -815,17 +815,17 @@ class _ActorPool(AutoscalingActorPool):
             # scaling up, ie if actor pool just scaled down, it'd still be able
             # to scale back up immediately.
             if (
-                not config.force and
-                self._last_upscaled_at is not None and (
-                    time.time() <= self._last_upscaled_at + self._ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S
+                not config.force
+                and self._last_upscaled_at is not None
+                and (
+                    time.time()
+                    <= self._last_upscaled_at
+                    + self._ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S
                 )
             ):
                 # NOTE: To avoid spamming logs unnecessarily, debounce log is produced once
                 #       per upscaling event
-                if (
-                    self._last_upscaled_at
-                    != self._last_downscaling_debounce_warning_ts
-                ):
+                if self._last_upscaled_at != self._last_downscaling_debounce_warning_ts:
                     logger.debug(
                         f"Ignoring scaling down request (request={config}; reason=debounced from scaling up at {self._last_upscaled_at})"
                     )

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -815,6 +815,7 @@ class _ActorPool(AutoscalingActorPool):
             # scaling up, ie if actor pool just scaled down, it'd still be able
             # to scale back up immediately.
             if (
+                not config.force and
                 self._last_upscaled_at is not None and (
                     time.time() <= self._last_upscaled_at + self._ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S
                 )

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -700,7 +700,7 @@ class _ActorPool(AutoscalingActorPool):
     actors when the operator is done submitting work to the pool.
     """
 
-    _ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S = 30
+    _ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S = 10
     _ACTOR_POOL_GRACEFUL_SHUTDOWN_TIMEOUT_S = 30
     _LOGICAL_ACTOR_ID_LABEL_KEY = "__ray_data_logical_actor_id"
 

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -161,7 +161,7 @@ class TestActorPool(unittest.TestCase):
             pool.scale(ActorPoolScalingRequest(delta=1, reason="scaling up"))
             # Assert we can't scale down immediately after scale up
             assert not pool._can_apply(downscaling_request)
-            assert pool._last_upscaling_ts == time.time()
+            assert pool._last_upscaled_at == time.time()
 
             # Advance clock
             f.tick(

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -4,6 +4,7 @@ import datetime
 import threading
 import time
 import unittest
+from dataclasses import replace
 from typing import Any, Dict, Optional, Tuple
 from unittest.mock import MagicMock
 
@@ -162,6 +163,12 @@ class TestActorPool(unittest.TestCase):
             # Assert we can't scale down immediately after scale up
             assert not pool._can_apply(downscaling_request)
             assert pool._last_upscaled_at == time.time()
+
+            # Check that we can still scale down if downscaling request
+            # is a forced one
+            assert pool._can_apply(
+                replace(downscaling_request, force=True)
+            )
 
             # Advance clock
             f.tick(

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -166,9 +166,7 @@ class TestActorPool(unittest.TestCase):
 
             # Check that we can still scale down if downscaling request
             # is a forced one
-            assert pool._can_apply(
-                replace(downscaling_request, force=True)
-            )
+            assert pool._can_apply(replace(downscaling_request, force=True))
 
             # Advance clock
             f.tick(

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -80,7 +80,9 @@ def test_actor_pool_scaling():
         yield
         setattr(mock, attr, original)
 
-    def assert_autoscaling_action(*, delta: int, expected_reason: Optional[str], force: bool = False):
+    def assert_autoscaling_action(
+        *, delta: int, expected_reason: Optional[str], force: bool = False
+    ):
         nonlocal actor_pool, op, op_state
 
         assert autoscaler._derive_target_scaling_config(

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -80,14 +80,14 @@ def test_actor_pool_scaling():
         yield
         setattr(mock, attr, original)
 
-    def assert_autoscaling_action(*, delta: int, expected_reason: Optional[str]):
+    def assert_autoscaling_action(*, delta: int, expected_reason: Optional[str], force: bool = False):
         nonlocal actor_pool, op, op_state
 
         assert autoscaler._derive_target_scaling_config(
             actor_pool=actor_pool,
             op=op,
             op_state=op_state,
-        ) == ActorPoolScalingRequest(delta=delta, reason=expected_reason)
+        ) == ActorPoolScalingRequest(delta=delta, force=force, reason=expected_reason)
 
     # Should scale up since the util above the threshold.
     assert actor_pool.get_pool_util() == 1.5
@@ -141,6 +141,7 @@ def test_actor_pool_scaling():
             assert_autoscaling_action(
                 delta=-1,
                 expected_reason="consumed all inputs",
+                force=True,
             )
 
     # Should scale down only once all inputs have been already dispatched AND
@@ -150,6 +151,7 @@ def test_actor_pool_scaling():
             with patch(op, "_inputs_complete", True, is_method=False):
                 assert_autoscaling_action(
                     delta=-1,
+                    force=True,
                     expected_reason="consumed all inputs",
                 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In 2.48 we introduced handling of "debouncing" that disallows downscaling for Actor Pool for 30s after latest upscaling to give AP Operator enough time to start utilizing upscaled actor(s).

However, that affected ability of the Actor Pool to downscale upon completion of the execution: when operator completes execution it should start downscaling immediately. This change addresses that.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
