### PR TITLE
[Data] Improved loading from column of URIs

### DIFF
--- a/doc/source/data/api/expressions.rst
+++ b/doc/source/data/api/expressions.rst
@@ -19,6 +19,7 @@ Public API
 
     col
     lit
+    download
 
 Expression Classes
 ------------------

--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -1422,6 +1422,20 @@ py_test(
 )
 
 py_test(
+    name = "test_download_expression",
+    size = "small",
+    srcs = ["tests/test_download_expression.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_context",
     size = "small",
     srcs = ["tests/test_context.py"],

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -145,12 +145,12 @@ class MapTransformer:
     def set_transform_fns(self, transform_fns: List[MapTransformFn]) -> None:
         """Set the transform functions."""
         assert len(transform_fns) > 0
-        assert (
-            transform_fns[0].input_type == MapTransformFnDataType.Block
-        ), "The first transform function must take blocks as input."
-        assert (
-            transform_fns[-1].output_type == MapTransformFnDataType.Block
-        ), "The last transform function must output blocks."
+        # assert (
+        #     transform_fns[0].input_type == MapTransformFnDataType.Block
+        # ), "The first transform function must take blocks as input."
+        # assert (
+        #     transform_fns[-1].output_type == MapTransformFnDataType.Block
+        # ), "The last transform function must output blocks."
 
         for i in range(len(transform_fns) - 1):
             assert transform_fns[i].output_type == transform_fns[i + 1].input_type, (

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -145,12 +145,12 @@ class MapTransformer:
     def set_transform_fns(self, transform_fns: List[MapTransformFn]) -> None:
         """Set the transform functions."""
         assert len(transform_fns) > 0
-        # assert (
-        #     transform_fns[0].input_type == MapTransformFnDataType.Block
-        # ), "The first transform function must take blocks as input."
-        # assert (
-        #     transform_fns[-1].output_type == MapTransformFnDataType.Block
-        # ), "The last transform function must output blocks."
+        assert (
+            transform_fns[0].input_type == MapTransformFnDataType.Block
+        ), "The first transform function must take blocks as input."
+        assert (
+            transform_fns[-1].output_type == MapTransformFnDataType.Block
+        ), "The last transform function must output blocks."
 
         for i in range(len(transform_fns) - 1):
             assert transform_fns[i].output_type == transform_fns[i + 1].input_type, (

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -370,8 +370,9 @@ class Download(AbstractMap):
         input_op: LogicalOperator,
         uri_column_name: str,
         output_bytes_column_name: str,
+        ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
-        super().__init__("Download", input_op)
+        super().__init__("Download", input_op, ray_remote_args=ray_remote_args)
         self._uri_column_name = uri_column_name
         self._output_bytes_column_name = output_bytes_column_name
 

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -360,3 +360,22 @@ class StreamingRepartition(AbstractMap):
 
     def can_modify_num_rows(self) -> bool:
         return False
+
+
+class Download(AbstractMap):
+    """Logical operator for download operation."""
+
+    def __init__(
+        self,
+        input_op: LogicalOperator,
+        uri_column_name: str,
+    ):
+        super().__init__("Download", input_op)
+        self._uri_column_name = uri_column_name
+
+    def can_modify_num_rows(self) -> bool:
+        return False
+
+    @property
+    def uri_column_name(self) -> str:
+        return self._uri_column_name

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -369,9 +369,11 @@ class Download(AbstractMap):
         self,
         input_op: LogicalOperator,
         uri_column_name: str,
+        output_bytes_column_name: str,
     ):
         super().__init__("Download", input_op)
         self._uri_column_name = uri_column_name
+        self._output_bytes_column_name = output_bytes_column_name
 
     def can_modify_num_rows(self) -> bool:
         return False
@@ -379,3 +381,7 @@ class Download(AbstractMap):
     @property
     def uri_column_name(self) -> str:
         return self._uri_column_name
+
+    @property
+    def output_bytes_column_name(self) -> str:
+        return self._output_bytes_column_name

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -1,0 +1,202 @@
+import logging
+import math
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List
+from urllib.parse import urlparse
+
+import pyarrow as pa
+from pyarrow.fs import FileSystem as pafs
+
+import ray
+from ray.data._internal.compute import ActorPoolStrategy, get_compute
+from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_transformer import (
+    BlockMapTransformFn,
+    MapTransformer,
+)
+from ray.data._internal.logical.operators.map_operator import Download
+from ray.data._internal.util import make_async_gen
+from ray.data.block import BlockAccessor
+from ray.data.context import DataContext
+
+logger = logging.getLogger(__name__)
+
+
+def plan_download_op(
+    op: Download,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
+) -> MapOperator:
+    """Plan the download operation with partitioning and downloading stages."""
+    assert len(physical_children) == 1
+    input_physical_dag = physical_children[0]
+    compute = get_compute(op._compute)
+    uri_column_name = op.uri_column_name
+    output_bytes_column_name = op.output_bytes_column_name
+
+    # Import _get_udf from the main planner file
+    from ray.data._internal.planner.plan_udf_map_op import (
+        _generate_transform_fn_for_map_batches,
+        _get_udf,
+    )
+
+    # PartitionActor is a callable class, so we need ActorPoolStrategy
+    partition_compute = ActorPoolStrategy(size=1)  # Use single actor for partitioning
+
+    fn, init_fn = _get_udf(PartitionActor, (), {}, (uri_column_name,), {})
+    partition_transform_fn = _generate_transform_fn_for_map_batches(fn)
+    partition_transform_fns = [
+        BlockMapTransformFn(partition_transform_fn),
+    ]
+    partition_map_transformer = MapTransformer(partition_transform_fns, init_fn)
+    partition_map_operator = MapOperator.create(
+        partition_map_transformer,
+        input_physical_dag,
+        data_context,
+        name="DownloadURIPartitioner",
+        compute_strategy=partition_compute,  # Use actor-based compute for callable class
+        ray_remote_args=op._ray_remote_args,
+        ray_remote_args_fn=op._ray_remote_args_fn,
+    )
+
+    fn, init_fn = _get_udf(
+        download_bytes_threaded,
+        (uri_column_name, output_bytes_column_name),
+        {},
+        None,
+        None,
+    )
+    download_transform_fn = _generate_transform_fn_for_map_batches(fn)
+    transform_fns = [
+        BlockMapTransformFn(download_transform_fn),
+    ]
+    download_map_transformer = MapTransformer(transform_fns, init_fn)
+    download_map_operator = MapOperator.create(
+        download_map_transformer,
+        partition_map_operator,
+        data_context,
+        name="DownloadURIDownloader",
+        compute_strategy=compute,
+        ray_remote_args=op._ray_remote_args,
+        ray_remote_args_fn=op._ray_remote_args_fn,
+    )
+
+    return download_map_operator
+
+
+def uri_to_path(uri: str) -> str:
+    """Convert a URI to a filesystem path."""
+    parsed = urlparse(uri)
+    return parsed.netloc + parsed.path
+
+
+def download_bytes_threaded(
+    block, uri_column_name, output_bytes_column_name, max_workers=16
+):
+    """Optimized version that uses make_async_gen for concurrent downloads."""
+    if not isinstance(block, pa.Table):
+        block = BlockAccessor.for_block(block).to_arrow()
+
+    # Extract URIs from PyArrow table
+    uris = block.column(uri_column_name).to_pylist()
+
+    if len(uris) == 0:
+        return block
+
+    fs, _ = pafs.from_uri(uris[0])  # from_uri returns (filesystem, path)
+
+    def download_uris(uri_iterator):
+        """Function that takes an iterator of URIs and yields downloaded bytes for each."""
+        for uri in uri_iterator:
+            try:
+                with fs.open_input_file(uri_to_path(uri)) as f:
+                    yield f.read()
+            except Exception:
+                yield None
+
+    # Use make_async_gen to download URIs concurrently
+    # This preserves the order of results to match the input URIs
+    uri_bytes = list(
+        make_async_gen(
+            base_iterator=iter(uris),
+            fn=download_uris,
+            preserve_ordering=True,
+            num_workers=max_workers,
+        )
+    )
+
+    # Add the new column to the PyArrow table
+    return block.add_column(
+        len(block.column_names), output_bytes_column_name, pa.array(uri_bytes)
+    )
+
+
+class PartitionActor:
+    """Actor that partitions download operations based on estimated file sizes."""
+
+    INIT_SAMPLE_BATCH_SIZE = 25
+
+    def __init__(self, uri_column_name: str):
+        self._uri_column_name = uri_column_name
+        self._batch_size_estimate = None
+
+    def _sample_sizes(self, uri_list, max_workers=16):
+        """Fetch file sizes in parallel using ThreadPoolExecutor."""
+
+        def get_file_size(uri, fs):
+            try:
+                return fs.get_file_info(uri_to_path(uri)).size
+            except Exception:
+                return None
+
+        file_sizes = []
+
+        # Use ThreadPoolExecutor for concurrent size fetching
+        fs, _ = pafs.from_uri(uri_list[0])
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Submit all size fetch tasks
+            futures = [executor.submit(get_file_size, uri, fs) for uri in uri_list]
+
+            # Collect results as they complete (order doesn't matter)
+            for future in as_completed(futures):
+                try:
+                    size = future.result()
+                    if size is not None:
+                        file_sizes.append(size)
+                except Exception as e:
+                    logger.warning(f"Error fetching file size for download: {e}")
+
+        return file_sizes
+
+    def _arrow_batcher(self, table, n):
+        """Batch a PyArrow table into smaller tables of size n using zero-copy slicing."""
+        num_rows = table.num_rows
+        for i in range(0, num_rows, n):
+            end_idx = min(i + n, num_rows)
+            # Use PyArrow's zero-copy slice operation
+            batch_table = table.slice(i, end_idx - i)
+            yield batch_table
+
+    def __call__(self, block):
+        if not isinstance(block, pa.Table):
+            block = BlockAccessor.for_block(block).to_arrow()
+
+        if self._batch_size_estimate is None:
+            # Extract URIs from PyArrow table for sampling
+            uris = block.column(self._uri_column_name).to_pylist()
+            sample_uris = uris[: self.INIT_SAMPLE_BATCH_SIZE]
+            file_sizes = self._sample_sizes(sample_uris)
+            if not file_sizes:
+                # Fallback to incoming block size if no file sizes could be determined
+                logger.warning(
+                    "No file sizes could be determined, using incoming block size"
+                )
+                self._batch_size_estimate = block.num_rows
+            else:
+                file_size_estimate = sum(file_sizes) / len(file_sizes)
+                ctx = ray.data.context.DatasetContext.get_current()
+                max_bytes = ctx.target_max_block_size
+                self._batch_size_estimate = math.floor(max_bytes / file_size_estimate)
+
+        yield from self._arrow_batcher(block, self._batch_size_estimate)

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -150,10 +150,15 @@ class PartitionActor:
             except Exception:
                 return None
 
-        file_sizes = []
+        # If no URIs, return empty list
+        if not uri_list:
+            return []
+
+        # Get the filesystem from the first URI
+        fs, _ = pafs.from_uri(uri_list[0])
 
         # Use ThreadPoolExecutor for concurrent size fetching
-        fs, _ = pafs.from_uri(uri_list[0])
+        file_sizes = []
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             # Submit all size fetch tasks
             futures = [executor.submit(get_file_size, uri, fs) for uri in uri_list]

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -223,13 +223,13 @@ def plan_filter_op(
             zero_copy_batch=True,
         )
     else:
-        udf_is_callable_class = isinstance(op._filter_expr, CallableClass)
+        udf_is_callable_class = isinstance(op._fn, CallableClass)
         filter_fn, init_fn = _get_udf(
-            op._filter_expr,
-            op._filter_expr_args,
-            op._filter_expr_kwargs,
-            op._filter_expr_constructor_args if udf_is_callable_class else None,
-            op._filter_expr_constructor_kwargs if udf_is_callable_class else None,
+            op._fn,
+            op._fn_args,
+            op._fn_kwargs,
+            op._fn_constructor_args if udf_is_callable_class else None,
+            op._fn_constructor_kwargs if udf_is_callable_class else None,
         )
         transform_fn = _generate_transform_fn_for_filter(filter_fn)
         map_transformer = _create_map_transformer_for_row_based_map_op(

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -16,7 +16,6 @@ from typing import (
     Tuple,
     TypeVar,
 )
-from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
@@ -44,7 +43,6 @@ from ray.data._internal.execution.operators.map_transformer import (
 from ray.data._internal.execution.util import make_callable_class_concurrent
 from ray.data._internal.logical.operators.map_operator import (
     AbstractUDFMap,
-    Download,
     Filter,
     FlatMap,
     MapBatches,
@@ -304,186 +302,6 @@ def plan_udf_map_op(
         ray_remote_args_fn=op._ray_remote_args_fn,
         ray_remote_args=op._ray_remote_args,
     )
-
-
-def plan_download_op(
-    op: Download,
-    physical_children: List[PhysicalOperator],
-    data_context: DataContext,
-) -> MapOperator:
-    assert len(physical_children) == 1
-    input_physical_dag = physical_children[0]
-    compute = get_compute(op._compute)
-    uri_column_name = op.uri_column_name
-    output_bytes_column_name = op.output_bytes_column_name
-
-    # PartitionActor is a callable class, so we need ActorPoolStrategy
-    from ray.data._internal.compute import ActorPoolStrategy
-
-    partition_compute = ActorPoolStrategy(size=1)  # Use single actor for partitioning
-
-    fn, init_fn = _get_udf(PartitionActor, (), {}, (uri_column_name,), {})
-    partition_transform_fn = _generate_transform_fn_for_map_batches(fn)
-    partition_transform_fns = [
-        BlockMapTransformFn(partition_transform_fn),
-    ]
-    partition_map_transformer = MapTransformer(partition_transform_fns, init_fn)
-    partition_map_operator = MapOperator.create(
-        partition_map_transformer,
-        input_physical_dag,
-        data_context,
-        name="DownloadURIPartitioner",
-        compute_strategy=partition_compute,  # Use actor-based compute for callable class
-        ray_remote_args=op._ray_remote_args,
-        ray_remote_args_fn=op._ray_remote_args_fn,
-    )
-
-    fn, init_fn = _get_udf(
-        download_bytes_threaded,
-        (uri_column_name, output_bytes_column_name),
-        {},
-        None,
-        None,
-    )
-    download_transform_fn = _generate_transform_fn_for_map_batches(fn)
-    transform_fns = [
-        BlockMapTransformFn(download_transform_fn),
-    ]
-    download_map_transformer = MapTransformer(transform_fns, init_fn)
-    download_map_operator = MapOperator.create(
-        download_map_transformer,
-        partition_map_operator,
-        data_context,
-        name="DownloadURIDownloader",
-        compute_strategy=compute,
-        ray_remote_args=op._ray_remote_args,
-        ray_remote_args_fn=op._ray_remote_args_fn,
-    )
-
-    return download_map_operator
-
-
-def uri_to_path(uri: str) -> str:
-    parsed = urlparse(uri)
-    return parsed.netloc + parsed.path
-
-
-def download_bytes_threaded(
-    block, uri_column_name, output_bytes_column_name, max_workers=16
-):
-    """Optimized version that uses make_async_gen for concurrent downloads."""
-    from pyarrow.fs import FileSystem as pafs
-
-    from ray.data._internal.util import make_async_gen
-
-    if not isinstance(block, pa.Table):
-        block = BlockAccessor.for_block(block).to_arrow()
-
-    # Extract URIs from PyArrow table
-    uris = block.column(uri_column_name).to_pylist()
-
-    if len(uris) == 0:
-        return block
-
-    fs, _ = pafs.from_uri(uris[0])  # from_uri returns (filesystem, path)
-
-    def download_uris(uri_iterator):
-        """Function that takes an iterator of URIs and yields downloaded bytes for each."""
-        for uri in uri_iterator:
-            try:
-                with fs.open_input_file(uri_to_path(uri)) as f:
-                    yield f.read()
-            except Exception:
-                yield None
-
-    # Use make_async_gen to download URIs concurrently
-    # This preserves the order of results to match the input URIs
-    uri_bytes = list(
-        make_async_gen(
-            base_iterator=iter(uris),
-            fn=download_uris,
-            preserve_ordering=True,
-            num_workers=max_workers,
-        )
-    )
-
-    # Add the new column to the PyArrow table
-    return block.add_column(
-        len(block.column_names), output_bytes_column_name, pa.array(uri_bytes)
-    )
-
-
-class PartitionActor:
-    INIT_SAMPLE_BATCH_SIZE = 25
-
-    def __init__(self, uri_column_name: str):
-        self._uri_column_name = uri_column_name
-        self._batch_size_estimate = None
-
-    def _sample_sizes(self, uri_list, max_workers=16):
-        """Fetch file sizes in parallel using ThreadPoolExecutor."""
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-
-        from pyarrow.fs import FileSystem as pafs
-
-        def get_file_size(uri, fs):
-            try:
-                return fs.get_file_info(uri_to_path(uri)).size
-            except Exception:
-                return None
-
-        file_sizes = []
-
-        # Use ThreadPoolExecutor for concurrent size fetching
-        fs, _ = pafs.from_uri(uri_list[0])
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Submit all size fetch tasks
-            futures = [executor.submit(get_file_size, uri, fs) for uri in uri_list]
-
-            # Collect results as they complete (order doesn't matter)
-            for future in as_completed(futures):
-                try:
-                    size = future.result()
-                    if size is not None:
-                        file_sizes.append(size)
-                except Exception as e:
-                    logger.warning(f"Error fetching file size for download: {e}")
-
-        return file_sizes
-
-    def _arrow_batcher(self, table, n):
-        """Batch a PyArrow table into smaller tables of size n using zero-copy slicing."""
-        num_rows = table.num_rows
-        for i in range(0, num_rows, n):
-            end_idx = min(i + n, num_rows)
-            # Use PyArrow's zero-copy slice operation
-            batch_table = table.slice(i, end_idx - i)
-            yield batch_table
-
-    def __call__(self, block):
-        if not isinstance(block, pa.Table):
-            block = BlockAccessor.for_block(block).to_arrow()
-
-        import math
-
-        if self._batch_size_estimate is None:
-            # Extract URIs from PyArrow table for sampling
-            uris = block.column(self._uri_column_name).to_pylist()
-            sample_uris = uris[: self.INIT_SAMPLE_BATCH_SIZE]
-            file_sizes = self._sample_sizes(sample_uris)
-            if not file_sizes:
-                # Fallback to incoming block size if no file sizes could be determined
-                logger.warning(
-                    "No file sizes could be determined, using incoming block size"
-                )
-                self._batch_size_estimate = block.num_rows
-            else:
-                file_size_estimate = sum(file_sizes) / len(file_sizes)
-                ctx = ray.data.context.DatasetContext.get_current()
-                max_bytes = ctx.target_max_block_size
-                self._batch_size_estimate = math.floor(max_bytes / file_size_estimate)
-
-        yield from self._arrow_batcher(block, self._batch_size_estimate)
 
 
 def _get_udf(

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -217,8 +217,11 @@ class Planner:
                 break
 
             curr_physical_op.set_logical_operators(logical_op)
-            queue.extend(physical_op.input_dependencies)
+            # Add this operator to the op_map so optimizer can find it
+            op_map[curr_physical_op] = logical_op
+            queue.extend(curr_physical_op.input_dependencies)
 
+        # Also add the final operator (in case the loop didn't catch it)
         op_map[physical_op] = logical_op
         return physical_op, op_map
 

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -26,6 +26,7 @@ from ray.data._internal.logical.operators.input_data_operator import InputData
 from ray.data._internal.logical.operators.join_operator import Join
 from ray.data._internal.logical.operators.map_operator import (
     AbstractUDFMap,
+    Download,
     Filter,
     Project,
     StreamingRepartition,
@@ -38,6 +39,7 @@ from ray.data._internal.logical.operators.write_operator import Write
 from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
 from ray.data._internal.planner.plan_read_op import plan_read_op
 from ray.data._internal.planner.plan_udf_map_op import (
+    plan_download_op,
     plan_filter_op,
     plan_project_op,
     plan_streaming_repartition_op,
@@ -157,6 +159,7 @@ class Planner:
         StreamingRepartition: plan_streaming_repartition_op,
         Join: plan_join_op,
         StreamingSplit: plan_streaming_split_op,
+        Download: plan_download_op,
     }
 
     def plan(self, logical_plan: LogicalPlan) -> PhysicalPlan:

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -37,9 +37,9 @@ from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.operators.streaming_split_operator import StreamingSplit
 from ray.data._internal.logical.operators.write_operator import Write
 from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
+from ray.data._internal.planner.plan_download_op import plan_download_op
 from ray.data._internal.planner.plan_read_op import plan_read_op
 from ray.data._internal.planner.plan_udf_map_op import (
-    plan_download_op,
     plan_filter_op,
     plan_project_op,
     plan_streaming_repartition_op,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -818,6 +818,7 @@ class Dataset:
             download_op = Download(
                 self._logical_plan.dag,
                 uri_column_name=expr.uri_column_name,
+                output_bytes_column_name=column_name,
             )
             logical_plan = LogicalPlan(download_op, self.context)
         else:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -819,6 +819,7 @@ class Dataset:
                 self._logical_plan.dag,
                 uri_column_name=expr.uri_column_name,
                 output_bytes_column_name=column_name,
+                ray_remote_args=ray_remote_args,
             )
             logical_plan = LogicalPlan(download_op, self.context)
         else:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -808,17 +808,27 @@ class Dataset:
         Returns:
             A new dataset with the added column evaluated via the expression.
         """
-        from ray.data._internal.logical.operators.map_operator import Project
+        from ray.data._internal.logical.operators.map_operator import Download, Project
+
+        # TODO: Once the expression API supports UDFs, we can clean up the code here.
+        from ray.data.expressions import DownloadExpr
 
         plan = self._plan.copy()
-        project_op = Project(
-            self._logical_plan.dag,
-            cols=None,
-            cols_rename=None,
-            exprs={column_name: expr},
-            ray_remote_args=ray_remote_args,
-        )
-        logical_plan = LogicalPlan(project_op, self.context)
+        if isinstance(expr, DownloadExpr):
+            download_op = Download(
+                self._logical_plan.dag,
+                uri_column_name=expr.uri_column_name,
+            )
+            logical_plan = LogicalPlan(download_op, self.context)
+        else:
+            project_op = Project(
+                self._logical_plan.dag,
+                cols=None,
+                cols_rename=None,
+                exprs={column_name: expr},
+                ray_remote_args=ray_remote_args,
+            )
+            logical_plan = LogicalPlan(project_op, self.context)
         return Dataset(plan, logical_plan)
 
     @PublicAPI(api_group=BT_API_GROUP)

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -239,6 +239,20 @@ class BinaryExpr(Expr):
         )
 
 
+@DeveloperAPI(stability="alpha")
+@dataclass(frozen=True, eq=False)
+class DownloadExpr(Expr):
+    """Expression that represents a download operation."""
+
+    uri_column_name: str
+
+    def structurally_equals(self, other: Any) -> bool:
+        return (
+            isinstance(other, DownloadExpr)
+            and self.uri_column_name == other.uri_column_name
+        )
+
+
 @PublicAPI(stability="beta")
 def col(name: str) -> ColumnExpr:
     """
@@ -301,6 +315,35 @@ def lit(value: Any) -> LiteralExpr:
     return LiteralExpr(value)
 
 
+@DeveloperAPI(stability="alpha")
+def download(uri_column_name: str) -> DownloadExpr:
+    """
+    Create a download expression that downloads content from URIs.
+
+    This creates an expression that will download bytes from URIs stored in
+    a specified column. When evaluated, it will fetch the content from each URI
+    and return the downloaded bytes.
+
+    Args:
+        uri_column_name: The name of the column containing URIs to download from
+
+    Returns:
+        A DownloadExpr that will download content from the specified URI column
+
+    Example:
+        >>> from ray.data.expressions import download
+        >>> import ray
+        >>> # Create dataset with URIs
+        >>> ds = ray.data.from_items([
+        ...     {"uri": "s3://bucket/file1.jpg", "id": "1"},
+        ...     {"uri": "s3://bucket/file2.jpg", "id": "2"}
+        ... ])
+        >>> # Add downloaded bytes column
+        >>> ds_with_bytes = ds.add_column("bytes", download("uri"))
+    """
+    return DownloadExpr(uri_column_name=uri_column_name)
+
+
 # ──────────────────────────────────────
 # Public API for evaluation
 # ──────────────────────────────────────
@@ -314,6 +357,8 @@ __all__ = [
     "ColumnExpr",
     "LiteralExpr",
     "BinaryExpr",
+    "DownloadExpr",
     "col",
     "lit",
+    "download",
 ]

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -326,7 +326,6 @@ def download(uri_column_name: str) -> DownloadExpr:
 
     Args:
         uri_column_name: The name of the column containing URIs to download from
-
     Returns:
         A DownloadExpr that will download content from the specified URI column
 
@@ -339,7 +338,7 @@ def download(uri_column_name: str) -> DownloadExpr:
         ...     {"uri": "s3://bucket/file2.jpg", "id": "2"}
         ... ])
         >>> # Add downloaded bytes column
-        >>> ds_with_bytes = ds.add_column("bytes", download("uri"))
+        >>> ds_with_bytes = ds.with_column("bytes", download("uri"))
     """
     return DownloadExpr(uri_column_name=uri_column_name)
 

--- a/python/ray/data/tests/test_download_expression.py
+++ b/python/ray/data/tests/test_download_expression.py
@@ -1,0 +1,243 @@
+import io
+
+import pyarrow as pa
+import pytest
+from PIL import Image
+
+import ray
+from ray.data.expressions import DownloadExpr, col, download
+
+
+class TestDownloadExpressionStructure:
+    """Test DownloadExpr structural equality and basic properties."""
+
+    def test_download_expression_creation(self):
+        """Test that download() creates a DownloadExpr with correct properties."""
+        expr = download("uri_column")
+
+        assert isinstance(expr, DownloadExpr)
+        assert expr.uri_column_name == "uri_column"
+
+    def test_download_expression_structural_equality(self):
+        """Test structural equality comparison for download expressions."""
+        # Same expressions should be equal
+        expr1 = download("uri")
+        expr2 = download("uri")
+        assert expr1.structurally_equals(expr2)
+        assert expr2.structurally_equals(expr1)
+
+        # Different URI column names should not be equal
+        expr3 = download("different_uri")
+        assert not expr1.structurally_equals(expr3)
+        assert not expr3.structurally_equals(expr1)
+
+        # Compare with non-DownloadExpr
+        non_download_expr = col("uri")
+        assert not expr1.structurally_equals(non_download_expr)
+        assert not non_download_expr.structurally_equals(expr1)
+
+
+class TestDownloadExpressionFunctionality:
+    """Test actual download functionality with real and mocked data."""
+
+    def test_download_expression_with_local_files(self, tmp_path):
+        """Test basic download expression functionality with local files."""
+        # Create sample files with different content types
+        sample_data = [
+            b"This is test file 1 content",
+            b"Different content for file 2",
+            b"File 3 has some binary data: \x00\x01\x02\x03",
+        ]
+
+        file_paths = []
+        for i, data in enumerate(sample_data):
+            file_path = tmp_path / f"test_file_{i}.txt"
+            file_path.write_bytes(data)
+            file_paths.append(str(file_path))
+
+        # Create dataset with file URIs and metadata
+        table = pa.Table.from_arrays(
+            [
+                pa.array([f"file://{path}" for path in file_paths]),
+                pa.array([f"id_{i}" for i in range(len(file_paths))]),
+                pa.array([f"metadata_{i}" for i in range(len(file_paths))]),
+                pa.array(range(len(file_paths))),
+            ],
+            names=["file_uri", "file_id", "metadata", "index"],
+        )
+
+        ds = ray.data.from_arrow(table)
+
+        # Add download column using expression
+        ds_with_downloads = ds.with_column("file_bytes", download("file_uri"))
+
+        # Verify results
+        results = ds_with_downloads.take_all()
+        assert len(results) == len(sample_data)
+
+        for i, result in enumerate(results):
+            # Download column should be added correctly
+            assert "file_bytes" in result
+            assert result["file_bytes"] == sample_data[i]
+
+            # All original columns should be preserved
+            assert result["file_id"] == f"id_{i}"
+            assert result["metadata"] == f"metadata_{i}"
+            assert result["index"] == i
+            assert result["file_uri"] == f"file://{file_paths[i]}"
+
+    def test_download_expression_empty_dataset(self):
+        """Test download expression with empty dataset."""
+        # Create empty dataset with correct schema
+        table = pa.Table.from_arrays(
+            [
+                pa.array([], type=pa.string()),
+            ],
+            names=["uri"],
+        )
+
+        ds = ray.data.from_arrow(table)
+        ds_with_downloads = ds.with_column("bytes", download("uri"))
+
+        results = ds_with_downloads.take_all()
+        assert len(results) == 0
+
+    def test_download_expression_with_different_file_types(self, tmp_path):
+        """Test download expression with various file types including actual images."""
+        # Create a small 8x8 RGB image
+        small_image = Image.new("RGB", (8, 8), color=(255, 0, 0))  # Red 8x8 image
+        image_buffer = io.BytesIO()
+        small_image.save(image_buffer, format="PNG")
+        image_bytes = image_buffer.getvalue()
+
+        # Create files with different types of content
+        test_files = [
+            ("text_file.txt", b"Simple text content"),
+            ("binary_file.dat", b"\x00\x01\x02\x03\x04\x05"),
+            ("json_file.json", b'{"key": "value", "number": 123}'),
+            ("small_image.png", image_bytes),  # Actual PNG image (primary use case)
+            ("empty_file.txt", b""),  # Empty file edge case
+        ]
+
+        file_paths = []
+        expected_data = []
+        for filename, content in test_files:
+            file_path = tmp_path / filename
+            file_path.write_bytes(content)
+            file_paths.append(str(file_path))
+            expected_data.append(content)
+
+        # Create dataset
+        table = pa.Table.from_arrays(
+            [
+                pa.array([f"file://{path}" for path in file_paths]),
+                pa.array(
+                    [f.split(".")[0] for f, _ in test_files]
+                ),  # filename without extension
+            ],
+            names=["file_uri", "file_type"],
+        )
+
+        ds = ray.data.from_arrow(table)
+        ds_with_downloads = ds.with_column("content", download("file_uri"))
+
+        results = ds_with_downloads.take_all()
+        assert len(results) == len(test_files)
+
+        for i, result in enumerate(results):
+            assert result["content"] == expected_data[i]
+            assert result["file_type"] == test_files[i][0].split(".")[0]
+
+            # Special verification for image file - ensure it can be loaded as an image
+            if test_files[i][0].endswith(".png"):
+                downloaded_image = Image.open(io.BytesIO(result["content"]))
+                assert downloaded_image.size == (8, 8)
+                assert downloaded_image.mode == "RGB"
+
+
+class TestDownloadExpressionErrors:
+    """Test error conditions and edge cases for download expressions."""
+
+    def test_download_expression_invalid_uri_column(self):
+        """Test download expression with non-existent URI column."""
+        table = pa.Table.from_arrays(
+            [
+                pa.array(["file://test.txt"]),
+            ],
+            names=["existing_column"],
+        )
+
+        ds = ray.data.from_arrow(table)
+        ds_with_downloads = ds.with_column("bytes", download("non_existent_column"))
+
+        # Should raise error when trying to execute
+        with pytest.raises(Exception):  # Could be KeyError or similar
+            ds_with_downloads.take_all()
+
+    def test_download_expression_with_null_uris(self):
+        """Test download expression handling of null/empty URIs."""
+        table = pa.Table.from_arrays(
+            [
+                pa.array(["file://test.txt", None, ""]),
+            ],
+            names=["uri"],
+        )
+
+        ds = ray.data.from_arrow(table)
+        ds_with_downloads = ds.with_column("bytes", download("uri"))
+
+        # Should handle nulls gracefully (exact behavior may vary)
+        # This test mainly ensures no crash occurs
+        try:
+            results = ds_with_downloads.take_all()
+            # If it succeeds, verify structure is reasonable
+            assert len(results) == 3
+            for result in results:
+                assert "bytes" in result
+        except Exception as e:
+            # If it fails, should be a reasonable error (not a crash)
+            assert isinstance(e, (ValueError, KeyError, RuntimeError))
+
+
+class TestDownloadExpressionIntegration:
+    """Integration tests combining download expressions with other Ray Data operations."""
+
+    def test_download_expression_with_map_batches(self, tmpdir):
+        """Test download expression followed by map_batches processing."""
+        # Create a test file
+        test_file = tmpdir.join("test.txt")
+        test_content = b"Hello, World!"
+        test_file.write_binary(test_content)
+
+        # Create dataset
+        table = pa.Table.from_arrays(
+            [
+                pa.array([f"file://{test_file}"]),
+            ],
+            names=["uri"],
+        )
+
+        ds = ray.data.from_arrow(table)
+
+        # Download then process
+        ds_with_content = ds.with_column("raw_bytes", download("uri"))
+
+        def decode_bytes(batch):
+            # Access the specific column containing the bytes data
+            batch["decoded_text"] = [
+                data.decode("utf-8") for data in batch["raw_bytes"]
+            ]
+            return batch
+
+        ds_decoded = ds_with_content.map_batches(decode_bytes)
+        results = ds_decoded.take_all()
+
+        assert len(results) == 1
+        assert results[0]["decoded_text"] == "Hello, World!"
+        assert results[0]["raw_bytes"] == test_content
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_download_expression.py
+++ b/python/ray/data/tests/test_download_expression.py
@@ -58,7 +58,7 @@ class TestDownloadExpressionFunctionality:
         # Create dataset with file URIs and metadata
         table = pa.Table.from_arrays(
             [
-                pa.array([f"file://{path}" for path in file_paths]),
+                pa.array([f"local://{path}" for path in file_paths]),
                 pa.array([f"id_{i}" for i in range(len(file_paths))]),
                 pa.array([f"metadata_{i}" for i in range(len(file_paths))]),
                 pa.array(range(len(file_paths))),
@@ -84,7 +84,7 @@ class TestDownloadExpressionFunctionality:
             assert result["file_id"] == f"id_{i}"
             assert result["metadata"] == f"metadata_{i}"
             assert result["index"] == i
-            assert result["file_uri"] == f"file://{file_paths[i]}"
+            assert result["file_uri"] == f"local://{file_paths[i]}"
 
     def test_download_expression_empty_dataset(self):
         """Test download expression with empty dataset."""
@@ -130,7 +130,7 @@ class TestDownloadExpressionFunctionality:
         # Create dataset
         table = pa.Table.from_arrays(
             [
-                pa.array([f"file://{path}" for path in file_paths]),
+                pa.array([f"local://{path}" for path in file_paths]),
                 pa.array(
                     [f.split(".")[0] for f, _ in test_files]
                 ),  # filename without extension
@@ -162,7 +162,7 @@ class TestDownloadExpressionErrors:
         """Test download expression with non-existent URI column."""
         table = pa.Table.from_arrays(
             [
-                pa.array(["file://test.txt"]),
+                pa.array(["local://test.txt"]),
             ],
             names=["existing_column"],
         )
@@ -178,7 +178,7 @@ class TestDownloadExpressionErrors:
         """Test download expression handling of null/empty URIs."""
         table = pa.Table.from_arrays(
             [
-                pa.array(["file://test.txt", None, ""]),
+                pa.array(["local://test.txt", None, ""]),
             ],
             names=["uri"],
         )
@@ -212,7 +212,7 @@ class TestDownloadExpressionIntegration:
         # Create dataset
         table = pa.Table.from_arrays(
             [
-                pa.array([f"file://{test_file}"]),
+                pa.array([f"local://{test_file}"]),
             ],
             names=["uri"],
         )


### PR DESCRIPTION
## Why are these changes needed?
There are many use cases for Ray Data where you might have a column of URIs, that you want to transform into a column of bytes corresponding to the bytes in those URIs. Currently Ray Data does, not handle this use case very well because the incoming number of bytes is quite small relative to the size of the bytes loaded when loading the data from the URIs. This introduces a new code path that can be used to estimate the size of the files, allowing for more adequate block sizes to be used leading to increased performance. In followups, we will introduce additional code to allow users to efficiently decode the bytes that have been loaded from the URIs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
