### PR TITLE
[core] Turn off -wshadow for tests

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -3,7 +3,7 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_library_public")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
-COPTS_WITHOUT_LOG = select({
+COPTS_TESTS = select({
     "//:opt": ["-DBAZEL_OPT"],
     "//conditions:default": [],
 }) + select({
@@ -16,7 +16,6 @@ COPTS_WITHOUT_LOG = select({
         "-Wconversion-null",
         "-Wno-misleading-indentation",
         "-Wimplicit-fallthrough",
-        "-Wshadow",
     ],
 }) + select({
     "//:clang-cl": [
@@ -26,7 +25,9 @@ COPTS_WITHOUT_LOG = select({
     "//conditions:default": [],
 })
 
-COPTS = COPTS_WITHOUT_LOG
+COPTS = COPTS_TESTS + select({
+    "//conditions:default": ["-Wshadow"],
+})
 
 PYX_COPTS = select({
     "//:msvc-cl": [],
@@ -145,7 +146,7 @@ def ray_cc_library(name, strip_include_prefix = "/src", copts = [], visibility =
 def ray_cc_test(name, linkopts = [], copts = [], **kwargs):
     cc_test(
         name = name,
-        copts = COPTS + copts,
+        copts = COPTS_TESTS + copts,
         linkopts = linkopts + ["-pie"],
         **kwargs
     )

--- a/src/ray/core_worker/tests/memory_store_test.cc
+++ b/src/ray/core_worker/tests/memory_store_test.cc
@@ -195,8 +195,8 @@ TEST(TestMemoryStore, TestObjectAllocator) {
     auto buf = object.GetData();
     mock_buffer_manager.AcquireMemory(buf->Size());
     auto data_factory = [&mock_buffer_manager, object]() -> std::shared_ptr<ray::Buffer> {
-      auto buf = object.GetData();
-      std::string data(reinterpret_cast<char *>(buf->Data()), buf->Size());
+      auto inner_buf = object.GetData();
+      std::string data(reinterpret_cast<char *>(inner_buf->Data()), inner_buf->Size());
       return std::make_shared<TestBuffer>(mock_buffer_manager, data);
     };
 

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -2560,10 +2560,10 @@ TEST_F(TaskManagerTest, TestObjectRefStreamBackpressure) {
   bool signal_called = false;
   ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
       req,
-      /*execution_signal_callback*/ [&signal_called](Status status,
+      /*execution_signal_callback*/ [&signal_called](Status callback_status,
                                                      int64_t num_objects_consumed) {
         signal_called = true;
-        ASSERT_TRUE(status.ok());
+        ASSERT_TRUE(callback_status.ok());
         ASSERT_EQ(num_objects_consumed, 0);
       }));
   ASSERT_TRUE(signal_called);

--- a/src/ray/gcs/gcs_client/tests/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/tests/gcs_client_test.cc
@@ -519,7 +519,7 @@ TEST_P(GcsClientTest, TestActorInfo) {
   ActorID actor_id = ActorID::FromBinary(actor_table_data->actor_id());
 
   // Subscribe to any update operations of an actor.
-  auto on_subscribe = [](const ActorID &actor_id, const rpc::ActorTableData &data) {};
+  auto on_subscribe = [](const ActorID &, const rpc::ActorTableData &) {};
   ASSERT_TRUE(SubscribeActor(actor_id, on_subscribe));
 
   // Register an actor to GCS.
@@ -689,7 +689,7 @@ TEST_P(GcsClientTest, TestActorTableResubscribe) {
   // All the notifications for the following `SubscribeActor` operation.
   std::vector<rpc::ActorTableData> subscribe_one_notifications;
   auto actor_subscribe = [&num_subscribe_one_notifications, &subscribe_one_notifications](
-                             const ActorID &actor_id, const rpc::ActorTableData &data) {
+                             const ActorID &, const rpc::ActorTableData &data) {
     subscribe_one_notifications.emplace_back(data);
     ++num_subscribe_one_notifications;
     RAY_LOG(INFO) << "The number of actor subscription messages received is "
@@ -829,7 +829,7 @@ TEST_P(GcsClientTest, TestMultiThreadSubAndUnsub) {
   auto job_id = JobID::FromInt(1);
   for (int index = 0; index < size; ++index) {
     threads[index].reset(new std::thread([this, sub_and_unsub_loop_count, job_id] {
-      for (int index = 0; index < sub_and_unsub_loop_count; ++index) {
+      for (int inner_index = 0; inner_index < sub_and_unsub_loop_count; ++inner_index) {
         auto actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
         ASSERT_TRUE(SubscribeActor(
             actor_id, [](const ActorID &id, const rpc::ActorTableData &result) {}));

--- a/src/ray/gcs/gcs_server/tests/export_api/gcs_actor_manager_export_event_test.cc
+++ b/src/ray/gcs/gcs_server/tests/export_api/gcs_actor_manager_export_event_test.cc
@@ -53,8 +53,8 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
     auto pending_it =
         std::find_if(actors.begin(),
                      actors.end(),
-                     [actor_id](const std::shared_ptr<gcs::GcsActor> &actor) {
-                       return actor->GetActorID() == actor_id;
+                     [actor_id](const std::shared_ptr<gcs::GcsActor> &current_actor) {
+                       return current_actor->GetActorID() == actor_id;
                      });
     if (pending_it != actors.end()) {
       actors.erase(pending_it);
@@ -234,7 +234,7 @@ class GcsActorManagerTest : public ::testing::Test {
     io_service_.post(
         [this, request, &promise]() {
           auto status = gcs_actor_manager_->RegisterActor(
-              request, [this, request, &promise](const Status &status) {
+              request, [this, request, &promise](const Status &) {
                 auto actor_id = ActorID::FromBinary(
                     request.task_spec().actor_creation_task_spec().actor_id());
                 promise.set_value(
@@ -285,9 +285,9 @@ TEST_F(GcsActorManagerTest, TestBasic) {
   std::vector<std::shared_ptr<gcs::GcsActor>> finished_actors;
   Status status = gcs_actor_manager_->CreateActor(
       create_actor_request,
-      [&finished_actors](const std::shared_ptr<gcs::GcsActor> &actor,
-                         const rpc::PushTaskReply &reply,
-                         const Status &status) { finished_actors.emplace_back(actor); });
+      [&finished_actors](const std::shared_ptr<gcs::GcsActor> &result_actor,
+                         const rpc::PushTaskReply &,
+                         const Status &) { finished_actors.emplace_back(result_actor); });
   RAY_CHECK_OK(status);
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::PENDING_CREATION, ""),
                1);

--- a/src/ray/object_manager/plasma/tests/object_store_test.cc
+++ b/src/ray/object_manager/plasma/tests/object_store_test.cc
@@ -129,8 +129,8 @@ TEST(ObjectStoreTest, PassThroughTest) {
     EXPECT_EQ(nullptr, store.SealObject(kId2));
 
     // delete sealed
-    EXPECT_CALL(allocator, Free(_)).Times(1).WillOnce(Invoke([&](auto &&allocation) {
-      EXPECT_EQ(alloc_str, Serialize(allocation));
+    EXPECT_CALL(allocator, Free(_)).Times(1).WillOnce(Invoke([&](auto &&allocation_arg) {
+      EXPECT_EQ(alloc_str, Serialize(allocation_arg));
     }));
 
     EXPECT_TRUE(store.DeleteObject(kId1));
@@ -175,8 +175,8 @@ TEST(ObjectStoreTest, PassThroughTest) {
     EXPECT_TRUE(entry->allocation_.fallback_allocated_);
 
     // delete unsealed
-    EXPECT_CALL(allocator, Free(_)).Times(1).WillOnce(Invoke([&](auto &&allocation) {
-      EXPECT_EQ(alloc_str, Serialize(allocation));
+    EXPECT_CALL(allocator, Free(_)).Times(1).WillOnce(Invoke([&](auto &&allocation_arg) {
+      EXPECT_EQ(alloc_str, Serialize(allocation_arg));
     }));
 
     EXPECT_TRUE(store.DeleteObject(kId2));


### PR DESCRIPTION
There's like 13 cpp tests failing to build right now with errors all over because of the -Wshadow we recently added.

Fixing some shadowing and then turning off -Wshadow for the tests.