### PR TITLE
Add warning for potential KubeRay autoscaling configuration conflicts

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -865,6 +865,15 @@ def start(
             # we enable the v2 autoscaler by default if RAY_enable_autoscaler_v2 is not set.
             os.environ.setdefault("RAY_enable_autoscaler_v2", "1")
 
+            # Add warning for potential KubeRay autoscaling configuration conflicts
+            if os.getenv("RAY_enable_autoscaler_v2") == "1":
+                cli_logger.warning(
+                    "KubeRay environment detected with RAY_enable_autoscaler_v2=1. "
+                    "If you encounter startup issues, ensure that 'enableInTreeAutoscaling: true' "
+                    "is set in your RayCluster CR, or set RAY_enable_autoscaler_v2=0 "
+                    "to disable autoscaler v2."
+                )
+
         num_redis_shards = None
         # Start Ray on the head node.
         if redis_shard_ports is not None and address is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When KubeRay has enableInTreeAutoscaling: false but Ray sets RAY_enable_autoscaler_v2 = 1, the head node fails to start with exit 1 status, leaving the cluster stuck in "starting" state.

<!-- Please give a short summary of the change and the problem this solves. -->

## Root Cause
**Configuration Conflict:**

- KubeRay side: enableInTreeAutoscaling: false → No autoscaler sidecar container
- Ray side: RAY_enable_autoscaler_v2 = 1 → Expects autoscaler service running

**Result:** Head node waits indefinitely for autoscaler service, causing startup failure.

## Solution

Add warning during Ray startup to detect this configuration conflict and provide clear guidance to users.


## Files Changed

- python/ray/scripts/scripts.py: Add conflict detection warning


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
