### PR TITLE
[serve] use shutdown async for microbenchmark cleanup

### DIFF
--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -145,7 +145,7 @@ async def _main(
                     num_requests=NUM_REQUESTS,
                 )
                 perf_metrics.extend(convert_latencies_to_perf_metrics(name, latencies))
-                serve.shutdown()
+                serve.shutdown_async()
 
         if run_throughput:
             # Microbenchmark: HTTP throughput
@@ -177,7 +177,7 @@ async def _main(
                     perf_metrics.extend(
                         convert_throughput_to_perf_metrics(test_name, mean, std)
                     )
-                    serve.shutdown()
+                    serve.shutdown_async()
 
         if run_streaming:
             # Direct streaming between replica
@@ -214,7 +214,7 @@ async def _main(
             perf_metrics.extend(
                 convert_latencies_to_perf_metrics("http_streaming", latencies)
             )
-            serve.shutdown()
+            serve.shutdown_async()
 
             # Streaming with intermediate router
             serve.run(
@@ -248,7 +248,7 @@ async def _main(
                     "http_intermediate_streaming", latencies
                 )
             )
-            serve.shutdown()
+            serve.shutdown_async()
 
     # GRPC
     if run_grpc:
@@ -280,7 +280,7 @@ async def _main(
                     num_requests=NUM_REQUESTS,
                 )
                 perf_metrics.extend(convert_latencies_to_perf_metrics(name, latencies))
-                serve.shutdown()
+                serve.shutdown_async()
 
         if run_throughput:
             # Microbenchmark: GRPC throughput
@@ -315,7 +315,7 @@ async def _main(
                     perf_metrics.extend(
                         convert_throughput_to_perf_metrics(test_name, mean, std)
                     )
-                    serve.shutdown()
+                    serve.shutdown_async()
 
     # Handle
     if run_handle:
@@ -330,7 +330,7 @@ async def _main(
                     num_requests=NUM_REQUESTS, payload=payload
                 )
                 perf_metrics.extend(convert_latencies_to_perf_metrics(name, latencies))
-                serve.shutdown()
+                serve.shutdown_async()
 
         if run_throughput:
             # Microbenchmark: Handle throughput
@@ -367,7 +367,7 @@ async def _main(
                     perf_metrics.extend(
                         convert_throughput_to_perf_metrics(test_name, mean, std)
                     )
-                    serve.shutdown()
+                    serve.shutdown_async()
 
         if run_streaming:
             h: DeploymentHandle = serve.run(
@@ -394,7 +394,7 @@ async def _main(
             perf_metrics.extend(
                 convert_latencies_to_perf_metrics("handle_streaming", latencies)
             )
-            serve.shutdown()
+            serve.shutdown_async()
 
     logging.info(f"Perf metrics:\n {json.dumps(perf_metrics, indent=4)}")
     results = {"perf_metrics": perf_metrics}

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -145,7 +145,7 @@ async def _main(
                     num_requests=NUM_REQUESTS,
                 )
                 perf_metrics.extend(convert_latencies_to_perf_metrics(name, latencies))
-                serve.shutdown_async()
+                await serve.shutdown_async()
 
         if run_throughput:
             # Microbenchmark: HTTP throughput
@@ -177,7 +177,7 @@ async def _main(
                     perf_metrics.extend(
                         convert_throughput_to_perf_metrics(test_name, mean, std)
                     )
-                    serve.shutdown_async()
+                    await serve.shutdown_async()
 
         if run_streaming:
             # Direct streaming between replica
@@ -214,7 +214,7 @@ async def _main(
             perf_metrics.extend(
                 convert_latencies_to_perf_metrics("http_streaming", latencies)
             )
-            serve.shutdown_async()
+            await serve.shutdown_async()
 
             # Streaming with intermediate router
             serve.run(
@@ -248,7 +248,7 @@ async def _main(
                     "http_intermediate_streaming", latencies
                 )
             )
-            serve.shutdown_async()
+            await serve.shutdown_async()
 
     # GRPC
     if run_grpc:
@@ -280,7 +280,7 @@ async def _main(
                     num_requests=NUM_REQUESTS,
                 )
                 perf_metrics.extend(convert_latencies_to_perf_metrics(name, latencies))
-                serve.shutdown_async()
+                await serve.shutdown_async()
 
         if run_throughput:
             # Microbenchmark: GRPC throughput
@@ -315,7 +315,7 @@ async def _main(
                     perf_metrics.extend(
                         convert_throughput_to_perf_metrics(test_name, mean, std)
                     )
-                    serve.shutdown_async()
+                    await serve.shutdown_async()
 
     # Handle
     if run_handle:
@@ -330,7 +330,7 @@ async def _main(
                     num_requests=NUM_REQUESTS, payload=payload
                 )
                 perf_metrics.extend(convert_latencies_to_perf_metrics(name, latencies))
-                serve.shutdown_async()
+                await serve.shutdown_async()
 
         if run_throughput:
             # Microbenchmark: Handle throughput
@@ -367,7 +367,7 @@ async def _main(
                     perf_metrics.extend(
                         convert_throughput_to_perf_metrics(test_name, mean, std)
                     )
-                    serve.shutdown_async()
+                    await serve.shutdown_async()
 
         if run_streaming:
             h: DeploymentHandle = serve.run(
@@ -394,7 +394,7 @@ async def _main(
             perf_metrics.extend(
                 convert_latencies_to_perf_metrics("handle_streaming", latencies)
             )
-            serve.shutdown_async()
+            await serve.shutdown_async()
 
     logging.info(f"Perf metrics:\n {json.dumps(perf_metrics, indent=4)}")
     results = {"perf_metrics": perf_metrics}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`serve.shutdown()` is best effort in async contexts. we should use `shutdown_async()`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
