### PR TITLE
[core] Fix flaky `shutdown_coordinator_test`

### DIFF
--- a/src/ray/core_worker/tests/shutdown_coordinator_test.cc
+++ b/src/ray/core_worker/tests/shutdown_coordinator_test.cc
@@ -398,9 +398,10 @@ TEST_F(ShutdownCoordinatorTest, Concurrent_DoubleForce_ForceExecutesOnce) {
 
   EXPECT_EQ(coordinator->GetState(), ShutdownState::kShutdown);
   EXPECT_EQ(coordinator->GetReason(), ShutdownReason::kForcedExit);
+  // Verify that only one forced shutdown was called
   EXPECT_EQ(fake_ptr->force_calls.load(), 1);
   EXPECT_EQ(fake_ptr->graceful_calls.load(), 0);
-  EXPECT_EQ(fake_ptr->last_detail, "force1");
+  EXPECT_TRUE(fake_ptr->last_detail == "force1" || fake_ptr->last_detail == "force2");
 }
 
 }  // namespace core


### PR DESCRIPTION
## Why are these changes needed?

In the concurrent force shutdown test, we need to validate that exactly one force shutdown went through. The detail message could be for any thread that wins the lock to force shutdown. But, other threads should not execute force shutdown then.

Closes #55801
