### PR TITLE
[core][gpu-objects] tensor shape/dtype is not necessary for send_multiple_tensors

### DIFF
--- a/python/ray/experimental/collective/collective_tensor_transport.py
+++ b/python/ray/experimental/collective/collective_tensor_transport.py
@@ -129,7 +129,6 @@ class CollectiveTensorTransport(TensorTransportManager):
     @staticmethod
     def send_multiple_tensors(
         tensors: List["torch.Tensor"],
-        tensor_transport_metadata: CollectiveTransportMetadata,
         communicator_metadata: CollectiveCommunicatorMetadata,
         device: "torch.device",
     ):

--- a/python/ray/experimental/collective/nixl_tensor_transport.py
+++ b/python/ray/experimental/collective/nixl_tensor_transport.py
@@ -109,7 +109,6 @@ class NixlTensorTransport(TensorTransportManager):
     @staticmethod
     def send_multiple_tensors(
         tensors: List["torch.Tensor"],
-        tensor_transport_metadata: NixlTransportMetadata,
         communicator_metadata: NixlCommunicatorMetadata,
         device: "torch.device",
     ):

--- a/python/ray/experimental/collective/tensor_transport_manager.py
+++ b/python/ray/experimental/collective/tensor_transport_manager.py
@@ -64,7 +64,6 @@ class TensorTransportManager(ABC):
     def send_object(
         src_actor: "ray.actor.ActorHandle",
         obj_id: str,
-        tensor_transport_metadata_ref: TensorTransportMetadata,
         communicator_metadata_ref: CommunicatorMetadata,
     ):
         """
@@ -73,7 +72,6 @@ class TensorTransportManager(ABC):
         Args:
             src_actor: The actor that runs this function.
             obj_id: The ID of the GPU object to send.
-            tensor_transport_metadata_ref: The ObjectRef of tensor transport metadata for the GPU object.
             communicator_metadata_ref: The ObjectRef of communicator metadata for the send/recv operation.
         """
         from ray.experimental.gpu_object_manager.gpu_object_store import __ray_send__
@@ -85,7 +83,6 @@ class TensorTransportManager(ABC):
         src_actor.__ray_call__.options(concurrency_group="_ray_system").remote(
             __ray_send__,
             obj_id,
-            tensor_transport_metadata_ref,
             communicator_metadata_ref,
         )
 
@@ -145,7 +142,6 @@ class TensorTransportManager(ABC):
     @abstractmethod
     def send_multiple_tensors(
         tensors: List["torch.Tensor"],
-        tensor_transport_metadata: TensorTransportMetadata,
         communicator_metadata: CommunicatorMetadata,
         device: "torch.device",
     ):
@@ -154,7 +150,6 @@ class TensorTransportManager(ABC):
 
         Args:
             tensors: The tensors to send.
-            tensor_transport_metadata: The tensor transport metadata for the GPU object.
             communicator_metadata: The communicator metadata for the send/recv operation.
             device: The device to send the tensors to.
         """

--- a/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
@@ -222,7 +222,6 @@ class GPUObjectManager:
                 tensor_transport_manager.send_object(
                     src_actor,
                     obj_id,
-                    tensor_transport_meta,
                     communicator_meta,
                 )
             tensor_transport_manager.recv_object(

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -48,7 +48,6 @@ def _tensor_transport_to_collective_backend(
 def __ray_send__(
     self,
     obj_id: str,
-    tensor_transport_meta: TensorTransportMetadata,
     communicator_meta: CommunicatorMetadata,
 ):
     """Helper function that runs on the src actor to send tensors to the dst actor."""
@@ -69,7 +68,6 @@ def __ray_send__(
     tensor_transport_manager = get_tensor_transport_manager(backend)
     tensor_transport_manager.send_multiple_tensors(
         tensors,
-        tensor_transport_meta,
         communicator_meta,
         device=device,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As title, only the receiver needs the tensor shape / dtype to receive tensors.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
