### PR TITLE
[Train] - Bump up test size for test_data_integration

### DIFF
--- a/python/ray/train/v2/BUILD
+++ b/python/ray/train/v2/BUILD
@@ -71,7 +71,7 @@ py_test(
 
 py_test(
     name = "test_data_integration",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_data_integration.py"],
     env = {"RAY_TRAIN_V2_ENABLED": "1"},
     tags = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_data_integration` seems to be timing out. Bumping to a medium test to increase the timeout.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
