### PR TITLE
[Core] Expose Default Fields in the Task Json Message

### DIFF
--- a/python/ray/_private/protobuf_compat.py
+++ b/python/ray/_private/protobuf_compat.py
@@ -1,6 +1,6 @@
 import inspect
 
-from google.protobuf.json_format import MessageToDict
+from google.protobuf.json_format import MessageToDict, MessageToJson
 
 """
 This module provides a compatibility layer for different versions of the protobuf
@@ -21,7 +21,7 @@ def _protobuf_has_old_arg_name():
 
 def rename_always_print_fields_with_no_presence(kwargs):
     """
-    Protobuf version 5.26.0rc2 renamed argument for `MessageToDict`:
+    Protobuf version 5.26.0rc2 renamed argument for `MessageToDict` and `MessageToJson`:
     `including_default_value_fields` -> `always_print_fields_with_no_presence`.
     See https://github.com/protocolbuffers/protobuf/commit/06e7caba58ede0220b110b89d08f329e5f8a7537#diff-8de817c14d6a087981503c9aea38730b1b3e98f4e306db5ff9d525c7c304f234L129  # noqa: E501
 
@@ -45,3 +45,8 @@ def rename_always_print_fields_with_no_presence(kwargs):
 def message_to_dict(*args, **kwargs):
     kwargs = rename_always_print_fields_with_no_presence(kwargs)
     return MessageToDict(*args, **kwargs)
