### PR TITLE
[core] add test rules for container tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -60,7 +60,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/_common/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,multi_gpu,spark_on_ray,ray_client,compiled_graphs,dask
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,runtime_env_container,manual,multi_gpu,spark_on_ray,ray_client,compiled_graphs,dask
         --install-mask all-ray-libraries
 
   - label: ":ray: core: cgraph python tests"
@@ -86,7 +86,7 @@ steps:
         --install-mask all-ray-libraries
         --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
         --python-version {{matrix.python}}
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,multi_gpu,spark_on_ray,ray_client,dask
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,runtime_env_container,manual,multi_gpu,spark_on_ray,ray_client,dask
     depends_on: corebuild-multipy
     matrix:
       setup:
@@ -115,7 +115,7 @@ steps:
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,multi_gpu,spark_on_ray,ray_client,dask
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,runtime_env_container,manual,multi_gpu,spark_on_ray,ray_client,dask
 
   - label: ":ray: core: memory pressure tests"
     tags:
@@ -433,10 +433,10 @@ steps:
       - raycpubase
       - corebuild
 
-  - label: ":ray: core: container tests"
+  - label: ":ray: core: runtime env container tests"
     tags:
-      - python
       - docker
+      - runtime_env_container
       - oss
     instance_type: medium
     commands:
@@ -447,7 +447,7 @@ steps:
       # Disable test DB, these tests will never succeed if run in the flaky step.
       - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
         --install-mask all-ray-libraries
-        --only-tags container
+        --only-tags runtime_env_container
     depends_on:
       - manylinux
       - forge

--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -99,6 +99,10 @@ python/ray/util/spark/
 @ python spark_on_ray
 ;
 
+python/ray/runtime_env/
+@ python runtime_env_container
+;
+
 python/
 @ ml tune train data
 # Python changes might impact cross language stack in Java.

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -1090,8 +1090,8 @@ py_test(
     size = "large",
     srcs = ["test_runtime_env_container.py"],
     tags = [
-        "container",
         "exclusive",
+        "runtime_env_container",
         "team:core",
     ],
     deps = [


### PR DESCRIPTION
The `core: container` test is pretty flaky on premerge and block PRs from time to time. This PR add a test rule to only run this test on a change that touches `python/ray/runtime_env`.

Test:
- CI