### PR TITLE
[wheel] add `gen_py_proto` script

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -516,6 +516,18 @@ genrule(
 )
 
 py_binary(
+    name = "gen_py_proto",
+    srcs = ["gen_py_proto.py"],
+    data = [
+        ":ray_py_proto_zip",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//bazel:gen_extract",
+    ],
+)
+
+py_binary(
     name = "gen_ray_pkg",
     srcs = ["gen_ray_pkg.py"],
     data = [

--- a/bazel/gen_extract.py
+++ b/bazel/gen_extract.py
@@ -16,7 +16,9 @@ def gen_extract(
 
     root_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
     if not root_dir:
-        raise ValueError("BUILD_WORKSPACE_DIRECTORY not set")
+        raise ValueError(
+            "BUILD_WORKSPACE_DIRECTORY not set; please run this script from 'bazelisk run'"
+        )
 
     if sub_dir:
         extract_dir = os.path.join(root_dir, sub_dir)

--- a/gen_py_proto.py
+++ b/gen_py_proto.py
@@ -1,0 +1,12 @@
+from bazel.gen_extract import gen_extract
+
+if __name__ == "__main__":
+    gen_extract(
+        [
+            "ray_py_proto.zip",
+        ],
+        clear_dir_first=[
+            "ray/core/generated",
+            "ray/serve/generated",
+        ],
+    )


### PR DESCRIPTION
as a replacement for `install_py_proto`, for people who only wants to regenerate the protobuf python files but not the ray core bits
