### PR TITLE
[python/ray/train/_internal] Add AsyncCheckpointWriter for non-blocking checkpoint uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,12 @@ scripts/nodes.txt
 
 # OS X folder attributes
 .DS_Store
+/bazel-out/
+/bazel-bin/
+/bazel-testlogs/
+/bazel-ray/
+/bazel-cache/
+myenv/
 
 # Debug files
 *.dSYM/

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -516,6 +516,26 @@ class CheckpointConfig:
 
 
 @dataclass
+@PublicAPI(stability="alpha")
+class CheckpointUploadConfig(CheckpointConfig):
+    """Extension of CheckpointConfig with async upload controls.
+
+    Args:
+        max_async_upload_threads: Maximum concurrent async checkpoint uploads per
+            worker. If None, Ray will use its internal default.
+    """
+
+    max_async_upload_threads: Optional[int] = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.max_async_upload_threads is not None and self.max_async_upload_threads <= 0:
+            raise ValueError(
+                "max_async_upload_threads must be None or an integer >= 1."
+            )
+
+
+@dataclass
 @PublicAPI(stability="stable")
 class RunConfig:
     """Runtime configuration for training and tuning runs.

--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -378,6 +378,20 @@ py_test(
 )
 
 py_test(
+    name = "test_async_checkpoint",
+    size = "medium",
+    srcs = ["tests/test_async_checkpoint.py"],
+    tags = [
+        "exclusive",
+        "team:ml",
+    ],
+    deps = [
+        ":conftest",
+        ":train_lib",
+    ],
+)
+
+py_test(
     name = "test_backend",
     size = "large",
     srcs = ["tests/test_backend.py"],

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -20,6 +20,7 @@ from ray.air.result import Result
 from ray.train._checkpoint import Checkpoint
 from ray.train._internal.data_config import DataConfig
 from ray.train._internal.session import async_report, get_checkpoint, get_dataset_shard, report
+from ray.train._internal.async_checkpoint import get_async_checkpoint_metrics, print_async_checkpoint_status
 from ray.train._internal.syncer import SyncConfig
 from ray.train.backend import BackendConfig
 from ray.train.constants import TRAIN_DATASET_KEY
@@ -45,9 +46,11 @@ if is_v2_enabled():
 
 __all__ = [
     "async_report",
+    "get_async_checkpoint_metrics",
     "get_checkpoint",
     "get_context",
     "get_dataset_shard",
+    "print_async_checkpoint_status",
     "report",
     "BackendConfig",
     "Checkpoint",
@@ -63,9 +66,11 @@ __all__ = [
 ]
 
 async_report.__module__ = "ray.train"
+get_async_checkpoint_metrics.__module__ = "ray.train"
 get_checkpoint.__module__ = "ray.train"
 get_context.__module__ = "ray.train"
 get_dataset_shard.__module__ = "ray.train"
+print_async_checkpoint_status.__module__ = "ray.train"
 report.__module__ = "ray.train"
 BackendConfig.__module__ = "ray.train"
 Checkpoint.__module__ = "ray.train"

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -19,8 +19,16 @@ from ray.air.result import Result
 # Import this first so it can be used in other modules
 from ray.train._checkpoint import Checkpoint
 from ray.train._internal.data_config import DataConfig
-from ray.train._internal.session import async_report, get_checkpoint, get_dataset_shard, report
-from ray.train._internal.async_checkpoint import get_async_checkpoint_metrics, print_async_checkpoint_status
+from ray.train._internal.session import (
+    async_report,
+    get_checkpoint,
+    get_dataset_shard,
+    report,
+)
+from ray.train._internal.async_checkpoint import (
+    get_async_checkpoint_metrics,
+    print_async_checkpoint_status,
+)
 from ray.train._internal.syncer import SyncConfig
 from ray.train.backend import BackendConfig
 from ray.train.constants import TRAIN_DATASET_KEY

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -19,7 +19,7 @@ from ray.air.result import Result
 # Import this first so it can be used in other modules
 from ray.train._checkpoint import Checkpoint
 from ray.train._internal.data_config import DataConfig
-from ray.train._internal.session import get_checkpoint, get_dataset_shard, report
+from ray.train._internal.session import async_report, get_checkpoint, get_dataset_shard, report
 from ray.train._internal.syncer import SyncConfig
 from ray.train.backend import BackendConfig
 from ray.train.constants import TRAIN_DATASET_KEY
@@ -44,6 +44,7 @@ if is_v2_enabled():
 
 
 __all__ = [
+    "async_report",
     "get_checkpoint",
     "get_context",
     "get_dataset_shard",
@@ -61,6 +62,7 @@ __all__ = [
     "TRAIN_DATASET_KEY",
 ]
 
+async_report.__module__ = "ray.train"
 get_checkpoint.__module__ = "ray.train"
 get_context.__module__ = "ray.train"
 get_dataset_shard.__module__ = "ray.train"

--- a/python/ray/train/_internal/async_checkpoint.py
+++ b/python/ray/train/_internal/async_checkpoint.py
@@ -187,9 +187,9 @@ class AsyncCheckpointWriter:
             maxsize=self._max_pending_uploads
         )
         self._completed_tasks: queue.Queue[_AsyncCheckpointTask] = queue.Queue()
-        self._failed_tasks: queue.Queue[Tuple[_AsyncCheckpointTask, Exception]] = (
-            queue.Queue()
-        )
+        self._failed_tasks: queue.Queue[
+            Tuple[_AsyncCheckpointTask, Exception]
+        ] = queue.Queue()
         self._shutdown = False
         self._lock = threading.Lock()
 

--- a/python/ray/train/_internal/async_checkpoint.py
+++ b/python/ray/train/_internal/async_checkpoint.py
@@ -1,0 +1,300 @@
+"""Async checkpoint writer for Ray Train.
+
+This module provides non-blocking checkpoint uploading capabilities for Ray Train,
+specifically designed for RL on reasoning models that checkpoint frequently.
+"""
+
+import concurrent.futures
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from ray.train import Checkpoint
+from ray.train._internal.storage import StorageContext, _pyarrow_fs_copy_files
+from ray.util.annotations import DeveloperAPI
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _AsyncCheckpointTask:
+    """Represents an async checkpoint upload task."""
+    checkpoint: Checkpoint
+    storage_context: StorageContext
+    metrics: Dict[str, Any]
+    checkpoint_fs_path: str
+    future: Optional[concurrent.futures.Future] = None
+    submit_time: float = 0.0
+
+
+class _AsyncCheckpointError(Exception):
+    """Raised when an async checkpoint operation fails."""
+    def __init__(self, message: str, original_exception: Exception):
+        super().__init__(message)
+        self.original_exception = original_exception
+
+
+@DeveloperAPI
+class AsyncCheckpointWriter:
+    """Manages asynchronous checkpoint uploads with backpressure control.
+    
+    Features:
+    - Non-blocking checkpoint uploads via background thread pool
+    - Backpressure control to prevent unlimited queuing
+    - Atomic manifest writing (LATEST.json) on upload completion
+    - Error reporting on next async_report call with flush=True
+    - Graceful shutdown with pending uploads completion
+    
+    This is designed for RL training where frequent checkpointing to S3/GCS
+    should not block the training step.
+    """
+
+    def __init__(self, max_concurrent_uploads: int = 2, max_pending_uploads: int = 5):
+        """Initialize the async checkpoint writer.
+        
+        Args:
+            max_concurrent_uploads: Maximum number of concurrent upload threads.
+            max_pending_uploads: Maximum number of pending uploads before blocking.
+        """
+        self._max_concurrent_uploads = max_concurrent_uploads
+        self._max_pending_uploads = max_pending_uploads
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_concurrent_uploads,
+            thread_name_prefix="async_checkpoint"
+        )
+        self._pending_tasks: queue.Queue[_AsyncCheckpointTask] = queue.Queue(
+            maxsize=max_pending_uploads
+        )
+        self._completed_tasks: queue.Queue[_AsyncCheckpointTask] = queue.Queue()
+        self._failed_tasks: queue.Queue[Tuple[_AsyncCheckpointTask, Exception]] = queue.Queue()
+        self._shutdown = False
+        self._lock = threading.Lock()
+        
+        # Start the task submission thread
+        self._submission_thread = threading.Thread(
+            target=self._submission_worker,
+            daemon=True,
+            name="async_checkpoint_submitter"
+        )
+        self._submission_thread.start()
+
+    def async_persist_checkpoint(
+        self,
+        checkpoint: Checkpoint,
+        storage_context: StorageContext,
+        metrics: Dict[str, Any],
+    ) -> None:
+        """Submit a checkpoint for asynchronous upload.
+        
+        Args:
+            checkpoint: The checkpoint to persist.
+            storage_context: Storage context for upload destination.
+            metrics: Metrics associated with this checkpoint.
+            
+        Raises:
+            _AsyncCheckpointError: If the queue is full (backpressure).
+        """
+        if self._shutdown:
+            raise RuntimeError("AsyncCheckpointWriter has been shut down")
+
+        # Create checkpoint fs path (same logic as StorageContext)
+        checkpoint_fs_path = storage_context.checkpoint_fs_path
+        
+        task = _AsyncCheckpointTask(
+            checkpoint=checkpoint,
+            storage_context=storage_context,
+            metrics=metrics,
+            checkpoint_fs_path=checkpoint_fs_path,
+            submit_time=time.time()
+        )
+        
+        try:
+            # Non-blocking put with timeout for backpressure
+            self._pending_tasks.put(task, block=True, timeout=0.1)
+            logger.debug(f"Queued async checkpoint upload to {checkpoint_fs_path}")
+        except queue.Full:
+            raise _AsyncCheckpointError(
+                "Too many pending checkpoint uploads. Consider reducing checkpoint frequency "
+                "or increasing max_pending_uploads.",
+                queue.Full()
+            )
+
+    def _submission_worker(self):
+        """Background thread that submits tasks to the thread pool executor."""
+        while not self._shutdown:
+            try:
+                task = self._pending_tasks.get(timeout=1.0)
+                if task is None:  # Shutdown signal
+                    break
+                    
+                # Submit the actual upload task
+                future = self._executor.submit(self._upload_checkpoint_task, task)
+                task.future = future
+                
+                # Add callback to handle completion
+                future.add_done_callback(lambda f, t=task: self._on_task_complete(f, t))
+                
+            except queue.Empty:
+                continue
+            except Exception as e:
+                logger.exception("Error in async checkpoint submission worker")
+
+    def _upload_checkpoint_task(self, task: _AsyncCheckpointTask) -> Checkpoint:
+        """Upload a single checkpoint (runs in background thread)."""
+        try:
+            # Validate storage path access (same as sync version)
+            task.storage_context._check_validation_file()
+            
+            # Create destination directory
+            task.storage_context.storage_filesystem.create_dir(task.checkpoint_fs_path)
+            
+            # Copy files to storage
+            logger.debug(
+                f"Starting async upload: {task.checkpoint.path} -> {task.checkpoint_fs_path}"
+            )
+            
+            _pyarrow_fs_copy_files(
+                source=task.checkpoint.path,
+                destination=task.checkpoint_fs_path,
+                source_filesystem=task.checkpoint.filesystem,
+                destination_filesystem=task.storage_context.storage_filesystem,
+            )
+            
+            # Create persisted checkpoint object
+            persisted_checkpoint = task.checkpoint.__class__(
+                filesystem=task.storage_context.storage_filesystem,
+                path=task.checkpoint_fs_path,
+            )
+            
+            # Write atomic manifest (LATEST.json)
+            self._write_latest_manifest(task.storage_context, task.metrics, persisted_checkpoint)
+            
+            logger.info(f"Async checkpoint upload completed: {persisted_checkpoint}")
+            return persisted_checkpoint
+            
+        except Exception as e:
+            logger.error(f"Async checkpoint upload failed: {e}")
+            raise
+
+    def _write_latest_manifest(
+        self,
+        storage_context: StorageContext,
+        metrics: Dict[str, Any],
+        checkpoint: Checkpoint
+    ):
+        """Write atomic LATEST.json manifest to indicate completed upload."""
+        try:
+            manifest_data = {
+                "checkpoint_path": checkpoint.path,
+                "metrics": metrics,
+                "timestamp": time.time(),
+                "upload_completed": True
+            }
+            
+            # Write to experiment directory  
+            manifest_path = Path(storage_context.experiment_fs_path, "LATEST.json").as_posix()
+            
+            # Write atomically by writing to temp file then renaming
+            temp_manifest_path = f"{manifest_path}.tmp"
+            
+            with storage_context.storage_filesystem.open_output_stream(temp_manifest_path) as f:
+                f.write(json.dumps(manifest_data, indent=2).encode())
+            
+            # Atomic rename (most filesystems support this atomically)
+            storage_context.storage_filesystem.move(temp_manifest_path, manifest_path)
+            
+            logger.debug(f"Wrote LATEST.json manifest to {manifest_path}")
+            
+        except Exception as e:
+            logger.warning(f"Failed to write LATEST.json manifest: {e}")
+            # Don't fail the whole upload for manifest issues
+
+    def _on_task_complete(self, future: concurrent.futures.Future, task: _AsyncCheckpointTask):
+        """Handle completion of an upload task."""
+        try:
+            if future.exception():
+                self._failed_tasks.put((task, future.exception()))
+            else:
+                result = future.result()
+                self._completed_tasks.put(task)
+        except Exception as e:
+            logger.exception("Error handling async checkpoint task completion")
+            self._failed_tasks.put((task, e))
+
+    def check_and_raise_errors(self):
+        """Check for failed uploads and raise the first error found.
+        
+        This should be called with flush=True to report errors from
+        previous async uploads.
+        """
+        try:
+            failed_task, exception = self._failed_tasks.get_nowait()
+            raise _AsyncCheckpointError(
+                f"Async checkpoint upload failed for {failed_task.checkpoint_fs_path}",
+                exception
+            )
+        except queue.Empty:
+            pass
+
+    def get_stats(self) -> Dict[str, int]:
+        """Get statistics about async checkpoint operations."""
+        return {
+            "pending_uploads": self._pending_tasks.qsize(),
+            "completed_uploads": self._completed_tasks.qsize(),
+            "failed_uploads": self._failed_tasks.qsize(),
+        }
+
+    def shutdown(self, timeout: float = 30.0):
+        """Gracefully shutdown the async checkpoint writer.
+        
+        Args:
+            timeout: Maximum time to wait for pending uploads to complete.
+        """
+        with self._lock:
+            if self._shutdown:
+                return
+            
+            self._shutdown = True
+            
+        logger.info("Shutting down AsyncCheckpointWriter...")
+        
+        # Signal submission worker to stop
+        try:
+            self._pending_tasks.put(None, timeout=1.0)
+        except queue.Full:
+            pass
+            
+        # Wait for submission thread
+        self._submission_thread.join(timeout=5.0)
+        
+        # Shutdown executor and wait for running tasks
+        self._executor.shutdown(wait=True)
+        
+        stats = self.get_stats()
+        logger.info(f"AsyncCheckpointWriter shutdown complete. Final stats: {stats}")
+
+
+# Global instance for the session
+_async_checkpoint_writer: Optional[AsyncCheckpointWriter] = None
+
+
+def _get_async_checkpoint_writer() -> AsyncCheckpointWriter:
+    """Get or create the global async checkpoint writer."""
+    global _async_checkpoint_writer
+    if _async_checkpoint_writer is None:
+        _async_checkpoint_writer = AsyncCheckpointWriter()
+    return _async_checkpoint_writer
+
+
+def _shutdown_async_checkpoint_writer():
+    """Shutdown the global async checkpoint writer."""
+    global _async_checkpoint_writer
+    if _async_checkpoint_writer is not None:
+        _async_checkpoint_writer.shutdown()
+        _async_checkpoint_writer = None

--- a/python/ray/train/_internal/async_checkpoint.py
+++ b/python/ray/train/_internal/async_checkpoint.py
@@ -1,7 +1,7 @@
 """Async checkpoint writer for Ray Train.
 
 This module provides non-blocking checkpoint uploading capabilities for Ray Train,
