### PR TITLE
[release] Use bazel workspace directory when referencing path from repo root

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -692,6 +692,20 @@ py_test(
     ],
 )
 
+py_test(
+    name = "test_template",
+    srcs = ["ray_release/tests/test_template.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    tags = [
+        "release_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_release",
+        bk_require("pytest"),
+    ],
+)
+
 py_binary(
     name = "build_pipeline",
     srcs = ["ray_release/scripts/build_pipeline.py"],

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -25,6 +25,7 @@ class TestEnvironment(dict):
 
 
 _test_env = None
+bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 
 
 def get_test_environment():
@@ -75,7 +76,7 @@ def render_yaml_template(template: str, env: Optional[Dict] = None):
 def get_working_dir(test: "Test", test_definition_root: Optional[str] = None) -> str:
     working_dir = test.get("working_dir", "")
     if working_dir.startswith("//"):
-        return bazel_runfile(working_dir.lstrip("//"))
+        return os.path.join(bazel_workspace_dir, working_dir.lstrip("//"))
     if test_definition_root:
         return os.path.join(test_definition_root, working_dir)
     return bazel_runfile("release", working_dir)

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -6,9 +6,9 @@ from typing import Optional, Dict, TYPE_CHECKING
 import jinja2
 import yaml
 
+from ray_release.bazel import bazel_runfile
 from ray_release.config import get_test_cloud_id
 from ray_release.exception import ReleaseTestConfigError
-from ray_release.utils import bazel_runfile
 
 if TYPE_CHECKING:
     from ray_release.config import Test

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -73,8 +73,14 @@ def render_yaml_template(template: str, env: Optional[Dict] = None):
         ) from e
 
 
-def get_working_dir(test: "Test", test_definition_root: Optional[str] = None) -> str:
-    if _bazel_workspace_dir and test_definition_root:
+def get_working_dir(
+    test: "Test",
+    test_definition_root: Optional[str] = None,
+    bazel_workspace_dir: Optional[str] = None,
+) -> str:
+    if not bazel_workspace_dir:
+        bazel_workspace_dir = _bazel_workspace_dir
+    if bazel_workspace_dir and test_definition_root:
         raise ReleaseTestConfigError(
             "test_definition_root should not be specified when running with Bazel."
         )
@@ -85,8 +91,8 @@ def get_working_dir(test: "Test", test_definition_root: Optional[str] = None) ->
         working_dir = working_dir.lstrip("//")
     else:
         working_dir = os.path.join("release", working_dir)
-    if _bazel_workspace_dir:
-        return os.path.join(_bazel_workspace_dir, working_dir)
+    if bazel_workspace_dir:
+        return os.path.join(bazel_workspace_dir, working_dir)
     else:
         return bazel_runfile(working_dir)
 

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -83,11 +83,8 @@ def get_working_dir(test: "Test", test_definition_root: Optional[str] = None) ->
         return os.path.join(test_definition_root, working_dir)
     if working_dir.startswith("//"):
         working_dir = working_dir.lstrip("//")
-        if _bazel_workspace_dir:
-            return os.path.join(_bazel_workspace_dir, working_dir)
-        else:
-            return bazel_runfile(working_dir)
-    working_dir = os.path.join("release", working_dir)
+    else:
+        working_dir = os.path.join("release", working_dir)
     if _bazel_workspace_dir:
         return os.path.join(_bazel_workspace_dir, working_dir)
     else:

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -79,7 +79,7 @@ def get_working_dir(test: "Test", test_definition_root: Optional[str] = None) ->
         return os.path.join(bazel_workspace_dir, working_dir.lstrip("//"))
     if test_definition_root:
         return os.path.join(test_definition_root, working_dir)
-    return bazel_runfile("release", working_dir)
+    return os.path.join(bazel_workspace_dir, "release", working_dir)
 
 
 def load_test_cluster_compute(

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -6,7 +6,6 @@ from typing import Optional, Dict, TYPE_CHECKING
 import jinja2
 import yaml
 
-from ray_release.bazel import bazel_runfile
 from ray_release.config import get_test_cloud_id
 from ray_release.exception import ReleaseTestConfigError
 

--- a/release/ray_release/tests/test_template.py
+++ b/release/ray_release/tests/test_template.py
@@ -14,8 +14,14 @@ def test_get_working_dir_with_path_from_root():
             "working_dir": "//ray_testing/ray_release/tests",
         }
     )
