### PR TITLE
[serve.llm] Add reset_prefix_cache remote method to llm server

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/llm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_engine.py
@@ -37,6 +37,10 @@ class LLMEngine(abc.ABC):
         pass
 
     @abc.abstractmethod
+    async def reset_prefix_cache(self) -> None:
+        """Restarts the prefix cache of the underlying engine"""
+
+    @abc.abstractmethod
     async def chat(
         self, request: "ChatCompletionRequest"
     ) -> AsyncGenerator[Union[str, "ChatCompletionResponse", "ErrorResponse"], None]:

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_engine.py
@@ -38,7 +38,7 @@ class LLMEngine(abc.ABC):
 
     @abc.abstractmethod
     async def reset_prefix_cache(self) -> None:
-        """Restarts the prefix cache of the underlying engine"""
+        """Reset the prefix cache of the underlying engine"""
 
     @abc.abstractmethod
     async def chat(

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -106,7 +106,7 @@ class _LLMServerBase(ABC):
 
     @abstractmethod
     async def reset_prefix_cache(self) -> None:
-        """Restarts the prefix cache of the underlying engine"""
+        """Reset the prefix cache of the underlying engine"""
 
     # TODO (Kourosh): This does not belong here.
     async def llm_config(self) -> Optional[LLMConfig]:
@@ -398,6 +398,7 @@ class LLMServer(_LLMServerBase):
             raise e
 
     async def reset_prefix_cache(self) -> None:
+        """Reset the prefix cache of the underlying engine"""
         if self.engine is None:
             return
         try:

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -104,6 +104,11 @@ class _LLMServerBase(ABC):
         """
         ...
 
+
+    @abstractmethod
+    async def reset_prefix_cache(self) -> None:
+        """Restarts the prefix cache of the underlying engine"""
+
     # TODO (Kourosh): This does not belong here.
     async def llm_config(self) -> Optional[LLMConfig]:
         return None
@@ -391,6 +396,15 @@ class LLMServer(_LLMServerBase):
             return await self.engine.check_health()
         except Exception as e:
             logger.error("Engine health check failed in LLMServer.check_health: %s", e)
+            raise e
+
+    async def reset_prefix_cache(self) -> None:
+        if self.engine is None:
+            return
+        try:
+            await self.engine.reset_prefix_cache()
+        except Exception as e:
+            logger.error("Engine reset prefix cache failed in LLMServer.reset_prefix_cache: %s", e)
             raise e
 
     async def llm_config(self) -> Optional[LLMConfig]:

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -104,7 +104,6 @@ class _LLMServerBase(ABC):
         """
         ...
 
-
     @abstractmethod
     async def reset_prefix_cache(self) -> None:
         """Restarts the prefix cache of the underlying engine"""
@@ -404,7 +403,10 @@ class LLMServer(_LLMServerBase):
         try:
             await self.engine.reset_prefix_cache()
         except Exception as e:
-            logger.error("Engine reset prefix cache failed in LLMServer.reset_prefix_cache: %s", e)
+            logger.error(
+                "Engine reset prefix cache failed in LLMServer.reset_prefix_cache: %s",
+                e,
+            )
             raise e
 
     async def llm_config(self) -> Optional[LLMConfig]:

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -478,3 +478,8 @@ class VLLMEngine(LLMEngine):
         except BaseException as e:
             logger.error("Healthcheck failed. The replica will be restarted")
             raise e from None
+
+
+    async def reset_prefix_cache(self) -> None:
+        assert self._engine_client is not None
+        await self._engine_client.reset_prefix_cache()

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -480,5 +480,5 @@ class VLLMEngine(LLMEngine):
             raise e from None
 
     async def reset_prefix_cache(self) -> None:
-        assert self._engine_client is not None
+        assert self._engine_client is not None, "engine_client is not initialized"
         await self._engine_client.reset_prefix_cache()

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -479,7 +479,6 @@ class VLLMEngine(LLMEngine):
             logger.error("Healthcheck failed. The replica will be restarted")
             raise e from None
 
-
     async def reset_prefix_cache(self) -> None:
         assert self._engine_client is not None
         await self._engine_client.reset_prefix_cache()

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -176,6 +176,29 @@ class TestLLMServer:
         assert server.engine.check_health_called
 
     @pytest.mark.asyncio
+    async def test_reset_prefix_cache(self, mock_llm_config):
+        """Test reset prefix cache functionality."""
+
+        # Mock the engine's reset_prefix_cache method
+        class LocalMockEngine(MockVLLMEngine):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.reset_prefix_cache_called = False
+
+            async def reset_prefix_cache(self):
+                self.reset_prefix_cache_called = True
+
+        # Create a server with a mocked engine
+        server = LLMServer.sync_init(mock_llm_config, engine_cls=LocalMockEngine)
+        await server.start()
+
+        # Perform the health check, no exceptions should be raised
+        await server.reset_prefix_cache()
+
+        # Check that the reset prefix cache method was called
+        assert server.engine.reset_prefix_cache_called
+
+    @pytest.mark.asyncio
     async def test_llm_config_property(self, mock_llm_config):
         """Test the llm_config property."""
         server = LLMServer.sync_init(mock_llm_config, engine_cls=MockVLLMEngine)

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -51,6 +51,11 @@ class MockVLLMEngine(LLMEngine):
         if not self.started:
             raise RuntimeError("Engine not started")
 
+    async def reset_prefix_cache(self) -> None:
+        """Reset the prefix cache of the mock engine."""
+        if not self.started:
+            raise RuntimeError("Engine not started")
+
     async def chat(
         self, request: ChatCompletionRequest
     ) -> AsyncGenerator[Union[str, ChatCompletionResponse, ErrorResponse], None]:


### PR DESCRIPTION
We need to be able to reset kv cache for proper benchmarking when prefix cache is enabled. This PR adds that capability to the LLMServer deployment. You can use the following script to restart the kv cache in an adhoc fashion. 


```python
from ray import serve
from ray.serve._private.common import RequestMetadata
import pickle
import ray
import argparse
import time

parser = argparse.ArgumentParser()
parser.add_argument(
    "--deployment-name", "-d", type=str, default="LLMDeploymentdsv3",
)
parser.add_argument(
    "--app-name", "-a", type=str, default="default"
)
pargs = parser.parse_args()

dh = serve.get_deployment_handle(deployment_name=pargs.deployment_name, app_name=pargs.app_name)
dh._init()
while not dh.running_replicas_populated():
    print("router is still None ...")
    time.sleep(1)


for replica in dh._router._asyncio_router._request_router._replica_id_set:
    print(f"Reseting kv cache on replica {replica.unique_id}")
    actor_name = replica.to_full_id_str()
    actorh = ray.get_actor(actor_name, namespace="serve")
    dummy_rm = pickle.dumps(RequestMetadata(
        request_id="1", internal_request_id="1", call_method="reset_prefix_cache"))
    ray.get(actorh.handle_request.remote(dummy_rm))

```