### PR TITLE
[Core] Use _Exit instead of std::quick_exit which may not exist on mac

### DIFF
--- a/src/ray/core_worker/core_worker_shutdown_executor.cc
+++ b/src/ray/core_worker/core_worker_shutdown_executor.cc
@@ -301,8 +301,7 @@ void CoreWorkerShutdownExecutor::DisconnectServices(
 
 void CoreWorkerShutdownExecutor::QuickExit() {
   RAY_LOG(WARNING) << "Quick exit - terminating process immediately";
-  RAY_LOG(WARNING) << "Quick exit - calling std::quick_exit(1)";
-  std::quick_exit(1);
+  ray::QuickExit();
   RAY_LOG(WARNING) << "Quick exit - this line should never be reached";
 }
 }  // namespace core


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`std::quick_exit` doesn't exist in our CI mac machines. Use `QuickExit()` in process.cc instead which calls `_Exit()`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
