### PR TITLE
[Data] Emit events rather than just logs for detected issues

### DIFF
--- a/python/ray/_private/event/export_event_logger.py
+++ b/python/ray/_private/event/export_event_logger.py
@@ -13,6 +13,9 @@ from ray._private.protobuf_compat import message_to_dict
 from ray.core.generated.export_dataset_metadata_pb2 import (
     ExportDatasetMetadata,
 )
+from ray.core.generated.export_dataset_operator_event_pb2 import (
+    ExportDatasetOperatorEventData,
+)
 from ray.core.generated.export_event_pb2 import ExportEvent
 from ray.core.generated.export_submission_job_event_pb2 import (
     ExportSubmissionJobEventData,
@@ -31,6 +34,7 @@ ExportEventDataType = Union[
     ExportTrainRunEventData,
     ExportTrainRunAttemptEventData,
     ExportDatasetMetadata,
+    ExportDatasetOperatorEventData,
 ]
 
 
@@ -43,6 +47,7 @@ class EventLogType(Enum):
         TRAIN_STATE: Export events related to training state, supporting train run and attempt events.
         SUBMISSION_JOB: Export events related to job submissions.
         DATASET_METADATA: Export events related to dataset metadata.
+        DATASET_OPERATOR_EVENT: Export events related to Ray Data operator.
     """
 
     TRAIN_STATE = (
@@ -51,6 +56,10 @@ class EventLogType(Enum):
     )
     SUBMISSION_JOB = ("EXPORT_SUBMISSION_JOB", {ExportSubmissionJobEventData})
     DATASET_METADATA = ("EXPORT_DATASET_METADATA", {ExportDatasetMetadata})
+    DATASET_OPERATOR_EVENT = (
+        "EXPORT_DATASET_OPERATOR_EVENT",
+        {ExportDatasetOperatorEventData},
+    )
 
     def __init__(self, log_type_name: str, event_types: set[ExportEventDataType]):
         """Initialize an EventLogType enum value.
@@ -119,6 +128,9 @@ class ExportEventLoggerAdapter:
         elif isinstance(event_data, ExportDatasetMetadata):
             event.dataset_metadata.CopyFrom(event_data)
             event.source_type = ExportEvent.SourceType.EXPORT_DATASET_METADATA
+        elif isinstance(event_data, ExportDatasetOperatorEventData):
+            event.dataset_operator_event_data.CopyFrom(event_data)
+            event.source_type = ExportEvent.SourceType.EXPORT_DATASET_OPERATOR_EVENT
         else:
             raise TypeError(f"Invalid event_data type: {type(event_data)}")
         if not self.log_type.supports_event_type(event_data):

--- a/python/ray/data/_internal/issue_detection/issue_detector_manager.py
+++ b/python/ray/data/_internal/issue_detection/issue_detector_manager.py
@@ -2,10 +2,18 @@ import logging
 import time
 from typing import TYPE_CHECKING, Dict, List
 
+from ray.core.generated.export_dataset_operator_event_pb2 import (
+    ExportDatasetOperatorEventData as ProtoOperatorEventData,
+)
 from ray.data._internal.issue_detection.issue_detector import (
     Issue,
     IssueDetector,
     IssueType,
+)
+from ray.data._internal.operator_event_exporter import (
+    OperatorEvent,
+    format_export_issue_event_name,
+    get_operator_event_exporter,
 )
 
 if TYPE_CHECKING:
@@ -27,6 +35,7 @@ class IssueDetectorManager:
             detector: time.perf_counter() for detector in self._issue_detectors
         }
         self.executor = executor
+        self._operator_event_exporter = get_operator_event_exporter()
 
     def invoke_detectors(self) -> None:
         curr_time = time.perf_counter()
@@ -47,8 +56,10 @@ class IssueDetectorManager:
 
     def _report_issues(self, issues: List[Issue]) -> None:
         operators: Dict[str, "PhysicalOperator"] = {}
-        for operator in self.executor._topology.keys():
+        op_to_id: Dict["PhysicalOperator", str] = {}
+        for i, operator in enumerate(self.executor._topology.keys()):
             operators[operator.id] = operator
+            op_to_id[operator] = self.executor._get_operator_id(operator, i)
             # Reset issue detector metrics for each operator so that previous issues
             # don't affect the current ones.
             operator.metrics._issue_detector_hanging = 0
@@ -59,6 +70,24 @@ class IssueDetectorManager:
             operator = operators.get(issue.operator_id)
             if not operator:
                 continue
