### PR TITLE
[core][feature] Add the warning about deprecating the ray.util.accelerators.XXX and add the method to print accelerator types 

### DIFF
--- a/doc/source/ray-core/api/utility.rst
+++ b/doc/source/ray-core/api/utility.rst
@@ -16,6 +16,9 @@ Utility
    ray.util.accelerators.tpu.get_current_pod_name
    ray.util.accelerators.tpu.get_num_tpu_chips_on_node
 
+   ray.util.accelerators.types.all_types
+   ray.util.accelerators.types.vendor_types
+
    ray.nodes
    ray.cluster_resources
    ray.available_resources

--- a/doc/source/ray-core/scheduling/accelerators.rst
+++ b/doc/source/ray-core/scheduling/accelerators.rst
@@ -674,6 +674,10 @@ Under the hood, the accelerator type option is implemented as a :ref:`custom res
 This forces the task or actor to be placed on a node with that particular accelerator type available.
 This also lets the multi-node-type autoscaler know that there is demand for that type of resource, potentially triggering the launch of new nodes providing that accelerator.
 
+.. note::
+
+    The method of referencing accelerator type constants (e.g., ``ray.util.accelerators.NVIDIA_A100``) will be deprecated in future versions. Please use string format instead (e.g., ``A100``).
+
 .. testcode::
     :hide:
 
@@ -681,6 +685,7 @@ This also lets the multi-node-type autoscaler know that there is demand for that
     import ray.util.accelerators
 
     v100_resource_name = f"accelerator_type:{ray.util.accelerators.NVIDIA_TESLA_V100}"
+    # v100_resource_name = "accelerator_type:V100"
     ray.init(num_gpus=4, resources={v100_resource_name: 1})
 
 .. testcode::
@@ -688,9 +693,15 @@ This also lets the multi-node-type autoscaler know that there is demand for that
     from ray.util.accelerators import NVIDIA_TESLA_V100
 
     @ray.remote(num_gpus=1, accelerator_type=NVIDIA_TESLA_V100)
+    # @ray.remote(num_gpus=1, accelerator_type="V100")
     def train(data):
         return "This function was run on a node with a Tesla V100 GPU"
 
     ray.get(train.remote(1))
 
 See :ref:`ray.util.accelerators <accelerator_types>` for available accelerator types.
+You can also discover them programmatically using the following methods:
+
+For a simple list of all type constants, use print(ray.util.accelerators.TYPES).
+For a categorized list of all accelerators, use ``ray.util.accelerators.TYPES`` or ``ray.util.accelerators.types.all_types()``.
+For accelerators from a specific vendor (e.g., NVIDIA), use ``ray.util.accelerators.types.vendor_types("NVIDIA")``.

--- a/python/ray/tests/accelerators/test_accelerators.py
+++ b/python/ray/tests/accelerators/test_accelerators.py
@@ -6,16 +6,116 @@ from ray.util import accelerators
 from ray.util.annotations import RayDeprecationWarning
 
 
-def test_accelerators():
-    assert accelerators.NVIDIA_TESLA_K80 == "K80"
-    assert accelerators.NVIDIA_A100 == "A100"
+def test_basic_accelerators():
+    """Test basic accelerator constants and warnings."""
+    with pytest.warns(
+        UserWarning,
+        match="NVIDIA_A100 can be replaced with NVIDIA_A100_40G or NVIDIA_A100_80G for more precise accelerator specification.",
+    ):
+        assert accelerators.NVIDIA_A100 == "A100"
+
+    with pytest.warns(
+        RayDeprecationWarning,
+        match="NVIDIA_TESLA_A100 is deprecated, use NVIDIA_A100 instead.",
+    ):
+        assert accelerators.NVIDIA_TESLA_A100 == "A100"
+
+    with pytest.warns(RayDeprecationWarning):
+        assert accelerators.AMD_INSTINCT_MI100 == "AMD-Instinct-MI100"
+
     with pytest.raises(
         AttributeError,
         match="module 'ray.util.accelerators' has no attribute 'NVIDIA_INVALID'",
     ):
         _ = accelerators.NVIDIA_INVALID
-    with pytest.warns(RayDeprecationWarning):
-        assert accelerators.NVIDIA_TESLA_A100 == "A100"
+
+
+def test_nvidia_accelerators():
+    """Test all NVIDIA accelerator constants."""
+    assert accelerators.NVIDIA_TESLA_V100 == "V100"
+    assert accelerators.NVIDIA_TESLA_P100 == "P100"
+    assert accelerators.NVIDIA_TESLA_T4 == "T4"
+    assert accelerators.NVIDIA_TESLA_P4 == "P4"
+    assert accelerators.NVIDIA_TESLA_K80 == "K80"
+    assert accelerators.NVIDIA_TESLA_A10G == "A10G"
+    assert accelerators.NVIDIA_L4 == "L4"
+    assert accelerators.NVIDIA_L40S == "L40S"
+    assert accelerators.NVIDIA_A100 == "A100"
+    assert accelerators.NVIDIA_H100 == "H100"
+    assert accelerators.NVIDIA_H200 == "H200"
+    assert accelerators.NVIDIA_H20 == "H20"
+    assert accelerators.NVIDIA_B200 == "B200"
+    assert accelerators.NVIDIA_A100_40G == "A100-40G"
+    assert accelerators.NVIDIA_A100_80G == "A100-80G"
+
+
+def test_intel_accelerators():
+    """Test all Intel accelerator constants."""
+    assert accelerators.INTEL_MAX_1550 == "Intel-GPU-Max-1550"
+    assert accelerators.INTEL_MAX_1100 == "Intel-GPU-Max-1100"
+    assert accelerators.INTEL_GAUDI == "Intel-GAUDI"
+
+
+def test_amd_accelerators():
+    """Test all AMD accelerator constants."""
+    assert accelerators.AMD_INSTINCT_MI100 == "AMD-Instinct-MI100"
+    assert accelerators.AMD_INSTINCT_MI250x == "AMD-Instinct-MI250X"
+    assert accelerators.AMD_INSTINCT_MI250 == "AMD-Instinct-MI250X-MI250"
+    assert accelerators.AMD_INSTINCT_MI210 == "AMD-Instinct-MI210"
+    assert accelerators.AMD_INSTINCT_MI300A == "AMD-Instinct-MI300A"
+    assert accelerators.AMD_INSTINCT_MI300x == "AMD-Instinct-MI300X-OAM"
+    assert accelerators.AMD_INSTINCT_MI300x_HF == "AMD-Instinct-MI300X-HF"
+    assert accelerators.AMD_INSTINCT_MI308x == "AMD-Instinct-MI308X"
+    assert accelerators.AMD_INSTINCT_MI325x == "AMD-Instinct-MI325X-OAM"
+    assert accelerators.AMD_RADEON_R9_200_HD_7900 == "AMD-Radeon-R9-200-HD-7900"
+    assert accelerators.AMD_RADEON_HD_7900 == "AMD-Radeon-HD-7900"
+
+
+def test_google_accelerators():
+    """Test all Google accelerator constants."""
+    assert accelerators.GOOGLE_TPU_V2 == "TPU-V2"
+    assert accelerators.GOOGLE_TPU_V3 == "TPU-V3"
+    assert accelerators.GOOGLE_TPU_V4 == "TPU-V4"
+    assert accelerators.GOOGLE_TPU_V5P == "TPU-V5P"
+    assert accelerators.GOOGLE_TPU_V5LITEPOD == "TPU-V5LITEPOD"
+    assert accelerators.GOOGLE_TPU_V6E == "TPU-V6E"
+
+
+def test_huawei_accelerators():
+    """Test all Huawei accelerator constants."""
+    assert accelerators.HUAWEI_NPU_910B == "Ascend910B"
+    assert accelerators.HUAWEI_NPU_910B4 == "Ascend910B4"
+
+
+def test_aws_accelerators():
+    """Test all AWS accelerator constants."""
+    assert accelerators.AWS_NEURON_CORE == "aws-neuron-core"
+
+
+def test_get_accelerator_type():
+    """Test accessing accelerator types in different ways."""
+    from ray.util.accelerators.types import all_types, vendor_types
+
+    target_accelerator = "NVIDIA_A100"
+    target_vendor = "NVIDIA"
+
+    all_types_result = all_types()
+    assert isinstance(all_types_result, str), "all_types() should return a string"
+    assert (
+        target_accelerator in all_types_result
+    ), f"all_types() should contain {target_accelerator}"
+
+    vendor_result = vendor_types(target_vendor)
+    assert isinstance(vendor_result, str), "vendor_types() should return a string"
+    assert (
+        target_accelerator in vendor_result
+    ), f"vendor_types('{target_vendor}') should contain {target_accelerator}"
+
+    other_vendor = "AMD"
+    other_vendor_result = vendor_types(other_vendor)
+    assert (
+        target_accelerator not in other_vendor_result
+    ), f"vendor_types('{other_vendor}') should not contain {target_accelerator}"
 
 
 if __name__ == "__main__":

--- a/python/ray/util/accelerators/__init__.py
+++ b/python/ray/util/accelerators/__init__.py
@@ -1,78 +1,48 @@
 import warnings
 
+import ray.util.accelerators.accelerators as _accelerators
 from ray.util.accelerators import tpu
-from ray.util.accelerators.accelerators import (
-    AMD_INSTINCT_MI100,
-    AMD_INSTINCT_MI210,
-    AMD_INSTINCT_MI250,
-    AMD_RADEON_HD_7900,
-    AMD_RADEON_R9_200_HD_7900,
-    AWS_NEURON_CORE,
-    GOOGLE_TPU_V2,
-    GOOGLE_TPU_V3,
-    GOOGLE_TPU_V4,
-    GOOGLE_TPU_V5LITEPOD,
-    GOOGLE_TPU_V5P,
-    GOOGLE_TPU_V6E,
-    INTEL_GAUDI,
-    INTEL_MAX_1100,
-    INTEL_MAX_1550,
-    NVIDIA_A100,
-    NVIDIA_H100,
-    NVIDIA_L4,
-    NVIDIA_TESLA_A10G,
-    NVIDIA_TESLA_K80,
-    NVIDIA_TESLA_P4,
-    NVIDIA_TESLA_P100,
-    NVIDIA_TESLA_T4,
-    NVIDIA_TESLA_V100,
-    AMD_INSTINCT_MI250x,
-    AMD_INSTINCT_MI300x,
-)
+from ray.util.accelerators.types import AcceleratorTypes
 
-__all__ = [
-    "tpu",
-    "NVIDIA_TESLA_V100",
-    "NVIDIA_TESLA_P100",
-    "NVIDIA_TESLA_T4",
-    "NVIDIA_TESLA_P4",
-    "NVIDIA_TESLA_K80",
-    "NVIDIA_TESLA_A10G",
-    "NVIDIA_L4",
-    "NVIDIA_A100",
-    "NVIDIA_A100_40G",
-    "NVIDIA_A100_80G",
-    "NVIDIA_H100",
-    "INTEL_MAX_1550",
-    "INTEL_MAX_1100",
-    "INTEL_GAUDI",
-    "AMD_INSTINCT_MI100",
-    "AMD_INSTINCT_MI210",
-    "AMD_INSTINCT_MI250",
-    "AMD_INSTINCT_MI250x",
-    "AMD_INSTINCT_MI300x",
-    "AMD_RADEON_R9_200_HD_7900",
-    "AMD_RADEON_HD_7900",
-    "AWS_NEURON_CORE",
-    "GOOGLE_TPU_V2",
-    "GOOGLE_TPU_V3",
-    "GOOGLE_TPU_V4",
-    "GOOGLE_TPU_V5P",
-    "GOOGLE_TPU_V5LITEPOD",
-    "GOOGLE_TPU_V6E",
-    # Deprecated
-    "NVIDIA_TESLA_A100",
+# Get all GPU constant names
+_GPU_CONSTANTS = [
+    name
+    for name in dir(_accelerators)
+    if not (name.startswith("__") and name.endswith("__"))
 ]
 
+__all__ = ["tpu"] + _GPU_CONSTANTS + ["NVIDIA_TESLA_A100"] + ["TYPES"]
 
-def __getattr__(name: str):
-    if name == "NVIDIA_TESLA_A100":
+
+# Dynamically get constants via `__getattr__` and warnings
+def __getattr__(name):
+    if name == "TYPES":
+        return AcceleratorTypes().all_constants
+
+    if name in __all__:
         from ray.util.annotations import RayDeprecationWarning
 
-        warnings.warn(
-            "NVIDIA_TESLA_A100 is deprecated, use NVIDIA_A100 instead.",
-            RayDeprecationWarning,
-            stacklevel=2,
-        )
-        return NVIDIA_A100
+        if name == "NVIDIA_TESLA_A100":
+            warnings.warn(
+                "NVIDIA_TESLA_A100 is deprecated, use NVIDIA_A100 instead.",
+                RayDeprecationWarning,
+                stacklevel=2,
+            )
+            name = "NVIDIA_A100"
+
+        elif name == "NVIDIA_A100":
+            warnings.warn(
+                "NVIDIA_A100 can be replaced with NVIDIA_A100_40G or NVIDIA_A100_80G for more precise accelerator specification.",
+                UserWarning,
+            )
+
+        else:
+            warnings.warn(
+                f"Accessing GPU constants via this method (ray.util.accelerators.{name}) is deprecated and will be removed in a future version. "
+                f"Please use just strings instead ('{getattr(_accelerators, name)}').",
+                RayDeprecationWarning,
+                stacklevel=2,
+            )
+
+        return getattr(_accelerators, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/ray/util/accelerators/types.py
+++ b/python/ray/util/accelerators/types.py
@@ -1,0 +1,103 @@
+import ray.util.accelerators.accelerators as _accelerators
+from ray.util.annotations import PublicAPI, DeveloperAPI
+
+
+@DeveloperAPI(stability="alpha")
+class AcceleratorTypes:
+    """Unified access point for all accelerator types supported by Ray, categorized by vendor.
+
+        Accelerator types are dynamically collected from the `ray.util.accelerators.accelerators`
+        module.
+
+    Example:
+
+            ############# Access via constant (TYPES) ###############
+            import ray
+            # Print all accelerator types as a raw string
+            print(ray.util.accelerators.TYPES)
+
+            ############# Access via AcceleratorTypes instance ###############
+            from ray.util.accelerators.types import all_types, vendor_types
+            # Print all accelerator types categorized by vendor
+            print (all_types())
+
+            # Print accelerator types for a specific vendor
+            print ("NVIDIA accelerators:", vendor_types("NVIDIA"))
+            print ("AMD accelerators:", vendor_types("AMD"))
+
+    Args:
+        No explicit arguments required. The class dynamically initializes accelerator types
+        by scanning the `ray.util.accelerators.accelerators` module on instantiation.
+    """
+
+    def __init__(self):
+        self._all_constants = {
+            name: getattr(_accelerators, name)
+            for name in dir(_accelerators)
+            if not (name.startswith("__") and name.endswith("__"))
+        }
+
+        VENDORS = ["NVIDIA", "AMD", "INTEL", "GOOGLE", "HUAWEI", "AWS"]
+        for vendor in VENDORS:
+            vendor_lower = vendor.lower()
+            type_list = sorted(
+                [
+                    name
+                    for name in self._all_constants.keys()
+                    if name.startswith(f"{vendor}_")
+                ]
+            )
+            setattr(self, f"{vendor_lower}_types", "\n".join(type_list))
+
+    def print_all(self):
+        """Return all accelerator types categorized by vendor as a string"""
+        vendor_map = {
+            "nvidia": "NVIDIA",
+            "amd": "AMD",
+            "intel": "Intel",
+            "google": "Google",
+            "huawei": "Huawei",
+            "aws": "AWS",
+        }
+        output = []
+        for vendor_key, vendor_name in vendor_map.items():
+            type_string = getattr(self, f"{vendor_key}_types")
+            if type_string:
+                output.append(f"\n{vendor_name} Accelerators:")
+                output.append(type_string)
+        return "\n".join(output)
+
+    @property
+    def all_constants(self):
+        return self.print_all()
+
+
+accelerator_types = AcceleratorTypes()
+
+
+@PublicAPI(stability="alpha")
+def all_types():
+    """Return all accelerator types categorized by vendor (via print_all)
+
+    Return: String of accelerator types categorized by vendor, separated by newlines
+    """
+    return accelerator_types.print_all()
+
+
+@PublicAPI(stability="alpha")
+def vendor_types(vendor: str):
+    """Return accelerator types for a specific vendor (uppercase input)
+
+    Args:
+        vendor: Uppercase vendor name (e.g., "NVIDIA", "AMD")
+
+    Returns:
+        String of accelerator types for the specified vendor, separated by newlines
+        Returns empty string if vendor is invalid or has no accelerators
+    """
+    valid_vendors = ["NVIDIA", "AMD", "INTEL", "GOOGLE", "HUAWEI", "AWS"]
+    vendor = vendor.upper()
+    if vendor not in valid_vendors:
+        return ""
+    vendor_lower = vendor.lower()
+    return getattr(accelerator_types, f"{vendor_lower}_types", "")

--- a/python/ray/util/accelerators/types.py
+++ b/python/ray/util/accelerators/types.py
@@ -1,5 +1,5 @@
 import ray.util.accelerators.accelerators as _accelerators
-from ray.util.annotations import PublicAPI, DeveloperAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 
 @DeveloperAPI(stability="alpha")


### PR DESCRIPTION
## Why are these changes needed?

Implement proposals 2, 3, 4, and 5 from issue #55686.

### Modification

- To proposal 2: Refactor accelerator utility to dynamically manage constants. Based on the previous step, add the warning about deprecating `ray.util.accelerators.XXX`.
- To proposal 3: Add deprecation notice for accelerator type constants, update examples to get all accelerator types and add the new api to the api reference in doc.
- To proposal 4: Add ray.util.accelerators.TYPES to print all accelerator types or accelerators of a specific type.
- To proposal 5: Add warning for NVIDIA_A100, which requires explicit memory specification.

### Test

We have completed the access tests for all types of accelerators in `python/ray/tests/accelerators/test_accelerators.py`, as well as captured and evaluated the `Warning`.

It can also be tested manually through the following script:

```python
from ray.util import accelerators
from ray.util.accelerators.types import all_types,vendor_types

print("1. NVIDIA_A100 can be replaced with NVIDIA_A100_40G or NVIDIA_A100_80G for more precise accelerator specification")
print(accelerators.NVIDIA_A100)
print("\n")

print("2. NVIDIA_TESLA_A100 is deprecated, use NVIDIA_A100 instead.")
print(accelerators.NVIDIA_TESLA_A100)
print("\n")

print("3.ray.util.accelerators.XXX deprecating warning:")
print(accelerators.NVIDIA_H100)

print("4. All accelerators types via ray.util.accelerators.TYPES:")
print(accelerators.TYPES)
print("\n")

print("5. All accelerators types via ray.util.accelerators.all_types():")
print(all_types())
print("\n")

print("6. Categorized accelerator groups:")
print("Google group sample:", vendor_types("GOOGLE"))
```

## Related issue number

issue #55686

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
