### PR TITLE
[RLlib] Fix `TensorType`.

### DIFF
--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
         jnp = jax.numpy
 
 # Represents a generic tensor type.
-# This could be an np.ndarray, tf.Tensor, or a torch.Tensor.
+# This could be an np.ndarray, jnp.ndarray, tf.Tensor, or a torch.Tensor.
 TensorType = Union[np.ndarray, "jnp.ndarray", "tf.Tensor", "torch.Tensor"]
 
 # Either a plain tensor, or a dict or tuple of tensors (or StructTensors).

--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 # Represents a generic tensor type.
 # This could be an np.ndarray, tf.Tensor, or a torch.Tensor.
-TensorType = Union[np.array, "jnp.ndarray", "tf.Tensor", "torch.Tensor"]
+TensorType = Union[np.ndarray, "jnp.ndarray", "tf.Tensor", "torch.Tensor"]
 
 # Either a plain tensor, or a dict or tuple of tensors (or StructTensors).
 TensorStructType = Union[TensorType, dict, tuple]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

RIght now `TensorType` is defined by the union of `np.array` and tensors, however, `np.array` is a function, the class is `np.ndarray`. This PR fixes this error.

## Related issue number

Closes #55288 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
