### PR TITLE
[Serve.llm][dashboard] Add prefix cache hit rate to Serve LLM dashboard

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -291,6 +291,27 @@ SERVE_LLM_GRAFANA_PANELS = [
         grid_pos=GridPos(0, 48, 12, 8),
     ),
     Panel(
+        id=27,
+        title="Tokens Per Request Per Model Last 7 Days",
+        description="",
+        unit="Tokens",
+        targets=[
+            Target(
+                expr='sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) / sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="In: {{ model_name}}",
+            ),
+            Target(
+                expr='sum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) / sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="Out: {{ model_name}}",
+            ),
+        ],
+        fill=1,
+        linewidth=2,
+        stack=False,
+        grid_pos=GridPos(12, 48, 12, 8),
+        template=PanelTemplate.GAUGE,
+    ),
+    Panel(
         id=14,
         title="Tokens Last 24 Hours",
         description="",
@@ -470,27 +491,6 @@ SERVE_LLM_GRAFANA_PANELS = [
         linewidth=2,
         stack=False,
         grid_pos=GridPos(12, 88, 12, 8),
-        template=PanelTemplate.GAUGE,
-    ),
-    Panel(
-        id=27,
-        title="Tokens Per Request Per Model Last 7 Days",
-        description="",
-        unit="Tokens",
-        targets=[
-            Target(
-                expr='sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) / sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
-                legend="In: {{ model_name}}",
-            ),
-            Target(
-                expr='sum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) / sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
-                legend="Out: {{ model_name}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 96, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
 ]

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -281,7 +281,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="percentunit",
         targets=[
             Target(
-                expr='rate(ray_vllm:gpu_prefix_cache_hits_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[30s]) / rate(ray_vllm:gpu_prefix_cache_queries_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[30s])',
+                expr='increase(ray_vllm:gpu_prefix_cache_hits_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[30s]) / increase(ray_vllm:gpu_prefix_cache_queries_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[30s])',
                 legend="GPU: {{model_name}} - {{WorkerId}}",
             ),
         ],

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -275,6 +275,22 @@ SERVE_LLM_GRAFANA_PANELS = [
         grid_pos=GridPos(12, 40, 12, 8),
     ),
     Panel(
+        id=28,
+        title="vLLM: Prefix Cache Hit Rate",
+        description="Percentage of prefix cache queries that resulted in a cache hit (GPU).",
+        unit="percentunit",
+        targets=[
+            Target(
+                expr='rate(ray_vllm:gpu_prefix_cache_hits_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[30s]) / rate(ray_vllm:gpu_prefix_cache_queries_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[30s])',
+                legend="GPU: {{model_name}} - {{WorkerId}}",
+            ),
+        ],
+        fill=1,
+        linewidth=2,
+        stack=False,
+        grid_pos=GridPos(0, 48, 12, 8),
+    ),
+    Panel(
         id=14,
         title="Tokens Last 24 Hours",
         description="",
@@ -292,7 +308,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(0, 48, 12, 8),
+        grid_pos=GridPos(0, 56, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
@@ -313,7 +329,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(12, 48, 12, 8),
+        grid_pos=GridPos(12, 56, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
@@ -330,7 +346,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(12, 56, 12, 8),
+        grid_pos=GridPos(0, 64, 12, 8),
         template=PanelTemplate.PIE_CHART,
     ),
     Panel(
@@ -347,7 +363,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(0, 64, 12, 8),
+        grid_pos=GridPos(12, 64, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
@@ -364,7 +380,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(12, 64, 12, 8),
+        grid_pos=GridPos(0, 72, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
@@ -381,7 +397,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(0, 72, 12, 8),
+        grid_pos=GridPos(12, 72, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
@@ -398,7 +414,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(12, 72, 12, 8),
+        grid_pos=GridPos(0, 80, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
     Panel(
@@ -415,7 +431,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(0, 80, 12, 8),
+        grid_pos=GridPos(12, 80, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
     Panel(
@@ -432,7 +448,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(12, 80, 12, 8),
+        grid_pos=GridPos(0, 88, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
     Panel(
@@ -453,7 +469,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(0, 88, 12, 8),
+        grid_pos=GridPos(12, 88, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
     Panel(
@@ -474,7 +490,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         fill=1,
         linewidth=2,
         stack=False,
-        grid_pos=GridPos(12, 88, 12, 8),
+        grid_pos=GridPos(0, 96, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Expose vLLM prefix cache hit rate per replica in Ray Serve LLM dashboard.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manual test
<img width="2032" height="1167" alt="Screenshot 2025-08-25 at 1 32 36 PM" src="https://github.com/user-attachments/assets/2ac7b289-0522-477f-9d11-2d43dcf2eac6" />
