### PR TITLE
[core] fix gpu profiler for non-root non-gpu containers

### DIFF
--- a/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
@@ -106,7 +106,7 @@ class GpuProfilingManager:
         try:
             subprocess.check_output(["nvidia-smi"], stderr=subprocess.DEVNULL)
             return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, PermissionError):
             return False
 
     @classmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
For containers without any GPU and running as non-root user, `nvidia-smi` in subprocess will raise a `PermissionError` rather than a `FileNotFoundError`.

In fact there are two ways to fix this:
1. use absolute path instead of relative path. i.e. `/usr/bin/nvidia-smi`
2. catch PermissionError at the same time

This PR uses the second since the absolute path may differ.

Otherwise, dashboard agent will fail to start up:
```
$ cat /tmp/ray/session_2025-08-25_09-55-04_706010_1/logs/dashboard_agent.log
2025-08-25 09:55:10,073	INFO agent.py:127 -- Dashboard agent grpc address: 0.0.0.0:61993
2025-08-25 09:55:10,073	INFO utils.py:304 -- Get all modules by type: DashboardAgentModule
2025-08-25 09:55:10,263	INFO utils.py:337 -- Available modules: [<class 'ray.dashboard.modules.aggregator.aggregator_agent.AggregatorAgent'>, <class 'ray.dashboard.modules.event.event_agent.EventAgent'>, <class 'ray.dashboard.modules.job.job_agent.JobAgent'>, <class 'ray.dashboard.modules.log.log_agent.LogAgent'>, <class 'ray.dashboard.modules.log.log_agent.LogAgentV1Grpc'>, <class 'ray.dashboard.modules.reporter.healthz_agent.HealthzAgent'>, <class 'ray.dashboard.modules.reporter.reporter_agent.ReporterAgent'>]
2025-08-25 09:55:10,263	INFO agent.py:143 -- Loading DashboardAgentModule: <class 'ray.dashboard.modules.aggregator.aggregator_agent.AggregatorAgent'>
2025-08-25 09:55:10,263	INFO agent.py:143 -- Loading DashboardAgentModule: <class 'ray.dashboard.modules.event.event_agent.EventAgent'>
2025-08-25 09:55:10,263	INFO event_agent.py:48 -- Event agent cache buffer size: 10240
2025-08-25 09:55:10,263	INFO agent.py:143 -- Loading DashboardAgentModule: <class 'ray.dashboard.modules.job.job_agent.JobAgent'>
2025-08-25 09:55:10,263	INFO agent.py:143 -- Loading DashboardAgentModule: <class 'ray.dashboard.modules.log.log_agent.LogAgent'>
2025-08-25 09:55:10,263	INFO agent.py:143 -- Loading DashboardAgentModule: <class 'ray.dashboard.modules.log.log_agent.LogAgentV1Grpc'>
2025-08-25 09:55:10,263	INFO agent.py:143 -- Loading DashboardAgentModule: <class 'ray.dashboard.modules.reporter.healthz_agent.HealthzAgent'>
2025-08-25 09:55:10,263	INFO agent.py:143 -- Loading DashboardAgentModule: <class 'ray.dashboard.modules.reporter.reporter_agent.ReporterAgent'>
2025-08-25 09:55:10,288	ERROR agent.py:453 -- Agent is working abnormally. It will exit immediately.
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/ray/dashboard/agent.py", line 451, in <module>
    loop.run_until_complete(agent.run())
  File "/usr/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/ray/dashboard/agent.py", line 166, in run
    modules = self._load_modules()
              ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/ray/dashboard/agent.py", line 146, in _load_modules
    c = cls(self)
        ^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/ray/dashboard/modules/reporter/reporter_agent.py", line 494, in __init__
    self._gpu_profiling_manager = GpuProfilingManager(
                                  ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/ray/dashboard/modules/reporter/gpu_profile_manager.py", line 77, in __init__
    if not self.node_has_gpus():
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/ray/dashboard/modules/reporter/gpu_profile_manager.py", line 107, in node_has_gpus
    subprocess.check_output(["nvidia-smi"], stderr=subprocess.DEVNULL)
  File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
PermissionError: [Errno 13] Permission denied: 'nvidia-smi'
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
