### PR TITLE
[core] Move CreateCall to polling thread and add documentation on grpc threads

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -356,19 +356,19 @@ RAY_CONFIG(uint32_t, maximum_gcs_storage_operation_batch_size, 1000)
 /// When getting objects from object store, max number of ids to print in the warning
 /// message.
 RAY_CONFIG(uint32_t, object_store_get_max_ids_to_print_in_warning, 20)
-/// Number of threads used by rpc server in gcs server.
+
+/// Number of polling threads used by rpc server in gcs server. These threads poll for
+/// requests and copy from the socket buffer to create the proto request object.
 RAY_CONFIG(uint32_t,
            gcs_server_rpc_server_thread_num,
            std::max(1U, std::thread::hardware_concurrency() / 4U))
-/// Number of threads used by rpc server in gcs server.
+
+/// Number of polling threads for raylet + worker clients on the GCS. These threads poll
+/// for replies and copy from the socket buffer to create the proto Reply object.
 RAY_CONFIG(uint32_t,
            gcs_server_rpc_client_thread_num,
            std::max(1U, std::thread::hardware_concurrency() / 4U))
-/// Allow up to 5 seconds for connecting to gcs service.
-/// Note: this only takes effect when gcs service is enabled.
-RAY_CONFIG(int64_t, gcs_service_connect_retries, 50)
-/// Waiting time for each gcs service connection.
-RAY_CONFIG(int64_t, internal_gcs_service_connect_wait_milliseconds, 100)
+
 /// The interval at which the gcs server will health check the connection to the
 /// external Redis server. If a health check fails, the GCS will crash itself.
 /// Set to zero to disable health checking.
@@ -385,10 +385,6 @@ RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5)
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)
 /// Maximum number of dead nodes in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 1000)
-// The interval at which the gcs server will pull a new resource.
-RAY_CONFIG(int, gcs_resource_report_poll_period_ms, 100)
-// The number of concurrent polls to polls to GCS.
-RAY_CONFIG(uint64_t, gcs_max_concurrent_resource_pulls, 100)
 // The storage backend to use for the GCS. It can be either 'redis' or 'memory'.
 RAY_CONFIG(std::string, gcs_storage, "memory")
 
@@ -428,9 +424,6 @@ RAY_CONFIG(uint32_t, gcs_rpc_server_reconnect_timeout_s, 60)
 
 /// The timeout for GCS connection in seconds
 RAY_CONFIG(int32_t, gcs_rpc_server_connect_timeout_s, 5)
-
-/// Minimum interval between reconnecting gcs rpc server when gcs server restarts.
-RAY_CONFIG(int32_t, minimum_gcs_reconnect_interval_milliseconds, 5000)
 
 /// gRPC channel reconnection related configs to GCS.
 /// Check https://grpc.github.io/grpc/core/group__grpc__arg__keys.html for details
@@ -950,8 +943,19 @@ RAY_CONFIG(int64_t, py_gcs_connect_timeout_s, 30)
 // The number of grpc clients between object managers.
 RAY_CONFIG(int, object_manager_client_connection_num, 4)
 
