### PR TITLE
[ci] Using editable mode compat flag for wheel building

### DIFF
--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -99,7 +99,9 @@ test_coverage() {
 }
 
 api_annotations() {
-  RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]"
+  python -m pip show setuptools || echo "setuptools not found"
+  python -m setuptools --version || true
+  RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]" --config-settings editable_mode=compat
   ./ci/lint/check_api_annotations.py
 }
 

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -99,8 +99,6 @@ test_coverage() {
 }
 
 api_annotations() {
-  python -m pip show setuptools || echo "setuptools not found"
-  python -m setuptools --version || true
   RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]" --config-settings editable_mode=compat
   ./ci/lint/check_api_annotations.py
 }
@@ -108,7 +106,7 @@ api_annotations() {
 api_policy_check() {
   # install ray and compile doc to generate API files
   make -C doc/ html
-  RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]"
+  RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]" --config-settings editable_mode=compat
 
   # validate the API files
   bazel run //ci/ray_ci/doc:cmd_check_api_discrepancy -- /ray "$@"

--- a/ci/raydepsets/raydepsets.py
+++ b/ci/raydepsets/raydepsets.py
@@ -1,5 +1,4 @@
 from ci.raydepsets.cli import cli
 
-# noop
 if __name__ == "__main__":
     cli()

--- a/ci/raydepsets/raydepsets.py
+++ b/ci/raydepsets/raydepsets.py
@@ -1,4 +1,5 @@
 from ci.raydepsets.cli import cli
 
+# noop
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
using `--config-settings editable_mode=compat` flag for editable install before `api_annotations` and `api_policy_check`

Will update test_rules.txt to prevent api lint jobs running on non-api related changes

Improvements: 

api_annotations 17min -> 10min
api_policy_check 41min -> 31min

before: https://buildkite.com/ray-project/microcheck/builds/23033
after: https://buildkite.com/ray-project/microcheck/builds/23102