### PR TITLE
[core] Update base exception group tests

### DIFF
--- a/python/ray/tests/test_exceptiongroup.py
+++ b/python/ray/tests/test_exceptiongroup.py
@@ -21,7 +21,7 @@ def test_baseexceptiongroup_task(ray_start_regular):
     def task():
         raise baseexceptiongroup
 
-    with pytest.raises(ray.exceptions.WorkerCrashedError):
+    with pytest.raises(ray.exceptions.BaseExceptionGroup):
         ray.get(task.remote())
 
 
@@ -35,7 +35,7 @@ def test_baseexceptiongroup_actor(ray_start_regular):
         def f(self):
             raise baseexceptiongroup
 
-    with pytest.raises(ray.exceptions.ActorDiedError):
+    with pytest.raises(ray.exceptions.BaseExceptionGroup):
         a = Actor.remote()
         ray.get(a.f.remote())
 

--- a/python/ray/tests/test_exceptiongroup.py
+++ b/python/ray/tests/test_exceptiongroup.py
@@ -21,7 +21,7 @@ def test_baseexceptiongroup_task(ray_start_regular):
     def task():
         raise baseexceptiongroup
 
-    with pytest.raises(BaseExceptionGroup):  # noqa: F821
+    with pytest.raises(ray.exceptions.RayTaskError):  # noqa: F821
         ray.get(task.remote())
 
 
@@ -35,7 +35,7 @@ def test_baseexceptiongroup_actor(ray_start_regular):
         def f(self):
             raise baseexceptiongroup
 
-    with pytest.raises(BaseExceptionGroup):  # noqa: F821
+    with pytest.raises(ray.exceptions.RayTaskError):  # noqa: F821
         a = Actor.remote()
         ray.get(a.f.remote())
 

--- a/python/ray/tests/test_exceptiongroup.py
+++ b/python/ray/tests/test_exceptiongroup.py
@@ -21,7 +21,7 @@ def test_baseexceptiongroup_task(ray_start_regular):
     def task():
         raise baseexceptiongroup
 
-    with pytest.raises(ray.exceptions.BaseExceptionGroup):
+    with pytest.raises(BaseExceptionGroup):  # noqa: F821
         ray.get(task.remote())
 
 
@@ -35,7 +35,7 @@ def test_baseexceptiongroup_actor(ray_start_regular):
         def f(self):
             raise baseexceptiongroup
 
-    with pytest.raises(ray.exceptions.BaseExceptionGroup):
+    with pytest.raises(BaseExceptionGroup):  # noqa: F821
         a = Actor.remote()
         ray.get(a.f.remote())
 


### PR DESCRIPTION
## Why are these changes needed?
Updating exception group tests bc BaseExceptionGroup gets to the user instead of worker crash per changes here https://github.com/ray-project/ray/pull/55602.