### PR TITLE
[Data] Prevent unbounded growth of_StatsActor.datasets

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -567,17 +567,12 @@ class _StatsActor:
         self.update_dataset_metadata_operator_states(dataset_tag, operator_states)
 
         # Evict the oldest finished datasets to ensure the `max_stats` limit is enforced.
-        if (
-            state["state"] == DatasetState.FINISHED.name
-            or state["state"] == DatasetState.FAILED.name
-        ):
+        if state["state"] in {DatasetState.FINISHED.name, DatasetState.FAILED.name}:
             self.finished_datasets_queue.append(dataset_tag)
             while len(self.datasets) > self.max_stats and self.finished_datasets_queue:
                 tag_to_evict = self.finished_datasets_queue.popleft()
-                if tag_to_evict in self.datasets:
-                    del self.datasets[tag_to_evict]
-                if tag_to_evict in self.dataset_metadatas:
-                    del self.dataset_metadatas[tag_to_evict]
+                self.datasets.pop(tag_to_evict, None)
+                self.dataset_metadatas.pop(tag_to_evict, None)
 
     def get_datasets(self, job_id: Optional[str] = None):
         if not job_id:

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -22,6 +22,7 @@ from ray.data._internal.execution.backpressure_policy import (
 from ray.data._internal.execution.backpressure_policy.backpressure_policy import (
     BackpressurePolicy,
 )
+from ray.data._internal.execution.dataset_state import DatasetState
 from ray.data._internal.execution.interfaces.op_runtime_metrics import TaskDurationStats
 from ray.data._internal.execution.interfaces.physical_operator import PhysicalOperator
 from ray.data._internal.stats import (
@@ -29,6 +30,7 @@ from ray.data._internal.stats import (
     NodeMetrics,
     StatsManager,
     _get_or_create_stats_actor,
+    _StatsActor,
 )
 from ray.data._internal.util import MemoryProfiler
 from ray.data.context import DataContext
@@ -1909,6 +1911,79 @@ def test_stats_actor_datasets(ray_start_cluster):
         assert value["progress"] == 20
         assert value["total"] == 20
         assert value["state"] == "FINISHED"
+
+
+def test_stats_actor_datasets_eviction(ray_start_cluster):
+    """
+    Tests that finished datasets are evicted from the _StatsActor when
+    the number of datasets exceeds the configured `max_stats` limit.
+    """
+    # Set a low max_stats limit to easily trigger eviction.
+    max_stats = 2
+    # Create a dedicated _StatsActor for this test to avoid interfering
+    # with the global actor.
+    stats_actor = _StatsActor.remote(max_stats=max_stats)
+
+    # Patch the function that retrieves the stats actor to return our
+    # test-specific actor instance.
+    with patch(
+        "ray.data._internal.stats._get_or_create_stats_actor",
+        return_value=stats_actor,
+    ):
+
+        def check_ds_finished(ds_name):
+            """Helper to check if a dataset is marked as FINISHED in the actor."""
+            datasets = ray.get(stats_actor.get_datasets.remote())
+            ds_tag = next((tag for tag in datasets if tag.startswith(ds_name)), None)
+            if not ds_tag:
+                return False
+            return datasets[ds_tag]["state"] == DatasetState.FINISHED.name
+
+        # --- DS1 ---
+        # Create and materialize the first dataset.
+        ds1 = ray.data.range(1, override_num_blocks=1)
+        ds1.set_name("ds1")
+        ds1.materialize()
+        # Wait until the actor has been updated with the FINISHED state.
+        wait_for_condition(lambda: check_ds_finished("ds1"))
+
+        # --- DS2 ---
+        # Create and materialize the second dataset.
+        # This brings the total number of datasets to the `max_stats` limit.
+        ds2 = ray.data.range(1, override_num_blocks=1)
+        ds2.set_name("ds2")
+        ds2.materialize()
+        wait_for_condition(lambda: check_ds_finished("ds2"))
+
+        # --- Verify state before eviction ---
+        # At this point, both ds1 and ds2 should be in the actor.
+        datasets = ray.get(stats_actor.get_datasets.remote())
+        names_in_actor = {k.split("_")[0] for k in datasets.keys()}
+        assert names_in_actor == {"ds1", "ds2"}
+
+        # --- DS3 ---
+        # Create and materialize the third dataset. This should trigger the
+        # eviction of the oldest finished dataset (ds1).
+        ds3 = ray.data.range(1, override_num_blocks=1)
+        ds3.set_name("ds3")
+        ds3.materialize()
+
+        def check_eviction():
+            """
+            Helper to check that the actor state reflects the eviction.
+            The actor should now contain ds2 and ds3, but not ds1.
+            """
+            datasets = ray.get(stats_actor.get_datasets.remote())
+            # The eviction happens asynchronously, so we might briefly see 3 datasets.
+            # We wait until the count is back to 2.
+            if len(datasets) == max_stats + 1:
+                return False
+            names = {k.split("_")[0] for k in datasets.keys()}
+            assert names == {"ds2", "ds3"}
+            return True
+
+        # Wait until the eviction has occurred and the actor state is correct.
+        wait_for_condition(check_eviction)
 
 
 @patch.object(StatsManager, "STATS_ACTOR_UPDATE_INTERVAL_SECONDS", new=0.5)


### PR DESCRIPTION
Background  
  Closes #43924.  

  The _StatsActor suffers from unbounded memory usage in long-running clusters. Its core metadata dictionaries, `datasets` and `dataset_metadatas`, lacked a proper garbage collection (GC) mechanism. This could lead to an Out-of-Memory (OOM) error in the _StatsActor when a large number of datasets are created.  

Solution  
  This patch implements an eviction policy for _StatsActor based on the `max_stats` configuration to effectively limit the size of the `datasets` and `dataset_metadatas` dictionaries, preventing their unbounded growth.  

  The implementation details are as follows:  
  1. **Optimize Queue Implementation**  
     The old, unused `fifo_queue` field has been removed. It is replaced by a new `collections.deque`, `finished_datasets_queue`, which serves as a more efficient FIFO queue for storing the tags of completed datasets.  

  2. **Implement Eviction Logic**  
     - When a dataset's status is updated to `FINISHED` or `FAILED`, its tag is appended to the `finished_datasets_queue`.  
     - A check is then immediately performed to see if the total number of entries in the `datasets` dictionary exceeds `max_stats`.  
     - If the limit is exceeded, the oldest dataset tag is popped from the front of the `finished_datasets_queue`, and the corresponding entries are synchronously deleted from the `datasets` and `dataset_metadatas` dictionaries.  

  3. **Clarify Limitation Strategy**  
     `max_stats` is not a strict hard limit. Since the eviction logic is only triggered when a dataset completes (`FINISHED` or `FAILED`), it is possible for the number of `RUNNING` datasets to cause the total entry count to temporarily exceed `max_stats`. This design ensures that metadata for in-progress tasks is never evicted, while still effectively preventing unbounded memory growth and OOM errors by cleaning up the oldest completed data as soon as a task finishes.  

Testing  
  To verify the correctness of this fix, a new unit test, `test_stats_actor_datasets_eviction`, has been added. This test sets a low `max_stats` value and asserts that the oldest finished dataset is correctly evicted when the limit is surpassed.  
