### PR TITLE
[ci] removing python 3.13 wheel verification for mac

### DIFF
--- a/.buildkite/release-automation/verify-macos-wheels.sh
+++ b/.buildkite/release-automation/verify-macos-wheels.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 
 set -x
 
-PYTHON_VERSIONS=("3.9" "3.10" "3.11" "3.12" "3.13")
+# TODO(#54047): Python 3.13 is skipped due to the bug
+# we should re-enable it when the bug is fixed.
+
+PYTHON_VERSIONS=("3.9" "3.10" "3.11" "3.12")
 BAZELISK_VERSION="v1.16.0"
 
 # Check arguments


### PR DESCRIPTION
removing python 3.13 wheel verification for macos due to this bug: https://github.com/ray-project/ray/issues/54047