### PR TITLE
[core][chore] Rename `obj_ref` to `object_refs` because `invocation` returns a list of ObjectRef in most cases

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -855,14 +855,18 @@ class ActorMethod:
         if self._decorator is not None:
             invocation = self._decorator(invocation)
 
-        obj_ref = invocation(args, kwargs)
+        object_refs = invocation(args, kwargs)
         if tensor_transport != TensorTransportEnum.OBJECT_STORE:
+            # Currently, we only support transfer tensor out-of-band when
+            # num_returns is 1.
+            assert isinstance(object_refs, ObjectRef)
+            object_ref = object_refs
             gpu_object_manager = ray._private.worker.global_worker.gpu_object_manager
             gpu_object_manager.add_gpu_object_ref(
-                obj_ref, self._actor, tensor_transport
+                object_ref, self._actor, tensor_transport
             )
 
-        return obj_ref
+        return object_refs
 
     def __getstate__(self):
         return {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```python
object_refs = invocation(args, kwargs)
```

`invocation` returns a list of object refs. It returns `ObjectRef` when there is only 1 object ref.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
