### PR TITLE
[core][autoscaler] fix races when waiting for stopping aws nodes to be reused by cache_stopped_nodes

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -127,6 +127,7 @@ class AWSNodeProvider(NodeProvider):
         self.ready_for_new_batch.set()
         self.tag_cache_lock = threading.Lock()
         self.count_lock = threading.Lock()
+        self.reuse_node_lock = threading.Lock()
 
         # Cache of node objects from the last nodes() call. This avoids
         # excessive DescribeInstances requests.
@@ -290,32 +291,35 @@ class AWSNodeProvider(NodeProvider):
                     }
                 )
 
-            reuse_nodes = list(self.ec2.instances.filter(Filters=filters))[:count]
-            reuse_node_ids = [n.id for n in reuse_nodes]
-            reused_nodes_dict = {n.id: n for n in reuse_nodes}
-            if reuse_nodes:
-                cli_logger.print(
-                    # todo: handle plural vs singular?
-                    "Reusing nodes {}. "
-                    "To disable reuse, set `cache_stopped_nodes: False` "
-                    "under `provider` in the cluster configuration.",
-                    cli_logger.render_list(reuse_node_ids),
-                )
+            with self.reuse_node_lock:
+                reuse_nodes = list(self.ec2.instances.filter(Filters=filters))[:count]
+                reuse_node_ids = [n.id for n in reuse_nodes]
+                reused_nodes_dict = {n.id: n for n in reuse_nodes}
+                if reuse_nodes:
+                    cli_logger.print(
+                        # todo: handle plural vs singular?
+                        "Reusing nodes {}. "
+                        "To disable reuse, set `cache_stopped_nodes: False` "
+                        "under `provider` in the cluster configuration.",
+                        cli_logger.render_list(reuse_node_ids),
+                    )
 
-                # todo: timed?
-                with cli_logger.group("Stopping instances to reuse"):
-                    for node in reuse_nodes:
-                        self.tag_cache[node.id] = from_aws_format(
-                            {x["Key"]: x["Value"] for x in node.tags}
-                        )
-                        if node.state["Name"] == "stopping":
-                            cli_logger.print("Waiting for instance {} to stop", node.id)
-                            node.wait_until_stopped()
+                    # todo: timed?
+                    with cli_logger.group("Stopping instances to reuse"):
+                        for node in reuse_nodes:
+                            self.tag_cache[node.id] = from_aws_format(
+                                {x["Key"]: x["Value"] for x in node.tags}
+                            )
+                            if node.state["Name"] == "stopping":
+                                cli_logger.print(
+                                    "Waiting for instance {} to stop", node.id
+                                )
+                                node.wait_until_stopped()
 
-                self.ec2.meta.client.start_instances(InstanceIds=reuse_node_ids)
-                for node_id in reuse_node_ids:
-                    self.set_node_tags(node_id, tags)
-                count -= len(reuse_node_ids)
+                    self.ec2.meta.client.start_instances(InstanceIds=reuse_node_ids)
+                    for node_id in reuse_node_ids:
+                        self.set_node_tags(node_id, tags)
+                    count -= len(reuse_node_ids)
 
         created_nodes_dict = {}
         if count:


### PR DESCRIPTION
## Why are these changes needed?

Currently, when `cache_stopped_nodes=True`, there is a race between concurrent `AWSNodeProvider.create_node` operations that try to find nodes to reuse, and this race can cause the concurrent operations to pick the same node, which is incorrect. The race becomes more easily triggered because the AWS node provider will try to wait for `stopping` nodes in the operation.
https://github.com/ray-project/ray/blob/d115cdaaa71642f874a32b692572f01bc993154b/python/ray/autoscaler/_private/aws/node_provider.py#L311-L313

For example, if we have 1 node in `stopping` state on AWS, and the provider gets 2 concurrent `create_node` invocations, we expect one of the invocations will reuse the stopping node, and the other one will create a new node. However, they behave like this:
```
C1: create_node()            C2: create_node()
    |                            |
    |-- sees node N (stopping) --|
    |                            |
    |<-- wait until stopped ---->|
    |                            |
    |-- claim N ---------------->|
    |                            |-- claim N (same node!) 
    |                            |
    |-- start N ---------------->|
    |                            |-- start N (again)
    |                            |
Result: both think they reused N, but only ONE node runs.
```

This PR solves this by adding a lock when finding and waiting for nodes to reuse.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
