### PR TITLE
[WIP][serve] Deflake `test_autoscaling_policy`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -161,7 +161,7 @@ test:asan-buildkite --test_env=LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libasan.so.
 aquery:ci --color=no
 aquery:ci --noshow_progress
 
-test:ci-base --test_output=errors
+test:ci-base --test_output=all
 test:ci-base --test_verbose_timeout_warnings
 test:ci-base --flaky_test_attempts=3
 

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -37,16 +37,17 @@ steps:
 
   # tests
   - label: ":ray-serve: serve: tests"
-    parallelism: 2
+    key: autoscaling_tests
+    #parallelism: 2
     tags:
       - serve
       - python
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //python/ray/tests/...  serve
+      - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests:test_autoscaling_policy serve
         --except-tags post_wheel_build,gpu,ha_integration,serve_tracing
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name servebuild --test-env=EXPECTED_PYTHON_VERSION=3.9
+        #--workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
     depends_on: "servebuild"
 
   - label: ":ray-serve: serve: pydantic < 2.0 tests"

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -355,7 +355,7 @@ class RouterMetricsManager:
             "queued_requests": self.num_queued_requests,
             "running_requests": running_requests,
         }
-        print(f"AGGREGATED REQUESTS: {result=}")
+        print(f"{time.perf_counter()} AGGREGATED REQUESTS: {result=}")
         return result
 
     async def shutdown(self):

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -351,10 +351,12 @@ class RouterMetricsManager:
                 for replica_id, num_requests in self.num_requests_sent_to_replicas.items()  # noqa: E501
             }
 
