### PR TITLE
[Core] [TaskEvent] Fix Missing Events Issue in Task Events

### DIFF
--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -277,8 +277,9 @@ void TaskStatusEvent::PopulateRpcRayEventBaseFields(
   }
 }
 
-void TaskStatusEvent::ToRpcRayEvents(RayEventsPair &ray_events_pair) {
-  auto &[task_definition_event_rpc, task_execution_event_rpc] = ray_events_pair;
+void TaskStatusEvent::ToRpcRayEvents(RayEventsTuple &ray_events_tuple) {
+  auto &[task_definition_event_rpc, task_execution_event_rpc, task_profile_event_rpc] =
+      ray_events_tuple;
 
   google::protobuf::Timestamp timestamp = AbslTimeNanosToProtoTimestamp(timestamp_);
 
@@ -354,16 +355,15 @@ void TaskProfileEvent::PopulateRpcRayEventBaseFields(
   ray_event.set_session_name(session_name_);
 }
 
-void TaskProfileEvent::ToRpcRayEvents(RayEventsPair &ray_events_pair) {
-  auto &[task_profile_Event, null_event] = ray_events_pair;
-  // Second element of the RayEventsPair will always be empty for TaskProfileEvent
-  null_event = std::nullopt;
+void TaskProfileEvent::ToRpcRayEvents(RayEventsTuple &ray_events_tuple) {
+  auto &[task_definition_event, task_execution_event, task_profile_event] =
+      ray_events_tuple;
 
   // Using profile start time as the event generation timestamp
   google::protobuf::Timestamp timestamp = AbslTimeNanosToProtoTimestamp(start_time_);
 
   // Populate Ray event base fields
-  auto &ray_event = task_profile_Event.emplace();
+  auto &ray_event = task_profile_event.emplace();
   PopulateRpcRayEventBaseFields(ray_event, timestamp);
 
   // Populate the task profile event
@@ -620,21 +620,24 @@ std::unique_ptr<rpc::TaskEventData> TaskEventBufferImpl::CreateTaskEventDataToSe
 
 std::unique_ptr<rpc::events::RayEventsData>
 TaskEventBufferImpl::CreateRayEventsDataToSend(
-    absl::flat_hash_map<TaskAttempt, RayEventsPair> &&agg_task_events,
+    absl::flat_hash_map<TaskAttempt, RayEventsTuple> &&agg_task_events,
     const absl::flat_hash_set<TaskAttempt> &dropped_task_attempts_to_send) {
   auto data = std::make_unique<rpc::events::RayEventsData>();
   // Move the ray events.
-  for (auto &[task_attempt, ray_events_pair] : agg_task_events) {
-    // For TaskStatusEvent: first = task definition event, second = task execution event
-    // For TaskProfileEvent: first = task profile event, second = nullopt (empty)
-    auto &[first_event, second_event] = ray_events_pair;
-    if (first_event) {
+  for (auto &[task_attempt, ray_events_tuple] : agg_task_events) {
+    auto &[task_definition_event, task_execution_event, task_profile_event] =
+        ray_events_tuple;
+    if (task_definition_event) {
       auto events = data->add_events();
-      *events = std::move(first_event.value());
+      *events = std::move(task_definition_event.value());
     }
-    if (second_event) {
+    if (task_execution_event) {
       auto events = data->add_events();
-      *events = std::move(second_event.value());
+      *events = std::move(task_execution_event.value());
+    }
+    if (task_profile_event) {
+      auto events = data->add_events();
+      *events = std::move(task_profile_event.value());
     }
   }
 
@@ -655,8 +658,8 @@ TaskEventBuffer::TaskEventDataToSend TaskEventBufferImpl::CreateDataToSend(
     const absl::flat_hash_set<TaskAttempt> &dropped_task_attempts_to_send) {
   // Aggregate the task events by TaskAttempt.
   absl::flat_hash_map<TaskAttempt, rpc::TaskEvents> agg_task_events;
-  // (task_attempt, (task_definition_event, task_execution_events))
-  absl::flat_hash_map<TaskAttempt, RayEventsPair> agg_ray_events;
+  // (task_attempt, (task_definition_event, task_execution_event, task_profile_event))
+  absl::flat_hash_map<TaskAttempt, RayEventsTuple> agg_ray_events;
 
   auto to_rpc_event_fn =
       [this, &agg_task_events, &agg_ray_events, &dropped_task_attempts_to_send](

--- a/src/ray/core_worker/tests/task_event_buffer_test.cc
+++ b/src/ray/core_worker/tests/task_event_buffer_test.cc
@@ -433,9 +433,10 @@ TEST_P(TaskEventBufferTestDifferentDestination, TestFlushEvents) {
     auto event = expected_task_event_data.add_events_by_task();
     task_event->ToRpcTaskEvents(event);
 
-    RayEventsPair ray_events_pair;
-    task_event->ToRpcRayEvents(ray_events_pair);
-    auto [task_definition_event, task_execution_event] = ray_events_pair;
+    RayEventsTuple ray_events_tuple;
+    task_event->ToRpcRayEvents(ray_events_tuple);
+    auto [task_definition_event, task_execution_event, task_profile_event] =
+        ray_events_tuple;
     if (task_definition_event) {
       auto new_event = expected_ray_events_data.add_events();
       *new_event = std::move(task_definition_event.value());
@@ -443,6 +444,10 @@ TEST_P(TaskEventBufferTestDifferentDestination, TestFlushEvents) {
     if (task_execution_event) {
       auto new_event = expected_ray_events_data.add_events();
       *new_event = std::move(task_execution_event.value());
+    }
+    if (task_profile_event) {
+      auto new_event = expected_ray_events_data.add_events();
+      *new_event = std::move(task_profile_event.value());
     }
   }
 
@@ -748,9 +753,10 @@ TEST_P(TaskEventBufferTestLimitBufferDifferentDestination,
         *static_cast<TaskStatusEvent *>(event_ptr.get()));
     event->ToRpcTaskEvents(expect_event);
 
-    RayEventsPair ray_events_pair;
-    event->ToRpcRayEvents(ray_events_pair);
-    auto [task_definition_event, task_execution_event] = ray_events_pair;
+    RayEventsTuple ray_events_tuple;
+    event->ToRpcRayEvents(ray_events_tuple);
+    auto [task_definition_event, task_execution_event, task_profile_event] =
+        ray_events_tuple;
     if (task_definition_event) {
       auto new_event = expected_ray_events_data.add_events();
       *new_event = std::move(task_definition_event.value());
@@ -758,6 +764,10 @@ TEST_P(TaskEventBufferTestLimitBufferDifferentDestination,
     if (task_execution_event) {
       auto new_event = expected_ray_events_data.add_events();
       *new_event = std::move(task_execution_event.value());
+    }
+    if (task_profile_event) {
+      auto new_event = expected_ray_events_data.add_events();
+      *new_event = std::move(task_profile_event.value());
     }
   }
 
@@ -948,20 +958,23 @@ TEST_F(TaskEventBufferTest, TestTaskProfileEventToRpcRayEvents) {
   profile_event->SetEndTime(2000);
   profile_event->SetExtraData("test_extra_data");
 
-  RayEventsPair ray_events_pair;
-  profile_event->ToRpcRayEvents(ray_events_pair);
+  RayEventsTuple ray_events_tuple;
+  profile_event->ToRpcRayEvents(ray_events_tuple);
 
-  auto &[first_event, second_event] = ray_events_pair;
+  auto &[task_definition_event, task_execution_event, task_profile_event] =
+      ray_events_tuple;
 
   // Verify that the second event is nullopt (empty)
-  EXPECT_FALSE(second_event.has_value())
-      << "TaskProfileEvent should set second element of RayEventsPair to nullopt";
+  EXPECT_FALSE(task_definition_event.has_value())
+      << "TaskProfileEvent should be populated at the third element of RayEventsTuple";
+  EXPECT_FALSE(task_execution_event.has_value())
+      << "TaskProfileEvent should be populated at the third element of RayEventsTuple";
 
   // Verify that the first event contains the profile event
-  ASSERT_TRUE(first_event.has_value())
-      << "TaskProfileEvent should populate first element of RayEventsPair";
+  ASSERT_TRUE(task_profile_event.has_value())
+      << "TaskProfileEvent should populate third element of RayEventsTuple";
 
-  const auto &ray_event = first_event.value();
+  const auto &ray_event = task_profile_event.value();
 
   // Verify base fields
   EXPECT_EQ(ray_event.source_type(), rpc::events::RayEvent::CORE_WORKER);
@@ -1016,13 +1029,13 @@ TEST_F(TaskEventBufferTest, TestCreateRayEventsDataWithProfileEvents) {
                                                           "test_session_name");
   profile_event->SetEndTime(6000);
 
-  absl::flat_hash_map<TaskAttempt, RayEventsPair> agg_ray_events;
+  absl::flat_hash_map<TaskAttempt, RayEventsTuple> agg_ray_events;
   TaskAttempt task_attempt = std::make_pair(task_id, attempt_number);
 
   // Populate the ray events pair
-  RayEventsPair ray_events_pair;
-  profile_event->ToRpcRayEvents(ray_events_pair);
-  agg_ray_events[task_attempt] = std::move(ray_events_pair);
+  RayEventsTuple ray_events_tuple;
+  profile_event->ToRpcRayEvents(ray_events_tuple);
+  agg_ray_events[task_attempt] = std::move(ray_events_tuple);
 
   // Create the data using the real implementation
   absl::flat_hash_set<TaskAttempt> dropped_task_attempts;
@@ -1044,17 +1057,20 @@ TEST_F(TaskEventBufferTest, TestCreateRayEventsDataWithProfileEvents) {
   EXPECT_EQ(task_profile_events.attempt_number(), attempt_number);
 }
 
-TEST_F(TaskEventBufferTest, TestMixedStatusAndProfileEventsToRayEvents) {
+TEST_P(TaskEventBufferTestDifferentDestination,
+       TestMixedStatusAndProfileEventsToRayEvents) {
   // Test that a mix of status events and profile events are correctly handled
-  auto task_id1 = RandomTaskId();
-  auto task_id2 = RandomTaskId();
+  const auto [to_gcs, to_aggregator] = GetParam();
+
+  // Generate the task id and job id
+  auto task_id = RandomTaskId();
   auto job_id = JobID::FromInt(789);
 
   // Create a status event (should populate both elements of RayEventsPair)
-  auto status_event = GenStatusTaskEvent(task_id1, 1, 1000);
+  auto status_event = GenStatusTaskEvent(task_id, 1, 1000);
 
   // Create a profile event (should populate only first element)
-  auto profile_event = std::make_unique<TaskProfileEvent>(task_id2,
+  auto profile_event = std::make_unique<TaskProfileEvent>(task_id,
                                                           job_id,
                                                           1,
                                                           "core_worker",
@@ -1063,56 +1079,75 @@ TEST_F(TaskEventBufferTest, TestMixedStatusAndProfileEventsToRayEvents) {
                                                           "mixed_test",
                                                           7000,
                                                           "test_session_name");
+  // Expect data flushed match. Generate the expected data
+  rpc::TaskEventData expected_task_event_data;
+  rpc::events::RayEventsData expected_ray_events_data;
+  auto event = expected_task_event_data.add_events_by_task();
+  status_event->ToRpcTaskEvents(event);
+  profile_event->ToRpcTaskEvents(event);
 
-  // Create aggregated events
-  absl::flat_hash_map<TaskAttempt, RayEventsPair> agg_ray_events;
-
-  // Add status event
-  RayEventsPair status_ray_events_pair;
-  status_event->ToRpcRayEvents(status_ray_events_pair);
-  agg_ray_events[std::make_pair(task_id1, 1)] = std::move(status_ray_events_pair);
-
-  // Add profile event
-  RayEventsPair profile_ray_events_pair;
-  profile_event->ToRpcRayEvents(profile_ray_events_pair);
-  agg_ray_events[std::make_pair(task_id2, 1)] = std::move(profile_ray_events_pair);
-
-  // Create the data
-  absl::flat_hash_set<TaskAttempt> dropped_task_attempts;
-  auto ray_events_data = task_event_buffer_->CreateRayEventsDataToSend(
-      std::move(agg_ray_events), dropped_task_attempts);
-
-  // Should have 2 events: 1 from status event (execution only since no task_spec) + 1
-  // from profile event
-  ASSERT_EQ(ray_events_data->events_size(), 2);
-
-  // Count event types
-  int task_definition_events = 0;
-  int task_execution_events = 0;
-  int task_profile_events = 0;
-
-  for (const auto &event : ray_events_data->events()) {
-    switch (event.event_type()) {
-    case rpc::events::RayEvent::TASK_DEFINITION_EVENT:
-      task_definition_events++;
-      break;
-    case rpc::events::RayEvent::TASK_EXECUTION_EVENT:
-      task_execution_events++;
-      break;
-    case rpc::events::RayEvent::TASK_PROFILE_EVENT:
-      task_profile_events++;
-      break;
-    default:
-      FAIL() << "Unexpected event type: " << event.event_type();
-    }
+  RayEventsTuple ray_events_tuple;
+  status_event->ToRpcRayEvents(ray_events_tuple);
+  profile_event->ToRpcRayEvents(ray_events_tuple);
+  auto [task_definition_event, task_execution_event, task_profile_event] =
+      ray_events_tuple;
+  if (task_definition_event) {
+    auto new_event = expected_ray_events_data.add_events();
+    *new_event = std::move(task_definition_event.value());
+  }
+  if (task_execution_event) {
+    auto new_event = expected_ray_events_data.add_events();
+    *new_event = std::move(task_execution_event.value());
+  }
+  if (task_profile_event) {
+    auto new_event = expected_ray_events_data.add_events();
+    *new_event = std::move(task_profile_event.value());
   }
 
-  EXPECT_EQ(task_definition_events, 0)
-      << "Should have 0 task definition events since GenStatusTaskEvent has no task_spec";
-  EXPECT_EQ(task_execution_events, 1)
-      << "Should have 1 task execution event from status event";
-  EXPECT_EQ(task_profile_events, 1)
-      << "Should have 1 task profile event from profile event";
+  // Add Events to the task event buffer
+  task_event_buffer_->AddTaskEvent(std::move(status_event));
+  task_event_buffer_->AddTaskEvent(std::move(profile_event));
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 2);
+
+  // Manually call flush should call GCS client's flushing grpc.
+  auto task_gcs_accessor =
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient())
+          ->mock_task_accessor;
+  if (to_gcs) {
+    EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData(_, _))
+        .WillOnce([&](std::unique_ptr<rpc::TaskEventData> actual_data,
+                      ray::gcs::StatusCallback callback) {
+          CompareTaskEventData(*actual_data, expected_task_event_data);
+          return Status::OK();
+        });
+  } else {
+    EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData(_, _)).Times(0);
+  }
+
+  // If ray events to aggregator is enabled, expect to call AddEvents grpc.
+  auto event_aggregator_client = static_cast<MockEventAggregatorClient *>(
+      task_event_buffer_->event_aggregator_client_.get());
+  rpc::events::AddEventsRequest add_events_request;
+  if (to_aggregator) {
+    rpc::events::AddEventsReply reply;
+    Status status = Status::OK();
+    EXPECT_CALL(*event_aggregator_client, AddEvents(_, _))
+        .WillOnce(DoAll(
+            Invoke([&](const rpc::events::AddEventsRequest &request,
+                       const rpc::ClientCallback<rpc::events::AddEventsReply> &callback) {
+              CompareRayEventsData(request.events_data(), expected_ray_events_data);
+            }),
+            MakeAction(
+                new MockEventAggregatorAddEvents(std::move(status), std::move(reply)))));
+  } else {
+    EXPECT_CALL(*event_aggregator_client, AddEvents(_, _)).Times(0);
+  }
+
+  // Flush events
+  task_event_buffer_->FlushEvents(false);
+
+  // Expect no more events.
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 0);
 }
 
 INSTANTIATE_TEST_SUITE_P(TaskEventBufferTest,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

During the bug bash in the task event pipeline, we found that there are events missing from aggregator agent. 

The root cause is that, in the task event buffer, when converting the task events to the corresponding proto messages, for events with the same task id & attempt number, the same RayEventPair is shared. In this sense, if a profile event has the same task id & attempt num as the task status event, the task definition event generated from the task status event can accidentally be overwritten. 

This PR fixed the issue by adding the profile event to the RayEventPair to make it a Tuple type and update the logic of proto message conversion to populate the profile event accordingly. 

The tests are updated accordingly as well. 

## Related issue number
N/A

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
