### PR TITLE
[core] Fix objects_valid with except from BaseException

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1029,7 +1029,7 @@ def serialize_retry_exception_allowlist(retry_exception_allowlist, function_desc
 
 cdef c_bool determine_if_retryable(
     c_bool should_retry_exceptions,
-    Exception e,
+    e: BaseException,
     const c_string serialized_retry_exception_allowlist,
     FunctionDescriptor function_descriptor,
 ):
@@ -2012,7 +2012,9 @@ cdef void execute_task(
                     task_exception = False
                 except AsyncioActorExit as e:
                     exit_current_actor_if_asyncio()
-                except Exception as e:
+                except (KeyboardInterrupt, SystemExit):
+                    raise
+                except BaseException as e:
                     is_retryable_error[0] = determine_if_retryable(
                                     should_retry_exceptions,
                                     e,
@@ -2121,8 +2123,9 @@ cdef void execute_task(
                     None, # ref_generator_id
                     c_tensor_transport
                 )
-
-        except Exception as e:
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException as e:
             num_errors_stored = store_task_errors(
                     worker, e, task_exception, actor, actor_id, function_name,
                     task_type, title, caller_address, returns, application_error, c_tensor_transport)

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1192,6 +1192,16 @@ def test_failed_task(ray_start_shared_local_modes, error_pubsub):
         assert False
 
 
+def test_base_exception_raised(ray_start_shared_local_modes):
+    @ray.remote
+    def f():
+        raise BaseException("rip")
+        return 1
+
+    with pytest.raises(BaseException):
+        ray.get(f.remote())
+
+
 def test_import_ray_does_not_import_grpc():
     # First unload grpc and ray
     if "grpc" in sys.modules:


### PR DESCRIPTION
## Why are these changes needed?
We would encounter a ray check failure on `objects_valid` whenever we get a function throws an exception that extends from `BaseException` instead of `Exception`. Fixing that by just excepting `BaseException` instead of `Exception` when we are vulnerable to exceptions thrown from user Python code. We still have to special case `SystemExit` and `KeyboardInterrupt` because we can consider those as critical errors ourselves and treat them as worker shutdown or task cancellation signals respectively.

## Related issue number
https://github.com/ray-project/ray/issues/43411