-specifically designed for RL on reasoning models that checkpoint frequently.
+specifically designed for training that checkpoint frequently and/or asynchronously.
 """
 
 import concurrent.futures
@@ -11,7 +11,8 @@ import os
 import queue
 import threading
 import time
-from dataclasses import dataclass
+from collections import defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
@@ -31,6 +32,9 @@ class _AsyncCheckpointTask:
     checkpoint_fs_path: str
     future: Optional[concurrent.futures.Future] = None
     submit_time: float = 0.0
+    retry_count: int = 0
+    checkpoint_size_bytes: int = 0
+    upload_start_time: Optional[float] = None
 
 
 class _AsyncCheckpointError(Exception):
@@ -38,6 +42,81 @@ class _AsyncCheckpointError(Exception):
     def __init__(self, message: str, original_exception: Exception):
         super().__init__(message)
         self.original_exception = original_exception
+
+
+@dataclass
+class UploadProgress:
+    """Progress information for an upload."""
+    checkpoint_path: str
+    bytes_uploaded: int = 0
+    total_bytes: int = 0
+    start_time: float = 0.0
+    current_file: str = ""
+    
+    @property
+    def progress_percent(self) -> float:
+        """Get upload progress as percentage."""
+        if self.total_bytes == 0:
+            return 0.0
+        return min(100.0, (self.bytes_uploaded / self.total_bytes) * 100.0)
+    
+    @property
+    def elapsed_time(self) -> float:
+        """Get elapsed upload time in seconds."""
+        return time.time() - self.start_time if self.start_time > 0 else 0.0
+    
+    @property
+    def upload_speed_mbps(self) -> float:
+        """Get current upload speed in MB/s."""
+        elapsed = self.elapsed_time
+        if elapsed == 0 or self.bytes_uploaded == 0:
+            return 0.0
+        return (self.bytes_uploaded / (1024 * 1024)) / elapsed
+
+
+@dataclass 
+class UploadMetrics:
+    """Aggregate metrics for all upload operations."""
+    total_uploads: int = 0
+    successful_uploads: int = 0
+    failed_uploads: int = 0
+    total_bytes_uploaded: int = 0
+    total_upload_time: float = 0.0
+    error_counts: Dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    active_uploads: Dict[str, UploadProgress] = field(default_factory=dict)
+    
+    @property
+    def success_rate(self) -> float:
+        """Get upload success rate as percentage."""
+        if self.total_uploads == 0:
+            return 100.0
+        return (self.successful_uploads / self.total_uploads) * 100.0
+    
+    @property
+    def average_upload_time(self) -> float:
+        """Get average upload time in seconds."""
+        if self.successful_uploads == 0:
+            return 0.0
+        return self.total_upload_time / self.successful_uploads
+    
+    @property
+    def average_upload_speed_mbps(self) -> float:
+        """Get average upload speed in MB/s."""
+        if self.total_upload_time == 0 or self.total_bytes_uploaded == 0:
+            return 0.0
+        return (self.total_bytes_uploaded / (1024 * 1024)) / self.total_upload_time
+
+
+def _get_default_config() -> Dict[str, Any]:
+    """Get default configuration from environment variables."""
+    return {
+        "max_concurrent_uploads": int(os.environ.get("RAY_ASYNC_CHECKPOINT_MAX_CONCURRENT", "2")),
+        "max_pending_uploads": int(os.environ.get("RAY_ASYNC_CHECKPOINT_MAX_PENDING", "5")),
+        "retry_attempts": int(os.environ.get("RAY_ASYNC_CHECKPOINT_RETRY_ATTEMPTS", "3")),
+        "retry_delay": float(os.environ.get("RAY_ASYNC_CHECKPOINT_RETRY_DELAY", "1.0")),
+        "upload_timeout": float(os.environ.get("RAY_ASYNC_CHECKPOINT_UPLOAD_TIMEOUT", "300.0")),
+        "enable_compression": os.environ.get("RAY_ASYNC_CHECKPOINT_COMPRESS", "false").lower() == "true",
+    }
 
 
 @DeveloperAPI
@@ -55,26 +134,48 @@ class AsyncCheckpointWriter:
     should not block the training step.
     """
 
