### PR TITLE
[serve] Add cached metric for handle

### DIFF
--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -38,6 +38,7 @@ from ray.serve._private.utils import (
     inside_ray_client_context,
     resolve_deployment_response,
 )
+from ray.util import metrics
 from ray.util.placement_group import PlacementGroup
 
 # NOTE: Please read carefully before changing!
@@ -150,6 +151,7 @@ def create_router(
     handle_id: str,
     deployment_id: DeploymentID,
     handle_options: InitHandleOptions,
+    handle_request_counter: metrics.Counter,
     request_router_class: Optional[Callable] = None,
 ) -> Router:
     # NOTE(edoakes): this is lazy due to a nasty circular import that should be fixed.
@@ -187,6 +189,7 @@ def create_router(
         node_id=node_id,
         availability_zone=availability_zone,
         prefer_local_node_routing=handle_options._prefer_local_routing,
+        handle_request_counter=handle_request_counter,
     )
 
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -317,7 +317,7 @@ class RouterMetricsManager:
                 consecutive_errors += 1
                 await asyncio.sleep(backoff_time_s)
 
-    def inc_handle_requests(self, route: str):
+    def inc_num_handle_requests(self, route: str):
         if self._cached_metrics_enabled:
             self._cached_num_handle_requests[route] += 1
         else:
@@ -443,7 +443,7 @@ class Router(ABC):
         pass
 
     @abstractmethod
-    def inc_handle_requests(self, route: str):
+    def inc_num_handle_requests(self, route: str):
         pass
 
 
@@ -884,8 +884,8 @@ class AsyncioRouter:
     async def shutdown(self):
         await self._metrics_manager.shutdown()
 
-    def inc_handle_requests(self, route: str):
-        self._metrics_manager.inc_handle_requests(route)
+    def inc_num_handle_requests(self, route: str):
+        self._metrics_manager.inc_num_handle_requests(route)
 
 
 class SingletonThreadRouter(Router):
@@ -990,8 +990,8 @@ class SingletonThreadRouter(Router):
             self._asyncio_router.shutdown(), loop=self._asyncio_loop
         )
 
-    def inc_handle_requests(self, route: str):
-        self._asyncio_router.inc_handle_requests(route)
+    def inc_num_handle_requests(self, route: str):
+        self._asyncio_router.inc_num_handle_requests(route)
 
 
 class SharedRouterLongPollClient:
@@ -1109,5 +1109,5 @@ class CurrentLoopRouter(Router):
     def shutdown(self) -> asyncio.Future:
         return self._asyncio_loop.create_task(self._asyncio_router.shutdown())
 
-    def inc_handle_requests(self, route: str):
-        self._asyncio_router.inc_handle_requests(route)
+    def inc_num_handle_requests(self, route: str):
+        self._asyncio_router.inc_num_handle_requests(route)

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -143,6 +143,7 @@ class _DeploymentHandleBase:
             handle_id=self.handle_id,
             deployment_id=self.deployment_id,
             handle_options=init_options,
+            handle_request_counter=self.request_counter,
         )
         self.init_options = init_options
 
@@ -200,12 +201,7 @@ class _DeploymentHandleBase:
             self.init_options, self.handle_options
         )
 
-        self.request_counter.inc(
-            tags={
-                "route": metadata.route,
-                "application": metadata.app_name,
-            }
-        )
+        self._router.inc_handle_requests(metadata.route)
 
         return self._router.assign_request(metadata, *args, **kwargs), metadata
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -201,7 +201,7 @@ class _DeploymentHandleBase:
             self.init_options, self.handle_options
         )
 
-        self._router.inc_handle_requests(metadata.route)
+        self._router.inc_num_handle_requests(metadata.route)
 
         return self._router.assign_request(metadata, *args, **kwargs), metadata
 

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -268,6 +268,7 @@ def setup_router(request) -> Tuple[AsyncioRouter, FakeRequestRouter]:
         node_id="test-node-id",
         availability_zone="test-az",
         prefer_local_node_routing=False,
+        handle_request_counter=FakeCounter(),
         _request_router_initialized_event=asyncio.Event(),
     )
     return router, fake_request_router
@@ -787,6 +788,7 @@ class TestRouterMetricsManager:
             "random_actor",
             DeploymentHandleSource.UNKNOWN,
             Mock(),
+            FakeCounter(tag_keys=("handle", "deployment", "route", "application")),
             FakeCounter(
                 tag_keys=("deployment", "route", "application", "handle", "actor_id")
             ),
@@ -817,6 +819,7 @@ class TestRouterMetricsManager:
             "random_actor",
             DeploymentHandleSource.UNKNOWN,
             Mock(),
+            FakeCounter(tag_keys=("handle", "deployment", "route", "application")),
             FakeCounter(
                 tag_keys=("deployment", "route", "application", "handle", "actor_id")
             ),
@@ -846,6 +849,7 @@ class TestRouterMetricsManager:
             "random_actor",
             DeploymentHandleSource.UNKNOWN,
             Mock(),
+            FakeCounter(tag_keys=("handle", "deployment", "route", "application")),
             FakeCounter(
                 tag_keys=("deployment", "route", "application", "handle", "actor_id")
             ),
@@ -930,6 +934,7 @@ class TestRouterMetricsManager:
             "random_actor",
             DeploymentHandleSource.UNKNOWN,
             Mock(),
+            FakeCounter(tag_keys=("handle", "deployment", "route", "application")),
             FakeCounter(
                 tag_keys=("deployment", "route", "application", "handle", "actor_id")
             ),
@@ -974,6 +979,7 @@ class TestRouterMetricsManager:
                 self_actor_id,
                 DeploymentHandleSource.PROXY,
                 mock_controller_handle,
+                FakeCounter(tag_keys=("handle", "deployment", "route", "application")),
                 FakeCounter(
                     tag_keys=(
                         "deployment",
@@ -1033,6 +1039,7 @@ class TestRouterMetricsManager:
             "some_actor",
             DeploymentHandleSource.PROXY,
             Mock(),
+            FakeCounter(tag_keys=("handle", "deployment", "route", "application")),
             FakeCounter(
                 tag_keys=(
                     "deployment",
@@ -1099,6 +1106,7 @@ class TestRouterMetricsManager:
             "random_actor",
             DeploymentHandleSource.UNKNOWN,
             Mock(),
+            FakeCounter(tag_keys=("handle", "deployment", "route", "application")),
             FakeCounter(
                 tag_keys=("deployment", "route", "application", "handle", "actor_id")
             ),
@@ -1137,6 +1145,7 @@ class TestSingletonThreadRouter:
             node_id="test-node-id",
             availability_zone="test-az",
             prefer_local_node_routing=False,
+            handle_request_counter=FakeCounter(),
         )
         router._asyncio_router = asyncio_router
         return router


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR caches the num handle requests value and updates the metric async instead of on the critical path.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
