### PR TITLE
[cli] Add warning for potential KubeRay autoscaling configuration conflicts

### DIFF
--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -4,6 +4,7 @@ import pprint
 import sys
 import time
 import shlex
+import subprocess
 from typing import Any, Dict, Optional, Tuple, Union
 
 import click
@@ -275,8 +276,13 @@ def submit(
         runtime_env_json=runtime_env_json,
         working_dir=working_dir,
     )
+    if sys.platform == "win32":
+        entrypoint_str = subprocess.list2cmdline(entrypoint)
+    else:
+        entrypoint_str = shlex.join(entrypoint)
+
     job_id = client.submit_job(
-        entrypoint=shlex.join(entrypoint),
+        entrypoint=entrypoint_str,
         submission_id=submission_id,
         runtime_env=final_runtime_env,
         metadata=metadata_json,

--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -3,7 +3,7 @@ import os
 import pprint
 import sys
 import time
-from subprocess import list2cmdline
+import shlex
 from typing import Any, Dict, Optional, Tuple, Union
 
 import click
@@ -276,7 +276,7 @@ def submit(
         working_dir=working_dir,
     )
     job_id = client.submit_job(
-        entrypoint=list2cmdline(entrypoint),
+        entrypoint=shlex.join(entrypoint),
         submission_id=submission_id,
         runtime_env=final_runtime_env,
         metadata=metadata_json,

--- a/python/ray/dashboard/modules/job/tests/test_cli.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli.py
@@ -150,7 +150,7 @@ class TestSubmit:
             result = runner.invoke(job_cli_group, ["submit", "--", "echo hello"])
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -166,7 +166,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env={"working_dir": "blah"},
                 metadata=None,
@@ -181,7 +181,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env={"working_dir": "'.'"},
                 metadata=None,
@@ -203,7 +203,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env=env_dict,
                 metadata=None,
@@ -220,7 +220,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env=env_dict,
                 metadata=None,
@@ -262,7 +262,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env=env_dict,
                 metadata=None,
@@ -286,7 +286,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env=env_dict,
                 metadata=None,
@@ -304,7 +304,7 @@ class TestSubmit:
             result = runner.invoke(job_cli_group, ["submit", "--", "echo hello"])
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -320,7 +320,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id="my_job_id",
                 runtime_env={},
                 metadata=None,
@@ -341,7 +341,7 @@ class TestSubmit:
             )
             assert result.exit_code == 0
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -362,7 +362,7 @@ class TestSubmit:
             )
             assert result.exit_code == 0
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -383,7 +383,7 @@ class TestSubmit:
             )
             assert result.exit_code == 0
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -416,7 +416,7 @@ class TestSubmit:
             print(result.output)
             assert result.exit_code == 0
             expected_kwargs = {
-                "entrypoint": '"echo hello"',
+                "entrypoint": 'echo hello',
                 "submission_id": None,
                 "runtime_env": {},
                 "metadata": None,
@@ -462,7 +462,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='"echo hello"',
+                entrypoint='echo hello',
                 submission_id=None,
                 runtime_env={},
                 entrypoint_num_cpus=None,
@@ -513,6 +513,44 @@ class TestSubmit:
             assert result.exit_code == 0
             mock_sdk_client.assert_called_with(
                 None, True, headers=None, verify=verify_param
+            )
+
+    def test_argument_parsing_preserves_quotes(self, mock_sdk_client):
+        """Test that entrypoint arguments with quotes and special characters are preserved correctly.
+        
+        This test verifies the fix for the bug where ray job submit was losing quotes
+        in command line arguments, causing inconsistent behavior between ray job submit
+        and direct python execution.
+        """
+        runner = CliRunner()
+        mock_client_instance = mock_sdk_client.return_value
+
+        with set_env_var("RAY_ADDRESS", "env_addr"):
+            # Test with complex argument containing quotes and special characters
+            result = runner.invoke(
+                job_cli_group,
+                [
+                    "submit",
+                    "--",
+                    "python3",
+                    "test.py",
+                    "--config",
+                    '{"key": "value", "nested": {"data": "test"}}'
+                ]
+            )
+            check_exit_code(result, 0)
+            
+            # Verify the entrypoint is correctly formatted without losing quotes
+            # This should now work correctly with shlex.join instead of list2cmdline
+            mock_client_instance.submit_job.assert_called_with(
+                entrypoint='python3 test.py --config {"key": "value", "nested": {"data": "test"}}',
+                submission_id=None,
+                runtime_env={},
+                metadata=None,
+                entrypoint_num_cpus=None,
+                entrypoint_num_gpus=None,
+                entrypoint_memory=None,
+                entrypoint_resources=None,
             )
 
 

--- a/python/ray/dashboard/modules/job/tests/test_cli.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli.py
@@ -150,7 +150,7 @@ class TestSubmit:
             result = runner.invoke(job_cli_group, ["submit", "--", "echo hello"])
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -166,7 +166,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env={"working_dir": "blah"},
                 metadata=None,
@@ -181,7 +181,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env={"working_dir": "'.'"},
                 metadata=None,
@@ -203,7 +203,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env=env_dict,
                 metadata=None,
@@ -220,7 +220,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env=env_dict,
                 metadata=None,
@@ -262,7 +262,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env=env_dict,
                 metadata=None,
@@ -286,7 +286,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env=env_dict,
                 metadata=None,
@@ -304,7 +304,7 @@ class TestSubmit:
             result = runner.invoke(job_cli_group, ["submit", "--", "echo hello"])
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -320,7 +320,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id="my_job_id",
                 runtime_env={},
                 metadata=None,
@@ -341,7 +341,7 @@ class TestSubmit:
             )
             assert result.exit_code == 0
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -362,7 +362,7 @@ class TestSubmit:
             )
             assert result.exit_code == 0
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -383,7 +383,7 @@ class TestSubmit:
             )
             assert result.exit_code == 0
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env={},
                 metadata=None,
