### PR TITLE
[core][autoscaler] let the event logger print the cluster resources with the sum of total resources on each node.

### DIFF
--- a/python/ray/autoscaler/v2/event_logger.py
+++ b/python/ray/autoscaler/v2/event_logger.py
@@ -3,8 +3,6 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 from ray._private.event.event_logger import EventLoggerAdapter
-from ray.autoscaler.v2.instance_manager.config import NodeTypeConfig
-from ray.autoscaler.v2.schema import NodeType
 from ray.autoscaler.v2.utils import ResourceRequestUtil
 from ray.core.generated.autoscaler_pb2 import (
     ClusterResourceConstraint,
@@ -31,8 +29,7 @@ class AutoscalerEventLogger:
 
     def log_cluster_scheduling_update(
         self,
-        node_type_configs: Dict[NodeType, NodeTypeConfig],
-        cluster_shape: Dict[NodeType, int],
+        cluster_resources: Dict[str, int],
         launch_requests: Optional[List[LaunchRequest]] = None,
         terminate_requests: Optional[List[TerminationRequest]] = None,
         infeasible_requests: Optional[List[ResourceRequest]] = None,
@@ -78,23 +75,16 @@ class AutoscalerEventLogger:
 
         # Cluster shape changes.
         if launch_requests or terminate_requests:
-            total_resources = defaultdict(float)
-
-            for node_type, count in cluster_shape.items():
-                node_config = node_type_configs[node_type]
-                for resource_name, resource_quantity in node_config.resources.items():
-                    total_resources[resource_name] += resource_quantity * count
-
-            num_cpus = total_resources.get("CPU", 0)
+            num_cpus = cluster_resources.get("CPU", 0)
             log_str = f"Resized to {int(num_cpus)} CPUs"
 
-            if "GPU" in total_resources:
-                log_str += f", {int(total_resources['GPU'])} GPUs"
-            if "TPU" in total_resources:
-                log_str += f", {int(total_resources['TPU'])} TPUs"
+            if "GPU" in cluster_resources:
+                log_str += f", {int(cluster_resources['GPU'])} GPUs"
+            if "TPU" in cluster_resources:
+                log_str += f", {int(cluster_resources['TPU'])} TPUs"
 
             self._logger.info(f"{log_str}.")
-            self._logger.debug(f"Current cluster shape: {dict(cluster_shape)}.")
+            self._logger.debug(f"Current cluster resources: {dict(cluster_resources)}.")
 
         # Log any infeasible requests.
         if infeasible_requests:

--- a/python/ray/autoscaler/v2/event_logger.py
+++ b/python/ray/autoscaler/v2/event_logger.py
@@ -29,7 +29,7 @@ class AutoscalerEventLogger:
 
     def log_cluster_scheduling_update(
         self,
-        cluster_resources: Dict[str, int],
+        cluster_resources: Dict[str, float],
         launch_requests: Optional[List[LaunchRequest]] = None,
         terminate_requests: Optional[List[TerminationRequest]] = None,
         infeasible_requests: Optional[List[ResourceRequest]] = None,
@@ -39,7 +39,29 @@ class AutoscalerEventLogger:
         ] = None,
     ) -> None:
         """
-        Log any update of the cluster scheduling state.
+        Log updates to the autoscaler scheduling state.
+
+        Emits:
+        - info logs for node launches and terminations (counts grouped by node type).
+        - an info log summarizing the cluster size after a resize (CPUs/GPUs/TPUs).
+        - warnings describing infeasible single resource requests, infeasible gang
+          (placement group) requests, and infeasible cluster resource constraints.
+
+        Args:
+            cluster_resources: Mapping of resource name to total resources for the
+                current cluster state.
+            launch_requests: Node launch requests issued in this scheduling step.
+            terminate_requests: Node termination requests issued in this scheduling
+                step.
+            infeasible_requests: Resource requests that could not be satisfied by
+                any available node type.
+            infeasible_gang_requests: Gang/placement group requests that could not
+                be scheduled.
+            infeasible_cluster_resource_constraints: Cluster-level resource
+                constraints that could not be satisfied.
+
+        Returns:
+            None
         """
 
         # Log any launch events.

--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -825,6 +825,17 @@ class ResourceDemandScheduler(IResourceScheduler):
                 cluster_shape[node.node_type] += 1
             return cluster_shape
 
+        def get_cluster_resources(self) -> Dict[str, float]:
+            cluster_resources = defaultdict(float)
+            for node in self._nodes:
+                if node.status == SchedulingNodeStatus.TO_TERMINATE:
+                    # Skip the nodes that are to be terminated.
+                    continue
+
+                for key, value in node.total_resources.items():
+                    cluster_resources[key] += value
+            return cluster_resources
+
         def get_idle_timeout_s(self) -> Optional[float]:
             return self._idle_timeout_s
 
@@ -949,8 +960,7 @@ class ResourceDemandScheduler(IResourceScheduler):
                     infeasible_requests=infeasible_requests,
                     infeasible_gang_requests=infeasible_gang_requests,
                     infeasible_cluster_resource_constraints=infeasible_constraints,
-                    cluster_shape=ctx.get_cluster_shape(),
-                    node_type_configs=ctx.get_node_type_configs(),
+                    cluster_resources=ctx.get_cluster_resources(),
                 )
             except Exception:
                 logger.exception("Failed to emit event logs.")

