### PR TITLE
[data] Wrap batch index in a `BatchMetadata` class

### DIFF
--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -7,30 +7,38 @@ from ray.types import ObjectRef
 
 
 @dataclass
-class Batch:
-    """A batch of data with a corresponding index.
+class BatchMetadata:
+    """Metadata associated with a batch.
 
     Attributes:
         batch_idx: The global index of this batch so that downstream operations can
             maintain ordering.
-        data: The batch of data.
     """
 
     batch_idx: int
+
+
+@dataclass
+class Batch:
+    """A batch of data.
+
+    Attributes:
+        metadata: Metadata associated with this batch.
+        data: The batch of data.
+    """
+
+    metadata: BatchMetadata
     data: DataBatch
 
 
 class CollatedBatch(Batch):
-    """A batch of collated data with a corresponding index.
+    """A batch of collated data.
 
     Attributes:
-        batch_idx: The global index of this batch so that downstream operations can
-            maintain ordering.
         data: The batch of data which is the output of a user provided collate_fn
             Therefore, the type of this data can be Any.
     """
 
-    batch_idx: int
     data: Any
 
 

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -382,8 +382,8 @@ def restore_original_order(batch_iter: Iterator[Batch]) -> Iterator[Batch]:
     next_index_required = 0
     buffer: Dict[int, Batch] = {}
     for batch in batch_iter:
-        assert batch.batch_idx not in buffer
-        buffer[batch.batch_idx] = batch
+        assert batch.metadata.batch_idx not in buffer
+        buffer[batch.metadata.batch_idx] = batch
         while next_index_required in buffer:
             yield buffer.pop(next_index_required)
             next_index_required += 1

--- a/python/ray/data/tests/block_batching/test_iter_batches.py
+++ b/python/ray/data/tests/block_batching/test_iter_batches.py
@@ -8,7 +8,11 @@ import pyarrow as pa
 import pytest
 
 import ray
-from ray.data._internal.block_batching.interfaces import Batch, BlockPrefetcher
+from ray.data._internal.block_batching.interfaces import (
+    Batch,
+    BatchMetadata,
+    BlockPrefetcher,
+)
 from ray.data._internal.block_batching.iter_batches import (
     BatchIterator,
     prefetch_batches_locally,
@@ -95,14 +99,14 @@ def test_prefetch_batches_locally(
 
 def test_restore_from_original_order():
     base_iterator = [
-        Batch(1, None),
-        Batch(0, None),
-        Batch(3, None),
-        Batch(2, None),
+        Batch(BatchMetadata(batch_idx=1), None),
+        Batch(BatchMetadata(batch_idx=0), None),
+        Batch(BatchMetadata(batch_idx=3), None),
+        Batch(BatchMetadata(batch_idx=2), None),
     ]
 
     ordered = list(restore_original_order(iter(base_iterator)))
-    idx = [batch.batch_idx for batch in ordered]
+    idx = [batch.metadata.batch_idx for batch in ordered]
     assert idx == [0, 1, 2, 3]
 
 


### PR DESCRIPTION
## Summary

Wrap batch metadata in a dataclass that we can extend in the future. Right now it only includes the batch index, but we could also include:
* Creation timestamp to  measure "average time spent on the iterator-side pipeline." 
* The block ID(s) that this batch was sliced from and whether it's safe to clear the block once the batch is consumed.