### PR TITLE
shorten date string format for session name

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -171,10 +171,10 @@ class Node:
                 # subsequent restarts of the head node.
                 maybe_key = self.check_persisted_session_name()
                 if maybe_key is None:
-                    # date including microsecond
-                    date_str = datetime.datetime.today().strftime(
-                        "%Y-%m-%d_%H-%M-%S_%f"
-                    )
+                    # date including the first 3 digits of the microsecond
+                    date_str = datetime.datetime.today().strftime("%y%m%d_%H%M%S_%f")[
+                        :17
+                    ]
                     self._session_name = f"session_{date_str}_{os.getpid()}"
                 else:
                     self._session_name = ray._common.utils.decode(maybe_key)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

AF_UNIX path length is limited to 107 for linux or 103 for mac. When the `temp-dir` of head node is too long, it will raise a OSError. I think the date string in the session name is a bit too long (26 digits). I also noticed that most date strings used in other functions in Ray only need the seconds precision. Therefore, I tried shortening this string using the following code. This could help mitigate such problem, especially when the path has to be very long while running experiments on clusters.

```python
# original
date_str = datetime.datetime.today().strftime("%Y-%m-%d_%H-%M-%S_%f") 
# 26 digits with 6-digit milliseconds: 2025-08-15_08-00-31_356086

# modified
date_str = datetime.datetime.today().strftime("%y%m%d_%H%M%S_%f")[:17]
# 17 digits with 3-digit milliseconds: 250815_080031_356
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/55255
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

