### PR TITLE
[core] Fix actor import error message for async actors

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -600,7 +600,11 @@ class FunctionActorManager:
         self, actor_class_name, actor_method_names, traceback_str
     ):
         class TemporaryActor:
-            pass
+            async def __dummy_method(self):
+                """Dummy method for this fake actor class to work for async actors.
+                Without this method, this temporary actor class fails to initialize
+                if the original actor class was async."""
+                pass
 
         def temporary_actor_method(*args, **kwargs):
             raise RuntimeError(

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -351,7 +351,8 @@ while True:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_fail_importing_actor():
+@pytest.mark.parametrize("async_actor", [True, False])
+def test_fail_importing_actor(async_actor):
     script = """
 import os
 import sys
@@ -380,13 +381,15 @@ def temporary_helper_function():
         def __init__(self):
             self.x = module.temporary_python_file()
 
-        def ready(self):
+        {}def ready(self):
             pass
 finally:
     os.unlink(f.name)
 
 ray.get(Foo.remote().ready.remote())
-"""
+""".format(
+        "async " if async_actor else ""
+    )
     proc = run_string_as_driver_nonblocking(script)
     err_str = proc.stderr.read().decode("ascii")
     print(err_str)

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -353,7 +353,7 @@ while True:
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("async_actor", [True, False])
 def test_fail_importing_actor(async_actor):
-    script = """
+    script = f"""
 import os
 import sys
 import tempfile
@@ -381,15 +381,13 @@ def temporary_helper_function():
         def __init__(self):
             self.x = module.temporary_python_file()
 
-        {}def ready(self):
+        {"async " if async_actor else ""}def ready(self):
             pass
 finally:
     os.unlink(f.name)
 
 ray.get(Foo.remote().ready.remote())
-""".format(
-        "async " if async_actor else ""
-    )
+"""
     proc = run_string_as_driver_nonblocking(script)
     err_str = proc.stderr.read().decode("ascii")
     print(err_str)


### PR DESCRIPTION
## Summary

When the Ray actor class fails to import upon actor creation, we create a TemporaryActor in its place to emit an error message. However, for async actors, the TemporaryActor creation fails to initialize due having no async methods. This PR adds a dummy async method to handle this case. 

## Example error

```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 35, in <module>
  File "/Users/justin/Developer/ray/python/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/justin/Developer/ray/python/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/justin/Developer/ray/python/ray/_private/worker.py", line 2896, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/justin/Developer/ray/python/ray/_private/worker.py", line 970, in get_objects
    raise value
ray.exceptions.ActorDiedError: The actor died because of an error raised in its creation task, ray::Foo.__init__() (pid=42078, ip=127.0.0.1, actor_id=7000b00899a3a8b1d05bbdc601000000, repr=<__main__.FunctionActorManager._create_fake_actor_class.<locals>.TemporaryActor object at 0x10732dc10>)
ray.exceptions.ActorDiedError: The actor died unexpectedly before finishing this task.
        class_name: TemporaryActor
        actor_id: 7000b00899a3a8b1d05bbdc601000000
Failed to create actor. You set the async flag, but the actor does not have any coroutine functions.
(TemporaryActor pid=42078) The original cause of the RayTaskError (<class 'ray.exceptions.ActorDiedError'>) isn't serializable: cannot pickle 'google._upb._message.Descriptor' object. Overwriting the cause to a RayError.
```