-    def __init__(self, max_concurrent_uploads: int = 2, max_pending_uploads: int = 5):
+    def __init__(
+        self, 
+        max_concurrent_uploads: Optional[int] = None,
+        max_pending_uploads: Optional[int] = None,
+        retry_attempts: Optional[int] = None,
+        retry_delay: Optional[float] = None,
+        upload_timeout: Optional[float] = None,
+        enable_compression: Optional[bool] = None,
+    ):
         """Initialize the async checkpoint writer.
         
         Args:
             max_concurrent_uploads: Maximum number of concurrent upload threads.
             max_pending_uploads: Maximum number of pending uploads before blocking.
+            retry_attempts: Number of retry attempts for failed uploads.
+            retry_delay: Base delay between retries (exponential backoff applied).
+            upload_timeout: Timeout in seconds for individual uploads.
+            enable_compression: Whether to compress checkpoints before upload.
         """
-        self._max_concurrent_uploads = max_concurrent_uploads
-        self._max_pending_uploads = max_pending_uploads
+        # Get defaults from environment variables
+        config = _get_default_config()
+        
+        self._max_concurrent_uploads = max_concurrent_uploads or config["max_concurrent_uploads"]
+        self._max_pending_uploads = max_pending_uploads or config["max_pending_uploads"] 
+        self._retry_attempts = retry_attempts or config["retry_attempts"]
+        self._retry_delay = retry_delay or config["retry_delay"]
+        self._upload_timeout = upload_timeout or config["upload_timeout"]
+        self._enable_compression = enable_compression or config["enable_compression"]
         self._executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=max_concurrent_uploads,
+            max_workers=self._max_concurrent_uploads,
             thread_name_prefix="async_checkpoint"
         )
         self._pending_tasks: queue.Queue[_AsyncCheckpointTask] = queue.Queue(
-            maxsize=max_pending_uploads
+            maxsize=self._max_pending_uploads
         )
         self._completed_tasks: queue.Queue[_AsyncCheckpointTask] = queue.Queue()
         self._failed_tasks: queue.Queue[Tuple[_AsyncCheckpointTask, Exception]] = queue.Queue()
         self._shutdown = False
         self._lock = threading.Lock()
