### PR TITLE
[core][autoscaler] Reword `Total Demands` and `Total Constraints` to `Pending Demands` and `From request_resources`

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/configuring-autoscaling.md
+++ b/doc/source/cluster/kubernetes/user-guides/configuring-autoscaling.md
@@ -431,7 +431,7 @@ Total Usage:
  0B/72.63GiB memory
  0B/33.53GiB object_store_memory
 
-Total Demands:
+Pending Demands:
  (no resource demands)
 
 Node: 40f427230584b2d9c9f113d8db51d10eaf914aa9bf61f81dc7fabc64

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -749,7 +749,7 @@ def get_constraint_report(request_demand: List[DictCount]):
     if len(constraint_lines) > 0:
         constraints_report = "\n".join(constraint_lines)
     else:
-        constraints_report = " (no request_resources())"
+        constraints_report = " (none)"
     return constraints_report
 
 

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -749,7 +749,7 @@ def get_constraint_report(request_demand: List[DictCount]):
     if len(constraint_lines) > 0:
         constraints_report = "\n".join(constraint_lines)
     else:
-        constraints_report = " (no request_resources() constraints)"
+        constraints_report = " (no request_resources())"
     return constraints_report
 
 
@@ -941,9 +941,9 @@ Resources
 {separator}
 Total Usage:
 {usage_report}
-Total Constraints:
+From request_resources:
 {constraints_report}
-Total Demands:
+Pending Demands:
 {demand_report}"""
 
     if verbose:

--- a/python/ray/autoscaler/v2/tests/test_utils.py
+++ b/python/ray/autoscaler/v2/tests/test_utils.py
@@ -567,9 +567,9 @@ Total Usage:
  0.0/4.0 GPU
  5.42KiB/10.04KiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'GPU': 2, 'CPU': 100}: 2 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 1, 'GPU': 1}: 11+ pending tasks/actors
  {'CPU': 1, 'GPU': 1} * 1 (STRICT_SPREAD): 1+ pending placement groups
  {'GPU': 2} * 1 (STRICT_PACK): 2+ pending placement groups

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -631,7 +631,7 @@ class ClusterStatusFormatter:
             constraint_lines.append(f" {bundle}: {count} from request_resources()")
         if constraint_lines:
             return "\n".join(constraint_lines)
-        return " (no request_resources())"
+        return " (none)"
 
     @staticmethod
     def _demand_report(data: ClusterStatus) -> str:

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -400,9 +400,9 @@ class ClusterStatusFormatter:
             separator,
             "Total Usage:",
             cluster_usage_report,
-            "Total Constraints:",
+            "From request_resources:",
             constraints_report,
-            "Total Demands:",
+            "Pending Demands:",
             demand_report,
             node_usage_report,
         ]
@@ -631,7 +631,7 @@ class ClusterStatusFormatter:
             constraint_lines.append(f" {bundle}: {count} from request_resources()")
         if constraint_lines:
             return "\n".join(constraint_lines)
-        return " (no request_resources() constraints)"
+        return " (no request_resources())"
 
     @staticmethod
     def _demand_report(data: ClusterStatus) -> str:

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -124,12 +124,15 @@ def test_ray_status_e2e(local_autoscaling_cluster, shutdown_only):
     actor = Actor.remote()
     ray.get(actor.ping.remote())
 
-    assert "Total Demands" in subprocess.check_output("ray status", shell=True).decode()
     assert (
-        "Total Demands" in subprocess.check_output("ray status -v", shell=True).decode()
+        "Pending Demands" in subprocess.check_output("ray status", shell=True).decode()
     )
     assert (
-        "Total Demands"
+        "Pending Demands"
+        in subprocess.check_output("ray status -v", shell=True).decode()
+    )
+    assert (
+        "Pending Demands"
         in subprocess.check_output("ray status --verbose", shell=True).decode()
     )
 

--- a/python/ray/tests/test_cli_patterns/test_ray_status.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status.txt
@@ -18,6 +18,6 @@ Total Usage:
  0.+
 
 From request_resources:
- \(no request_resources\(\)\)
+ \(none\)
 Pending Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status.txt
@@ -17,7 +17,7 @@ Total Usage:
  0.+
  0.+
 
-Total Constraints:
- \(no request_resources\(\) constraints\)
-Total Demands:
+From request_resources:
+ \(no request_resources\(\)\)
+Pending Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_multinode.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_multinode.txt
@@ -20,7 +20,7 @@ Total Usage:
  0.+
  0.+
 
-Total Constraints:
- \(no request_resources\(\) constraints\)
-Total Demands:
+From request_resources:
+ \(no request_resources\(\)\)
+Pending Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_multinode.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_multinode.txt
@@ -21,6 +21,6 @@ Total Usage:
  0.+
 
 From request_resources:
- \(no request_resources\(\)\)
+ \(none\)
 Pending Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_multinode_v1.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_multinode_v1.txt
@@ -18,7 +18,7 @@ Total Usage:
  0.+
  0.+
 
-Total Constraints:
- \(no request_resources\(\) constraints\)
-Total Demands:
+From request_resources:
+ \(no request_resources\(\)\)
+Pending Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_multinode_v1.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_multinode_v1.txt
@@ -19,6 +19,6 @@ Total Usage:
  0.+
 
 From request_resources:
- \(no request_resources\(\)\)
+ \(none\)
 Pending Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_v1.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_v1.txt
@@ -15,7 +15,7 @@ Total Usage:
  0.+
  0.+
 
-Total Constraints:
- \(no request_resources\(\) constraints\)
-Total Demands:
+From request_resources:
+ \(no request_resources\(\)\)
+Pending Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_v1.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_v1.txt
@@ -16,6 +16,6 @@ Total Usage:
  0.+
 
 From request_resources:
- \(no request_resources\(\)\)
+ \(none\)
 Pending Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -3284,9 +3284,9 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'CPU': 16}: 100 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
 """.strip()
@@ -3341,10 +3341,10 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'CPU': 16}: 100 from request_resources()
  {'CPU': 1, 'GPU': 16}: 10 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
 """.strip()
@@ -3433,9 +3433,9 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'CPU': 16}: 100 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
 
@@ -3548,9 +3548,9 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'CPU': 16}: 100 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
 
@@ -3640,9 +3640,9 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'CPU': 16}: 100 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
 """.strip()
@@ -3735,9 +3735,9 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'CPU': 16}: 100 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
 """.strip()
@@ -3828,9 +3828,9 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'CPU': 16}: 100 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
 """.strip()
@@ -3917,9 +3917,9 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
-Total Constraints:
+From request_resources:
  {'CPU': 16}: 100 from request_resources()
-Total Demands:
+Pending Demands:
  {'CPU': 2.0}: 153+ pending tasks/actors (3+ using placement groups)
  {'GPU': 0.5}: 100+ pending tasks/actors (100+ using placement groups)
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups


### PR DESCRIPTION
## Why are these changes needed?

The `Total Demands` in the autoscaler status output actually contains only pending demands, so we rename it to `Pending Demands` to avoid further confusion.

`Total Constraints` actually simply reflects `request_resources`. It has nothing to do with demands and current cluster usages. And the word `Constraints` is a bit inaccurate. They are met by autoscaler in a best effort way. So we rename it to `From request_resources` to avoid further confusion. Put a capitalized `From` first to align with other sections.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
