### PR TITLE
[Serve.llm] Add start/stop_profile method to LLMServer

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -108,6 +108,14 @@ class _LLMServerBase(ABC):
     async def reset_prefix_cache(self) -> None:
         """Reset the prefix cache of the underlying engine"""
 
+    @abstractmethod
+    async def start_profile(self) -> None:
+        """Start profiling"""
+
+    @abstractmethod
+    async def stop_profile(self) -> None:
+        """Stop profiling"""
+
     # TODO (Kourosh): This does not belong here.
     async def llm_config(self) -> Optional[LLMConfig]:
         return None
@@ -408,6 +416,28 @@ class LLMServer(_LLMServerBase):
                 "Engine reset prefix cache failed in LLMServer.reset_prefix_cache: %s",
                 e,
             )
+            raise e
+
+    async def start_profile(self) -> None:
+        """Start profiling"""
+        if self.engine is None:
+            return
+        try:
+            await self.engine.start_profile()
+        except Exception as e:
+            logger.error(
+                "Engine start profile failed in LLMServer.start_profile: %s", e
+            )
+            raise e
+
+    async def stop_profile(self) -> None:
+        """Stop profiling"""
+        if self.engine is None:
+            return
+        try:
+            await self.engine.stop_profile()
+        except Exception as e:
+            logger.error("Engine stop profile failed in LLMServer.stop_profile: %s", e)
             raise e
 
     async def llm_config(self) -> Optional[LLMConfig]:

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -454,3 +454,11 @@ class VLLMEngine(LLMEngine):
     async def reset_prefix_cache(self) -> None:
         assert self._engine_client is not None, "engine_client is not initialized"
         await self._engine_client.reset_prefix_cache()
+
+    async def start_profile(self) -> None:
+        assert self._engine_client is not None, "engine_client is not initialized"
+        await self._engine_client.start_profile()
+
+    async def stop_profile(self) -> None:
+        assert self._engine_client is not None, "engine_client is not initialized"
+        await self._engine_client.stop_profile()

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -192,11 +192,57 @@ class TestLLMServer:
         server = LLMServer.sync_init(mock_llm_config, engine_cls=LocalMockEngine)
         await server.start()
 
-        # Perform the health check, no exceptions should be raised
+        # Reset prefix cache, no exceptions should be raised
         await server.reset_prefix_cache()
 
         # Check that the reset prefix cache method was called
         assert server.engine.reset_prefix_cache_called
+
+    @pytest.mark.asyncio
+    async def test_start_profile(self, mock_llm_config):
+        """Test start profile functionality."""
+
+        # Mock the engine's start_profile method
+        class LocalMockEngine(MockVLLMEngine):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.start_profile_called = False
+
+            async def start_profile(self):
+                self.start_profile_called = True
+
+        # Create a server with a mocked engine
+        server = LLMServer.sync_init(mock_llm_config, engine_cls=LocalMockEngine)
+        await server.start()
+
+        # Start profile, no exceptions should be raised
+        await server.start_profile()
+
+        # Check that the start profile method was called
+        assert server.engine.start_profile_called
+
+    @pytest.mark.asyncio
+    async def test_stop_profile(self, mock_llm_config):
+        """Test stop profile functionality."""
+
+        # Mock the engine's stop_profile method
+        class LocalMockEngine(MockVLLMEngine):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.stop_profile_called = False
+
+            async def stop_profile(self):
+                self.stop_profile_called = True
+
+        # Create a server with a mocked engine
+        server = LLMServer.sync_init(mock_llm_config, engine_cls=LocalMockEngine)
+        await server.start()
+
+        # Stop profile, no exceptions should be raised
+        await server.stop_profile()
+
+        # Check that the stop profile method was called
+        assert server.engine.stop_profile_called
 
     @pytest.mark.asyncio
     async def test_llm_config_property(self, mock_llm_config):

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -56,6 +56,16 @@ class MockVLLMEngine(LLMEngine):
         if not self.started:
             raise RuntimeError("Engine not started")
 
+    async def start_profile(self) -> None:
+        """Start profiling of the mock engine."""
+        if not self.started:
+            raise RuntimeError("Engine not started")
+
+    async def stop_profile(self) -> None:
+        """Stop profiling of the mock engine."""
+        if not self.started:
+            raise RuntimeError("Engine not started")
+
     async def chat(
         self, request: ChatCompletionRequest
     ) -> AsyncGenerator[Union[str, ChatCompletionResponse, ErrorResponse], None]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR adds support for torch profile start/stop functionality for Ray Serve LLM.

Example script to trigger it:
```
from ray import serve
from ray.serve._private.common import RequestMetadata
import pickle
import ray
import argparse
import time

parser = argparse.ArgumentParser()
parser.add_argument(
    "--deployment-name", "-d", type=str, default="LLMDeploymentdsv3",
)
parser.add_argument(
    "--app-name", "-a", type=str, default="default"
)
parser.add_argument(
    "--start", "-t", type=bool, default=False
)
parser.add_argument(
    "--stop", "-p", type=bool, default=False
)
parser.add_argument(
    "--replica-id", "-r", type=str, default=None
)
pargs = parser.parse_args()

if pargs.start and pargs.stop:
    print("Cannot start and stop at the same time")
    exit(1)

if pargs.stop:
    if pargs.replica_id is None:
        print("Replica ID is required to stop profile")
        exit(1)

dh = serve.get_deployment_handle(deployment_name=pargs.deployment_name, app_name=pargs.app_name)
dh._init()
while not dh.running_replicas_populated():
    print("router is still None ...")
    time.sleep(1)


if pargs.start:
    replica_set = dh._router._asyncio_router._request_router._replica_id_set
    replica = next(iter(replica_set)) if replica_set else None
    print(f"Start profiling on replica {replica.unique_id}")
    actor_name = replica.to_full_id_str()
    actorh = ray.get_actor(actor_name, namespace="serve")
    dummy_rm = pickle.dumps(RequestMetadata(
        request_id="1", internal_request_id="1", call_method="start_profile"))
    ray.get(actorh.handle_request.remote(dummy_rm))

if pargs.stop:
    replica_set = dh._router._asyncio_router._request_router._replica_id_set
    profile_replica = None
    for replica in replica_set:
        if replica.unique_id == pargs.replica_id:
            profile_replica = replica
            break
    if profile_replica is None:
        print(f"Replica {pargs.replica_id} not found")
        exit(1)

    print(f"Stop profiling on replica {profile_replica.unique_id}")
    actor_name = profile_replica.to_full_id_str()
    actorh = ray.get_actor(actor_name, namespace="serve")
    dummy_rm = pickle.dumps(RequestMetadata(
        request_id="1", internal_request_id="1", call_method="stop_profile"))
    ray.get(actorh.handle_request.remote(dummy_rm))
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [x] Manual test: checked that the profile is indeed generated after the start and stop call
   - [ ] This PR is not tested :(
