### PR TITLE
[data] Sample schemas in unification

### DIFF
--- a/python/ray/data/_internal/equalize.py
+++ b/python/ray/data/_internal/equalize.py
@@ -41,7 +41,7 @@ def _equalize(
 
     # phase 2: based on the num rows needed for each shaved split, split the leftovers
     # in the shape that exactly matches the rows needed.
-    schema = unify_ref_bundles_schema(per_split_bundles)
+    schema = unify_ref_bundles_schema(per_split_bundles, sample_size=1)
     leftover_bundle = RefBundle(leftovers, owns_blocks=owned_by_consumer, schema=schema)
     leftover_splits = _split_leftovers(leftover_bundle, per_split_needed_rows)
 

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -179,7 +179,7 @@ def _bundles_to_block_list(bundles: Iterator[RefBundle]) -> BlockList:
         blocks.extend(ref_bundle.block_refs)
         metadata.extend(ref_bundle.metadata)
         schemas.append(ref_bundle.schema)
-    unified_schema = unify_schemas_with_validation(schemas)
+    unified_schema = unify_schemas_with_validation(schemas, sample_size=None)
     return BlockList(
         blocks, metadata, owned_by_consumer=owns_blocks, schema=unified_schema
     )

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -179,7 +179,7 @@ def _bundles_to_block_list(bundles: Iterator[RefBundle]) -> BlockList:
         blocks.extend(ref_bundle.block_refs)
         metadata.extend(ref_bundle.metadata)
         schemas.append(ref_bundle.schema)
-    unified_schema = unify_schemas_with_validation(schemas, sample_size=None)
+    unified_schema = unify_schemas_with_validation(schemas, sample_size=1)
     return BlockList(
         blocks, metadata, owned_by_consumer=owns_blocks, schema=unified_schema
     )

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -669,7 +669,7 @@ def _merge_ref_bundles(*bundles: RefBundle) -> RefBundle:
         )
     )
     owns_blocks = all(bundle.owns_blocks for bundle in bundles if bundle is not None)
-    schema = unify_ref_bundles_schema(bundles)
+    schema = unify_ref_bundles_schema(bundles, sample_size=1)
     return RefBundle(blocks, owns_blocks=owns_blocks, schema=schema)
 
 

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -794,7 +794,10 @@ def dedupe_schemas_with_validation(
             f"new schema: {bundle.schema}. This may lead to unexpected behavior."
         )
     if allow_divergent:
-        old_schema = unify_schemas_with_validation([old_schema, bundle.schema])
+        # allow_divergent is default false, so this will not run most of the times.
+        old_schema = unify_schemas_with_validation(
+            [old_schema, bundle.schema], sample_size=None
+        )
 
     return (
         RefBundle(

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -28,7 +28,7 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
             len(input_metadata),
         )
         # `owns_blocks` is False because this op may be shared by multiple Datasets.
-        self._schema = unify_block_metadata_schema(input_metadata, sample_size=None)
+        self._schema = unify_block_metadata_schema(input_metadata, sample_size=1)
         self._input_data = [
             RefBundle(
                 [(input_blocks[i], input_metadata[i])],

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -28,7 +28,7 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
             len(input_metadata),
         )
         # `owns_blocks` is False because this op may be shared by multiple Datasets.
-        self._schema = unify_block_metadata_schema(input_metadata)
+        self._schema = unify_block_metadata_schema(input_metadata, sample_size=None)
         self._input_data = [
             RefBundle(
                 [(input_blocks[i], input_metadata[i])],

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -49,7 +49,7 @@ class InputData(LogicalOperator, SourceOperator):
             return None
 
     def infer_schema(self):
-        return unify_ref_bundles_schema(self.input_data)
+        return unify_ref_bundles_schema(self.input_data, sample_size=None)
 
     def is_lineage_serializable(self) -> bool:
         # This operator isn't serializable because it contains ObjectRefs.

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -49,7 +49,7 @@ class InputData(LogicalOperator, SourceOperator):
             return None
 
     def infer_schema(self):
-        return unify_ref_bundles_schema(self.input_data, sample_size=None)
+        return unify_ref_bundles_schema(self.input_data, sample_size=1)
 
     def is_lineage_serializable(self) -> bool:
         # This operator isn't serializable because it contains ObjectRefs.

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -105,7 +105,7 @@ class Read(AbstractMap, SourceOperator):
 
         schema = None
         if schemas:
-            schema = unify_schemas_with_validation(schemas)
+            schema = unify_schemas_with_validation(schemas, sample_size=None)
         return BlockMetadataWithSchema(metadata=meta, schema=schema)
 
     def can_modify_num_rows(self) -> bool:

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -105,7 +105,7 @@ class Read(AbstractMap, SourceOperator):
 
         schema = None
         if schemas:
-            schema = unify_schemas_with_validation(schemas, sample_size=None)
+            schema = unify_schemas_with_validation(schemas, sample_size=1)
         return BlockMetadataWithSchema(metadata=meta, schema=schema)
 
     def can_modify_num_rows(self) -> bool:

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -518,7 +518,7 @@ class ExecutionPlan:
                 output_bundles = self._logical_plan.dag.output_data()
                 schema = self._logical_plan.dag.infer_schema()
                 owns_blocks = all(bundle.owns_blocks for bundle in output_bundles)
-                schema = unify_ref_bundles_schema(output_bundles)
+                schema = unify_ref_bundles_schema(output_bundles, sample_size=None)
                 bundle = RefBundle(
                     [
                         (block, metadata)

--- a/python/ray/data/_internal/planner/aggregate.py
+++ b/python/ray/data/_internal/planner/aggregate.py
@@ -52,7 +52,7 @@ def generate_aggregate_fn(
             metadata.extend(ref_bundle.metadata)
         if len(blocks) == 0:
             return (blocks, {})
-        unified_schema = unify_ref_bundles_schema(refs)
+        unified_schema = unify_ref_bundles_schema(refs, sample_size=None)
         for agg_fn in aggs:
             agg_fn._validate(unified_schema)
 

--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -749,7 +749,7 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
             input_files=None,
             exec_stats=stats.build(),
         )
-        schema = unify_schemas_with_validation(schemas)
+        schema = unify_schemas_with_validation(schemas, sample_size=1)
         meta_with_schema = BlockMetadataWithSchema(metadata=meta, schema=schema)
         yield meta_with_schema
 

--- a/python/ray/data/_internal/planner/sort.py
+++ b/python/ray/data/_internal/planner/sort.py
@@ -36,7 +36,7 @@ def generate_sort_fn(
             blocks.extend(ref_bundle.block_refs)
         if len(blocks) == 0:
             return (blocks, {})
-        sort_key.validate_schema(unify_ref_bundles_schema(refs))
+        sort_key.validate_schema(unify_ref_bundles_schema(refs, sample_size=None))
 
         num_mappers = len(blocks)
         # Use same number of output partitions.

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -775,7 +775,7 @@ def unify_schemas_with_validation(
             for schema in schemas_to_unify:
                 if not _is_empty_schema(schema):
                     non_empty_schemas_to_unify.append(schema)
-                    if len(non_empty_schemas_to_unify) >= sample_size:
+                    if sample_size is not None and len(non_empty_schemas_to_unify) >= sample_size:
                         break
             return unify_schemas(non_empty_schemas_to_unify, promote_types=True)
         # Otherwise, if the resulting schemas are simple types (e.g. int),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
unification of schemas is slow. Provide a way to limit the number of schemas being sampled. When sample_size=1, unification is skipped and we just return the first non empty schema.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
