### PR TITLE
[pydoclint] Fix baseline violations for `DOC201` in `python/ray/data`

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1005,13 +1005,8 @@ python/ray/dashboard/utils.py
     DOC103: Method `RateLimitedModule.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [logger: Optional[logging.Logger], max_num_call: int].
     DOC201: Function `compose_state_message` does not have a return section in docstring
 --------------------
-python/ray/data/_internal/arrow_ops/transform_pyarrow.py
-    DOC201: Function `combine_chunks` does not have a return section in docstring
-    DOC201: Function `combine_chunked_array` does not have a return section in docstring
---------------------
 python/ray/data/_internal/block_batching/iter_batches.py
     DOC103: Function `_format_in_threadpool`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_iter: Iterator[Batch]]. Arguments in the docstring but not in the function signature: [logical_batch_iterator: ].
-    DOC201: Function `_format_in_threadpool` does not have a return section in docstring
 --------------------
 python/ray/data/_internal/block_batching/util.py
     DOC402: Function `resolve_block_refs` has "yield" statements, but the docstring does not have a "Yields" section
@@ -1044,8 +1039,6 @@ python/ray/data/_internal/datasource/tfrecords_datasource.py
     DOC103: Method `TFRecordDatasource.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**file_based_datasource_kwargs: , paths: Union[str, List[str]], tf_schema: Optional['schema_pb2.Schema'], tfx_read_options: Optional['TFXReadOptions']].
 --------------------
 python/ray/data/_internal/datasource/webdataset_datasource.py
-    DOC201: Function `_valid_sample` does not have a return section in docstring
-    DOC201: Function `_check_suffix` does not have a return section in docstring
     DOC101: Function `_tar_file_iterator`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `_tar_file_iterator`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [filerename: Optional[Union[bool, callable, list]], verbose_open: bool].
     DOC402: Function `_tar_file_iterator` has "yield" statements, but the docstring does not have a "Yields" section
@@ -1054,11 +1047,9 @@ python/ray/data/_internal/datasource/webdataset_datasource.py
     DOC404: Function `_group_by_keys` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
     DOC101: Function `_default_decoder`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `_default_decoder`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [format: Optional[Union[bool, str]]].
-    DOC201: Function `_default_decoder` does not have a return section in docstring
     DOC101: Function `_default_encoder`: Docstring contains fewer arguments than in function signature.
     DOC111: Function `_default_encoder`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
     DOC103: Function `_default_encoder`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [format: Optional[Union[str, bool]]].
-    DOC201: Function `_default_encoder` does not have a return section in docstring
     DOC102: Method `WebDatasetDatasource._read_stream`: Docstring contains more arguments than in function signature.
     DOC103: Method `WebDatasetDatasource._read_stream`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [decoder: , fileselect: , suffixes: , verbose_open: ].
     DOC403: Method `WebDatasetDatasource._read_stream` has a "Yields" section in the docstring, but there are no "yield" statements, or the return annotation is not a Generator/Iterator/Iterable. (Or it could be because the function lacks a return annotation.)
@@ -1070,19 +1061,13 @@ python/ray/data/_internal/equalize.py
     DOC103: Function `_shave_all_splits`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [per_split_num_rows: List[List[int]]].
 --------------------
 python/ray/data/_internal/execution/interfaces/execution_options.py
-    DOC201: Method `ExecutionResources.for_limits` does not have a return section in docstring
     DOC101: Method `ExecutionResources.add`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `ExecutionResources.add`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [other: 'ExecutionResources'].
     DOC101: Method `ExecutionResources.subtract`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `ExecutionResources.subtract`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [other: 'ExecutionResources'].
     DOC107: Method `ExecutionResources.satisfies_limit`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC201: Method `ExecutionResources.satisfies_limit` does not have a return section in docstring
     DOC101: Method `ExecutionOptions.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `ExecutionOptions.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor_locality_enabled: bool, exclude_resources: Optional[ExecutionResources], locality_with_output: Union[bool, List[NodeIdStr]], preserve_order: bool, resource_limits: Optional[ExecutionResources], verbose_progress: Optional[bool]].
