### PR TITLE
[core] Remove job submission code for using JobAgent on a random worker node.

### DIFF
--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -7,15 +7,13 @@ import os
 import time
 import traceback
 from datetime import datetime
-from random import choice
-from typing import AsyncIterator, Dict, List, Optional, Tuple
+from typing import AsyncIterator, Dict, Optional, Tuple
 
 import aiohttp.web
 from aiohttp.client import ClientResponse
 from aiohttp.web import Request, Response, StreamResponse
 
 import ray
-import ray.dashboard.consts as dashboard_consts
 from ray import NodeID
 from ray._common.utils import get_or_create_event_loop, load_class
 from ray._common.pydantic_compat import BaseModel, Extra, Field, validator
@@ -249,86 +247,7 @@ class JobHead(SubprocessModule):
         Raises:
             TimeoutError: If the operation times out.
         """
-        if RAY_JOB_AGENT_USE_HEAD_NODE_ONLY:
-            return await self._get_head_node_agent(timeout_s)
-
-        return await self._pick_random_agent(timeout_s)
-
-    async def _pick_random_agent(
-        self, timeout_s: float
-    ) -> Optional[JobAgentSubmissionClient]:
-        """
-        Try to disperse as much as possible to select one of
-        the `CANDIDATE_AGENT_NUMBER` agents to solve requests.
-        the agents will not pop from `self._agents` unless
-        it's dead. Saved in `self._agents` is the agent that was
-        used before.
-        Strategy:
-            1. if the number of `self._agents` has reached
-               `CANDIDATE_AGENT_NUMBER`, randomly select one agent from
-               `self._agents`.
-            2. if not, randomly select one agent from all available agents,
-               it is possible that the selected one already exists in
-               `self._agents`.
-
-        If there's no agent available at all, or there's exception, it will retry every
-        `TRY_TO_GET_AGENT_INFO_INTERVAL_SECONDS` seconds indefinitely.
-
-        Args:
-            timeout_s: The timeout for the operation.
-
-        Returns:
-            A `JobAgentSubmissionClient` for interacting with jobs via an agent process.
-
-        Raises:
-            TimeoutError: If the operation times out.
-        """
-        start_time_s = time.time()
-        last_exception = None
-        while time.time() < start_time_s + timeout_s:
-            try:
-                return await self._pick_random_agent_once()
-            except Exception as e:
-                last_exception = e
-                logger.exception(
-                    f"Failed to pick a random agent, retrying in {TRY_TO_GET_AGENT_INFO_INTERVAL_SECONDS} seconds..."
-                )
-                await asyncio.sleep(TRY_TO_GET_AGENT_INFO_INTERVAL_SECONDS)
-        raise TimeoutError(
-            f"Failed to pick a random agent within {timeout_s} seconds. The last exception is {last_exception}"
-        )
-
-    async def _pick_random_agent_once(self) -> JobAgentSubmissionClient:
-        """
-        Query the internal kv for all agent infos, and pick agents randomly. May raise
-        exception if there's no agent available at all or there's network error.
-        """
-        # NOTE: Following call will block until there's at least 1 agent info
-        #       being populated from GCS
-        agent_node_ids = await self._fetch_all_agent_node_ids()
-
-        # delete dead agents.
-        for dead_node in set(self._agents) - set(agent_node_ids):
-            client = self._agents.pop(dead_node)
-            await client.close()
-
-        if len(self._agents) >= dashboard_consts.CANDIDATE_AGENT_NUMBER:
-            node_id = choice(list(self._agents))
-            return self._agents[node_id]
-        else:
-            # Randomly select one from among all agents, it is possible that
-            # the selected one already exists in `self._agents`
-            node_id = choice(list(agent_node_ids))
-
-            if node_id not in self._agents:
-                # Fetch agent info from InternalKV, and create a new
-                # JobAgentSubmissionClient. May raise if the node_id is removed in
-                # InternalKV after the _fetch_all_agent_node_ids, though unlikely.
-                ip, http_port, _ = await self._fetch_agent_info(node_id)
-                agent_http_address = f"http://{build_address(ip, http_port)}"
-                self._agents[node_id] = JobAgentSubmissionClient(agent_http_address)
-
-            return self._agents[node_id]
+        return await self._get_head_node_agent(timeout_s)
 
     async def _get_head_node_agent_once(self) -> JobAgentSubmissionClient:
         head_node_id_hex = await get_head_node_id(self.gcs_client)
@@ -373,26 +292,6 @@ class JobHead(SubprocessModule):
         raise TimeoutError(
             f"Failed to get head node agent within {timeout_s} seconds. The last exception is {exception}"
         )
-
-    async def _fetch_all_agent_node_ids(self) -> List[NodeID]:
-        """
-        Fetches all NodeIDs with agent infos in the cluster.
-
-        May raise exception if there's no agent available at all or there's network error.
-        Returns: List[NodeID]
-        """
-        keys = await self.gcs_client.async_internal_kv_keys(
-            f"{DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}".encode(),
-            namespace=KV_NAMESPACE_DASHBOARD,
-            timeout=GCS_RPC_TIMEOUT_SECONDS,
-        )
-        if not keys:
-            # No agent keys found, retry
-            raise Exception("No agents found in InternalKV.")
-        return [
-            NodeID.from_hex(key[len(DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX) :].decode())
-            for key in keys
-        ]
 
     async def _fetch_agent_info(self, target_node_id: NodeID) -> Tuple[str, int, int]:
         """

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -17,7 +17,7 @@ import ray
 from ray import NodeID
 from ray._common.utils import get_or_create_event_loop, load_class
 from ray._common.pydantic_compat import BaseModel, Extra, Field, validator
