### PR TITLE
[train] Revert "Make ray.train.get_dataset_shard lazily configure the dataset sharding (#55230)"

### DIFF
--- a/doc/source/tune/examples/index.rst
+++ b/doc/source/tune/examples/index.rst
@@ -6,7 +6,7 @@ Ray Tune Examples
 =================
 
 .. tip:: 
-    See :ref:`tune-main` to learn more about Tune features.
+    See :ref:`overview` to learn more about Tune features.
 
 
 Below are examples for using Ray Tune for a variety use cases and sorted by categories:

--- a/doc/source/tune/examples/index.rst
+++ b/doc/source/tune/examples/index.rst
@@ -6,7 +6,7 @@ Ray Tune Examples
 =================
 
 .. tip:: 
-    See :ref:`overview` to learn more about Tune features.
+    See :ref:`tune-main` to learn more about Tune features.
 
 
 Below are examples for using Ray Tune for a variety use cases and sorted by categories:

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -1,160 +1,18 @@
-import asyncio
 import copy
-from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Union
 
 import ray.train
-from ray.data import DataIterator, Dataset, NodeIdStr
+from ray.data import Dataset
 from ray.data.context import DataContext
 from ray.train.v2._internal.execution.callback import WorkerGroupCallback
 from ray.train.v2._internal.execution.worker_group.worker_group import (
     Worker,
     WorkerGroup,
 )
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 # A type representing either a ray.data.Dataset or a function that returns a
 # ray.data.Dataset and accepts no arguments.
 GenDataset = Union[Dataset, Callable[[], Dataset]]
-
-
-@dataclass
-class DatasetShardMetadata:
-    """Metadata about a dataset shard used for lookup and configuration."""
-
-    dataset_name: str
-    world_rank: int
-
-
-class DatasetManager:
-    """Manages the dataset shards for datasets configured in the trainer."""
-
-    def __init__(
-        self,
-        datasets: Dict[str, GenDataset],
-        data_config: ray.train.DataConfig,
-        data_context: DataContext,
-        world_size: int,
-        worker_node_ids: List[NodeIdStr],
-    ):
-        self._datasets = {k: v() if callable(v) else v for k, v in datasets.items()}
-        self._data_config = data_config
-        self._datasets_to_split = (
-            set(self._datasets.keys())
-            if data_config._datasets_to_split == "all"
-            else set(data_config._datasets_to_split)
-        )
-        self._world_size = world_size
-        self._worker_node_ids = worker_node_ids
-
-        # Maps dataset name to a list of cached `DataIterator`s corresponding to
-        # Train worker ranks.
-        self._dataset_iterators: Dict[str, List[DataIterator]] = {}
-
-        # A condition variable to synchronize the calls to the async `get_dataset_shard` method.
-        self._condition = asyncio.Condition()
-
-        DataContext._set_current(data_context)
-
-    def _create_dataset_iterators(
-        self, dataset_info: DatasetShardMetadata, base_dataset: Dataset
-    ) -> List[DataIterator]:
-        dataset_name = dataset_info.dataset_name
-
-        iterators_per_rank = self._data_config.configure(
-            datasets={dataset_name: base_dataset},
-            world_size=self._world_size,
-            worker_handles=None,
-            worker_node_ids=self._worker_node_ids,
-        )
-        assert len(iterators_per_rank) == self._world_size
-        # TODO: Update DataConfig to return a List[DataIterator] directly
-        # for configuring a single dataset.
-        # Convert the List[Dict[str, DataIterator]] to a List[DataIterator],
-        # since we only configured one dataset.
-        return [iterators_per_rank[i][dataset_name] for i in range(self._world_size)]
-
-    def _get_unsharded_dataset_iterator(
-        self, dataset_info: DatasetShardMetadata
-    ) -> DataIterator:
-        """Returns the dataset iterator for a dataset that is excluded
-        from `DataConfig.datasets_to_split`.
-
-        Note that this method is NOT a barrier across workers and can be called
-        by any subset of workers and will return immediately.
-        """
-        dataset_name = dataset_info.dataset_name
-        world_rank = dataset_info.world_rank
-
-        if dataset_name not in self._dataset_iterators:
-            self._dataset_iterators[dataset_name] = self._create_dataset_iterators(
-                dataset_info, self._datasets[dataset_name]
-            )
-
-        return self._dataset_iterators[dataset_name][world_rank]
-
-    async def _get_sharded_dataset_iterator(
-        self, dataset_info: DatasetShardMetadata
-    ) -> DataIterator:
-        """Returns the dataset iterator for a dataset that is included
-        in `DataConfig.datasets_to_split`.
-
-        Note that this method is a barrier across workers,
-        and all workers must call this method before training.
-        """
-        dataset_name = dataset_info.dataset_name
-        world_rank = dataset_info.world_rank
-
-        async with self._condition:
-            if dataset_name in self._dataset_iterators:
-                # If the dataset iterators have already been created, return the
-                # existing one.
-                iterator = self._dataset_iterators[dataset_name][world_rank]
-            elif world_rank == 0:
-                # In this case, the dataset iterators have not been created yet.
-                # The dataset only needs to be configured once globally for all workers.
-                # Do it only when the rank 0 worker calls this method.
-                iterators = self._create_dataset_iterators(
-                    dataset_info, self._datasets[dataset_name]
-                )
-                iterator = iterators[world_rank]
-
-                # Cache the dataset iterators for future use.
-                self._dataset_iterators[dataset_name] = iterators
-                self._condition.notify_all()
-            else:
-                # Wait for the dataset iterators to be created by the rank 0 worker.
-                await self._condition.wait_for(
-                    lambda: dataset_name in self._dataset_iterators
-                )
-                iterator = self._dataset_iterators[dataset_name][world_rank]
-        return iterator
-
-    async def get_dataset_shard(
-        self,
-        dataset_info: DatasetShardMetadata,
-    ) -> DataIterator:
-        """Create and return the dataset shard iterator for a Ray Train worker's
-        call to `ray.train.get_dataset_shard`.
-
-        This method is a barrier that should be called by all Ray Train workers at once.
-        If the dataset iterators have already been created, return the existing ones.
-        Otherwise, create the dataset iterators and cache them.
-
-        Here's an example of how this method is used with 4 workers:
-
-        Rank 2 calls get_dataset_shard, waits on the condition variable.
-        Rank 1 calls get_dataset_shard, waits on the condition variable.
-        Rank 0 calls get_dataset_shard, creates the dataset iterators, caches them,
-        and notifies all workers hanging on the condition variable.
-        Rank 3 calls get_dataset_shard, returns the cached iterator.
-        """
-        dataset_name = dataset_info.dataset_name
-
-        if dataset_name in self._datasets_to_split:
-            return await self._get_sharded_dataset_iterator(dataset_info)
-        else:
-            return self._get_unsharded_dataset_iterator(dataset_info)
 
 
 class DatasetsSetupCallback(WorkerGroupCallback):
