### PR TITLE
[core] Remove `gcs_rpc_server.h` dependency from `GcsWorkerManager`

### DIFF
--- a/src/ray/gcs/gcs_server/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/BUILD.bazel
@@ -143,8 +143,8 @@ ray_cc_library(
         ":gcs_kv_manager",
         ":gcs_table_storage",
         ":gcs_usage_stats_client",
+        ":grpc_service_interfaces",
         "//src/ray/gcs/pubsub:gcs_pub_sub_lib",
-        "//src/ray/rpc:gcs_server",
         "//src/ray/stats:stats_metric",
     ],
 )

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -704,7 +704,9 @@ void GcsServer::InitGcsWorkerManager() {
   gcs_worker_manager_ = std::make_unique<GcsWorkerManager>(
       *gcs_table_storage_, io_context_provider_.GetDefaultIOContext(), *gcs_publisher_);
   rpc_server_.RegisterService(std::make_unique<rpc::WorkerInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(), *gcs_worker_manager_));
+      io_context_provider_.GetDefaultIOContext(),
+      *gcs_worker_manager_,
+      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
 }
 
 void GcsServer::InitGcsAutoscalerStateManager(const GcsInitData &gcs_init_data) {

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.h
@@ -18,9 +18,9 @@
 
 #include "ray/gcs/gcs_server/gcs_kv_manager.h"
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
+#include "ray/gcs/gcs_server/grpc_service_interfaces.h"
 #include "ray/gcs/gcs_server/usage_stats_client.h"
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
-#include "ray/rpc/gcs/gcs_rpc_server.h"
 
 namespace ray {
 namespace gcs {

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.h
@@ -25,8 +25,7 @@
 namespace ray {
 namespace gcs {
 
-/// This implementation class of `WorkerInfoHandler`.
-class GcsWorkerManager : public rpc::WorkerInfoHandler {
+class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
  public:
   GcsWorkerManager(gcs::GcsTableStorage &gcs_table_storage,
                    instrumented_io_context &io_context,

--- a/src/ray/gcs/gcs_server/grpc_service_interfaces.h
+++ b/src/ray/gcs/gcs_server/grpc_service_interfaces.h
@@ -64,6 +64,15 @@ class NodeInfoGcsServiceHandler {
                                     SendReplyCallback send_reply_callback) = 0;
 };
 
+class RuntimeEnvGcsServiceHandler {
+ public:
+  virtual ~RuntimeEnvGcsServiceHandler() = default;
+
+  virtual void HandlePinRuntimeEnvURI(PinRuntimeEnvURIRequest request,
+                                      PinRuntimeEnvURIReply *reply,
+                                      SendReplyCallback send_reply_callback) = 0;
+};
+
 class WorkerInfoGcsServiceHandler {
  public:
   virtual ~WorkerInfoGcsServiceHandler() = default;

--- a/src/ray/gcs/gcs_server/grpc_service_interfaces.h
+++ b/src/ray/gcs/gcs_server/grpc_service_interfaces.h
@@ -64,5 +64,35 @@ class NodeInfoGcsServiceHandler {
                                     SendReplyCallback send_reply_callback) = 0;
 };
 
+class WorkerInfoGcsServiceHandler {
+ public:
+  virtual ~WorkerInfoGcsServiceHandler() = default;
+
+  virtual void HandleReportWorkerFailure(ReportWorkerFailureRequest request,
+                                         ReportWorkerFailureReply *reply,
+                                         SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetWorkerInfo(GetWorkerInfoRequest request,
+                                   GetWorkerInfoReply *reply,
+                                   SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetAllWorkerInfo(GetAllWorkerInfoRequest request,
+                                      GetAllWorkerInfoReply *reply,
+                                      SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleAddWorkerInfo(AddWorkerInfoRequest request,
+                                   AddWorkerInfoReply *reply,
+                                   SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleUpdateWorkerDebuggerPort(UpdateWorkerDebuggerPortRequest request,
+                                              UpdateWorkerDebuggerPortReply *reply,
+                                              SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleUpdateWorkerNumPausedThreads(
+      UpdateWorkerNumPausedThreadsRequest request,
+      UpdateWorkerNumPausedThreadsReply *reply,
+      SendReplyCallback send_reply_callback) = 0;
+};
+
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/grpc_services.cc
+++ b/src/ray/gcs/gcs_server/grpc_services.cc
@@ -36,5 +36,21 @@ void NodeInfoGrpcService::InitServerCallFactories(
   RPC_SERVICE_HANDLER(NodeInfoGcsService, CheckAlive, max_active_rpcs_per_handler_)
 }
 
+void WorkerInfoGrpcService::InitServerCallFactories(
+    const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+    std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
+    const ClusterID &cluster_id) {
+  RPC_SERVICE_HANDLER(
+      WorkerInfoGcsService, ReportWorkerFailure, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(WorkerInfoGcsService, GetWorkerInfo, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(
+      WorkerInfoGcsService, GetAllWorkerInfo, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(WorkerInfoGcsService, AddWorkerInfo, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(
+      WorkerInfoGcsService, UpdateWorkerDebuggerPort, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(
+      WorkerInfoGcsService, UpdateWorkerNumPausedThreads, max_active_rpcs_per_handler_)
+}
+
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/grpc_services.cc
+++ b/src/ray/gcs/gcs_server/grpc_services.cc
@@ -36,6 +36,14 @@ void NodeInfoGrpcService::InitServerCallFactories(
   RPC_SERVICE_HANDLER(NodeInfoGcsService, CheckAlive, max_active_rpcs_per_handler_)
 }
 
+void RuntimeEnvGrpcService::InitServerCallFactories(
+    const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+    std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
+    const ClusterID &cluster_id) {
+  RPC_SERVICE_HANDLER(
+      RuntimeEnvGcsService, PinRuntimeEnvURI, max_active_rpcs_per_handler_);
+}
+
 void WorkerInfoGrpcService::InitServerCallFactories(
     const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
     std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,

--- a/src/ray/gcs/gcs_server/grpc_services.h
+++ b/src/ray/gcs/gcs_server/grpc_services.h
@@ -58,5 +58,28 @@ class NodeInfoGrpcService : public GrpcService {
   int64_t max_active_rpcs_per_handler_;
 };
 
+class WorkerInfoGrpcService : public GrpcService {
+ public:
+  explicit WorkerInfoGrpcService(instrumented_io_context &io_service,
+                                 WorkerInfoGcsServiceHandler &handler,
+                                 int64_t max_active_rpcs_per_handler)
+      : GrpcService(io_service),
+        service_handler_(handler),
+        max_active_rpcs_per_handler_(max_active_rpcs_per_handler){};
+
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
+
+  void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
+      const ClusterID &cluster_id) override;
+
+ private:
+  WorkerInfoGcsService::AsyncService service_;
+  WorkerInfoGcsServiceHandler &service_handler_;
+  int64_t max_active_rpcs_per_handler_;
+};
+
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/grpc_services.h
+++ b/src/ray/gcs/gcs_server/grpc_services.h
@@ -58,6 +58,28 @@ class NodeInfoGrpcService : public GrpcService {
   int64_t max_active_rpcs_per_handler_;
 };
 
+class RuntimeEnvGrpcService : public GrpcService {
+ public:
+  explicit RuntimeEnvGrpcService(instrumented_io_context &io_service,
+                                 RuntimeEnvGcsServiceHandler &handler,
+                                 int64_t max_active_rpcs_per_handler)
+      : GrpcService(io_service),
+        service_handler_(handler),
+        max_active_rpcs_per_handler_(max_active_rpcs_per_handler) {}
+
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
+  void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
+      const ClusterID &cluster_id) override;
+
+ private:
+  RuntimeEnvGcsService::AsyncService service_;
+  RuntimeEnvGcsServiceHandler &service_handler_;
+  int64_t max_active_rpcs_per_handler_;
+};
+
 class WorkerInfoGrpcService : public GrpcService {
  public:
   explicit WorkerInfoGrpcService(instrumented_io_context &io_service,

--- a/src/ray/rpc/gcs/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs/gcs_rpc_server.h
@@ -142,11 +142,6 @@ namespace rpc {
                       HANDLER,                   \
                       RayConfig::instance().gcs_max_active_rpcs_per_handler())
 
-#define WORKER_INFO_SERVICE_RPC_HANDLER(HANDLER) \
-  RPC_SERVICE_HANDLER(WorkerInfoGcsService,      \
-                      HANDLER,                   \
-                      RayConfig::instance().gcs_max_active_rpcs_per_handler())
-
 #define PLACEMENT_GROUP_INFO_SERVICE_RPC_HANDLER(HANDLER) \
   RPC_SERVICE_HANDLER(PlacementGroupInfoGcsService,       \
                       HANDLER,                            \
@@ -364,68 +359,6 @@ class NodeResourceInfoGrpcService : public GrpcService {
   NodeResourceInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
   NodeResourceInfoGcsServiceHandler &service_handler_;
-};
-
-class WorkerInfoGcsServiceHandler {
- public:
-  virtual ~WorkerInfoGcsServiceHandler() = default;
-
-  virtual void HandleReportWorkerFailure(ReportWorkerFailureRequest request,
-                                         ReportWorkerFailureReply *reply,
-                                         SendReplyCallback send_reply_callback) = 0;
-
-  virtual void HandleGetWorkerInfo(GetWorkerInfoRequest request,
-                                   GetWorkerInfoReply *reply,
-                                   SendReplyCallback send_reply_callback) = 0;
-
-  virtual void HandleGetAllWorkerInfo(GetAllWorkerInfoRequest request,
-                                      GetAllWorkerInfoReply *reply,
-                                      SendReplyCallback send_reply_callback) = 0;
-
-  virtual void HandleAddWorkerInfo(AddWorkerInfoRequest request,
-                                   AddWorkerInfoReply *reply,
-                                   SendReplyCallback send_reply_callback) = 0;
-
-  virtual void HandleUpdateWorkerDebuggerPort(UpdateWorkerDebuggerPortRequest request,
-                                              UpdateWorkerDebuggerPortReply *reply,
-                                              SendReplyCallback send_reply_callback) = 0;
-
-  virtual void HandleUpdateWorkerNumPausedThreads(
-      UpdateWorkerNumPausedThreadsRequest request,
-      UpdateWorkerNumPausedThreadsReply *reply,
-      SendReplyCallback send_reply_callback) = 0;
-};
-
-/// The `GrpcService` for `WorkerInfoGcsService`.
-class WorkerInfoGrpcService : public GrpcService {
- public:
-  /// Constructor.
-  ///
-  /// \param[in] handler The service handler that actually handle the requests.
-  explicit WorkerInfoGrpcService(instrumented_io_context &io_service,
-                                 WorkerInfoGcsServiceHandler &handler)
-      : GrpcService(io_service), service_handler_(handler){};
-
- protected:
-  grpc::Service &GetGrpcService() override { return service_; }
-
-  void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
-      const ClusterID &cluster_id) override {
-    WORKER_INFO_SERVICE_RPC_HANDLER(ReportWorkerFailure);
-    WORKER_INFO_SERVICE_RPC_HANDLER(GetWorkerInfo);
-    WORKER_INFO_SERVICE_RPC_HANDLER(GetAllWorkerInfo);
-    WORKER_INFO_SERVICE_RPC_HANDLER(AddWorkerInfo);
-    WORKER_INFO_SERVICE_RPC_HANDLER(UpdateWorkerDebuggerPort);
-    WORKER_INFO_SERVICE_RPC_HANDLER(UpdateWorkerNumPausedThreads);
-  }
-
- private:
-  /// The grpc async service object.
-  WorkerInfoGcsService::AsyncService service_;
-  /// The service handler that actually handle the requests.
-  WorkerInfoGcsServiceHandler &service_handler_;
 };
 
 class PlacementGroupInfoGcsServiceHandler {
@@ -696,7 +629,6 @@ class InternalPubSubGrpcService : public GrpcService {
 using JobInfoHandler = JobInfoGcsServiceHandler;
 using ActorInfoHandler = ActorInfoGcsServiceHandler;
 using NodeResourceInfoHandler = NodeResourceInfoGcsServiceHandler;
-using WorkerInfoHandler = WorkerInfoGcsServiceHandler;
 using PlacementGroupInfoHandler = PlacementGroupInfoGcsServiceHandler;
 using InternalKVHandler = InternalKVGcsServiceHandler;
 using InternalPubSubHandler = InternalPubSubGcsServiceHandler;


### PR DESCRIPTION
Splitting gRPC service interface from implementation.