-from ray._private.ray_constants import KV_NAMESPACE_DASHBOARD, env_bool
+from ray._private.ray_constants import KV_NAMESPACE_DASHBOARD
 from ray._private.runtime_env.packaging import (
     package_exists,
     pin_runtime_env_uri,
@@ -54,12 +54,6 @@ from ray.dashboard.subprocesses.utils import ResponseType
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-# Feature flag controlling whether critical Ray Job control operations are performed
-# exclusively by the Job Agent running on the Head node (or randomly sampled Worker one)
-#
-# NOTE: This flag serves as a temporary kill-switch and should be eventually cleaned up
-RAY_JOB_AGENT_USE_HEAD_NODE_ONLY = env_bool("RAY_JOB_AGENT_USE_HEAD_NODE_ONLY", True)
 
 
 class RayActivityStatus(str, enum.Enum):

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import os
@@ -8,7 +7,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -17,7 +16,6 @@ import requests
 import yaml
 
 import ray
-from ray import NodeID
 from ray._private.runtime_env.packaging import (
     create_package,
     download_and_unpack_package,
@@ -26,16 +24,10 @@ from ray._private.runtime_env.packaging import (
 from ray._private.test_utils import (
     chdir,
     format_web_url,
-    ray_constants,
     wait_until_server_available,
-)
-from ray.dashboard.consts import (
-    DASHBOARD_AGENT_ADDR_IP_PREFIX,
-    DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX,
 )
 from ray.dashboard.modules.dashboard_sdk import ClusterInfo, parse_cluster_info
 from ray.dashboard.modules.job.common import uri_to_http_components
-from ray.dashboard.modules.job.job_head import JobHead
 from ray.dashboard.modules.job.pydantic_models import JobDetails
 from ray.dashboard.modules.job.tests.test_cli_integration import set_env_var
 from ray.dashboard.modules.version import CURRENT_VERSION
@@ -744,202 +736,6 @@ ray.init(address="auto")
 
     with open(path) as f:
         assert f.read().strip() == "Ray rocks!"
-
-
-@pytest.mark.asyncio
-async def test_job_head_pick_random_job_agent(monkeypatch):
-    with set_env_var("CANDIDATE_AGENT_NUMBER", "2"):
-        import importlib
-
-        importlib.reload(ray.dashboard.consts)
-
-        # Fake GCS client
-        class _FakeGcsClient:
-            def __init__(self):
-                self._kv: Dict[bytes, bytes] = {}
-
-            @staticmethod
-            def ensure_bytes(key: Union[bytes, str]) -> bytes:
-                return key.encode() if isinstance(key, str) else key
-
-            async def async_internal_kv_put(
-                self, key: Union[bytes, str], value: bytes, **kwargs
-            ):
-                key = self.ensure_bytes(key)
-                self._kv[key] = value
-
-            async def async_internal_kv_get(self, key: Union[bytes, str], **kwargs):
-                key = self.ensure_bytes(key)
-                return self._kv.get(key, None)
-
-            async def async_internal_kv_multi_get(
-                self, keys: List[Union[bytes, str]], **kwargs
-            ):
-                return {key: self.internal_kv_get(key) for key in keys}
-
-            async def async_internal_kv_del(self, key: Union[bytes, str], **kwargs):
-                key = self.ensure_bytes(key)
-                self._kv.pop(key)
-
-            async def async_internal_kv_keys(self, prefix: Union[bytes, str], **kwargs):
-                prefix = self.ensure_bytes(prefix)
-                return [key for key in self._kv.keys() if key.startswith(prefix)]
-
-        class MockJobHead(JobHead):
-            def __init__(self):
-                self._agents = dict()
-                self._gcs_client = _FakeGcsClient()
-
-            @property
-            def gcs_client(self):
-                # Overrides JobHead.gcs_client
-                return self._gcs_client
-
-        job_head = MockJobHead()
-        job_head._gcs_client = _FakeGcsClient()
-
-        async def add_agent(agent):
-            node_id = agent[0]
-            node_ip = agent[1]["ipAddress"]
-            http_port = agent[1]["httpPort"]
-            grpc_port = agent[1]["grpcPort"]
-
-            await job_head._gcs_client.async_internal_kv_put(
-                f"{DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{node_id.hex()}".encode(),
-                json.dumps([node_ip, http_port, grpc_port]).encode(),
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
-            await job_head._gcs_client.async_internal_kv_put(
-                f"{DASHBOARD_AGENT_ADDR_IP_PREFIX}{node_ip}".encode(),
-                json.dumps([node_id.hex(), http_port, grpc_port]).encode(),
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
-
-        async def del_agent(agent):
-            node_id = agent[0]
-            node_ip = agent[1]["ipAddress"]
-            await job_head._gcs_client.async_internal_kv_del(
-                f"{DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{node_id.hex()}".encode(),
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
-            await job_head._gcs_client.async_internal_kv_del(
-                f"{DASHBOARD_AGENT_ADDR_IP_PREFIX}{node_ip}".encode(),
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
-
-        head_node_id = NodeID.from_random()
-        await job_head._gcs_client.async_internal_kv_put(
-            ray_constants.KV_HEAD_NODE_ID_KEY,
-            head_node_id.hex().encode(),
-            namespace=ray_constants.KV_NAMESPACE_JOB,
-        )
-
-        agent_1 = (
-            head_node_id,
-            dict(
-                ipAddress="1.1.1.1",
-                httpPort=1,
-                grpcPort=1,
-                httpAddress="1.1.1.1:1",
-            ),
-        )
-        agent_2 = (
-            NodeID.from_random(),
-            dict(
-                ipAddress="2.2.2.2",
-                httpPort=2,
-                grpcPort=2,
-                httpAddress="2.2.2.2:2",
-            ),
-        )
-        agent_3 = (
-            NodeID.from_random(),
-            dict(
-                ipAddress="3.3.3.3",
-                httpPort=3,
-                grpcPort=3,
-                httpAddress="3.3.3.3:3",
-            ),
-        )
-
-        # Disable Head-node routing for the Ray job critical ops (enabling
-        # random agent sampling)
-        monkeypatch.setattr(
-            f"{JobHead.__module__}.RAY_JOB_AGENT_USE_HEAD_NODE_ONLY", False
-        )
-
-        # Check only 1 agent present, only agent being returned
-        await add_agent(agent_1)
-        job_agent_client = await job_head.get_target_agent()
-        assert job_agent_client._agent_address == "http://1.1.1.1:1"
-
-        # Remove only agent, no agents present, should time out
-        await del_agent(agent_1)
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(job_head.get_target_agent(), timeout=3)
-
-        # Enable Head-node routing for the Ray job critical ops (disabling
-        # random agent sampling)
-        monkeypatch.setattr(
-            f"{JobHead.__module__}.RAY_JOB_AGENT_USE_HEAD_NODE_ONLY", True
-        )
-
-        # Add 3 agents
-        await add_agent(agent_1)
-        await add_agent(agent_2)
-        await add_agent(agent_3)
-
-        # Make sure returned agent is a head-node
-        # NOTE: We run 3 tims to make sure we're not hitting branch probabilistically
-        for _ in range(3):
-            job_agent_client = await job_head.get_target_agent()
-            assert job_agent_client._agent_address == "http://1.1.1.1:1"
-
-        # Disable Head-node routing for the Ray job critical ops (enabling
-        # random agent sampling)
-        monkeypatch.setattr(
-            f"{JobHead.__module__}.RAY_JOB_AGENT_USE_HEAD_NODE_ONLY", False
-        )
-
-        # Theoretically, the probability of failure is 1/3^100
-        addresses_1 = set()
-        for address in range(100):
-            job_agent_client = await job_head.get_target_agent()
-            addresses_1.add(job_agent_client._agent_address)
-        assert len(addresses_1) == 2
-        addresses_2 = set()
-        for address in range(100):
-            job_agent_client = await job_head.get_target_agent()
-            addresses_2.add(job_agent_client._agent_address)
-        assert len(addresses_2) == 2 and addresses_1 == addresses_2
-
-        for agent in [agent_1, agent_2, agent_3]:
-            if f"http://{agent[1]['httpAddress']}" in addresses_2:
-                break
-        await del_agent(agent)
-
-        # Theoretically, the probability of failure is 1/2^100
-        addresses_3 = set()
-        for address in range(100):
-            job_agent_client = await job_head.get_target_agent()
-            addresses_3.add(job_agent_client._agent_address)
-        assert len(addresses_3) == 2
-        assert addresses_2 - addresses_3 == {f"http://{agent[1]['httpAddress']}"}
-        addresses_4 = set()
-        for address in range(100):
-            job_agent_client = await job_head.get_target_agent()
-            addresses_4.add(job_agent_client._agent_address)
-        assert addresses_4 == addresses_3
-
-        for agent in [agent_1, agent_2, agent_3]:
-            if f"http://{agent[1]['httpAddress']}" in addresses_4:
-                break
-        await del_agent(agent)
-        address = None
-        for _ in range(3):
-            job_agent_client = await job_head.get_target_agent()
-            assert address is None or address == job_agent_client._agent_address
-            address = job_agent_client._agent_address
 
 
 @pytest.mark.asyncio

--- a/python/ray/dashboard/modules/job/tests/test_sdk.py
+++ b/python/ray/dashboard/modules/job/tests/test_sdk.py
@@ -181,7 +181,6 @@ def get_register_agents_number(gcs_client):
                 RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR: "1",
                 "RAY_health_check_initial_delay_ms": "0",
                 "RAY_health_check_period_ms": "1000",
-                "RAY_JOB_AGENT_USE_HEAD_NODE_ONLY": "0",
             },
         }
     ],

--- a/python/ray/dashboard/modules/job/tests/test_sdk.py
+++ b/python/ray/dashboard/modules/job/tests/test_sdk.py
@@ -187,7 +187,7 @@ def get_register_agents_number(gcs_client):
     indirect=True,
 )
 def test_head_node_job_agent_always_used(ray_start_cluster_head_with_env_vars):
-    """This test creates makes sure that job submission always uses the head node's job agent.
+    """Makes sure that job submission always uses the head node's job agent.
 
     1. Create a cluster with a worker node and a head node.
     2. Submit 10 jobs.

--- a/python/ray/dashboard/modules/job/tests/test_sdk.py
+++ b/python/ray/dashboard/modules/job/tests/test_sdk.py
@@ -12,7 +12,6 @@ import ray
 from ray._common.test_utils import wait_for_condition
 import ray.experimental.internal_kv as kv
 from ray._private.ray_constants import (
-    DEFAULT_DASHBOARD_AGENT_LISTEN_PORT,
     KV_NAMESPACE_DASHBOARD,
 )
 from ray._private.test_utils import (
@@ -36,8 +35,6 @@ from ray.dashboard.tests.conftest import *  # noqa
 from ray.runtime_env.runtime_env import RuntimeEnv
 from ray.tests.conftest import _ray_start
 from ray.util.state import list_nodes
-
-import psutil
 
 
 def _check_job_succeeded(client: JobSubmissionClient, job_id: str) -> bool:
@@ -166,13 +163,6 @@ def test_temporary_uri_reference(monkeypatch, expiration_s):
                 print("Internal KV was GC'ed at time ", time.time() - start)
 
 
-@pytest.fixture
-def mock_candidate_number():
-    os.environ["CANDIDATE_AGENT_NUMBER"] = "2"
-    yield
-    os.environ.pop("CANDIDATE_AGENT_NUMBER", None)
-
-
 def get_register_agents_number(gcs_client):
     keys = gcs_client.internal_kv_keys(
         prefix=DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX,
@@ -188,7 +178,6 @@ def get_register_agents_number(gcs_client):
         {
             "include_dashboard": True,
             "env_vars": {
-                "CANDIDATE_AGENT_NUMBER": "2",
                 RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR: "1",
                 "RAY_health_check_initial_delay_ms": "0",
                 "RAY_health_check_period_ms": "1000",
@@ -198,114 +187,38 @@ def get_register_agents_number(gcs_client):
     ],
     indirect=True,
 )
-def test_job_head_choose_job_agent_E2E(ray_start_cluster_head_with_env_vars):
+def test_head_node_job_agent_always_used(ray_start_cluster_head_with_env_vars):
+    """This test creates makes sure that job submission always uses the head node's job agent.
+
+    1. Create a cluster with a worker node and a head node.
+    2. Submit 10 jobs.
+    3. Make sure they all execute on the head node's job agent.
+    """
     cluster = ray_start_cluster_head_with_env_vars
     assert wait_until_server_available(cluster.webui_url) is True
     webui_url = cluster.webui_url
     webui_url = format_web_url(webui_url)
     client = JobSubmissionClient(webui_url)
-    gcs_client = GcsClient(address=cluster.gcs_address)
 
-    def submit_job_and_wait_finish():
-        submission_id = client.submit_job(entrypoint="echo hello")
+    cluster_nodes = cluster.list_all_nodes()
+    assert len(cluster_nodes) == 1 and cluster_nodes[0].is_head
+    head_node_id = cluster_nodes[0].node_id
 
+    # add a worker node.
+    cluster.add_node()
+
+    job_ids = [client.submit_job(entrypoint="echo hello")]
+
+    for job_id in job_ids:
         wait_for_condition(
-            _check_job_succeeded, client=client, job_id=submission_id, timeout=30
+            _check_job_succeeded, client=client, job_id=job_id, timeout=30
         )
 
-    head_http_port = DEFAULT_DASHBOARD_AGENT_LISTEN_PORT
-    worker_1_http_port = 52366
-    cluster.add_node(dashboard_agent_listen_port=worker_1_http_port)
-    wait_for_condition(lambda: get_register_agents_number(gcs_client) == 2, timeout=20)
-    assert len(cluster.worker_nodes) == 1
-    node_try_to_kill = list(cluster.worker_nodes)[0]
+    actors = ray.state.actors()
 
-    def make_sure_worker_node_run_job(port):
-        actors = ray.state.actors()
-
-        def _kill_all_driver():
-            for _, actor_info in actors.items():
-                if actor_info["State"] != "ALIVE":
-                    continue
-                if actor_info["Name"].startswith("_ray_internal_job_actor"):
-                    proc = psutil.Process(actor_info["Pid"])
-                    try:
-                        proc.kill()
-                    except Exception:
-                        pass
-
-        try:
-            for _, actor_info in actors.items():
-                if actor_info["State"] != "ALIVE":
-                    continue
-                if actor_info["Name"].startswith("_ray_internal_job_actor"):
-                    proc = psutil.Process(actor_info["Pid"])
-                    parent_proc = proc.parent()
-                    if f"--listen-port={port}" in " ".join(parent_proc.cmdline()):
-                        _kill_all_driver()
-                        return True
-        except Exception as ex:
-            print("Got exception:", ex)
-            raise
-        client.submit_job(entrypoint="sleep 3600")
-        return False
-
-    # Make `list(cluster.worker_nodes)[0]` and head node called at least once
-    wait_for_condition(
-        lambda: make_sure_worker_node_run_job(worker_1_http_port), timeout=60
-    )
-    wait_for_condition(
-        lambda: make_sure_worker_node_run_job(head_http_port), timeout=60
-    )
-
-    worker_2_http_port = 52367
-    cluster.add_node(dashboard_agent_listen_port=worker_2_http_port)
-    wait_for_condition(lambda: get_register_agents_number(gcs_client) == 3, timeout=20)
-
-    # The third `JobAgent` will not be called here.
-    submit_job_and_wait_finish()
-    submit_job_and_wait_finish()
-    submit_job_and_wait_finish()
-
-    def get_all_new_supervisor_actor_info(old_supervisor_actor_ids):
-        all_actors = ray.state.state.actor_table(None)
-        res = dict()
-        for actor_id, actor_info in all_actors.items():
-            if actor_id in old_supervisor_actor_ids:
-                continue
-            if not actor_info["Name"].startswith("_ray_internal_job_actor"):
-                continue
-            res[actor_id] = actor_info
-        return res
-
-    old_supervisor_actor_ids = set()
-    new_supervisor_actor = get_all_new_supervisor_actor_info(old_supervisor_actor_ids)
-    new_owner_port = set()
-    for actor_id, actor_info in new_supervisor_actor.items():
-        old_supervisor_actor_ids.add(actor_id)
-        new_owner_port.add(actor_info["OwnerAddress"]["Port"])
-
-    assert len(new_owner_port) == 2
-    old_owner_port = new_owner_port
-
-    node_try_to_kill.kill_raylet()
-
-    # make sure the head updates the info of the dead node.
-    wait_for_condition(lambda: get_register_agents_number(gcs_client) == 2, timeout=20)
-
-    # Make sure the third JobAgent will be called here.
-    wait_for_condition(
-        lambda: make_sure_worker_node_run_job(worker_2_http_port), timeout=60
-    )
-
-    new_supervisor_actor = get_all_new_supervisor_actor_info(old_supervisor_actor_ids)
-    new_owner_port = set()
-    for actor_id, actor_info in new_supervisor_actor.items():
-        old_supervisor_actor_ids.add(actor_id)
-        new_owner_port.add(actor_info["OwnerAddress"]["Port"])
-    assert len(new_owner_port) == 2
-    assert len(old_owner_port - new_owner_port) == 1
-    assert len(new_owner_port - old_owner_port) == 1
+    for _, actor_info in actors.items():
+        if actor_info["Name"].startswith("_ray_internal_job_actor"):
+            assert actor_info["Address"]["NodeID"] == head_node_id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When a Job is submitted through the SDK/JobClient, the request goes to the dashboard's JobHead.

The JobHead submits a request to a JobAgent which has a JobManager. The JobManager creates a JobSupervisor actor which manages the lifecycle of the job. 

In #47147, the `RAY_JOB_AGENT_USE_HEAD_NODE_ONLY` feature flag to force head node's JobAgent to be used for job submission. The flag was intended to be a temporary kill switch if head_node only scheduling had issues. 

Now that #47147 has been merged for over a year, I'm cleaning up the flag in this PR and making it the default (and only behavior).