### PR TITLE
core: replace hashlib.sha1 with sha256 for internal hash usages

### DIFF
--- a/doc/source/templates/05_dreambooth_finetuning/dreambooth/generate.py
+++ b/doc/source/templates/05_dreambooth_finetuning/dreambooth/generate.py
@@ -24,7 +24,7 @@ def run(args):
             for i, prompt in zip(batch["idx"], batch["prompt"]):
                 # Generate 1 image at a time to reduce memory consumption.
                 for image in self.pipeline(prompt).images:
-                    hash_image = hashlib.sha1(image.tobytes()).hexdigest()
+                    hash_image = hashlib.sha256(image.tobytes()).hexdigest()
                     image_filename = path.join(self.output_dir, f"{i}-{hash_image}.jpg")
                     image.save(image_filename)
                     print(f"Saved {image_filename}")

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -214,7 +214,7 @@ def inject_dependencies(
 def _get_conda_env_hash(conda_dict: Dict) -> str:
     # Set `sort_keys=True` so that different orderings yield the same hash.
     serialized_conda_spec = json.dumps(conda_dict, sort_keys=True)
-    hash = hashlib.sha1(serialized_conda_spec.encode("utf-8")).hexdigest()
+    hash = hashlib.sha256(serialized_conda_spec.encode("utf-8")).hexdigest()
     return hash
 
 

--- a/python/ray/_private/runtime_env/conda_utils.py
+++ b/python/ray/_private/runtime_env/conda_utils.py
@@ -83,7 +83,7 @@ def get_conda_bin_executable(executable_name: str) -> str:
 
 def _get_conda_env_name(conda_env_path: str) -> str:
     conda_env_contents = open(conda_env_path).read()
-    return "ray-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
+    return "ray-%s" % hashlib.sha256(conda_env_contents.encode("utf-8")).hexdigest()
 
 
 def create_conda_env_if_needed(

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -125,8 +125,8 @@ def _hash_file_content_or_directory_name(
 
     BUF_SIZE = 4096 * 1024
 
-    sha1 = hashlib.sha1()
-    sha1.update(str(filepath.relative_to(relative_path)).encode())
+    sha256 = hashlib.sha256()
+    sha256.update(str(filepath.relative_to(relative_path)).encode())
     if not filepath.is_dir():
         try:
             f = filepath.open("rb")
@@ -139,12 +139,12 @@ def _hash_file_content_or_directory_name(
             try:
                 data = f.read(BUF_SIZE)
                 while len(data) != 0:
-                    sha1.update(data)
+                    sha256.update(data)
                     data = f.read(BUF_SIZE)
             finally:
                 f.close()
 
-    return sha1.digest()
+    return sha256.digest()
 
 
 def _hash_file(
@@ -469,7 +469,7 @@ def get_uri_for_package(package: Path) -> str:
             protocol=Protocol.GCS.value, whl_filename=package.name
         )
     else:
-        hash_val = hashlib.sha1(package.read_bytes()).hexdigest()
+        hash_val = hashlib.sha256(package.read_bytes()).hexdigest()
         return "{protocol}://{pkg_name}.zip".format(
             protocol=Protocol.GCS.value, pkg_name=RAY_PKG_PREFIX + hash_val
         )

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -20,7 +20,7 @@ default_logger = logging.getLogger(__name__)
 
 def _get_pip_hash(pip_dict: Dict) -> str:
     serialized_pip_spec = json.dumps(pip_dict, sort_keys=True)
-    hash_val = hashlib.sha1(serialized_pip_spec.encode("utf-8")).hexdigest()
+    hash_val = hashlib.sha256(serialized_pip_spec.encode("utf-8")).hexdigest()
     return hash_val
 
 

--- a/python/ray/air/_internal/filelock.py
+++ b/python/ray/air/_internal/filelock.py
@@ -27,7 +27,7 @@ class TempFileLock:
         self.path = path
         temp_dir = Path(ray._common.utils.get_user_temp_dir()).resolve()
         self._lock_dir = temp_dir / RAY_LOCKFILE_DIR
-        self._path_hash = hashlib.sha1(
+        self._path_hash = hashlib.sha256(
             str(Path(self.path).resolve()).encode("utf-8")
         ).hexdigest()
         self._lock_path = self._lock_dir / f"{self._path_hash}.lock"

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -168,8 +168,8 @@ class SSHCommandRunner(CommandRunnerInterface):
         use_internal_ip,
     ):
 
-        ssh_control_hash = hashlib.sha1(cluster_name.encode()).hexdigest()
-        ssh_user_hash = hashlib.sha1(getuser().encode()).hexdigest()
+        ssh_control_hash = hashlib.sha256(cluster_name.encode()).hexdigest()
+        ssh_user_hash = hashlib.sha256(getuser().encode()).hexdigest()
         ssh_control_path = "/tmp/ray_ssh_{}/{}".format(
             ssh_user_hash[:HASH_MAX_LENGTH], ssh_control_hash[:HASH_MAX_LENGTH]
         )

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -336,7 +336,7 @@ def _bootstrap_config(
     config = prepare_config(config)
     # NOTE: multi-node-type autoscaler is guaranteed to be in use after this.
 
-    hasher = hashlib.sha1()
+    hasher = hashlib.sha256()
     hasher.update(json.dumps([config], sort_keys=True).encode("utf-8"))
     cache_key = os.path.join(
         tempfile.gettempdir(), "ray-config-{}".format(hasher.hexdigest())

--- a/python/ray/data/preprocessors/utils.py
+++ b/python/ray/data/preprocessors/utils.py
@@ -14,6 +14,6 @@ def simple_split_tokenizer(value: str) -> List[str]:
 def simple_hash(value: object, num_features: int) -> int:
     """Deterministically hash a value into the integer space."""
     encoded_value = str(value).encode()
-    hashed_value = hashlib.sha1(encoded_value)
+    hashed_value = hashlib.sha256(encoded_value)
     hashed_value_int = int(hashed_value.hexdigest(), 16)
     return hashed_value_int % num_features

--- a/python/ray/serve/_private/deploy_utils.py
+++ b/python/ray/serve/_private/deploy_utils.py
@@ -106,4 +106,4 @@ def get_app_code_version(app_config: ServeApplicationSchema) -> str:
         },
         sort_keys=True,
     ).encode("utf-8")
-    return hashlib.sha1(encoded).hexdigest()
+    return hashlib.sha256(encoded).hexdigest()

--- a/python/ray/tests/gcp/test_gcp_tpu_command_runner.py
+++ b/python/ray/tests/gcp/test_gcp_tpu_command_runner.py
@@ -45,8 +45,8 @@ def test_tpu_ssh_command_runner():
     instance = MockTpuInstance(num_workers=num_workers)
     provider.create_node({}, {}, 1)
     cluster_name = "cluster"
-    ssh_control_hash = hashlib.sha1(cluster_name.encode()).hexdigest()
-    ssh_user_hash = hashlib.sha1(getuser().encode()).hexdigest()
+    ssh_control_hash = hashlib.sha256(cluster_name.encode()).hexdigest()
+    ssh_user_hash = hashlib.sha256(getuser().encode()).hexdigest()
     ssh_control_path = "/tmp/ray_ssh_{}/{}".format(
         ssh_user_hash[:10], ssh_control_hash[:10]
     )
@@ -119,8 +119,8 @@ def test_tpu_docker_command_runner():
     instance = MockTpuInstance(num_workers=num_workers)
     provider.create_node({}, {}, 1)
     cluster_name = "cluster"
-    ssh_control_hash = hashlib.sha1(cluster_name.encode()).hexdigest()
-    ssh_user_hash = hashlib.sha1(getuser().encode()).hexdigest()
+    ssh_control_hash = hashlib.sha256(cluster_name.encode()).hexdigest()
+    ssh_user_hash = hashlib.sha256(getuser().encode()).hexdigest()
     ssh_control_path = "/tmp/ray_ssh_{}/{}".format(
         ssh_user_hash[:10], ssh_control_hash[:10]
     )

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -62,8 +62,8 @@ def test_ssh_command_runner():
     provider = MockProvider()
     provider.create_node({}, {}, 1)
     cluster_name = "cluster"
-    ssh_control_hash = hashlib.sha1(cluster_name.encode()).hexdigest()
-    ssh_user_hash = hashlib.sha1(getuser().encode()).hexdigest()
+    ssh_control_hash = hashlib.sha256(cluster_name.encode()).hexdigest()
+    ssh_user_hash = hashlib.sha256(getuser().encode()).hexdigest()
     ssh_control_path = "/tmp/ray_ssh_{}/{}".format(
         ssh_user_hash[:10], ssh_control_hash[:10]
     )
@@ -129,8 +129,8 @@ def test_docker_command_runner():
     provider = MockProvider()
     provider.create_node({}, {}, 1)
     cluster_name = "cluster"
-    ssh_control_hash = hashlib.sha1(cluster_name.encode()).hexdigest()
-    ssh_user_hash = hashlib.sha1(getuser().encode()).hexdigest()
+    ssh_control_hash = hashlib.sha256(cluster_name.encode()).hexdigest()
+    ssh_user_hash = hashlib.sha256(getuser().encode()).hexdigest()
     ssh_control_path = "/tmp/ray_ssh_{}/{}".format(
         ssh_user_hash[:10], ssh_control_hash[:10]
     )

--- a/python/ray/tune/impl/placeholder.py
+++ b/python/ray/tune/impl/placeholder.py
@@ -15,7 +15,7 @@ def create_resolvers_map():
 
 def _id_hash(path_tuple):
     """Compute a hash for the specific placeholder based on its path."""
-    return hashlib.sha1(str(path_tuple).encode("utf-8")).hexdigest()[:ID_HASH_LENGTH]
+    return hashlib.sha256(str(path_tuple).encode("utf-8")).hexdigest()[:ID_HASH_LENGTH]
 
 
 class _FunctionResolver:

--- a/python/ray/util/collective/const.py
+++ b/python/ray/util/collective/const.py
@@ -14,11 +14,11 @@ def get_store_name(group_name):
     Args:
         group_name: unique user name for the store.
     Return:
-        str: SHA1-hexlified name for the store.
+        str: SHA256-hexlified name for the store.
     """
     if not group_name:
         raise ValueError("group_name is None.")
-    hexlified_name = hashlib.sha1(group_name.encode()).hexdigest()
+    hexlified_name = hashlib.sha256(group_name.encode()).hexdigest()
     return hexlified_name
 
 


### PR DESCRIPTION
## Why are these changes needed?

This PR replaces all internal uses of `hashlib.sha1` with `hashlib.sha256` for better security and consistency.  
The change only affects internal hashing logic (e.g., `runtime_env`, `conda`, `pip`, `packaging`, `command_runner`, etc.)  
and does not modify any public API or user-facing behavior.

## Related issue number

Closes https://github.com/ray-project/ray/issues/53435

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [ ] I've made sure the tests are passing. (CI will validate)

### Testing Strategy
- [ ] Unit tests
- [ ] Release tests
- [x] This PR is not tested :(
   (Relies on existing test coverage for the modified code paths)
