### PR TITLE
[ci] release test: use rayci to perform test init

### DIFF
--- a/.buildkite/release/config.yml
+++ b/.buildkite/release/config.yml
@@ -15,3 +15,8 @@ env:
   RAYCI_SKIP_UPLOAD: "true"
 hook_env_keys:
   - RAYCI_CHECKOUT_DIR
+build_env_keys:
+  - AUTOMATIC
+  - RELEASE_FREQUENCY
+docker_plugin:
+  allow_mount_buildkite_agent: true

--- a/.buildkite/release/test-init.sh
+++ b/.buildkite/release/test-init.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ ${BUILDKITE_COMMIT} == "HEAD" ]]; then
+  BUILDKITE_COMMIT="$(git rev-parse HEAD)"
+  export BUILDKITE_COMMIT
+fi
+
+aws ecr get-login-password --region us-west-2 | \
+    docker login --username AWS --password-stdin 029272617770.dkr.ecr.us-west-2.amazonaws.com
+
+bash release/gcloud_docker_login.sh release/aws2gce_iam.json
+export PATH="${PWD}/google-cloud-sdk/bin:$PATH"
+
+if [[ "${AUTOMATIC:-0}" == "1" && "${BUILDKITE_BRANCH}" == "master" ]]; then
+  export REPORT_TO_RAY_TEST_DB=1
+fi
+
+RUN_FLAGS=()
+
+if [[ "${AUTOMATIC:-0}" == "0" || "${BUILDKITE_BRANCH}" == "releases/"* ]]; then
+  RUN_FLAGS+=(--run-jailed-tests)
+fi
+if [[ "${BUILDKITE_BRANCH}" != "releases/"* ]]; then
+  RUN_FLAGS+=(--run-unstable-tests)
+fi
+
+echo "---- Build test steps"
+bazelisk run //release:build_pipeline -- "${RUN_FLAGS[@]}" \
+    | buildkite-agent pipeline upload

--- a/.buildkite/release/test.rayci.yml
+++ b/.buildkite/release/test.rayci.yml
@@ -1,0 +1,11 @@
+group: test init
+tags:
+  - oss
+steps:
+  - label: "test init"
+    key: test-init
+    instance_type: release-medium
+    commands:
+      - /bin/bash .buildkite/release/test-init.sh
+    mount_buildkite_agent: true
+    depends_on: forge


### PR DESCRIPTION
so that rayci buildid can be populated
