### PR TITLE
[core][obsclean/05] add an interface for metric

### DIFF
--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -16,3 +16,11 @@ ray_cc_library(
         "@io_opentelemetry_cpp//sdk/src/metrics",
     ],
 )
+
+ray_cc_library(
+    name = "metric_interface",
+    hdrs = ["metric_interface.h"],
+    deps = [
+        "@io_opencensus_cpp//opencensus/stats",
+    ],
+)

--- a/src/ray/observability/metric_interface.h
+++ b/src/ray/observability/metric_interface.h
@@ -1,0 +1,49 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "opencensus/tags/tag_key.h"
+
+namespace ray {
+
+// TODO(can-anyscale): Use stats namespace for backward compatibility. We will remove
+// these types soon when opencensus is removed, and then we can remove this namespace.
+namespace stats {
+
+using TagKeyType = opencensus::tags::TagKey;
+using TagsType = std::vector<std::pair<TagKeyType, std::string>>;
+
+}  // namespace stats
+
+namespace observability {
+
+class MetricInterface {
+ public:
+  virtual ~MetricInterface() = default;
+
+  virtual void Record(double value) = 0;
+  virtual void Record(double value, stats::TagsType tags) = 0;
+  virtual void Record(double value,
+                      const std::unordered_map<std::string, std::string> &tags) = 0;
+  virtual void Record(double value,
+                      const std::unordered_map<std::string_view, std::string> &tags) = 0;
+};
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/stats/BUILD.bazel
+++ b/src/ray/stats/BUILD.bazel
@@ -10,10 +10,11 @@ ray_cc_library(
     hdrs = [
         "metric.h",
         "metric_defs.h",
-        "tag_defs.h",
     ],
     deps = [
+        ":tag_defs",
         "//src/ray/common:ray_config",
+        "//src/ray/observability:metric_interface",
         "//src/ray/observability:open_telemetry_metric_recorder",
         "//src/ray/util:logging",
         "//src/ray/util:size_literals",
@@ -37,7 +38,6 @@ ray_cc_library(
         "metric.h",
         "metric_exporter.h",
         "stats.h",
-        "tag_defs.h",
     ],
     linkopts = select({
         "@platforms//os:windows": [
@@ -48,9 +48,20 @@ ray_cc_library(
     }),
     deps = [
         ":stats_metric",
+        ":tag_defs",
+        "//src/ray/observability:metric_interface",
         "//src/ray/rpc:metrics_agent_client",
         "//src/ray/util:network_util",
         "//src/ray/util:size_literals",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+    ],
+)
+
+ray_cc_library(
+    name = "tag_defs",
+    srcs = ["tag_defs.cc"],
+    hdrs = ["tag_defs.h"],
+    deps = [
+        "//src/ray/observability:metric_interface",
     ],
 )

--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -175,7 +175,7 @@ void Metric::Record(double value, TagsType tags) {
 }
 
 void Metric::Record(double value,
-                    std::unordered_map<std::string_view, std::string> tags) {
+                    const std::unordered_map<std::string_view, std::string> &tags) {
   TagsType tags_pair_vec;
   tags_pair_vec.reserve(tags.size());
   std::for_each(tags.begin(), tags.end(), [&tags_pair_vec](auto &tag) {
@@ -185,7 +185,8 @@ void Metric::Record(double value,
   Record(value, std::move(tags_pair_vec));
 }
 
-void Metric::Record(double value, std::unordered_map<std::string, std::string> tags) {
+void Metric::Record(double value,
+                    const std::unordered_map<std::string, std::string> &tags) {
   TagsType tags_pair_vec;
   tags_pair_vec.reserve(tags.size());
   std::for_each(tags.begin(), tags.end(), [&tags_pair_vec](auto &tag) {

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -29,15 +29,14 @@
 #include "opencensus/stats/stats_exporter.h"
 #include "opencensus/tags/tag_key.h"
 #include "ray/common/ray_config.h"
+#include "ray/observability/metric_interface.h"
 #include "ray/observability/open_telemetry_metric_recorder.h"
+#include "ray/stats/tag_defs.h"
 #include "ray/util/logging.h"
 
 namespace ray {
 
 namespace stats {
-
-/// Include tag_defs.h to define tag items
-#include "ray/stats/tag_defs.h"
 
 using OpenTelemetryMetricRecorder = ray::observability::OpenTelemetryMetricRecorder;
 
@@ -107,7 +106,7 @@ class StatsConfig final {
 };
 
 /// A thin wrapper that wraps the `opencensus::tag::measure` for using it simply.
-class Metric {
+class Metric : public observability::MetricInterface {
  public:
   Metric(const std::string &name,
          std::string description,
@@ -124,20 +123,22 @@ class Metric {
   const std::string &GetName() const { return name_; }
 
   /// Record the value for this metric.
-  void Record(double value) { Record(value, TagsType{}); }
+  void Record(double value) override { Record(value, TagsType{}); }
 
   /// Record the value for this metric.
   ///
   /// \param value The value that we record.
   /// \param tags The tag values that we want to record for this metric record.
-  void Record(double value, TagsType tags);
+  void Record(double value, TagsType tags) override;
 
   /// Record the value for this metric.
   ///
   /// \param value The value that we record.
   /// \param tags The map tag values that we want to record for this metric record.
-  void Record(double value, std::unordered_map<std::string_view, std::string> tags);
-  void Record(double value, std::unordered_map<std::string, std::string> tags);
+  void Record(double value,
+              const std::unordered_map<std::string_view, std::string> &tags) override;
+  void Record(double value,
+              const std::unordered_map<std::string, std::string> &tags) override;
 
  protected:
   virtual void RegisterView() = 0;

--- a/src/ray/stats/tag_defs.cc
+++ b/src/ray/stats/tag_defs.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/stats/metric.h"
+#include "ray/stats/tag_defs.h"
 
 namespace ray {
 namespace stats {

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -14,11 +14,13 @@
 
 #pragma once
 
+#include "ray/observability/metric_interface.h"
+
 /// The definitions of tag keys that you can use every where.
 /// You can follow these examples to define and register your tag keys.
 
-using TagKeyType = opencensus::tags::TagKey;
-using TagsType = std::vector<std::pair<opencensus::tags::TagKey, std::string>>;
+namespace ray {
+namespace stats {
 
 extern const TagKeyType ComponentKey;
 
@@ -66,3 +68,6 @@ constexpr char kObjectUnsealed[] = "UNSEALED";
 // GCS task manager tags
 constexpr char kGcsTaskStatusEventDropped[] = "STATUS_EVENT";
 constexpr char kGcsProfileEventDropped[] = "PROFILE_EVENT";
+
+}  // namespace stats
+}  // namespace ray


### PR DESCRIPTION
Add an interface for Metric class. This interface will allow us to move metric from being statically initialized to be a class members, etc, both reduce build time + avoid static destruction issues.
- I add the `MetricInterface` under the `observability` namespace; all metrics, events and logs will be migrated to this new namespace, so any new file I also add to this new namespace
- Fix `tag_defs.h` which currently doesn't have namespace and is included in a weird way to have namespace

Test:
- CI