---------------------
-python/ray/data/_internal/execution/interfaces/executor.py
-    DOC201: Method `OutputIterator.get_next` does not have a return section in docstring
-    DOC201: Method `Executor.execute` does not have a return section in docstring
 --------------------
 python/ray/data/_internal/execution/interfaces/physical_operator.py
     DOC201: Method `DataOpTask.on_data_ready` does not have a return section in docstring
@@ -1108,7 +1093,6 @@ python/ray/data/_internal/execution/operators/hash_shuffle.py
 --------------------
 python/ray/data/_internal/execution/operators/map_operator.py
     DOC103: Method `MapOperator.create`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [init_fn: , transform_fn: ].
-    DOC201: Method `MapOperator.create` does not have a return section in docstring
     DOC101: Function `_map_task`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `_map_task`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Dict[str, Any], *blocks: Block, ctx: TaskContext, data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [blocks: , fn: ].
     DOC402: Function `_map_task` has "yield" statements, but the docstring does not have a "Yields" section
@@ -1155,17 +1139,12 @@ python/ray/data/_internal/execution/streaming_executor.py
     DOC103: Method `StreamingExecutor._scheduling_loop_step`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [topology: Topology].
 --------------------
 python/ray/data/_internal/execution/streaming_executor_state.py
-    DOC201: Method `OpBufferQueue.has_next` does not have a return section in docstring
     DOC101: Method `OpState.get_output_blocking`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `OpState.get_output_blocking`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [output_split_idx: Optional[int]].
 --------------------
 python/ray/data/_internal/iterator/stream_split_iterator.py
     DOC101: Method `SplitCoordinator.start_epoch`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `SplitCoordinator.start_epoch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [split_idx: int].
---------------------
-python/ray/data/_internal/logging.py
-    DOC201: Function `register_dataset_logger` does not have a return section in docstring
-    DOC201: Function `unregister_dataset_logger` does not have a return section in docstring
 --------------------
 python/ray/data/_internal/logical/operators/all_to_all_operator.py
     DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
@@ -1231,9 +1210,6 @@ python/ray/data/_internal/planner/exchange/interfaces.py
     DOC101: Method `ExchangeTaskScheduler.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `ExchangeTaskScheduler.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [exchange_spec: ExchangeTaskSpec].
 --------------------
-python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
-    DOC201: Method `_ConvertToArrowExpressionVisitor.visit_UnaryOp` does not have a return section in docstring
---------------------
 python/ray/data/_internal/stats.py
     DOC107: Method `DatasetStatsSummary.to_string`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
     DOC104: Method `OperatorStatsSummary.from_block_metadata`: Arguments are the same in the docstring and the function signature, but are in a different order.
@@ -1244,14 +1220,12 @@ python/ray/data/_internal/stats.py
     DOC103: Method `OperatorStatsSummary.__repr__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [level: ].
 --------------------
 python/ray/data/_internal/util.py
-    DOC201: Function `_estimate_avail_cpus` does not have a return section in docstring
     DOC107: Function `_check_import`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
     DOC402: Function `make_async_gen` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `make_async_gen` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
     DOC103: Method `RetryingPyFileSystemHandler.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [retryable_errors: List[str]]. Arguments in the docstring but not in the function signature: [context: ].
     DOC104: Function `call_with_retry`: Arguments are the same in the docstring and the function signature, but are in a different order.
     DOC105: Function `call_with_retry`: Argument names match, but type hints in these args do not match: f, description, match, max_attempts, max_backoff_s
-    DOC201: Function `call_with_retry` does not have a return section in docstring
     DOC104: Function `iterate_with_retry`: Arguments are the same in the docstring and the function signature, but are in a different order.
     DOC105: Function `iterate_with_retry`: Argument names match, but type hints in these args do not match: iterable_factory, description, match, max_attempts, max_backoff_s
     DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
@@ -1260,32 +1234,18 @@ python/ray/data/_internal/util.py
     DOC103: Method `MemoryProfiler.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [poll_interval_s: Optional[float]].
 --------------------
 python/ray/data/block.py
