### PR TITLE
[core] Remove perf test in `shutdown_coordinator_test`

### DIFF
--- a/src/ray/core_worker/tests/shutdown_coordinator_test.cc
+++ b/src/ray/core_worker/tests/shutdown_coordinator_test.cc
@@ -281,8 +281,11 @@ TEST_F(ShutdownCoordinatorTest, Worker_HandleExit_OnIdleTimeout) {
 }
 
 TEST_F(ShutdownCoordinatorTest, ShouldEarlyExit_Performance_IsFast) {
+#ifdef _RAY_TSAN_BUILD
+  GTEST_SKIP() << "Disabled in tsan because of performance";
+#endif
   auto coordinator = CreateCoordinator();
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = std::chrono::steady_clock::now();
   constexpr int iterations = 1000000;
   volatile bool result = false;
 
@@ -290,7 +293,7 @@ TEST_F(ShutdownCoordinatorTest, ShouldEarlyExit_Performance_IsFast) {
     result = coordinator->ShouldEarlyExit();
   }
 
-  auto end = std::chrono::high_resolution_clock::now();
+  auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
 
   // Should be very fast (less than 100ns per call on modern hardware)
@@ -298,7 +301,6 @@ TEST_F(ShutdownCoordinatorTest, ShouldEarlyExit_Performance_IsFast) {
   EXPECT_LT(ns_per_call, 100.0)
       << "ShouldEarlyExit too slow: " << ns_per_call << "ns per call";
 
-  // Prevent unused variable warning
   (void)result;
 }
 

--- a/src/ray/core_worker/tests/shutdown_coordinator_test.cc
+++ b/src/ray/core_worker/tests/shutdown_coordinator_test.cc
@@ -280,30 +280,6 @@ TEST_F(ShutdownCoordinatorTest, Worker_HandleExit_OnIdleTimeout) {
                                            ShutdownReason::kIdleTimeout));
 }
 
-TEST_F(ShutdownCoordinatorTest, ShouldEarlyExit_Performance_IsFast) {
-#ifdef _RAY_TSAN_BUILD
-  GTEST_SKIP() << "Disabled in tsan because of performance";
-#endif
-  auto coordinator = CreateCoordinator();
-  auto start = std::chrono::steady_clock::now();
-  constexpr int iterations = 1000000;
-  volatile bool result = false;
-
-  for (int i = 0; i < iterations; ++i) {
-    result = coordinator->ShouldEarlyExit();
-  }
-
-  auto end = std::chrono::steady_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
-
-  // Should be very fast (less than 100ns per call on modern hardware)
-  double ns_per_call = static_cast<double>(duration.count()) / iterations;
-  EXPECT_LT(ns_per_call, 100.0)
-      << "ShouldEarlyExit too slow: " << ns_per_call << "ns per call";
-
-  (void)result;
-}
-
 TEST_F(ShutdownCoordinatorTest, StringRepresentations_StateAndReason_AreReadable) {
   auto coordinator = CreateCoordinator();
 


### PR DESCRIPTION
## Why are these changes needed?

The test microbenchmarks a method (`ShutdownCoordinator::ShouldEarlyExit`) which uses a lock. It's checked at task boundaries and event loop posts. That's orders of magnitude less frequent than per-object/serialization loops. But, it is not very useful. So, removing the test.

## Related issue number

Closes #55801