+        
+        self._metrics = UploadMetrics()
+        self._metrics_lock = threading.Lock()
         
         # Start the task submission thread
         self._submission_thread = threading.Thread(
@@ -103,27 +204,65 @@ class AsyncCheckpointWriter:
         if self._shutdown:
             raise RuntimeError("AsyncCheckpointWriter has been shut down")
 
-        # Create checkpoint fs path (same logic as StorageContext)
         checkpoint_fs_path = storage_context.checkpoint_fs_path
         
+        checkpoint_size = self._calculate_checkpoint_size(checkpoint)
         task = _AsyncCheckpointTask(
             checkpoint=checkpoint,
             storage_context=storage_context,
             metrics=metrics,
             checkpoint_fs_path=checkpoint_fs_path,
-            submit_time=time.time()
+            submit_time=time.time(),
+            checkpoint_size_bytes=checkpoint_size,
         )
         
         try:
-            # Non-blocking put with timeout for backpressure
             self._pending_tasks.put(task, block=True, timeout=0.1)
             logger.debug(f"Queued async checkpoint upload to {checkpoint_fs_path}")
+            with self._metrics_lock:
+                self._metrics.total_uploads += 1
+                
         except queue.Full:
             raise _AsyncCheckpointError(
                 "Too many pending checkpoint uploads. Consider reducing checkpoint frequency "
                 "or increasing max_pending_uploads.",
                 queue.Full()
             )
+
+    def _calculate_checkpoint_size(self, checkpoint: Checkpoint) -> int:
+        """Calculate the total size of a checkpoint in bytes."""
+        try:
+            if hasattr(checkpoint.filesystem, 'get_file_info'):
+                # PyArrow filesystem
+                file_info = checkpoint.filesystem.get_file_info([checkpoint.path])
+                if file_info and len(file_info) > 0:
+                    info = file_info[0]
+                    if info.type.name == 'Directory':
+                        # Sum all files in directory
+                        total_size = 0
+                        for file_path in checkpoint.filesystem.get_file_info(
+                            checkpoint.filesystem.get_file_info(checkpoint.path, recursive=True)
+                        ):
+                            if hasattr(file_path, 'size') and file_path.size:
+                                total_size += file_path.size
+                        return total_size
+                    else:
+                        return info.size or 0
+            
+            # Fallback: use local filesystem if possible
+            if isinstance(checkpoint.filesystem, type(checkpoint.filesystem)) and hasattr(checkpoint.filesystem, 'type_name'):
+                if checkpoint.filesystem.type_name == 'local':
+                    path = Path(checkpoint.path)
+                    if path.is_file():
+                        return path.stat().st_size
+                    elif path.is_dir():
+                        return sum(f.stat().st_size for f in path.rglob('*') if f.is_file())
+            
+            return 0  # Unknown size
+            
+        except Exception as e:
+            logger.warning(f"Could not calculate checkpoint size: {e}")
+            return 0
 
     def _submission_worker(self):
         """Background thread that submits tasks to the thread pool executor."""
@@ -146,19 +285,108 @@ class AsyncCheckpointWriter:
                 logger.exception("Error in async checkpoint submission worker")
 
     def _upload_checkpoint_task(self, task: _AsyncCheckpointTask) -> Checkpoint:
-        """Upload a single checkpoint (runs in background thread)."""
+        """Upload a single checkpoint with retry logic and timeout."""
+        task.upload_start_time = time.time()
+        last_exception = None
+        
+        # Create progress tracker
+        progress = UploadProgress(
+            checkpoint_path=task.checkpoint_fs_path,
+            total_bytes=task.checkpoint_size_bytes,
+            start_time=task.upload_start_time,
+        )
+        
+        with self._metrics_lock:
+            self._metrics.active_uploads[task.checkpoint_fs_path] = progress
+        
         try:
-            # Validate storage path access (same as sync version)
-            task.storage_context._check_validation_file()
-            
-            # Create destination directory
-            task.storage_context.storage_filesystem.create_dir(task.checkpoint_fs_path)
-            
-            # Copy files to storage
-            logger.debug(
-                f"Starting async upload: {task.checkpoint.path} -> {task.checkpoint_fs_path}"
-            )
-            
+            for attempt in range(self._retry_attempts):
+                try:
+                    task.retry_count = attempt
+                    
+                    # Validate storage path access (same as sync version)
+                    task.storage_context._check_validation_file()
+                    
+                    # Create destination directory
+                    task.storage_context.storage_filesystem.create_dir(task.checkpoint_fs_path)
+                    
+                    # Copy files to storage with timeout
+                    logger.debug(
+                        f"Starting async upload attempt {attempt + 1}/{self._retry_attempts}: "
+                        f"{task.checkpoint.path} -> {task.checkpoint_fs_path}"
+                    )
+                    
+                    upload_future = self._executor.submit(
+                        self._copy_files_with_progress,
+                        task,
+                        progress
+                    )
+                    
+                    # Wait for upload with timeout
+                    try:
+                        upload_future.result(timeout=self._upload_timeout)
+                    except concurrent.futures.TimeoutError:
+                        upload_future.cancel()
+                        raise TimeoutError(f"Upload timed out after {self._upload_timeout} seconds")
+                    
+                    # Create persisted checkpoint object
+                    persisted_checkpoint = task.checkpoint.__class__(
+                        filesystem=task.storage_context.storage_filesystem,
+                        path=task.checkpoint_fs_path,
+                    )
+                    
+                    # Write atomic manifest (LATEST.json)
+                    self._write_latest_manifest(task.storage_context, task.metrics, persisted_checkpoint)
+                    
+                    # Update metrics on success
+                    upload_time = time.time() - task.upload_start_time
+                    with self._metrics_lock:
+                        self._metrics.successful_uploads += 1
+                        self._metrics.total_bytes_uploaded += task.checkpoint_size_bytes
+                        self._metrics.total_upload_time += upload_time
+                        if task.checkpoint_fs_path in self._metrics.active_uploads:
+                            del self._metrics.active_uploads[task.checkpoint_fs_path]
+                    
+                    logger.info(
+                        f"Async checkpoint upload completed in {upload_time:.2f}s: {persisted_checkpoint}"
+                    )
+                    return persisted_checkpoint
+                    
+                except Exception as e:
+                    last_exception = e
+                    error_type = type(e).__name__
+                    
+                    with self._metrics_lock:
+                        self._metrics.error_counts[error_type] += 1
+                    
+                    if attempt < self._retry_attempts - 1:
+                        wait_time = self._retry_delay * (2 ** attempt)  # Exponential backoff
+                        logger.warning(
+                            f"Upload attempt {attempt + 1} failed, retrying in {wait_time}s: {e}"
+                        )
+                        time.sleep(wait_time)
+                    else:
+                        logger.error(
+                            f"Upload failed after {self._retry_attempts} attempts: {e}"
+                        )
+                        
+            # If we get here, all retries failed
+            with self._metrics_lock:
+                self._metrics.failed_uploads += 1
+                if task.checkpoint_fs_path in self._metrics.active_uploads:
+                    del self._metrics.active_uploads[task.checkpoint_fs_path]
+                    
+            raise last_exception or RuntimeError("Upload failed for unknown reason")
+                
+        finally:
+            # Always clean up active uploads tracking
+            with self._metrics_lock:
+                if task.checkpoint_fs_path in self._metrics.active_uploads:
+                    del self._metrics.active_uploads[task.checkpoint_fs_path]
+
+    def _copy_files_with_progress(self, task: _AsyncCheckpointTask, progress: UploadProgress):
+        """Copy files with progress tracking."""
+        try:
             _pyarrow_fs_copy_files(
                 source=task.checkpoint.path,
                 destination=task.checkpoint_fs_path,
@@ -166,20 +394,11 @@ class AsyncCheckpointWriter:
                 destination_filesystem=task.storage_context.storage_filesystem,
             )
             
-            # Create persisted checkpoint object
-            persisted_checkpoint = task.checkpoint.__class__(
-                filesystem=task.storage_context.storage_filesystem,
-                path=task.checkpoint_fs_path,
-            )
-            
-            # Write atomic manifest (LATEST.json)
-            self._write_latest_manifest(task.storage_context, task.metrics, persisted_checkpoint)
-            
-            logger.info(f"Async checkpoint upload completed: {persisted_checkpoint}")
-            return persisted_checkpoint
+            # Update progress to 100% on completion
+            progress.bytes_uploaded = progress.total_bytes
             
         except Exception as e:
-            logger.error(f"Async checkpoint upload failed: {e}")
+            logger.error(f"File copy failed: {e}")
             raise
 
     def _write_latest_manifest(
@@ -243,12 +462,61 @@ class AsyncCheckpointWriter:
             pass
 
     def get_stats(self) -> Dict[str, int]:
-        """Get statistics about async checkpoint operations."""
+        """Get basic statistics about async checkpoint operations."""
         return {
             "pending_uploads": self._pending_tasks.qsize(),
             "completed_uploads": self._completed_tasks.qsize(),
             "failed_uploads": self._failed_tasks.qsize(),
         }
+
+    def get_upload_metrics(self) -> UploadMetrics:
+        """Get detailed upload metrics and progress information."""
+        with self._metrics_lock:
+            # Create a copy of metrics to avoid race conditions
+            metrics_copy = UploadMetrics(
+                total_uploads=self._metrics.total_uploads,
+                successful_uploads=self._metrics.successful_uploads,
+                failed_uploads=self._metrics.failed_uploads,
+                total_bytes_uploaded=self._metrics.total_bytes_uploaded,
+                total_upload_time=self._metrics.total_upload_time,
+                error_counts=dict(self._metrics.error_counts),
+                active_uploads=dict(self._metrics.active_uploads),
+            )
+        return metrics_copy
+
+    def get_active_uploads(self) -> Dict[str, UploadProgress]:
+        """Get progress information for currently active uploads."""
+        with self._metrics_lock:
+            return dict(self._metrics.active_uploads)
+
+    def print_upload_status(self) -> None:
+        """Print a human-readable status of all uploads."""
+        metrics = self.get_upload_metrics()
+        active_uploads = self.get_active_uploads()
+        
+        print(f"\n=== Async Checkpoint Upload Status ===")
+        print(f"Total uploads: {metrics.total_uploads}")
+        print(f"Successful: {metrics.successful_uploads} ({metrics.success_rate:.1f}%)")
+        print(f"Failed: {metrics.failed_uploads}")
+        print(f"Active uploads: {len(active_uploads)}")
+        print(f"Pending uploads: {self._pending_tasks.qsize()}")
+        
+        if metrics.successful_uploads > 0:
+            print(f"Average upload time: {metrics.average_upload_time:.2f}s")
+            print(f"Average upload speed: {metrics.average_upload_speed_mbps:.2f} MB/s")
+            print(f"Total data uploaded: {metrics.total_bytes_uploaded / (1024*1024):.1f} MB")
+        
+        if active_uploads:
+            print(f"\nActive uploads:")
+            for path, progress in active_uploads.items():
+                print(f"  {Path(path).name}: {progress.progress_percent:.1f}% "
+                      f"({progress.upload_speed_mbps:.2f} MB/s)")
+        
+        if metrics.error_counts:
+            print(f"\nError summary:")
+            for error_type, count in metrics.error_counts.items():
+                print(f"  {error_type}: {count}")
+        print("=" * 40)
 
     def shutdown(self, timeout: float = 30.0):
         """Gracefully shutdown the async checkpoint writer.
@@ -290,6 +558,27 @@ def _get_async_checkpoint_writer() -> AsyncCheckpointWriter:
     if _async_checkpoint_writer is None:
         _async_checkpoint_writer = AsyncCheckpointWriter()
     return _async_checkpoint_writer
+
+
+def get_async_checkpoint_metrics() -> Optional[UploadMetrics]:
+    """Get detailed metrics about async checkpoint operations.
+    
+    Returns:
+        UploadMetrics object with detailed statistics, or None if no writer exists.
+    """
+    global _async_checkpoint_writer
+    if _async_checkpoint_writer is not None:
+        return _async_checkpoint_writer.get_upload_metrics()
+    return None
+
+
+def print_async_checkpoint_status() -> None:
+    """Print human-readable status of async checkpoint operations."""
+    global _async_checkpoint_writer
+    if _async_checkpoint_writer is not None:
+        _async_checkpoint_writer.print_upload_status()
+    else:
+        print("No async checkpoint writer active.")
 
 
 def _shutdown_async_checkpoint_writer():

--- a/python/ray/train/examples/async_checkpoint_example.py
+++ b/python/ray/train/examples/async_checkpoint_example.py
@@ -1,0 +1,158 @@
+"""Example demonstrating async checkpoint functionality for training.
+
+This example shows how to use async_report for non-blocking checkpoint uploads,
+particularly useful for training that checkpoints asynchronously.
+"""
+
+import tempfile
+import time
+import torch
+import torch.nn as nn
+from pathlib import Path
+
+from ray import train
+from ray.train import Checkpoint
+from ray.train.torch import TorchTrainer
+
+
+class SimpleModel(nn.Module):
+    """Simple model for demonstration."""
+    
+    def __init__(self, input_size=10, hidden_size=20, output_size=1):
+        super().__init__()
+        self.network = nn.Sequential(
+            nn.Linear(input_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, output_size)
+        )
+    
+    def forward(self, x):
+        return self.network(x)
+
+
+def train_func(config):
+    """Training function demonstrating async checkpointing."""
+    print("Starting training with async checkpointing...")
+    
+    model = SimpleModel()
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.get("lr", 0.001))
+    
+    num_episodes = config.get("num_episodes", 50)
+    checkpoint_freq = config.get("checkpoint_freq", 5)
+    
+    for episode in range(num_episodes):
+        start_time = time.time()
+        # dummy fwd/bwd pass
+        x = torch.randn(32, 10)
+        y_pred = model(x)
+        loss = torch.mean(y_pred ** 2) 
+        
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        
+        step_time = time.time() - start_time
+        
+        metrics = {
+            "episode": episode,
+            "loss": loss.item(),
+            "step_time": step_time,
+            "lr": optimizer.param_groups[0]["lr"],
+        }
+        
+        if episode % checkpoint_freq == 0:
+            print(f"Episode {episode}: Creating checkpoint...")
+            
+            checkpoint_start = time.time()
+            
+            with tempfile.TemporaryDirectory() as temp_checkpoint_dir:
+                # Save model and optimizer state
+                model_path = Path(temp_checkpoint_dir) / "model.pt"
+                optimizer_path = Path(temp_checkpoint_dir) / "optimizer.pt"
+                config_path = Path(temp_checkpoint_dir) / "config.json"
+                
+                torch.save(model.state_dict(), model_path)
+                torch.save(optimizer.state_dict(), optimizer_path)
+                
+                # Save training config
+                import json
+                with open(config_path, "w") as f:
+                    json.dump({
+                        "episode": episode,
+                        "lr": config.get("lr", 0.001),
+                        "model_config": {
+                            "input_size": 10,
+                            "hidden_size": 20,
+                            "output_size": 1,
+                        }
+                    }, f)
+                
+                checkpoint = Checkpoint.from_directory(temp_checkpoint_dir)
+                
+                train.async_report(metrics, checkpoint=checkpoint)
+                
+                checkpoint_time = time.time() - checkpoint_start
+                print(f"Episode {episode}: Checkpoint created in {checkpoint_time:.3f}s (non-blocking)")
+        else:
+            train.async_report(metrics)
+        
+        if episode % 10 == 0 and episode > 0:
+            print(f"Episode {episode}: Checking for async upload errors...")
+            train.async_report({}, flush=True)
+        
+        time.sleep(0.01)
+    
+    print("Training complete! Checking for any remaining upload errors...")
+    train.async_report({}, flush=True)
+    print("All async uploads completed successfully!")
+
+
+def main():
+    """Run the example."""
+    import tempfile
+    
+    with tempfile.TemporaryDirectory() as temp_storage:
+        storage_path = Path(temp_storage) / "checkpoints"
+        storage_path.mkdir()
+        
+        print(f"Using storage path: {storage_path}")
+        
+        trainer = TorchTrainer(
+            train_func,
+            train_loop_config={
+                "lr": 0.001,
+                "num_episodes": 30,
+                "checkpoint_freq": 3,
+            },
+            scaling_config=train.ScalingConfig(num_workers=1),
+            run_config=train.RunConfig(
+                name="async_checkpoint_example",
+                storage_path=str(storage_path),
+            ),
+        )
+        
+        print("Starting trainer...")
+        result = trainer.fit()
+        
+        print(f"\nTraining completed!")
+        print(f"Final metrics: {result.metrics}")
+        
+        checkpoint_dirs = list(storage_path.glob("**/checkpoint_*"))
+        print(f"\nCheckpoints created: {len(checkpoint_dirs)}")
+        for checkpoint_dir in checkpoint_dirs:
+            files = list(checkpoint_dir.rglob("*"))
+            print(f"  {checkpoint_dir.name}: {len(files)} files")
+        
+        latest_files = list(storage_path.rglob("LATEST.json"))
+        if latest_files:
+            print(f"\nFound LATEST.json manifest files: {len(latest_files)}")
+            for latest_file in latest_files:
+                print(f"  {latest_file}")
+                with open(latest_file) as f:
+                    import json
+                    manifest = json.load(f)
+                    print(f"    Last checkpoint metrics: {manifest.get('metrics', {})}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/ray/train/examples/async_checkpoint_example.py
+++ b/python/ray/train/examples/async_checkpoint_example.py
@@ -17,15 +17,15 @@ from ray.train.torch import TorchTrainer
 
 class SimpleModel(nn.Module):
     """Simple model for demonstration."""
-    
+
     def __init__(self, input_size=10, hidden_size=20, output_size=1):
         super().__init__()
         self.network = nn.Sequential(
             nn.Linear(input_size, hidden_size),
             nn.ReLU(),
-            nn.Linear(hidden_size, output_size)
+            nn.Linear(hidden_size, output_size),
         )
-    
+
     def forward(self, x):
         return self.network(x)
 
@@ -33,78 +33,84 @@ class SimpleModel(nn.Module):
 def train_func(config):
     """Training function demonstrating async checkpointing."""
     print("Starting training with async checkpointing...")
-    
+
     model = SimpleModel()
     optimizer = torch.optim.Adam(model.parameters(), lr=config.get("lr", 0.001))
-    
+
     num_episodes = config.get("num_episodes", 50)
     checkpoint_freq = config.get("checkpoint_freq", 5)
-    
+
     for episode in range(num_episodes):
         start_time = time.time()
         # dummy fwd/bwd pass
         x = torch.randn(32, 10)
         y_pred = model(x)
-        loss = torch.mean(y_pred ** 2) 
-        
+        loss = torch.mean(y_pred**2)
+
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
-        
+
         step_time = time.time() - start_time
-        
+
         metrics = {
             "episode": episode,
             "loss": loss.item(),
             "step_time": step_time,
             "lr": optimizer.param_groups[0]["lr"],
         }
-        
+
         if episode % checkpoint_freq == 0:
             print(f"Episode {episode}: Creating checkpoint...")
-            
+
             checkpoint_start = time.time()
-            
+
             with tempfile.TemporaryDirectory() as temp_checkpoint_dir:
                 # Save model and optimizer state
                 model_path = Path(temp_checkpoint_dir) / "model.pt"
                 optimizer_path = Path(temp_checkpoint_dir) / "optimizer.pt"
                 config_path = Path(temp_checkpoint_dir) / "config.json"
-                
+
                 torch.save(model.state_dict(), model_path)
                 torch.save(optimizer.state_dict(), optimizer_path)
-                
+
                 # Save training config
                 import json
+
                 with open(config_path, "w") as f:
-                    json.dump({
-                        "episode": episode,
-                        "lr": config.get("lr", 0.001),
-                        "model_config": {
-                            "input_size": 10,
-                            "hidden_size": 20,
-                            "output_size": 1,
-                        }
-                    }, f)
-                
+                    json.dump(
+                        {
+                            "episode": episode,
+                            "lr": config.get("lr", 0.001),
+                            "model_config": {
+                                "input_size": 10,
+                                "hidden_size": 20,
+                                "output_size": 1,
+                            },
+                        },
+                        f,
+                    )
+
                 checkpoint = Checkpoint.from_directory(temp_checkpoint_dir)
-                
+
                 train.async_report(metrics, checkpoint=checkpoint)
-                
+
                 checkpoint_time = time.time() - checkpoint_start
-                print(f"Episode {episode}: Checkpoint created in {checkpoint_time:.3f}s (non-blocking)")
+                print(
+                    f"Episode {episode}: Checkpoint created in {checkpoint_time:.3f}s (non-blocking)"
+                )
         else:
             train.async_report(metrics)
-        
+
         if episode % 10 == 0 and episode > 0:
             print(f"Episode {episode}: Checking for async upload errors...")
             train.async_report({}, flush=True)
-            
-            # Print upload status  
+
+            # Print upload status
             train.print_async_checkpoint_status()
-        
+
         time.sleep(0.01)
-    
+
     print("Training complete! Checking for any remaining upload errors...")
     train.async_report({}, flush=True)
     print("All async uploads completed successfully!")
@@ -113,13 +119,13 @@ def train_func(config):
 def main():
     """Run the example."""
     import tempfile
-    
+
     with tempfile.TemporaryDirectory() as temp_storage:
         storage_path = Path(temp_storage) / "checkpoints"
         storage_path.mkdir()
-        
+
         print(f"Using storage path: {storage_path}")
-        
+
         trainer = TorchTrainer(
             train_func,
             train_loop_config={
@@ -133,19 +139,19 @@ def main():
                 storage_path=str(storage_path),
             ),
         )
-        
+
         print("Starting trainer...")
         result = trainer.fit()
-        
+
         print(f"\nTraining completed!")
         print(f"Final metrics: {result.metrics}")
-        
+
         checkpoint_dirs = list(storage_path.glob("**/checkpoint_*"))
         print(f"\nCheckpoints created: {len(checkpoint_dirs)}")
         for checkpoint_dir in checkpoint_dirs:
             files = list(checkpoint_dir.rglob("*"))
             print(f"  {checkpoint_dir.name}: {len(files)} files")
-        
+
         latest_files = list(storage_path.rglob("LATEST.json"))
         if latest_files:
             print(f"\nFound LATEST.json manifest files: {len(latest_files)}")
@@ -153,6 +159,7 @@ def main():
                 print(f"  {latest_file}")
                 with open(latest_file) as f:
                     import json
+
                     manifest = json.load(f)
                     print(f"    Last checkpoint metrics: {manifest.get('metrics', {})}")
 

--- a/python/ray/train/examples/async_checkpoint_example.py
+++ b/python/ray/train/examples/async_checkpoint_example.py
@@ -99,6 +99,9 @@ def train_func(config):
         if episode % 10 == 0 and episode > 0:
             print(f"Episode {episode}: Checking for async upload errors...")
             train.async_report({}, flush=True)
+            
+            # Print upload status  
+            train.print_async_checkpoint_status()
         
         time.sleep(0.01)
     

--- a/python/ray/train/tests/test_async_checkpoint.py
+++ b/python/ray/train/tests/test_async_checkpoint.py
@@ -35,13 +35,16 @@ class TestAsyncCheckpointWriter:
         """Cleanup after each test."""
         _shutdown_async_checkpoint_writer()
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def _create_mock_storage_context(self) -> StorageContext:
         """Create a mock storage context for testing."""
         storage_context = Mock(spec=StorageContext)
         storage_context.storage_filesystem = self.local_fs
-        storage_context.checkpoint_fs_path = Path(self.storage_path, "checkpoint_000001").as_posix()
+        storage_context.checkpoint_fs_path = Path(
+            self.storage_path, "checkpoint_000001"
+        ).as_posix()
         storage_context.experiment_fs_path = self.storage_path
         storage_context._check_validation_file = Mock()
         storage_context.storage_filesystem.create_dir = Mock()
@@ -50,77 +53,77 @@ class TestAsyncCheckpointWriter:
     def test_async_checkpoint_writer_initialization(self):
         """Test AsyncCheckpointWriter initialization."""
         writer = AsyncCheckpointWriter(max_concurrent_uploads=3, max_pending_uploads=10)
-        
+
         assert writer._max_concurrent_uploads == 3
         assert writer._max_pending_uploads == 10
         assert not writer._shutdown
         assert writer._submission_thread.is_alive()
-        
+
         writer.shutdown()
 
     def test_async_persist_checkpoint_success(self):
         """Test successful async checkpoint persistence."""
         writer = AsyncCheckpointWriter()
         storage_context = self._create_mock_storage_context()
-        
+
         # Create a test checkpoint
         checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
         os.makedirs(checkpoint_dir)
         Path(checkpoint_dir, "model.pt").write_text("fake model data")
-        
+
         checkpoint = Checkpoint.from_directory(checkpoint_dir)
         metrics = {"loss": 0.5, "accuracy": 0.8}
-        
+
         # Should not raise
         writer.async_persist_checkpoint(checkpoint, storage_context, metrics)
-        
+
         # Wait a bit for task to be processed
         time.sleep(0.1)
-        
+
         stats = writer.get_stats()
         assert stats["pending_uploads"] >= 0
-        
+
         writer.shutdown(timeout=5.0)
 
     def test_backpressure_control(self):
         """Test backpressure when queue is full."""
         writer = AsyncCheckpointWriter(max_concurrent_uploads=1, max_pending_uploads=1)
         storage_context = self._create_mock_storage_context()
-        
+
         # Create test checkpoint
         checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
         os.makedirs(checkpoint_dir)
         Path(checkpoint_dir, "model.pt").write_text("fake model data")
         checkpoint = Checkpoint.from_directory(checkpoint_dir)
-        
+
         # Fill the queue
         writer.async_persist_checkpoint(checkpoint, storage_context, {"step": 1})
-        
+
         # This should raise due to backpressure
         with pytest.raises(_AsyncCheckpointError):
             writer.async_persist_checkpoint(checkpoint, storage_context, {"step": 2})
-        
+
         writer.shutdown()
 
     def test_shutdown_waits_for_pending_uploads(self):
         """Test that shutdown waits for pending uploads."""
         writer = AsyncCheckpointWriter()
-        
+
         # Mock a slow upload
-        with patch.object(writer, '_upload_checkpoint_task') as mock_upload:
+        with patch.object(writer, "_upload_checkpoint_task") as mock_upload:
             mock_upload.side_effect = lambda task: time.sleep(0.5)
-            
+
             storage_context = self._create_mock_storage_context()
             checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
             os.makedirs(checkpoint_dir)
             checkpoint = Checkpoint.from_directory(checkpoint_dir)
-            
+
             writer.async_persist_checkpoint(checkpoint, storage_context, {})
-            
+
             start_time = time.time()
             writer.shutdown(timeout=2.0)
             elapsed = time.time() - start_time
-            
+
             # Should have waited for the upload
             assert elapsed >= 0.4
 
@@ -128,29 +131,29 @@ class TestAsyncCheckpointWriter:
         """Test LATEST.json manifest writing."""
         writer = AsyncCheckpointWriter()
         storage_context = self._create_mock_storage_context()
-        
+
         # Setup real filesystem for manifest test
         os.makedirs(self.storage_path, exist_ok=True)
         storage_context.storage_filesystem = pyarrow.fs.LocalFileSystem()
-        
+
         checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
         os.makedirs(checkpoint_dir)
         checkpoint = Checkpoint.from_directory(checkpoint_dir)
         metrics = {"step": 100, "loss": 0.1}
-        
+
         writer._write_latest_manifest(storage_context, metrics, checkpoint)
-        
+
         # Check manifest was written
         manifest_path = Path(self.storage_path, "LATEST.json")
         assert manifest_path.exists()
-        
+
         with open(manifest_path) as f:
             manifest_data = json.load(f)
-        
+
         assert manifest_data["metrics"] == metrics
         assert manifest_data["upload_completed"] is True
         assert "timestamp" in manifest_data
-        
+
         writer.shutdown()
 
 
@@ -161,11 +164,13 @@ class TestAsyncReportIntegration:
         """Setup Ray Train session for testing."""
         self.temp_dir = tempfile.mkdtemp()
         self.storage_path = Path(self.temp_dir, "storage").as_posix()
-        
+
         # Mock storage context
         storage_context = Mock(spec=StorageContext)
         storage_context.storage_filesystem = pyarrow.fs.LocalFileSystem()
-        storage_context.checkpoint_fs_path = Path(self.storage_path, "checkpoint_000001").as_posix()
+        storage_context.checkpoint_fs_path = Path(
+            self.storage_path, "checkpoint_000001"
+        ).as_posix()
         storage_context.experiment_fs_path = self.storage_path
         storage_context.checkpoint_dir_name = "checkpoint_000001"
         storage_context._check_validation_file = Mock()
@@ -173,7 +178,7 @@ class TestAsyncReportIntegration:
         storage_context.persist_artifacts = Mock()
         storage_context.sync_config = Mock()
         storage_context.sync_config.sync_artifacts_on_checkpoint = False
-        
+
         # Initialize session
         init_session(
             training_func=lambda: None,
@@ -191,12 +196,13 @@ class TestAsyncReportIntegration:
         shutdown_session()
         _shutdown_async_checkpoint_writer()
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_async_report_without_checkpoint(self):
         """Test async_report with only metrics."""
         metrics = {"loss": 0.5, "accuracy": 0.8}
-        
+
         # Should not raise
         async_report(metrics)
 
@@ -207,14 +213,14 @@ class TestAsyncReportIntegration:
         os.makedirs(checkpoint_dir)
         Path(checkpoint_dir, "model.pt").write_text("fake model data")
         checkpoint = Checkpoint.from_directory(checkpoint_dir)
-        
+
         metrics = {"loss": 0.5, "step": 10}
-        
+
         # Should not raise and should return immediately
         start_time = time.time()
         async_report(metrics, checkpoint=checkpoint)
         elapsed = time.time() - start_time
-        
+
         # Should be much faster than a real upload
         assert elapsed < 0.1
 
@@ -227,25 +233,29 @@ class TestAsyncReportIntegration:
     def test_async_report_fallback_on_backpressure(self):
         """Test fallback to sync when async queue is full."""
         # Create a writer with very small queue
-        with patch('ray.train._internal.session._get_async_checkpoint_writer') as mock_get_writer:
+        with patch(
+            "ray.train._internal.session._get_async_checkpoint_writer"
+        ) as mock_get_writer:
             mock_writer = Mock()
             mock_writer.async_persist_checkpoint.side_effect = _AsyncCheckpointError(
                 "Queue full", Exception()
             )
             mock_get_writer.return_value = mock_writer
-            
+
             checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
             os.makedirs(checkpoint_dir)
             checkpoint = Checkpoint.from_directory(checkpoint_dir)
-            
+
             # Should fall back to sync upload without raising
             async_report({"step": 1}, checkpoint=checkpoint)
 
     def test_torch_tensor_validation(self):
         """Test that torch tensors in metrics are rejected."""
         # Mock torch being imported
-        with patch.dict('sys.modules', {'torch': Mock()}):
-            with patch('ray.air._internal.torch_utils.contains_tensor', return_value=True):
+        with patch.dict("sys.modules", {"torch": Mock()}):
+            with patch(
+                "ray.air._internal.torch_utils.contains_tensor", return_value=True
+            ):
                 with pytest.raises(ValueError, match="Torch tensors"):
                     async_report({"tensor": "fake_tensor"})
 
@@ -263,14 +273,16 @@ class TestAsyncCheckpointEndToEnd:
         """Cleanup after each test."""
         _shutdown_async_checkpoint_writer()
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_end_to_end_upload_with_manifest(self):
         """Test complete upload flow with manifest writing."""
         writer = AsyncCheckpointWriter()
-        
+
         # Create real storage context
         from ray.train._internal.storage import StorageContext
+
         storage_context = StorageContext(
             storage_path=self.storage_path,
             experiment_dir_name="test_experiment",
@@ -278,41 +290,41 @@ class TestAsyncCheckpointEndToEnd:
             storage_filesystem=pyarrow.fs.LocalFileSystem(),
             sync_config=Mock(),
         )
-        
+
         # Create real checkpoint
         checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
         os.makedirs(checkpoint_dir)
-        
+
         # Write some files to checkpoint
         Path(checkpoint_dir, "model.pt").write_text("model weights")
         Path(checkpoint_dir, "optimizer.pt").write_text("optimizer state")
         subdir = Path(checkpoint_dir, "subdir")
         subdir.mkdir()
         Path(subdir, "config.json").write_text('{"lr": 0.001}')
-        
+
         checkpoint = Checkpoint.from_directory(checkpoint_dir)
         metrics = {"epoch": 5, "loss": 0.1, "accuracy": 0.95}
-        
+
         # Persist async
         writer.async_persist_checkpoint(checkpoint, storage_context, metrics)
-        
+
         # Wait for completion
         writer.shutdown(timeout=10.0)
-        
+
         # Verify files were uploaded
         uploaded_checkpoint = Path(storage_context.checkpoint_fs_path)
         assert uploaded_checkpoint.exists()
         assert (uploaded_checkpoint / "model.pt").exists()
         assert (uploaded_checkpoint / "optimizer.pt").exists()
         assert (uploaded_checkpoint / "subdir" / "config.json").exists()
-        
+
         # Verify manifest
         manifest_path = Path(storage_context.experiment_fs_path, "LATEST.json")
         assert manifest_path.exists()
-        
+
         with open(manifest_path) as f:
             manifest_data = json.load(f)
-        
+
         assert manifest_data["metrics"] == metrics
         assert manifest_data["upload_completed"] is True
 
@@ -323,32 +335,32 @@ class TestErrorHandling:
     def test_upload_failure_reporting(self):
         """Test that upload failures are properly reported."""
         writer = AsyncCheckpointWriter()
-        
+
         # Mock failing upload
-        with patch.object(writer, '_upload_checkpoint_task') as mock_upload:
+        with patch.object(writer, "_upload_checkpoint_task") as mock_upload:
             mock_upload.side_effect = Exception("Upload failed")
-            
+
             storage_context = Mock()
             checkpoint = Mock()
-            
+
             writer.async_persist_checkpoint(checkpoint, storage_context, {})
-            
+
             # Wait for failure
             time.sleep(0.2)
-            
+
             # Should have failed task in queue
             with pytest.raises(_AsyncCheckpointError):
                 writer.check_and_raise_errors()
-        
+
         writer.shutdown()
 
     def test_shutdown_during_uploads(self):
         """Test shutdown behavior when uploads are in progress."""
         writer = AsyncCheckpointWriter()
-        
+
         # Start shutdown immediately
         writer.shutdown(timeout=1.0)
-        
+
         # Should be shutdown
         assert writer._shutdown
 

--- a/python/ray/train/tests/test_async_checkpoint.py
+++ b/python/ray/train/tests/test_async_checkpoint.py
@@ -1,24 +1,21 @@
 """Tests for async checkpoint functionality in Ray Train."""
 
-import json
 import os
 import tempfile
 import time
-import pytest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pyarrow.fs
+import pytest
 
 from ray.train import Checkpoint, async_report
 from ray.train._internal.async_checkpoint import (
     AsyncCheckpointWriter,
     _AsyncCheckpointError,
-    _AsyncCheckpointTask,
-    _get_async_checkpoint_writer,
     _shutdown_async_checkpoint_writer,
 )
-from ray.train._internal.session import _TrainSession, init_session, shutdown_session
+from ray.train._internal.session import init_session, shutdown_session
 from ray.train._internal.storage import StorageContext
 
 

--- a/python/ray/train/tests/test_async_checkpoint.py
+++ b/python/ray/train/tests/test_async_checkpoint.py
@@ -1,0 +1,357 @@
+"""Tests for async checkpoint functionality in Ray Train."""
+
+import json
+import os
+import tempfile
+import time
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pyarrow.fs
+
+from ray.train import Checkpoint, async_report
+from ray.train._internal.async_checkpoint import (
+    AsyncCheckpointWriter,
+    _AsyncCheckpointError,
+    _AsyncCheckpointTask,
+    _get_async_checkpoint_writer,
+    _shutdown_async_checkpoint_writer,
+)
+from ray.train._internal.session import _TrainSession, init_session, shutdown_session
+from ray.train._internal.storage import StorageContext
+
+
+class TestAsyncCheckpointWriter:
+    """Unit tests for AsyncCheckpointWriter."""
+
+    def setup_method(self):
+        """Setup for each test."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage_path = Path(self.temp_dir, "storage").as_posix()
+        self.local_fs = pyarrow.fs.LocalFileSystem()
+
+    def teardown_method(self):
+        """Cleanup after each test."""
+        _shutdown_async_checkpoint_writer()
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _create_mock_storage_context(self) -> StorageContext:
+        """Create a mock storage context for testing."""
+        storage_context = Mock(spec=StorageContext)
+        storage_context.storage_filesystem = self.local_fs
+        storage_context.checkpoint_fs_path = Path(self.storage_path, "checkpoint_000001").as_posix()
+        storage_context.experiment_fs_path = self.storage_path
+        storage_context._check_validation_file = Mock()
+        storage_context.storage_filesystem.create_dir = Mock()
+        return storage_context
+
+    def test_async_checkpoint_writer_initialization(self):
+        """Test AsyncCheckpointWriter initialization."""
+        writer = AsyncCheckpointWriter(max_concurrent_uploads=3, max_pending_uploads=10)
+        
+        assert writer._max_concurrent_uploads == 3
+        assert writer._max_pending_uploads == 10
+        assert not writer._shutdown
+        assert writer._submission_thread.is_alive()
+        
+        writer.shutdown()
+
+    def test_async_persist_checkpoint_success(self):
+        """Test successful async checkpoint persistence."""
+        writer = AsyncCheckpointWriter()
+        storage_context = self._create_mock_storage_context()
+        
+        # Create a test checkpoint
+        checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
+        os.makedirs(checkpoint_dir)
+        Path(checkpoint_dir, "model.pt").write_text("fake model data")
+        
+        checkpoint = Checkpoint.from_directory(checkpoint_dir)
+        metrics = {"loss": 0.5, "accuracy": 0.8}
+        
+        # Should not raise
+        writer.async_persist_checkpoint(checkpoint, storage_context, metrics)
+        
+        # Wait a bit for task to be processed
+        time.sleep(0.1)
+        
+        stats = writer.get_stats()
+        assert stats["pending_uploads"] >= 0
+        
+        writer.shutdown(timeout=5.0)
+
+    def test_backpressure_control(self):
+        """Test backpressure when queue is full."""
+        writer = AsyncCheckpointWriter(max_concurrent_uploads=1, max_pending_uploads=1)
+        storage_context = self._create_mock_storage_context()
+        
+        # Create test checkpoint
+        checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
+        os.makedirs(checkpoint_dir)
+        Path(checkpoint_dir, "model.pt").write_text("fake model data")
+        checkpoint = Checkpoint.from_directory(checkpoint_dir)
+        
+        # Fill the queue
+        writer.async_persist_checkpoint(checkpoint, storage_context, {"step": 1})
+        
+        # This should raise due to backpressure
+        with pytest.raises(_AsyncCheckpointError):
+            writer.async_persist_checkpoint(checkpoint, storage_context, {"step": 2})
+        
+        writer.shutdown()
+
+    def test_shutdown_waits_for_pending_uploads(self):
+        """Test that shutdown waits for pending uploads."""
+        writer = AsyncCheckpointWriter()
+        
+        # Mock a slow upload
+        with patch.object(writer, '_upload_checkpoint_task') as mock_upload:
+            mock_upload.side_effect = lambda task: time.sleep(0.5)
+            
+            storage_context = self._create_mock_storage_context()
+            checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
+            os.makedirs(checkpoint_dir)
+            checkpoint = Checkpoint.from_directory(checkpoint_dir)
+            
+            writer.async_persist_checkpoint(checkpoint, storage_context, {})
+            
+            start_time = time.time()
+            writer.shutdown(timeout=2.0)
+            elapsed = time.time() - start_time
+            
+            # Should have waited for the upload
+            assert elapsed >= 0.4
+
+    def test_latest_manifest_writing(self):
+        """Test LATEST.json manifest writing."""
+        writer = AsyncCheckpointWriter()
+        storage_context = self._create_mock_storage_context()
+        
+        # Setup real filesystem for manifest test
+        os.makedirs(self.storage_path, exist_ok=True)
+        storage_context.storage_filesystem = pyarrow.fs.LocalFileSystem()
+        
+        checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
+        os.makedirs(checkpoint_dir)
+        checkpoint = Checkpoint.from_directory(checkpoint_dir)
+        metrics = {"step": 100, "loss": 0.1}
+        
+        writer._write_latest_manifest(storage_context, metrics, checkpoint)
+        
+        # Check manifest was written
+        manifest_path = Path(self.storage_path, "LATEST.json")
+        assert manifest_path.exists()
+        
+        with open(manifest_path) as f:
+            manifest_data = json.load(f)
+        
+        assert manifest_data["metrics"] == metrics
+        assert manifest_data["upload_completed"] is True
+        assert "timestamp" in manifest_data
+        
+        writer.shutdown()
+
+
+class TestAsyncReportIntegration:
+    """Integration tests for async_report function."""
+
+    def setup_method(self):
+        """Setup Ray Train session for testing."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage_path = Path(self.temp_dir, "storage").as_posix()
+        
+        # Mock storage context
+        storage_context = Mock(spec=StorageContext)
+        storage_context.storage_filesystem = pyarrow.fs.LocalFileSystem()
+        storage_context.checkpoint_fs_path = Path(self.storage_path, "checkpoint_000001").as_posix()
+        storage_context.experiment_fs_path = self.storage_path
+        storage_context.checkpoint_dir_name = "checkpoint_000001"
+        storage_context._check_validation_file = Mock()
+        storage_context._update_checkpoint_index = Mock()
+        storage_context.persist_artifacts = Mock()
+        storage_context.sync_config = Mock()
+        storage_context.sync_config.sync_artifacts_on_checkpoint = False
+        
+        # Initialize session
+        init_session(
+            training_func=lambda: None,
+            world_rank=0,
+            local_rank=0,
+            node_rank=0,
+            local_world_size=1,
+            world_size=1,
+            storage=storage_context,
+            synchronous_result_reporting=True,
+        )
+
+    def teardown_method(self):
+        """Cleanup after each test."""
+        shutdown_session()
+        _shutdown_async_checkpoint_writer()
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_async_report_without_checkpoint(self):
+        """Test async_report with only metrics."""
+        metrics = {"loss": 0.5, "accuracy": 0.8}
+        
+        # Should not raise
+        async_report(metrics)
+
+    def test_async_report_with_checkpoint(self):
+        """Test async_report with checkpoint."""
+        # Create test checkpoint
+        checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
+        os.makedirs(checkpoint_dir)
+        Path(checkpoint_dir, "model.pt").write_text("fake model data")
+        checkpoint = Checkpoint.from_directory(checkpoint_dir)
+        
+        metrics = {"loss": 0.5, "step": 10}
+        
+        # Should not raise and should return immediately
+        start_time = time.time()
+        async_report(metrics, checkpoint=checkpoint)
+        elapsed = time.time() - start_time
+        
+        # Should be much faster than a real upload
+        assert elapsed < 0.1
+
+    def test_async_report_flush_errors(self):
+        """Test error reporting with flush=True."""
+        # This test would need to simulate upload failures
+        # For now, just test that flush=True doesn't crash
+        async_report({}, flush=True)
+
+    def test_async_report_fallback_on_backpressure(self):
+        """Test fallback to sync when async queue is full."""
+        # Create a writer with very small queue
+        with patch('ray.train._internal.session._get_async_checkpoint_writer') as mock_get_writer:
+            mock_writer = Mock()
+            mock_writer.async_persist_checkpoint.side_effect = _AsyncCheckpointError(
+                "Queue full", Exception()
+            )
+            mock_get_writer.return_value = mock_writer
+            
+            checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
+            os.makedirs(checkpoint_dir)
+            checkpoint = Checkpoint.from_directory(checkpoint_dir)
+            
+            # Should fall back to sync upload without raising
+            async_report({"step": 1}, checkpoint=checkpoint)
+
+    def test_torch_tensor_validation(self):
+        """Test that torch tensors in metrics are rejected."""
+        # Mock torch being imported
+        with patch.dict('sys.modules', {'torch': Mock()}):
+            with patch('ray.air._internal.torch_utils.contains_tensor', return_value=True):
+                with pytest.raises(ValueError, match="Torch tensors"):
+                    async_report({"tensor": "fake_tensor"})
+
+
+class TestAsyncCheckpointEndToEnd:
+    """End-to-end tests with real filesystem operations."""
+
+    def setup_method(self):
+        """Setup real storage for e2e tests."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage_path = Path(self.temp_dir, "storage").as_posix()
+        os.makedirs(self.storage_path)
+
+    def teardown_method(self):
+        """Cleanup after each test."""
+        _shutdown_async_checkpoint_writer()
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_end_to_end_upload_with_manifest(self):
+        """Test complete upload flow with manifest writing."""
+        writer = AsyncCheckpointWriter()
+        
+        # Create real storage context
+        from ray.train._internal.storage import StorageContext
+        storage_context = StorageContext(
+            storage_path=self.storage_path,
+            experiment_dir_name="test_experiment",
+            trial_dir_name="trial_1",
+            storage_filesystem=pyarrow.fs.LocalFileSystem(),
+            sync_config=Mock(),
+        )
+        
+        # Create real checkpoint
+        checkpoint_dir = Path(self.temp_dir, "checkpoint").as_posix()
+        os.makedirs(checkpoint_dir)
+        
+        # Write some files to checkpoint
+        Path(checkpoint_dir, "model.pt").write_text("model weights")
+        Path(checkpoint_dir, "optimizer.pt").write_text("optimizer state")
+        subdir = Path(checkpoint_dir, "subdir")
+        subdir.mkdir()
+        Path(subdir, "config.json").write_text('{"lr": 0.001}')
+        
+        checkpoint = Checkpoint.from_directory(checkpoint_dir)
+        metrics = {"epoch": 5, "loss": 0.1, "accuracy": 0.95}
+        
+        # Persist async
+        writer.async_persist_checkpoint(checkpoint, storage_context, metrics)
+        
+        # Wait for completion
+        writer.shutdown(timeout=10.0)
+        
+        # Verify files were uploaded
+        uploaded_checkpoint = Path(storage_context.checkpoint_fs_path)
+        assert uploaded_checkpoint.exists()
+        assert (uploaded_checkpoint / "model.pt").exists()
+        assert (uploaded_checkpoint / "optimizer.pt").exists()
+        assert (uploaded_checkpoint / "subdir" / "config.json").exists()
+        
+        # Verify manifest
+        manifest_path = Path(storage_context.experiment_fs_path, "LATEST.json")
+        assert manifest_path.exists()
+        
+        with open(manifest_path) as f:
+            manifest_data = json.load(f)
+        
+        assert manifest_data["metrics"] == metrics
+        assert manifest_data["upload_completed"] is True
+
+
+class TestErrorHandling:
+    """Tests for error handling in async checkpoints."""
+
+    def test_upload_failure_reporting(self):
+        """Test that upload failures are properly reported."""
+        writer = AsyncCheckpointWriter()
+        
+        # Mock failing upload
+        with patch.object(writer, '_upload_checkpoint_task') as mock_upload:
+            mock_upload.side_effect = Exception("Upload failed")
+            
+            storage_context = Mock()
+            checkpoint = Mock()
+            
+            writer.async_persist_checkpoint(checkpoint, storage_context, {})
+            
+            # Wait for failure
+            time.sleep(0.2)
+            
+            # Should have failed task in queue
+            with pytest.raises(_AsyncCheckpointError):
+                writer.check_and_raise_errors()
+        
+        writer.shutdown()
+
+    def test_shutdown_during_uploads(self):
+        """Test shutdown behavior when uploads are in progress."""
+        writer = AsyncCheckpointWriter()
+        
+        # Start shutdown immediately
+        writer.shutdown(timeout=1.0)
+        
+        # Should be shutdown
+        assert writer._shutdown
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Currently `train.report(..., checkpoint=...)` blocks the training step until checkpoint upload to S3/GCS completes (takes several minutes for large models).  

This PR adds `AsyncCheckpointWriter` to enable non-blocking checkpoint uploads:
- New `async_report()` API that uploads checkpoints in background threads
- Training continues immediately while uploads happen in parallel  
- Backpressure control prevents unlimited queuing
- Atomic `LATEST.json` manifest written on completion
- Error reporting on subsequent `flush=True` calls

Community has requested this feature for workloads that checkpoint frequently and/or asynchronously.