### PR TITLE
[ci] enable bazel strict action env by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,14 +1,10 @@
 # Must be first. Enables build:windows, build:linux, build:macos, build:freebsd, build:openbsd
 build --enable_platform_specific_config
 
-build:linux --workspace_status_command="bash ./bazel/workspace_status.sh"
-
-# Provides users an option to turn on strict action env.
-# TODO(aslonnie): make this default, fix the python tests.
-# NOTE(edoakes): enable this by default locally by adding a .user.bazelrc file with:
-# build --config=strict
-# test --config=strict
+build --incompatible_strict_action_env
 build:strict --incompatible_strict_action_env
+
+build:linux --workspace_status_command="bash ./bazel/workspace_status.sh"
 
 # To distinguish different incompatible environments.
 build --action_env=RAY_BUILD_ENV
@@ -84,8 +80,6 @@ build:iwyu --output_groups=report
 build:windows --attempt_to_print_relative_paths
 # Save disk space by hardlinking cache hits instead of copying
 build:windows --experimental_repository_cache_hardlinks
-# Clean the environment before building, to make builds more deterministic
-build:windows --incompatible_strict_action_env
 # For colored output (seems necessary on Windows)
 build:windows --color=yes
 # For compiler colored output (seems necessary on Windows)
@@ -167,6 +161,18 @@ aquery:ci --noshow_progress
 test:ci-base --test_output=errors
 test:ci-base --test_verbose_timeout_warnings
 test:ci-base --flaky_test_attempts=3
+
+# Sending in PATH is required for tests to run on CI, after we enable
+# --incompatible_strict_action_env, until we either convert all Python tests to
+# hermetic tests -- which not only requires pinning all Python dependencies with bazel,
+# but also requires building ray(test) wheel with bazel. Alternatively, we can
+# also stop using bazel test to run ray's Python tests.
+#
+# This PATH test_env is intentionally not enabled on non-CI so that C/C++
+# tests, which are all hermetic, can build, test and cache as intended, ray
+# Python developers do not really use bazel test to run tests locally, but more
+# often just run tests with "pytest" directly.
+test:ci-base --test_env=PATH
 
 build:ci --color=yes
 build:ci --curses=no

--- a/python/setup.py
+++ b/python/setup.py
@@ -635,13 +635,6 @@ def build(build_python, build_java, build_cpp):
         bazel_precmd_flags = []
         if sys.platform == "win32":
             bazel_precmd_flags = ["--output_user_root=C:/tmp"]
-        # Using --incompatible_strict_action_env so that the build is more
-        # cache-able We cannot turn this on for Python tests yet, as Ray's
-        # Python bazel tests are not hermetic.
-        #
-        # And we put it here so that does not change behavior of
-        # conda-forge build.
-        bazel_flags.append("--incompatible_strict_action_env")
 
     bazel_targets = []
     bazel_targets += ["//:gen_ray_pkg"] if build_python else []


### PR DESCRIPTION
so that action env vars are properly captured and sandboxed, makes caching working properly.
