### PR TITLE
[core] [DoNotMerge] Investigate repetitions in ray system errors

### DIFF
--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -536,7 +536,9 @@ class SerializationContext:
                     object_tensors,
                 )
             except Exception as e:
+                logger.error("=== START logging exception ===")
                 logger.exception(e)
+                logger.error("=== END logging exception ===")
                 obj = RaySystemError(e, traceback.format_exc())
             finally:
                 # Must clear ObjectRef to not hold a reference.

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -968,6 +968,7 @@ class Worker:
                     if isinstance(value, RayTaskError):
                         raise value.as_instanceof_cause()
                     else:
+                        print("== Raise exception to user ==")
                         raise value
 
         return values, debugger_breakpoint

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -475,9 +475,13 @@ class RaySystemError(RayError):
         self.traceback_str = traceback_str
 
     def __str__(self):
-        error_msg = f"\n\n== Start of System Error ==\n\n System error: {self.client_exc}"
+        error_msg = (
+            f"\n\n== Start of System Error ==\n\n System error: {self.client_exc}"
+        )
         if self.traceback_str:
-            error_msg += f"\ntraceback: {self.traceback_str} \n == End of System Error == \n"
+            error_msg += (
+                f"\ntraceback: {self.traceback_str} \n == End of System Error == \n"
+            )
         return error_msg
 
 

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -475,9 +475,9 @@ class RaySystemError(RayError):
         self.traceback_str = traceback_str
 
     def __str__(self):
-        error_msg = f"System error: {self.client_exc}"
+        error_msg = f"\n\n== Start of System Error ==\n\n System error: {self.client_exc}"
         if self.traceback_str:
-            error_msg += f"\ntraceback: {self.traceback_str}"
+            error_msg += f"\ntraceback: {self.traceback_str} \n == End of System Error == \n"
         return error_msg
 
 


### PR DESCRIPTION
This pr is for investigating the duplication of exception stack traces when dealing with unserializable exceptions. It does not add any code changes which need to be merged to master.

Sample test code
```python
import openai
import ray
from openai import AuthenticationError


def call_openai_and_error_out():
    client = openai.OpenAI(
        base_url="https://api.endpoints.anyscale.com/v1",
        api_key="test",
    )
    try:
        client.chat.completions.create(
            model="gpt-3.5-turbo",
            messages=[
                {"role": "system", "content": "You are a chatbot."},
                {"role": "user", "content": "What is the capital of France?"},
            ],
        )
    except AuthenticationError as e:
        print("Errored as expected given API key is invalid.")
        raise e

remote_fn = ray.remote(call_openai_and_error_out)
ray.get(remote_fn.remote())
```

Logs with debug statements
```python
2025-08-19 08:02:24,465 ERROR serialization.py:539 -- === START logging exception ===
2025-08-19 08:02:24,465 ERROR serialization.py:540 -- Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=916486, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>
Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 50, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
TypeError: __init__() missing 2 required keyword-only arguments: 'response' and 'body'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 532, in deserialize_objects
    obj = self._deserialize_object(
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 396, in _deserialize_object
    return RayError.from_bytes(obj)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 44, in from_bytes
    return RayError.from_ray_exception(ray_exception)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 63, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=916486, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>

2025-08-19 08:02:24,466 ERROR serialization.py:541 -- === END logging exception ===
== Raise exception to user ==
Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/test.py", line 24, in <module>
    ray.get(remote_fn.remote())
  File "/home/ubuntu/clone/ray/python/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/home/ubuntu/clone/ray/python/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/clone/ray/python/ray/_private/worker.py", line 2884, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File "/home/ubuntu/clone/ray/python/ray/_private/worker.py", line 972, in get_objects
    raise value
ray.exceptions.RaySystemError: 

== Start of System Error ==

 System error: Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=916486, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>

traceback: Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 50, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
TypeError: __init__() missing 2 required keyword-only arguments: 'response' and 'body'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 532, in deserialize_objects
    obj = self._deserialize_object(
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 396, in _deserialize_object
    return RayError.from_bytes(obj)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 44, in from_bytes
    return RayError.from_ray_exception(ray_exception)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 63, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=916486, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>

 
 == End of System Error == 
```

