### PR TITLE
[Core] Print out docker run output when it fails

### DIFF
--- a/python/ray/tests/conftest_docker.py
+++ b/python/ray/tests/conftest_docker.py
@@ -221,7 +221,14 @@ def podman_docker_cluster():
         "-f",
         "/dev/null",
     ]
-    container_id = subprocess.check_output(start_container_command).decode("utf-8")
+    try:
+        container_id = subprocess.check_output(start_container_command).decode("utf-8")
+    except subprocess.CalledProcessError as e:
+        error_output = e.output.decode("utf-8") if e.output else "No output"
+        print(f"Command failed with return code {e.returncode}")
+        print(f"Full error output:\n{error_output}")
+        raise
+
     container_id = container_id.strip()
 
     # Get group id that owns the docker socket file. Add user `ray` to

--- a/python/ray/tests/conftest_docker.py
+++ b/python/ray/tests/conftest_docker.py
@@ -222,7 +222,9 @@ def podman_docker_cluster():
         "/dev/null",
     ]
     try:
-        container_id = subprocess.check_output(start_container_command).decode("utf-8")
+        container_id = subprocess.check_output(
+            start_container_command, stderr=subprocess.STDOUT
+        ).decode("utf-8")
     except subprocess.CalledProcessError as e:
         error_output = e.output.decode("utf-8") if e.output else "No output"
         print(f"Command failed with return code {e.returncode}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This helps debug test failures caused by the failed `docker run` command.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