-// The number of object manager thread. By default, it's
-//     std::min(std::max(2, num_cpus / 4), 8)
+// The actual number of threads for object transfers through the object manager is this
+// number * 3. There num_threads started for each of these 3 things:
+//   1. RPC server polling threads - poll for new requests and copy the requests from
+//      the socket buffer to the proto request objects.
+//   2. RPC client polling threads - poll for replies and copy the replies from the
+//      socket buffer to proto reply objects.
+//   3. RPC server handling io_context threads - These are the threads that execute the
+//      HandleX functions and mainly do both the server-side copying from the PushRequest
+//      to plasma and the client-side copying from plasma to PushRequest to socket buffer.
+// This means that this number of threads * 3 is the # of threads that will be
+// started for transfers.
+// By default, it's
+//     std::min(std::max(2, num_cpus / 4), 8) - At least 2, at most 8
 // Update this to overwrite it.
 RAY_CONFIG(int, object_manager_rpc_threads_num, 0)
 

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -203,8 +203,8 @@ GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
   metrics_agent_client_ = std::make_unique<rpc::MetricsAgentClientImpl>(
       "127.0.0.1",
       config_.metrics_agent_port,
-      io_context_provider_.GetIOContext<observability::RayEventRecorder>(),
-      event_aggregator_client_call_manager_);
+      io_context_provider_.GetDefaultIOContext(),
+      client_call_manager_);
 }
 
 GcsServer::~GcsServer() { Stop(); }

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -203,8 +203,8 @@ GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
   metrics_agent_client_ = std::make_unique<rpc::MetricsAgentClientImpl>(
       "127.0.0.1",
       config_.metrics_agent_port,
-      io_context_provider_.GetDefaultIOContext(),
-      client_call_manager_);
+      io_context_provider_.GetIOContext<observability::RayEventRecorder>(),
+      event_aggregator_client_call_manager_);
 }
 
 GcsServer::~GcsServer() { Stop(); }

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -364,7 +364,8 @@ class ClientCallManager {
   /// The main event loop, to which the callback functions will be posted.
   instrumented_io_context &main_service_;
 
-  /// The number of polling threads.
+  /// The number of threads that are polling for replies and creating the proto reply
+  /// objects.
   int num_threads_;
 
   /// Whether to record stats for these client calls.

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -162,32 +162,47 @@ class GrpcServer {
 
   /// Name of this server, used for logging and debugging purpose.
   const std::string name_;
+
   /// Port of this server.
   int port_;
+
   /// Listen to localhost (127.0.0.1) only if it's true, otherwise listen to all network
   /// interfaces (0.0.0.0)
   const bool listen_to_localhost_only_;
+
   /// Token representing ID of this cluster.
   ClusterID cluster_id_;
+
   /// Authentication token for token-based authentication.
   std::optional<AuthenticationToken> auth_token_;
+
   /// Indicates whether this server is in shutdown state.
   std::atomic<bool> is_shutdown_;
+
   /// The `grpc::Service` objects which should be registered to `ServerBuilder`.
   std::vector<std::unique_ptr<grpc::Service>> grpc_services_;
+
   /// The `GrpcService`(defined below) objects which contain grpc::Service objects not in
   /// the above vector.
   std::vector<std::unique_ptr<GrpcService>> services_;
+
   /// The `ServerCallFactory` objects.
   std::vector<std::unique_ptr<ServerCallFactory>> server_call_factories_;
-  /// The number of completion queues the server is polling from.
+
+  /// The number of threads and completion queues the server is polling from for incoming
+  /// requests. These threads are also responsible for creating the proto request objects.
   int num_threads_;
+
   /// The `ServerCompletionQueue` object used for polling events.
   std::vector<std::unique_ptr<grpc::ServerCompletionQueue>> cqs_;
+
   /// The `Server` object.
   std::unique_ptr<grpc::Server> server_;
-  /// The polling threads used to check the completion queues.
+
+  /// The polling threads used to check the completion queues and create the proto request
+  /// objects.
   std::vector<std::thread> polling_threads_;
+
   /// The interval to send a new gRPC keepalive timeout from server -> client.
   /// gRPC server cannot get the ping response within the time, it triggers
   /// the watchdog timer fired error, which will close the connection.

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -241,6 +241,59 @@ class ServerCallImpl : public ServerCall {
     if (record_metrics_) {
       grpc_server_req_handling_counter_.Record(1.0, {{"Method", call_name_}});
     }
+    if constexpr (std::is_base_of_v<DelayedServiceHandler, ServiceHandler>) {
+      if (!service_handler_initialized_) {
+        service_handler_.WaitUntilInitialized();
+        service_handler_initialized_ = true;
+      }
+    }
+    state_ = ServerCallState::PROCESSING;
+    // NOTE(hchen): This `factory` local variable is needed. Because `SendReply` runs in
+    // a different thread, and will cause `this` to be deleted.
+    const auto &factory = factory_;
+    if (factory.GetMaxActiveRPCs() == -1) {
+      // Create a new `ServerCall` to accept the next incoming request.
+      // We create this before handling the request only when no back pressure limit is
+      // set. So that the it can be populated by the completion queue in the background if
+      // a new request comes in.
+      factory.CreateCall();
+    }
+    if (!io_service_.stopped()) {
+      io_service_.post([this, auth_success] { HandleRequestImpl(auth_success); },
+                       call_name_ + ".HandleRequestImpl",
+                       // Implement the delay of the rpc server call as the
+                       // delay of HandleRequestImpl().
+                       ray::asio::testing::GetDelayUs(call_name_));
+    } else {
+      // Handle service for rpc call has stopped, we must handle the call here
+      // to send reply and remove it from cq
+      RAY_LOG(DEBUG) << "Handle service has been closed.";
+      if (auth_success) {
+        SendReply(Status::Invalid("HandleServiceClosed"));
+      } else {
+        SendReply(Status::AuthError("WrongClusterID"));
+      }
+    }
+  }
+
+  void HandleRequestImpl(bool auth_success) {
+    if constexpr (std::is_base_of_v<DelayedServiceHandler, ServiceHandler>) {
+      if (!service_handler_initialized_) {
+        service_handler_.WaitUntilInitialized();
+        service_handler_initialized_ = true;
+      }
+    }
+    state_ = ServerCallState::PROCESSING;
+    // NOTE(hchen): This `factory` local variable is needed. Because `SendReply` runs in
+    // a different thread, and will cause `this` to be deleted.
+    const auto &factory = factory_;
+    if (factory.GetMaxActiveRPCs() == -1) {
+      // Create a new `ServerCall` to accept the next incoming request.
+      // We create this before handling the request only when no back pressure limit is
+      // set. So that the it can be populated by the completion queue in the background if
+      // a new request comes in.
+      factory.CreateCall();
+    }
     if (!io_service_.stopped()) {
       io_service_.post(
           [this, auth_success, token_auth_failed, cluster_id_auth_failed] {
@@ -268,20 +321,6 @@ class ServerCallImpl : public ServerCall {
   void HandleRequestImpl(bool auth_success,
                          bool token_auth_failed,
                          bool cluster_id_auth_failed) {
-    if constexpr (std::is_base_of_v<DelayedServiceHandler, ServiceHandler>) {
-      if (!service_handler_initialized_) {
-        service_handler_.WaitUntilInitialized();
-        service_handler_initialized_ = true;
-      }
-    }
-    state_ = ServerCallState::PROCESSING;
-    if (factory_.GetMaxActiveRPCs() == -1) {
-      // Create a new `ServerCall` to accept the next incoming request.
-      // We create this before handling the request only when no back pressure limit is
-      // set. So that the it can be populated by the completion queue in the background if
-      // a new request comes in.
-      factory_.CreateCall();
-    }
     if (!auth_success) {
       boost::asio::post(GetServerCallExecutor(), [this, token_auth_failed]() {
         if (token_auth_failed) {


### PR DESCRIPTION
## Why are these changes needed?
Today our gRPC servers have polling thread(s) that do the data copying into the ServerCallImpl object. We currently create the new call object after a post to the io_context. It makes more sense to create the call object right after the previous request has been received rather than when the handle callback starts on the io_context. Creating the call is also a non-zero amount of work and the # of polling threads can be scaled up without concurrency issues.

I've also added some documentation on what the thread configs actually do and deleted some unused configs.