### PR TITLE
[Core] Add Logic to Check Label Selector in PG Scheduling

### DIFF
--- a/python/ray/tests/test_bundle_label_selector.py
+++ b/python/ray/tests/test_bundle_label_selector.py
@@ -11,21 +11,25 @@ from ray._private.test_utils import placement_group_assert_no_leak
 
 def test_bundle_label_selector_with_repeated_labels(ray_start_cluster):
     cluster = ray_start_cluster
-    num_nodes = 2
-    for _ in range(num_nodes):
-        cluster.add_node(num_cpus=4, labels={"ray.io/accelerator-type": "A100"})
+    cluster.add_node(num_cpus=4, labels={"ray.io/accelerator-type": "A100"})
+    node = cluster.add_node(num_cpus=4, labels={"ray.io/accelerator-type": "TPU"})
     ray.init(address=cluster.address)
 
     bundles = [{"CPU": 1}, {"CPU": 1}]
-    label_selector = [{"ray.io/accelerator-type": "A100"}] * 2
+    label_selector = [{"ray.io/accelerator-type": "TPU"}] * 2
 
     placement_group = ray.util.placement_group(
         name="repeated_labels_pg",
-        strategy="PACK",
         bundles=bundles,
         bundle_label_selector=label_selector,
     )
     ray.get(placement_group.ready())
+
+    bundles_to_node_id = ray.util.placement_group_table()[placement_group.id.hex()][
+        "bundles_to_node_id"
+    ]
+    assert bundles_to_node_id[0] == node.node_id
+    assert bundles_to_node_id[1] == node.node_id
 
     placement_group_assert_no_leak([placement_group])
 
@@ -42,7 +46,6 @@ def test_unschedulable_bundle_label_selector(ray_start_cluster):
 
     placement_group = ray.util.placement_group(
         name="unschedulable_labels_pg",
-        strategy="STRICT_PACK",
         bundles=bundles,
         bundle_label_selector=label_selector,
     )
@@ -53,7 +56,7 @@ def test_unschedulable_bundle_label_selector(ray_start_cluster):
     state = ray.util.placement_group_table()[placement_group.id.hex()]["stats"][
         "scheduling_state"
     ]
-    assert state == "INFEASIBLE"
+    assert state == "NO_RESOURCES"
 
 
 def test_bundle_label_selectors_match_bundle_resources(ray_start_cluster):
@@ -89,7 +92,6 @@ def test_bundle_label_selectors_match_bundle_resources(ray_start_cluster):
 
     pg = ray.util.placement_group(
         name="label_selectors_match_resources",
-        strategy="SPREAD",
         bundles=bundles,
         bundle_label_selector=bundle_label_selectors,
     )

--- a/src/ray/raylet/scheduling/policy/scorer.cc
+++ b/src/ray/raylet/scheduling/policy/scorer.cc
@@ -21,6 +21,12 @@ namespace raylet_scheduling_policy {
 
 double LeastResourceScorer::Score(const ResourceRequest &required_resources,
                                   const NodeResources &node_resources) {
+  // Check if the node has required labels before scoring on the resources.
+  const auto &label_selector = required_resources.GetLabelSelector();
+  if (!node_resources.HasRequiredLabels(label_selector)) {
+    return -1.;
+  }
+
   // In GCS-based actor scheduling, the `NodeResources` are only acquired or released by
   // actor scheduling, instead of being updated by resource reports from raylets. So we
   // have to subtract normal task resources (if exist) from the current available


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR fixed the issue where the placement group label bundle selector doesn't honor the label value when specified. 

The root cause was that during the bundle scheduling, we didn't check the labels but just check the required resources.

The fix is to add the logic to check the required label selectors before checking the resources. The corresponding tests are updated as well to test the code path. 

## Related issue number
#55590 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