@@ -416,7 +416,7 @@ class TestSubmit:
             print(result.output)
             assert result.exit_code == 0
             expected_kwargs = {
-                "entrypoint": 'echo hello',
+                "entrypoint": "echo hello",
                 "submission_id": None,
                 "runtime_env": {},
                 "metadata": None,
@@ -462,7 +462,7 @@ class TestSubmit:
             )
             check_exit_code(result, 0)
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='echo hello',
+                entrypoint="echo hello",
                 submission_id=None,
                 runtime_env={},
                 entrypoint_num_cpus=None,
@@ -517,7 +517,6 @@ class TestSubmit:
 
     def test_argument_parsing_preserves_quotes(self, mock_sdk_client):
         """Test that entrypoint arguments with quotes and special characters are preserved correctly.
-        
         This test verifies the fix for the bug where ray job submit was losing quotes
         in command line arguments, causing inconsistent behavior between ray job submit
         and direct python execution.
@@ -539,9 +538,9 @@ class TestSubmit:
                 ]
             )
             check_exit_code(result, 0)
-            
+
             # Verify the entrypoint is correctly formatted without losing quotes
-            # This should now work correctly with shlex.join instead of list2cmdline
+            # This should now work correctly with cross-platform command line formatting
             mock_client_instance.submit_job.assert_called_with(
                 entrypoint='python3 test.py --config {"key": "value", "nested": {"data": "test"}}',
                 submission_id=None,

--- a/python/ray/dashboard/modules/job/tests/test_cli.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli.py
@@ -534,8 +534,8 @@ class TestSubmit:
                     "python3",
                     "test.py",
                     "--config",
-                    '{"key": "value", "nested": {"data": "test"}}'
-                ]
+                    '{"key": "value", "nested": {"data": "test"}}',
+                ],
             )
             check_exit_code(result, 0)
 

--- a/python/ray/dashboard/modules/job/tests/test_cli.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli.py
@@ -542,7 +542,7 @@ class TestSubmit:
             # Verify the entrypoint is correctly formatted without losing quotes
             # This should now work correctly with cross-platform command line formatting
             mock_client_instance.submit_job.assert_called_with(
-                entrypoint='python3 test.py --config {"key": "value", "nested": {"data": "test"}}',
+                entrypoint='python3 test.py --config \'{"key": "value", "nested": {"data": "test"}}\'',
                 submission_id=None,
                 runtime_env={},
                 metadata=None,

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -865,6 +865,15 @@ def start(
             # we enable the v2 autoscaler by default if RAY_enable_autoscaler_v2 is not set.
             os.environ.setdefault("RAY_enable_autoscaler_v2", "1")
 
+            # Add warning for potential KubeRay autoscaling configuration conflicts
+            if os.getenv("RAY_enable_autoscaler_v2") == "1":
+                cli_logger.warning(
+                    "KubeRay environment detected with RAY_enable_autoscaler_v2=1. "
+                    "If you encounter startup issues, ensure that 'enableInTreeAutoscaling: true' "
+                    "is set in your RayCluster CR, or set RAY_enable_autoscaler_v2=0 "
+                    "to disable autoscaler v2."
+                )
+
         num_redis_shards = None
         # Start Ray on the head node.
         if redis_shard_ports is not None and address is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When KubeRay has enableInTreeAutoscaling: false but Ray sets RAY_enable_autoscaler_v2 = 1, the head node fails to start with exit 1 status, leaving the cluster stuck in "starting" state.

<!-- Please give a short summary of the change and the problem this solves. -->

## Root Cause
**Configuration Conflict:**

- KubeRay side: enableInTreeAutoscaling: false → No autoscaler sidecar container
- Ray side: RAY_enable_autoscaler_v2 = 1 → Expects autoscaler service running

**Result:** Head node waits indefinitely for autoscaler service, causing startup failure.

## Solution

Add warning during Ray startup to detect this configuration conflict and provide clear guidance to users.


## Files Changed

- python/ray/scripts/scripts.py: Add conflict detection warning


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
