### PR TITLE
Revert "[core] Fix objects_valid with except from BaseException"

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1029,7 +1029,7 @@ def serialize_retry_exception_allowlist(retry_exception_allowlist, function_desc
 
 cdef c_bool determine_if_retryable(
     c_bool should_retry_exceptions,
-    e: BaseException,
+    Exception e,
     const c_string serialized_retry_exception_allowlist,
     FunctionDescriptor function_descriptor,
 ):
@@ -2012,9 +2012,7 @@ cdef void execute_task(
                     task_exception = False
                 except AsyncioActorExit as e:
                     exit_current_actor_if_asyncio()
-                except (KeyboardInterrupt, SystemExit):
-                    raise
-                except BaseException as e:
+                except Exception as e:
                     is_retryable_error[0] = determine_if_retryable(
                                     should_retry_exceptions,
                                     e,
@@ -2123,9 +2121,8 @@ cdef void execute_task(
                     None, # ref_generator_id
                     c_tensor_transport
                 )
-        except (KeyboardInterrupt, SystemExit):
-            raise
-        except BaseException as e:
+
+        except Exception as e:
             num_errors_stored = store_task_errors(
                     worker, e, task_exception, actor, actor_id, function_name,
                     task_type, title, caller_address, returns, application_error, c_tensor_transport)

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1192,16 +1192,6 @@ def test_failed_task(ray_start_shared_local_modes, error_pubsub):
         assert False
 
 
-def test_base_exception_raised(ray_start_shared_local_modes):
-    @ray.remote
-    def f():
-        raise BaseException("rip")
-        return 1
-
-    with pytest.raises(BaseException):
-        ray.get(f.remote())
-
-
 def test_import_ray_does_not_import_grpc():
     # First unload grpc and ray
     if "grpc" in sys.modules:

--- a/python/ray/tests/test_streaming_generator.py
+++ b/python/ray/tests/test_streaming_generator.py
@@ -576,48 +576,6 @@ def test_streaming_generator_exception(shutdown_only):
         ray.get(next(g))
 
 
-def test_baseexception_streaming_generator(shutdown_only):
-    ray.init()
-
-    class MyBaseException(BaseException):
-        pass
-
-    @ray.remote
-    def raise_at_beginning():
-        raise MyBaseException("rip")
-        yield 1
-
-    raise_at_beginning_ref = raise_at_beginning.remote()
-    with pytest.raises(MyBaseException):
-        ray.get(next(raise_at_beginning_ref))
-
-    @ray.remote
-    def raise_at_middle():
-        for i in range(1, 10):
-            if i == 5:
-                raise MyBaseException("rip")
-            yield i
-
-    raise_at_middle_ref = raise_at_middle.remote()
-    for i in range(1, 5):
-        assert i == ray.get(next(raise_at_middle_ref))
-    with pytest.raises(MyBaseException):
-        ray.get(next(raise_at_middle_ref))
-
-    @ray.remote(_generator_backpressure_num_objects=1)
-    def raise_after_backpressure():
-        for i in range(1, 10):
-            if i == 5:
-                raise MyBaseException("rip")
-            yield i
-
-    raise_after_backpressure_ref = raise_after_backpressure.remote()
-    for i in range(1, 5):
-        assert i == ray.get(next(raise_after_backpressure_ref))
-    with pytest.raises(MyBaseException):
-        ray.get(next(raise_after_backpressure_ref))
-
-
 if __name__ == "__main__":
 
     sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
Reverts ray-project/ray#55602

fails to handle python 3.12 exception groups