### PR TITLE
[core][obsclean/05] define ray_tasks using the Metric interface

### DIFF
--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -27,6 +27,7 @@ ray_cc_library(
         ":profile_event",
         ":reference_count",
         ":task_event_buffer",
+        ":task_metric",
         "//src/ray/common/cgroup:cgroup_context",
         "//src/ray/common/cgroup:cgroup_manager",
         "//src/ray/common/cgroup:constants",
@@ -56,6 +57,14 @@ ray_cc_library(
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_prod",
+    ],
+)
+
+ray_cc_library(
+    name = "task_metric",
+    hdrs = ["task_metric.h"],
+    deps = [
+        "//src/ray/stats:stats_lib",
     ],
 )
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -79,7 +79,7 @@ class TaskCounter {
   enum class TaskStatusType { kPending, kRunning, kFinished };
 
  public:
-  TaskCounter();
+  explicit TaskCounter(ray::stats::Gauge &ray_metric_tasks);
 
   void BecomeActor(const std::string &actor_name) {
     absl::MutexLock l(&mu_);
@@ -137,6 +137,9 @@ class TaskCounter {
   // Used for actor state tracking.
   std::string actor_name_ ABSL_GUARDED_BY(mu_);
   int64_t num_tasks_running_ ABSL_GUARDED_BY(mu_) = 0;
+
+  /// Metrics
+  ray::stats::Gauge &ray_metric_tasks_;
 };
 
 struct TaskToRetry {
@@ -200,7 +203,8 @@ class CoreWorker {
              std::unique_ptr<ActorManager> actor_manager,
              instrumented_io_context &task_execution_service,
              std::unique_ptr<worker::TaskEventBuffer> task_event_buffer,
-             uint32_t pid);
+             uint32_t pid,
+             ray::stats::Gauge &ray_metric_tasks);
 
   CoreWorker(CoreWorker const &) = delete;
 
@@ -1927,5 +1931,8 @@ class CoreWorker {
   std::mutex gcs_client_node_cache_populated_mutex_;
   std::condition_variable gcs_client_node_cache_populated_cv_;
   bool gcs_client_node_cache_populated_ = false;
+
+  /// Metrics
+  ray::stats::Gauge &ray_metric_tasks_;
 };
 }  // namespace ray::core

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -449,7 +449,8 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
         RAY_CHECK(addr.has_value()) << "Actor address not found for actor " << actor_id;
         return core_worker->core_worker_client_pool_->GetOrConnect(addr.value());
       },
