### PR TITLE
[LLM][Serve] Allow setting `data_parallel_size=1` in engine_kwargs

### DIFF
--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -526,18 +526,22 @@ class LLMConfig(BaseModelExtended):
         # Configure DP deployment options.
         # TODO(rui): move the following to DPServer, e.g.,
         # deployment_options = DPServer.get_deployment_options(llm_config)
-        dp_size = self.engine_kwargs.get("data_parallel_size", None)
-        if dp_size is not None:
+        dp_size = self.engine_kwargs.get("data_parallel_size", 1)
+        try:
+            dp_size = int(dp_size)
+        except ValueError:
+            raise ValueError(f"Invalid data_parallel_size: {dp_size}")
+        if dp_size != 1:
             if "num_replicas" in deployment_options:
                 raise ValueError(
                     "num_replicas should not be specified for DP deployment, "
-                    "use engine_kwargs.data_parallel_size instead."
+                    f"use engine_kwargs.data_parallel_size={dp_size} instead."
                 )
             if "autoscaling_config" in deployment_options:
                 raise ValueError(
                     "autoscaling_config is not supported for DP deployment, "
-                    "use engine_kwargs.data_parallel_size to set a fixed number "
-                    "of replicas instead."
+                    f"use engine_kwargs.data_parallel_size={dp_size} to set a "
+                    "fixed number of replicas instead."
                 )
             deployment_options["num_replicas"] = dp_size
             deployment_options["max_ongoing_requests"] = DEFAULT_MAX_ONGOING_REQUESTS

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -527,10 +527,10 @@ class LLMConfig(BaseModelExtended):
         # TODO(rui): move the following to DPServer, e.g.,
         # deployment_options = DPServer.get_deployment_options(llm_config)
         dp_size = self.engine_kwargs.get("data_parallel_size", 1)
-        try:
-            dp_size = int(dp_size)
-        except ValueError:
-            raise ValueError(f"Invalid data_parallel_size: {dp_size}")
+        if not (isinstance(dp_size, int) and dp_size > 0):
+            raise ValueError(
+                f"Invalid data_parallel_size: {dp_size}, expecting " "positive integer."
+            )
         if dp_size != 1:
             if "num_replicas" in deployment_options:
                 raise ValueError(

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -1,4 +1,5 @@
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 import pydantic
@@ -304,6 +305,56 @@ class TestModelConfig:
                 log_engine_metrics=True,
                 engine_kwargs={"disable_log_stats": True},
             )
+
+    @pytest.mark.parametrize(
+        "data_parallel_size,num_replica,allowed",
+        [
+            (None, 1, True),
+            (None, 2, True),
+            (None, 3, True),
+            (1, 1, True),
+            (1, 2, True),
+            (1, 3, True),
+            (2, 2, False),
+            (2, 3, False),
+            (4, 2, False),
+            (2, None, True),
+            (None, None, True),
+        ],
+    )
+    def test_multi_replica_dp_validation(
+        self, data_parallel_size, num_replica, allowed
+    ):
+        """Test that multi-replica and DP size are mutually exclusive.
+
+        Ray.llm's implementation does not yet support multi-replica
+        deployment along with DP.
+        """
+        engine_kwargs = (
+            {}
+            if data_parallel_size is None
+            else {"data_parallel_size": data_parallel_size}
+        )
+        deployment_config = {} if num_replica is None else {"num_replicas": num_replica}
+
+        def get_serve_options_with_num_replica():
+            return LLMConfig(
+                model_loading_config=dict(model_id="test_model"),
+                engine_kwargs=deepcopy(engine_kwargs),
+                deployment_config=deepcopy(deployment_config),
+            ).get_serve_options(name_prefix="Test:")
+
+        if allowed:
+            serve_options = get_serve_options_with_num_replica()
+            actual_num_replicas = serve_options.get("num_replicas", 1)
+            expected_num_replicas = (data_parallel_size or 1) * (num_replica or 1)
+            assert actual_num_replicas == expected_num_replicas
+        else:
+            with pytest.raises(
+                ValueError,
+                match="use engine_kwargs.data_parallel_size",
+            ):
+                get_serve_options_with_num_replica()
 
 
 class TestFieldValidators:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray.llm currently reuse `num_replicas` to implement DP, which means DP>1 and multi-replica are mutual exclusive.

`dp_size==1` should have same semantic as not setting it at all in `engine_kwargs`. However with current logic, if user sets `data_parallel_size=1` as well as multi-replica, we (mistakenly) raise error.

This PR allows user either leave `data_parallel_size` unset or set as 1.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
