### PR TITLE
Fix GPU metrics

### DIFF
--- a/python/ray/dashboard/modules/node/datacenter.py
+++ b/python/ray/dashboard/modules/node/datacenter.py
@@ -221,7 +221,7 @@ class DataOrganizer:
                     break
 
             for gpu_stats in node_physical_stats.get("gpus", []):
-                # gpu_stats.get("processes") can be None, an empty list or a
+                # gpu_stats.get("processesPids") can be None, an empty list or a
                 # list of dictionaries.
                 for process in gpu_stats.get("processesPids") or []:
                     if process["pid"] == pid:

--- a/python/ray/dashboard/modules/reporter/gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/gpu_providers.py
@@ -230,9 +230,9 @@ class NvidiaGpuProvider(GpuProvider):
             1       7175     C     86     26      -      -      -      -    ray::TorchGPUWo
             2          -     -      -      -      -      -      -      -    -
 
-        Returns a dict mapping GPU index to list of ProcessGPUInfo.
+        Returns a dict mapping GPU index to dict of pid to ProcessGPUInfo.
         """
-        process_utilizations = defaultdict(list)
+        process_utilizations = defaultdict(dict)
         lines = nvsmi_stdout.splitlines()
         # Get the first line that is started with #
         table_header = None
@@ -275,7 +275,7 @@ class NvidiaGpuProvider(GpuProvider):
                 ),  # Convert percentage to MB
                 gpu_utilization=sm,
             )
-            process_utilizations[gpu_id].append(process_info)
+            process_utilizations[gpu_id][pid] = process_info
         return process_utilizations
 
     def _get_pynvml_gpu_usage(self) -> List[GpuUtilizationInfo]:

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -937,7 +937,7 @@ class ReporterAgent(
                     processes = gpu.get("processes_pids")
                     if processes:
                         for proc in processes.values():
-                            gpu_pid_mapping[proc.pid].append(proc)
+                            gpu_pid_mapping[proc["pid"]].append(proc)
 
             result = []
             for w in self._workers.values():
@@ -1762,6 +1762,14 @@ class ReporterAgent(
                 )
 
             self._metrics_agent.clean_all_dead_worker_metrics()
+
+        # Convert processes_pids back to a list of dictionaries to maintain backwards-compatibility
+        for gpu in stats["gpus"]:
+            if gpu["processes_pids"] is not None:
+                gpu["processes_pids"] = list(gpu["processes_pids"].values())
+
+        # TODO(aguo): Add a pydantic model for this dict to maintain compatibility
+        # with the Ray Dashboard API and UI code.
 
         return jsonify_asdict(stats)
 

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1777,6 +1777,7 @@ class ReporterAgent(
         # TODO(aguo): Add a pydantic model for this dict to maintain compatibility
         # with the Ray Dashboard API and UI code.
 
+        # NOTE: This converts keys to "Google style", (e.g: "processes_pids" -> "processesPids")
         return jsonify_asdict(stats)
 
     async def run(self, server):

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -937,7 +937,7 @@ class ReporterAgent(
                     processes = gpu.get("processes_pids")
                     if processes:
                         for proc in processes.values():
-                            gpu_pid_mapping[proc.pid].append(proc)
+                            gpu_pid_mapping[proc["pid"]].append(proc)
 
             result = []
             for w in self._workers.values():

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1765,7 +1765,7 @@ class ReporterAgent(
 
         # Convert processes_pids back to a list of dictionaries to maintain backwards-compatibility
         for gpu in stats["gpus"]:
-            if gpu["processes_pids"] is not None:
+            if isinstance(gpu.get("processes_pids"), dict):
                 gpu["processes_pids"] = list(gpu["processes_pids"].values())
 
         # TODO(aguo): Add a pydantic model for this dict to maintain compatibility

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -937,7 +937,7 @@ class ReporterAgent(
                     processes = gpu.get("processes_pids")
                     if processes:
                         for proc in processes.values():
-                            gpu_pid_mapping[proc["pid"]].append(proc)
+                            gpu_pid_mapping[proc.pid].append(proc)
 
             result = []
             for w in self._workers.values():

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -893,7 +893,7 @@ class ReporterAgent(
     def _generate_worker_key(self, proc: psutil.Process) -> Tuple[int, float]:
         return (proc.pid, proc.create_time())
 
-    def _get_workers(self, gpus: Optional[List[GpuUtilizationInfo]] = None):
+    def _get_worker_processes(self):
         raylet_proc = self._get_raylet_proc()
         if raylet_proc is None:
             return []
@@ -910,7 +910,13 @@ class ReporterAgent(
                     self._generate_worker_key(proc): proc
                     for proc in raylet_proc.children()
                 }
+            return workers
 
+    def _get_workers(self, gpus: Optional[List[GpuUtilizationInfo]] = None):
+        workers = self._get_worker_processes()
+        if not workers:
+            return []
+        else:
             # We should keep `raylet_proc.children()` in `self` because
             # when `cpu_percent` is first called, it returns the meaningless 0.
             # See more: https://github.com/ray-project/ray/issues/29848

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -1247,7 +1247,6 @@ def test_reporter_worker_cpu_percent():
         def _get_worker_processes(self):
             return ReporterAgent._get_worker_processes(self)
 
-
     obj = ReporterAgentDummy()
 
     try:

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -723,7 +723,7 @@ def test_report_per_component_stats_gpu():
         "_get_agent_proc": lambda: agent_proc_mock,
     }
 
-    with patch.multiple(agent, **mock_patches) as mocks:
+    with patch.multiple(agent, **mock_patches):
         # Call _collect_stats to actually run through the collection process
         collected_stats_result = agent._collect_stats()
 

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -777,7 +777,7 @@ def test_report_per_component_stats_gpu():
         else:
             assert record.value == 86
 
-        # Test stats with two tasks on one GPU.
+    # Test stats with two tasks on one GPU.
     NVSMI_OUTPUT_TWO_TASK_ON_ONE_GPUS = (
         "# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command \n"
         "# Idx           #    C/G      %      %      %      %      %      %    name \n"

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -1244,6 +1244,10 @@ def test_reporter_worker_cpu_percent():
         def _generate_worker_key(self, proc):
             return (proc.pid, proc.create_time())
 
+        def _get_worker_processes(self):
+            return ReporterAgent._get_worker_processes(self)
+
+
     obj = ReporterAgentDummy()
 
     try:

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -543,7 +543,20 @@ def test_report_per_component_stats_gpu():
                 "memory_full_info": Bunch(uss=51428381),
                 "cpu_percent": 10.0,
                 "num_fds": 5,
-                "cmdline": ["ray::TorchGPUWorker.dummy_method", "", "", "", "", "", "", "", "", "", "", ""],
+                "cmdline": [
+                    "ray::TorchGPUWorker.dummy_method",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                ],
                 "create_time": 1614826391.338613,
                 "pid": 7175,
                 "cpu_times": Bunch(
@@ -552,7 +565,7 @@ def test_report_per_component_stats_gpu():
                     children_user=0.0,
                     children_system=0.0,
                 ),
-            }
+            },
         ],
         "gcs": {
             "memory_info": Bunch(rss=18354171, vms=6921486336, pfaults=6203, pageins=2),
@@ -688,25 +701,26 @@ def test_report_per_component_stats_gpu():
         mock_workers[agent._generate_worker_key(agent_proc_mock)] = agent_proc_mock
         return mock_workers
 
-
-
     # Mock all the individual methods that _collect_stats calls to return predictable data
     mock_patches = {
-        '_get_network_stats': lambda: (13621160960, 11914936320),
-        '_get_disk_io_stats': lambda: (100, 100, 100, 100),
-        '_get_gpu_usage': lambda: mock_collected_stats["gpus"],
-        '_get_cpu_percent': lambda _: 57.4,
-        '_get_mem_usage': lambda: (17179869184, 5723353088, 66.7, 9234341888),
-        '_get_shm_usage': lambda: 456,
-        '_get_raylet': lambda: mock_collected_stats["raylet"],
-        '_get_agent': lambda: mock_collected_stats["agent"],
-        '_get_boot_time': lambda: 1612934656.0,
-        '_get_load_avg': lambda: ((4.4521484375, 3.61083984375, 3.5400390625), (0.56, 0.45, 0.44)),
-        '_get_disk_usage': lambda: mock_collected_stats["disk"],
-        '_get_tpu_usage': lambda: [],
-        '_get_gcs': lambda: mock_collected_stats["gcs"],
-        '_get_worker_processes': lambda: create_mock_worker_processes(),
-        '_get_agent_proc': lambda: agent_proc_mock,
+        "_get_network_stats": lambda: (13621160960, 11914936320),
+        "_get_disk_io_stats": lambda: (100, 100, 100, 100),
+        "_get_gpu_usage": lambda: mock_collected_stats["gpus"],
+        "_get_cpu_percent": lambda _: 57.4,
+        "_get_mem_usage": lambda: (17179869184, 5723353088, 66.7, 9234341888),
+        "_get_shm_usage": lambda: 456,
+        "_get_raylet": lambda: mock_collected_stats["raylet"],
+        "_get_agent": lambda: mock_collected_stats["agent"],
+        "_get_boot_time": lambda: 1612934656.0,
+        "_get_load_avg": lambda: (
+            (4.4521484375, 3.61083984375, 3.5400390625),
+            (0.56, 0.45, 0.44),
+        ),
+        "_get_disk_usage": lambda: mock_collected_stats["disk"],
+        "_get_tpu_usage": lambda: [],
+        "_get_gcs": lambda: mock_collected_stats["gcs"],
+        "_get_worker_processes": lambda: create_mock_worker_processes(),
+        "_get_agent_proc": lambda: agent_proc_mock,
     }
 
     with patch.multiple(agent, **mock_patches) as mocks:
@@ -720,7 +734,12 @@ def test_report_per_component_stats_gpu():
         assert len(collected_stats_result["gpus"]) == 2
         assert len(collected_stats_result["workers"]) == 2
         assert collected_stats_result["cpu"] == 57.4
-        assert collected_stats_result["mem"] == (17179869184, 5723353088, 66.7, 9234341888)
+        assert collected_stats_result["mem"] == (
+            17179869184,
+            5723353088,
+            66.7,
+            9234341888,
+        )
         assert collected_stats_result["shm"] == 456
         assert collected_stats_result["network"] == (13621160960, 11914936320)
         assert collected_stats_result["disk_io"] == (100, 100, 100, 100)
@@ -732,7 +751,9 @@ def test_report_per_component_stats_gpu():
         "    0       7175     C     84     26      -      -      -      -    ray::TorchGPUWo\n"
         "    1       7175     C     86     26      -      -      -      -    ray::TorchGPUWo\n"
     )
-    collected_stats_result["gpu_processes"] = NvidiaGpuProvider._parse_nvsmi_pmon_output(
+    collected_stats_result[
+        "gpu_processes"
+    ] = NvidiaGpuProvider._parse_nvsmi_pmon_output(
         NVSMI_OUTPUT_TWO_TASK_ON_TWO_GPUS, collected_stats_result["gpus"]
     )
 
@@ -766,7 +787,9 @@ def test_report_per_component_stats_gpu():
     )
 
     # Update the collected stats result for the second test scenario
-    collected_stats_result["gpu_processes"] = NvidiaGpuProvider._parse_nvsmi_pmon_output(
+    collected_stats_result[
+        "gpu_processes"
+    ] = NvidiaGpuProvider._parse_nvsmi_pmon_output(
         NVSMI_OUTPUT_TWO_TASK_ON_ONE_GPUS, collected_stats_result["gpus"]
     )
     # Move process from GPU 1 to GPU 0
@@ -776,13 +799,24 @@ def test_report_per_component_stats_gpu():
 
     # Add the second GPU worker to the collected stats result
     gpu_worker_2 = {
-        "memory_info": Bunch(
-            rss=55934976, vms=7026937856, pfaults=15354, pageins=0
-        ),
+        "memory_info": Bunch(rss=55934976, vms=7026937856, pfaults=15354, pageins=0),
         "memory_full_info": Bunch(uss=51428381),
         "cpu_percent": 15.0,
         "num_fds": 6,
-        "cmdline": ["ray::TorchGPUWorker.dummy_method_2", "", "", "", "", "", "", "", "", "", "", ""],
+        "cmdline": [
+            "ray::TorchGPUWorker.dummy_method_2",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ],
         "create_time": 1614826391.338613,
         "pid": 7176,
         "cpu_times": Bunch(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Bugs introduced in #52102 

Two bugs:
- proc is a TypedDict so it needs to be fetched via `proc["pid"]` instead of `proc.pid`.
- Changing `processes_pid` is backwards-incompatible change that ends up changing the dashboard APIs that power the ray dashboard. Maintain backwards-compatibility

<!-- Please give a short summary of the change and the problem this solves. -->

Verified fix:
Metrics work again:
<img width="947" height="441" alt="Screenshot 2025-08-27 at 12 22 40 PM" src="https://github.com/user-attachments/assets/0a9a83e7-b720-4ad0-b90e-1baa394edde5" />


Ray Dashboard works again:
<img width="1824" height="1029" alt="Screenshot 2025-08-27 at 12 21 51 PM" src="https://github.com/user-attachments/assets/6b0e08e4-69c9-4223-b736-ff69b8d306db" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