+
+
+def message_to_json(*args, **kwargs):
+    kwargs = rename_always_print_fields_with_no_presence(kwargs)
+    return MessageToJson(*args, **kwargs)

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -271,7 +271,8 @@ class AggregatorAgent(
 
         # Convert protobuf objects to JSON dictionaries for HTTP POST
         filtered_event_batch_json = [
-            json.loads(MessageToJson(event)) for event in filtered_event_batch
+            json.loads(MessageToJson(event), use_integers_for_enums=True)
+            for event in filtered_event_batch
         ]
 
         try:

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -10,8 +10,7 @@ import logging
 from urllib3.util import Retry
 from requests import Session
 from requests.adapters import HTTPAdapter
-
-from google.protobuf.json_format import MessageToJson
+from ray._private.protobuf_compat import message_to_json
 
 try:
     import prometheus_client
@@ -211,7 +210,7 @@ class AggregatorAgent(
         Receives events from the request, adds them to the event buffer,
         """
         if not self._event_processing_enabled:
-            return events_event_aggregator_service_pb2.AddEventReply()
+            return events_event_aggregator_service_pb2.AddEventsReply()
 
         # TODO(myan) #54515: Considering adding a mechanism to also send out the events
         # metadata (e.g. dropped task attempts) to help with event processing at the
@@ -271,7 +270,9 @@ class AggregatorAgent(
 
         # Convert protobuf objects to JSON dictionaries for HTTP POST
         filtered_event_batch_json = [
-            json.loads(MessageToJson(event), including_default_value_fields=True)
+            json.loads(
+                message_to_json(event, always_print_fields_with_no_presence=True)
+            )
             for event in filtered_event_batch
         ]
 

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -271,7 +271,7 @@ class AggregatorAgent(
 
         # Convert protobuf objects to JSON dictionaries for HTTP POST
         filtered_event_batch_json = [
-            json.loads(MessageToJson(event), use_integers_for_enums=True)
+            json.loads(MessageToJson(event), including_default_value_fields=True)
             for event in filtered_event_batch
         ]
 

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -26,6 +26,12 @@ from ray.core.generated.events_event_aggregator_service_pb2 import (
     TaskEventsMetadata,
 )
 from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.core.generated.events_task_definition_event_pb2 import (
+    TaskDefinitionEvent,
+)
+from ray.core.generated.events_task_execution_event_pb2 import (
+    TaskExecutionEvent,
+)
 from ray.core.generated.profile_events_pb2 import ProfileEvents, ProfileEventEntry
 from ray.core.generated.events_task_profile_events_pb2 import TaskProfileEvents
 from ray.core.generated.events_driver_job_definition_event_pb2 import (
@@ -38,6 +44,15 @@ from ray.core.generated.runtime_env_common_pb2 import (
     RuntimeEnvInfo,
     RuntimeEnvUris,
     RuntimeEnvConfig,
+)
+from ray.core.generated.common_pb2 import (
+    TaskType,
+    Language,
+    FunctionDescriptor,
+    PythonFunctionDescriptor,
+    TaskStatus,
+    ErrorType,
+    RayErrorInfo,
 )
 
 from ray.dashboard.modules.aggregator.aggregator_agent import AggregatorAgent
@@ -122,6 +137,47 @@ def test_aggregator_agent_http_target_not_enabled(
     agent = AggregatorAgent(dashboard_agent)
     assert agent._event_http_target_enabled == expected_http_target_enabled
     assert agent._event_processing_enabled == expected_event_processing_enabled
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": "",
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_event_processing_disabled(
+    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
+):
+    cluster = ray_start_cluster_head_with_env_vars
+    stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[
+                RayEvent(
+                    event_id=b"1",
+                    source_type=RayEvent.SourceType.CORE_WORKER,
+                    event_type=RayEvent.EventType.TASK_DEFINITION_EVENT,
+                    timestamp=fake_timestamp[0],
+                    severity=RayEvent.Severity.INFO,
+                    message="hello",
+                ),
+            ],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+    stub.AddEvents(request)
 
 
 @_with_aggregator_port
@@ -394,45 +450,174 @@ def test_aggregator_agent_profile_events_not_exposed(
     assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
 
 
-@pytest.mark.parametrize(
-    "ray_start_cluster_head_with_env_vars",
-    [
-        {
-            "env_vars": {
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
-                "RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES": "TASK_DEFINITION_EVENT,TASK_EXECUTION_EVENT,ACTOR_TASK_DEFINITION_EVENT,ACTOR_TASK_EXECUTION_EVENT,TASK_PROFILE_EVENT",
-            },
-        },
-    ],
-    indirect=True,
-)
-def test_aggregator_agent_receive_profile_events(
-    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
-):
-    cluster = ray_start_cluster_head_with_env_vars
-    stub = get_event_aggregator_grpc_stub(
-        cluster.gcs_address, cluster.head_node.node_id
-    )
-
-    httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
-
-    request = AddEventsRequest(
-        events_data=RayEventsData(
-            events=[_create_profile_event_request(fake_timestamp[0])],
-            task_events_metadata=TaskEventsMetadata(
-                dropped_task_attempts=[],
+def _create_task_definition_event_proto(timestamp):
+    return RayEvent(
+        event_id=b"1",
+        source_type=RayEvent.SourceType.CORE_WORKER,
+        event_type=RayEvent.EventType.TASK_DEFINITION_EVENT,
+        timestamp=timestamp,
+        severity=RayEvent.Severity.INFO,
+        session_name="test_session",
+        task_definition_event=TaskDefinitionEvent(
+            task_id=b"1",
+            task_attempt=1,
+            task_type=TaskType.NORMAL_TASK,
+            language=Language.PYTHON,
+            task_func=FunctionDescriptor(
+                python_function_descriptor=PythonFunctionDescriptor(
+                    module_name="test_module",
+                    class_name="test_class",
+                    function_name="test_function",
+                    function_hash="test_hash",
+                ),
             ),
-        )
+            task_name="test_task",
+            required_resources={
+                "CPU": 1.0,
+                "GPU": 0.0,
+            },
+            runtime_env_info=RuntimeEnvInfo(
+                serialized_runtime_env="{}",
+            ),
+            job_id=b"1",
+            parent_task_id=b"1",
+            placement_group_id=b"1",
+            ref_ids={
+                "key1": b"value1",
+                "key2": b"value2",
+            },
+        ),
     )
 
-    stub.AddEvents(request)
 
-    wait_for_condition(lambda: len(httpserver.log) == 1)
+def _verify_task_definition_event_json(req_json, expected_timestamp):
+    assert len(req_json) == 1
 
-    req, _ = httpserver.log[0]
-    req_json = json.loads(req.data)
+    # Verify the base event fields
+    assert req_json[0]["eventId"] == base64.b64encode(b"1").decode()
+    assert req_json[0]["sourceType"] == "CORE_WORKER"
+    assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
+    assert req_json[0]["timestamp"] == expected_timestamp
+    assert req_json[0]["severity"] == "INFO"
+    assert (
+        req_json[0]["message"] == ""
+    )  # Make sure the default value is included when it is not set
+    assert req_json[0]["sessionName"] == "test_session"
 
-    _verify_profile_event_json(req_json, fake_timestamp[1])
+    # Verify the task definition event specific fields
+    assert (
+        req_json[0]["taskDefinitionEvent"]["taskId"] == base64.b64encode(b"1").decode()
+    )
+    assert req_json[0]["taskDefinitionEvent"]["taskAttempt"] == 1
+    assert req_json[0]["taskDefinitionEvent"]["taskType"] == "NORMAL_TASK"
+    assert req_json[0]["taskDefinitionEvent"]["language"] == "PYTHON"
+    assert (
+        req_json[0]["taskDefinitionEvent"]["taskFunc"]["pythonFunctionDescriptor"][
+            "moduleName"
+        ]
+        == "test_module"
+    )
+    assert (
+        req_json[0]["taskDefinitionEvent"]["taskFunc"]["pythonFunctionDescriptor"][
+            "className"
+        ]
+        == "test_class"
+    )
+    assert (
+        req_json[0]["taskDefinitionEvent"]["taskFunc"]["pythonFunctionDescriptor"][
+            "functionName"
+        ]
+        == "test_function"
+    )
+    assert (
+        req_json[0]["taskDefinitionEvent"]["taskFunc"]["pythonFunctionDescriptor"][
+            "functionHash"
+        ]
+        == "test_hash"
+    )
+    assert req_json[0]["taskDefinitionEvent"]["taskName"] == "test_task"
+    assert req_json[0]["taskDefinitionEvent"]["requiredResources"] == {
+        "CPU": 1.0,
+        "GPU": 0.0,
+    }
+    assert (
+        req_json[0]["taskDefinitionEvent"]["runtimeEnvInfo"]["serializedRuntimeEnv"]
+        == "{}"
+    )
+    assert (
+        req_json[0]["taskDefinitionEvent"]["jobId"] == base64.b64encode(b"1").decode()
+    )
+    assert (
+        req_json[0]["taskDefinitionEvent"]["parentTaskId"]
+        == base64.b64encode(b"1").decode()
+    )
+    assert (
+        req_json[0]["taskDefinitionEvent"]["placementGroupId"]
+        == base64.b64encode(b"1").decode()
+    )
+    assert req_json[0]["taskDefinitionEvent"]["refIds"] == {
+        "key1": base64.b64encode(b"value1").decode(),
+        "key2": base64.b64encode(b"value2").decode(),
+    }
+
+
+def _create_task_execution_event_proto(timestamp):
+    return RayEvent(
+        event_id=b"1",
+        source_type=RayEvent.SourceType.CORE_WORKER,
+        event_type=RayEvent.EventType.TASK_EXECUTION_EVENT,
+        timestamp=timestamp,
+        severity=RayEvent.Severity.INFO,
+        session_name="test_session",
+        task_execution_event=TaskExecutionEvent(
+            task_id=b"1",
+            task_attempt=1,
+            task_state={
+                TaskStatus.RUNNING: timestamp,
+            },
+            ray_error_info=RayErrorInfo(
+                error_type=ErrorType.TASK_EXECUTION_EXCEPTION,
+            ),
+            node_id=b"1",
+            worker_id=b"1",
+            worker_pid=1,
+        ),
+    )
+
+
+def _verify_task_execution_event_json(req_json, expected_timestamp):
+    assert len(req_json) == 1
+
+    # Verify the base event fields
+    assert req_json[0]["eventId"] == base64.b64encode(b"1").decode()
+    assert req_json[0]["sourceType"] == "CORE_WORKER"
+    assert req_json[0]["eventType"] == "TASK_EXECUTION_EVENT"
+    assert req_json[0]["timestamp"] == expected_timestamp
+    assert req_json[0]["severity"] == "INFO"
+    assert (
+        req_json[0]["message"] == ""
+    )  # Make sure the default value is included when it is not set
+    assert req_json[0]["sessionName"] == "test_session"
+
+    # Verify the task execution event specific fields
+    assert (
+        req_json[0]["taskExecutionEvent"]["taskId"] == base64.b64encode(b"1").decode()
+    )
+    assert req_json[0]["taskExecutionEvent"]["taskAttempt"] == 1
+    assert req_json[0]["taskExecutionEvent"]["taskState"] == {
+        "8": expected_timestamp,
+    }
+    assert (
+        req_json[0]["taskExecutionEvent"]["rayErrorInfo"]["errorType"]
+        == "TASK_EXECUTION_EXCEPTION"
+    )
+    assert (
+        req_json[0]["taskExecutionEvent"]["nodeId"] == base64.b64encode(b"1").decode()
+    )
+    assert (
+        req_json[0]["taskExecutionEvent"]["workerId"] == base64.b64encode(b"1").decode()
+    )
+    assert req_json[0]["taskExecutionEvent"]["workerPid"] == 1
 
 
 def _create_profile_event_request(timestamp):
@@ -495,6 +680,65 @@ def _verify_profile_event_json(req_json, expected_timestamp):
     assert event_entry["startTime"] == "1751302230130000000"
     assert event_entry["endTime"] == "1751302230131000000"
     assert event_entry["extraData"] == '{"cpu_usage": 0.8}'
+
+
+# tuple: (create_event, verify)
+EVENT_TYPES_TO_TEST = [
+    pytest.param(
+        _create_task_definition_event_proto,
+        _verify_task_definition_event_json,
+        id="task_definition_event",
+    ),
+    pytest.param(
+        _create_task_execution_event_proto,
+        _verify_task_execution_event_json,
+        id="task_execution_event",
+    ),
+    pytest.param(
+        _create_profile_event_request, _verify_profile_event_json, id="profile_event"
+    ),
+]
+
+
+@pytest.mark.parametrize("create_event, verify_event", EVENT_TYPES_TO_TEST)
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES": "TASK_DEFINITION_EVENT,TASK_EXECUTION_EVENT,ACTOR_TASK_DEFINITION_EVENT,ACTOR_TASK_EXECUTION_EVENT,TASK_PROFILE_EVENT",
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_receive_events(
+    create_event,
+    verify_event,
+    ray_start_cluster_head_with_env_vars,
+    httpserver,
+    fake_timestamp,
+):
+    cluster = ray_start_cluster_head_with_env_vars
+    stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+    httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[create_event(fake_timestamp[0])],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    stub.AddEvents(request)
+    wait_for_condition(lambda: len(httpserver.log) == 1)
+    req, _ = httpserver.log[0]
+    req_json = json.loads(req.data)
+    verify_event(req_json, fake_timestamp[1])
 
 
 @_with_aggregator_port


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixed 2 issues we found in the task event pipeline with additional tests added:
1. When converting the task events to json, add the option to include the fields with default values
2. A typo in generating the add event response when the http endpoint is not configured. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
N/A

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
