### PR TITLE
Fix ray job submit argument parsing in CLI and tests

### DIFF
--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -4,6 +4,7 @@ import pprint
 import sys
 import time
 from subprocess import list2cmdline
+import shlex
 from typing import Any, Dict, Optional, Tuple, Union
 
 import click
@@ -275,8 +276,13 @@ def submit(
         runtime_env_json=runtime_env_json,
         working_dir=working_dir,
     )
+    if sys.platform == "win32":
+        entrypoint_str = list2cmdline(entrypoint)
+    else:
+        entrypoint_str = shlex.join(entrypoint)
+
     job_id = client.submit_job(
-        entrypoint=list2cmdline(entrypoint),
+        entrypoint=entrypoint_str,
         submission_id=submission_id,
         runtime_env=final_runtime_env,
         metadata=metadata_json,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix `ray job submit` command argument parsing issue where quotes are inconsistently lost in certain command line arguments, causing unpredictable behavior between ray job submit and direct python execution.

**Bug Description:**
When using `ray job submit`, some command line arguments containing quotes are incorrectly stripped:

- `ray job submit -- python3 test.py --resource "{'ps-auc':{'cnt':1}}"` returns `{ps-auc:{cnt:1}}` (quotes lost)
- `python3 test.py --resource "{'ps-auc':{'cnt':1}}"` returns `{'ps-auc':{'cnt':1}}` (correct format)

Note: Not all arguments lose quotes - this appears to be inconsistent behavior depending on argument complexity.

**Test Script (test.py):**
```python
import argparse
import json
import os

def main():
    parser = argparse.ArgumentParser(description='Script to process resource arguments and parse JSON')
    parser.add_argument('--resource',
                        type=str,
                        required=True,
                        help='Specify JSON string or JSON file path')
    args = parser.parse_args()
    print(args.resource)

main()
```

**Root Cause:**
`list2cmdline()` function has inconsistent behavior when converting complex arguments to command line format, sometimes causing quote loss.

**Fix:**
Replace `list2cmdline(entrypoint)` with `shlex.join(entrypoint)` to ensure consistent and predictable argument formatting across all platforms and argument types.


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
