### PR TITLE
[Data] - Don't lauch actors for operators until they're eligible to run

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -443,6 +443,40 @@ class PhysicalOperator(Operator):
         """
         self._started = True
 
+    def can_start_immediately(self) -> bool:
+        """Return whether this operator can start immediately during topology setup.
+
+        Most operators can start immediately, but some (like actor operators) should
+        wait until their stage becomes eligible for execution.
+
+        Returns:
+            True if the operator can start immediately, False if it should wait
+            until its stage is eligible to run.
+        """
+        return True
+
+    def should_start_execution(self) -> bool:
+        """Return whether this operator should start its execution-related resources.
+
+        This is called when the operator becomes eligible to run. For actor operators,
+        this is when actors should be launched.
+
+        Returns:
+            True if execution resources should be started now.
+        """
+        return True
+
+    def start_execution(self, options: ExecutionOptions) -> None:
+        """Start execution-related resources for this operator.
+
+        This is called when the operator first becomes eligible to run.
+        For actor operators, this is where actors should be launched.
+
+        Args:
+            options: The global options used for the overall execution.
+        """
+        pass
+
     def should_add_input(self) -> bool:
         """Return whether it is desirable to add input to this operator right now.
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -445,6 +445,7 @@ class StreamingExecutor(Executor, threading.Thread):
                 topology,
                 self._resource_manager,
                 self._backpressure_policies,
+                self._options,
                 # If consumer is idling (there's nothing for it to consume)
                 # enforce liveness, ie that at least a single task gets scheduled
                 ensure_liveness=self._consumer_idling(),

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -259,7 +259,7 @@ def test_get_eligible_operators_to_run():
     )
 
     def _get_eligible_ops_to_run(ensure_liveness: bool):
-        return get_eligible_operators(topo, [], ensure_liveness=ensure_liveness)
+        return get_eligible_operators(topo, [], opts, ensure_liveness=ensure_liveness)
 
     # Test empty.
     assert _get_eligible_ops_to_run(ensure_liveness=False) == []
@@ -297,7 +297,7 @@ def test_get_eligible_operators_to_run():
 
         def _get_eligible_ops_to_run_with_policy(ensure_liveness: bool):
             return get_eligible_operators(
-                topo, [test_policy], ensure_liveness=ensure_liveness
+                topo, [test_policy], opts, ensure_liveness=ensure_liveness
             )
 
         assert _get_eligible_ops_to_run_with_policy(ensure_liveness=False) == [o3]
@@ -389,7 +389,7 @@ def test_select_ops_to_run():
         topo, _ = build_streaming_topology(o4, opts)
 
         selected = select_operator_to_run(
-            topo, resource_manager, [], ensure_liveness=ensure_liveness
+            topo, resource_manager, [], opts, ensure_liveness=ensure_liveness
         )
 
         assert selected is o4
@@ -400,7 +400,7 @@ def test_select_ops_to_run():
         topo, _ = build_streaming_topology(o3, opts)
 
         selected = select_operator_to_run(
-            topo, resource_manager, [], ensure_liveness=ensure_liveness
+            topo, resource_manager, [], opts, ensure_liveness=ensure_liveness
         )
 
         assert selected is o1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Let's take this example: 
```
ray.data.read_parquet(...)
 .repartition(key=...)
 .map_batches(Actor, ...)  
 .aggregate(...)
```
The actors in `map_batches` operator shouldn't kick off pre-maturely until repartition has completed (or any `AlltoAllOperator`). Point being you want to maximize resource efficiency and allocate resources to the blocking operator and have it finish as quickly as possible to go back to streaming mode.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
