### PR TITLE
[data.llm] Adjust LLM engine timing logic

### DIFF
--- a/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
@@ -177,22 +177,25 @@ class SGLangEngineWrapper:
 
     async def generate_async(
         self, row: Dict[str, Any]
-    ) -> Tuple[SGLangEngineRequest, Dict[str, Any]]:
+    ) -> Tuple[SGLangEngineRequest, Dict[str, Any], float]:
         """Process a single request.
 
         Args:
             request: The request.
 
         Returns:
-            A tuple of index in batch, request output and bypassed custom fields.
+            A tuple of index in batch, request output and bypassed custom fields, and time taken.
         """
         request = await self._prepare_llm_request(row)
+        t = time.perf_counter()
 
         async with self.semaphore:
             output = await self._generate_async(request)
 
+        time_taken = time.perf_counter() - t
+
         output_data = SGLangOutputData.from_sglang_engine_output(output)
-        return request, output_data.model_dump()
+        return request, output_data.model_dump(), time_taken
 
     async def _generate_async(self, request: SGLangEngineRequest) -> Any:
         """Process a single request.
@@ -321,29 +324,28 @@ class SGLangEngineStageUDF(StatefulStageUDF):
             The response of the SGLang engine.
         """
         batch_uuid = uuid.uuid4()
-        t = time.perf_counter()
+        batch_start_time = time.perf_counter()
 
         tasks = [asyncio.create_task(self.llm.generate_async(row)) for row in batch]
 
-        time_taken = -1.0
         for resp in asyncio.as_completed(tasks):
-            request, output = await resp
-            time_taken = time.perf_counter() - t
+            request, output, time_taken_llm = await resp
 
             yield {
                 **output,
                 "request_id": request.request_id,
                 self.IDX_IN_BATCH_COLUMN: request.idx_in_batch,
                 "batch_uuid": batch_uuid.hex,
-                "time_taken_llm": time_taken,
+                "time_taken_llm": time_taken_llm,
                 "params": str(request.params),
             }
 
+        batch_time_taken = time.perf_counter() - batch_start_time
         logger.info(
             "[SGLang] Elapsed time for batch %s with size %d: %s",
             batch_uuid.hex,
             len(batch),
-            time_taken,
+            batch_time_taken,
         )
 
     def __del__(self):

--- a/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
@@ -42,6 +42,7 @@ def mock_sglang_wrapper():
                     "generated_text": f"Response to: {row['prompt']}",
                     "num_generated_tokens": 3,
                 },
+                0.1,  # time_taken_llm
             )
 
         mock_instance.generate_async.side_effect = mock_generate
@@ -226,9 +227,10 @@ async def test_sglang_wrapper(
     assert mock_generate_async.call_count == batch_size
 
     # Verify the outputs match expected values
-    for i, (request, output) in enumerate(results):
+    for i, (request, output, time_taken_llm) in enumerate(results):
         assert output["prompt"] == f"Test {i}"
         assert output["num_generated_tokens"] == i + 5  # max_new_tokens we set
+        assert time_taken_llm > 0
 
 
 @pytest.mark.asyncio

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -46,6 +46,7 @@ def mock_vllm_wrapper():
                     "num_generated_tokens": 3,
                     "time_per_token": 0.1,
                 },
+                0.1,  # time_taken_llm
             )
 
         mock_instance.generate_async.side_effect = mock_generate
@@ -298,10 +299,11 @@ async def test_vllm_wrapper_generate(model_llama_3_2_216M):
     tasks = [asyncio.create_task(wrapper.generate_async(row)) for row in batch]
 
     for resp in asyncio.as_completed(tasks):
-        request, output = await resp
+        request, output, time_taken_llm = await resp
         params = request.params
         max_tokens = params.max_tokens
         assert max_tokens == output["num_generated_tokens"]
+        assert time_taken_llm > 0
 
     # Clean up GPU memory
     wrapper.shutdown()
@@ -332,8 +334,9 @@ async def test_vllm_wrapper_embed(model_opt_125m):
     tasks = [asyncio.create_task(wrapper.generate_async(row)) for row in batch]
 
     for resp in asyncio.as_completed(tasks):
-        _, output = await resp
+        _, output, time_taken_llm = await resp
         assert output["embeddings"].shape == (768,)
+        assert time_taken_llm > 0
 
     # Clean up GPU memory
     wrapper.shutdown()
@@ -380,10 +383,11 @@ async def test_vllm_wrapper_lora(model_llama_3_2_216M, model_llama_3_2_216M_lora
     tasks = [asyncio.create_task(wrapper.generate_async(row)) for row in batch]
 
     for resp in asyncio.as_completed(tasks):
-        request, output = await resp
+        request, output, time_taken_llm = await resp
         params = request.params
         max_tokens = params.max_tokens
         assert max_tokens == output["num_generated_tokens"]
+        assert time_taken_llm > 0
 
     # Clean up GPU memory
     wrapper.shutdown()
@@ -430,12 +434,13 @@ async def test_vllm_wrapper_json(model_llama_3_2_1B_instruct):
     tasks = [asyncio.create_task(wrapper.generate_async(row)) for row in batch]
 
     for resp in asyncio.as_completed(tasks):
-        _, output = await resp
+        _, output, time_taken_llm = await resp
         json_obj = json.loads(output["generated_text"])
         assert "answer" in json_obj
         assert isinstance(json_obj["answer"], int)
         assert "explain" in json_obj
         assert isinstance(json_obj["explain"], str)
+        assert time_taken_llm > 0
 
     # Clean up GPU memory
     wrapper.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Modified timing logic to measure individual request engine processing time separately from batch timing rather than the cumulative time across all requests.

## Related issue number

The problem is identified during the development of #55179. 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