+
+            issue_event_type = format_export_issue_event_name(issue.issue_type)
+            if (
+                self._operator_event_exporter is not None
+                and issue_event_type
+                in ProtoOperatorEventData.DatasetOperatorEventType.keys()
+            ):
+                event_time = time.time()
+                operator_event = OperatorEvent(
+                    dataset_id=issue.dataset_name,
+                    operator_id=op_to_id[operator],
+                    operator_name=operator.name,
+                    event_time=event_time,
+                    event_type=issue_event_type,
+                    message=issue.message,
+                )
+                self._operator_event_exporter.export_operator_event(operator_event)
+
             if issue.issue_type == IssueType.HANGING:
                 operator.metrics._issue_detector_hanging += 1
             if issue.issue_type == IssueType.HIGH_MEMORY:

--- a/python/ray/data/_internal/operator_event_exporter.py
+++ b/python/ray/data/_internal/operator_event_exporter.py
@@ -1,0 +1,164 @@
+"""Exporter API for Ray Data operator events."""
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import ray
+from ray._private.event.export_event_logger import (
+    EventLogType,
+    check_export_api_enabled,
+    get_export_event_logger,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OperatorEvent:
+    """Represents an Ray Data operator event, such as issue detection
+
+    Attributes:
+        dataset_id: The id of the dataset.
+        operator_id: The id of the operator within the DAG structure, typically
+            incorporating a position or index (e.g., "ReadParquet_0")
+        operator_name: The name of the operator.
+        event_time: The timestamp when the event is emitted (in seconds since epoch).
+        event_type: The type of the event.
+        message: The content of the event message.
+    """
+
+    dataset_id: str
+    operator_id: str
+    operator_name: str
+    event_time: float
+    event_type: str
+    message: str
+
+
+def operator_event_to_proto(operator_event: OperatorEvent) -> Any:
+    """Convert the operator event to a protobuf message.
+
+    Args:
+        operator_event: OperatorEvent object containing the event details
+
+    Returns:
+        The protobuf message representing the operator event.
+    """
+
+    from ray.core.generated.export_dataset_operator_event_pb2 import (
+        ExportDatasetOperatorEventData as ProtoOperatorEventData,
+    )
+
+    # Create the protobuf message
+    proto_operator_event_data = ProtoOperatorEventData(
+        dataset_id=operator_event.dataset_id,
+        operator_id=operator_event.operator_id,
+        operator_name=operator_event.operator_name,
+        event_time=operator_event.event_time,
+        event_type=ProtoOperatorEventData.DatasetOperatorEventType.Value(
+            operator_event.event_type
+        ),
+        message=operator_event.message,
+    )
+
+    return proto_operator_event_data
+
+
+def format_export_issue_event_name(issue_name: str) -> str:
+    return "ISSUE_DETECTION_" + issue_name.upper().replace(" ", "_")
+
+
+def get_operator_event_exporter() -> "OperatorEventExporter":
+    """Get the operator event exporter instance.
+
+    Returns:
+        The operator event exporter instance.
+    """
+    return LoggerOperatorEventExporter.create_if_enabled()
+
+
+class OperatorEventExporter(ABC):
+    """Abstract base class for operator event exporters.
+
+    Implementations of this interface can export Ray Data operator event to various
+    destinations like log files, databases, or monitoring systems.
+    """
+
+    @abstractmethod
+    def export_operator_event(self, operator_event: OperatorEvent) -> None:
+        """Export operator event to the destination.
+
+        Args:
+            operator_event: OperatorEvent object containing operator event details.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def create_if_enabled(cls) -> Optional["OperatorEventExporter"]:
+        """Create an event exporter instance if the export functionality is enabled.
+
+        Returns:
+            An event exporter instance if enabled, none otherwise.
+        """
+        pass
+
+
+class LoggerOperatorEventExporter(OperatorEventExporter):
+    """Operator event exporter implementation that uses the Ray export event logger.
+
+    This exporter writes operator event to log files using Ray's export event system.
+    """
+
+    def __init__(self, logger: logging.Logger):
+        """Initialize with a configured export event logger.
+
+        Args:
+            logger: The export event logger to use for writing events.
+        """
+        self._export_logger = logger
+
+    def export_operator_event(self, operator_event: OperatorEvent) -> None:
+        """Export operator event using the export event logger.
+
+        Args:
+            operator_event: OperatorEvent object containing operator event details.
+        """
+        operator_event_proto = operator_event_to_proto(operator_event)
+        self._export_logger.send_event(operator_event_proto)
+
+    @classmethod
+    def create_if_enabled(cls) -> Optional["LoggerOperatorEventExporter"]:
+        """Create a logger-based exporter if the export API is enabled.
+
+        Returns:
+            A LoggerOperatorEventExporter instance, none otherwise.
+        """
+        from ray.core.generated.export_event_pb2 import ExportEvent
+
+        is_operator_event_export_api_enabled = check_export_api_enabled(
+            ExportEvent.SourceType.EXPORT_DATASET_OPERATOR_EVENT
+        )
+        if not is_operator_event_export_api_enabled:
+            # The export API is not enabled, so we shouldn't create an exporter
+            return None
+
+        log_directory = os.path.join(
+            ray._private.worker._global_node.get_session_dir_path(), "logs"
+        )
+
+        try:
+            logger = get_export_event_logger(
+                EventLogType.DATASET_OPERATOR_EVENT,
+                log_directory,
+            )
+            return LoggerOperatorEventExporter(logger)
+        except Exception:
+            logger.exception(
+                "Unable to initialize the export event logger, so no operator export "
+                "events will be written."
+            )
+            return None

--- a/python/ray/data/tests/test_issue_detection_manager.py
+++ b/python/ray/data/tests/test_issue_detection_manager.py
@@ -1,14 +1,19 @@
+import json
+import os
 import sys
 from unittest.mock import MagicMock
 
 import pytest
 
+import ray
+from ray._private import ray_constants
 from ray.data._internal.execution.operators.input_data_buffer import (
     InputDataBuffer,
 )
 from ray.data._internal.execution.operators.task_pool_map_operator import (
     MapOperator,
 )
+from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.issue_detection.issue_detector import (
     Issue,
     IssueType,
@@ -16,10 +21,30 @@ from ray.data._internal.issue_detection.issue_detector import (
 from ray.data._internal.issue_detection.issue_detector_manager import (
     IssueDetectorManager,
 )
+from ray.data._internal.operator_event_exporter import (
+    format_export_issue_event_name,
+)
 from ray.data.context import DataContext
 
 
+def _get_exported_data():
+    exported_file = os.path.join(
+        ray._private.worker._global_node.get_session_dir_path(),
+        "logs",
+        "export_events",
+        "event_EXPORT_DATASET_OPERATOR_EVENT.log",
+    )
+    assert os.path.isfile(exported_file)
+
+    with open(exported_file, "r") as f:
+        data = f.readlines()
+
+    return [json.loads(line) for line in data]
+
+
 def test_report_issues():
+    ray.init()
+    ray_constants.RAY_ENABLE_EXPORT_API_WRITE_CONFIG = "EXPORT_DATASET_OPERATOR_EVENT"
     ctx = DataContext.get_current()
     input_operator = InputDataBuffer(ctx, input_data=[])
     map_operator = MapOperator.create(
@@ -29,7 +54,8 @@ def test_report_issues():
         ray_remote_args={},
     )
     topology = {input_operator: MagicMock(), map_operator: MagicMock()}
-    executor = MagicMock(_topology=topology)
+    executor = StreamingExecutor(ctx)
+    executor._topology = topology
     detector = IssueDetectorManager(executor)
 
     detector._report_issues(
@@ -52,6 +78,23 @@ def test_report_issues():
     assert input_operator.metrics.issue_detector_high_memory == 0
     assert map_operator.metrics.issue_detector_hanging == 0
     assert map_operator.metrics.issue_detector_high_memory == 1
+
+    data = _get_exported_data()
+    assert len(data) == 2
+    assert data[0]["event_data"]["dataset_id"] == "dataset"
+    assert data[0]["event_data"]["operator_id"] == f"{input_operator.name}_0"
+    assert data[0]["event_data"]["operator_name"] == input_operator.name
+    assert data[0]["event_data"]["event_type"] == format_export_issue_event_name(
+        IssueType.HANGING
+    )
+    assert data[0]["event_data"]["message"] == "Hanging detected"
+    assert data[1]["event_data"]["dataset_id"] == "dataset"
+    assert data[1]["event_data"]["operator_id"] == f"{map_operator.name}_1"
+    assert data[1]["event_data"]["operator_name"] == map_operator.name
+    assert data[1]["event_data"]["event_type"] == format_export_issue_event_name(
+        IssueType.HIGH_MEMORY
+    )
+    assert data[1]["event_data"]["message"] == "High memory usage detected"
 
 
 if __name__ == "__main__":

--- a/src/ray/protobuf/BUILD.bazel
+++ b/src/ray/protobuf/BUILD.bazel
@@ -254,6 +254,7 @@ proto_library(
     deps = [
         ":export_actor_event_proto",
         ":export_dataset_metadata_proto",
+        ":export_dataset_operator_event_proto",
         ":export_driver_job_event_proto",
         ":export_node_event_proto",
         ":export_submission_job_event_proto",
@@ -345,6 +346,16 @@ proto_library(
 cc_proto_library(
     name = "export_train_state_cc_proto",
     deps = [":export_train_state_proto"],
+)
+
+proto_library(
+    name = "export_dataset_operator_event_proto",
+    srcs = ["export_dataset_operator_event.proto"],
+)
+
+cc_proto_library(
+    name = "export_dataset_operator_event_cc_proto",
+    deps = [":export_dataset_operator_event_proto"],
 )
 
 proto_library(

--- a/src/ray/protobuf/export_dataset_operator_event.proto
+++ b/src/ray/protobuf/export_dataset_operator_event.proto
@@ -1,0 +1,46 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option cc_enable_arenas = true;
+package ray.rpc;
+
+// This message defines the event_data stored by the export API for
+// EXPORT_DATASET_OPERATOR type events from Ray Data operators.
+message ExportDatasetOperatorEventData {
+  enum DatasetOperatorEventType {
+    UNSPECIFIED = 0;
+    ISSUE_DETECTION_HANGING = 1;
+    ISSUE_DETECTION_HIGH_MEMORY = 2;
+  }
+
+  // The dataset ID
+  string dataset_id = 1;
+
+  // The operator ID
+  string operator_id = 2;
+
+  // The operator name
+  string operator_name = 3;
+
+  // The timestamp when event is emitted (in seconds since epoch)
+  double event_time = 4;
+
+  // The type of the event
+  DatasetOperatorEventType event_type = 5;
+
+  // The content of the event message
+  string message = 6;
+}

--- a/src/ray/protobuf/export_event.proto
+++ b/src/ray/protobuf/export_event.proto
@@ -23,6 +23,7 @@ import "src/ray/protobuf/export_driver_job_event.proto";
 import "src/ray/protobuf/export_submission_job_event.proto";
 
 import "src/ray/protobuf/export_train_state.proto";
+import "src/ray/protobuf/export_dataset_operator_event.proto";
 import "src/ray/protobuf/export_dataset_metadata.proto";
 
 // ExportEvent defines events stored by the export API. This
@@ -37,6 +38,7 @@ message ExportEvent {
     EXPORT_TRAIN_RUN = 5;
     EXPORT_TRAIN_RUN_ATTEMPT = 6;
     EXPORT_DATASET_METADATA = 7;
+    EXPORT_DATASET_OPERATOR_EVENT = 8;
   }
 
   // event_id is the unique ID of this event
@@ -56,5 +58,6 @@ message ExportEvent {
     ExportTrainRunEventData train_run_event_data = 9;
     ExportTrainRunAttemptEventData train_run_attempt_event_data = 10;
     ExportDatasetMetadata dataset_metadata = 11;
+    ExportDatasetOperatorEventData dataset_operator_event_data = 12;
   }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In Ray Data, we have an issue detection feature, but they are only available as printed logs. We also want to show these insights at our Data Dashboard for users to debug their code, by exporting these events.

Example export event:
```
{
  "event_id": "Ce4Ee1B7AFd9Cb13B3",
  "timestamp": 1756423457,
  "source_type": "EXPORT_DATASET_OPERATOR_EVENT",
  "event_data": {
    "dataset_id": "dataset_6_0",
    "operator_id": "ReadImage->Map(preprocess_image)_1",
    "operator_name": "ReadImage->Map(preprocess_image)",
    "event_time": 1756423457.9333386,
    "event_type": "ISSUE_DETECTION_HIGH_MEMORY",
    "message": "\n\nOperator 'ReadImage->Map(preprocess_image)' uses xxx of memory per\ntask on average, but Ray only requests xxx per task at the start of\nthe pipeline.\n\nTo avoid out-of-memory errors, consider setting `memory=xxx` in the\nappropriate function or method call. (This might be unnecessary if the\nnumber of concurrent tasks is low.)\n\nTo change the frequency of this warning, set\n`DataContext.get_current().issue_detectors_config.high_memory_detector_config.detection_time_interval_s`,\nor disable the warning by setting value to -1. (current value: xxx)\n"
  }
},
{
  "event_id": "bE831Ee49c4AadAcFB",
  "timestamp": 1756423458,
  "source_type": "EXPORT_DATASET_OPERATOR_EVENT",
  "event_data": {
    "dataset_id": "dataset_6_0",
    "operator_id": "MapBatches(ResnetModel)_2",
    "operator_name": "MapBatches(ResnetModel)",
    "event_time": 1756423458.1420121,
    "event_type": "ISSUE_DETECTION_HANGING",
    "message": "A task of operator MapBatches(ResnetModel) with task index xxx has been running for xxxs, which is longer than the average task duration of this operator (xxxs). If this message persists, please check the stack trace of the task for potential hanging issues."
  }
}
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
