### PR TITLE
[core][gpu-objects] Fail fetch after 600s not 60s #55512

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -593,10 +593,18 @@ RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE = env_bool(
     "RAY_experimental_enable_open_telemetry_on_core", False
 )
 
+# How long to wait for a fetch to complete during ray.get before warning the user.
+#
+# NOTE: This must be kept in sync with the C++ definition of
+# `RayConfig::fetch_warn_timeout_milliseconds`.
+FETCH_WARN_TIMEOUT_SECONDS = (
+    env_integer("RAY_fetch_warn_timeout_milliseconds", 60000) / 1000
+)
+
 # How long to wait for a fetch to complete during ray.get before timing out and raising an exception to the user.
 #
 # NOTE: This must be kept in sync with the C++ definition of
 # `RayConfig::fetch_fail_timeout_milliseconds`.
 FETCH_FAIL_TIMEOUT_SECONDS = (
-    env_integer("RAY_fetch_fail_timeout_milliseconds", 60000) / 1000
+    env_integer("RAY_fetch_fail_timeout_milliseconds", 600000) / 1000
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes the FETCH_FAIL_TIMEOUT_SECONDS typo from 60 to 600 seconds making it in sync with the internal C++ implementations.
And It Introduces FETCH_WARN_TIMEOUT_SECONDS to 60 seconds to warn the. user after 60 seconds again making it in sync with the internal C++ implementations. 


## Related issue number

Closes #55512 

## Checks
N/A
