### PR TITLE
[data] Change default batch_format of map_batches from numpy to pandas for better compatibility

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -101,7 +101,7 @@ BlockPartition = List[Tuple[ObjectRef[Block], "BlockMetadata"]]
 BlockPartitionMetadata = List["BlockMetadata"]
 
 VALID_BATCH_FORMATS = ["pandas", "pyarrow", "numpy", None]
-DEFAULT_BATCH_FORMAT = "numpy"
+DEFAULT_BATCH_FORMAT = "pandas"
 
 
 def _is_empty_schema(schema: Optional[Schema]) -> bool:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -589,9 +589,9 @@ class Dataset:
                 ``batch_size`` if ``batch_size`` doesn't evenly divide the block(s) sent
                 to a given map task. Default ``batch_size`` is ``None``.
             compute: This argument is deprecated. Use ``concurrency`` argument.
-            batch_format: If ``"default"`` or ``"numpy"``, batches are
-                ``Dict[str, numpy.ndarray]``. If ``"pandas"``, batches are
-                ``pandas.DataFrame``. If ``"pyarrow"``, batches are
+            batch_format: If ``"default"`` or ``"pandas"``, batches are
+                ``pandas.DataFrame``. If ``"numpy"``, batches are
+                ``Dict[str, numpy.ndarray]``. If ``"pyarrow"``, batches are
                 ``pyarrow.Table``.
             zero_copy_batch: Whether ``fn`` should be provided zero-copy, read-only
                 batches. If this is ``True`` and no copy is required for the
@@ -4961,9 +4961,10 @@ class Dataset:
                 blocks as batches (blocks may contain different numbers of rows).
                 The final batch may include fewer than ``batch_size`` rows if
                 ``drop_last`` is ``False``. Defaults to 256.
-            batch_format: If ``"default"`` or ``"numpy"``, batches are
-                ``Dict[str, numpy.ndarray]``. If ``"pandas"``, batches are
-                ``pandas.DataFrame``.
+            batch_format: If ``"default"`` or ``"pandas"``, batches are
+                ``pandas.DataFrame``. If ``"numpy"``, batches are
+                ``Dict[str, numpy.ndarray]``. If ``"pyarrow"``, batches are
+                ``pyarrow.Table``.
             drop_last: Whether to drop the last batch if it's incomplete.
             local_shuffle_buffer_size: If not ``None``, the data is randomly shuffled
                 using a local in-memory shuffle buffer, and this value serves as the


### PR DESCRIPTION
## Problem Description

The current default numpy batch_format has several critical functional issues，i believe that default configurations should prioritize functional completeness and data correctness over raw performance

### 1. Improper Null Value Handling
- **Float columns**: null values are incorrectly converted to NaN, leading to data corruption
- **Data integrity**: Original null semantics are lost during conversion
- **Example**: A float column with legitimate null values becomes indistinguishable from actual NaN values

**Code Example:**
```python
import pyarrow as pa
import pyarrow.parquet as pq
import tempfile
import os
import ray
import pandas as pd
import logging

# Generate test Parquet file
def create_test_parquet():
    temp_dir = tempfile.mkdtemp()
    file_path = os.path.join(temp_dir, "test_input.parquet")
    
    # Create test data containing null values (2 rows)
    data = {
        'id': [1, 1],
        'float_col': [1.1, None],
        'int_col': [10, 20]    
    }
    
    table = pa.table({
        'id': pa.array(data['id'], type=pa.int64()),
        'float_col': pa.array(data['float_col'], type=pa.float64()),
        'int_col': pa.array(data['int_col'], type=pa.int64())})
    
    pq.write_table(table, file_path)
    return file_path

# Data processing function
def process_batch(batch):
    # Simulate original batch processing logic
    return batch

# Main execution function
def main():
    # Initialize Ray
    # Modify the ray.data logging level
    ray.init(ignore_reinit_error=True, logging_level="ERROR", log_to_driver=False)
    
    try:
        # Create test file
        input_path = create_test_parquet()
        print(f"Created test file: {input_path}")
        
        # Read Parquet file
        dataset = ray.data.read_parquet(input_path)
        print(f"Original dataset schema:\n{dataset.schema()}\n")
        
        # Print original data before processing
        print("=== Original Data ===")
        dataset.show()
        
        # Test different batch formats
        batch_formats = ["pyarrow", "pandas", "numpy"]
        results = {}
        
        print("=== Batch Format Comparison Results ===")
        for format in batch_formats:
            print(f"Processing with batch_format: {format}")
            
            # Process data with current batch format
            processed = dataset.map_batches(
                process_batch,
                batch_format=format
            )
            
            # Write output file
            output_dir = tempfile.mkdtemp()
            processed.write_parquet(output_dir)
            
            # Validate results
            result = ray.data.read_parquet(output_dir)
            result.show()
        
    finally:
        # Clean up resources
        ray.shutdown()

if __name__ == "__main__":
    main()
```

### 2. Complex Type Processing Errors
- **List columns with None**: Causes runtime errors when list columns contain None values
- **Nested structures**: Limited support for complex/nested data structures
- **Type conversion failures**: Inconsistent behavior with mixed data types


<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
