### PR TITLE
feat(runtime_env): add Azure ABFSS Blob Storage support

### DIFF
--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -30,13 +30,15 @@ class ProtocolsProvider:
             "gs",
             # Remote azure blob storage path, assumes everything packed in one zip file.
             "azure",
+            # Remote Azure Blob File System Secure path, assumes everything packed in one zip file.
+            "abfss",
             # File storage path, assumes everything packed in one zip file.
             "file",
         }
 
     @classmethod
     def get_remote_protocols(cls):
-        return {"https", "s3", "gs", "azure", "file"}
+        return {"https", "s3", "gs", "azure", "abfss", "file"}
 
     @classmethod
     def _handle_s3_protocol(cls):
@@ -123,6 +125,46 @@ class ProtocolsProvider:
         return open_file, transport_params
 
     @classmethod
+    def _handle_abfss_protocol(cls):
+        """Set up Azure Blob File System Secure (ABFSS) protocol handling.
+
+        Returns:
+            tuple: (open_file function, transport_params)
+
+        Raises:
+            ImportError: If required dependencies are not installed.
+            ValueError: If required environment variables are not set.
+        """
+        try:
+            from azure.identity import DefaultAzureCredential
+            from azure.storage.blob import BlobServiceClient  # noqa: F401
+            from smart_open import open as open_file
+        except ImportError:
+            raise ImportError(
+                "You must `pip install azure-storage-blob azure-identity smart_open[azure]` "
+                "to fetch URIs in Azure Blob File System Secure. "
+                + cls._MISSING_DEPENDENCIES_WARNING
+            )
+
+        # Define authentication variable
+        azure_storage_account_name = os.getenv("AZURE_STORAGE_ACCOUNT")
+
+        if not azure_storage_account_name:
+            raise ValueError(
+                "Azure Blob File System Secure authentication requires "
+                "AZURE_STORAGE_ACCOUNT environment variable to be set."
+            )
+
+        account_url = f"https://{azure_storage_account_name}.dfs.core.windows.net/"
+        transport_params = {
+            "client": BlobServiceClient(
+                account_url=account_url, credential=DefaultAzureCredential()
+            )
+        }
+
+        return open_file, transport_params
+
+    @classmethod
     def download_remote_uri(cls, protocol: str, source_uri: str, dest_file: str):
         """Download file from remote URI to destination file.
 
@@ -151,6 +193,8 @@ class ProtocolsProvider:
             open_file, tp = cls._handle_gs_protocol()
         elif protocol == "azure":
             open_file, tp = cls._handle_azure_protocol()
+        elif protocol == "abfss":
+            open_file, tp = cls._handle_abfss_protocol()
         else:
             try:
                 from smart_open import open as open_file

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -491,7 +491,11 @@ class TestParseUri:
             ("https://test.com/file.zip", Protocol.HTTPS, "https_test_com_file.zip"),
             ("gs://bucket/file.zip", Protocol.GS, "gs_bucket_file.zip"),
             ("azure://container/file.zip", Protocol.AZURE, "azure_container_file.zip"),
-            ("abfss://container@account.dfs.core.windows.net/file.zip", Protocol.ABFSS, "abfss_container_account_dfs_core_windows_net_file.zip"),
+            (
+                "abfss://container@account.dfs.core.windows.net/file.zip",
+                Protocol.ABFSS,
+                "abfss_container_account_dfs_core_windows_net_file.zip",
+            ),
             (
                 "https://test.com/package-0.0.1-py2.py3-none-any.whl?param=value",
                 Protocol.HTTPS,

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -491,6 +491,7 @@ class TestParseUri:
             ("https://test.com/file.zip", Protocol.HTTPS, "https_test_com_file.zip"),
             ("gs://bucket/file.zip", Protocol.GS, "gs_bucket_file.zip"),
             ("azure://container/file.zip", Protocol.AZURE, "azure_container_file.zip"),
+            ("abfss://container@account.dfs.core.windows.net/file.zip", Protocol.ABFSS, "abfss_container_account_dfs_core_windows_net_file.zip"),
             (
                 "https://test.com/package-0.0.1-py2.py3-none-any.whl?param=value",
                 Protocol.HTTPS,
@@ -554,6 +555,11 @@ class TestParseUri:
                 "azure_fake_2022-10-21T13_11_35_00_00_package.zip",
             ),
             (
+                "abfss://container@account.dfs.core.windows.net/2022-10-21T13:11:35+00:00/package.zip",
+                Protocol.ABFSS,
+                "abfss_container_account_dfs_core_windows_net_2022-10-21T13_11_35_00_00_package.zip",
+            ),
+            (
                 "file:///fake/2022-10-21T13:11:35+00:00/package.zip",
                 Protocol.FILE,
                 "file__fake_2022-10-21T13_11_35_00_00_package.zip",
@@ -592,6 +598,11 @@ class TestParseUri:
             (
                 "azure://fake/2022-10-21T13:11:35+00:00/package.whl",
                 Protocol.AZURE,
+                "package.whl",
+            ),
+            (
+                "abfss://container@account.dfs.core.windows.net/2022-10-21T13:11:35+00:00/package.whl",
+                Protocol.ABFSS,
                 "package.whl",
             ),
             (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


abfss:// 

Context: This stands for Azure Blob File System Secure and is used specifically with Azure Data Lake Storage 

Gen2.Usage: It is the actual protocol used by Spark, Hadoop, and other big data tools to securely access files in ADLS 

Gen2.Security: The abfss:// scheme ensures secure communication (HTTPS) and is preferred over abfs://, which is non-secure.

Example: abfss://myfilesystem@myaccount.dfs.core.windows.net/myfolder/myfile.csv



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
