### PR TITLE
[Data] Make `ray.get` patch less brittle in `test_sort`

### DIFF
--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -558,9 +558,9 @@ def patch_ray_remote(condition, callback):
 def patch_ray_get(callback):
     original_ray_get = ray.get
 
-    def ray_get_override(object_refs):
+    def ray_get_override(object_refs, *args, **kwargs):
         callback(object_refs)
-        return original_ray_get(object_refs)
+        return original_ray_get(object_refs, *args, **kwargs)
 
     ray.get = ray_get_override
     return original_ray_get


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_push_based_shuffle_reduce_stage_scheduling` patches `ray.get` with a function that takes a single `refs` argument. This is problematic because if Ray Data calls `ray.get` with any other arguments (e.g., `timeout`), then Python errors and complains that argument is unexpected.

> TypeError: ray_get_override() got an unexpected keyword argument 'timeout'

To address this issue, this PR allows the patched `ray.get` to accept additional arguments.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
