### PR TITLE
[Serve.llm] Use DEFAULT_MAX_ONGOING_REQUESTS for DPServer

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/data_parallel/dp_server.py
+++ b/python/ray/llm/_internal/serve/deployments/data_parallel/dp_server.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from ray import serve
+from ray.llm._internal.serve.configs.constants import DEFAULT_MAX_ONGOING_REQUESTS
 from ray.llm._internal.serve.configs.server_models import LLMConfig
 from ray.llm._internal.serve.deployments.data_parallel.dp_rank_assigner import (
     DPRankAssigner,
@@ -76,6 +77,7 @@ def build_dp_deployment(
     deployment_options = {
         "name": name,
         "num_replicas": dp_size,
+        "max_ongoing_requests": DEFAULT_MAX_ONGOING_REQUESTS,
     }
     return DPServer.as_deployment(deployment_options).bind(
         llm_config=llm_config, dp_rank_assigner=dp_rank_assigner


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We want to use a very large number for `max_ongoing_requests` and make it configurable.
This is consistent with `LLMDeployment`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