--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -826,6 +826,15 @@ class ResourceDemandScheduler(IResourceScheduler):
             return cluster_shape
 
         def get_cluster_resources(self) -> Dict[str, float]:
+            """
+            Aggregate total cluster resources.
+
+            Sums each node's `total_resources` across the current context,
+            excluding nodes marked `TO_TERMINATE`.
+
+            Returns:
+                A dict mapping resource names to their summed resources.
+            """
             cluster_resources = defaultdict(float)
             for node in self._nodes:
                 if node.status == SchedulingNodeStatus.TO_TERMINATE:

--- a/python/ray/autoscaler/v2/tests/test_event_logger.py
+++ b/python/ray/autoscaler/v2/tests/test_event_logger.py
@@ -5,7 +5,6 @@ import sys
 import pytest
 
 from ray.autoscaler.v2.event_logger import AutoscalerEventLogger
-from ray.autoscaler.v2.instance_manager.config import NodeTypeConfig
 from ray.autoscaler.v2.tests.util import MockEventLogger
 from ray.autoscaler.v2.utils import ResourceRequestUtil
 from ray.core.generated.autoscaler_pb2 import (
@@ -83,21 +82,7 @@ def test_log_scheduling_updates():
                 )
             )
         ],
-        cluster_shape={"type-1": 1, "type-2": 2},
-        node_type_configs={
-            "type-1": NodeTypeConfig(
-                name="type-1",
-                max_worker_nodes=10,
-                min_worker_nodes=1,
-                resources={"CPU": 1, "GPU": 1},
-            ),
-            "type-2": NodeTypeConfig(
-                name="type-2",
-                max_worker_nodes=10,
-                min_worker_nodes=1,
-                resources={"CPU": 2, "GPU": 2, "TPU": 1},
-            ),
-        },
+        cluster_resources={"CPU": 5, "GPU": 5, "TPU": 2},
     )
 
     assert mock_logger.get_logs("info") == [
@@ -117,7 +102,7 @@ def test_log_scheduling_updates():
 
     assert mock_logger.get_logs("error") == []
     assert mock_logger.get_logs("debug") == [
-        "Current cluster shape: {'type-1': 1, 'type-2': 2}."
+        "Current cluster resources: {'CPU': 5, 'GPU': 5, 'TPU': 2}."
     ]
 
 


### PR DESCRIPTION
## Why are these changes needed?

Currently, the autoscaler event logger will print the number of current cluster resources by multiplying the resource_quantity in the node config and the current node count. This doesn't work if nodes have different sizes than their configs.

This PR changes to print out the sum of total_resources in all current live nodes. There are no behavior changes in the INFO level logs for now. For DEBEG level logs, instead of printing `Current cluster shape`, now we print `Current cluster resources`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