-      gcs_client);
+      gcs_client,
+      ray_metric_tasks_);
 
   auto on_excess_queueing = [this](const ActorID &actor_id, uint64_t num_queued) {
     auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(
@@ -652,7 +653,8 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
                                    std::move(actor_manager),
                                    task_execution_service_,
                                    std::move(task_event_buffer),
-                                   pid);
+                                   pid,
+                                   ray_metric_tasks_);
   return core_worker;
 }
 

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "ray/core_worker/core_worker_options.h"
+#include "ray/core_worker/task_metric.h"
 #include "ray/util/mutex_protected.h"
 
 namespace ray {
@@ -177,6 +178,9 @@ class CoreWorkerProcessImpl {
 
   /// The proxy service handler that routes the RPC calls to the core worker.
   std::unique_ptr<CoreWorkerServiceHandlerProxy> service_handler_;
+
+  /// Metrics
+  ray::stats::Gauge ray_metric_tasks_{GetTaskMetric()};
 };
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -38,6 +38,8 @@
 namespace ray {
 namespace core {
 
+using std::literals::operator""sv;
+
 class ActorManager;
 
 using TaskStatusCounter = CounterMap<std::tuple<std::string, rpc::TaskStatus, bool>>;
@@ -180,7 +182,8 @@ class TaskManager : public TaskManagerInterface {
       worker::TaskEventBuffer &task_event_buffer,
       std::function<std::shared_ptr<ray::rpc::CoreWorkerClientInterface>(const ActorID &)>
           client_factory,
-      std::shared_ptr<gcs::GcsClient> gcs_client)
+      std::shared_ptr<gcs::GcsClient> gcs_client,
+      ray::stats::Gauge &ray_metric_tasks)
       : in_memory_store_(in_memory_store),
         reference_counter_(reference_counter),
         put_in_local_plasma_callback_(std::move(put_in_local_plasma_callback)),
@@ -190,16 +193,17 @@ class TaskManager : public TaskManagerInterface {
         max_lineage_bytes_(max_lineage_bytes),
         task_event_buffer_(task_event_buffer),
         get_actor_rpc_client_callback_(std::move(client_factory)),
-        gcs_client_(std::move(gcs_client)) {
+        gcs_client_(std::move(gcs_client)),
+        ray_metric_tasks_(ray_metric_tasks) {
     task_counter_.SetOnChangeCallback(
         [this](const std::tuple<std::string, rpc::TaskStatus, bool> &key)
             ABSL_EXCLUSIVE_LOCKS_REQUIRED(&mu_) {
-              ray::stats::STATS_tasks.Record(
+              ray_metric_tasks_.Record(
                   task_counter_.Get(key),
-                  {{"State", rpc::TaskStatus_Name(std::get<1>(key))},
-                   {"Name", std::get<0>(key)},
-                   {"IsRetry", std::get<2>(key) ? "1" : "0"},
-                   {"Source", "owner"}});
+                  {{"State"sv, rpc::TaskStatus_Name(std::get<1>(key))},
+                   {"Name"sv, std::get<0>(key)},
+                   {"IsRetry"sv, std::get<2>(key) ? "1" : "0"},
+                   {"Source"sv, "owner"}});
             });
     reference_counter_.SetReleaseLineageCallback(
         [this](const ObjectID &object_id, std::vector<ObjectID> *ids_to_release) {
@@ -794,6 +798,9 @@ class TaskManager : public TaskManagerInterface {
       get_actor_rpc_client_callback_;
 
   std::shared_ptr<gcs::GcsClient> gcs_client_;
+
+  /// Metrics
+  ray::stats::Gauge &ray_metric_tasks_;
 
   friend class TaskManagerTest;
 };

--- a/src/ray/core_worker/task_metric.h
+++ b/src/ray/core_worker/task_metric.h
@@ -1,0 +1,48 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/stats/metric.h"
+
+namespace ray::core {
+
+/// Returns the metric definition for the ray_tasks metrics. We define a helper function
+/// since the metric is re-defined in multiple processes (raylet, core_worker, etc.).
+///
+/// Do not reuse this file to define other metrics. Doing so will potentially bloat the
+/// build dependency graph, causing the build to take longer. For most use cases, metrics
+/// should be directly defined inside the component that uses it.
+inline ray::stats::Gauge GetTaskMetric() {
+  /// Tracks tasks by state, including pending, running, and finished tasks.
+  /// This metric may be recorded from multiple components processing the task in Ray,
+  /// including the submitting core worker, executor core worker, and pull manager.
+  ///
+  /// To avoid metric collection conflicts between components reporting on the same task,
+  /// we use the "Source" required label.
+  return ray::stats::Gauge{
+      /*name=*/"tasks",
+      // State: the task state, as described by rpc::TaskState proto in common.proto.
+      // Name: the name of the function called (Keep in sync with the
+      // TASK_OR_ACTOR_NAME_TAG_KEY in
+      // python/ray/_private/telemetry/metric_cardinality.py) Source: component reporting,
+      // e.g., "core_worker", "executor", or "pull_manager". IsRetry: whether this task is
+      // a retry.
+      /*description=*/"Current number of tasks currently in a particular state.",
+      /*unit=*/"",
+      /*tag_keys=*/{"State", "Name", "Source", "IsRetry", "JobId"},
+  };
+}
+
+}  // namespace ray::core

--- a/src/ray/core_worker/test/BUILD.bazel
+++ b/src/ray/core_worker/test/BUILD.bazel
@@ -78,6 +78,7 @@ ray_cc_test(
         "//src/ray/core_worker:reference_count",
         "//src/ray/core_worker:task_event_buffer",
         "//src/ray/core_worker:task_manager",
+        "//src/ray/core_worker:task_metric",
         "//src/ray/gcs/gcs_client:gcs_client_lib",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -38,6 +38,7 @@
 #include "ray/core_worker/object_recovery_manager.h"
 #include "ray/core_worker/reference_count.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
+#include "ray/core_worker/task_metric.h"
 #include "ray/core_worker/task_submission/actor_task_submitter.h"
 #include "ray/core_worker/task_submission/normal_task_submitter.h"
 #include "ray/rpc/worker/core_worker_client_pool.h"
@@ -159,7 +160,8 @@ class CoreWorkerHandleGetObjectStatusTest : public ::testing::Test {
         [](const ActorID &actor_id) {
           return std::make_shared<rpc::CoreWorkerClientInterface>();
         },
-        mock_gcs_client);
+        mock_gcs_client,
+        ray_metric_tasks_);
 
     auto object_recovery_manager = std::make_unique<ObjectRecoveryManager>(
         rpc_address,
@@ -243,7 +245,8 @@ class CoreWorkerHandleGetObjectStatusTest : public ::testing::Test {
                                                 std::move(actor_manager),
                                                 task_execution_service_,
                                                 std::move(task_event_buffer),
-                                                getpid());
+                                                getpid(),
+                                                ray_metric_tasks_);
   }
 
  protected:
@@ -260,6 +263,7 @@ class CoreWorkerHandleGetObjectStatusTest : public ::testing::Test {
   std::shared_ptr<ReferenceCounter> reference_counter_;
   std::shared_ptr<CoreWorkerMemoryStore> memory_store_;
   std::shared_ptr<CoreWorker> core_worker_;
+  ray::stats::Gauge ray_metric_tasks_{ray::core::GetTaskMetric()};
 };
 
 std::shared_ptr<RayObject> MakeRayObject(const std::string &data_str,

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -31,6 +31,7 @@
 #include "ray/core_worker/reference_count.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/task_event_buffer.h"
+#include "ray/core_worker/task_metric.h"
 
 namespace ray {
 namespace core {
@@ -178,7 +179,8 @@ class TaskManagerTest : public ::testing::Test {
                 -> std::shared_ptr<ray::rpc::CoreWorkerClientInterface> {
               return nullptr;
             },
-            mock_gcs_client_) {}
+            mock_gcs_client_,
+            ray_metric_tasks_) {}
 
   virtual void TearDown() { AssertNoLeaks(); }
 
@@ -225,6 +227,7 @@ class TaskManagerTest : public ::testing::Test {
   uint32_t last_delay_ms_ = 0;
   bool last_object_recovery_ = false;
   std::unordered_set<ObjectID> stored_in_plasma;
+  ray::stats::Gauge ray_metric_tasks_{ray::core::GetTaskMetric()};
 };
 
 class TaskManagerLineageTest : public TaskManagerTest {

--- a/src/ray/raylet/BUILD.bazel
+++ b/src/ray/raylet/BUILD.bazel
@@ -26,6 +26,7 @@ ray_cc_library(
     deps = [
         "//src/ray/common:id",
         "//src/ray/common:task_common",
+        "//src/ray/core_worker:task_metric",
         "//src/ray/object_manager",
         "//src/ray/util:counter_map",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -37,24 +37,6 @@ namespace ray::stats {
 /// =========== PUBLIC METRICS; keep in sync with ray-metrics.rst =================
 /// ===============================================================================
 
-/// Tracks tasks by state, including pending, running, and finished tasks.
-/// This metric may be recorded from multiple components processing the task in Ray,
-/// including the submitting core worker, executor core worker, and pull manager.
-///
-/// To avoid metric collection conflicts between components reporting on the same task,
-/// we use the "Source" required label.
-DEFINE_stats(
-    tasks,
-    "Current number of tasks currently in a particular state.",
-    // State: the task state, as described by rpc::TaskState proto in common.proto.
-    // Name: the name of the function called (Keep in sync with the
-    // TASK_OR_ACTOR_NAME_TAG_KEY in python/ray/_private/telemetry/metric_cardinality.py)
-    // Source: component reporting, e.g., "core_worker", "executor", or "pull_manager".
-    // IsRetry: whether this task is a retry.
-    ("State", "Name", "Source", "IsRetry", "JobId"),
-    (),
-    ray::stats::GAUGE);
-
 /// Tracks actors by state, including pending, running, and idle actors.
 ///
 /// To avoid metric collection conflicts between components reporting on the same task,

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -42,9 +42,6 @@ namespace stats {
 /// ray_[component]_[metrics_name]_total (e.g., ray_pull_manager_total)
 ///
 
-/// Tasks stats, broken down by state.
-DECLARE_stats(tasks);
-
 /// Actor stats, broken down by state.
 DECLARE_stats(actors);
 


### PR DESCRIPTION
Ray core currently offers two APIs for defining internal metrics: a static object-oriented (OO) API and a template/extern-based API. The OO API is also used for defining custom metrics at the Ray application level, and I personally find it easier to read. This series of PRs aims to unify all metric definitions under the OO API.

-----

This PR define `ray_tasks` using the Metric interface. If this looks good I can apply the same trick to the rest.

Test:
- CI