-    DOC201: Method `BlockAccessor.iter_rows` does not have a return section in docstring
-    DOC201: Method `BlockAccessor.to_numpy` does not have a return section in docstring
     DOC102: Method `BlockAccessor._get_group_boundaries_sorted`: Docstring contains more arguments than in function signature.
     DOC103: Method `BlockAccessor._get_group_boundaries_sorted`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [block: ].
 --------------------
-python/ray/data/context.py
-    DOC201: Method `DataContext.get_current` does not have a return section in docstring
-    DOC201: Method `DataContext.get_config` does not have a return section in docstring
---------------------
 python/ray/data/dataset.py
     DOC103: Method `Dataset.map`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
-    DOC201: Method `Dataset.map` does not have a return section in docstring
     DOC103: Method `Dataset.map_batches`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
-    DOC201: Method `Dataset.map_batches` does not have a return section in docstring
     DOC103: Method `Dataset.add_column`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
-    DOC201: Method `Dataset.add_column` does not have a return section in docstring
     DOC103: Method `Dataset.drop_columns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
-    DOC201: Method `Dataset.drop_columns` does not have a return section in docstring
     DOC103: Method `Dataset.select_columns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
-    DOC201: Method `Dataset.select_columns` does not have a return section in docstring
     DOC103: Method `Dataset.rename_columns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
-    DOC201: Method `Dataset.rename_columns` does not have a return section in docstring
     DOC103: Method `Dataset.flat_map`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
-    DOC201: Method `Dataset.flat_map` does not have a return section in docstring
     DOC103: Method `Dataset.filter`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
-    DOC201: Method `Dataset.filter` does not have a return section in docstring
     DOC101: Method `Dataset.random_shuffle`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `Dataset.random_shuffle`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: , num_blocks: Optional[int]].
     DOC103: Method `Dataset.union`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*other: List['Dataset']]. Arguments in the docstring but not in the function signature: [other: ].
@@ -1300,9 +1260,6 @@ python/ray/data/dataset.py
     DOC103: Method `Dataset.write_lance`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [concurrency: Optional[int], ray_remote_args: Dict[str, Any]].
     DOC101: Method `Dataset.iter_batches`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `Dataset.iter_batches`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_collate_fn: Optional[Callable[[DataBatch], CollatedData]]].
-    DOC201: Method `Dataset.to_random_access_dataset` does not have a return section in docstring
-    DOC201: Method `Dataset.stats` does not have a return section in docstring
-    DOC201: Method `Dataset.has_serializable_lineage` does not have a return section in docstring
     DOC101: Method `Dataset._repr_mimebundle_`: Docstring contains fewer arguments than in function signature.
     DOC106: Method `Dataset._repr_mimebundle_`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC103: Method `Dataset._repr_mimebundle_`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
@@ -1328,17 +1285,9 @@ python/ray/data/datasource/file_meta_provider.py
     DOC101: Function `_expand_directory`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `_expand_directory`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [ignore_missing_path: bool].
 --------------------
-python/ray/data/datasource/filename_provider.py
-    DOC201: Method `FilenameProvider.get_filename_for_block` does not have a return section in docstring
-    DOC201: Method `FilenameProvider.get_filename_for_row` does not have a return section in docstring
---------------------
 python/ray/data/datasource/parquet_meta_provider.py
     DOC101: Method `ParquetMetadataProvider.prefetch_file_metadata`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `ParquetMetadataProvider.prefetch_file_metadata`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ].
---------------------
-python/ray/data/datasource/path_util.py
-    DOC201: Function `_has_file_extension` does not have a return section in docstring
-    DOC201: Function `_resolve_paths_and_filesystem` does not have a return section in docstring
 --------------------
 python/ray/data/grouped_data.py
     DOC103: Method `GroupedData.aggregate`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*aggs: AggregateFn]. Arguments in the docstring but not in the function signature: [aggs: ].
@@ -1347,7 +1296,6 @@ python/ray/data/grouped_data.py
 python/ray/data/preprocessor.py
     DOC101: Method `Preprocessor._derive_and_validate_output_columns`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `Preprocessor._derive_and_validate_output_columns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [columns: List[str], output_columns: Optional[List[str]]].
