### PR TITLE
[data.llm] Skip safetensor file downloads for runai streamer mode

### DIFF
--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -462,12 +462,15 @@ class vLLMEngineStageUDF(StatefulStageUDF):
         if self.max_pending_requests > 0:
             logger.info("Max pending requests is set to %d", self.max_pending_requests)
 
+        runai_streamer = self.engine_kwargs.get("load_format") == "runai_streamer"
+
         # Download the model if needed.
         model_source = download_model_files(
             model_id=self.model,
             mirror_config=None,
             download_model=NodeModelDownloadable.MODEL_AND_TOKENIZER,
             download_extra_files=False,
+            runai_streamer=runai_streamer
         )
 
         # Create an LLM engine.

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -473,7 +473,7 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             model_id=self.model,
             mirror_config=None,
             download_model=download_model,
-            download_extra_files=False
+            download_extra_files=False,
         )
 
         # Create an LLM engine.

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -462,15 +462,18 @@ class vLLMEngineStageUDF(StatefulStageUDF):
         if self.max_pending_requests > 0:
             logger.info("Max pending requests is set to %d", self.max_pending_requests)
 
-        runai_streamer = self.engine_kwargs.get("load_format") == "runai_streamer"
+        exclude_safetensors = self.engine_kwargs.get("load_format") == "runai_streamer"
+        if exclude_safetensors:
+            download_model = NodeModelDownloadable.EXCLUDE_SAFETENSORS
+        else:
+            download_model = NodeModelDownloadable.MODEL_AND_TOKENIZER
 
         # Download the model if needed.
         model_source = download_model_files(
             model_id=self.model,
             mirror_config=None,
-            download_model=NodeModelDownloadable.MODEL_AND_TOKENIZER,
-            download_extra_files=False,
-            runai_streamer=runai_streamer
+            download_model=download_model,
+            download_extra_files=False
         )
 
         # Create an LLM engine.

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -462,7 +462,10 @@ class vLLMEngineStageUDF(StatefulStageUDF):
         if self.max_pending_requests > 0:
             logger.info("Max pending requests is set to %d", self.max_pending_requests)
 
-        exclude_safetensors = self.engine_kwargs.get("load_format") == "runai_streamer"
+        exclude_safetensors = self.engine_kwargs.get("load_format") in [
+            "runai_streamer",
+            "tensorizer",
+        ]
         if exclude_safetensors:
             download_model = NodeModelDownloadable.EXCLUDE_SAFETENSORS
         else:

--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -284,7 +284,7 @@ class CloudFileSystem:
 
     @staticmethod
     def download_model(
-        destination_path: str, bucket_uri: str, tokenizer_only: bool, runai_streamer: bool=False
+        destination_path: str, bucket_uri: str, tokenizer_only: bool, exclude_safetensors: bool=False
     ) -> None:
         """Download a model from cloud storage.
 
@@ -295,7 +295,7 @@ class CloudFileSystem:
             destination_path: Path where the model will be stored
             bucket_uri: URI of the cloud directory containing the model
             tokenizer_only: If True, only download tokenizer-related files
-            runai_streamer: If True, skip download of safetensor files
+            exclude_safetensors: If True, skip download of safetensor files
         """
         try:
             fs, source_path = CloudFileSystem.get_fs_and_path(bucket_uri)
@@ -336,7 +336,7 @@ class CloudFileSystem:
                 ["tokenizer", "config.json"] if tokenizer_only else []
             )
 
-            safetensors_to_exclude = [".safetensors"] if runai_streamer else None
+            safetensors_to_exclude = [".safetensors"] if exclude_safetensors else None
 
             CloudFileSystem.download_files(
                 path=destination_dir,

--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -284,7 +284,10 @@ class CloudFileSystem:
 
     @staticmethod
     def download_model(
-        destination_path: str, bucket_uri: str, tokenizer_only: bool, exclude_safetensors: bool=False
+        destination_path: str,
+        bucket_uri: str,
+        tokenizer_only: bool,
+        exclude_safetensors: bool = False,
     ) -> None:
         """Download a model from cloud storage.
 
@@ -342,7 +345,7 @@ class CloudFileSystem:
                 path=destination_dir,
                 bucket_uri=bucket_uri,
                 substrings_to_include=tokenizer_file_substrings,
-                suffixes_to_exclude=safetensors_to_exclude
+                suffixes_to_exclude=safetensors_to_exclude,
             )
 
         except Exception as e:

--- a/python/ray/llm/_internal/common/utils/download_utils.py
+++ b/python/ray/llm/_internal/common/utils/download_utils.py
@@ -116,7 +116,7 @@ class CloudModelDownloader(CloudModelAccessor):
     def get_model(
         self,
         tokenizer_only: bool,
-        exclude_safetensors: bool=False,
+        exclude_safetensors: bool = False,
     ) -> str:
         """Gets a model from cloud storage and stores it locally.
 
@@ -148,7 +148,7 @@ class CloudModelDownloader(CloudModelAccessor):
                         destination_path=path,
                         bucket_uri=bucket_uri,
                         tokenizer_only=tokenizer_only,
-                        exclude_safetensors=exclude_safetensors
+                        exclude_safetensors=exclude_safetensors,
                     )
                     logger.info(
                         "Finished downloading %s for %s from %s storage",
@@ -231,7 +231,7 @@ def download_model_files(
     model_id: Optional[str] = None,
     mirror_config: Optional[CloudMirrorConfig] = None,
     download_model: NodeModelDownloadable = NodeModelDownloadable.MODEL_AND_TOKENIZER,
-    download_extra_files: bool = True
+    download_extra_files: bool = True,
 ) -> Optional[str]:
     """
     Download the model files from the cloud storage. We support two ways to specify
@@ -293,7 +293,8 @@ def download_model_files(
     if download_model != NodeModelDownloadable.NONE:
         model_path_or_id = downloader.get_model(
             tokenizer_only=download_model == NodeModelDownloadable.TOKENIZER_ONLY,
-            exclude_safetensors=download_model == NodeModelDownloadable.EXCLUDE_SAFETENSORS
+            exclude_safetensors=download_model
+            == NodeModelDownloadable.EXCLUDE_SAFETENSORS,
         )
 
     if download_extra_files:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray LLM is downloading models to disk even when runai streamer is turned on, this causes significant startup overhead and network costs to download the model at scale. This change aims to first check for "load_format" in the engine kwargs, and skip the download of the safetensors files if runai streamer is on. 

NOTE: vLLM currently has a bug when trying to load in models using runai streamer for the LLM and AsyncLLMEngine classes because it skips the download of the tokenizer and config.json. This PR needs to be in tandem with vLLM's issue fix for the functionality to work as expected.
vLLM Issue: https://github.com/issues/created?issue=vllm-project%7Cvllm%7C22843
## Related issue number

Closes #55574 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
