### PR TITLE
[core] Fix TSAN build for `redis_store_client_test`

### DIFF
--- a/src/ray/gcs/store_client/tests/in_memory_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/in_memory_store_client_test.cc
@@ -27,8 +27,6 @@ class InMemoryStoreClientTest : public StoreClientTestBase {
   void InitStoreClient() override {
     store_client_ = std::make_shared<InMemoryStoreClient>();
   }
-
-  void DisconnectStoreClient() override {}
 };
 
 TEST_F(InMemoryStoreClientTest, AsyncPutAndAsyncGetTest) { TestAsyncPutAndAsyncGet(); }

--- a/src/ray/gcs/store_client/tests/observable_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/observable_store_client_test.cc
@@ -29,8 +29,6 @@ class ObservableStoreClientTest : public StoreClientTestBase {
     store_client_ =
         std::make_shared<ObservableStoreClient>(std::make_unique<InMemoryStoreClient>());
   }
-
-  void DisconnectStoreClient() override {}
 };
 
 TEST_F(ObservableStoreClientTest, AsyncPutAndAsyncGetTest) { TestAsyncPutAndAsyncGet(); }

--- a/src/ray/gcs/store_client/tests/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/tests/redis_store_client_test.cc
@@ -79,8 +79,6 @@ class RedisStoreClientTest : public StoreClientTestBase {
     store_client_ = std::make_shared<RedisStoreClient>(io_context, options);
   }
 
-  void DisconnectStoreClient() override { store_client_.reset(); }
-
  protected:
   std::unique_ptr<std::thread> t_;
   std::atomic<bool> stopped_ = false;

--- a/src/ray/gcs/store_client/tests/store_client_test_base.h
+++ b/src/ray/gcs/store_client/tests/store_client_test_base.h
@@ -48,16 +48,12 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void TearDown() override {
-    DisconnectStoreClient();
-
     io_service_pool_->Stop();
 
     key_to_value_.clear();
   }
 
   virtual void InitStoreClient() = 0;
-
-  virtual void DisconnectStoreClient() = 0;
 
  protected:
   void Put() {


### PR DESCRIPTION
Prior to my PR combining the `RedisClient` and `RedisStoreClient`, `RedisClient::Disconnect` did nothing: https://github.com/ray-project/ray/pull/55655/files#diff-2d6d8cd30f5c1efd0051a66b40bddb2e72497afae5aa1fa12ef1491d476b04e5L52

This was called in the `DisconnectStoreClient` method of the test. I changed it to do `store_client.reset()`. This is invalid because there might still be async callbacks scheduled on the loop that depend on the primary Redis context.

Reverting to doing nothing for disconnection and directly stopping the loop instead.