-    DOC201: Method `Preprocessor._derive_and_validate_output_columns` does not have a return section in docstring
 --------------------
 python/ray/data/preprocessors/chain.py
     DOC103: Method `Chain.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*preprocessors: Preprocessor]. Arguments in the docstring but not in the function signature: [preprocessors: ].

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -793,6 +793,9 @@ def combine_chunks(table: "pyarrow.Table", copy: bool = False) -> "pyarrow.Table
     Args:
         table: Table with chunked columns to be combined into contiguous arrays.
         copy: Skip copying when copy is False and there is exactly 1 chunk.
+
+    Returns:
+        pyarrow.Table: A new table with combined chunks for all columns.
     """
 
     new_column_values_arrays = []
@@ -822,6 +825,9 @@ def combine_chunked_array(
         array: The chunked array to be combined into a single contiguous array.
         ensure_copy: Skip copying when ensure_copy is False and there's exactly
            1 chunk.
+
+    Returns:
+        Union[pyarrow.Array, pyarrow.ChunkedArray]: A combined array or chunked array depending on the input type and safety constraints.
     """
 
     import pyarrow as pa

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -287,6 +287,9 @@ def _format_in_threadpool(
             as batches.
         collate_fn: A function to apply to each data batch before returning it.
         num_threadpool_workers: The number of threads to use in the threadpool.
+
+    Returns:
+        Iterator[Batch]: An iterator over formatted and collated batches.
     """
 
     def threadpool_computations_format_collate(

--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -39,6 +39,9 @@ def _valid_sample(sample: Dict[str, Any]):
 
     Args:
         sample: sample to be checked
+
+    Returns:
+        bool: True if the sample is valid, False otherwise.
     """
     return (
         sample is not None
@@ -83,6 +86,9 @@ def _check_suffix(suffix: str, suffixes: Union[list, callable]):
     Args:
         suffix: suffix to be checked
         suffixes: list of valid suffixes
+
+    Returns:
+        bool: True if the suffix is valid according to the suffixes rules, False otherwise.
     """
     if suffixes is None:
         return True
@@ -182,6 +188,9 @@ def _default_decoder(sample: Dict[str, Any], format: Optional[Union[bool, str]] 
 
     Args:
         sample: sample, modified in place
+
+    Returns:
+        Dict[str, Any]: The decoded sample dictionary with appropriate data types for each file extension.
     """
     sample = dict(sample)
     for key, value in sample.items():
@@ -234,6 +243,9 @@ def _default_encoder(sample: Dict[str, Any], format: Optional[Union[str, bool]] 
 
     Args:
         sample (Dict[str, Any]): sample
+
+    Returns:
+        Dict[str, Any]: The encoded sample dictionary with values converted to bytes format.
     """
     sample = dict(sample)
     for key, value in sample.items():

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -63,6 +63,9 @@ class ExecutionResources:
             gpu: Amount of logical GPU slots.
             object_store_memory: Amount of object store memory.
             memory: Amount of logical memory in bytes.
+
+        Returns:
+            ExecutionResources: A new ExecutionResources object configured with the specified resource limits.
         """
         return ExecutionResources(
             cpu=safe_or(cpu, float("inf")),
@@ -220,6 +223,9 @@ class ExecutionResources:
             limit: The resource limits to check against.
             ignore_object_store_memory: If True, ignore the object store memory
                 limit when checking if this resource struct meets the limits.
+
+        Returns:
+            bool: True if this resource struct satisfies all the specified limits, False otherwise.
         """
         return (
             self.cpu <= limit.cpu

--- a/python/ray/data/_internal/execution/interfaces/executor.py
+++ b/python/ray/data/_internal/execution/interfaces/executor.py
@@ -25,6 +25,9 @@ class OutputIterator(Iterator[RefBundle], ABC):
             output_split_idx: The output split index to get results for. This arg is
                 only allowed for iterators created by `Dataset.streaming_split()`.
 
+        Returns:
+            RefBundle: The next bundle of output data from the execution.
+
         Raises:
             StopIteration: If there are no more outputs to return.
         """
@@ -56,6 +59,9 @@ class Executor(ContextManager, ABC):
             dag: The operator graph to execute.
             initial_stats: The DatasetStats to prepend to the stats returned by the
                 executor. These stats represent actions done to compute inputs.
+
+        Returns:
+            OutputIterator: An iterator over the execution results.
         """
         ...
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -207,6 +207,9 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
             ray_remote_args: Customize the :func:`ray.remote` args for this op's tasks.
+
+        Returns:
+            MapOperator: A new MapOperator instance configured according to the compute strategy.
         """
         if compute_strategy is None:
             compute_strategy = TaskPoolStrategy()

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -94,6 +94,9 @@ class OpBufferQueue:
         Args:
             output_split_idx: If specified, only check ref bundles with the
                 given output split.
+
+        Returns:
+            bool: True if there is a next RefBundle available for the specified output split, False otherwise.
         """
         if output_split_idx is None:
             with self._lock:

--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -275,7 +275,7 @@ def update_dataset_logger_for_worker(dataset_id: Optional[str]) -> None:
         logger.addHandler(log_handler)
 
 
-def register_dataset_logger(dataset_id: str) -> Optional[int]:
+def register_dataset_logger(dataset_id: str) -> Optional[str]:
     """Create a log handler for a dataset with the given ID. Activate the handler if
     this is the only active dataset. Otherwise, print a warning to that handler and
     keep it inactive until it becomes the only active dataset.
@@ -313,7 +313,7 @@ def register_dataset_logger(dataset_id: str) -> Optional[int]:
     return _ACTIVE_DATASET
 
 
-def unregister_dataset_logger(dataset_id: str) -> Optional[int]:
+def unregister_dataset_logger(dataset_id: str) -> Optional[str]:
     """Remove the logger for a dataset with the given ID.
 
     Args:

--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -282,6 +282,9 @@ def register_dataset_logger(dataset_id: str) -> Optional[int]:
 
     Args:
         dataset_id: The ID of the dataset.
+
+    Returns:
+        Optional[int]: The number of active dataset loggers after registration, or None if registration failed.
     """
     global _DATASET_LOGGER_HANDLER
     global _ACTIVE_DATASET
@@ -315,6 +318,9 @@ def unregister_dataset_logger(dataset_id: str) -> Optional[int]:
 
     Args:
         dataset_id: The ID of the dataset.
+
+    Returns:
+        Optional[int]: The number of remaining active dataset loggers after removal, or None if the dataset ID was not found.
     """
     global _DATASET_LOGGER_HANDLER
     global _ACTIVE_DATASET

--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -284,7 +284,7 @@ def register_dataset_logger(dataset_id: str) -> Optional[int]:
         dataset_id: The ID of the dataset.
 
     Returns:
-        Optional[int]: The number of active dataset loggers after registration, or None if registration failed.
+        Optional[str]: The ID of the active dataset logger, or None if no logger is active after registration.
     """
     global _DATASET_LOGGER_HANDLER
     global _ACTIVE_DATASET
@@ -320,7 +320,7 @@ def unregister_dataset_logger(dataset_id: str) -> Optional[int]:
         dataset_id: The ID of the dataset.
 
     Returns:
-        Optional[int]: The number of remaining active dataset loggers after removal, or None if the dataset ID was not found.
+        Optional[str]: The ID of the active dataset logger after unregistering, or None if no logger is active.
     """
     global _DATASET_LOGGER_HANDLER
     global _ACTIVE_DATASET

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -167,7 +167,11 @@ class _ConvertToArrowExpressionVisitor(ast.NodeVisitor):
         comparators=[UnaryOp(op=USub(), operand=Constant(value=1))])
 
         Args:
-            node: The constant value."""
+            node: The constant value.
+
+        Returns:
+            ds.Expression: A PyArrow dataset expression representing the unary operation.
+        """
 
         op = node.op
         if isinstance(op, ast.USub):

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -284,6 +284,9 @@ def _estimate_avail_cpus(cur_pg: Optional["PlacementGroup"]) -> int:
 
     Args:
         cur_pg: The current placement group, if any.
+
+    Returns:
+        int: The estimated number of available CPUs for dataset operations.
     """
     cluster_cpus = int(ray.cluster_resources().get("CPU", 1))
     cluster_gpus = int(ray.cluster_resources().get("GPU", 0))
@@ -1424,6 +1427,9 @@ def call_with_retry(
             example, "open the file".
         max_attempts: The maximum number of attempts to retry.
         max_backoff_s: The maximum number of seconds to backoff.
+
+    Returns:
+        Any: The return value of the function f if it succeeds within the retry limit.
     """
     assert max_attempts >= 1, f"`max_attempts` must be positive. Got {max_attempts}."
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -343,7 +343,7 @@ class BlockAccessor:
             columns: Name of columns to convert, or None if converting all columns.
 
         Returns:
-            numpy.ndarray: The block data converted to a NumPy array format.
+            Union[numpy.ndarray, Dict[str, numpy.ndarray]]: The block data converted to a NumPy array format.
         """
         raise NotImplementedError
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -288,6 +288,9 @@ class BlockAccessor:
         Args:
             public_row_format: Whether to cast rows into the public Dict row
                 format (this incurs extra copy conversions).
+
+        Returns:
+            Iterator: An iterator over individual rows in the block.
         """
         raise NotImplementedError
 
@@ -338,6 +341,9 @@ class BlockAccessor:
 
         Args:
             columns: Name of columns to convert, or None if converting all columns.
+
+        Returns:
+            numpy.ndarray: The block data converted to a NumPy array format.
         """
         raise NotImplementedError
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -633,6 +633,10 @@ class DataContext:
                 # ds2's target_max_block_size will be 1MB
                 ds2.take_all()
 
+        Returns:
+            DataContext: The current global DataContext instance. If no context
+                exists, a new one is created with default settings.
+
         Developer notes: Avoid using `DataContext.get_current()` in data
         internal components, use the DataContext object captured in the
         Dataset and pass it around as arguments.
@@ -683,7 +687,9 @@ class DataContext:
         Args:
             key: The key of the config.
             default: The default value to return if the key is not found.
-        Returns: The value for the key, or the default value if the key is not found.
+
+        Returns:
+            Any: The value for the key, or the default value if the key is not found.
         """
         return self._kv_configs.get(key, default)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -383,6 +383,9 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 Ray for each map worker. See :func:`ray.remote` for details.
 
+        Returns:
+            Dataset: A new dataset with the function applied to each row.
+
         .. seealso::
 
             :meth:`~Dataset.flat_map`
@@ -644,6 +647,9 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 Ray for each map worker. See :func:`ray.remote` for details.
 
+        Returns:
+            Dataset: A new dataset with the function applied to batches of data.
+
         .. note::
 
             The size of the batches provided to ``fn`` might be smaller than the
@@ -876,6 +882,9 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
                 :func:`ray.remote` for details.
+
+        Returns:
+            Dataset: A new dataset with the specified column added.
         """
         # Check that batch_format
         accepted_batch_formats = ["pandas", "pyarrow", "numpy"]
@@ -983,6 +992,9 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
                 :func:`ray.remote` for details.
+
+        Returns:
+            Dataset: A new dataset with the specified columns removed.
         """  # noqa: E501
 
         if len(cols) != len(set(cols)):
@@ -1046,6 +1058,9 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
                 :func:`ray.remote` for details.
+
+        Returns:
+            Dataset: A new dataset containing only the specified columns.
         """  # noqa: E501
         if isinstance(cols, str):
             cols = [cols]
@@ -1138,6 +1153,9 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
                 :func:`ray.remote` for details.
+
+        Returns:
+            Dataset: A new dataset with the specified column names changed.
         """  # noqa: E501
 
         if isinstance(names, dict):
@@ -1316,6 +1334,9 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 Ray for each map worker. See :func:`ray.remote` for details.
 
+        Returns:
+            Dataset: A new dataset with the function applied to each row and results flattened into individual rows.
+
         .. seealso::
 
             :meth:`~Dataset.map_batches`
@@ -1434,6 +1455,9 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
                 :func:`ray.remote` for details.
+
+        Returns:
+            Dataset: A new dataset containing only the rows that satisfy the predicate condition. The original dataset is unchanged.
         """
         # Ensure exactly one of fn or expr is provided
         resolved_expr = None
@@ -5874,6 +5898,9 @@ class Dataset:
                 in the cluster by four. As a rule of thumb, you can expect each worker
                 to provide ~3000 records / second via ``get_async()``, and
                 ~10000 records / second via ``multiget()``.
+
+        Returns:
+            RandomAccessDataset: A dataset that supports random access operations by index.
         """
         if num_workers is None:
             num_workers = 4 * len(ray.nodes())
@@ -5960,6 +5987,8 @@ class Dataset:
             * Output size bytes: 0 min, 8 max, 4 mean, 80 total
             * Tasks per node: 20 min, 20 max, 20 mean; 1 nodes used
 
+        Returns:
+            str: Statistics about this dataset including execution timing, memory usage, and data lineage information.
         """
         if self._current_executor:
             return self._current_executor.get_stats().to_summary().to_string()
@@ -6060,6 +6089,9 @@ class Dataset:
             False
             >>> ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv").has_serializable_lineage()
             True
+
+        Returns:
+            bool: True if the dataset's lineage can be serialized and reconstructed later, False otherwise.
         """  # noqa: E501
         return all(
             op.is_lineage_serializable()

--- a/python/ray/data/datasource/filename_provider.py
+++ b/python/ray/data/datasource/filename_provider.py
@@ -65,6 +65,9 @@ class FilenameProvider:
             write_uuid: The UUID of the write operation.
             task_index: The index of the write task.
             block_index: The index of the block *within* the write task.
+
+        Returns:
+            str: A unique filename for the specified block.
         """
         raise NotImplementedError
 
@@ -97,6 +100,9 @@ class FilenameProvider:
             task_index: The index of the write task.
             block_index: The index of the block *within* the write task.
             row_index: The index of the row *within* the block.
+
+        Returns:
+            str: A unique filename for the specified row.
         """
         raise NotImplementedError
 

--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -26,6 +26,9 @@ def _has_file_extension(path: str, extensions: Optional[List[str]]) -> bool:
         path: The path to check.
         extensions: A list of extensions to check against. If `None`, any extension is
             considered valid.
+
+    Returns:
+        bool: True if the path has one of the specified extensions, False otherwise.
     """
     assert extensions is None or isinstance(extensions, list), type(extensions)
 
@@ -53,6 +56,9 @@ def _resolve_paths_and_filesystem(
             None, the provided filesystem will still be validated against all
             filesystems inferred from the provided paths to ensure
             compatibility.
+
+    Returns:
+        Tuple[List[str], pyarrow.fs.FileSystem]: A tuple containing the normalized paths and the resolved filesystem.
     """
     import pyarrow as pa
     from pyarrow.fs import (

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -336,6 +336,9 @@ class Preprocessor(abc.ABC):
         Checks if the columns are explicitly set, otherwise defaulting to
         the input columns.
 
+        Returns:
+            List[str]: The validated output column names, either from output_columns or derived from input columns.
+
         Raises:
             ValueError: If the length of the output columns does not match the
                 length of the input columns.


### PR DESCRIPTION

  ## Why are these changes needed?

  This PR fixes the `DOC201` pydoclint violations in `python/ray/data` by adding properly formatted "Returns:" sections to function and method docstrings. 

The descriptions have been LLM generated, and so please reviewer, help me ensure they make sense 🙏 

  **Changes made:**
  - Added Returns sections to Dataset's public API methods (`map`, `filter`, `add_column`, etc.)
  - Added Returns sections to DataContext and BlockAccessor methods
  - Added Returns sections to internal Ray Data functions

  ## Related issue number

n/a, just cleaning up the baseline file

  ## Checks

  - [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
  - [x] I've run `scripts/format.sh` to lint the changes in this PR.
  - [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
      - [x] I've added any new APIs to the API Reference. For example, if I added a
             method in Tune, I've added it in `doc/source/tune/api/` under the
             corresponding `.rst` file.
  - [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures
  at https://flakey-tests.ray.io/
  - Testing Strategy
     - [x] Unit tests (no functional changes, only docstring additions)
     - [ ] Release tests
     - [ ] This PR is not tested :(
