### PR TITLE
[data] truncate sequences in sanitize for struct

### DIFF
--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -179,9 +179,7 @@ def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
     elif isinstance(obj, (Sequence, set)):
         # Convert all sequence-like types (lists, tuples, sets, bytes, other sequences) to lists
         taken, dropped = obj[:truncate_length], obj[truncate_length:]
-        return res + (
-          ["..."] if dropped else []
-        )
+        return taken + (["..."] if dropped else [])
     else:
         try:
             if is_dataclass(obj):

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -178,13 +178,10 @@ def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
         return _add_ellipsis_for_string(obj, truncate_length)
     elif isinstance(obj, (Sequence, set)):
         # Convert all sequence-like types (lists, tuples, sets, bytes, other sequences) to lists
-        res = []
-        for i, v in enumerate(obj):
-            if i >= truncate_length:
-                res.append("...")
-                break
-            res.append(sanitize_for_struct(v, truncate_length))
-        return res
+        taken, dropped = obj[:truncate_length], obj[truncate_length:]
+        return res + (
+          ["..."] if dropped else []
+        )
     else:
         try:
             if is_dataclass(obj):

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -179,7 +179,7 @@ def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
     elif isinstance(obj, (Sequence, set)):
         # Convert all sequence-like types (lists, tuples, sets, bytes, other sequences) to lists
         taken, dropped = obj[:truncate_length], obj[truncate_length:]
-        return taken + (["..."] if dropped else [])
+        return taken + ["..."] if dropped else []
     else:
         try:
             if is_dataclass(obj):

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -157,7 +157,7 @@ class DatasetMetadata:
     state: str
 
 
-def _add_ellipsis(s: str, truncate_length: int) -> str:
+def _add_ellipsis_for_string(s: str, truncate_length: int) -> str:
     if len(s) > truncate_length:
         return s[:truncate_length] + "..."
     return s
@@ -175,18 +175,24 @@ def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
         # protobuf Struct key names must be strings.
         return {str(k): sanitize_for_struct(v, truncate_length) for k, v in obj.items()}
     elif isinstance(obj, str):
-        return _add_ellipsis(obj, truncate_length)
+        return _add_ellipsis_for_string(obj, truncate_length)
     elif isinstance(obj, (Sequence, set)):
         # Convert all sequence-like types (lists, tuples, sets, bytes, other sequences) to lists
-        return [sanitize_for_struct(v, truncate_length=truncate_length) for v in obj]
+        res = []
+        for v in obj:
+            res.append(sanitize_for_struct(v, truncate_length))
+            if len(res) >= truncate_length:
+                res.append("...")
+                break
+        return res
     else:
         try:
             if is_dataclass(obj):
                 return sanitize_for_struct(asdict(obj), truncate_length)
-            return _add_ellipsis(str(obj), truncate_length)
+            return _add_ellipsis_for_string(str(obj), truncate_length)
         except Exception:
             unk_name = f"{UNKNOWN}: {type(obj).__name__}"
-            return _add_ellipsis(unk_name, truncate_length)
+            return _add_ellipsis_for_string(unk_name, truncate_length)
 
 
 def dataset_metadata_to_proto(dataset_metadata: DatasetMetadata) -> Any:

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -178,8 +178,13 @@ def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
         return _add_ellipsis_for_string(obj, truncate_length)
     elif isinstance(obj, (Sequence, set)):
         # Convert all sequence-like types (lists, tuples, sets, bytes, other sequences) to lists
-        taken, dropped = obj[:truncate_length], obj[truncate_length:]
-        return taken + ["..."] if dropped else []
+        res = []
+        for i, v in enumerate(obj):
+            if i >= truncate_length:
+                res.append("...")
+                break
+            res.append(sanitize_for_struct(v, truncate_length))
+        return res
     else:
         try:
             if is_dataclass(obj):

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -179,11 +179,11 @@ def sanitize_for_struct(obj, truncate_length=DEFAULT_TRUNCATION_LENGTH):
     elif isinstance(obj, (Sequence, set)):
         # Convert all sequence-like types (lists, tuples, sets, bytes, other sequences) to lists
         res = []
-        for v in obj:
-            res.append(sanitize_for_struct(v, truncate_length))
-            if len(res) >= truncate_length:
+        for i, v in enumerate(obj):
+            if i >= truncate_length:
                 res.append("...")
                 break
+            res.append(sanitize_for_struct(v, truncate_length))
         return res
     else:
         try:

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -627,7 +627,7 @@ class BasicObject:
         # Test sequence truncation - list longer than truncate_length gets truncated
         (
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-            ["1", "2", "3", "..."],  # Only first 3 elements after truncation
+            ["1", "2", "..."],  # Only first 3 elements after truncation
             3,
         ),
     ],

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -627,7 +627,7 @@ class BasicObject:
         # Test sequence truncation - list longer than truncate_length gets truncated
         (
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-            ["1", "2", "..."],  # Only first 3 elements after truncation
+            ["1", "2", "3", "..."],  # Only first 3 elements after truncation + ...
             3,
         ),
     ],

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -624,6 +624,12 @@ class BasicObject:
             },
             100,
         ),
+        # Test sequence truncation - list longer than truncate_length gets truncated
+        (
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            ["1", "2", "3", "..."],  # Only first 3 elements after truncation
+            3,
+        ),
     ],
 )
 def test_sanitize_for_struct(input_obj, expected_output, truncate_length):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`input_files` and other lists can be quite large. We assume that user args aren't that many (and therefore dictionaries shouldn't need to be truncated), and that Logical Operators aren't deeply nested.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
