### PR TITLE
[core][otel] change+simplify the feature flag for open telemetry

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -578,20 +578,9 @@ RAY_METRIC_CARDINALITY_LEVEL = os.environ.get("RAY_metric_cardinality_level", "l
 # Defaults to False to use pynvml to collect usage.
 RAY_METRIC_ENABLE_GPU_NVSMI = env_bool("RAY_metric_enable_gpu_nvsmi", False)
 
-# Whether enable OpenTelemetry as the metrics collection backend on the driver
-# component. This flag is only used during the migration of the  metric collection
-# backend from OpenCensus to OpenTelemetry. It will be removed in the future.
-RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT = env_bool(
-    "RAY_experimental_enable_open_telemetry_on_agent", False
-)
-
-# Whether enable OpenTelemetry as the metrics collection backend on the core
-# components (core workers, gcs server, raylet, etc.). This flag is only used during
-# the migration of the  metric collection backend from OpenCensus to OpenTelemetry.
-# It will be removed in the future.
-RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE = env_bool(
-    "RAY_experimental_enable_open_telemetry_on_core", False
-)
+# Whether enable OpenTelemetry as the metrics collection backend. The default is
+# using OpenCensus.
+RAY_ENABLE_OPEN_TELEMETRY = env_bool("RAY_enable_open_telemetry", False)
 
 # How long to wait for a fetch to complete during ray.get before timing out and raising an exception to the user.
 #

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -41,8 +41,7 @@ from ray._private import utils
 from ray._private.metrics_agent import Gauge, MetricsAgent, Record
 from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_STATUS,
-    RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT,
-    RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE,
+    RAY_ENABLE_OPEN_TELEMETRY,
     env_integer,
 )
 from ray._private.telemetry.open_telemetry_metric_recorder import (
@@ -1734,7 +1733,7 @@ class ReporterAgent(
 
             records = self._to_records(stats, cluster_stats)
 
-            if RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT:
+            if RAY_ENABLE_OPEN_TELEMETRY:
                 self._open_telemetry_metric_recorder.record_and_export(
                     records,
                     global_tags={
@@ -1758,7 +1757,7 @@ class ReporterAgent(
     async def run(self, server):
         if server:
             reporter_pb2_grpc.add_ReporterServiceServicer_to_server(self, server)
-            if RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE:
+            if RAY_ENABLE_OPEN_TELEMETRY:
                 metrics_service_pb2_grpc.add_MetricsServiceServicer_to_server(
                     self, server
                 )

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -200,11 +200,11 @@ def enable_open_telemetry(request):
     Fixture to enable OpenTelemetry for the test.
     """
     if request.param:
-        os.environ["RAY_experimental_enable_open_telemetry_on_agent"] = "1"
+        os.environ["RAY_enable_open_telemetry"] = "1"
     else:
-        os.environ["RAY_experimental_enable_open_telemetry_on_agent"] = "0"
+        os.environ["RAY_enable_open_telemetry"] = "0"
     yield
-    os.environ.pop("RAY_experimental_enable_open_telemetry_on_agent", None)
+    os.environ.pop("RAY_enable_open_telemetry", None)
 
 
 @pytest.mark.skipif(prometheus_client is None, reason="prometheus_client not installed")

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -83,8 +83,7 @@ py_test_module_list(
 py_test_module_list(
     size = "medium",
     env = {
-        "RAY_experimental_enable_open_telemetry_on_agent": "1",
-        "RAY_experimental_enable_open_telemetry_on_core": "1",
+        "RAY_enable_open_telemetry": "1",
     },
     files = [
         "test_metric_cardinality.py",

--- a/python/ray/tests/test_metric_cardinality.py
+++ b/python/ray/tests/test_metric_cardinality.py
@@ -39,14 +39,7 @@ def _setup_cluster_for_test(request, ray_start_cluster):
         _system_config={
             "enable_metrics_collection": True,
             "metric_cardinality_level": core_metric_cardinality_level,
-            "experimental_enable_open_telemetry_on_agent": os.getenv(
-                "RAY_experimental_enable_open_telemetry_on_agent"
-            )
-            == "1",
-            "experimental_enable_open_telemetry_on_core": os.getenv(
-                "RAY_experimental_enable_open_telemetry_on_core"
-            )
-            == "1",
+            "enable_open_telemetry": os.getenv("RAY_enable_open_telemetry") == "1",
         }
     )
     cluster.wait_for_nodes()
@@ -152,8 +145,8 @@ def test_cardinality_recommended_and_legacy_levels(
 # implementation doesn't support low cardinality.
 @pytest.mark.skipif(prometheus_client is None, reason="Prometheus not installed")
 @pytest.mark.skipif(
-    os.getenv("RAY_experimental_enable_open_telemetry_on_agent") != "1",
-    reason="OpenTelemetry is not enabled on agent",
+    os.getenv("RAY_enable_open_telemetry") != "1",
+    reason="OpenTelemetry is not enabled",
 )
 @pytest.mark.parametrize(
     "_setup_cluster_for_test,cardinality_level",

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -196,14 +196,7 @@ def _setup_cluster_for_test(request, ray_start_cluster):
             "event_stats_print_interval_ms": 500,
             "event_stats": True,
             "enable_metrics_collection": enable_metrics_collection,
-            "experimental_enable_open_telemetry_on_agent": os.getenv(
-                "RAY_experimental_enable_open_telemetry_on_agent"
-            )
-            == "1",
-            "experimental_enable_open_telemetry_on_core": os.getenv(
-                "RAY_experimental_enable_open_telemetry_on_core"
-            )
-            == "1",
+            "enable_open_telemetry": os.getenv("RAY_enable_open_telemetry") == "1",
         }
     )
     # Add worker nodes.
@@ -277,8 +270,7 @@ def _setup_cluster_for_test(request, ray_start_cluster):
 
 @pytest.mark.skipif(prometheus_client is None, reason="Prometheus not installed")
 @pytest.mark.skipif(
-    os.environ.get("RAY_experimental_enable_open_telemetry_on_core") == "1"
-    and sys.platform == "darwin",
+    os.environ.get("RAY_enable_open_telemetry") == "1" and sys.platform == "darwin",
     reason="OpenTelemetry is not working on macOS yet.",
 )
 @pytest.mark.parametrize("_setup_cluster_for_test", [True], indirect=True)
@@ -319,7 +311,7 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
                 "test_driver_counter_total",
                 "test_gauge",
             ]
-            if os.environ.get("RAY_experimental_enable_open_telemetry_on_core") != "1"
+            if os.environ.get("RAY_enable_open_telemetry") != "1"
             else [
                 "test_counter_total",
                 "test_driver_counter_total",
@@ -770,7 +762,7 @@ def test_histogram(_setup_cluster_for_test):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not working in Windows.")
 @pytest.mark.skipif(
-    os.environ.get("RAY_experimental_enable_open_telemetry_on_core") == "1",
+    os.environ.get("RAY_enable_open_telemetry") == "1",
     reason="OpenTelemetry backend does not support Counter exported as gauge.",
 )
 def test_counter_exported_as_gauge(shutdown_only):

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -191,7 +191,7 @@ class Counter(Metric):
         if self._discard_metric:
             self._metric = None
         else:
-            if os.environ.get("RAY_experimental_enable_open_telemetry_on_core") == "1":
+            if os.environ.get("RAY_enable_open_telemetry") == "1":
                 """
                 For the new opentelemetry implementation, we'll correctly use Counter
                 rather than Sum.

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2858,8 +2858,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: stress_tests/placement_group_tests_compute.yaml
 
   run:
@@ -2933,8 +2932,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: tpl_64.yaml
 
   run:
@@ -3215,8 +3213,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
@@ -3258,8 +3255,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
@@ -3393,8 +3389,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: stress_tests/stress_tests_single_node_oom_compute.yaml
 
   run:
@@ -3558,8 +3553,7 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: single_node.yaml
 
   run:
@@ -3587,8 +3581,7 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: object_store.yaml
 
   run:
@@ -3617,8 +3610,7 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: object_store/small_objects.yaml
 
   run:
@@ -3642,8 +3634,7 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: object_store/large_objects.yaml
 
   run:
@@ -3667,8 +3658,7 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: distributed.yaml
 
   run:
@@ -3717,8 +3707,7 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: distributed.yaml
 
   run:
@@ -3747,8 +3736,7 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: distributed.yaml
 
   run:
@@ -3798,8 +3786,7 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-        - RAY_experimental_enable_open_telemetry_on_agent=1
-        - RAY_experimental_enable_open_telemetry_on_core=1
+        - RAY_enable_open_telemetry=1
     cluster_compute: many_nodes.yaml
 
   run:

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -520,16 +520,9 @@ RAY_CONFIG(bool, enable_metrics_collection, true)
 /// RAY_METRIC_CARDINALITY_LEVEL in ray_constants.py
 RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
 
-/// Whether enable OpenTelemetry as the metrics collection backend on the driver
-/// component. This flag is only used during the migration of the  metric collection
-/// backend from OpenCensus to OpenTelemetry. It will be removed in the future.
-RAY_CONFIG(bool, experimental_enable_open_telemetry_on_agent, false)
-
-/// Whether enable OpenTelemetry as the metrics collection backend on the core
-/// components (core workers, gcs server, raylet, etc.). This flag is only used during
-/// the migration of the  metric collection backend from OpenCensus to OpenTelemetry.
-/// It will be removed in the future.
-RAY_CONFIG(bool, experimental_enable_open_telemetry_on_core, false)
+/// Whether enable OpenTelemetry as the metrics collection backend. The default is
+/// using OpenCensus.
+RAY_CONFIG(bool, enable_open_telemetry, false)
 
 /// Comma separated list of components we enable grpc metrics collection for.
 /// Only effective if `enable_metrics_collection` is also true. Will have some performance

--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -113,7 +113,7 @@ void Metric::Record(double value, TagsType tags) {
     return;
   }
 
-  if (::RayConfig::instance().experimental_enable_open_telemetry_on_core()) {
+  if (::RayConfig::instance().enable_open_telemetry()) {
     // Register the metric if it hasn't been registered yet; otherwise, this is a no-op.
     // We defer metric registration until the first time it's recorded, rather than during
     // construction, to avoid issues with static initialization order. Specifically, our

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -265,7 +265,7 @@ void RegisterView(const std::string &name,
                   const std::string &description,
                   const std::vector<opencensus::tags::TagKey> &tag_keys,
                   const std::vector<double> &buckets) {
-  if (!::RayConfig::instance().experimental_enable_open_telemetry_on_core()) {
+  if (!::RayConfig::instance().enable_open_telemetry()) {
     // OpenTelemetry is not enabled, register the view as an OpenCensus view.
     using I = StatsTypeMap<T>;
     auto view_descriptor = opencensus::stats::ViewDescriptor()

--- a/src/ray/stats/tests/BUILD.bazel
+++ b/src/ray/stats/tests/BUILD.bazel
@@ -5,7 +5,7 @@ ray_cc_test(
     size = "small",
     srcs = ["metric_with_open_telemetry_test.cc"],
     env = {
-        "RAY_experimental_enable_open_telemetry_on_core": "1",
+        "RAY_enable_open_telemetry": "1",
     },
     tags = ["team:core"],
     deps = [


### PR DESCRIPTION
Change and simplify the feature flag to enable open telemetry. This will enable us to enable open telemetry for the next Ray release version, without worrying about messing up previous Ray release versions.

Test:
- CI