### PR TITLE
[Core] Bind dashboard agent grpc to specified ip instead of 0.0.0.0

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1792,7 +1792,7 @@ def start_raylet(
         os.path.join(RAY_PATH, "dashboard", "agent.py"),
         f"--node-ip-address={node_ip_address}",
         f"--metrics-export-port={metrics_export_port}",
-        f"--dashboard-agent-port={metrics_agent_port}",
+        f"--grpc-port={metrics_agent_port}",
         f"--listen-port={dashboard_agent_listen_port}",
         "--node-manager-port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
         f"--object-store-name={plasma_store_name}",

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -111,10 +111,9 @@ class DashboardAgent:
                 ),
             )  # noqa
         )
-        grpc_ip = "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0"
         try:
             self.grpc_port = add_port_to_grpc_server(
-                self.server, build_address(grpc_ip, self.dashboard_agent_port)
+                self.server, build_address(self.ip, self.dashboard_agent_port)
             )
         except Exception:
             # TODO(SongGuyang): Catch the exception here because there is
@@ -129,7 +128,7 @@ class DashboardAgent:
         else:
             logger.info(
                 "Dashboard agent grpc address: %s",
-                build_address(grpc_ip, self.grpc_port),
+                build_address(self.ip, self.grpc_port),
             )
 
         # If the agent is not minimal it should start the http server

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -91,8 +91,15 @@ static inline void Init(
                                   static_cast<uint64_t>(500))));
   // Register the metric recorder.
   if (RayConfig::instance().enable_open_telemetry()) {
+    std::string otlp_exporter_host = "127.0.0.1";
+    for (const auto &tag_pair : global_tags) {
+      if (tag_pair.first == NodeAddressKey) {
+        otlp_exporter_host = tag_pair.second;
+        break;
+      }
+    }
     OpenTelemetryMetricRecorder::GetInstance().RegisterGrpcExporter(
-        BuildAddress("127.0.0.1", metrics_agent_port),
+        BuildAddress(otlp_exporter_host, metrics_agent_port),
         std::chrono::milliseconds(
             absl::ToInt64Milliseconds(StatsConfig::instance().GetReportInterval())),
         std::chrono::milliseconds(

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -107,9 +107,17 @@ static inline void Init(
         StatsConfig::instance().GetReportInterval());
     opencensus::stats::DeltaProducer::Get()->SetHarvestInterval(
         StatsConfig::instance().GetHarvestInterval());
+    // Use node IP address for connecting to the metrics agent when not on loopback.
+    std::string oc_exporter_host = "127.0.0.1";
+    for (const auto &tag_pair : global_tags) {
+      if (tag_pair.first == NodeAddressKey) {
+        oc_exporter_host = tag_pair.second;
+        break;
+      }
+    }
     OpenCensusProtoExporter::Register(metrics_agent_port,
                                       (*metrics_io_service),
-                                      "127.0.0.1",
+                                      oc_exporter_host,
                                       worker_id,
                                       metrics_report_batch_size,
                                       max_grpc_payload_size);

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -91,15 +91,8 @@ static inline void Init(
                                   static_cast<uint64_t>(500))));
   // Register the metric recorder.
   if (RayConfig::instance().enable_open_telemetry()) {
-    std::string otlp_exporter_host = "127.0.0.1";
-    for (const auto &tag_pair : global_tags) {
-      if (tag_pair.first == NodeAddressKey) {
-        otlp_exporter_host = tag_pair.second;
-        break;
-      }
-    }
     OpenTelemetryMetricRecorder::GetInstance().RegisterGrpcExporter(
-        BuildAddress(otlp_exporter_host, metrics_agent_port),
+        BuildAddress("127.0.0.1", metrics_agent_port),
         std::chrono::milliseconds(
             absl::ToInt64Milliseconds(StatsConfig::instance().GetReportInterval())),
         std::chrono::milliseconds(
@@ -114,17 +107,9 @@ static inline void Init(
         StatsConfig::instance().GetReportInterval());
     opencensus::stats::DeltaProducer::Get()->SetHarvestInterval(
         StatsConfig::instance().GetHarvestInterval());
-    // Use node IP address for connecting to the metrics agent when not on loopback.
-    std::string oc_exporter_host = "127.0.0.1";
-    for (const auto &tag_pair : global_tags) {
-      if (tag_pair.first == NodeAddressKey) {
-        oc_exporter_host = tag_pair.second;
-        break;
-      }
-    }
     OpenCensusProtoExporter::Register(metrics_agent_port,
                                       (*metrics_io_service),
-                                      oc_exporter_host,
+                                      "127.0.0.1",
                                       worker_id,
                                       metrics_report_batch_size,
                                       max_grpc_payload_size);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

For better security practice, we want to avoid having our servers listening to all interfaces and instead bind to the specified ip.

Changed conditional logic from binding to all interfaces to only the IP that is passed in.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
