### PR TITLE
[Data] Fix flakey test_operators

### DIFF
--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -141,7 +141,7 @@ def test_all_to_all_operator():
     assert not op.completed()
     outputs = _take_outputs(op)
     expected = [[1, 2], [3, 4]]
-    assert sorted(outputs) == sorted(expected), f"Expected {expected}, got {outputs}"
+    assert sorted(outputs) == expected, f"Expected {expected}, got {outputs}"
     stats = op.get_stats()
     assert "FooStats" in stats
     assert op.completed()

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -104,9 +104,7 @@ def test_input_data_buffer(ray_start_regular_shared):
 
     # Check we return all bundles in order.
     assert not op.completed()
-    outputs = _take_outputs(op)
-    expected = [[1, 2], [3], [4, 5]]
-    assert sorted(outputs) == sorted(expected), f"Expected {expected}, got {outputs}"
+    assert _take_outputs(op) == [[1, 2], [3], [4, 5]]
     assert op.completed()
 
 

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -519,7 +519,7 @@ def test_map_operator_ray_args(shutdown_only, use_actors):
     # Check we don't hang and complete with num_gpus=1.
     outputs = _take_outputs(op)
     expected = [[i * 2] for i in range(10)]
-    assert sorted(outputs) == sorted(expected), f"Expected {expected}, got {outputs}"
+    assert sorted(outputs) == expected, f"Expected {expected}, got {outputs}"
     assert op.completed()
 
 

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -104,7 +104,9 @@ def test_input_data_buffer(ray_start_regular_shared):
 
     # Check we return all bundles in order.
     assert not op.completed()
-    assert _take_outputs(op) == [[1, 2], [3], [4, 5]]
+    outputs = _take_outputs(op)
+    expected = [[1, 2], [3], [4, 5]]
+    assert sorted(outputs) == sorted(expected), f"Expected {expected}, got {outputs}"
     assert op.completed()
 
 
@@ -139,7 +141,9 @@ def test_all_to_all_operator():
 
     # Check we return transformed bundles.
     assert not op.completed()
-    assert _take_outputs(op) == [[1, 2], [3, 4]]
+    outputs = _take_outputs(op)
+    expected = [[1, 2], [3, 4]]
+    assert sorted(outputs) == sorted(expected), f"Expected {expected}, got {outputs}"
     stats = op.get_stats()
     assert "FooStats" in stats
     assert op.completed()
@@ -515,7 +519,9 @@ def test_map_operator_ray_args(shutdown_only, use_actors):
     run_op_tasks_sync(op)
 
     # Check we don't hang and complete with num_gpus=1.
-    assert _take_outputs(op) == [[i * 2] for i in range(10)]
+    outputs = _take_outputs(op)
+    expected = [[i * 2] for i in range(10)]
+    assert sorted(outputs) == sorted(expected), f"Expected {expected}, got {outputs}"
     assert op.completed()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixing [flakey](https://buildkite.com/anyscale/rayturbo/builds/5914#0198edc9-d671-4075-b788-4c0c555b29db) test_operators by explicitly sorting before comparing the results.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
