### PR TITLE
[core][gpu-objects] Fix #55987

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -831,7 +831,7 @@ class ActorMethod:
                 self._actor, tensor_transport
             ):
                 raise ValueError(
-                    f"{self._actor} does not have tensor transport {tensor_transport.name} available. Please create a communicator with "
+                    f'{self._actor} does not have tensor transport {tensor_transport.name} available. If using a collective-based transport ("nccl" or "gloo"), please create a communicator with '
                     "`ray.experimental.collective.create_collective_group` "
                     "before calling actor tasks with non-default tensor_transport."
                 )

--- a/python/ray/experimental/collective/nixl_tensor_transport.py
+++ b/python/ray/experimental/collective/nixl_tensor_transport.py
@@ -33,7 +33,7 @@ class NixlTensorTransport(TensorTransportManager):
             try:
                 nixl_backend = get_group_handle(NIXL_GROUP_NAME)
                 return nixl_backend is not None
-            except:
+            except Exception:
                 return False
 
         return ray.get(

--- a/python/ray/experimental/collective/nixl_tensor_transport.py
+++ b/python/ray/experimental/collective/nixl_tensor_transport.py
@@ -1,10 +1,12 @@
 from typing import Optional, List, TYPE_CHECKING
 
 import ray
+from ray.util.collective.types import Backend
 from ray.experimental.collective.tensor_transport_manager import (
     TensorTransportManager,
     TensorTransportEnum,
 )
+from ray.util.collective.collective import get_group_handle
 from ray.util.collective.types import (
     NIXL_GROUP_NAME,
     NixlTransportMetadata,
@@ -16,9 +18,29 @@ if TYPE_CHECKING:
 
 
 class NixlTensorTransport(TensorTransportManager):
+    @property
+    def tensor_transport_backend(self) -> Backend:
+        return Backend.NIXL
+
     @staticmethod
     def is_one_sided() -> bool:
         return True
+
+    def actor_has_tensor_transport(self, actor: "ray.actor.ActorHandle") -> bool:
+        def __ray_actor_has_tensor_transport__(
+            self: "ray.actor.ActorHandle",
+        ) -> bool:
+            try:
+                nixl_backend = get_group_handle(NIXL_GROUP_NAME)
+                return nixl_backend is not None
+            except:
+                return False
+
+        return ray.get(
+            actor.__ray_call__.options(concurrency_group="_ray_system").remote(
+                __ray_actor_has_tensor_transport__
+            )
+        )
 
     @staticmethod
     def get_tensor_transport_metadata(

--- a/python/ray/experimental/collective/tensor_transport_manager.py
+++ b/python/ray/experimental/collective/tensor_transport_manager.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional, TYPE_CHECKING
 from ray.util.collective.types import TensorTransportMetadata, CommunicatorMetadata
+from ray.util.collective.types import Backend
 from ray._private.custom_types import TensorTransportEnum
 
 import ray
@@ -10,6 +11,15 @@ if TYPE_CHECKING:
 
 
 class TensorTransportManager(ABC):
+    @property
+    @abstractmethod
+    def tensor_transport_backend(self) -> Backend:
+        """The tensor transport backend, e.g., NCCL.
+
+        Returns:
+            Backend: The backend of the tensor transport.
+        """
+
     @staticmethod
     @abstractmethod
     def is_one_sided() -> bool:
@@ -17,6 +27,17 @@ class TensorTransportManager(ABC):
 
         Returns:
             bool: True if the backend is one-sided, False otherwise.
+        """
+
+    @abstractmethod
+    def actor_has_tensor_transport(self, actor: "ray.actor.ActorHandle") -> bool:
+        """Whether the actor has the tensor transport available.
+
+        Args:
+            actor: The actor to check.
+
+        Returns:
+            bool: True if the actor has the tensor transport available, False otherwise.
         """
 
     @staticmethod
@@ -64,6 +85,7 @@ class TensorTransportManager(ABC):
     def send_object(
         src_actor: "ray.actor.ActorHandle",
         obj_id: str,
+        tensor_transport_meta: TensorTransportMetadata,
         communicator_metadata_ref: CommunicatorMetadata,
     ):
         """
@@ -83,6 +105,7 @@ class TensorTransportManager(ABC):
         src_actor.__ray_call__.options(concurrency_group="_ray_system").remote(
             __ray_send__,
             obj_id,
+            tensor_transport_meta,
             communicator_metadata_ref,
         )
 

--- a/python/ray/experimental/collective/tensor_transport_manager.py
+++ b/python/ray/experimental/collective/tensor_transport_manager.py
@@ -94,6 +94,7 @@ class TensorTransportManager(ABC):
         Args:
             src_actor: The actor that runs this function.
             obj_id: The ID of the GPU object to send.
+            tensor_transport_meta: The tensor transport metadata for the GPU object.
             communicator_metadata_ref: The ObjectRef of communicator metadata for the send/recv operation.
         """
         from ray.experimental.gpu_object_manager.gpu_object_store import __ray_send__

--- a/python/ray/experimental/collective/util.py
+++ b/python/ray/experimental/collective/util.py
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
 
 # Singleton instances for tensor transport managers
 _nixl_tensor_transport_manager = None
-_collective_tensor_transport_manager = None
+_gloo_tensor_transport_manager = None
+_nccl_tensor_transport_manager = None
 
 
 def get_tensor_transport_manager(
@@ -35,11 +36,16 @@ def get_tensor_transport_manager(
         if _nixl_tensor_transport_manager is None:
             _nixl_tensor_transport_manager = NixlTensorTransport()
         return _nixl_tensor_transport_manager
-    elif tensor_transport == Backend.TORCH_GLOO or tensor_transport == Backend.NCCL:
-        global _collective_tensor_transport_manager
-        if _collective_tensor_transport_manager is None:
-            _collective_tensor_transport_manager = CollectiveTensorTransport()
-        return _collective_tensor_transport_manager
+    elif tensor_transport == Backend.TORCH_GLOO:
+        global _gloo_tensor_transport_manager
+        if _gloo_tensor_transport_manager is None:
+            _gloo_tensor_transport_manager = CollectiveTensorTransport(tensor_transport)
+        return _gloo_tensor_transport_manager
+    elif tensor_transport == Backend.NCCL:
+        global _nccl_tensor_transport_manager
+        if _nccl_tensor_transport_manager is None:
+            _nccl_tensor_transport_manager = CollectiveTensorTransport(tensor_transport)
+        return _nccl_tensor_transport_manager
     else:
         raise ValueError(f"Unsupported tensor transport protocol: {tensor_transport}")
 

--- a/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
@@ -222,6 +222,7 @@ class GPUObjectManager:
                 tensor_transport_manager.send_object(
                     src_actor,
                     obj_id,
+                    tensor_transport_meta,
                     communicator_meta,
                 )
             tensor_transport_manager.recv_object(
@@ -269,7 +270,7 @@ class GPUObjectManager:
         """
         # Import get_collective_groups here to avoid dependency on
         # collective libraries for default Ray installation.
-        from ray.experimental.collective import get_collective_groups
+        from ray.experimental.collective import get_tensor_transport_manager
         from ray.experimental.gpu_object_manager.gpu_object_store import (
             _tensor_transport_to_collective_backend,
         )
@@ -277,5 +278,7 @@ class GPUObjectManager:
         tensor_transport_backend = _tensor_transport_to_collective_backend(
             tensor_transport
         )
-        communicators = get_collective_groups([actor], backend=tensor_transport_backend)
-        return len(communicators) > 0
+        tensor_transport_manager = get_tensor_transport_manager(
+            tensor_transport_backend
+        )
+        return tensor_transport_manager.actor_has_tensor_transport(actor)

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -43,6 +43,7 @@ def _tensor_transport_to_collective_backend(
 def __ray_send__(
     self,
     obj_id: str,
+    tensor_transport_meta: TensorTransportMetadata,
     communicator_meta: CommunicatorMetadata,
 ):
     """Helper function that runs on the src actor to send tensors to the dst actor."""
@@ -66,6 +67,7 @@ def __ray_send__(
         )
     tensor_transport_manager.send_multiple_tensors(
         tensors,
+        tensor_transport_meta,
         communicator_meta,
     )
 

--- a/python/ray/tests/test_gpu_objects_gloo.py
+++ b/python/ray/tests/test_gpu_objects_gloo.py
@@ -225,7 +225,7 @@ def test_p2p_errors_before_group_creation(ray_start_regular):
 
     with pytest.raises(
         ValueError,
-        match="Actor.* does not have tensor transport GLOO available. Please create a communicator with `ray.experimental.collective.create_collective_group` before calling actor tasks with non-default tensor_transport.",
+        match="Actor.* does not have tensor transport GLOO available.*",
     ):
         sender.echo.remote(small_tensor)
 


### PR DESCRIPTION
## Why are these changes needed?

Miscellaneous bug fixes introduced by some hidden merge conflicts:
- Check whether NIXL is available on actors instead of checking whether a collective group has been created
- Add back `tensor_transport_metadata` as an argument when coordinating transfers

## Related issue number

Closes #55987.