### PR TITLE
[ci] upgrading uv binary and updating test (2/4)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -125,8 +125,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "10f204426ff188925d22a53c1d0310d190a8d4d24513712e1b8e2ca9873f0666",
-    urls = ["https://github.com/astral-sh/uv/releases/download/0.7.20/uv-x86_64-unknown-linux-gnu.tar.gz"],
+    sha256 = "2c4392591fe9469d006452ef22f32712f35087d87fb1764ec03e23544eb8770d",
+    urls = ["https://github.com/astral-sh/uv/releases/download/0.8.10/uv-x86_64-unknown-linux-gnu.tar.gz"],
 )
 
 http_archive(

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -94,7 +94,7 @@ class TestCli(unittest.TestCase):
             stderr=subprocess.PIPE,
         )
         assert result.returncode == 0
-        assert "uv 0.7.20" in result.stdout.decode("utf-8")
+        assert "uv 0.8.10" in result.stdout.decode("utf-8")
         assert result.stderr.decode("utf-8") == ""
 
     def test_compile(self):


### PR DESCRIPTION
- upgrading uv from 0.7.20 -> 0.8.10 to gain parity with uv used compile llm lock files job
- updating unit test