### PR TITLE
[air] update `/python/ray/air` CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,13 +51,16 @@
 /rllib/ @ray-project/ray-rllib
 /doc/source/rllib/ @ray-project/ray-rllib @ray-project/ray-docs
 
-# Tune
+# Ray Tune
 /python/ray/tune/ @ray-project/ray-tune
 /doc/source/tune/ @ray-project/ray-tune @ray-project/ray-docs
 
-# Train
+# Ray Train
 /python/ray/train/ @ray-project/ray-train
 /doc/source/train/ @ray-project/ray-train @ray-project/ray-docs
+
+# Ray AIR
+/python/ray/air/ @ray-project/ray-train
 
 # LLM
 /python/ray/llm/ @ray-project/ray-llm


### PR DESCRIPTION
Add Ray Train maintainers as the CODEOWNERS for `/python/ray/air` sub-directory.

Without this change, this directory will have Ray Core assigned as the CODEOWNER due to [this line](https://github.com/matthewdeng/ray/blob/ca2d866a95385aea4fd3de1c3b9f5148f899c282/.github/CODEOWNERS#L20-L21).