-        return {
+        result = {
             "queued_requests": self.num_queued_requests,
             "running_requests": running_requests,
         }
+        print(f"AGGREGATED REQUESTS: {result=}")
+        return result
 
     async def shutdown(self):
         """Shutdown metrics manager gracefully."""

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -306,9 +306,12 @@ def check_num_replicas_eq(
     if use_controller:
         dep = serve.status().applications[app_name].deployments[name]
         num_running_replicas = dep.replica_states.get(ReplicaState.RUNNING, 0)
+        print("num_running_replicas", num_running_replicas)
         assert num_running_replicas == target
     else:
-        assert get_num_alive_replicas(name, app_name) == target
+        num_alive_replicas = get_num_alive_replicas(name, app_name)
+        print("num_alive_replicas", num_alive_replicas)
+        assert num_alive_replicas == target
 
     return True
 

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -306,11 +306,11 @@ def check_num_replicas_eq(
     if use_controller:
         dep = serve.status().applications[app_name].deployments[name]
         num_running_replicas = dep.replica_states.get(ReplicaState.RUNNING, 0)
-        print("num_running_replicas", num_running_replicas)
+        print(f"{time.perf_counter()} num_running_replicas", num_running_replicas)
         assert num_running_replicas == target
     else:
         num_alive_replicas = get_num_alive_replicas(name, app_name)
-        print("num_alive_replicas", num_alive_replicas)
+        print(f"{time.perf_counter()} num_alive_replicas", num_alive_replicas)
         assert num_alive_replicas == target
 
     return True

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -1,6 +1,7 @@
 import logging
 import math
 from typing import Any, Dict, Optional, Tuple
+import time
 
 from ray.serve._private.autoscaling_state import AutoscalingContext
 from ray.serve._private.constants import CONTROL_LOOP_INTERVAL_S, SERVE_LOGGER_NAME
@@ -44,7 +45,7 @@ def _calculate_desired_num_replicas(
         autoscaling_config.get_target_ongoing_requests() * num_running_replicas
     )
     error_ratio: float = total_num_requests / target_num_requests
-    print(f"ERROR RATIO: {error_ratio=} {total_num_requests=} {target_num_requests=}")
+    print(f"{time.perf_counter()} ERROR RATIO: {error_ratio=} {total_num_requests=} {target_num_requests=}")
 
     # If error ratio >= 1, then the number of ongoing requests per
     # replica exceeds the target and we will make an upscale decision,
@@ -126,7 +127,7 @@ def replica_queue_length_autoscaling_policy(
         override_min_replicas=capacity_adjusted_min_replicas,
         override_max_replicas=capacity_adjusted_max_replicas,
     )
-    print(f"DECISION HERE: {decision_num_replicas=} {desired_num_replicas=} {decision_counter=}")
+    print(f"{time.perf_counter()} DECISION HERE: {decision_num_replicas=} {desired_num_replicas=} {decision_counter=}")
     # Scale up.
     if desired_num_replicas > curr_target_num_replicas:
         # If the previous decision was to scale down (the counter was

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -44,6 +44,7 @@ def _calculate_desired_num_replicas(
         autoscaling_config.get_target_ongoing_requests() * num_running_replicas
     )
     error_ratio: float = total_num_requests / target_num_requests
+    print(f"ERROR RATIO: {error_ratio=} {total_num_requests=} {target_num_requests=}")
 
     # If error ratio >= 1, then the number of ongoing requests per
     # replica exceeds the target and we will make an upscale decision,
@@ -125,6 +126,7 @@ def replica_queue_length_autoscaling_policy(
         override_min_replicas=capacity_adjusted_min_replicas,
         override_max_replicas=capacity_adjusted_max_replicas,
     )
+    print(f"DECISION HERE: {decision_num_replicas=} {desired_num_replicas=} {decision_counter=}")
     # Scale up.
     if desired_num_replicas > curr_target_num_replicas:
         # If the previous decision was to scale down (the counter was

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -180,79 +180,79 @@ class TestAutoscalingMetrics:
         wait_for_condition(check_num_requests_eq, client=client, id=dep_id, expected=0)
         tlog("Queued and ongoing requests dropped to 0.")
 
-    @pytest.mark.skipif(
-        not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
-        reason="Needs metric collection at handle.",
-    )
-    @pytest.mark.parametrize("use_generator", [True, False])
-    def test_replicas_die(self, serve_instance_with_signal, use_generator):
-        """If replicas die while requests are still executing, that
-        should be tracked correctly."""
+#     @pytest.mark.skipif(
+#         not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
+#         reason="Needs metric collection at handle.",
+#     )
+#     @pytest.mark.parametrize("use_generator", [True, False])
+#     def test_replicas_die(self, serve_instance_with_signal, use_generator):
+#         """If replicas die while requests are still executing, that
+#         should be tracked correctly."""
 
-        client, signal = serve_instance_with_signal
+#         client, signal = serve_instance_with_signal
 
-        config = {
-            "autoscaling_config": {
-                "target_ongoing_requests": 10,
-                "metrics_interval_s": 0.1,
-                "min_replicas": 1,
-                "max_replicas": 10,
-                "upscale_delay_s": 0,
-                "downscale_delay_s": 0,
-                "look_back_period_s": 1,
-            },
-            "graceful_shutdown_timeout_s": 0.1,
-            "max_ongoing_requests": 25,
-        }
+#         config = {
+#             "autoscaling_config": {
+#                 "target_ongoing_requests": 10,
+#                 "metrics_interval_s": 0.1,
+#                 "min_replicas": 1,
+#                 "max_replicas": 10,
+#                 "upscale_delay_s": 0,
+#                 "downscale_delay_s": 0,
+#                 "look_back_period_s": 1,
+#             },
+#             "graceful_shutdown_timeout_s": 0.1,
+#             "max_ongoing_requests": 25,
+#         }
 
-        if use_generator:
+#         if use_generator:
 
-            @serve.deployment(**config)
-            class A:
-                async def __call__(self):
-                    await signal.wait.remote()
-                    async for i in range(3):
-                        yield i
+#             @serve.deployment(**config)
+#             class A:
+#                 async def __call__(self):
+#                     await signal.wait.remote()
+#                     async for i in range(3):
+#                         yield i
 
-        else:
+#         else:
 
-            @serve.deployment(**config)
-            class A:
-                async def __call__(self):
-                    await signal.wait.remote()
+#             @serve.deployment(**config)
+#             class A:
+#                 async def __call__(self):
+#                     await signal.wait.remote()
 
-        handle = serve.run(A.bind(), name="app1").options(stream=use_generator)
-        dep_id = DeploymentID(name="A", app_name="app1")
-        [handle.remote() for _ in range(50)]
+#         handle = serve.run(A.bind(), name="app1").options(stream=use_generator)
+#         dep_id = DeploymentID(name="A", app_name="app1")
+#         [handle.remote() for _ in range(50)]
 
-        # Many queries should be inflight.
-        wait_for_condition(check_num_requests_ge, client=client, id=dep_id, expected=45)
-        print("Confirmed many queries are inflight.")
+#         # Many queries should be inflight.
+#         wait_for_condition(check_num_requests_ge, client=client, id=dep_id, expected=45)
+#         print("Confirmed many queries are inflight.")
 
-        wait_for_condition(
-            check_num_replicas_eq, name="A", target=5, app_name="app1", timeout=20
-        )
-        print("Confirmed deployment scaled to 5 replicas.")
+#         wait_for_condition(
+#             check_num_replicas_eq, name="A", target=5, app_name="app1", timeout=20
+#         )
+#         print("Confirmed deployment scaled to 5 replicas.")
 
-        # Wait for all requests to be scheduled to replicas so they'll be failed
-        # when the replicas are removed.
-        wait_for_condition(lambda: ray.get(signal.cur_num_waiters.remote()) == 50)
+#         # Wait for all requests to be scheduled to replicas so they'll be failed
+#         # when the replicas are removed.
+#         wait_for_condition(lambda: ray.get(signal.cur_num_waiters.remote()) == 50)
 
-        # Remove all replicas before they can finish the requests.
-        serve.delete("app1")
+#         # Remove all replicas before they can finish the requests.
+#         serve.delete("app1")
 
-        # Num requests should still drop to 0 despite all requests failing.
-        def check_handle_metrics(handle):
-            metrics_manager = handle._router._asyncio_router._metrics_manager
-            num_requests = metrics_manager.num_requests_sent_to_replicas
-            for replica_id, num in num_requests.items():
-                assert (
-                    num == 0
-                ), f"Replica {replica_id} still has {num} ongoing requests"
+#         # Num requests should still drop to 0 despite all requests failing.
+#         def check_handle_metrics(handle):
+#             metrics_manager = handle._router._asyncio_router._metrics_manager
+#             num_requests = metrics_manager.num_requests_sent_to_replicas
+#             for replica_id, num in num_requests.items():
+#                 assert (
+#                     num == 0
+#                 ), f"Replica {replica_id} still has {num} ongoing requests"
 
-            return True
+#             return True
 
-        wait_for_condition(check_handle_metrics, handle=handle)
+#         wait_for_condition(check_handle_metrics, handle=handle)
 
     @pytest.mark.skipif(
         not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
@@ -390,1134 +390,1134 @@ class TestAutoscalingMetrics:
         )
 
 
-@pytest.mark.parametrize("min_replicas", [1, 2])
-def test_e2e_scale_up_down_basic(min_replicas, serve_instance_with_signal):
-    """Send 100 requests and check that we autoscale up, and then back down."""
-
-    client, signal = serve_instance_with_signal
-
-    @serve.deployment(
-        autoscaling_config={
-            "metrics_interval_s": 0.1,
-            "min_replicas": min_replicas,
-            "max_replicas": 3,
-            "look_back_period_s": 0.2,
-            "downscale_delay_s": 0.5,
-            "upscale_delay_s": 0,
-        },
-        # We will send over a lot of queries. This will make sure replicas are
-        # killed quickly during cleanup.
-        graceful_shutdown_timeout_s=1,
-        max_ongoing_requests=1000,
-    )
-    class A:
-        async def __call__(self):
-            await signal.wait.remote()
-
-    handle = serve.run(A.bind())
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-    start_time = get_deployment_start_time(client._controller, "A")
-
-    [handle.remote() for _ in range(100)]
-
-    # scale up one more replica from min_replicas
-    wait_for_condition(check_num_replicas_gte, name="A", target=min_replicas + 1)
-    # check_deployment_status(controller, "A", DeploymentStatus.UPSCALING)
-    signal.send.remote()
-
-    # As the queue is drained, we should scale back down.
-    wait_for_condition(
-        check_num_replicas_lte, name="A", target=min_replicas, timeout=20
-    )
-
-    # Make sure start time did not change for the deployment
-    assert get_deployment_start_time(client._controller, "A") == start_time
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-@pytest.mark.parametrize("scaling_factor", [1, 0.2])
-@pytest.mark.parametrize("use_upscale_downscale_config", [True, False])
-@mock.patch(
-    "ray.serve._private.router.RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S", 1
-)
-def test_e2e_scale_up_down_with_0_replica(
-    serve_instance_with_signal,
-    scaling_factor,
-    use_upscale_downscale_config,
-):
-    """Send 100 requests and check that we autoscale up, and then back down."""
-
-    client, signal = serve_instance_with_signal
-    controller = client._controller
-
-    autoscaling_config = {
-        "metrics_interval_s": 0.1,
-        "min_replicas": 0,
-        "max_replicas": 2,
-        "look_back_period_s": 0.2,
-        "downscale_delay_s": 0.5,
-        "upscale_delay_s": 0,
-    }
-    if use_upscale_downscale_config:
-        autoscaling_config["upscaling_factor"] = scaling_factor
-        autoscaling_config["downscaling_factor"] = scaling_factor
-    else:
-        autoscaling_config["smoothing_factor"] = scaling_factor
-
-    @serve.deployment(
-        autoscaling_config=autoscaling_config,
-        # We will send over a lot of queries. This will make sure replicas are
-        # killed quickly during cleanup.
-        graceful_shutdown_timeout_s=1,
-        max_ongoing_requests=1000,
-        version="v1",
-    )
-    class A:
-        def __call__(self):
-            ray.get(signal.wait.remote())
-
-    handle = serve.run(A.bind())
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-    start_time = get_deployment_start_time(controller, "A")
-
-    results = [handle.remote() for _ in range(100)]
-
-    # After the blocking requests are sent, the number of replicas
-    # should increase.
-    wait_for_condition(check_num_replicas_gte, name="A", target=1)
-    # Release the signal, which should unblock all requests.
-    print("Number of replicas reached at least 1, releasing signal.")
-    signal.send.remote()
-
-    # As the queue is drained, we should scale back down.
-    wait_for_condition(check_num_replicas_eq, name="A", target=0)
-    # Make sure no requests were dropped.
-    # If the deployment (unexpectedly) scaled down before the
-    # blocking signal was released, chances are some requests failed b/c
-    # they were assigned to a replica that died. Therefore, this for
-    # loop is intended to help make sure that didn't happen.
-    for res in results:
-        res.result()
-
-    # Make sure start time did not change for the deployment
-    assert get_deployment_start_time(controller, "A") == start_time
-
-
-@mock.patch.object(ServeController, "run_control_loop")
-def test_initial_num_replicas(mock, serve_instance):
-    """assert that the inital amount of replicas a deployment is launched with
-    respects the bounds set by autoscaling_config.
-
-    For this test we mock out the run event loop, make sure the number of
-    replicas is set correctly before we hit the autoscaling procedure.
-    """
-
-    @serve.deployment(
-        autoscaling_config={
-            "min_replicas": 2,
-            "max_replicas": 4,
-        },
-    )
-    class A:
-        def __call__(self):
-            return "ok!"
-
-    serve.run(A.bind())
-    check_num_replicas_eq("A", 2)
-
-
-def test_cold_start_time(serve_instance):
-    """Test a request is served quickly by a deployment that's scaled to zero"""
-
-    @serve.deployment(
-        autoscaling_config={
-            "min_replicas": 0,
-            "max_replicas": 1,
-            "look_back_period_s": 0.2,
-        },
-    )
-    class A:
-        def __call__(self):
-            return "hello"
-
-    handle = serve.run(A.bind())
-
-    def check_running():
-        assert serve.status().applications["default"].status == "RUNNING"
-        return True
-
-    wait_for_condition(check_running)
-
-    assert httpx.post("http://localhost:8000/-/healthz").status_code == 200
-    assert httpx.post("http://localhost:8000/-/routes").status_code == 200
-
-    start = time.time()
-    result = handle.remote().result()
-    cold_start_time = time.time() - start
-    if sys.platform == "win32":
-        timeout = 10  # Windows has a longer tail.
-    else:
-        timeout = 3
-    assert cold_start_time < timeout
-    print(
-        "Time taken for deployment at 0 replicas to serve first request:",
-        cold_start_time,
-    )
-    assert result == "hello"
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_e2e_bursty(serve_instance_with_signal):
-    """
-    Sends 100 requests in bursts. Uses delays for smooth provisioning.
-    """
-
-    client, signal = serve_instance_with_signal
-    controller = client._controller
-
-    @serve.deployment(
-        autoscaling_config={
-            "metrics_interval_s": 0.1,
-            "min_replicas": 1,
-            "max_replicas": 2,
-            "look_back_period_s": 0.5,
-            "downscale_delay_s": 0.5,
-            "upscale_delay_s": 0.5,
-        },
-        # We will send over a lot of queries. This will make sure replicas are
-        # killed quickly during cleanup.
-        graceful_shutdown_timeout_s=1,
-        max_ongoing_requests=1000,
-        version="v1",
-    )
-    class A:
-        def __init__(self):
-            logging.getLogger("ray.serve").setLevel(logging.ERROR)
-
-        async def __call__(self):
-            await signal.wait.remote()
-
-    handle = serve.run(A.bind())
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-    start_time = get_deployment_start_time(controller, "A")
-
-    [handle.remote() for _ in range(100)]
-
-    wait_for_condition(check_num_replicas_gte, name="A", target=2)
-
-    num_replicas = get_num_alive_replicas("A")
-    signal.send.remote()
-
-    # Execute a bursty workload that issues 100 requests every 0.05 seconds
-    # The SignalActor allows all requests in a burst to be queued before they
-    # are all executed, which increases the
-    # target_in_flight_requests_per_replica. Then the send method will bring
-    # it back to 0. This bursty behavior should be smoothed by the delay
-    # parameters.
-    for _ in range(5):
-        ray.get(signal.send.remote(clear=True))
-        check_num_replicas_eq("A", num_replicas)
-        responses = [handle.remote() for _ in range(100)]
-        signal.send.remote()
-        [r.result() for r in responses]
-        time.sleep(0.05)
-
-    # As the queue is drained, we should scale back down.
-    wait_for_condition(check_num_replicas_lte, name="A", target=1)
-
-    # Make sure start time did not change for the deployment
-    assert get_deployment_start_time(controller, "A") == start_time
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-@mock.patch(
-    "ray.serve._private.router.RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S", 1
-)
-def test_e2e_intermediate_downscaling(serve_instance_with_signal):
-    """
-    Scales up, then down, and up again.
-    """
-
-    client, signal = serve_instance_with_signal
-    controller = client._controller
-
-    @serve.deployment(
-        autoscaling_config={
-            "metrics_interval_s": 0.1,
-            "min_replicas": 0,
-            "max_replicas": 20,
-            "look_back_period_s": 0.2,
-            "downscale_delay_s": 0.2,
-            "upscale_delay_s": 0.2,
-        },
-        # We will send over a lot of queries. This will make sure replicas are
-        # killed quickly during cleanup.
-        graceful_shutdown_timeout_s=1,
-        max_ongoing_requests=1000,
-    )
-    class A:
-        async def __call__(self):
-            await signal.wait.remote()
-
-    handle = serve.run(A.bind())
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-    start_time = get_deployment_start_time(controller, "A")
-
-    [handle.remote() for _ in range(50)]
-
-    wait_for_condition(check_num_replicas_gte, name="A", target=20, timeout=30)
-    signal.send.remote()
-
-    wait_for_condition(check_num_replicas_lte, name="A", target=1, timeout=30)
-    signal.send.remote(clear=True)
-
-    [handle.remote() for _ in range(50)]
-    wait_for_condition(check_num_replicas_gte, name="A", target=20, timeout=30)
-
-    signal.send.remote()
-    # As the queue is drained, we should scale back down.
-    wait_for_condition(check_num_replicas_eq, name="A", target=0, timeout=30)
-
-    # Make sure start time did not change for the deployment
-    assert get_deployment_start_time(controller, "A") == start_time
-
-
-@pytest.mark.parametrize("initial_replicas", [2, 3])
-@pytest.mark.parametrize("use_deprecated_smoothing_factor", [True, False])
-def test_downscaling_with_fractional_scaling_factor(
-    serve_instance_with_signal,
-    initial_replicas: int,
-    use_deprecated_smoothing_factor: bool,
-):
-    client, signal = serve_instance_with_signal
-    signal.send.remote(clear=True)
-
-    app_config = {
-        "import_path": "ray.serve.tests.test_config_files.get_signal.app",
-        "deployments": [
-            {
-                "name": "A",
-                "autoscaling_config": {
-                    "metrics_interval_s": 0.1,
-                    "min_replicas": 0,
-                    "max_replicas": 5,
-                    "initial_replicas": initial_replicas,
-                    "look_back_period_s": 0.2,
-                    "downscale_delay_s": 5,
-                },
-                "graceful_shutdown_timeout_s": 1,
-                "max_ongoing_requests": 1000,
-            }
-        ],
-    }
-    if use_deprecated_smoothing_factor:
-        app_config["deployments"][0]["autoscaling_config"][
-            "downscale_smoothing_factor"
-        ] = 0.5
-    else:
-        app_config["deployments"][0]["autoscaling_config"]["downscaling_factor"] = 0.5
-
-    # Deploy with initial replicas = 2+, smoothing factor = 0.5
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-
-    # Send a blocked request to one of two replicas.
-    # Deployment should still have the initial number of replicas since
-    # downscale delay = 5
-    h = serve.get_app_handle(SERVE_DEFAULT_APP_NAME)
-    h.remote()
-    check_num_replicas_eq("A", initial_replicas)
-
-    # There is 1 ongoing (blocked) request and 2+ replicas. The
-    # deployment should autoscale down to 1 replica despite the
-    # smoothing factor
-    current_num_replicas = initial_replicas
-    while current_num_replicas > 1:
-        wait_for_condition(
-            check_num_replicas_eq, name="A", target=current_num_replicas - 1
-        )
-        current_num_replicas -= 1
-        print(f"Deployment has downscaled to {current_num_replicas} replicas.")
-
-    # Release signal so we don't get an ugly error message from the
-    # replica when the signal actor goes out of scope and gets killed
-    ray.get(signal.send.remote())
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-@pytest.mark.skip(reason="Currently failing with undefined behavior")
-def test_e2e_update_autoscaling_deployment(serve_instance_with_signal):
-    # See https://github.com/ray-project/ray/issues/21017 for details
-
-    client, signal = serve_instance_with_signal
-    controller = client._controller
-
-    app_config = {
-        "import_path": "ray.serve.tests.test_config_files.get_signal.app",
-        "deployments": [
-            {
-                "name": "A",
-                "autoscaling_config": {
-                    "metrics_interval_s": 0.1,
-                    "min_replicas": 0,
-                    "max_replicas": 10,
-                    "look_back_period_s": 0.2,
-                    "downscale_delay_s": 0.2,
-                    "upscale_delay_s": 0.2,
-                },
-                "graceful_shutdown_timeout_s": 1,
-                "max_ongoing_requests": 1000,
-            }
-        ],
-    }
-
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    print("Deployed A with min_replicas 1 and max_replicas 10.")
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-    handle = serve.get_deployment_handle("A", "default")
-    start_time = get_deployment_start_time(controller, "A")
-
-    check_num_replicas_eq("A", 0)
-    [handle.remote() for _ in range(400)]
-    print("Issued 400 requests.")
-
-    wait_for_condition(check_num_replicas_gte, name="A", target=10)
-    print("Scaled to 10 replicas.")
-    first_deployment_replicas = get_running_replica_ids("A", controller)
-
-    check_num_replicas_lte("A", 20)
-
-    [handle.remote() for _ in range(458)]
-    time.sleep(3)
-    print("Issued 458 requests. Request routing in-progress.")
-
-    app_config["deployments"][0]["autoscaling_config"]["min_replicas"] = 2
-    app_config["deployments"][0]["autoscaling_config"]["max_replicas"] = 20
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    print("Redeployed A.")
-
-    wait_for_condition(check_num_replicas_gte, name="A", target=20)
-    print("Scaled up to 20 requests.")
-    second_deployment_replicas = get_running_replica_ids("A", controller)
-
-    # Confirm that none of the original replicas were de-provisioned
-    assert_no_replicas_deprovisioned(
-        first_deployment_replicas, second_deployment_replicas
-    )
-
-    signal.send.remote()
-
-    # As the queue is drained, we should scale back down.
-    wait_for_condition(check_num_replicas_lte, name="A", target=2)
-    check_num_replicas_gte("A", 2)
-
-    # Make sure start time did not change for the deployment
-    assert get_deployment_start_time(controller, "A") == start_time
-
-    # scale down to 0
-    app_config["deployments"][0]["autoscaling_config"]["min_replicas"] = 0
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    print("Redeployed A.")
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-
-    wait_for_condition(check_num_replicas_eq, name="A", target=0)
-    check_num_replicas_eq("A", 0)
-
-    # scale up
-    [handle.remote() for _ in range(400)]
-    wait_for_condition(check_num_replicas_gte, name="A", target=0)
-    signal.send.remote()
-    wait_for_condition(check_num_replicas_eq, name="A", target=0)
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_e2e_raise_min_replicas(serve_instance_with_signal):
-    """Raise min replicas from 0 to 2."""
-
-    client, signal = serve_instance_with_signal
-    controller = client._controller
-
-    app_config = {
-        "import_path": "ray.serve.tests.test_config_files.get_signal.app",
-        "deployments": [
-            {
-                "name": "A",
-                "autoscaling_config": {
-                    "metrics_interval_s": 0.1,
-                    "min_replicas": 0,
-                    "max_replicas": 10,
-                    "look_back_period_s": 0.2,
-                    "downscale_delay_s": 0.2,
-                    "upscale_delay_s": 0.2,
-                },
-                "graceful_shutdown_timeout_s": 1,
-                "max_ongoing_requests": 1000,
-            }
-        ],
-    }
-
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    tlog("Deployed A.")
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-    start_time = get_deployment_start_time(controller, "A")
-    tlog(f"Deployment A is healthy, {start_time=}")
-
-    check_num_replicas_eq("A", 0)
-
-    handle = serve.get_deployment_handle("A", "default")
-    handle.remote()
-    tlog("Issued one request.")
-
-    wait_for_condition(check_num_replicas_eq, name="A", target=1, timeout=5)
-    tlog("Scaled up to 1 replica.")
-
-    first_deployment_replicas = get_running_replica_ids("A", controller)
-
-    app_config["deployments"][0]["autoscaling_config"]["min_replicas"] = 2
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    tlog("Redeployed A with min_replicas set to 2.")
-    wait_for_condition(
-        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-    )
-
-    # Confirm that autoscaler doesn't scale above 2 even after waiting
-    with pytest.raises(RuntimeError, match="timeout"):
-        wait_for_condition(check_num_replicas_gte, name="A", target=3, timeout=5)
-    tlog("Autoscaled to 2 without issuing any new requests.")
-
-    second_deployment_replicas = get_running_replica_ids("A", controller)
-
-    # Confirm that none of the original replicas were de-provisioned
-    assert_no_replicas_deprovisioned(
-        first_deployment_replicas, second_deployment_replicas
-    )
-
-    signal.send.remote()
-    time.sleep(1)
-    tlog("Completed request.")
-
-    # As the queue is drained, we should scale back down.
-    wait_for_condition(check_num_replicas_lte, name="A", target=2)
-    check_num_replicas_gte("A", 2)
-    tlog("Stayed at 2 replicas.")
-
-    # Make sure start time did not change for the deployment
-    assert get_deployment_start_time(controller, "A") == start_time
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_e2e_initial_replicas(serve_instance):
-    @serve.deployment(
-        autoscaling_config=AutoscalingConfig(
-            min_replicas=1,
-            initial_replicas=2,
-            max_replicas=5,
-            downscale_delay_s=3,
-        ),
-    )
-    def f():
-        return os.getpid()
-
-    serve.run(f.bind())
-    check_num_replicas_eq("f", target=2)
-
-    # f should scale down to min_replicas (1) deployments
-    wait_for_condition(check_num_replicas_eq, name="f", target=1, timeout=20)
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_e2e_preserve_prev_replicas(serve_instance_with_signal):
-    _, signal = serve_instance_with_signal
-
-    @serve.deployment(
-        max_ongoing_requests=5,
-        # The config makes the deployment scale up really quickly and then
-        # wait nearly forever to downscale.
-        autoscaling_config=AutoscalingConfig(
-            min_replicas=1,
-            max_replicas=2,
-            downscale_delay_s=600,
-            upscale_delay_s=0,
-            metrics_interval_s=1,
-            look_back_period_s=1,
-        ),
-    )
-    def scaler():
-        ray.get(signal.wait.remote())
-        time.sleep(0.2)
-        return os.getpid()
-
-    handle = serve.run(scaler.bind())
-    dep_id = DeploymentID(name="scaler")
-    responses = [handle.remote() for _ in range(20)]
-
-    wait_for_condition(
-        check_num_replicas_eq,
-        name="scaler",
-        target=2,
-        use_controller=True,
-        retry_interval_ms=1000,
-        timeout=20,
-    )
-
-    ray.get(signal.send.remote())
-
-    pids = {r.result() for r in responses}
-    assert len(pids) == 2
-
-    # Now re-deploy the application, make sure it is still 2 replicas and it shouldn't
-    # be scaled down.
-    handle = serve.run(scaler.bind())
-    responses = [handle.remote() for _ in range(10)]
-    pids = {r.result() for r in responses}
-    assert len(pids) == 2
-
-    def check_num_replicas(live: int, dead: int):
-        live_actors = state_api.list_actors(
-            filters=[
-                ("class_name", "=", dep_id.to_replica_actor_class_name()),
-                ("state", "=", "ALIVE"),
-            ]
-        )
-        dead_actors = state_api.list_actors(
-            filters=[
-                ("class_name", "=", dep_id.to_replica_actor_class_name()),
-                ("state", "=", "DEAD"),
-            ]
-        )
-
-        return len(live_actors) == live and len(dead_actors) == dead
-
-    wait_for_condition(
-        check_num_replicas, retry_interval_ms=1000, timeout=20, live=2, dead=2
-    )
-    ray.get(signal.send.remote())
-
-    # re-deploy the application with initial_replicas. This should override the
-    # previous number of replicas.
-    scaler = scaler.options(
-        autoscaling_config=AutoscalingConfig(
-            min_replicas=1,
-            initial_replicas=3,
-            max_replicas=5,
-            downscale_delay_s=600,
-            upscale_delay_s=600,
-            metrics_interval_s=1,
-            look_back_period_s=1,
-        )
-    )
-    handle = serve.run(scaler.bind())
-    responses = [handle.remote() for _ in range(15)]
-    pids = {r.result() for r in responses}
-    assert len(pids) == 3
-
-    wait_for_condition(
-        check_num_replicas, retry_interval_ms=1000, timeout=20, live=3, dead=4
-    )
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_e2e_preserve_prev_replicas_rest_api(serve_instance_with_signal):
-    client, signal = serve_instance_with_signal
-
-    # Step 1: Prepare the script in a zip file so it can be submitted via REST API.
-    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_path:
-        with zipfile.ZipFile(tmp_path, "w") as zip_obj:
-            with zip_obj.open("app.py", "w") as f:
-                f.write(
-                    """
-from ray import serve
-import ray
-import os
-
-@serve.deployment
-async def g():
-    signal = ray.get_actor("signal123")
-    await signal.wait.remote()
-    return os.getpid()
-
-
-app = g.bind()
-""".encode()
-                )
-
-    # Step 2: Deploy it with max_replicas=1
-    app_config = {
-        "import_path": "app:app",
-        "runtime_env": {"working_dir": f"file://{tmp_path.name}"},
-        "deployments": [
-            {
-                "name": "g",
-                "autoscaling_config": {
-                    "min_replicas": 0,
-                    "max_replicas": 1,
-                    "downscale_delay_s": 600,
-                    "upscale_delay_s": 0,
-                    "metrics_interval_s": 1,
-                    "look_back_period_s": 1,
-                },
-            }
-        ],
-    }
-
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    wait_for_condition(
-        lambda: serve.status().applications[SERVE_DEFAULT_APP_NAME].status == "RUNNING"
-    )
-
-    # Step 3: Verify that it can scale from 0 to 1.
-    @ray.remote
-    def send_request():
-        return httpx.get("http://localhost:8000/").text
-
-    ref = send_request.remote()
-
-    wait_for_condition(
-        check_num_replicas_eq, name="g", target=1, retry_interval_ms=1000, timeout=20
-    )
-
-    signal.send.remote()
-    existing_pid = int(ray.get(ref))
-
-    # Step 4: Change the max replicas to 2
-    app_config["deployments"][0]["autoscaling_config"]["max_replicas"] = 2
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    wait_for_condition(
-        lambda: serve.status().applications[SERVE_DEFAULT_APP_NAME].status == "RUNNING"
-    )
-    wait_for_condition(
-        check_num_replicas_eq, name="g", target=1, retry_interval_ms=1000, timeout=20
-    )
-
-    # Step 5: Make sure it is the same replica (lightweight change).
-    for _ in range(10):
-        other_pid = int(ray.get(send_request.remote()))
-        assert other_pid == existing_pid
-
-    # Step 6: Make sure initial_replicas overrides previous replicas
-    app_config["deployments"][0]["autoscaling_config"]["max_replicas"] = 5
-    app_config["deployments"][0]["autoscaling_config"]["initial_replicas"] = 3
-    app_config["deployments"][0]["autoscaling_config"]["upscale_delay"] = 600
-    client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    wait_for_condition(
-        lambda: serve.status().applications[SERVE_DEFAULT_APP_NAME].status == "RUNNING"
-    )
-    wait_for_condition(
-        check_num_replicas_eq, name="g", target=3, retry_interval_ms=1000, timeout=20
-    )
-
-    # Step 7: Make sure original replica is still running (lightweight change)
-    pids = {int(pid) for pid in ray.get([send_request.remote() for _ in range(20)])}
-    assert existing_pid in pids
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-@pytest.mark.skipif(
-    not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
-    reason="Only works when collecting request metrics at handle.",
-)
-def test_max_ongoing_requests_set_to_one(serve_instance_with_signal):
-    assert RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
-    _, signal = serve_instance_with_signal
-
-    @serve.deployment(
-        autoscaling_config=AutoscalingConfig(
-            target_ongoing_requests=1.0,
-            min_replicas=1,
-            max_replicas=3,
-            upscale_delay_s=0.5,
-            downscale_delay_s=0.5,
-            metrics_interval_s=0.5,
-            look_back_period_s=2,
-        ),
-        max_ongoing_requests=1,
-        graceful_shutdown_timeout_s=1,
-        ray_actor_options={"num_cpus": 0},
-    )
-    async def f():
-        await signal.wait.remote()
-        return os.getpid()
-
-    h = serve.run(f.bind())
-
-    check_num_replicas_eq("f", 1)
-
-    # Repeatedly (5 times):
-    # 1. Send a new request.
-    # 2. Wait for the number of waiters on signal to increase by 1.
-    # 3. Assert the number of replicas has increased by 1.
-    refs = []
-    for i in range(3):
-        refs.append(h.remote())
-
-        def check_num_waiters(target: int):
-            num_waiters = ray.get(signal.cur_num_waiters.remote())
-            assert num_waiters == target
-            return True
-
-        wait_for_condition(check_num_waiters, target=i + 1)
-        print(time.time(), f"Number of waiters on signal reached {i+1}.")
-        check_num_replicas_eq("f", i + 1)
-        print(time.time(), f"Confirmed number of replicas are at {i+1}.")
-
-    print(time.time(), "Releasing signal.")
-    signal.send.remote()
-
-    # Check that pids returned are unique
-    # This implies that each replica only served one request, so the
-    # number of "running" requests per replica was at most 1 at any time;
-    # meaning the "queued" requests were taken into consideration for
-    # autoscaling.
-    pids = [ref.result() for ref in refs]
-    assert len(pids) == len(set(pids)), f"Pids {pids} are not unique."
-    print("Confirmed each replica only served one request.")
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_autoscaling_status_changes(serve_instance):
-    """Test status changes when autoscaling deployments are deployed.
-
-    This test runs an autoscaling deployment and an actor called the
-    EventManager. During initialization, each replica creates an asyncio.Event
-    in the EventManager, and it waits on the event. Once the event is set, the
-    replica can finish initializing. The test uses this EventManager to control
-    the number of replicas that should be running at a given time.
-
-    The test does the following:
-
-    1.  Starts an EventManager.
-    2.  Deploys an autoscaling deployment with min_replicas 3.
-    3.  Releases 2 replicas via the EventManager.
-    4.  Checks that the deployment remains in the UPDATING status.
-    5.  Redeploys the deployment with min_replicas 4.
-    6.  Releases 1 more replica via the EventManager.
-    7.  Checks that the deployment remains in the UPDATING status.
-    8.  Releases 1 more replica.
-    9.  Checks that the deployment enters HEALTHY status.
-    10. Redeploys the deployment with min_replicas 5.
-    11. Checks that the deployment re-enters and remains in the UPDATING status.
-    12. Releases 1 more replica.
-    13  Checks that the deployment enters HEALTHY status.
-    """
-
-    @ray.remote
-    class EventManager:
-        """Manages events for each deployment replica.
-
-        This actor uses a goal-state architecture. The test sets a max number
-        of replicas to run. Whenever this manager creates or removes an event,
-        it checks how many replicas are running and attempts to match the goal
-        state.
-        """
-
-        def __init__(self):
-            self._max_replicas_to_run = 0
-
-            # This dictionary maps replica names -> asyncio.Event.
-            self._events: Dict[str, asyncio.Event] = dict()
-
-        def get_num_running_replicas(self):
-            running_replicas = [
-                actor_name
-                for actor_name, event in self._events.items()
-                if event.is_set()
-            ]
-            return len(running_replicas)
-
-        def release_replicas(self):
-            """Releases replicas until self._max_replicas_to_run are released."""
-
-            num_replicas_released = 0
-            for _, event in self._events.items():
-                if self.get_num_running_replicas() < self._max_replicas_to_run:
-                    if not event.is_set():
-                        event.set()
-                        num_replicas_released += 1
-                else:
-                    break
-
-            if num_replicas_released > 0:
-                print(
-                    f"Started running {num_replicas_released} replicas. "
-                    f"{self.get_waiter_statuses()}"
-                )
-
-        async def wait(self, actor_name):
-            print(f"Replica {actor_name} started waiting...")
-            event = asyncio.Event()
-            self._events[actor_name] = event
-            self.release_replicas()
-            await event.wait()
-            print(f"Replica {actor_name} finished waiting.")
-
-        async def set_max_replicas_to_run(self, max_num_replicas: int = 1):
-            print(f"Setting _max_replicas_to_run to {max_num_replicas}.")
-            self._max_replicas_to_run = max_num_replicas
-            self.release_replicas()
-
-        async def get_max_replicas_to_run(self) -> int:
-            return self._max_replicas_to_run
-
-        async def num_active_replicas(self) -> int:
-            """The number of replicas that are waiting or running."""
-
-            return len(self._events)
-
-        def get_waiter_statuses(self) -> Dict[str, bool]:
-            return {
-                actor_name: event.is_set() for actor_name, event in self._events.items()
-            }
-
-        async def clear_dead_replicas(self):
-            """Clears dead replicas from internal _events dictionary."""
-
-            actor_names = list(self._events.keys())
-            for name in actor_names:
-                try:
-                    ray.get_actor(name=name, namespace=SERVE_NAMESPACE)
-                except ValueError:
-                    print(f"Actor {name} has died. Removing event.")
-                    self._events.pop(name)
-
-            self.release_replicas()
-
-    print("Starting EventManager actor...")
-
-    event_manager_actor_name = "event_manager_actor"
-    event_manager = EventManager.options(
-        name=event_manager_actor_name, namespace=SERVE_NAMESPACE
-    ).remote()
-
-    print("Starting Serve app...")
-
-    deployment_name = "autoscaling_app"
-    min_replicas = 3
-    max_replicas = 15
-
-    @serve.deployment(
-        name=deployment_name,
-        autoscaling_config=AutoscalingConfig(
-            min_replicas=min_replicas,
-            max_replicas=max_replicas,
-        ),
-        ray_actor_options=dict(num_cpus=0),
-        graceful_shutdown_timeout_s=0,
-    )
-    class AutoscalingDeployment:
-        """Deployment that autoscales."""
-
-        async def __init__(self):
-            self.name = ray.get_runtime_context().get_actor_name()
-            print(f"Replica {self.name} initializing...")
-            event_manager = ray.get_actor(
-                name=event_manager_actor_name, namespace=SERVE_NAMESPACE
-            )
-            await event_manager.wait.remote(self.name)
-            print(f"Replica {self.name} has initialized.")
-
-    app_name = "autoscaling_app"
-    app = AutoscalingDeployment.bind()
-
-    # Start the AutoscalingDeployment.
-    serve._run(app, name=app_name, _blocking=False)
-
-    # Active replicas are replicas that are waiting or running.
-    expected_num_active_replicas: int = min_replicas
-
-    def check_num_active_replicas(expected: int) -> bool:
-        ray.get(event_manager.clear_dead_replicas.remote())
-        assert ray.get(event_manager.num_active_replicas.remote()) == expected
-        return True
-
-    wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
-    print("Replicas have started waiting. Releasing some replicas...")
-
-    ray.get(event_manager.set_max_replicas_to_run.remote(min_replicas - 1))
-
-    # Wait for replicas to start.
-    print("Waiting for replicas to run.")
-
-    def replicas_running(expected_num_running_replicas: int) -> bool:
-        ray.get(event_manager.clear_dead_replicas.remote())
-        status = serve.status()
-        app_status = status.applications[app_name]
-        deployment_status = app_status.deployments[deployment_name]
-        num_running_replicas = deployment_status.replica_states.get(
-            ReplicaState.RUNNING, 0
-        )
-        assert num_running_replicas == expected_num_running_replicas, (
-            f"{app_status}, {ray.available_resources()}, "
-            f"{ray.get(event_manager.get_waiter_statuses.remote())}, "
-            f"{ray.get(event_manager.get_max_replicas_to_run.remote())}"
-        )
-        return True
-
-    wait_for_condition(
-        replicas_running,
-        expected_num_running_replicas=(min_replicas - 1),
-        timeout=15,
-    )
-
-    def check_expected_statuses(
-        expected_app_status: ApplicationStatus,
-        expected_deployment_status: DeploymentStatus,
-        expected_deployment_status_trigger: DeploymentStatusTrigger,
-    ) -> bool:
-        status = serve.status()
-
-        app_status = status.applications[app_name]
-        assert app_status.status == expected_app_status, f"{app_status}"
-
-        deployment_status = app_status.deployments[deployment_name]
-        assert (
-            deployment_status.status == expected_deployment_status
-        ), f"{deployment_status}"
-        assert (
-            deployment_status.status_trigger == expected_deployment_status_trigger
-        ), f"{deployment_status}"
-
-        return True
-
-    check_expected_statuses(
-        ApplicationStatus.DEPLOYING,
-        DeploymentStatus.UPDATING,
-        DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-    )
-
-    # Check that these statuses don't change over time.
-    print("Statuses are as expected. Sleeping briefly and checking again...")
-    time.sleep(1.5)
-    check_expected_statuses(
-        ApplicationStatus.DEPLOYING,
-        DeploymentStatus.UPDATING,
-        DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-    )
-
-    print("Statuses are still as expected. Redeploying...")
-
-    # Check the status after redeploying the deployment.
-    min_replicas += 1
-    app = AutoscalingDeployment.options(
-        autoscaling_config=AutoscalingConfig(
-            min_replicas=min_replicas,
-            max_replicas=max_replicas,
-        )
-    ).bind()
-    serve._run(app, name=app_name, _blocking=False)
-    expected_num_active_replicas = min_replicas
-
-    wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
-    print("Replicas have started waiting. Releasing some replicas...")
-
-    ray.get(event_manager.set_max_replicas_to_run.remote(min_replicas - 1))
-    wait_for_condition(
-        replicas_running,
-        expected_num_running_replicas=(min_replicas - 1),
-        timeout=20,
-    )
-
-    check_expected_statuses(
-        ApplicationStatus.DEPLOYING,
-        DeploymentStatus.UPDATING,
-        DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-    )
-
-    print("Statuses are as expected. Sleeping briefly and checking again...")
-    time.sleep(1.5)
-    check_expected_statuses(
-        ApplicationStatus.DEPLOYING,
-        DeploymentStatus.UPDATING,
-        DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-    )
-
-    print(
-        "Statuses are still as expected. "
-        "Releasing some replicas and checking again..."
-    )
-
-    wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
-
-    # Release enough replicas for deployment to enter autoscaling bounds.
-    ray.get(event_manager.set_max_replicas_to_run.remote(min_replicas))
-    wait_for_condition(
-        replicas_running,
-        expected_num_running_replicas=min_replicas,
-        timeout=20,
-    )
-
-    check_expected_statuses(
-        ApplicationStatus.RUNNING,
-        DeploymentStatus.HEALTHY,
-        DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED,
-    )
-
-    print("Statuses are as expected. Redeploying with higher min_replicas...")
-    min_replicas += 1
-    app = AutoscalingDeployment.options(
-        autoscaling_config=AutoscalingConfig(
-            min_replicas=min_replicas,
-            max_replicas=max_replicas,
-        )
-    ).bind()
-    serve._run(app, name=app_name, _blocking=False)
-    expected_num_active_replicas = min_replicas
-
-    wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
-    print("Replicas have started waiting. Checking statuses...")
-
-    # DeploymentStatus should return to UPDATING because the
-    # autoscaling_config changed.
-    wait_for_condition(
-        check_expected_statuses,
-        expected_app_status=ApplicationStatus.DEPLOYING,
-        expected_deployment_status=DeploymentStatus.UPDATING,
-        expected_deployment_status_trigger=(
-            DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
-        ),
-    )
-
-    print("Statuses are as expected. Sleeping briefly and checking again...")
-    time.sleep(1.5)
-    check_expected_statuses(
-        ApplicationStatus.DEPLOYING,
-        DeploymentStatus.UPDATING,
-        DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-    )
-
-    print(
-        "Statuses are still as expected. Releasing some replicas and checking again..."
-    )
-
-    ray.get(event_manager.set_max_replicas_to_run.remote(min_replicas))
-    wait_for_condition(
-        replicas_running,
-        expected_num_running_replicas=min_replicas,
-        timeout=20,
-    )
-
-    check_expected_statuses(
-        ApplicationStatus.RUNNING,
-        DeploymentStatus.HEALTHY,
-        DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED,
-    )
-
-    print("Statuses are as expected.")
+# @pytest.mark.parametrize("min_replicas", [1, 2])
+# def test_e2e_scale_up_down_basic(min_replicas, serve_instance_with_signal):
+#     """Send 100 requests and check that we autoscale up, and then back down."""
+
+#     client, signal = serve_instance_with_signal
+
+#     @serve.deployment(
+#         autoscaling_config={
+#             "metrics_interval_s": 0.1,
+#             "min_replicas": min_replicas,
+#             "max_replicas": 3,
+#             "look_back_period_s": 0.2,
+#             "downscale_delay_s": 0.5,
+#             "upscale_delay_s": 0,
+#         },
+#         # We will send over a lot of queries. This will make sure replicas are
+#         # killed quickly during cleanup.
+#         graceful_shutdown_timeout_s=1,
+#         max_ongoing_requests=1000,
+#     )
+#     class A:
+#         async def __call__(self):
+#             await signal.wait.remote()
+
+#     handle = serve.run(A.bind())
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+#     start_time = get_deployment_start_time(client._controller, "A")
+
+#     [handle.remote() for _ in range(100)]
+
+#     # scale up one more replica from min_replicas
+#     wait_for_condition(check_num_replicas_gte, name="A", target=min_replicas + 1)
+#     # check_deployment_status(controller, "A", DeploymentStatus.UPSCALING)
+#     signal.send.remote()
+
+#     # As the queue is drained, we should scale back down.
+#     wait_for_condition(
+#         check_num_replicas_lte, name="A", target=min_replicas, timeout=20
+#     )
+
+#     # Make sure start time did not change for the deployment
+#     assert get_deployment_start_time(client._controller, "A") == start_time
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# @pytest.mark.parametrize("scaling_factor", [1, 0.2])
+# @pytest.mark.parametrize("use_upscale_downscale_config", [True, False])
+# @mock.patch(
+#     "ray.serve._private.router.RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S", 1
+# )
+# def test_e2e_scale_up_down_with_0_replica(
+#     serve_instance_with_signal,
+#     scaling_factor,
+#     use_upscale_downscale_config,
+# ):
+#     """Send 100 requests and check that we autoscale up, and then back down."""
+
+#     client, signal = serve_instance_with_signal
+#     controller = client._controller
+
+#     autoscaling_config = {
+#         "metrics_interval_s": 0.1,
+#         "min_replicas": 0,
+#         "max_replicas": 2,
+#         "look_back_period_s": 0.2,
+#         "downscale_delay_s": 0.5,
+#         "upscale_delay_s": 0,
+#     }
+#     if use_upscale_downscale_config:
+#         autoscaling_config["upscaling_factor"] = scaling_factor
+#         autoscaling_config["downscaling_factor"] = scaling_factor
+#     else:
+#         autoscaling_config["smoothing_factor"] = scaling_factor
+
+#     @serve.deployment(
+#         autoscaling_config=autoscaling_config,
+#         # We will send over a lot of queries. This will make sure replicas are
+#         # killed quickly during cleanup.
+#         graceful_shutdown_timeout_s=1,
+#         max_ongoing_requests=1000,
+#         version="v1",
+#     )
+#     class A:
+#         def __call__(self):
+#             ray.get(signal.wait.remote())
+
+#     handle = serve.run(A.bind())
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+#     start_time = get_deployment_start_time(controller, "A")
+
+#     results = [handle.remote() for _ in range(100)]
+
+#     # After the blocking requests are sent, the number of replicas
+#     # should increase.
+#     wait_for_condition(check_num_replicas_gte, name="A", target=1)
+#     # Release the signal, which should unblock all requests.
+#     print("Number of replicas reached at least 1, releasing signal.")
+#     signal.send.remote()
+
+#     # As the queue is drained, we should scale back down.
+#     wait_for_condition(check_num_replicas_eq, name="A", target=0)
+#     # Make sure no requests were dropped.
+#     # If the deployment (unexpectedly) scaled down before the
+#     # blocking signal was released, chances are some requests failed b/c
+#     # they were assigned to a replica that died. Therefore, this for
+#     # loop is intended to help make sure that didn't happen.
+#     for res in results:
+#         res.result()
+
+#     # Make sure start time did not change for the deployment
+#     assert get_deployment_start_time(controller, "A") == start_time
+
+
+# @mock.patch.object(ServeController, "run_control_loop")
+# def test_initial_num_replicas(mock, serve_instance):
+#     """assert that the inital amount of replicas a deployment is launched with
+#     respects the bounds set by autoscaling_config.
+
+#     For this test we mock out the run event loop, make sure the number of
+#     replicas is set correctly before we hit the autoscaling procedure.
+#     """
+
+#     @serve.deployment(
+#         autoscaling_config={
+#             "min_replicas": 2,
+#             "max_replicas": 4,
+#         },
+#     )
+#     class A:
+#         def __call__(self):
+#             return "ok!"
+
+#     serve.run(A.bind())
+#     check_num_replicas_eq("A", 2)
+
+
+# def test_cold_start_time(serve_instance):
+#     """Test a request is served quickly by a deployment that's scaled to zero"""
+
+#     @serve.deployment(
+#         autoscaling_config={
+#             "min_replicas": 0,
+#             "max_replicas": 1,
+#             "look_back_period_s": 0.2,
+#         },
+#     )
+#     class A:
+#         def __call__(self):
+#             return "hello"
+
+#     handle = serve.run(A.bind())
+
+#     def check_running():
+#         assert serve.status().applications["default"].status == "RUNNING"
+#         return True
+
+#     wait_for_condition(check_running)
+
+#     assert httpx.post("http://localhost:8000/-/healthz").status_code == 200
+#     assert httpx.post("http://localhost:8000/-/routes").status_code == 200
+
+#     start = time.time()
+#     result = handle.remote().result()
+#     cold_start_time = time.time() - start
+#     if sys.platform == "win32":
+#         timeout = 10  # Windows has a longer tail.
+#     else:
+#         timeout = 3
+#     assert cold_start_time < timeout
+#     print(
+#         "Time taken for deployment at 0 replicas to serve first request:",
+#         cold_start_time,
+#     )
+#     assert result == "hello"
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# def test_e2e_bursty(serve_instance_with_signal):
+#     """
+#     Sends 100 requests in bursts. Uses delays for smooth provisioning.
+#     """
+
+#     client, signal = serve_instance_with_signal
+#     controller = client._controller
+
+#     @serve.deployment(
+#         autoscaling_config={
+#             "metrics_interval_s": 0.1,
+#             "min_replicas": 1,
+#             "max_replicas": 2,
+#             "look_back_period_s": 0.5,
+#             "downscale_delay_s": 0.5,
+#             "upscale_delay_s": 0.5,
+#         },
+#         # We will send over a lot of queries. This will make sure replicas are
+#         # killed quickly during cleanup.
+#         graceful_shutdown_timeout_s=1,
+#         max_ongoing_requests=1000,
+#         version="v1",
+#     )
+#     class A:
+#         def __init__(self):
+#             logging.getLogger("ray.serve").setLevel(logging.ERROR)
+
+#         async def __call__(self):
+#             await signal.wait.remote()
+
+#     handle = serve.run(A.bind())
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+#     start_time = get_deployment_start_time(controller, "A")
+
+#     [handle.remote() for _ in range(100)]
+
+#     wait_for_condition(check_num_replicas_gte, name="A", target=2)
+
+#     num_replicas = get_num_alive_replicas("A")
+#     signal.send.remote()
+
+#     # Execute a bursty workload that issues 100 requests every 0.05 seconds
+#     # The SignalActor allows all requests in a burst to be queued before they
+#     # are all executed, which increases the
+#     # target_in_flight_requests_per_replica. Then the send method will bring
+#     # it back to 0. This bursty behavior should be smoothed by the delay
+#     # parameters.
+#     for _ in range(5):
+#         ray.get(signal.send.remote(clear=True))
+#         check_num_replicas_eq("A", num_replicas)
+#         responses = [handle.remote() for _ in range(100)]
+#         signal.send.remote()
+#         [r.result() for r in responses]
+#         time.sleep(0.05)
+
+#     # As the queue is drained, we should scale back down.
+#     wait_for_condition(check_num_replicas_lte, name="A", target=1)
+
+#     # Make sure start time did not change for the deployment
+#     assert get_deployment_start_time(controller, "A") == start_time
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# @mock.patch(
+#     "ray.serve._private.router.RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S", 1
+# )
+# def test_e2e_intermediate_downscaling(serve_instance_with_signal):
+#     """
+#     Scales up, then down, and up again.
+#     """
+
+#     client, signal = serve_instance_with_signal
+#     controller = client._controller
+
+#     @serve.deployment(
+#         autoscaling_config={
+#             "metrics_interval_s": 0.1,
+#             "min_replicas": 0,
+#             "max_replicas": 20,
+#             "look_back_period_s": 0.2,
+#             "downscale_delay_s": 0.2,
+#             "upscale_delay_s": 0.2,
+#         },
+#         # We will send over a lot of queries. This will make sure replicas are
+#         # killed quickly during cleanup.
+#         graceful_shutdown_timeout_s=1,
+#         max_ongoing_requests=1000,
+#     )
+#     class A:
+#         async def __call__(self):
+#             await signal.wait.remote()
+
+#     handle = serve.run(A.bind())
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+#     start_time = get_deployment_start_time(controller, "A")
+
+#     [handle.remote() for _ in range(50)]
+
+#     wait_for_condition(check_num_replicas_gte, name="A", target=20, timeout=30)
+#     signal.send.remote()
+
+#     wait_for_condition(check_num_replicas_lte, name="A", target=1, timeout=30)
+#     signal.send.remote(clear=True)
+
+#     [handle.remote() for _ in range(50)]
+#     wait_for_condition(check_num_replicas_gte, name="A", target=20, timeout=30)
+
+#     signal.send.remote()
+#     # As the queue is drained, we should scale back down.
+#     wait_for_condition(check_num_replicas_eq, name="A", target=0, timeout=30)
+
+#     # Make sure start time did not change for the deployment
+#     assert get_deployment_start_time(controller, "A") == start_time
+
+
+# @pytest.mark.parametrize("initial_replicas", [2, 3])
+# @pytest.mark.parametrize("use_deprecated_smoothing_factor", [True, False])
+# def test_downscaling_with_fractional_scaling_factor(
+#     serve_instance_with_signal,
+#     initial_replicas: int,
+#     use_deprecated_smoothing_factor: bool,
+# ):
+#     client, signal = serve_instance_with_signal
+#     signal.send.remote(clear=True)
+
+#     app_config = {
+#         "import_path": "ray.serve.tests.test_config_files.get_signal.app",
+#         "deployments": [
+#             {
+#                 "name": "A",
+#                 "autoscaling_config": {
+#                     "metrics_interval_s": 0.1,
+#                     "min_replicas": 0,
+#                     "max_replicas": 5,
+#                     "initial_replicas": initial_replicas,
+#                     "look_back_period_s": 0.2,
+#                     "downscale_delay_s": 5,
+#                 },
+#                 "graceful_shutdown_timeout_s": 1,
+#                 "max_ongoing_requests": 1000,
+#             }
+#         ],
+#     }
+#     if use_deprecated_smoothing_factor:
+#         app_config["deployments"][0]["autoscaling_config"][
+#             "downscale_smoothing_factor"
+#         ] = 0.5
+#     else:
+#         app_config["deployments"][0]["autoscaling_config"]["downscaling_factor"] = 0.5
+
+#     # Deploy with initial replicas = 2+, smoothing factor = 0.5
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+
+#     # Send a blocked request to one of two replicas.
+#     # Deployment should still have the initial number of replicas since
+#     # downscale delay = 5
+#     h = serve.get_app_handle(SERVE_DEFAULT_APP_NAME)
+#     h.remote()
+#     check_num_replicas_eq("A", initial_replicas)
+
+#     # There is 1 ongoing (blocked) request and 2+ replicas. The
+#     # deployment should autoscale down to 1 replica despite the
+#     # smoothing factor
+#     current_num_replicas = initial_replicas
+#     while current_num_replicas > 1:
+#         wait_for_condition(
+#             check_num_replicas_eq, name="A", target=current_num_replicas - 1
+#         )
+#         current_num_replicas -= 1
+#         print(f"Deployment has downscaled to {current_num_replicas} replicas.")
+
+#     # Release signal so we don't get an ugly error message from the
+#     # replica when the signal actor goes out of scope and gets killed
+#     ray.get(signal.send.remote())
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# @pytest.mark.skip(reason="Currently failing with undefined behavior")
+# def test_e2e_update_autoscaling_deployment(serve_instance_with_signal):
+#     # See https://github.com/ray-project/ray/issues/21017 for details
+
+#     client, signal = serve_instance_with_signal
+#     controller = client._controller
+
+#     app_config = {
+#         "import_path": "ray.serve.tests.test_config_files.get_signal.app",
+#         "deployments": [
+#             {
+#                 "name": "A",
+#                 "autoscaling_config": {
+#                     "metrics_interval_s": 0.1,
+#                     "min_replicas": 0,
+#                     "max_replicas": 10,
+#                     "look_back_period_s": 0.2,
+#                     "downscale_delay_s": 0.2,
+#                     "upscale_delay_s": 0.2,
+#                 },
+#                 "graceful_shutdown_timeout_s": 1,
+#                 "max_ongoing_requests": 1000,
+#             }
+#         ],
+#     }
+
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     print("Deployed A with min_replicas 1 and max_replicas 10.")
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+#     handle = serve.get_deployment_handle("A", "default")
+#     start_time = get_deployment_start_time(controller, "A")
+
+#     check_num_replicas_eq("A", 0)
+#     [handle.remote() for _ in range(400)]
+#     print("Issued 400 requests.")
+
+#     wait_for_condition(check_num_replicas_gte, name="A", target=10)
+#     print("Scaled to 10 replicas.")
+#     first_deployment_replicas = get_running_replica_ids("A", controller)
+
+#     check_num_replicas_lte("A", 20)
+
+#     [handle.remote() for _ in range(458)]
+#     time.sleep(3)
+#     print("Issued 458 requests. Request routing in-progress.")
+
+#     app_config["deployments"][0]["autoscaling_config"]["min_replicas"] = 2
+#     app_config["deployments"][0]["autoscaling_config"]["max_replicas"] = 20
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     print("Redeployed A.")
+
+#     wait_for_condition(check_num_replicas_gte, name="A", target=20)
+#     print("Scaled up to 20 requests.")
+#     second_deployment_replicas = get_running_replica_ids("A", controller)
+
+#     # Confirm that none of the original replicas were de-provisioned
+#     assert_no_replicas_deprovisioned(
+#         first_deployment_replicas, second_deployment_replicas
+#     )
+
+#     signal.send.remote()
+
+#     # As the queue is drained, we should scale back down.
+#     wait_for_condition(check_num_replicas_lte, name="A", target=2)
+#     check_num_replicas_gte("A", 2)
+
+#     # Make sure start time did not change for the deployment
+#     assert get_deployment_start_time(controller, "A") == start_time
+
+#     # scale down to 0
+#     app_config["deployments"][0]["autoscaling_config"]["min_replicas"] = 0
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     print("Redeployed A.")
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+
+#     wait_for_condition(check_num_replicas_eq, name="A", target=0)
+#     check_num_replicas_eq("A", 0)
+
+#     # scale up
+#     [handle.remote() for _ in range(400)]
+#     wait_for_condition(check_num_replicas_gte, name="A", target=0)
+#     signal.send.remote()
+#     wait_for_condition(check_num_replicas_eq, name="A", target=0)
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# def test_e2e_raise_min_replicas(serve_instance_with_signal):
+#     """Raise min replicas from 0 to 2."""
+
+#     client, signal = serve_instance_with_signal
+#     controller = client._controller
+
+#     app_config = {
+#         "import_path": "ray.serve.tests.test_config_files.get_signal.app",
+#         "deployments": [
+#             {
+#                 "name": "A",
+#                 "autoscaling_config": {
+#                     "metrics_interval_s": 0.1,
+#                     "min_replicas": 0,
+#                     "max_replicas": 10,
+#                     "look_back_period_s": 0.2,
+#                     "downscale_delay_s": 0.2,
+#                     "upscale_delay_s": 0.2,
+#                 },
+#                 "graceful_shutdown_timeout_s": 1,
+#                 "max_ongoing_requests": 1000,
+#             }
+#         ],
+#     }
+
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     tlog("Deployed A.")
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+#     start_time = get_deployment_start_time(controller, "A")
+#     tlog(f"Deployment A is healthy, {start_time=}")
+
+#     check_num_replicas_eq("A", 0)
+
+#     handle = serve.get_deployment_handle("A", "default")
+#     handle.remote()
+#     tlog("Issued one request.")
+
+#     wait_for_condition(check_num_replicas_eq, name="A", target=1, timeout=5)
+#     tlog("Scaled up to 1 replica.")
+
+#     first_deployment_replicas = get_running_replica_ids("A", controller)
+
+#     app_config["deployments"][0]["autoscaling_config"]["min_replicas"] = 2
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     tlog("Redeployed A with min_replicas set to 2.")
+#     wait_for_condition(
+#         check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+#     )
+
+#     # Confirm that autoscaler doesn't scale above 2 even after waiting
+#     with pytest.raises(RuntimeError, match="timeout"):
+#         wait_for_condition(check_num_replicas_gte, name="A", target=3, timeout=5)
+#     tlog("Autoscaled to 2 without issuing any new requests.")
+
+#     second_deployment_replicas = get_running_replica_ids("A", controller)
+
+#     # Confirm that none of the original replicas were de-provisioned
+#     assert_no_replicas_deprovisioned(
+#         first_deployment_replicas, second_deployment_replicas
+#     )
+
+#     signal.send.remote()
+#     time.sleep(1)
+#     tlog("Completed request.")
+
+#     # As the queue is drained, we should scale back down.
+#     wait_for_condition(check_num_replicas_lte, name="A", target=2)
+#     check_num_replicas_gte("A", 2)
+#     tlog("Stayed at 2 replicas.")
+
+#     # Make sure start time did not change for the deployment
+#     assert get_deployment_start_time(controller, "A") == start_time
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# def test_e2e_initial_replicas(serve_instance):
+#     @serve.deployment(
+#         autoscaling_config=AutoscalingConfig(
+#             min_replicas=1,
+#             initial_replicas=2,
+#             max_replicas=5,
+#             downscale_delay_s=3,
+#         ),
+#     )
+#     def f():
+#         return os.getpid()
+
+#     serve.run(f.bind())
+#     check_num_replicas_eq("f", target=2)
+
+#     # f should scale down to min_replicas (1) deployments
+#     wait_for_condition(check_num_replicas_eq, name="f", target=1, timeout=20)
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# def test_e2e_preserve_prev_replicas(serve_instance_with_signal):
+#     _, signal = serve_instance_with_signal
+
+#     @serve.deployment(
+#         max_ongoing_requests=5,
+#         # The config makes the deployment scale up really quickly and then
+#         # wait nearly forever to downscale.
+#         autoscaling_config=AutoscalingConfig(
+#             min_replicas=1,
+#             max_replicas=2,
+#             downscale_delay_s=600,
+#             upscale_delay_s=0,
+#             metrics_interval_s=1,
+#             look_back_period_s=1,
+#         ),
+#     )
+#     def scaler():
+#         ray.get(signal.wait.remote())
+#         time.sleep(0.2)
+#         return os.getpid()
+
+#     handle = serve.run(scaler.bind())
+#     dep_id = DeploymentID(name="scaler")
+#     responses = [handle.remote() for _ in range(20)]
+
+#     wait_for_condition(
+#         check_num_replicas_eq,
+#         name="scaler",
+#         target=2,
+#         use_controller=True,
+#         retry_interval_ms=1000,
+#         timeout=20,
+#     )
+
+#     ray.get(signal.send.remote())
+
+#     pids = {r.result() for r in responses}
+#     assert len(pids) == 2
+
+#     # Now re-deploy the application, make sure it is still 2 replicas and it shouldn't
+#     # be scaled down.
+#     handle = serve.run(scaler.bind())
+#     responses = [handle.remote() for _ in range(10)]
+#     pids = {r.result() for r in responses}
+#     assert len(pids) == 2
+
+#     def check_num_replicas(live: int, dead: int):
+#         live_actors = state_api.list_actors(
+#             filters=[
+#                 ("class_name", "=", dep_id.to_replica_actor_class_name()),
+#                 ("state", "=", "ALIVE"),
+#             ]
+#         )
+#         dead_actors = state_api.list_actors(
+#             filters=[
+#                 ("class_name", "=", dep_id.to_replica_actor_class_name()),
+#                 ("state", "=", "DEAD"),
+#             ]
+#         )
+
+#         return len(live_actors) == live and len(dead_actors) == dead
+
+#     wait_for_condition(
+#         check_num_replicas, retry_interval_ms=1000, timeout=20, live=2, dead=2
+#     )
+#     ray.get(signal.send.remote())
+
+#     # re-deploy the application with initial_replicas. This should override the
+#     # previous number of replicas.
+#     scaler = scaler.options(
+#         autoscaling_config=AutoscalingConfig(
+#             min_replicas=1,
+#             initial_replicas=3,
+#             max_replicas=5,
+#             downscale_delay_s=600,
+#             upscale_delay_s=600,
+#             metrics_interval_s=1,
+#             look_back_period_s=1,
+#         )
+#     )
+#     handle = serve.run(scaler.bind())
+#     responses = [handle.remote() for _ in range(15)]
+#     pids = {r.result() for r in responses}
+#     assert len(pids) == 3
+
+#     wait_for_condition(
+#         check_num_replicas, retry_interval_ms=1000, timeout=20, live=3, dead=4
+#     )
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# def test_e2e_preserve_prev_replicas_rest_api(serve_instance_with_signal):
+#     client, signal = serve_instance_with_signal
+
+#     # Step 1: Prepare the script in a zip file so it can be submitted via REST API.
+#     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_path:
+#         with zipfile.ZipFile(tmp_path, "w") as zip_obj:
+#             with zip_obj.open("app.py", "w") as f:
+#                 f.write(
+#                     """
+# from ray import serve
+# import ray
+# import os
+
+# @serve.deployment
+# async def g():
+#     signal = ray.get_actor("signal123")
+#     await signal.wait.remote()
+#     return os.getpid()
+
+
+# app = g.bind()
+# """.encode()
+#                 )
+
+#     # Step 2: Deploy it with max_replicas=1
+#     app_config = {
+#         "import_path": "app:app",
+#         "runtime_env": {"working_dir": f"file://{tmp_path.name}"},
+#         "deployments": [
+#             {
+#                 "name": "g",
+#                 "autoscaling_config": {
+#                     "min_replicas": 0,
+#                     "max_replicas": 1,
+#                     "downscale_delay_s": 600,
+#                     "upscale_delay_s": 0,
+#                     "metrics_interval_s": 1,
+#                     "look_back_period_s": 1,
+#                 },
+#             }
+#         ],
+#     }
+
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     wait_for_condition(
+#         lambda: serve.status().applications[SERVE_DEFAULT_APP_NAME].status == "RUNNING"
+#     )
+
+#     # Step 3: Verify that it can scale from 0 to 1.
+#     @ray.remote
+#     def send_request():
+#         return httpx.get("http://localhost:8000/").text
+
+#     ref = send_request.remote()
+
+#     wait_for_condition(
+#         check_num_replicas_eq, name="g", target=1, retry_interval_ms=1000, timeout=20
+#     )
+
+#     signal.send.remote()
+#     existing_pid = int(ray.get(ref))
+
+#     # Step 4: Change the max replicas to 2
+#     app_config["deployments"][0]["autoscaling_config"]["max_replicas"] = 2
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     wait_for_condition(
+#         lambda: serve.status().applications[SERVE_DEFAULT_APP_NAME].status == "RUNNING"
+#     )
+#     wait_for_condition(
+#         check_num_replicas_eq, name="g", target=1, retry_interval_ms=1000, timeout=20
+#     )
+
+#     # Step 5: Make sure it is the same replica (lightweight change).
+#     for _ in range(10):
+#         other_pid = int(ray.get(send_request.remote()))
+#         assert other_pid == existing_pid
+
+#     # Step 6: Make sure initial_replicas overrides previous replicas
+#     app_config["deployments"][0]["autoscaling_config"]["max_replicas"] = 5
+#     app_config["deployments"][0]["autoscaling_config"]["initial_replicas"] = 3
+#     app_config["deployments"][0]["autoscaling_config"]["upscale_delay"] = 600
+#     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
+#     wait_for_condition(
+#         lambda: serve.status().applications[SERVE_DEFAULT_APP_NAME].status == "RUNNING"
+#     )
+#     wait_for_condition(
+#         check_num_replicas_eq, name="g", target=3, retry_interval_ms=1000, timeout=20
+#     )
+
+#     # Step 7: Make sure original replica is still running (lightweight change)
+#     pids = {int(pid) for pid in ray.get([send_request.remote() for _ in range(20)])}
+#     assert existing_pid in pids
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# @pytest.mark.skipif(
+#     not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
+#     reason="Only works when collecting request metrics at handle.",
+# )
+# def test_max_ongoing_requests_set_to_one(serve_instance_with_signal):
+#     assert RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
+#     _, signal = serve_instance_with_signal
+
+#     @serve.deployment(
+#         autoscaling_config=AutoscalingConfig(
+#             target_ongoing_requests=1.0,
+#             min_replicas=1,
+#             max_replicas=3,
+#             upscale_delay_s=0.5,
+#             downscale_delay_s=0.5,
+#             metrics_interval_s=0.5,
+#             look_back_period_s=2,
+#         ),
+#         max_ongoing_requests=1,
+#         graceful_shutdown_timeout_s=1,
+#         ray_actor_options={"num_cpus": 0},
+#     )
+#     async def f():
+#         await signal.wait.remote()
+#         return os.getpid()
+
+#     h = serve.run(f.bind())
+
+#     check_num_replicas_eq("f", 1)
+
+#     # Repeatedly (5 times):
+#     # 1. Send a new request.
+#     # 2. Wait for the number of waiters on signal to increase by 1.
+#     # 3. Assert the number of replicas has increased by 1.
+#     refs = []
+#     for i in range(3):
+#         refs.append(h.remote())
+
+#         def check_num_waiters(target: int):
+#             num_waiters = ray.get(signal.cur_num_waiters.remote())
+#             assert num_waiters == target
+#             return True
+
+#         wait_for_condition(check_num_waiters, target=i + 1)
+#         print(time.time(), f"Number of waiters on signal reached {i+1}.")
+#         check_num_replicas_eq("f", i + 1)
+#         print(time.time(), f"Confirmed number of replicas are at {i+1}.")
+
+#     print(time.time(), "Releasing signal.")
+#     signal.send.remote()
+
+#     # Check that pids returned are unique
+#     # This implies that each replica only served one request, so the
+#     # number of "running" requests per replica was at most 1 at any time;
+#     # meaning the "queued" requests were taken into consideration for
+#     # autoscaling.
+#     pids = [ref.result() for ref in refs]
+#     assert len(pids) == len(set(pids)), f"Pids {pids} are not unique."
+#     print("Confirmed each replica only served one request.")
+
+
+# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# def test_autoscaling_status_changes(serve_instance):
+#     """Test status changes when autoscaling deployments are deployed.
+
+#     This test runs an autoscaling deployment and an actor called the
+#     EventManager. During initialization, each replica creates an asyncio.Event
+#     in the EventManager, and it waits on the event. Once the event is set, the
+#     replica can finish initializing. The test uses this EventManager to control
+#     the number of replicas that should be running at a given time.
+
+#     The test does the following:
+
+#     1.  Starts an EventManager.
+#     2.  Deploys an autoscaling deployment with min_replicas 3.
+#     3.  Releases 2 replicas via the EventManager.
+#     4.  Checks that the deployment remains in the UPDATING status.
+#     5.  Redeploys the deployment with min_replicas 4.
+#     6.  Releases 1 more replica via the EventManager.
+#     7.  Checks that the deployment remains in the UPDATING status.
+#     8.  Releases 1 more replica.
+#     9.  Checks that the deployment enters HEALTHY status.
+#     10. Redeploys the deployment with min_replicas 5.
+#     11. Checks that the deployment re-enters and remains in the UPDATING status.
+#     12. Releases 1 more replica.
+#     13  Checks that the deployment enters HEALTHY status.
+#     """
+
+#     @ray.remote
+#     class EventManager:
+#         """Manages events for each deployment replica.
+
+#         This actor uses a goal-state architecture. The test sets a max number
+#         of replicas to run. Whenever this manager creates or removes an event,
+#         it checks how many replicas are running and attempts to match the goal
+#         state.
+#         """
+
+#         def __init__(self):
+#             self._max_replicas_to_run = 0
+
+#             # This dictionary maps replica names -> asyncio.Event.
+#             self._events: Dict[str, asyncio.Event] = dict()
+
+#         def get_num_running_replicas(self):
+#             running_replicas = [
+#                 actor_name
+#                 for actor_name, event in self._events.items()
+#                 if event.is_set()
+#             ]
+#             return len(running_replicas)
+
+#         def release_replicas(self):
+#             """Releases replicas until self._max_replicas_to_run are released."""
+
+#             num_replicas_released = 0
+#             for _, event in self._events.items():
+#                 if self.get_num_running_replicas() < self._max_replicas_to_run:
+#                     if not event.is_set():
+#                         event.set()
+#                         num_replicas_released += 1
+#                 else:
+#                     break
+
+#             if num_replicas_released > 0:
+#                 print(
+#                     f"Started running {num_replicas_released} replicas. "
+#                     f"{self.get_waiter_statuses()}"
+#                 )
+
+#         async def wait(self, actor_name):
+#             print(f"Replica {actor_name} started waiting...")
+#             event = asyncio.Event()
+#             self._events[actor_name] = event
+#             self.release_replicas()
+#             await event.wait()
+#             print(f"Replica {actor_name} finished waiting.")
+
+#         async def set_max_replicas_to_run(self, max_num_replicas: int = 1):
+#             print(f"Setting _max_replicas_to_run to {max_num_replicas}.")
+#             self._max_replicas_to_run = max_num_replicas
+#             self.release_replicas()
+
+#         async def get_max_replicas_to_run(self) -> int:
+#             return self._max_replicas_to_run
+
+#         async def num_active_replicas(self) -> int:
+#             """The number of replicas that are waiting or running."""
+
+#             return len(self._events)
+
+#         def get_waiter_statuses(self) -> Dict[str, bool]:
+#             return {
+#                 actor_name: event.is_set() for actor_name, event in self._events.items()
+#             }
+
+#         async def clear_dead_replicas(self):
+#             """Clears dead replicas from internal _events dictionary."""
+
+#             actor_names = list(self._events.keys())
+#             for name in actor_names:
+#                 try:
+#                     ray.get_actor(name=name, namespace=SERVE_NAMESPACE)
+#                 except ValueError:
+#                     print(f"Actor {name} has died. Removing event.")
+#                     self._events.pop(name)
+
+#             self.release_replicas()
+
+#     print("Starting EventManager actor...")
+
+#     event_manager_actor_name = "event_manager_actor"
+#     event_manager = EventManager.options(
+#         name=event_manager_actor_name, namespace=SERVE_NAMESPACE
+#     ).remote()
+
+#     print("Starting Serve app...")
+
+#     deployment_name = "autoscaling_app"
+#     min_replicas = 3
+#     max_replicas = 15
+
+#     @serve.deployment(
+#         name=deployment_name,
+#         autoscaling_config=AutoscalingConfig(
+#             min_replicas=min_replicas,
+#             max_replicas=max_replicas,
+#         ),
+#         ray_actor_options=dict(num_cpus=0),
+#         graceful_shutdown_timeout_s=0,
+#     )
+#     class AutoscalingDeployment:
+#         """Deployment that autoscales."""
+
+#         async def __init__(self):
+#             self.name = ray.get_runtime_context().get_actor_name()
+#             print(f"Replica {self.name} initializing...")
+#             event_manager = ray.get_actor(
+#                 name=event_manager_actor_name, namespace=SERVE_NAMESPACE
+#             )
+#             await event_manager.wait.remote(self.name)
+#             print(f"Replica {self.name} has initialized.")
+
+#     app_name = "autoscaling_app"
+#     app = AutoscalingDeployment.bind()
+
+#     # Start the AutoscalingDeployment.
+#     serve._run(app, name=app_name, _blocking=False)
+
+#     # Active replicas are replicas that are waiting or running.
+#     expected_num_active_replicas: int = min_replicas
+
+#     def check_num_active_replicas(expected: int) -> bool:
+#         ray.get(event_manager.clear_dead_replicas.remote())
+#         assert ray.get(event_manager.num_active_replicas.remote()) == expected
+#         return True
+
+#     wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
+#     print("Replicas have started waiting. Releasing some replicas...")
+
+#     ray.get(event_manager.set_max_replicas_to_run.remote(min_replicas - 1))
+
+#     # Wait for replicas to start.
+#     print("Waiting for replicas to run.")
+
+#     def replicas_running(expected_num_running_replicas: int) -> bool:
+#         ray.get(event_manager.clear_dead_replicas.remote())
+#         status = serve.status()
+#         app_status = status.applications[app_name]
+#         deployment_status = app_status.deployments[deployment_name]
+#         num_running_replicas = deployment_status.replica_states.get(
+#             ReplicaState.RUNNING, 0
+#         )
+#         assert num_running_replicas == expected_num_running_replicas, (
+#             f"{app_status}, {ray.available_resources()}, "
+#             f"{ray.get(event_manager.get_waiter_statuses.remote())}, "
+#             f"{ray.get(event_manager.get_max_replicas_to_run.remote())}"
+#         )
+#         return True
+
+#     wait_for_condition(
+#         replicas_running,
+#         expected_num_running_replicas=(min_replicas - 1),
+#         timeout=15,
+#     )
+
+#     def check_expected_statuses(
+#         expected_app_status: ApplicationStatus,
+#         expected_deployment_status: DeploymentStatus,
+#         expected_deployment_status_trigger: DeploymentStatusTrigger,
+#     ) -> bool:
+#         status = serve.status()
+
+#         app_status = status.applications[app_name]
+#         assert app_status.status == expected_app_status, f"{app_status}"
+
+#         deployment_status = app_status.deployments[deployment_name]
+#         assert (
+#             deployment_status.status == expected_deployment_status
+#         ), f"{deployment_status}"
+#         assert (
+#             deployment_status.status_trigger == expected_deployment_status_trigger
+#         ), f"{deployment_status}"
+
+#         return True
+
+#     check_expected_statuses(
+#         ApplicationStatus.DEPLOYING,
+#         DeploymentStatus.UPDATING,
+#         DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+#     )
+
+#     # Check that these statuses don't change over time.
+#     print("Statuses are as expected. Sleeping briefly and checking again...")
+#     time.sleep(1.5)
+#     check_expected_statuses(
+#         ApplicationStatus.DEPLOYING,
+#         DeploymentStatus.UPDATING,
+#         DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+#     )
+
+#     print("Statuses are still as expected. Redeploying...")
+
+#     # Check the status after redeploying the deployment.
+#     min_replicas += 1
+#     app = AutoscalingDeployment.options(
+#         autoscaling_config=AutoscalingConfig(
+#             min_replicas=min_replicas,
+#             max_replicas=max_replicas,
+#         )
+#     ).bind()
+#     serve._run(app, name=app_name, _blocking=False)
+#     expected_num_active_replicas = min_replicas
+
+#     wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
+#     print("Replicas have started waiting. Releasing some replicas...")
+
+#     ray.get(event_manager.set_max_replicas_to_run.remote(min_replicas - 1))
+#     wait_for_condition(
+#         replicas_running,
+#         expected_num_running_replicas=(min_replicas - 1),
+#         timeout=20,
+#     )
+
+#     check_expected_statuses(
+#         ApplicationStatus.DEPLOYING,
+#         DeploymentStatus.UPDATING,
+#         DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+#     )
+
+#     print("Statuses are as expected. Sleeping briefly and checking again...")
+#     time.sleep(1.5)
+#     check_expected_statuses(
+#         ApplicationStatus.DEPLOYING,
+#         DeploymentStatus.UPDATING,
+#         DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+#     )
+
+#     print(
+#         "Statuses are still as expected. "
+#         "Releasing some replicas and checking again..."
+#     )
+
+#     wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
+
+#     # Release enough replicas for deployment to enter autoscaling bounds.
+#     ray.get(event_manager.set_max_replicas_to_run.remote(min_replicas))
+#     wait_for_condition(
+#         replicas_running,
+#         expected_num_running_replicas=min_replicas,
+#         timeout=20,
+#     )
+
+#     check_expected_statuses(
+#         ApplicationStatus.RUNNING,
+#         DeploymentStatus.HEALTHY,
+#         DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED,
+#     )
+
+#     print("Statuses are as expected. Redeploying with higher min_replicas...")
+#     min_replicas += 1
+#     app = AutoscalingDeployment.options(
+#         autoscaling_config=AutoscalingConfig(
+#             min_replicas=min_replicas,
+#             max_replicas=max_replicas,
+#         )
+#     ).bind()
+#     serve._run(app, name=app_name, _blocking=False)
+#     expected_num_active_replicas = min_replicas
+
+#     wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
+#     print("Replicas have started waiting. Checking statuses...")
+
+#     # DeploymentStatus should return to UPDATING because the
+#     # autoscaling_config changed.
+#     wait_for_condition(
+#         check_expected_statuses,
+#         expected_app_status=ApplicationStatus.DEPLOYING,
+#         expected_deployment_status=DeploymentStatus.UPDATING,
+#         expected_deployment_status_trigger=(
+#             DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
+#         ),
+#     )
+
+#     print("Statuses are as expected. Sleeping briefly and checking again...")
+#     time.sleep(1.5)
+#     check_expected_statuses(
+#         ApplicationStatus.DEPLOYING,
+#         DeploymentStatus.UPDATING,
+#         DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+#     )
+
+#     print(
+#         "Statuses are still as expected. Releasing some replicas and checking again..."
+#     )
+
+#     ray.get(event_manager.set_max_replicas_to_run.remote(min_replicas))
+#     wait_for_condition(
+#         replicas_running,
+#         expected_num_running_replicas=min_replicas,
+#         timeout=20,
+#     )
+
+#     check_expected_statuses(
+#         ApplicationStatus.RUNNING,
+#         DeploymentStatus.HEALTHY,
+#         DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED,
+#     )
+
+#     print("Statuses are as expected.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The `test_autoscaling_policy` test is flaky on both Linux and Windows because of a change to how metrics are updated in https://github.com/ray-project/ray/pull/55635.

To make autoscaling decisions, controller gets the following metrics from the router:
1. num queued requests at the router
2. num requests sent to replica and not yet returned

The refactor PR slightly changed when both of these metrics are updated. Now, the router will increment the second counter as soon as it sends the request to the replica, even if the replica hasn't accepted the request. When the replica rejects the request, the router will decrement the counter. Semantically, the metric is pretty much the same. However, the autoscaler uses the rolling average of this metric, so the number of request sent to replica will be > 0 even though the current value of the metric is 0. Because the router increments the metric every time the request is sent, even though the request may be rejected, the value of the metric from the autoscaler's POV will be > 0. This causes the autoscaler to upscale slightly more replicas than needed, which results in failures to the autoscaling tests, since they check that an exact number of replicas have upscaled.

tests that are flaky:
in `test_autoscaling_policy.py`:
* `test_handle_deleted_on_crashed_replica`
* any test that has `wait_for_condition(check_num_replicas_eq, name="A", target=5)`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