-    assert get_working_dir(test_with_path_from_root, None, "/tmp/bazel_workspace") == "/tmp/bazel_workspace/ray_testing/ray_release/tests"
-    assert get_working_dir(test_with_path_from_root, None, None) == bazel_runfile("ray_testing/ray_release/tests")
+    assert (
+        get_working_dir(test_with_path_from_root, None, "/tmp/bazel_workspace")
+        == "/tmp/bazel_workspace/ray_testing/ray_release/tests"
+    )
+    assert get_working_dir(test_with_path_from_root, None, None) == bazel_runfile(
+        "ray_testing/ray_release/tests"
+    )
+
 
 def test_get_working_dir_with_relative_path():
     test_with_relative_path = Test(
@@ -24,8 +30,14 @@ def test_get_working_dir_with_relative_path():
             "working_dir": "ray_release/tests",
         }
     )
-    assert get_working_dir(test_with_relative_path, None, "/tmp/bazel_workspace") == "/tmp/bazel_workspace/release/ray_release/tests"
-    assert get_working_dir(test_with_relative_path, None, None) == bazel_runfile("release/ray_release/tests")
+    assert (
+        get_working_dir(test_with_relative_path, None, "/tmp/bazel_workspace")
+        == "/tmp/bazel_workspace/release/ray_release/tests"
+    )
+    assert get_working_dir(test_with_relative_path, None, None) == bazel_runfile(
+        "release/ray_release/tests"
+    )
+
 
 def test_get_working_dir_fail():
     test_with_path_from_root = Test(
@@ -35,7 +47,10 @@ def test_get_working_dir_fail():
         }
     )
     with pytest.raises(ReleaseTestConfigError):
-        get_working_dir(test_with_path_from_root, "/tmp/test_definition_root", "tmp/bazel_workspace")
+        get_working_dir(
+            test_with_path_from_root, "/tmp/test_definition_root", "tmp/bazel_workspace"
+        )
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_template.py
+++ b/release/ray_release/tests/test_template.py
@@ -1,0 +1,41 @@
+import sys
+
+import pytest
+
+from ray_release.test import Test
+from ray_release.template import get_working_dir, bazel_runfile
+from ray_release.exception import ReleaseTestConfigError
+
+
+def test_get_working_dir_with_path_from_root():
+    test_with_path_from_root = Test(
+        {
+            "name": "test",
+            "working_dir": "//ray_testing/ray_release/tests",
+        }
+    )
+    assert get_working_dir(test_with_path_from_root, None, "/tmp/bazel_workspace") == "/tmp/bazel_workspace/ray_testing/ray_release/tests"
+    assert get_working_dir(test_with_path_from_root, None, None) == bazel_runfile("ray_testing/ray_release/tests")
+
+def test_get_working_dir_with_relative_path():
+    test_with_relative_path = Test(
+        {
+            "name": "test",
+            "working_dir": "ray_release/tests",
+        }
+    )
+    assert get_working_dir(test_with_relative_path, None, "/tmp/bazel_workspace") == "/tmp/bazel_workspace/release/ray_release/tests"
+    assert get_working_dir(test_with_relative_path, None, None) == bazel_runfile("release/ray_release/tests")
+
+def test_get_working_dir_fail():
+    test_with_path_from_root = Test(
+        {
+            "name": "test",
+            "working_dir": "//ray_testing/ray_release/tests",
+        }
+    )
+    with pytest.raises(ReleaseTestConfigError):
+        get_working_dir(test_with_path_from_root, "/tmp/test_definition_root", "tmp/bazel_workspace")
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Currently, this uses Bazel runfiles which causes a problem when `run_release_test` is called as a binary with Bazel, some files in the working directory not included in Bazel binary data don't get packaged into the zip file when submitting as Anyscale job. This switches to use a path with Bazel workspace directory which points to the source code and doesn't have issues of missing files in the zip file.