### PR TITLE
[core] Remove `gcs_rpc_server.h` dependency from `GcsNodeManager`

### DIFF
--- a/src/ray/gcs/gcs_server/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/BUILD.bazel
@@ -240,7 +240,6 @@ ray_cc_library(
         "grpc_services.h",
     ],
     implementation_deps = [
-        ":gcs_node_manager",
         "//src/ray/common:ray_config",
     ],
     visibility = ["//visibility:private"],

--- a/src/ray/gcs/gcs_server/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/BUILD.bazel
@@ -72,9 +72,9 @@ ray_cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
     ],
     deps = [
-        ":grpc_service_interfaces",
         ":gcs_init_data",
         ":gcs_table_storage",
+        ":grpc_service_interfaces",
         "//src/ray/common:asio",
         "//src/ray/common:id",
         "//src/ray/common:ray_config",
@@ -248,9 +248,9 @@ ray_cc_library(
         ":grpc_service_interfaces",
         "//src/ray/common:asio",
         "//src/ray/common:id",
+        "//src/ray/protobuf:gcs_service_cc_grpc",
         "//src/ray/rpc:grpc_server",
         "//src/ray/rpc:server_call",
-        "//src/ray/protobuf:gcs_service_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
     ],
 )

--- a/src/ray/gcs/gcs_server/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/BUILD.bazel
@@ -72,6 +72,7 @@ ray_cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
     ],
     deps = [
+        ":grpc_service_interfaces",
         ":gcs_init_data",
         ":gcs_table_storage",
         "//src/ray/common:asio",
@@ -80,7 +81,6 @@ ray_cc_library(
         "//src/ray/gcs/pubsub:gcs_pub_sub_lib",
         "//src/ray/protobuf:gcs_service_cc_proto",
         "//src/ray/protobuf:ray_syncer_cc_proto",
-        "//src/ray/rpc:gcs_server",
         "//src/ray/rpc:node_manager_client",
         "//src/ray/util:event",
         "//src/ray/util:logging",
@@ -220,6 +220,42 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "grpc_service_interfaces",
+    hdrs = [
+        "grpc_service_interfaces.h",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/ray/common:status",
+        "//src/ray/protobuf:gcs_service_cc_grpc",
+    ],
+)
+
+ray_cc_library(
+    name = "grpc_services",
+    srcs = [
+        "grpc_services.cc",
+    ],
+    hdrs = [
+        "grpc_services.h",
+    ],
+    implementation_deps = [
+        ":gcs_node_manager",
+        "//src/ray/common:ray_config",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":grpc_service_interfaces",
+        "//src/ray/common:asio",
+        "//src/ray/common:id",
+        "//src/ray/rpc:grpc_server",
+        "//src/ray/rpc:server_call",
+        "//src/ray/protobuf:gcs_service_cc_grpc",
+        "@com_github_grpc_grpc//:grpc++",
+    ],
+)
+
+ray_cc_library(
     name = "gcs_server_lib",
     srcs = [
         "gcs_actor_manager.cc",
@@ -255,6 +291,8 @@ ray_cc_library(
         ":gcs_task_manager",
         ":gcs_usage_stats_client",
         ":gcs_worker_manager",
+        ":grpc_service_interfaces",
+        ":grpc_services",
         "//src/ray/gcs/pubsub:gcs_pub_sub_lib",
         "//src/ray/gcs/store_client",
         "//src/ray/gcs/store_client:in_memory_store_client",

--- a/src/ray/gcs/gcs_server/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/BUILD.bazel
@@ -239,9 +239,6 @@ ray_cc_library(
     hdrs = [
         "grpc_services.h",
     ],
-    implementation_deps = [
-        "//src/ray/common:ray_config",
-    ],
     visibility = ["//visibility:private"],
     deps = [
         ":grpc_service_interfaces",

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -88,7 +88,7 @@ void GcsNodeManager::HandleRegisterNode(rpc::RegisterNodeRequest request,
           .WithField(node_id)
           .WithField("node_name", node_info.node_name())
           .WithField("node_address", node_info.node_manager_address())
-      << "Registering new node.";
+      << "Registering new node. ";
 
   auto on_done = [this, node_id, node_info_copy = node_info, reply, send_reply_callback](
                      const Status &status) mutable {

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -88,7 +88,7 @@ void GcsNodeManager::HandleRegisterNode(rpc::RegisterNodeRequest request,
           .WithField(node_id)
           .WithField("node_name", node_info.node_name())
           .WithField("node_address", node_info.node_manager_address())
-      << "Registering new node. ";
+      << "Registering new node.";
 
   auto on_done = [this, node_id, node_info_copy = node_info, reply, send_reply_callback](
                      const Status &status) mutable {

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -24,8 +24,8 @@
 #include "ray/common/id.h"
 #include "ray/gcs/gcs_server/gcs_init_data.h"
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
+#include "ray/gcs/gcs_server/grpc_service_interfaces.h"
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
-#include "ray/rpc/gcs/gcs_rpc_server.h"
 #include "ray/rpc/node_manager/raylet_client_pool.h"
 #include "ray/util/event.h"
 #include "src/ray/protobuf/gcs.pb.h"
@@ -39,7 +39,7 @@ class GcsStateTest;
 /// GcsNodeManager is responsible for managing and monitoring nodes as well as handing
 /// node and resource related rpc requests.
 /// This class is not thread-safe.
-class GcsNodeManager : public rpc::NodeInfoHandler {
+class GcsNodeManager {
  public:
   /// Create a GcsNodeManager.
   ///
@@ -54,32 +54,32 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Handle register rpc request come from raylet.
   void HandleGetClusterId(rpc::GetClusterIdRequest request,
                           rpc::GetClusterIdReply *reply,
-                          rpc::SendReplyCallback send_reply_callback) override;
+                          rpc::SendReplyCallback send_reply_callback);
 
   /// Handle register rpc request come from raylet.
   void HandleRegisterNode(rpc::RegisterNodeRequest request,
                           rpc::RegisterNodeReply *reply,
-                          rpc::SendReplyCallback send_reply_callback) override;
+                          rpc::SendReplyCallback send_reply_callback);
 
   /// Handle unregister rpc request come from raylet.
   void HandleUnregisterNode(rpc::UnregisterNodeRequest request,
                             rpc::UnregisterNodeReply *reply,
-                            rpc::SendReplyCallback send_reply_callback) override;
+                            rpc::SendReplyCallback send_reply_callback);
 
   /// Handle unregister rpc request come from raylet.
   void HandleDrainNode(rpc::DrainNodeRequest request,
                        rpc::DrainNodeReply *reply,
-                       rpc::SendReplyCallback send_reply_callback) override;
+                       rpc::SendReplyCallback send_reply_callback);
 
   /// Handle get all node info rpc request.
   void HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
                             rpc::GetAllNodeInfoReply *reply,
-                            rpc::SendReplyCallback send_reply_callback) override;
+                            rpc::SendReplyCallback send_reply_callback);
 
   /// Handle check alive request for GCS.
   void HandleCheckAlive(rpc::CheckAliveRequest request,
                         rpc::CheckAliveReply *reply,
-                        rpc::SendReplyCallback send_reply_callback) override;
+                        rpc::SendReplyCallback send_reply_callback);
 
   /// Handle a node failure. This will mark the failed node as dead in gcs
   /// node table.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -39,7 +39,7 @@ class GcsStateTest;
 /// GcsNodeManager is responsible for managing and monitoring nodes as well as handing
 /// node and resource related rpc requests.
 /// This class is not thread-safe.
-class GcsNodeManager {
+class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
  public:
   /// Create a GcsNodeManager.
   ///
@@ -54,32 +54,32 @@ class GcsNodeManager {
   /// Handle register rpc request come from raylet.
   void HandleGetClusterId(rpc::GetClusterIdRequest request,
                           rpc::GetClusterIdReply *reply,
-                          rpc::SendReplyCallback send_reply_callback);
+                          rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle register rpc request come from raylet.
   void HandleRegisterNode(rpc::RegisterNodeRequest request,
                           rpc::RegisterNodeReply *reply,
-                          rpc::SendReplyCallback send_reply_callback);
+                          rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle unregister rpc request come from raylet.
   void HandleUnregisterNode(rpc::UnregisterNodeRequest request,
                             rpc::UnregisterNodeReply *reply,
-                            rpc::SendReplyCallback send_reply_callback);
+                            rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle unregister rpc request come from raylet.
   void HandleDrainNode(rpc::DrainNodeRequest request,
                        rpc::DrainNodeReply *reply,
-                       rpc::SendReplyCallback send_reply_callback);
+                       rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle get all node info rpc request.
   void HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
                             rpc::GetAllNodeInfoReply *reply,
-                            rpc::SendReplyCallback send_reply_callback);
+                            rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle check alive request for GCS.
   void HandleCheckAlive(rpc::CheckAliveRequest request,
                         rpc::CheckAliveReply *reply,
-                        rpc::SendReplyCallback send_reply_callback);
+                        rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a node failure. This will mark the failed node as dead in gcs
   /// node table.

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -357,7 +357,9 @@ void GcsServer::InitGcsNodeManager(const GcsInitData &gcs_init_data) {
   // Initialize by gcs tables data.
   gcs_node_manager_->Initialize(gcs_init_data);
   rpc_server_.RegisterService(std::make_unique<rpc::NodeInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(), *gcs_node_manager_));
+      io_context_provider_.GetDefaultIOContext(),
+      *gcs_node_manager_,
+      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
 }
 
 void GcsServer::InitGcsHealthCheckManager(const GcsInitData &gcs_init_data) {

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -29,6 +29,7 @@
 #include "ray/gcs/gcs_server/gcs_placement_group_mgr.h"
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/gcs/gcs_server/gcs_worker_manager.h"
+#include "ray/gcs/gcs_server/grpc_services.h"
 #include "ray/gcs/gcs_server/store_client_kv.h"
 #include "ray/gcs/store_client/in_memory_store_client.h"
 #include "ray/gcs/store_client/observable_store_client.h"

--- a/src/ray/gcs/gcs_server/grpc_service_interfaces.h
+++ b/src/ray/gcs/gcs_server/grpc_service_interfaces.h
@@ -1,0 +1,61 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/common/status.h"
+#include "src/ray/protobuf/gcs_service.grpc.pb.h"
+
+namespace ray {
+namespace rpc {
+
+using SendReplyCallback = std::function<void(
+    Status status, std::function<void()> success, std::function<void()> failure)>;
+
+#define GCS_RPC_SEND_REPLY(send_reply_callback, reply, status)        \
+  reply->mutable_status()->set_code(static_cast<int>(status.code())); \
+  reply->mutable_status()->set_message(status.message());             \
+  send_reply_callback(ray::Status::OK(), nullptr, nullptr)
+
+class NodeInfoGcsServiceHandler {
+ public:
+  virtual ~NodeInfoGcsServiceHandler() = default;
+
+  virtual void HandleGetClusterId(GetClusterIdRequest request,
+                                  GetClusterIdReply *reply,
+                                  SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleRegisterNode(RegisterNodeRequest request,
+                                  RegisterNodeReply *reply,
+                                  SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleUnregisterNode(UnregisterNodeRequest request,
+                                    UnregisterNodeReply *reply,
+                                    SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleCheckAlive(CheckAliveRequest request,
+                                CheckAliveReply *reply,
+                                SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleDrainNode(DrainNodeRequest request,
+                               DrainNodeReply *reply,
+                               SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetAllNodeInfo(GetAllNodeInfoRequest request,
+                                    GetAllNodeInfoReply *reply,
+                                    SendReplyCallback send_reply_callback) = 0;
+};
+
+}  // namespace rpc
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/grpc_service_interfaces.h
+++ b/src/ray/gcs/gcs_server/grpc_service_interfaces.h
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*
+ * This file defines the gRPC service *INTERFACES* only.
+ * The subcomponent that handles a given interface should inherit from the relevant
+ * class. The target for the subcomponent should depend only on this file, not on
+ * grpc_services.h.
+ */
+
 #pragma once
 
 #include "ray/common/status.h"

--- a/src/ray/gcs/gcs_server/grpc_service_interfaces.h
+++ b/src/ray/gcs/gcs_server/grpc_service_interfaces.h
@@ -1,4 +1,4 @@
-// Copyright 2017 The Ray Authors.
+// Copyright 2025 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/gcs/gcs_server/grpc_services.cc
+++ b/src/ray/gcs/gcs_server/grpc_services.cc
@@ -1,0 +1,69 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ray/gcs/gcs_server/grpc_services.h"
+
+#include <memory>
+#include <vector>
+
+#include "ray/common/asio/instrumented_io_context.h"
+#include "ray/common/id.h"
+#include "ray/common/ray_config.h"
+#include "ray/rpc/grpc_server.h"
+#include "ray/rpc/server_call.h"
+#include "src/ray/protobuf/autoscaler.grpc.pb.h"
+#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
+#include "src/ray/protobuf/gcs_service.grpc.pb.h"
+
+namespace ray {
+namespace rpc {
+
+void NodeInfoGrpcService::InitServerCallFactories(
+    const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+    std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
+    const ClusterID &cluster_id) {
+  // XXX: inject?
+  auto max_active_rpcs_per_handler = RayConfig::instance().gcs_max_active_rpcs_per_handler();
+
+  // We only allow one cluster ID in the lifetime of a client.
+  // So, if a client connects, it should not have a pre-existing different ID.
+  RPC_SERVICE_HANDLER_CUSTOM_AUTH(
+      NodeInfoGcsService,
+      GetClusterId,
+      max_active_rpcs_per_handler,
+      AuthType::EMPTY_AUTH);
+
+  RPC_SERVICE_HANDLER(NodeInfoGcsService,
+                      RegisterNode,
+                      max_active_rpcs_per_handler)
+
+  RPC_SERVICE_HANDLER(NodeInfoGcsService,
+                      UnregisterNode,
+                      max_active_rpcs_per_handler)
+
+  RPC_SERVICE_HANDLER(NodeInfoGcsService,
+                      DrainNode,
+                      max_active_rpcs_per_handler)
+
+  RPC_SERVICE_HANDLER(NodeInfoGcsService,
+                      GetAllNodeInfo,
+                      max_active_rpcs_per_handler)
+
+  RPC_SERVICE_HANDLER(NodeInfoGcsService,
+                      CheckAlive,
+                      max_active_rpcs_per_handler)
+}
+
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/grpc_services.cc
+++ b/src/ray/gcs/gcs_server/grpc_services.cc
@@ -16,8 +16,6 @@
 #include <memory>
 #include <vector>
 
-#include "ray/common/ray_config.h"
-
 namespace ray {
 namespace rpc {
 
@@ -25,26 +23,17 @@ void NodeInfoGrpcService::InitServerCallFactories(
     const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
     std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
     const ClusterID &cluster_id) {
-  // XXX: inject?
-  auto max_active_rpcs_per_handler =
-      RayConfig::instance().gcs_max_active_rpcs_per_handler();
-
   // We only allow one cluster ID in the lifetime of a client.
   // So, if a client connects, it should not have a pre-existing different ID.
   RPC_SERVICE_HANDLER_CUSTOM_AUTH(NodeInfoGcsService,
                                   GetClusterId,
-                                  max_active_rpcs_per_handler,
+                                  max_active_rpcs_per_handler_,
                                   AuthType::EMPTY_AUTH);
-
-  RPC_SERVICE_HANDLER(NodeInfoGcsService, RegisterNode, max_active_rpcs_per_handler)
-
-  RPC_SERVICE_HANDLER(NodeInfoGcsService, UnregisterNode, max_active_rpcs_per_handler)
-
-  RPC_SERVICE_HANDLER(NodeInfoGcsService, DrainNode, max_active_rpcs_per_handler)
-
-  RPC_SERVICE_HANDLER(NodeInfoGcsService, GetAllNodeInfo, max_active_rpcs_per_handler)
-
-  RPC_SERVICE_HANDLER(NodeInfoGcsService, CheckAlive, max_active_rpcs_per_handler)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, RegisterNode, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, UnregisterNode, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, DrainNode, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, GetAllNodeInfo, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, CheckAlive, max_active_rpcs_per_handler_)
 }
 
 }  // namespace rpc

--- a/src/ray/gcs/gcs_server/grpc_services.cc
+++ b/src/ray/gcs/gcs_server/grpc_services.cc
@@ -33,37 +33,26 @@ void NodeInfoGrpcService::InitServerCallFactories(
     std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
     const ClusterID &cluster_id) {
   // XXX: inject?
-  auto max_active_rpcs_per_handler = RayConfig::instance().gcs_max_active_rpcs_per_handler();
+  auto max_active_rpcs_per_handler =
+      RayConfig::instance().gcs_max_active_rpcs_per_handler();
 
   // We only allow one cluster ID in the lifetime of a client.
   // So, if a client connects, it should not have a pre-existing different ID.
-  RPC_SERVICE_HANDLER_CUSTOM_AUTH(
-      NodeInfoGcsService,
-      GetClusterId,
-      max_active_rpcs_per_handler,
-      AuthType::EMPTY_AUTH);
+  RPC_SERVICE_HANDLER_CUSTOM_AUTH(NodeInfoGcsService,
+                                  GetClusterId,
+                                  max_active_rpcs_per_handler,
+                                  AuthType::EMPTY_AUTH);
 
-  RPC_SERVICE_HANDLER(NodeInfoGcsService,
-                      RegisterNode,
-                      max_active_rpcs_per_handler)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, RegisterNode, max_active_rpcs_per_handler)
 
-  RPC_SERVICE_HANDLER(NodeInfoGcsService,
-                      UnregisterNode,
-                      max_active_rpcs_per_handler)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, UnregisterNode, max_active_rpcs_per_handler)
 
-  RPC_SERVICE_HANDLER(NodeInfoGcsService,
-                      DrainNode,
-                      max_active_rpcs_per_handler)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, DrainNode, max_active_rpcs_per_handler)
 
-  RPC_SERVICE_HANDLER(NodeInfoGcsService,
-                      GetAllNodeInfo,
-                      max_active_rpcs_per_handler)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, GetAllNodeInfo, max_active_rpcs_per_handler)
 
-  RPC_SERVICE_HANDLER(NodeInfoGcsService,
-                      CheckAlive,
-                      max_active_rpcs_per_handler)
+  RPC_SERVICE_HANDLER(NodeInfoGcsService, CheckAlive, max_active_rpcs_per_handler)
 }
 
-
-}  // namespace gcs
+}  // namespace rpc
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/grpc_services.cc
+++ b/src/ray/gcs/gcs_server/grpc_services.cc
@@ -16,14 +16,7 @@
 #include <memory>
 #include <vector>
 
-#include "ray/common/asio/instrumented_io_context.h"
-#include "ray/common/id.h"
 #include "ray/common/ray_config.h"
-#include "ray/rpc/grpc_server.h"
-#include "ray/rpc/server_call.h"
-#include "src/ray/protobuf/autoscaler.grpc.pb.h"
-#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
-#include "src/ray/protobuf/gcs_service.grpc.pb.h"
 
 namespace ray {
 namespace rpc {

--- a/src/ray/gcs/gcs_server/grpc_services.cc
+++ b/src/ray/gcs/gcs_server/grpc_services.cc
@@ -1,4 +1,4 @@
-// Copyright 2017 The Ray Authors.
+// Copyright 2025 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/gcs/gcs_server/grpc_services.h
+++ b/src/ray/gcs/gcs_server/grpc_services.h
@@ -29,7 +29,7 @@
 #include "ray/common/id.h"
 #include "ray/rpc/grpc_server.h"
 #include "ray/rpc/server_call.h"
-#include "src/ray/gcs/gcs_server/grpc_service_interfaces.h"
+#include "ray/gcs/gcs_server/grpc_service_interfaces.h"
 #include "src/ray/protobuf/gcs_service.grpc.pb.h"
 
 namespace ray {

--- a/src/ray/gcs/gcs_server/grpc_services.h
+++ b/src/ray/gcs/gcs_server/grpc_services.h
@@ -27,9 +27,9 @@
 
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/id.h"
+#include "ray/gcs/gcs_server/grpc_service_interfaces.h"
 #include "ray/rpc/grpc_server.h"
 #include "ray/rpc/server_call.h"
-#include "ray/gcs/gcs_server/grpc_service_interfaces.h"
 #include "src/ray/protobuf/gcs_service.grpc.pb.h"
 
 namespace ray {

--- a/src/ray/gcs/gcs_server/grpc_services.h
+++ b/src/ray/gcs/gcs_server/grpc_services.h
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*
+ * This file defines the gRPC service handlers for the GCS server binary.
+ * Subcomponents that implement a given interface should inherit from the relevant
+ * class in grpc_service_interfaces.h.
+ *
+ * The GCS server main binary should be the only user of this target.
+ */
+
 #pragma once
 
 #include <memory>

--- a/src/ray/gcs/gcs_server/grpc_services.h
+++ b/src/ray/gcs/gcs_server/grpc_services.h
@@ -1,0 +1,50 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "ray/common/asio/instrumented_io_context.h"
+#include "ray/common/id.h"
+#include "ray/rpc/grpc_server.h"
+#include "ray/rpc/server_call.h"
+#include "src/ray/gcs/gcs_server/grpc_service_interfaces.h"
+#include "src/ray/protobuf/gcs_service.grpc.pb.h"
+
+namespace ray {
+namespace rpc {
+
+class NodeInfoGrpcService : public GrpcService {
+ public:
+  explicit NodeInfoGrpcService(instrumented_io_context &io_service,
+                               NodeInfoGcsServiceHandler &service_handler)
+      : GrpcService(io_service), service_handler_(service_handler){};
+
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
+
+  void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
+      const ClusterID &cluster_id) override;
+
+ private:
+  NodeInfoGcsService::AsyncService service_;
+  NodeInfoGcsServiceHandler &service_handler_;
+};
+
+}  // namespace rpc
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/grpc_services.h
+++ b/src/ray/gcs/gcs_server/grpc_services.h
@@ -38,8 +38,11 @@ namespace rpc {
 class NodeInfoGrpcService : public GrpcService {
  public:
   explicit NodeInfoGrpcService(instrumented_io_context &io_service,
-                               NodeInfoGcsServiceHandler &service_handler)
-      : GrpcService(io_service), service_handler_(service_handler){};
+                               NodeInfoGcsServiceHandler &service_handler,
+                               int64_t max_active_rpcs_per_handler)
+      : GrpcService(io_service),
+        service_handler_(service_handler),
+        max_active_rpcs_per_handler_(max_active_rpcs_per_handler){};
 
  protected:
   grpc::Service &GetGrpcService() override { return service_; }
@@ -52,6 +55,7 @@ class NodeInfoGrpcService : public GrpcService {
  private:
   NodeInfoGcsService::AsyncService service_;
   NodeInfoGcsServiceHandler &service_handler_;
+  int64_t max_active_rpcs_per_handler_;
 };
 
 }  // namespace rpc

--- a/src/ray/gcs/gcs_server/grpc_services.h
+++ b/src/ray/gcs/gcs_server/grpc_services.h
@@ -1,4 +1,4 @@
-// Copyright 2017 The Ray Authors.
+// Copyright 2025 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Drops compilation time of `gcs_node_manager` target from ~24s to ~14s (measured locally on a change to `gcs_node_manager.cc`).