## Explanation:
- the first large exception block (contained within `=== START logging exception ===` and `=== END logging exception ===`) is because we log the exception  before building the `RaySystemError` in `serialization.py` file
  - the users exception is repeated twice in this log because `log.excception()` also logs the traceback along with the exception when called from within an `except` block. [docs](https://docs.python.org/3/library/logging.html#logging.Logger.exception)
- the second large block is the actual Ray System Error. (wrapped between `== Start of System Error ==` and `== End of System Error ==`)
  - we throw a ray system error because calling `from_ray_exception()` on the `RayTaskError` throws a `RuntimeError` due to the exception serializability issue.
  - the repetition in the `RaySystemError's` exception is because both the exception and traceback(which will also have a copy of the original exception) is used to build the System Error message (refer `__str__()` of `RaySystemError` in `exception.py`)
  
  ## Potential Improvements
- remove the log statement in `serialization.py`
  - will remove a large chunk of the exception message improving readability
  - before removing this we need to be sure that we are not loosing any important debug logs (given the RaySystem error captures the exception details I dont think we are loosing info here)
- in `RayError.from_ray_exception()` log the exception message (containing the original string representation of the User error instead of throwing it as a `RuntimeError`. after logging the original error rethrow the serialization exception so that it is properly raised as a `RaySystem` error (or we can think of introducing a new class of error like `RaySerializationError` )
  - Once we start supporting configurable serializers for exceptions, Users can then use `register_serializer()` to pass custom exception serializers to better handle these problematic exceptions

when implementing the above recommendations, the logs will be reduced to:
```python
python test.py 
2025-08-19 08:26:37,987 INFO worker.py:1944 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265 
2025-08-19 08:26:41,233 ERROR exceptions.py:63 -- Failed to unpickle serialized exception
Original exception (string repr):
ray.exceptions.RayTaskError: ray::call_openai_and_error_out() (pid=923510, ip=172.31.5.49)
  File "/home/ubuntu/clone/ray/test.py", line 12, in call_openai_and_error_out
    client.chat.completions.create(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/ubuntu/.local/lib/python3.9/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: <html lang="en">
<head></head>
<meta charset="UTF-8">
        <p>Thank you for using Anyscale's Public Endpoints API.</p>
        <p>Effective August 1, 2024 Anyscale Endpoints API is available exclusively through the fully Hosted Anyscale Platform. Multi-tenant access to LLM models has been removed.</p><p>With the Hosted Anyscale Platform, you can access the latest GPUs billed by <a href="https://www.anyscale.com/pricing">the second</a>, and deploy models on your own dedicated instances. Enjoy full customization to build your end-to-end applications with Anyscale. <a href="https://console.anyscale.com/register/ha">Get started</a> today.</p>
</body>
</html>

== Raise exception to user ==
Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/test.py", line 24, in <module>
    ray.get(remote_fn.remote())
  File "/home/ubuntu/clone/ray/python/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/home/ubuntu/clone/ray/python/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/clone/ray/python/ray/_private/worker.py", line 2884, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File "/home/ubuntu/clone/ray/python/ray/_private/worker.py", line 972, in get_objects
    raise value
ray.exceptions.RaySystemError: 

== Start of System Error ==

 System error: __init__() missing 2 required keyword-only arguments: 'response' and 'body'
traceback: Traceback (most recent call last):
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 532, in deserialize_objects
    obj = self._deserialize_object(
  File "/home/ubuntu/clone/ray/python/ray/_private/serialization.py", line 396, in _deserialize_object
    return RayError.from_bytes(obj)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 44, in from_bytes
    return RayError.from_ray_exception(ray_exception)
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 64, in from_ray_exception
    raise e
  File "/home/ubuntu/clone/ray/python/ray/exceptions.py", line 50, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
TypeError: __init__() missing 2 required keyword-only arguments: 'response' and 'body'
 
 == End of System Error == 
```

[Note: We can also consider revisiting `RaySystemError` to see if we really want to include both the exception and traceback. imo it should be ok to keep this and instead focus on the other optimisations]