### PR TITLE
[core] avoid copying node labels when updating them from sync messages

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -301,7 +301,7 @@ void GcsResourceManager::OnNodeAdd(const rpc::GcsNodeInfo &node) {
 
   absl::flat_hash_map<std::string, std::string> labels(node.labels().begin(),
                                                        node.labels().end());
-  cluster_resource_manager_.SetNodeLabels(scheduling_node_id, labels);
+  cluster_resource_manager_.SetNodeLabels(scheduling_node_id, std::move(labels));
 
   rpc::ResourcesData data;
   data.set_node_id(node_id.Binary());

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2767,7 +2767,7 @@ void NodeManager::ConsumeSyncMessage(
     // Set node labels when node added.
     auto node_labels = MapFromProtobuf(resource_view_sync_message.labels());
     cluster_resource_scheduler_.GetClusterResourceManager().SetNodeLabels(
-        scheduling::NodeID(node_id.Binary()), node_labels);
+        scheduling::NodeID(node_id.Binary()), std::move(node_labels));
     ResourceRequest resources;
     for (auto &resource_entry : resource_view_sync_message.resources_total()) {
       resources.Set(scheduling::ResourceID(resource_entry.first),

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -293,13 +293,13 @@ BundleLocationIndex &ClusterResourceManager::GetBundleLocationIndex() {
 
 void ClusterResourceManager::SetNodeLabels(
     const scheduling::NodeID &node_id,
-    const absl::flat_hash_map<std::string, std::string> &labels) {
+    absl::flat_hash_map<std::string, std::string> labels) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     NodeResources node_resources;
     it = nodes_.emplace(node_id, node_resources).first;
   }
-  it->second.GetMutableLocalView()->labels = labels;
+  it->second.GetMutableLocalView()->labels = std::move(labels);
 }
 
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -138,7 +138,7 @@ class ClusterResourceManager {
   BundleLocationIndex &GetBundleLocationIndex();
 
   void SetNodeLabels(const scheduling::NodeID &node_id,
-                     const absl::flat_hash_map<std::string, std::string> &labels);
+                     absl::flat_hash_map<std::string, std::string> labels);
 
  private:
   friend class ClusterResourceScheduler;


### PR DESCRIPTION
## Why are these changes needed?

Try to minimize the overhead of updating labels for each sync view message.
Ref: https://github.com/ray-project/ray/pull/55727#discussion_r2299058790

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
