### PR TITLE
Change the ray_accel_env_var_override_on_zero warning to future_warning

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1984,10 +1984,11 @@ def init(
         True,
     )
     if override_on_zero and log_once("ray_accel_env_var_override_on_zero"):
-        logger.warning(
+        warnings.warn(
             "Tip: In future versions of Ray, Ray will no longer override accelerator "
             "visible devices env var if num_gpus=0 or num_gpus=None (default). To enable "
-            "this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0"
+            "this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0",
+            FutureWarning,
         )
 
     node_id = global_worker.core_worker.get_current_node_id()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before this pr:
```
python /ray-workspace/temp.py
2025-08-18 18:26:21,621 INFO worker.py:1943 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265 
2025-08-18 18:26:53,873 WARNING worker.py:1991 -- Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
```

After this pr:
```
2025-08-20 19:08:41,923 INFO worker.py:1939 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265 
/sgl-workspace/ray/python/ray/_private/worker.py:1987: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
This is to refine #54928 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
