### PR TITLE
[Core] Simplify get_event_aggregator_grpc_stub to not depend on webui_url

### DIFF
--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -14,10 +14,8 @@ from ray._private.test_utils import wait_for_condition
 from ray._raylet import GcsClient
 import ray.dashboard.consts as dashboard_consts
 from ray._private.test_utils import (
-    wait_until_server_available,
     find_free_port,
 )
-from ray._common.network_utils import parse_address, build_address
 
 from ray.core.generated.events_event_aggregator_service_pb2_grpc import (
     EventAggregatorServiceStub,

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -55,23 +55,24 @@ _with_aggregator_port = pytest.mark.parametrize(
 )
 
 
-def get_event_aggregator_grpc_stub(webui_url, gcs_address, head_node_id):
+def get_event_aggregator_grpc_stub(gcs_address, head_node_id):
     """
     An helper function to get the gRPC stub for the event aggregator agent.
     Should only be used in tests.
     """
-    ip, _ = parse_address(webui_url)
-    agent_address = build_address(ip, ray_constants.DEFAULT_DASHBOARD_AGENT_LISTEN_PORT)
-    assert wait_until_server_available(agent_address)
 
     gcs_address = gcs_address
     gcs_client = GcsClient(address=gcs_address)
-    agent_addr = gcs_client.internal_kv_get(
-        f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{head_node_id}".encode(),
-        namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-        timeout=dashboard_consts.GCS_RPC_TIMEOUT_SECONDS,
-    )
-    ip, http_port, grpc_port = json.loads(agent_addr)
+
+    def get_addr():
+        return gcs_client.internal_kv_get(
+            f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{head_node_id}".encode(),
+            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+            timeout=dashboard_consts.GCS_RPC_TIMEOUT_SECONDS,
+        )
+
+    wait_for_condition(lambda: get_addr() is not None)
+    ip, _, grpc_port = json.loads(get_addr())
     options = ray_constants.GLOBAL_GRPC_OPTIONS
     channel = init_grpc_channel(f"{ip}:{grpc_port}", options=options)
     return EventAggregatorServiceStub(channel)
@@ -83,7 +84,7 @@ def test_aggregator_agent_receive_publish_events_normally(
 ):
     cluster = ray_start_cluster_head_with_env_vars
     stub = get_event_aggregator_grpc_stub(
-        cluster.webui_url, cluster.gcs_address, cluster.head_node.node_id
+        cluster.gcs_address, cluster.head_node.node_id
     )
 
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
@@ -145,7 +146,7 @@ def test_aggregator_agent_receive_event_full(
 ):
     cluster = ray_start_cluster_head_with_env_vars
     stub = get_event_aggregator_grpc_stub(
-        cluster.webui_url, cluster.gcs_address, cluster.head_node.node_id
+        cluster.gcs_address, cluster.head_node.node_id
     )
 
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
@@ -197,7 +198,7 @@ def test_aggregator_agent_receive_multiple_events(
 ):
     cluster = ray_start_cluster_head_with_env_vars
     stub = get_event_aggregator_grpc_stub(
-        cluster.webui_url, cluster.gcs_address, cluster.head_node.node_id
+        cluster.gcs_address, cluster.head_node.node_id
     )
 
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
@@ -260,7 +261,7 @@ def test_aggregator_agent_receive_multiple_events_failures(
 ):
     cluster = ray_start_cluster_head_with_env_vars
     stub = get_event_aggregator_grpc_stub(
-        cluster.webui_url, cluster.gcs_address, cluster.head_node.node_id
+        cluster.gcs_address, cluster.head_node.node_id
     )
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
     now = time.time_ns()
@@ -311,7 +312,7 @@ def test_aggregator_agent_receive_empty_events(
 ):
     cluster = ray_start_cluster_head_with_env_vars
     stub = get_event_aggregator_grpc_stub(
-        cluster.webui_url, cluster.gcs_address, cluster.head_node.node_id
+        cluster.gcs_address, cluster.head_node.node_id
     )
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
     request = AddEventsRequest(
@@ -333,7 +334,7 @@ def test_aggregator_agent_profile_events_not_exposed(
     """Test that profile events are not sent when not in exposable event types."""
     cluster = ray_start_cluster_head_with_env_vars
     stub = get_event_aggregator_grpc_stub(
-        cluster.webui_url, cluster.gcs_address, cluster.head_node.node_id
+        cluster.gcs_address, cluster.head_node.node_id
     )
 
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
@@ -395,7 +396,7 @@ def test_aggregator_agent_receive_profile_events(
 ):
     cluster = ray_start_cluster_head_with_env_vars
     stub = get_event_aggregator_grpc_stub(
-        cluster.webui_url, cluster.gcs_address, cluster.head_node.node_id
+        cluster.gcs_address, cluster.head_node.node_id
     )
 
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -489,7 +489,7 @@ def test_metrics_export_event_aggregator_agent(
 ):
     cluster = ray_start_cluster_head_with_env_vars
     stub = get_event_aggregator_grpc_stub(
-        cluster.webui_url, cluster.gcs_address, cluster.head_node.node_id
+        cluster.gcs_address, cluster.head_node.node_id
     )
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We can just check the existence of `{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{head_node_id}` key to decide whether dashboard agent is up and ready to serve requests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
