### PR TITLE
[core] Remove `core_worker_lib` dependency from `shutdown_coordinator_test`

### DIFF
--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -70,6 +70,7 @@ ray_cc_library(
     hdrs = [
         "shutdown_coordinator.h",
     ],
+    visibility = [":__subpackages__"],
     deps = [
         ":common",
         "//src/ray/common:buffer",

--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -72,8 +72,8 @@ ray_cc_library(
     ],
     visibility = [":__subpackages__"],
     deps = [
-        ":common",
         "//src/ray/common:buffer",
+        "//src/ray/protobuf:common_cc_proto",
     ],
 )
 

--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -6,14 +6,12 @@ ray_cc_library(
         "core_worker.cc",
         "core_worker_process.cc",
         "core_worker_shutdown_executor.cc",
-        "shutdown_coordinator.cc",
     ],
     hdrs = [
         "core_worker.h",
         "core_worker_process.h",
         "core_worker_rpc_proxy.h",
         "core_worker_shutdown_executor.h",
-        "shutdown_coordinator.h",
     ],
     deps = [
         ":actor_handle",
@@ -30,6 +28,7 @@ ray_cc_library(
         ":plasma_store_provider",
         ":profile_event",
         ":reference_count",
+        ":shutdown_coordinator",
         ":task_event_buffer",
         "//src/ray/common/cgroup:cgroup_context",
         "//src/ray/common/cgroup:cgroup_manager",
@@ -60,6 +59,20 @@ ray_cc_library(
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_prod",
+    ],
+)
+
+ray_cc_library(
+    name = "shutdown_coordinator",
+    srcs = [
+        "shutdown_coordinator.cc",
+    ],
+    hdrs = [
+        "shutdown_coordinator.h",
+    ],
+    deps = [
+        ":common",
+        "//src/ray/common:buffer",
     ],
 )
 

--- a/src/ray/core_worker/shutdown_coordinator.cc
+++ b/src/ray/core_worker/shutdown_coordinator.cc
@@ -22,14 +22,13 @@
 #include <string_view>
 #include <utility>
 
-#include "ray/common/buffer.h"       // LocalMemoryBuffer
-#include "ray/core_worker/common.h"  // for WorkerType alias
+#include "ray/common/buffer.h"  // LocalMemoryBuffer
 namespace ray {
 
 namespace core {
 
 ShutdownCoordinator::ShutdownCoordinator(
-    std::unique_ptr<ShutdownExecutorInterface> executor, WorkerType worker_type)
+    std::unique_ptr<ShutdownExecutorInterface> executor, rpc::WorkerType worker_type)
     : executor_(std::move(executor)), worker_type_(worker_type) {
   RAY_CHECK(executor_)
       << "ShutdownCoordinator requires a non-null ShutdownExecutorInterface. "
@@ -156,12 +155,12 @@ void ShutdownCoordinator::ExecuteShutdownSequence(
     std::chrono::milliseconds timeout_ms,
     const std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb_bytes) {
   switch (worker_type_) {
-  case WorkerType::DRIVER:
+  case rpc::WorkerType::DRIVER:
     ExecuteDriverShutdown(force_shutdown, detail, timeout_ms);
     break;
-  case WorkerType::WORKER:
-  case WorkerType::SPILL_WORKER:
-  case WorkerType::RESTORE_WORKER:
+  case rpc::WorkerType::WORKER:
+  case rpc::WorkerType::SPILL_WORKER:
+  case rpc::WorkerType::RESTORE_WORKER:
     ExecuteWorkerShutdown(
         force_shutdown, detail, timeout_ms, creation_task_exception_pb_bytes);
     break;

--- a/src/ray/core_worker/shutdown_coordinator.h
+++ b/src/ray/core_worker/shutdown_coordinator.h
@@ -21,8 +21,7 @@
 #include <string>
 #include <string_view>
 
-// Bring in WorkerType alias and common types
-#include "ray/core_worker/common.h"
+#include "src/ray/protobuf/common.pb.h"
 
 namespace ray {
 class LocalMemoryBuffer;
@@ -137,7 +136,7 @@ class ShutdownCoordinator {
   /// \param executor Shutdown executor implementation
   /// \param worker_type Type of worker for shutdown behavior customization
   explicit ShutdownCoordinator(std::unique_ptr<ShutdownExecutorInterface> executor,
-                               WorkerType worker_type = WorkerType::WORKER);
+                               rpc::WorkerType worker_type = rpc::WorkerType::WORKER);
 
   ~ShutdownCoordinator() = default;
 
@@ -278,7 +277,7 @@ class ShutdownCoordinator {
 
   // Executor and configuration
   std::unique_ptr<ShutdownExecutorInterface> executor_;
-  WorkerType worker_type_;
+  rpc::WorkerType worker_type_;
 
   // Mutex-guarded shutdown state
   mutable std::mutex mu_;

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -17,7 +17,7 @@ ray_cc_test(
     srcs = ["shutdown_coordinator_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/core_worker:core_worker_lib",
+        "//src/ray/core_worker:shutdown_coordinator",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],


### PR DESCRIPTION
## Why are these changes needed?

Create and use a minimal `:shutdown_coordinator` target; point `shutdown_coordinator_test` to it directly. Pure build hygiene; no behavior changes.