@@ -173,7 +31,7 @@ class DatasetsSetupCallback(WorkerGroupCallback):
         # Capture the current DataContext to propagate it to
         # the Train workers later.
         # The propagation works in the following way:
-        # 1. This callback is created when user creates the Trainer.
+        # 1. This callback is created when user create the Trainer.
         # 2. Then this callback will be passed to the Controller actor.
         # 3. Lastly, when the worker group is initialized, the Controller
         #    will call the `after_worker_group_start` callback to propagate
@@ -187,39 +45,26 @@ class DatasetsSetupCallback(WorkerGroupCallback):
         these resources logically from its available pool."""
         return scaling_config.total_resources
 
-    # --------------------------
-    # WorkerGroupCallback
-    # --------------------------
-
     def before_init_train_context(self, workers: List[Worker]) -> Dict[str, List[Any]]:
-        if not self._datasets:
-            return {"dataset_manager": [None] * len(workers)}
+        # Configure dataset shards
+        datasets = {k: v() if callable(v) else v for k, v in self._datasets.items()}
+        node_ids = [worker.metadata.node_id for worker in workers]
 
-        world_size = len(workers)
-        worker_node_ids = [worker.metadata.node_id for worker in workers]
-
+        # Notify the DataConfig about the total resources reserved for training.
         total_train_resources = self.get_train_total_resources(self._scaling_config)
         self._data_config.set_train_total_resources(
             total_train_resources.get("CPU", 0), total_train_resources.get("GPU", 0)
         )
 
-        dataset_manager = (
-            ray.remote(DatasetManager)
-            .options(
-                num_cpus=0,
-                scheduling_strategy=NodeAffinitySchedulingStrategy(
-                    ray.get_runtime_context().get_node_id(), soft=False
-                ),
-            )
-            .remote(
-                datasets=self._datasets,
-                data_config=self._data_config,
-                data_context=self._data_context,
-                world_size=world_size,
-                worker_node_ids=worker_node_ids,
-            )
+        dataset_shards = self._data_config.configure(
+            datasets,
+            world_size=len(workers),
+            worker_handles=None,
+            worker_node_ids=node_ids,
         )
-        return {"dataset_manager": [dataset_manager] * len(workers)}
+        assert len(dataset_shards) == len(workers)
+
+        return {"dataset_shards": dataset_shards}
 
     def after_worker_group_start(self, worker_group: WorkerGroup):
         # Propagate DataContext

--- a/python/ray/train/v2/_internal/execution/train_fn_utils.py
+++ b/python/ray/train/v2/_internal/execution/train_fn_utils.py
@@ -57,13 +57,7 @@ class TrainFnUtils:
         Returns:
             The DataIterator shard for this worker.
         """
