### PR TITLE
[core][ci] Kill debug wheel step

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -19,17 +19,6 @@ steps:
       - manylinux
       - forge
 
-  - label: ":tapioca: build: debug wheel"
-    tags:
-      - linux_wheels
-      - oss
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:build_in_docker -- wheel --build-type debug --upload
-    depends_on:
-      - manylinux
-      - forge
-
   - label: ":tapioca: build: jar"
     key: java_wheels
     tags:


### PR DESCRIPTION
## Why are these changes needed?
The point of a debug build is that you run it and it will find deadlocks, bad memory usage, have better debug symbols, etc. But we build the debug wheel and don't actually use it in ci anywhere. There's this step that will run on postmerge but it will do the debug build itself anyways. https://github.com/ray-project/ray/blob/dda42b2d97768dbebdbaf766a7ed2e2e2372cc8b/.buildkite/core.rayci.yml#L215-L226