### PR TITLE
[ci] point refresh compile commands to :ray_pkg_zip

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -117,7 +117,7 @@ alias(
 refresh_compile_commands(
     name = "refresh_compile_commands",
     targets = {
-        "//:ray_pkg": "",
+        "//:ray_pkg_zip": "",
     },
 )
 


### PR DESCRIPTION
deprecating `:ray_pkg` rule
