### PR TITLE
[Data] Fix `UnboundLocalError` when `read_parquet` with columns and no partitioning

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -825,4 +825,7 @@ def _infer_data_and_partition_columns(
         partition_columns = [
             column for column in user_specified_columns if column in partitions
         ]
+    else:
+        partition_columns = []
+
     return data_columns, partition_columns

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -2224,12 +2224,14 @@ def test_parquet_write_parallel_overwrite(
 
 
 def test_read_parquet_with_none_partitioning_and_columns(tmp_path):
+    # Test for https://github.com/ray-project/ray/pull/55820.
     table = pa.table({"column": [42]})
     path = os.path.join(tmp_path, "file.parquet")
     pq.write_table(table, path)
 
     ds = ray.data.read_parquet(path, partitioning=None, columns=["column"])
-    ds.take_all()
+
+    assert ds.take_all() == [{"column": 42}]
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -2224,7 +2224,7 @@ def test_parquet_write_parallel_overwrite(
 
 
 def test_read_parquet_with_none_partitioning_and_columns(tmp_path):
-    # Test for https://github.com/ray-project/ray/pull/55820.
+    # Test for https://github.com/ray-project/ray/issues/55279.
     table = pa.table({"column": [42]})
     path = os.path.join(tmp_path, "file.parquet")
     pq.write_table(table, path)

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -2223,6 +2223,15 @@ def test_parquet_write_parallel_overwrite(
     assert result.count() == 1000
 
 
+def test_read_parquet_with_none_partitioning_and_columns(tmp_path):
+    table = pa.table({"column": [42]})
+    path = os.path.join(tmp_path, "file.parquet")
+    pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(path, partitioning=None, columns=["column"])
+    ds.take_all()
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you call `read_parquet` with `partitioning=None` and non-empty `columns`, then Ray Data raises a error because of a missing branch. This PR fixes that issue.

```
Traceback (most recent call last):
  File "/root/lab42_vr/test.py", line 6, in <module>
    ds = ray.data.read_parquet(input_s3_path, partitioning=None, columns=columns)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/ray/data/read_api.py", line 950, in read_parquet
    datasource = ParquetDatasource(
                 ^^^^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/ray/data/_internal/datasource/parquet_datasource.py", line 262, in __init__
    data_columns, partition_columns = _infer_data_and_partition_columns(
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/ray/data/_internal/datasource/parquet_datasource.py", line 817, in _infer_data_and_partition_columns
    return data_columns, partition_columns
                         ^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'partition_columns' where it is not associated with a value
```

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/55279

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
