### PR TITLE
[serve] skip running soft-fail tests on premerge

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -54,6 +54,7 @@ steps:
     tags:
       - serve
       - python
+      - skip-on-premerge
     instance_type: large
     soft_fail: true
     commands:
@@ -68,6 +69,7 @@ steps:
     tags:
       - serve
       - python
+      - skip-on-premerge
     instance_type: large
     soft_fail: true
     commands:


### PR DESCRIPTION
they never blocks merging practically, and when they are flaky, their retries just make PR merging take longer time without any meaningful blocking.
