### PR TITLE
[core] Kill Retrying to get node with node ID log

### DIFF
--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -429,7 +429,7 @@ ray::Status GlobalStateAccessor::GetNode(const std::string &node_id_hex_str,
           ". The node registration may not be complete yet before the timeout." +
           " Try increase the RAY_raylet_start_wait_time_s config.");
     }
-    RAY_LOG(INFO) << "Retrying to get node with node ID " << node_id_hex_str;
+    RAY_LOG(DEBUG) << "Retrying to get node with node ID " << node_id_hex_str;
     // Some of the information may not be in GCS yet, so wait a little bit.
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }


### PR DESCRIPTION
## Why are these changes needed?
After https://github.com/ray-project/ray/pull/55389, when starting up we sometimes see this log because the first request to the GCS to get node info might fail. The log is only an info log but this can possibly happen before logging redirecting is configured meaning it could get shown to a user.