-        from ray.train.v2._internal.callbacks.datasets import DatasetShardMetadata
-
-        dataset_info = DatasetShardMetadata(
-            dataset_name=dataset_name,
-            world_rank=get_internal_train_context().get_world_rank(),
-        )
-        return get_internal_train_context().get_dataset_shard(dataset_info)
+        return get_internal_train_context().get_dataset_shard(dataset_name)
 
     def get_context(self) -> ExternalTrainContext:
         return ExternalTrainContext()


### PR DESCRIPTION
## Summary

Reverts #55230 because it introduced a performance regression.

Ray dataset objects can contain a lot of metadata (e.g., for `read_images`, if the dataset has a lot of files, the metadata contains all of the filepaths) and the dataset object size can get into the GBs. These objects take a while to serialize and ship over to remote actors.

#55230 introduced a `DatasetManager` actor that would send over the dataset iterator objects one by one to each train worker. The actor method return values would be serialized one by one, which meant that the train workers would need to wait one by one to receive their data iterator object.

## Repro script

```python
import ray
import ray.data
from ray.data import DataContext
from ray.train.v2._internal.callbacks.datasets import DatasetManager
from ray.data.datasource.partitioning import Partitioning


train_dir = "s3://anyscale-imagenet/ILSVRC/Data/CLS-LOC/train"
train_partitioning = Partitioning(
    "dir", base_dir=train_dir, field_names=["class"]
)
train_ds = ray.data.read_images(
    train_dir,
    mode="RGB",
    include_paths=False,
    partitioning=train_partitioning,
)

num_workers = 16

datasets = {"train": train_ds, "val": train_ds}
dataset_manager = ray.remote(DatasetManager).remote(
    datasets=datasets,
    data_config=ray.train.DataConfig(),
    data_context=DataContext.get_current(),
    world_size=num_workers,
    worker_node_ids=None,
)

def get_size_bytes(obj):
    import ray.cloudpickle as ray_pickle
    size_bytes = len(ray_pickle.dumps(obj))
    return size_bytes

import time

start = time.perf_counter()
ray.get([consumer.remote(it) for it in iters])
end = time.perf_counter()
print("elapsed: ", end - start)

@ray.remote(num_gpus=1)
def consumer(dm, rank):
    from ray.train.v2._internal.callbacks.datasets import DatasetShardMetadata
    dataset_info = DatasetShardMetadata("train", rank)

    import time
    start = time.perf_counter()
    ds_shard = ray.get(dm.get_dataset_shard.remote(dataset_info))
    end = time.perf_counter()

    size_mb = get_size_bytes(ds_shard) / (1024*1024)

    print(f"[{rank=}] TIME TO GET THE DATASET SHARD (SIZE={size_mb}MB):", end - start)

    
tasks = ray.get([consumer.remote(dataset_manager, rank) for rank in range(num_workers)])

```

```python
(consumer pid=119449, ip=10.0.159.6) [rank=0] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 31.03426499699981
(consumer pid=111901, ip=10.0.152.248) [rank=5] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 42.119795100000374
(consumer pid=130910, ip=10.0.188.145) [rank=12] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 53.78782823600068
(consumer pid=111903, ip=10.0.152.248) [rank=7] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 66.02914485200017
(consumer pid=111897, ip=10.0.152.248) [rank=3] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 77.95694264599933
(consumer pid=111899, ip=10.0.152.248) [rank=6] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 89.89265315800003
(consumer pid=119443, ip=10.0.159.6) [rank=1] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 102.69119121899985
(consumer pid=119452, ip=10.0.159.6) [rank=4] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 114.67034755900022
(consumer pid=130914, ip=10.0.188.145) [rank=14] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 125.7356306720003
(consumer pid=130913, ip=10.0.188.145) [rank=13] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 137.7492523689998
(consumer pid=119450, ip=10.0.159.6) [rank=2] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 151.02738245799992
(consumer pid=130915, ip=10.0.188.145) [rank=15] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 162.16050169899972
(consumer pid=115521, ip=10.0.159.125) [rank=8] TIME TO GET THE DATASET SHARD (SIZE=782.4418258666992MB): 174.8550526050003
```