### PR TITLE
Bump Ray image to 2.49.0, align Torch to 2.7.1, and clean notebook outputs in multimodal AI workloads example

### DIFF
--- a/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/containerfile
+++ b/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/containerfile
@@ -1,6 +1,6 @@
 # Start with an Anyscale base image.
 # Use the drop-down above to browse through all available images.
-FROM anyscale/ray:2.48.0-slim-py312-cu128
+FROM anyscale/ray:2.49.0-slim-py312-cu128
 
 # Add your pip dependencies here. Disable cache for a smaller image to optimize build and cluster startup time.
 # RUN pip install --no-cache-dir --upgrade <package1> <package2>

--- a/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/01-Batch-Inference.ipynb
+++ b/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/01-Batch-Inference.ipynb
@@ -31,9 +31,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[92mSuccessfully registered `ipywidgets, matplotlib` and 4 other packages to be installed on all cluster nodes.\u001b[0m\n",
-      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_1dp3fa7w5hu3i83ldsi7lqvp9t?workspace-tab=dependencies\u001b[0m\n",
+      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_23ry3pgfn3jgq2jk3e5z25udhz?workspace-tab=dependencies\u001b[0m\n",
       "\u001b[92mSuccessfully registered `doggos` package to be installed on all cluster nodes.\u001b[0m\n",
-      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_1dp3fa7w5hu3i83ldsi7lqvp9t?workspace-tab=dependencies\u001b[0m\n"
+      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_23ry3pgfn3jgq2jk3e5z25udhz?workspace-tab=dependencies\u001b[0m\n"
      ]
     }
    ],
@@ -121,23 +121,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:14:08,238\tINFO worker.py:1747 -- Connecting to existing Ray cluster at address: 10.0.52.10:6379...\n",
-      "2025-08-22 00:14:08,250\tINFO worker.py:1918 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-466hy7cqu1gzrp8zk8l4byz7l7.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
-      "2025-08-22 00:14:08,255\tINFO packaging.py:588 -- Creating a file package for local module '/home/ray/default/doggos/doggos'.\n",
-      "2025-08-22 00:14:08,258\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_0193267f6c9951ce.zip' (0.02MiB) to Ray cluster...\n",
-      "2025-08-22 00:14:08,259\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_0193267f6c9951ce.zip'.\n",
-      "2025-08-22 00:14:08,262\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_6d26725922931a7a9e87fca928dfafe4f4e5e54b.zip' (1.18MiB) to Ray cluster...\n",
-      "2025-08-22 00:14:08,268\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_6d26725922931a7a9e87fca928dfafe4f4e5e54b.zip'.\n",
-      "2025-08-22 00:14:08,550\tINFO dataset.py:3057 -- Tip: Use `take_batch()` instead of `take() / show()` to return records in pandas or numpy batch format.\n",
-      "2025-08-22 00:14:08,552\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_59_0\n",
-      "2025-08-22 00:14:08,641\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_59_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "2025-08-22 00:14:08,642\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_59_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> LimitOperator[limit=1]\n"
+      "2025-08-28 05:00:43,606\tINFO worker.py:1771 -- Connecting to existing Ray cluster at address: 10.0.17.148:6379...\n",
+      "2025-08-28 05:00:43,617\tINFO worker.py:1942 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-jhxhj69d6ttkjctcxfnsfe7gwk.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
+      "2025-08-28 05:00:43,621\tINFO packaging.py:588 -- Creating a file package for local module '/home/ray/default/doggos/doggos'.\n",
+      "2025-08-28 05:00:43,625\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_7400f2bea399eebc.zip' (0.02MiB) to Ray cluster...\n",
+      "2025-08-28 05:00:43,625\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_7400f2bea399eebc.zip'.\n",
+      "2025-08-28 05:00:43,628\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_a31dca6092632244a5c9467084f1b1f8df982200.zip' (1.10MiB) to Ray cluster...\n",
+      "2025-08-28 05:00:43,634\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_a31dca6092632244a5c9467084f1b1f8df982200.zip'.\n",
+      "2025-08-28 05:00:48,035\tINFO dataset.py:3248 -- Tip: Use `take_batch()` instead of `take() / show()` to return records in pandas or numpy batch format.\n",
+      "2025-08-28 05:00:48,039\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_1_0\n",
+      "2025-08-28 05:00:48,101\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_1_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:00:48,102\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_1_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> LimitOperator[limit=1] -> TaskPoolMapOperator[ReadFiles]\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b6862146286847ef9294638c1aa3d311",
+       "model_id": "d08e184535944a6c8ea162eca5674cd1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -151,7 +151,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "86a135d7d9cd45bc8ad9e5f0e5c477ad",
+       "model_id": "ac866daca29b4379b67367b2c50c65f0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -165,12 +165,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4bfc88e39a7b450c945855a2d3f908e4",
+       "model_id": "724c3b66392442aebf0d756157799e44",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "- ReadFiles 2: 0.00 row [00:00, ? row/s]"
+       "- limit=1 2: 0.00 row [00:00, ? row/s]"
       ]
      },
      "metadata": {},
@@ -179,12 +179,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1071a49d524e424498985dc424a029a1",
+       "model_id": "c1d6a10ed6c04fce8135dc2a98b8ebe3",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "- limit=1 3: 0.00 row [00:00, ? row/s]"
+       "- ReadFiles 3: 0.00 row [00:00, ? row/s]"
       ]
      },
      "metadata": {},
@@ -194,63 +194,63 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:14:08,686\tWARNING resource_manager.py:130 -- ⚠️  Ray's object store is configured to use only 28.2% of available memory (67.8GB out of 240.5GB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n",
-      "2025-08-22 00:15:25,802\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_59_0 execution finished in 77.16 seconds\n"
+      "2025-08-28 05:00:48,137\tWARNING resource_manager.py:134 -- ⚠️  Ray's object store is configured to use only 27.3% of available memory (8.7GiB out of 32.0GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n",
+      "2025-08-28 05:00:52,084\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_1_0 execution finished in 3.98 seconds\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{'image': array([[[123, 118,  78],\n",
-       "          [125, 120,  80],\n",
-       "          [128, 120,  83],\n",
+       "[{'image': array([[[ 71,  93,  81],\n",
+       "          [ 71,  93,  81],\n",
+       "          [ 71,  91,  79],\n",
        "          ...,\n",
-       "          [162, 128,  83],\n",
-       "          [162, 128,  83],\n",
-       "          [161, 127,  82]],\n",
+       "          [ 99, 129, 137],\n",
+       "          [101, 131, 139],\n",
+       "          [102, 132, 140]],\n",
        "  \n",
-       "         [[123, 118,  78],\n",
-       "          [125, 120,  80],\n",
-       "          [127, 119,  82],\n",
+       "         [[ 61,  81,  70],\n",
+       "          [ 61,  81,  70],\n",
+       "          [ 61,  81,  69],\n",
        "          ...,\n",
-       "          [162, 128,  83],\n",
-       "          [162, 128,  83],\n",
-       "          [161, 127,  82]],\n",
+       "          [ 93, 123, 131],\n",
+       "          [ 96, 125, 133],\n",
+       "          [ 97, 127, 135]],\n",
        "  \n",
-       "         [[123, 118,  78],\n",
-       "          [125, 120,  80],\n",
-       "          [127, 119,  82],\n",
+       "         [[ 51,  68,  58],\n",
+       "          [ 51,  68,  58],\n",
+       "          [ 50,  68,  56],\n",
        "          ...,\n",
-       "          [161, 128,  83],\n",
-       "          [161, 128,  83],\n",
-       "          [160, 127,  82]],\n",
+       "          [ 82, 111, 117],\n",
+       "          [ 85, 112, 119],\n",
+       "          [ 86, 115, 121]],\n",
        "  \n",
        "         ...,\n",
        "  \n",
-       "         [[235, 234, 239],\n",
-       "          [233, 232, 237],\n",
-       "          [221, 220, 225],\n",
+       "         [[ 83, 101, 103],\n",
+       "          [ 83, 101, 103],\n",
+       "          [ 84, 102, 106],\n",
        "          ...,\n",
-       "          [158,  95,  54],\n",
-       "          [150,  85,  53],\n",
-       "          [151,  88,  57]],\n",
+       "          [ 94,  82,  56],\n",
+       "          [ 97,  85,  59],\n",
+       "          [ 99,  87,  61]],\n",
        "  \n",
-       "         [[219, 220, 222],\n",
-       "          [227, 228, 230],\n",
-       "          [222, 223, 225],\n",
+       "         [[ 82, 100, 102],\n",
+       "          [ 82, 100, 102],\n",
+       "          [ 83, 101, 105],\n",
        "          ...,\n",
-       "          [153,  91,  54],\n",
-       "          [146,  83,  52],\n",
-       "          [149,  88,  59]],\n",
+       "          [ 95,  83,  57],\n",
+       "          [ 98,  86,  60],\n",
+       "          [ 99,  87,  61]],\n",
        "  \n",
-       "         [[213, 217, 216],\n",
-       "          [217, 221, 220],\n",
-       "          [213, 214, 216],\n",
+       "         [[ 85, 100, 103],\n",
+       "          [ 85, 100, 103],\n",
+       "          [ 83, 101, 103],\n",
        "          ...,\n",
-       "          [153,  91,  54],\n",
-       "          [144,  83,  54],\n",
-       "          [149,  88,  60]]], dtype=uint8),\n",
-       "  'path': 'doggos-dataset/train/border_collie/border_collie_1055.jpg'}]"
+       "          [ 95,  84,  56],\n",
+       "          [ 99,  88,  60],\n",
+       "          [100,  89,  61]]], dtype=uint8),\n",
+       "  'path': 'doggos-dataset/train/malamute/malamute_11814.jpg'}]"
       ]
      },
      "execution_count": null,
@@ -498,15 +498,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:15:55,241\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_64_0\n",
-      "2025-08-22 00:15:55,265\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_64_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "2025-08-22 00:15:55,267\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_64_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)->Write]\n"
+      "2025-08-28 05:00:55,737\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_6_0\n",
+      "2025-08-28 05:00:55,756\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_6_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:00:55,757\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_6_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)->Write]\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6d183707412548d5acd113c34ed06a4c",
+       "model_id": "7dbb9f0a9c364c529da80ff9e3266eb4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -518,9 +518,16 @@
      "output_type": "display_data"
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"asctime\":\"2025-08-28 05:00:55,808\",\"levelname\":\"E\",\"message\":\"Actor with class name: 'MapWorker(MapBatches(EmbedImages))' and ID: '1e923c76f6e2b92256b942a802000000' has constructor arguments in the object store and max_restarts > 0. If the arguments in the object store go out of scope or are lost, the actor restart will fail. See https://github.com/ray-project/ray/issues/53727 for more details.\",\"filename\":\"core_worker.cc\",\"lineno\":2254}\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "658e7e6b56fd4ddca63a85f903dc598c",
+       "model_id": "02bc199f5f074df19b376272e8c29ba8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -534,7 +541,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ea845b3839f341fe96882d806ad16146",
+       "model_id": "70ce40105ae34580a6ebb69dfada0de0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -548,7 +555,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "83e3d887e66844b7a414f95163268c4f",
+       "model_id": "36450487d0614de89dab8cb02e4e7180",
        "version_major": 2,
        "version_minor": 0
       },
@@ -562,7 +569,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dca912f45aab4457b4188f74fb21ab63",
+       "model_id": "1197937e481a43bb90094625f2c8a569",
        "version_major": 2,
        "version_minor": 0
       },
@@ -576,7 +583,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1b0ab6aaffeb45aea51b8a3c7b75540a",
+       "model_id": "c6277d187bd345ff9a773b33bbc03ea6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -591,30 +598,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(autoscaler +2m12s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n",
-      "\u001b[36m(autoscaler +2m17s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
-      "\u001b[36m(autoscaler +2m17s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +2m57s)\u001b[0m [autoscaler] Cluster upscaled to {104 CPU, 8 GPU}.\n"
+      "\u001b[36m(autoscaler +20s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n",
+      "\u001b[36m(autoscaler +20s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
+      "\u001b[36m(autoscaler +25s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(_MapWorker pid=3333, ip=10.0.27.32)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
-      "\u001b[36m(MapBatches(drop_columns)->Write pid=116142)\u001b[0m FilenameProvider have to provide proper filename template including '{{i}}' macro to ensure unique filenames when writing multiple files. Appending '{{i}}' macro to the end of the file. For more details on the expected filename template checkout PyArrow's `write_to_dataset` API\n",
-      "\u001b[36m(_MapWorker pid=3332, ip=10.0.27.32)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\u001b[32m [repeated 3x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)\u001b[0m\n",
-      "\u001b[36m(MapBatches(drop_columns)->Write pid=34034, ip=10.0.171.239)\u001b[0m FilenameProvider have to provide proper filename template including '{{i}}' macro to ensure unique filenames when writing multiple files. Appending '{{i}}' macro to the end of the file. For more details on the expected filename template checkout PyArrow's `write_to_dataset` API\u001b[32m [repeated 32x across cluster]\u001b[0m\n",
-      "2025-08-22 00:18:30,236\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_64_0 execution finished in 154.97 seconds\n",
-      "2025-08-22 00:18:30,323\tINFO dataset.py:4621 -- Data sink Parquet finished. 2880 rows and 5.8MB data written.\n"
+      "2025-08-28 05:01:19,478\tWARNING resource_manager.py:551 -- Cluster resources are not engough to run any task from ActorPoolMapOperator[MapBatches(EmbedImages)]. The job may hang forever unless the cluster scales up.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(autoscaler +6m52s)\u001b[0m [autoscaler] Downscaling node i-0b5c2c9a5a27cfba2 (node IP: 10.0.27.32) due to node idle termination.\n",
-      "\u001b[36m(autoscaler +6m52s)\u001b[0m [autoscaler] Cluster resized to {56 CPU, 4 GPU}.\n"
+      "\u001b[36m(autoscaler +1m10s)\u001b[0m [autoscaler] Cluster upscaled to {56 CPU, 4 GPU}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(MapWorker(MapBatches(EmbedImages)) pid=3337, ip=10.0.5.252)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
+      "2025-08-28 05:03:39,362\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_6_0 execution finished in 163.60 seconds\n",
+      "2025-08-28 05:03:39,422\tINFO dataset.py:4871 -- Data sink Parquet finished. 2880 rows and 5.8MB data written.\n"
      ]
     }
    ],
@@ -718,12 +727,12 @@
      "output_type": "stream",
      "text": [
       "Output\n",
-      "(anyscale +0.9s) Submitting job with config JobConfig(name='image-batch-embeddings', image_uri='anyscale/ray:2.48.0-slim-py312-cu128', compute_config=None, env_vars=None, py_modules=['/home/ray/default/doggos'], py_executable=None, cloud=None, project=None, ray_version=None, job_queue_config=None).\n",
-      "(anyscale +3.0s) Uploading local dir '/home/ray/default' to cloud storage.\n",
-      "(anyscale +4.2s) Uploading local dir '/home/ray/default/doggos' to cloud storage.\n",
-      "(anyscale +5.2s) Job 'image-batch-embeddings' submitted, ID: 'prodjob_cmhr6w7l9fb42be6xjsz1rnxsl'.\n",
-      "(anyscale +5.2s) View the job in the UI: https://console.anyscale.com/jobs/prodjob_cmhr6w7l9fb42be6xjsz1rnxsl\n",
-      "(anyscale +5.2s) Use `--wait` to wait for the job to run and stream logs.\n"
+      "(anyscale +0.8s) Submitting job with config JobConfig(name='image-batch-embeddings', image_uri='anyscale/ray:2.48.0-slim-py312-cu128', compute_config=None, env_vars=None, py_modules=['/home/ray/default/doggos'], py_executable=None, cloud=None, project=None, ray_version=None, job_queue_config=None).\n",
+      "(anyscale +7.2s) Uploading local dir '/home/ray/default' to cloud storage.\n",
+      "(anyscale +7.9s) Uploading local dir '/home/ray/default/doggos' to cloud storage.\n",
+      "(anyscale +9.2s) Job 'image-batch-embeddings' submitted, ID: 'prodjob_7e1fsj9xzs2iryayj7hgbhifl8'.\n",
+      "(anyscale +9.2s) View the job in the UI: https://console.anyscale.com/jobs/prodjob_7e1fsj9xzs2iryayj7hgbhifl8\n",
+      "(anyscale +9.2s) Use `--wait` to wait for the job to run and stream logs.\n"
      ]
     }
    ],
@@ -792,6 +801,118 @@
     },
     {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "91c47446fb224d72987f0f9b4c9c5e90",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "preprocessor_config.json:   0%|          | 0.00/316 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f44ab36a497d4830b53f0f01332874cc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer_config.json:   0%|          | 0.00/592 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "447faa2934744c54a55e3345fcfe610a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "vocab.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ff548355c8814fcf8909c4604834e02b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "merges.txt: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dfbda3ce262e4870b995cd3417c2726c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cbe3dccb4dfe4f13a501bb5ac5c136d0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "special_tokens_map.json:   0%|          | 0.00/389 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "30a784399393416c8fba7baa266e0193",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f3881086a97f42e1b8b09c0a958d5c0e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "pytorch_model.bin:   0%|          | 0.00/605M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
       "text/plain": [
        "(512,)"
       ]
@@ -819,21 +940,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:23:04,494\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_66_0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-08-22 00:23:04,500\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_66_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "2025-08-22 00:23:04,501\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_66_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles]\n"
+      "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/datasource/parquet_datasource.py:750: FutureWarning: The default `file_extensions` for `read_parquet` will change from `None` to ['parquet'] after Ray 2.43, and your dataset contains files that don't match the new `file_extensions`. To maintain backwards compatibility, set `file_extensions=None` explicitly.\n",
+      "  warnings.warn(\n",
+      "2025-08-28 05:03:56,303\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_8_0\n",
+      "2025-08-28 05:03:56,308\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_8_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:03:56,309\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_8_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles]\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7b04bc8e4d444e82950af699e0891b1e",
+       "model_id": "5d82b793825b412c9ab72693c6fb92ce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -847,7 +964,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5c7fffbb6cf44a29904a90f20015ab9b",
+       "model_id": "bdd005beb194490e8c641ef7548fdf09",
        "version_major": 2,
        "version_minor": 0
       },
@@ -861,7 +978,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "57a3c6fc76d448b49941e9459d88b051",
+       "model_id": "884a8230054a42c88e655c178827a68f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -873,10 +990,24 @@
      "output_type": "display_data"
     },
     {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6f2d6a1e74fd41f6a9be6c2fefdadf64",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/605M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:23:05,178\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_66_0 execution finished in 0.68 seconds\n"
+      "2025-08-28 05:03:57,382\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_8_0 execution finished in 1.07 seconds\n"
      ]
     },
     {
@@ -893,112 +1024,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(autoscaler +12m47s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
-      "\u001b[36m(autoscaler +12m52s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +13m37s)\u001b[0m [autoscaler] Cluster upscaled to {104 CPU, 8 GPU}.\n",
-      "\u001b[36m(autoscaler +15m32s)\u001b[0m [autoscaler] [8CPU-32GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
-      "\u001b[36m(autoscaler +15m32s)\u001b[0m [autoscaler] [8CPU-32GB|m5.2xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +16m2s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 1 to 2).\n",
-      "\u001b[36m(autoscaler +16m2s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +16m7s)\u001b[0m [autoscaler] Cluster upscaled to {112 CPU, 8 GPU}.\n",
-      "\u001b[36m(autoscaler +16m52s)\u001b[0m [autoscaler] Cluster upscaled to {160 CPU, 12 GPU}.\n",
-      "\u001b[36m(autoscaler +19m52s)\u001b[0m [autoscaler] Downscaling node i-0e941ed71ef3480ee (node IP: 10.0.34.27) due to node idle termination.\n",
-      "\u001b[36m(autoscaler +19m52s)\u001b[0m [autoscaler] Cluster resized to {112 CPU, 8 GPU}.\n",
-      "\u001b[36m(autoscaler +20m42s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
-      "\u001b[36m(autoscaler +20m47s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB|g4dn.2xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +20m47s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 1 to 2).\n",
-      "\u001b[36m(autoscaler +20m52s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +21m32s)\u001b[0m [autoscaler] Cluster upscaled to {120 CPU, 9 GPU}.\n",
-      "\u001b[36m(autoscaler +21m37s)\u001b[0m [autoscaler] Cluster upscaled to {168 CPU, 13 GPU}.\n",
-      "\u001b[36m(autoscaler +25m22s)\u001b[0m [autoscaler] Downscaling node i-0ffe5abae6e899f5a (node IP: 10.0.60.138) due to node idle termination.\n",
-      "\u001b[36m(autoscaler +25m27s)\u001b[0m [autoscaler] Cluster resized to {120 CPU, 9 GPU}.\n",
-      "\u001b[36m(autoscaler +28m22s)\u001b[0m [autoscaler] Downscaling node i-0aa72cef9b8921af5 (node IP: 10.0.31.199) due to node idle termination.\n",
-      "\u001b[36m(autoscaler +28m27s)\u001b[0m [autoscaler] Cluster resized to {112 CPU, 8 GPU}.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Using CPython 3.12.11 interpreter at: /home/ray/anaconda3/bin/python3.12\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Creating virtual environment at: .venv\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m    Building doggos @ file:///tmp/ray/session_2025-08-21_18-48-13_464408_2298/runtime_resources/working_dir_files/_ray_pkg_f79228c33bd2a431/doggos\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pillow (6.3MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading grpcio (5.9MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading sqlalchemy (3.2MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pydantic-core (1.9MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading jedi (1.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading virtualenv (5.7MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pandas (11.4MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading setuptools (1.1MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading uvloop (4.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading nvidia-cuda-nvrtc-cu12 (22.6MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading sympy (6.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading numpy (15.9MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading kiwisolver (1.4MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading tokenizers (3.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pyarrow (38.2MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading botocore (13.3MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading fonttools (4.7MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading widgetsnbextension (2.1MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading mlflow-skinny (5.6MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading aiohttp (1.6MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading networkx (1.9MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pygments (1.2MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading debugpy (4.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading py-spy (2.6MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading scikit-learn (12.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading hf-xet (3.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading matplotlib (8.2MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading torch (783.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading transformers (10.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading scipy (33.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading polars (36.7MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading mlflow (26.1MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading triton (148.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m       Built doggos @ file:///tmp/ray/session_2025-08-21_18-48-13_464408_2298/runtime_resources/working_dir_files/_ray_pkg_f79228c33bd2a431/doggos\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pillow\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading grpcio\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading sqlalchemy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pydantic-core\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading jedi\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading virtualenv\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading setuptools\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading uvloop\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cuda-cupti-cu12\u001b[32m [repeated 13x across cluster]\u001b[0m\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading sympy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading kiwisolver\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading tokenizers\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading fonttools\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading widgetsnbextension\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading mlflow-skinny\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading aiohttp\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading networkx\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pygments\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading debugpy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading py-spy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading hf-xet\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading matplotlib\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading transformers\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading scikit-learn\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading numpy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading botocore\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pandas\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading polars\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cuda-nvrtc-cu12\u001b[32m [repeated 2x across cluster]\u001b[0m\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading scipy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading mlflow\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pyarrow\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-curand-cu12\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cusparselt-cu12\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading triton\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cublas-cu12\u001b[32m [repeated 5x across cluster]\u001b[0m\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading torch\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m          If the cache and target directories are on different filesystems, hardlinking may not be supported.\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m          If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cudnn-cu12\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Installed 172 packages in 1.96s\n"
+      "\u001b[36m(autoscaler +7m14s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 1 to 2).\n",
+      "\u001b[36m(autoscaler +7m14s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
+      "\u001b[36m(autoscaler +8m0s)\u001b[0m [autoscaler] Cluster upscaled to {104 CPU, 8 GPU}.\n"
      ]
     }
    ],

--- a/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/02-Distributed-Training.ipynb
+++ b/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/02-Distributed-Training.ipynb
@@ -33,9 +33,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[92mSuccessfully registered `ipywidgets, matplotlib` and 4 other packages to be installed on all cluster nodes.\u001b[0m\n",
-      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_1dp3fa7w5hu3i83ldsi7lqvp9t?workspace-tab=dependencies\u001b[0m\n",
+      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_23ry3pgfn3jgq2jk3e5z25udhz?workspace-tab=dependencies\u001b[0m\n",
       "\u001b[92mSuccessfully registered `doggos` package to be installed on all cluster nodes.\u001b[0m\n",
-      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_1dp3fa7w5hu3i83ldsi7lqvp9t?workspace-tab=dependencies\u001b[0m\n"
+      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_23ry3pgfn3jgq2jk3e5z25udhz?workspace-tab=dependencies\u001b[0m\n"
      ]
     }
    ],
@@ -104,19 +104,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:26:10,081\tINFO worker.py:1747 -- Connecting to existing Ray cluster at address: 10.0.52.10:6379...\n",
-      "2025-08-22 00:26:10,093\tINFO worker.py:1918 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-466hy7cqu1gzrp8zk8l4byz7l7.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
-      "2025-08-22 00:26:10,108\tINFO packaging.py:588 -- Creating a file package for local module '/home/ray/default/doggos/doggos'.\n",
-      "2025-08-22 00:26:10,114\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_86fb5903fc73ddf5.zip' (0.03MiB) to Ray cluster...\n",
-      "2025-08-22 00:26:10,115\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_86fb5903fc73ddf5.zip'.\n",
-      "2025-08-22 00:26:10,118\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_e23a31aacd3983306ac777f59fba2eff0e5e9963.zip' (1.16MiB) to Ray cluster...\n",
-      "2025-08-22 00:26:10,124\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_e23a31aacd3983306ac777f59fba2eff0e5e9963.zip'.\n"
+      "2025-08-28 05:06:48,041\tINFO worker.py:1771 -- Connecting to existing Ray cluster at address: 10.0.17.148:6379...\n",
+      "2025-08-28 05:06:48,052\tINFO worker.py:1942 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-jhxhj69d6ttkjctcxfnsfe7gwk.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
+      "2025-08-28 05:06:48,061\tINFO packaging.py:588 -- Creating a file package for local module '/home/ray/default/doggos/doggos'.\n",
+      "2025-08-28 05:06:48,064\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_86cc12e3f2760ca4.zip' (0.03MiB) to Ray cluster...\n",
+      "2025-08-28 05:06:48,065\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_86cc12e3f2760ca4.zip'.\n",
+      "2025-08-28 05:06:48,068\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_563e3191c4f9ed5f5d5e8601702cfa5ff10660e4.zip' (1.09MiB) to Ray cluster...\n",
+      "2025-08-28 05:06:48,073\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_563e3191c4f9ed5f5d5e8601702cfa5ff10660e4.zip'.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "143376de26ec4095b9e1f3956e0a86f5",
+       "model_id": "c853a046148f42b8baa50711e3057054",
        "version_major": 2,
        "version_minor": 0
       },
@@ -144,11 +144,11 @@
        "    </tr>\n",
        "    <tr>\n",
        "        <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "        <td style=\"text-align: left\"><b>2.48.0</b></td>\n",
+       "        <td style=\"text-align: left\"><b>2.49.0</b></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
-       "    <td style=\"text-align: left\"><b><a href=\"http://session-466hy7cqu1gzrp8zk8l4byz7l7.i.anyscaleuserdata.com\" target=\"_blank\">http://session-466hy7cqu1gzrp8zk8l4byz7l7.i.anyscaleuserdata.com</a></b></td>\n",
+       "    <td style=\"text-align: left\"><b><a href=\"http://session-jhxhj69d6ttkjctcxfnsfe7gwk.i.anyscaleuserdata.com\" target=\"_blank\">http://session-jhxhj69d6ttkjctcxfnsfe7gwk.i.anyscaleuserdata.com</a></b></td>\n",
        "</tr>\n",
        "\n",
        "</table>\n",
@@ -157,7 +157,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='session-466hy7cqu1gzrp8zk8l4byz7l7.i.anyscaleuserdata.com', python_version='3.12.11', ray_version='2.48.0', ray_commit='61d1966b0b02ce07f95d8f046ea7f6f92f7be190')"
+       "RayContext(dashboard_url='session-jhxhj69d6ttkjctcxfnsfe7gwk.i.anyscaleuserdata.com', python_version='3.12.11', ray_version='2.49.0', ray_commit='8b349d73c5d5c4b56dc719fcc447d18ae8571dd4')"
       ]
      },
      "execution_count": null,
@@ -337,16 +337,22 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:26:17,487\tINFO dataset.py:3057 -- Tip: Use `take_batch()` instead of `take() / show()` to return records in pandas or numpy batch format.\n",
-      "2025-08-22 00:26:17,490\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_72_0\n",
-      "2025-08-22 00:26:17,522\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_72_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "2025-08-22 00:26:17,523\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_72_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)] -> AllToAllOperator[Aggregate] -> LimitOperator[limit=1]\n"
+      "2025-08-28 05:06:54,182\tINFO dataset.py:3248 -- Tip: Use `take_batch()` instead of `take() / show()` to return records in pandas or numpy batch format.\n",
+      "2025-08-28 05:06:54,184\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_14_0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-28 05:06:54,206\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_14_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:06:54,207\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_14_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)] -> AllToAllOperator[Aggregate] -> LimitOperator[limit=1]\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aa17a81a379547a6b397907ffafec33b",
+       "model_id": "66271b6a5fb7493998bb818d81eb9d12",
        "version_major": 2,
        "version_minor": 0
       },
@@ -360,7 +366,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "08f021fb0f014335ab09e4baf362d6c3",
+       "model_id": "342323504f9046f5ab79cc8fab75fd3d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -374,7 +380,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bb9749220ab644db83ab9ac57348c6df",
+       "model_id": "4ad27f68f4954b839ec614deb470dc2c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -388,7 +394,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7cd4f59d163149d8b1200348eaabebab",
+       "model_id": "ec8f2f8c07134885bcf1e339079e5602",
        "version_major": 2,
        "version_minor": 0
       },
@@ -402,7 +408,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9a7fe9e6350a4ce88f4c4a12c3e83fc1",
+       "model_id": "8af9685130484d73bdcc36ff9a7b6742",
        "version_major": 2,
        "version_minor": 0
       },
@@ -416,7 +422,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "38470d9ffbeb4f4ca11c2c7d4e70886b",
+       "model_id": "8e2ff9a70b3047b78d3421a9c6ba4a2a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -430,7 +436,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ea5ecfb1d6fb4eadb1d55130cdf0ec04",
+       "model_id": "5d47b1e760004a8ba310e0cda5de47f0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -444,7 +450,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e75cd967f3494a7cad6204c9f523ccad",
+       "model_id": "d4a4b8c2fd3240a1ad46f9abd4869497",
        "version_major": 2,
        "version_minor": 0
       },
@@ -458,7 +464,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "37294f34620d4ed99e4c6db7f489e870",
+       "model_id": "c881bfe545de4d8e9384ad4a4c4a3346",
        "version_major": 2,
        "version_minor": 0
       },
@@ -473,8 +479,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:26:17,662\tWARNING resource_manager.py:130 -- ⚠️  Ray's object store is configured to use only 28.2% of available memory (67.8GB out of 240.5GB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n",
-      "2025-08-22 00:26:29,748\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_72_0 execution finished in 12.22 seconds\n"
+      "2025-08-28 05:06:54,275\tWARNING resource_manager.py:134 -- ⚠️  Ray's object store is configured to use only 28.5% of available memory (63.9GiB out of 224.0GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n",
+      "2025-08-28 05:07:03,480\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_14_0 execution finished in 9.27 seconds\n"
      ]
     }
    ],
@@ -513,15 +519,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:26:30,402\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_80_0\n",
-      "2025-08-22 00:26:30,433\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_80_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "2025-08-22 00:26:30,435\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_80_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)->Write]\n"
+      "2025-08-28 05:07:04,254\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_22_0\n",
+      "2025-08-28 05:07:04,270\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_22_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:07:04,271\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_22_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)->Write]\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9a4fc2809c524fdea65f33187089279c",
+       "model_id": "05ab1c63234c4c779fbca8267b744477",
        "version_major": 2,
        "version_minor": 0
       },
@@ -535,7 +541,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ed00402d404430596be9d367c53de16",
+       "model_id": "310392fbcf7f4b50bc122405fdfdaaac",
        "version_major": 2,
        "version_minor": 0
       },
@@ -549,7 +555,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cb833a76da3245a0bfcf5d7d7959e847",
+       "model_id": "b600d27a67dc42159f5a97a445538560",
        "version_major": 2,
        "version_minor": 0
       },
@@ -563,7 +569,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2223e2ee8e046079a76f8cdcef8abf5",
+       "model_id": "fbb9d22bf6c74df7b21af88c7363adad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -577,7 +583,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "14d3a76ba8f84b3ba6729d43dcd221d8",
+       "model_id": "5b6f5b9affbb4f458851974ec2811594",
        "version_major": 2,
        "version_minor": 0
       },
@@ -591,116 +597,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5b5ea2e535b04e95b3bb8739e478a678",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "- MapBatches(drop_columns)->Write 5: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(autoscaler +25s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n",
-      "\u001b[36m(autoscaler +25s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
-      "\u001b[36m(autoscaler +30s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +1m15s)\u001b[0m [autoscaler] Cluster upscaled to {104 CPU, 8 GPU}.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(_MapWorker pid=3320, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
-      "\u001b[36m(MapBatches(drop_columns)->Write pid=44781, ip=10.0.171.239)\u001b[0m FilenameProvider have to provide proper filename template including '{{i}}' macro to ensure unique filenames when writing multiple files. Appending '{{i}}' macro to the end of the file. For more details on the expected filename template checkout PyArrow's `write_to_dataset` API\n",
-      "\u001b[36m(_MapWorker pid=3323, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\u001b[32m [repeated 3x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)\u001b[0m\n",
-      "\u001b[36m(MapBatches(drop_columns)->Write pid=44781, ip=10.0.171.239)\u001b[0m FilenameProvider have to provide proper filename template including '{{i}}' macro to ensure unique filenames when writing multiple files. Appending '{{i}}' macro to the end of the file. For more details on the expected filename template checkout PyArrow's `write_to_dataset` API\u001b[32m [repeated 32x across cluster]\u001b[0m\n",
-      "2025-08-22 00:29:10,480\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_80_0 execution finished in 160.04 seconds\n",
-      "2025-08-22 00:29:10,570\tINFO dataset.py:4621 -- Data sink Parquet finished. 2880 rows and 5.9MB data written.\n",
-      "2025-08-22 00:29:10,582\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_83_0\n",
-      "2025-08-22 00:29:10,601\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_83_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "2025-08-22 00:29:10,603\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_83_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)->Write]\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0abbbeeb2a35431a95d00c4c921ee61b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bf9288444a51499a8b1083a1b784b210",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "- ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8ec81536f155464c9a2ecf135cf83d80",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "- ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "512fded93ca04523b3ed812aec1ada77",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "- Map(add_class)->Map(convert_to_label) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b3b9c393001d49f4b0535b625a132edb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "- MapBatches(EmbedImages) 4: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5f38287bfd4b4795a3839f44b0d2b1a8",
+       "model_id": "936041324dbb49dda5872a3e6d3fa979",
        "version_major": 2,
        "version_minor": 0
       },
@@ -715,36 +612,115 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:29:12,374\tWARNING streaming_executor_state.py:764 -- Operator produced a RefBundle with a different schema than the previous one. Previous schema: image: extension<ray.data.arrow_variable_shaped_tensor<ArrowVariableShapedTensorType>>\n",
+      "\u001b[36m(MapWorker(MapBatches(EmbedImages)) pid=9215, ip=10.0.5.252)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
+      "2025-08-28 05:07:20,682\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_22_0 execution finished in 16.41 seconds\n",
+      "2025-08-28 05:07:20,747\tINFO dataset.py:4871 -- Data sink Parquet finished. 2880 rows and 5.9MB data written.\n",
+      "2025-08-28 05:07:20,759\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_25_0\n",
+      "2025-08-28 05:07:20,774\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_25_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:07:20,775\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_25_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)->Write]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cb6abfa554bd48a8a91f6bf67b72321d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Running 0: 0.00 row [00:00, ? row/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ebd4d9a7ce0e494cbd256531e82c76a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "- ListFiles 1: 0.00 row [00:00, ? row/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bbf925aa09a9434d9a0e1b0a0434a977",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "- ReadFiles 2: 0.00 row [00:00, ? row/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c061d8e4bee4444fa9d1ddfafa9f99bc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "- Map(add_class)->Map(convert_to_label) 3: 0.00 row [00:00, ? row/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "47cb0744205149d1860913bf2124338d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "- MapBatches(EmbedImages) 4: 0.00 row [00:00, ? row/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a68e006347144beca6b0593d148d0f8d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "- MapBatches(drop_columns)->Write 5: 0.00 row [00:00, ? row/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-28 05:07:22,417\tWARNING streaming_executor_state.py:790 -- Operator produced a RefBundle with a different schema than the previous one. Previous schema: image: extension<ray.data.arrow_variable_shaped_tensor<ArrowVariableShapedTensorType>>\n",
       "path: string, new schema: image: extension<ray.data.arrow_tensor_v2<ArrowTensorTypeV2>>\n",
       "path: string. This may lead to unexpected behavior.\n",
-      "2025-08-22 00:29:13,110\tWARNING streaming_executor_state.py:764 -- Operator produced a RefBundle with a different schema than the previous one. Previous schema: image: extension<ray.data.arrow_variable_shaped_tensor<ArrowVariableShapedTensorType>>\n",
+      "2025-08-28 05:07:22,642\tWARNING streaming_executor_state.py:790 -- Operator produced a RefBundle with a different schema than the previous one. Previous schema: image: extension<ray.data.arrow_variable_shaped_tensor<ArrowVariableShapedTensorType>>\n",
       "path: string\n",
       "class: string\n",
       "label: int64, new schema: image: extension<ray.data.arrow_tensor_v2<ArrowTensorTypeV2>>\n",
       "path: string\n",
       "class: string\n",
       "label: int64. This may lead to unexpected behavior.\n",
-      "\u001b[36m(_MapWorker pid=3910, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
-      "\u001b[36m(MapBatches(drop_columns)->Write pid=121066)\u001b[0m FilenameProvider have to provide proper filename template including '{{i}}' macro to ensure unique filenames when writing multiple files. Appending '{{i}}' macro to the end of the file. For more details on the expected filename template checkout PyArrow's `write_to_dataset` API\u001b[32m [repeated 7x across cluster]\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(autoscaler +3m10s)\u001b[0m [autoscaler] [8CPU-32GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
-      "\u001b[36m(autoscaler +3m10s)\u001b[0m [autoscaler] [8CPU-32GB|m5.2xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(_MapWorker pid=4731, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\u001b[32m [repeated 3x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(drop_columns)->Write pid=45557, ip=10.0.171.239)\u001b[0m FilenameProvider have to provide proper filename template including '{{i}}' macro to ensure unique filenames when writing multiple files. Appending '{{i}}' macro to the end of the file. For more details on the expected filename template checkout PyArrow's `write_to_dataset` API\u001b[32m [repeated 6x across cluster]\u001b[0m\n",
-      "2025-08-22 00:29:24,485\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_83_0 execution finished in 13.88 seconds\n",
-      "2025-08-22 00:29:24,531\tINFO dataset.py:4621 -- Data sink Parquet finished. 720 rows and 1.5MB data written.\n"
+      "\u001b[36m(MapWorker(MapBatches(EmbedImages)) pid=23307, ip=10.0.5.252)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\u001b[32m [repeated 4x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)\u001b[0m\n",
+      "2025-08-28 05:07:33,184\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_25_0 execution finished in 12.41 seconds\n",
+      "2025-08-28 05:07:33,214\tINFO dataset.py:4871 -- Data sink Parquet finished. 720 rows and 1.5MB data written.\n"
      ]
     }
    ],
@@ -941,21 +917,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:29:25,511\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_85_0\n",
-      "2025-08-22 00:29:25,523\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_85_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-08-22 00:29:25,524\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_85_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)] -> LimitOperator[limit=3]\n"
+      "2025-08-28 05:07:34,380\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_27_0\n",
+      "2025-08-28 05:07:34,394\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_27_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:07:34,395\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_27_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)] -> LimitOperator[limit=3]\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c596b6e4878f41a9ac527bfb3925c95e",
+       "model_id": "a81b12e57aba4dc3b16c2fafcb91cade",
        "version_major": 2,
        "version_minor": 0
       },
@@ -969,7 +939,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "124f996b75cd452d89bb404100035d45",
+       "model_id": "c176ff7a83b54b9b99fc7f5dc12e92c7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -983,7 +953,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f76037bae4334040bf81176c7ddab96d",
+       "model_id": "59f86a3defeb41de9be9874b6ae8a234",
        "version_major": 2,
        "version_minor": 0
       },
@@ -997,7 +967,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "323cdef1b95f405da16d7478a2295072",
+       "model_id": "1acb1ef77faf42119ee3702dcaa2bcd7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1011,7 +981,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2f9da19c9b7046b68d748780426d7886",
+       "model_id": "59526fe14e3a41cd8abb44b306127a7d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1025,7 +995,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3ff417b842ae472f8ef0e640443d3897",
+       "model_id": "98c20dcbec0b4cb8871a4635a3d02815",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1039,7 +1009,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b3b34ef888164ae8a618828d9832fd8f",
+       "model_id": "09f2cbe0afe04bc1a046e4e45a387fc1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1054,19 +1024,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(_MapWorker pid=4911, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
-      "2025-08-22 00:29:36,437\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_85_0 execution finished in 10.91 seconds\n",
-      "/tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\n",
+      "\u001b[36m(MapWorker(MapBatches(EmbedImages)) pid=26114, ip=10.0.5.252)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
+      "2025-08-28 05:07:45,755\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_27_0 execution finished in 11.36 seconds\n",
+      "/tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\n",
       "  tensor_batch[key] = torch.as_tensor(\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'embedding': tensor([[ 0.4219,  0.3688, -0.1833,  ...,  0.6288,  0.2298, -0.3989],\n",
-       "         [ 0.0385,  0.3297,  0.2076,  ...,  0.3434, -0.5492,  0.0362],\n",
-       "         [ 0.1881,  0.1737, -0.3069,  ...,  0.3336,  0.1783, -0.0299]]),\n",
-       " 'label': tensor([11, 34,  7])}"
+       "{'embedding': tensor([[ 0.0245,  0.6505,  0.0627,  ...,  0.4001, -0.2721, -0.0673],\n",
+       "         [-0.2416,  0.2315,  0.0255,  ...,  0.4065,  0.2805, -0.1156],\n",
+       "         [-0.2301, -0.3628,  0.1086,  ...,  0.3038,  0.0543,  0.6214]]),\n",
+       " 'label': tensor([10, 29, 27])}"
       ]
      },
      "execution_count": null,
@@ -1321,7 +1291,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/datasource/parquet_datasource.py:750: FutureWarning: The default `file_extensions` for `read_parquet` will change from `None` to ['parquet'] after Ray 2.43, and your dataset contains files that don't match the new `file_extensions`. To maintain backwards compatibility, set `file_extensions=None` explicitly.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "# Load preprocessed datasets.\n",
     "preprocessed_train_ds = ray.data.read_parquet(preprocessed_train_path)\n",
@@ -1349,2375 +1328,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(TrainController pid=125066)\u001b[0m [State Transition] INITIALIZING -> SCHEDULING.\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m Attempting to start training worker group of size 4 with the following resources: [{'CPU': 8, 'GPU': 2, 'accelerator_type:T4': 0.001}] * 4\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(autoscaler +3m40s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 1 to 2).\n",
-      "\u001b[36m(autoscaler +3m40s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +3m45s)\u001b[0m [autoscaler] Cluster upscaled to {112 CPU, 8 GPU}.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(TrainController pid=125066)\u001b[0m Retrying the launch of the training worker group. The previous launch attempt encountered the following failure:\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m The worker group startup timed out after 30.0 seconds waiting for 4 workers. Potential causes include: (1) temporary insufficient cluster resources while waiting for autoscaling (ignore this warning in this case), (2) infeasible resource request where the provided `ScalingConfig` cannot be satisfied), and (3) transient network issues. Set the RAY_TRAIN_WORKER_GROUP_START_TIMEOUT_S environment variable to increase the timeout.\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m [State Transition] SCHEDULING -> RESCHEDULING.\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m [State Transition] RESCHEDULING -> SCHEDULING.\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m Attempting to start training worker group of size 4 with the following resources: [{'CPU': 8, 'GPU': 2, 'accelerator_type:T4': 0.001}] * 4\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(autoscaler +4m30s)\u001b[0m [autoscaler] Cluster upscaled to {160 CPU, 12 GPU}.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(RayTrainWorker pid=3319, ip=10.0.34.27)\u001b[0m Setting up process group for: env:// [rank=0, world_size=4]\n",
-      "\u001b[36m(RayTrainWorker pid=16056, ip=10.0.4.102)\u001b[0m Moving model to device: cuda:0\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m Started training worker group of size 4: \n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m - (ip=10.0.34.27, pid=3319) world_rank=0, local_rank=0, node_rank=0\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m - (ip=10.0.34.27, pid=3320) world_rank=1, local_rank=1, node_rank=0\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m - (ip=10.0.4.102, pid=16056) world_rank=2, local_rank=0, node_rank=1\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m - (ip=10.0.4.102, pid=16055) world_rank=3, local_rank=1, node_rank=1\n",
-      "\u001b[36m(TrainController pid=125066)\u001b[0m [State Transition] SCHEDULING -> RUNNING.\n",
-      "\u001b[36m(RayTrainWorker pid=3319, ip=10.0.34.27)\u001b[0m 2025/08/22 00:32:11 INFO mlflow.tracking.fluent: Experiment with name 'doggos' does not exist. Creating a new experiment.\n",
-      "\u001b[36m(RayTrainWorker pid=16056, ip=10.0.4.102)\u001b[0m Wrapping provided model in DistributedDataParallel.\n",
-      "\u001b[36m(RayTrainWorker pid=3319, ip=10.0.34.27)\u001b[0m /home/ray/anaconda3/lib/python3.12/site-packages/ray/data/iterator.py:445: RayDeprecationWarning: Passing a function to `iter_torch_batches(collate_fn)` is deprecated in Ray 2.47. Please switch to using a callable class that inherits from `ArrowBatchCollateFn`, `NumpyBatchCollateFn`, or `PandasBatchCollateFn`.\n",
-      "\u001b[36m(RayTrainWorker pid=3319, ip=10.0.34.27)\u001b[0m   warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2f9b807b07e24754b872e832186a7ecc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "477c2f56fd9e4c31974d33eec3c722a0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3b3d7e99c85a496ebad1cba791a6bcd1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2263907df3504600a2281cb5bb1feb81",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Registered dataset logger for dataset train_88_0\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Starting execution of Dataset train_88_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Execution plan of Dataset train_88_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> OutputSplitter[split(4, equal=True)]\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m ⚠️  Ray's object store is configured to use only 28.5% of available memory (195.9GB out of 687.2GB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n",
-      "\u001b[36m(RayTrainWorker pid=16056, ip=10.0.4.102)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\n",
-      "\u001b[36m(RayTrainWorker pid=3319, ip=10.0.34.27)\u001b[0m Moving model to device: cuda:0\n",
-      "\u001b[36m(RayTrainWorker pid=3319, ip=10.0.34.27)\u001b[0m Wrapping provided model in DistributedDataParallel.\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m ✔️  Dataset train_88_0 execution finished in 2.84 seconds\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dbfdddd23f0a43658486e78ef5db13ec",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4a0cd95efca346bcbd9c962648fb8d18",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d0c2a55758742729e3e4c41aff6daf7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fbab3701238a4fc3a295d6116e1908f4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8cca0efc0fdf42309956588e2ebad8d9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c4a5eedd70c540c68156ae60bd821773",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "692887626f444deaa309ee332a270796",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "364d9c81b14d44b18703999214217018",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(RayTrainWorker pid=16055, ip=10.0.4.102)\u001b[0m /home/ray/anaconda3/lib/python3.12/site-packages/ray/data/iterator.py:445: RayDeprecationWarning: Passing a function to `iter_torch_batches(collate_fn)` is deprecated in Ray 2.47. Please switch to using a callable class that inherits from `ArrowBatchCollateFn`, `NumpyBatchCollateFn`, or `PandasBatchCollateFn`.\u001b[32m [repeated 3x across cluster]\u001b[0m\n",
-      "\u001b[36m(RayTrainWorker pid=16055, ip=10.0.4.102)\u001b[0m   warnings.warn(\u001b[32m [repeated 3x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Registered dataset logger for dataset train_88_1\u001b[32m [repeated 2x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Starting execution of Dataset train_88_1. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\u001b[32m [repeated 2x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Execution plan of Dataset train_88_1: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> OutputSplitter[split(4, equal=True)]\u001b[32m [repeated 2x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125822)\u001b[0m ⚠️  Ray's object store is configured to use only 28.5% of available memory (195.9GB out of 687.2GB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c94637fd36f7408887c53978632c81d6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d9c770c92271481e824deabb97479d02",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e9394ea598c44b8eaed72c3a567e8f80",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78f5d148c07843d6ba79aa4443fac4c2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f3c0cca34393418db7a85bf3b5da8de0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1cf9d449bed34bd58633604913c4b6da",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0f9207fa9fe74fb480d20ab6792412e8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d2d38403e0ea479c8745ba86e479e5b6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9245ec966b7142a39ccc3fb881ea1895",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "547f6b9e985a4fbf942e01dd9687245d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "03a5c5eeddbc4c0dbc4b2ae694a2cf23",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a12199d167f24ecab2b9dfe37adafee1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f4a3036c6d42495db3704671a5913e97",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(RayTrainWorker pid=3320, ip=10.0.34.27)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 3x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125822)\u001b[0m ✔️  Dataset val_89_2 execution finished in 0.14 seconds\u001b[32m [repeated 5x across cluster]\u001b[0m\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8daad09e465a4c95b282f6bff58488c4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1c61f75ca7ca467c8995ea64d5fbe622",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9686329d65264f15b583f6a26966ca46",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f06b9dd78b594b3e8abbede8e584d6f6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2dac4a6c6b69497cbfb1c2730ae4c84b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "310c75a42eef4481bf92376c8225732a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "19eca161119f4c38839e2b2ff2a4bb36",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "59f241a3d0364ebbbae4e7a5a94037a5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7c6147789fbc4007bbc309f7537782fa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ae5a1436d1e148cdb8a4aac594e2ee5a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0e6c03e36b9b4373b9e61c5e73e3943a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5d154effa9e84089b1fac7bc66574802",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e8ce7b2eef094a078cb3b516e6d381d2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fc4f18d5ca0747f49cb7d070fa984f13",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8a02cba1818049cabd118a8cb4ad16fd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2faf9980bf2f44d98a4ba61cd943ca2e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "17eb0e1b001444d5b9b089e3540143ed",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c614080c873a4658b47a79ea793ec211",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "59bed3f576ba412091b1431810674dc1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6c28eaa475dd461c9a4c3524ab635758",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4a396b6c1f8243b289ac96f5b8c5e354",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b7a446b66d4447c68b6cd69ae370aec9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fff93ed630644210b0e7fdb218c0fba4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df70761adc79445ea206305bdbef50fa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e9917e5b9629429eb6423cb23d1ac8ca",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "02466fb2e05e40f781ba101d2e1c5394",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cba46412a0e1470093b37dd44571c867",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d5c3e448d3254eb2bd6ac87c2ee60ff7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4a46866464514d189d040bff9c170371",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f77002b71fd641f79a0b1320045ce8bf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1b58d2b8f06c4d688d1062b11ab9ad1c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(SplitCoordinator pid=125822)\u001b[0m Registered dataset logger for dataset val_89_6\u001b[32m [repeated 11x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125822)\u001b[0m Starting execution of Dataset val_89_6. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\u001b[32m [repeated 11x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125822)\u001b[0m Execution plan of Dataset val_89_6: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> OutputSplitter[split(4, equal=True)]\u001b[32m [repeated 11x across cluster]\u001b[0m\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "072e8ee325c546f1ae10cb085631db3e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a0ed51b8f63d43c3a75bd861e63d4e23",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a0f4b65c405644829fd3e560487979ba",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1743714b36eb4c3a9e066854bc55e9a0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c91384d8ab642eda0883c097edeea4f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "abfa908329d34ee192c35a5aec2b38b0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8c1c6421140e4ea99f06bd917697fadf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6ce5252ebcb244fa9493dde86699516f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f8a34c741f594ef89fd99172e59a34c5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9cb4841bc8fa49448e31612719799b03",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "50f1a2962113459884deef4975308b07",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "59ec7aee99934c6bbc3c73a093e3b4fe",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a1bc4dd100464a549bc322eedf97512f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f9be5454b006445d8a75769c7264d770",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "82326f0ca01b4f5c92731f21a14e7bbb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2ce3abb1f2ac4320a05ab07b9e530679",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "774c642be6a143e482201d2a60b4f725",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ea41e9ce5d4749269ab068ee3fc4c3f1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fdeb575b9f12491d85437877bf16b0f0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "05fdb6464b7542bd894d27043329da01",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6cbeb9d41ce746e6af9f74ea3db2dd58",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe06543c2f074c4a8778f11d493b40f6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c35a3a74fb4a42eaba77b7c9bf57835f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aec3501a42bf4e7488ef6d6fdf931b7c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "838a6b8cb0f8462bafd777ba17ca0145",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2735cdc36bb34dd68340fbbe8e4a007d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bb69d8033e3e44fcba6bd2c12b076344",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c8de0eb20bc34c7799e701bd8dfdf093",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(SplitCoordinator pid=125822)\u001b[0m ✔️  Dataset val_89_9 execution finished in 0.12 seconds\u001b[32m [repeated 14x across cluster]\u001b[0m\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "94b5b81bb4d549ff852bb292d5eabe0a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1f2a660cfbe5483683fdaa6de6e83731",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ed36ce7aeeba40bea644c1ec216917cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7f549b806ec443fab242e9734063166f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5ca785575831425182c8606cef4c22ed",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "44e5707abbc545e3b52a327e338d42c8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8f2719cac015410883ffbb3e5bf95f35",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a19c11e6356345c2b1e255492d1c1077",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "21ba9584d021403dacca550bb11ee8a2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "63be175948ae4d41b17c7a4c2c3de9d9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3cb193c2285649bd8f987b98ae9b4705",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1d227a26a0514824a0ea7c2964688e6b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "543c26f1127447cf90765a009caf2b67",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2bc02cb3fe2846f983128f974a822fba",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f71f650ff2884e8fa4538cd059a7408f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6fa5b191ae2c45d2a0dac2f718cbed08",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1bc7f991b39444bcaed694e25020c82e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0c7df79581f94f4eb66f0fcb95260e1e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "adab6b6ea3ca44f6be524a1deb1ef639",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e757b1e650e04c6abf451db64a698bb5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c042c13431d34e08bfbd78e31d3d5de6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d09c9c885b60411fa6331b4cbb0725dc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ce85530f583f4b40a46ac81f83abeb36",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "236a34616ba048bbb2695c5aaf9416f5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "24fca83b96a842318cf502782e1ed1b6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "057b1ec3b01a478f80a58686bd171735",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4f862da0dfbb45e5a60f80b9636e071b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "58a97c021f5a49e69202f99f38bad1c0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d7eb25150fb74086a63d7fe5ac160cb1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f17b808f250d41929e4870bb83fc477c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "feb8925122f74f11a0b4d406549a8998",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9cb0e78fa32d417bbd237ea1b790ad86",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aae13b8832ff40c4a768e08fc1489292",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8663407dc9a745408be1707fdcb3de64",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1f3fe18d3a114499bb0e8aedc9087516",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dde2396c4c4743828a5b45b5ae8dd077",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c28151437dc45b19eea8a774a565d54",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d4da9d395b3b40b7beaf40f96b020e4d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "72f25e200d844c3c8fb2e46bceba5e0e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "745b8abd99a148cfb35a207634053f68",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Registered dataset logger for dataset train_88_15\u001b[32m [repeated 17x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Starting execution of Dataset train_88_15. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\u001b[32m [repeated 17x across cluster]\u001b[0m\n",
-      "\u001b[36m(SplitCoordinator pid=125821)\u001b[0m Execution plan of Dataset train_88_15: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> OutputSplitter[split(4, equal=True)]\u001b[32m [repeated 17x across cluster]\u001b[0m\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ea923fad3a6b427e95fc73aca1de7d0b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ee86e41631394e14a447e76d51b0b55b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b1b038c8a53f437b962ea4b2728f7ee2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ab1e205e2d2a4e40b0399497be2d3eaf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b0bc3fcded44cbcada0d64d6c03dd9c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c90593c23a5342cb9fb45b59a6d23954",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c01556845fd474abd85d9bf39424908",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c35afae5f34c43b88d1461be949ab7e2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "63741d7ac05b462893c79533aab90adb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e9a9894f3518447c8d977460cde7fd2b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a198c557b1e84c15975bafcc67ca2501",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6cfd359d3fc24709933a740eb38fe408",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2dd17bebcef148bfb4267274ea6538bf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6381b5c191cd4a608067dad981936f29",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e54bd73a22084efaa21246f9ab88be18",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "efe59371cb0b40489158ba929bfcadd9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d0fb221f5fb4f1c865fb2d383f3f66f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ee62c3c15ec5423baf0613424d66b960",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3d1adb75395c4367ac14d510c6f9e891",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4cd34884675440ffafd0334783920856",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "472913bf0ccb485b90de55a05501629f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "81d1e24ae643455d92707226660390fe",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a7f776485f714d66922fffe6f75d4aeb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c753d595da314ff687d8357a56484ac2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ffd47b8311b44a6d9ef72e99ebda6b3e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "99cf3b9ba6c042a39dafe5cef3e49349",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "644e2243a1724d40bc6ad9ac5cd349b0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "933dc5a56bd64ee69ba1bd23c806c434",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "59a2b83763e04146aeec9edacaf72ed8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "801a70882a9546b1b9c2e7998178d6cf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "526adc86f7674fae8b0e44cde52fd920",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18414e84c96048a196a579fe5e5cdf79",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125821) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(SplitCoordinator pid=125822)\u001b[0m ✔️  Dataset val_89_18 execution finished in 0.12 seconds\u001b[32m [repeated 18x across cluster]\u001b[0m\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1e1a34e9e96c4109b1ff5b38e23eef3d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) Running 0: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c377ec61738f42dfa1ee8638ce0fb4ed",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ListFiles 1: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "086c0e1c3c8443659adcdb4d5ec55d85",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - ReadFiles 2: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f7fe6c34adb44a4780cb4c7f320ab3f4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "(pid=125822) - split(4, equal=True) 3: 0.00 row [00:00, ? row/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(TrainController pid=125066)\u001b[0m [State Transition] RUNNING -> FINISHED.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Train.\n",
     "results = trainer.fit()\n"
@@ -3784,31 +1395,31 @@
     {
      "data": {
       "text/plain": [
-       "run_id                                      fcb9ef8c96f844f08bcd0185601f3dbd\n",
-       "experiment_id                                             858816514880031760\n",
+       "run_id                                      d54aa07059384d139ea572123ae9409c\n",
+       "experiment_id                                             653138458592289747\n",
        "status                                                              FINISHED\n",
-       "artifact_uri               file:///mnt/cluster_storage/mlflow/doggos/8588...\n",
-       "start_time                                  2025-08-22 00:32:11.522000+00:00\n",
-       "end_time                                    2025-08-22 00:32:32.895000+00:00\n",
-       "metrics.train_loss                                                   0.35504\n",
-       "metrics.val_loss                                                    0.593301\n",
+       "artifact_uri               file:///mnt/cluster_storage/mlflow/doggos/6531...\n",
+       "start_time                                  2025-08-28 05:10:15.049000+00:00\n",
+       "end_time                                    2025-08-28 05:10:33.936000+00:00\n",
        "metrics.lr                                                             0.001\n",
-       "params.lr_patience                                                         3\n",
-       "params.dropout_p                                                         0.3\n",
-       "params.num_epochs                                                         20\n",
-       "params.lr                                                              0.001\n",
-       "params.num_classes                                                        36\n",
+       "metrics.val_loss                                                    0.778273\n",
+       "metrics.train_loss                                                   0.39104\n",
+       "params.lr_factor                                                         0.8\n",
        "params.hidden_dim                                                        256\n",
+       "params.embedding_dim                                                     512\n",
+       "params.dropout_p                                                         0.3\n",
        "params.experiment_name                                                doggos\n",
        "params.batch_size                                                        256\n",
+       "params.lr                                                              0.001\n",
+       "params.num_classes                                                        36\n",
+       "params.class_to_label      {'pomeranian': 0, 'rottweiler': 1, 'boxer': 2,...\n",
+       "params.num_epochs                                                         20\n",
+       "params.lr_patience                                                         3\n",
        "params.model_registry                     /mnt/cluster_storage/mlflow/doggos\n",
-       "params.class_to_label      {'border_collie': 0, 'pomeranian': 1, 'basset'...\n",
-       "params.lr_factor                                                         0.8\n",
-       "params.embedding_dim                                                     512\n",
-       "tags.mlflow.user                                                         ray\n",
-       "tags.mlflow.source.type                                                LOCAL\n",
-       "tags.mlflow.runName                                      enthused-donkey-931\n",
        "tags.mlflow.source.name    /home/ray/anaconda3/lib/python3.12/site-packag...\n",
+       "tags.mlflow.source.type                                                LOCAL\n",
+       "tags.mlflow.runName                                      judicious-panda-916\n",
+       "tags.mlflow.user                                                         ray\n",
        "Name: 0, dtype: object"
       ]
      },
@@ -3856,12 +1467,12 @@
      "output_type": "stream",
      "text": [
       "Output\n",
-      "(anyscale +0.9s) Submitting job with config JobConfig(name='train-image-model', image_uri='anyscale/ray:2.48.0-slim-py312-cu128', compute_config=None, env_vars=None, py_modules=['/home/ray/default/doggos'], py_executable=None, cloud=None, project=None, ray_version=None, job_queue_config=None).\n",
-      "(anyscale +2.8s) Uploading local dir '/home/ray/default' to cloud storage.\n",
-      "(anyscale +4.3s) Uploading local dir '/home/ray/default/doggos' to cloud storage.\n",
-      "(anyscale +5.4s) Job 'train-image-model' submitted, ID: 'prodjob_ac1sxbql2i2vah66k2462bhxie'.\n",
-      "(anyscale +5.4s) View the job in the UI: https://console.anyscale.com/jobs/prodjob_ac1sxbql2i2vah66k2462bhxie\n",
-      "(anyscale +5.4s) Use `--wait` to wait for the job to run and stream logs.\n"
+      "(anyscale +0.8s) Submitting job with config JobConfig(name='train-image-model', image_uri='anyscale/ray:2.48.0-slim-py312-cu128', compute_config=None, env_vars=None, py_modules=['/home/ray/default/doggos'], py_executable=None, cloud=None, project=None, ray_version=None, job_queue_config=None).\n",
+      "(anyscale +3.0s) Uploading local dir '/home/ray/default' to cloud storage.\n",
+      "(anyscale +3.8s) Uploading local dir '/home/ray/default/doggos' to cloud storage.\n",
+      "(anyscale +4.9s) Job 'train-image-model' submitted, ID: 'prodjob_zfy5ak9a5masjb4vuidtxvxpqt'.\n",
+      "(anyscale +4.9s) View the job in the UI: https://console.anyscale.com/jobs/prodjob_zfy5ak9a5masjb4vuidtxvxpqt\n",
+      "(anyscale +4.9s) Use `--wait` to wait for the job to run and stream logs.\n"
      ]
     }
    ],
@@ -3966,15 +1577,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:34:12,802\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_96_0\n",
-      "2025-08-22 00:34:12,814\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_96_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "2025-08-22 00:34:12,815\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_96_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)] -> TaskPoolMapOperator[MapBatches(TorchPredictor)] -> LimitOperator[limit=1]\n"
+      "2025-08-28 05:10:42,369\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_40_0\n",
+      "2025-08-28 05:10:42,388\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_40_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:10:42,388\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_40_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)] -> TaskPoolMapOperator[MapBatches(TorchPredictor)] -> LimitOperator[limit=1]\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "50d1c62a744146a398da57614e787e8c",
+       "model_id": "9c8deb98ca3d40cd8aea0fdaaa3abadc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3988,7 +1599,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b2d9b9453d0f40928a76a188f7a30eb4",
+       "model_id": "34c194e15c044a308d3d89e3c99414be",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4002,7 +1613,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "85b1f60100d8451995792b7da3f8ac83",
+       "model_id": "7c6efd5cc49744a594a647449d67e6c5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4016,7 +1627,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d6f46bc81e674ba38e39f807dae62551",
+       "model_id": "e9edf72e22d64cf6adaeda87459d0c0b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4030,7 +1641,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9133c6ae847f4d52955482803d33c67f",
+       "model_id": "1fd89ff72f0e42689114fc21b8748658",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4044,7 +1655,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9ecc392709b442f4b123fcad7fc7e60b",
+       "model_id": "984b6bbdeaee4207aaa18b88cbaa2691",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4058,7 +1669,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5df8844d4afa424f8e750c4b362e3667",
+       "model_id": "6dca7e9346d34396b3d758f7e8eb34f6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4072,7 +1683,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d2838a72543d43f4a41520dc98f9dd57",
+       "model_id": "cd539308a7ef471f927d664745cebb49",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4087,26 +1698,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(_MapWorker pid=18066, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(autoscaler +8m20s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
-      "\u001b[36m(autoscaler +8m25s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB|g4dn.2xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n",
-      "\u001b[36m(autoscaler +8m25s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB] Attempting to add 1 node to the cluster (increasing from 1 to 2).\n",
-      "\u001b[36m(autoscaler +8m30s)\u001b[0m [autoscaler] [4xT4:48CPU-192GB|g4dn.12xlarge] [us-west-2a] [on-demand] Launched 1 instance.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(MapBatches(TorchPredictor) pid=19185, ip=10.0.4.102)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\n",
-      "\u001b[36m(_MapWorker pid=18062, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\u001b[32m [repeated 3x across cluster]\u001b[0m\n",
-      "2025-08-22 00:34:50,050\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_96_0 execution finished in 37.23 seconds\n"
+      "\u001b[36m(MapWorker(MapBatches(EmbedImages)) pid=33395, ip=10.0.5.252)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=34104, ip=10.0.5.252)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\n",
+      "\u001b[36m(MapWorker(MapBatches(EmbedImages)) pid=6674, ip=10.0.5.20)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\u001b[32m [repeated 3x across cluster]\u001b[0m\n",
+      "2025-08-28 05:10:59,374\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_40_0 execution finished in 16.98 seconds\n"
      ]
     },
     {
@@ -4114,7 +1709,7 @@
       "text/plain": [
        "[{'path': 'doggos-dataset/test/basset/basset_10005.jpg',\n",
        "  'class': 'basset',\n",
-       "  'label': 2,\n",
+       "  'label': 30,\n",
        "  'embedding': array([ 8.86104554e-02, -5.89382686e-02,  1.15464866e-01,  2.15815112e-01,\n",
        "         -3.43266308e-01, -3.35150540e-01,  1.48883224e-01, -1.02369718e-01,\n",
        "         -1.69915810e-01,  4.34856862e-03,  2.41593361e-01,  1.79200619e-01,\n",
@@ -4292,21 +1887,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:34:50,290\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_99_0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-08-22 00:34:50,303\tINFO streaming_executor.py:117 -- Starting execution of Dataset dataset_99_0. Full logs are in /tmp/ray/session_2025-08-21_18-48-13_464408_2298/logs/ray-data\n",
-      "2025-08-22 00:34:50,304\tINFO streaming_executor.py:118 -- Execution plan of Dataset dataset_99_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)] -> TaskPoolMapOperator[MapBatches(TorchPredictor)] -> TaskPoolMapOperator[MapBatches(batch_metric)] -> AllToAllOperator[Aggregate] -> LimitOperator[limit=1]\n"
+      "2025-08-28 05:10:59,627\tINFO logging.py:295 -- Registered dataset logger for dataset dataset_43_0\n",
+      "2025-08-28 05:10:59,639\tINFO streaming_executor.py:159 -- Starting execution of Dataset dataset_43_0. Full logs are in /tmp/ray/session_2025-08-28_04-57-43_348032_12595/logs/ray-data\n",
+      "2025-08-28 05:10:59,640\tINFO streaming_executor.py:160 -- Execution plan of Dataset dataset_43_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> TaskPoolMapOperator[ReadFiles] -> TaskPoolMapOperator[Map(add_class)->Map(convert_to_label)] -> ActorPoolMapOperator[MapBatches(EmbedImages)] -> TaskPoolMapOperator[MapBatches(drop_columns)] -> TaskPoolMapOperator[MapBatches(TorchPredictor)] -> TaskPoolMapOperator[MapBatches(batch_metric)] -> AllToAllOperator[Aggregate] -> LimitOperator[limit=1]\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1bf87bfd70924161a7f4f956a92eb23f",
+       "model_id": "d6accaaab88244f09ad25c06860ef15f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4320,7 +1909,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2114df52a7ac4646aabfda7f7802a648",
+       "model_id": "b5716638e4bf437399f7192ed356d610",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4334,7 +1923,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d889fe01be0545939617a037455180df",
+       "model_id": "d691aeac306d4249ad7cb71172b81f5c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4348,7 +1937,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e8b23a2321514f21a50825b660f670bf",
+       "model_id": "f9175ec54ce64fd18afcc7d2b31b2e4b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4362,7 +1951,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "627c443e2450449c8683775fc89d7a8f",
+       "model_id": "ac75a05d32484b918a46a7c082a6c88a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4376,7 +1965,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d41291adfbf4c86817b203dc9e6f181",
+       "model_id": "e0f1ce17c2c54a9ea96762fc0004c543",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4390,7 +1979,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a2831719e1324270a3662420aff4c1e0",
+       "model_id": "b3fccdab34974505a9b518ff286f390f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4404,7 +1993,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "120a18eec3a64dfda631fa6dbff06232",
+       "model_id": "3d9e617f49b847a0891fbbdb5185aae6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4418,7 +2007,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18834b310df94e338ad7ad76aaf77ec5",
+       "model_id": "52a0cd72c7be435894e9ad1981c50301",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4432,7 +2021,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "898fc65b6d6e491f9bd6dd33572f0d6d",
+       "model_id": "000b77243d824ddf8a2c199357ce6cf1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4446,7 +2035,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7c7712b3872448c49f04dd6ed1af48f6",
+       "model_id": "51122559786d45c8856839c1818a7158",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4460,7 +2049,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "970b96aca5db4f1aab1e487105e61cae",
+       "model_id": "361ff1a618994ef2819407518534ecd7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4474,7 +2063,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aecfe233dbf249b7ab34fc9d26184bc5",
+       "model_id": "20681d4878dd485e8ca817c2ee333ccc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4489,35 +2078,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(_MapWorker pid=19193, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
-      "\u001b[36m(_MapWorker pid=25926, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\u001b[32m [repeated 2x across cluster]\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(autoscaler +9m10s)\u001b[0m [autoscaler] Cluster upscaled to {120 CPU, 9 GPU}.\n",
-      "\u001b[36m(autoscaler +9m15s)\u001b[0m [autoscaler] Cluster upscaled to {168 CPU, 13 GPU}.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(MapBatches(TorchPredictor) pid=2582, ip=10.0.31.199)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\n",
-      "\u001b[36m(_MapWorker pid=27577, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=2578, ip=10.0.31.199)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=2576, ip=10.0.31.199)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=3977, ip=10.0.60.138)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 3x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=4229, ip=10.0.60.138)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 2x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=2579, ip=10.0.31.199)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=2581, ip=10.0.31.199)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=5094, ip=10.0.60.138)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=5289, ip=10.0.60.138)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=5548, ip=10.0.60.138)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
-      "\u001b[36m(MapBatches(TorchPredictor) pid=5816, ip=10.0.60.138)\u001b[0m /tmp/ipykernel_120810/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
-      "2025-08-22 00:38:03,968\tINFO streaming_executor.py:231 -- ✔️  Dataset dataset_99_0 execution finished in 193.66 seconds\n"
+      "\u001b[36m(MapWorker(MapBatches(EmbedImages)) pid=34103, ip=10.0.5.252)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=8149, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\n",
+      "\u001b[36m(MapWorker(MapBatches(EmbedImages)) pid=40389, ip=10.0.5.252)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\u001b[32m [repeated 3x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=8263, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=8340, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=17879, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=18144, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=18411, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=18682, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=18950, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=19219, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "\u001b[36m(MapBatches(TorchPredictor) pid=19564, ip=10.0.5.20)\u001b[0m /tmp/ipykernel_31027/417303983.py:6: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)\u001b[32m [repeated 4x across cluster]\u001b[0m\n",
+      "2025-08-28 05:12:20,741\tINFO streaming_executor.py:279 -- ✔️  Dataset dataset_43_0 execution finished in 81.10 seconds\n"
      ]
     }
    ],
@@ -4552,101 +2125,6 @@
       "Recall: 0.84\n",
       "F1: 0.84\n",
       "Accuracy: 0.98\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(autoscaler +13m0s)\u001b[0m [autoscaler] Downscaling node i-0ffe5abae6e899f5a (node IP: 10.0.60.138) due to node idle termination.\n",
-      "\u001b[36m(autoscaler +13m5s)\u001b[0m [autoscaler] Cluster resized to {120 CPU, 9 GPU}.\n",
-      "\u001b[36m(autoscaler +16m0s)\u001b[0m [autoscaler] Downscaling node i-0aa72cef9b8921af5 (node IP: 10.0.31.199) due to node idle termination.\n",
-      "\u001b[36m(autoscaler +16m5s)\u001b[0m [autoscaler] Cluster resized to {112 CPU, 8 GPU}.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Using CPython 3.12.11 interpreter at: /home/ray/anaconda3/bin/python3.12\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Creating virtual environment at: .venv\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m    Building doggos @ file:///tmp/ray/session_2025-08-21_18-48-13_464408_2298/runtime_resources/working_dir_files/_ray_pkg_f79228c33bd2a431/doggos\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pillow (6.3MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading grpcio (5.9MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading sqlalchemy (3.2MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pydantic-core (1.9MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading jedi (1.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading virtualenv (5.7MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pandas (11.4MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading setuptools (1.1MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading uvloop (4.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading nvidia-cuda-nvrtc-cu12 (22.6MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading sympy (6.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading numpy (15.9MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading kiwisolver (1.4MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading tokenizers (3.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pyarrow (38.2MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading botocore (13.3MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading fonttools (4.7MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading widgetsnbextension (2.1MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading mlflow-skinny (5.6MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading aiohttp (1.6MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading networkx (1.9MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading pygments (1.2MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading debugpy (4.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading py-spy (2.6MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading scikit-learn (12.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading hf-xet (3.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading matplotlib (8.2MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading torch (783.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading transformers (10.0MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading scipy (33.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading polars (36.7MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading mlflow (26.1MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Downloading triton (148.5MiB)\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m       Built doggos @ file:///tmp/ray/session_2025-08-21_18-48-13_464408_2298/runtime_resources/working_dir_files/_ray_pkg_f79228c33bd2a431/doggos\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pillow\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading grpcio\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading sqlalchemy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pydantic-core\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading jedi\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading virtualenv\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading setuptools\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading uvloop\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cuda-cupti-cu12\u001b[32m [repeated 13x across cluster]\u001b[0m\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading sympy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading kiwisolver\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading tokenizers\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading fonttools\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading widgetsnbextension\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading mlflow-skinny\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading aiohttp\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading networkx\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pygments\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading debugpy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading py-spy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading hf-xet\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading matplotlib\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading transformers\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading scikit-learn\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading numpy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading botocore\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pandas\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading polars\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cuda-nvrtc-cu12\u001b[32m [repeated 2x across cluster]\u001b[0m\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading scipy\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading mlflow\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading pyarrow\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-curand-cu12\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cusparselt-cu12\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading triton\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cublas-cu12\u001b[32m [repeated 5x across cluster]\u001b[0m\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading torch\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m          If the cache and target directories are on different filesystems, hardlinking may not be supported.\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m          If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m  Downloading nvidia-cudnn-cu12\n",
-      "\u001b[33m(raylet, ip=10.0.4.102)\u001b[0m Installed 172 packages in 1.96s\n"
      ]
     }
    ],

--- a/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/03-Online-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/03-Online-Serving.ipynb
@@ -25,9 +25,9 @@
      "output_type": "stream",
      "text": [
       "\u001b[92mSuccessfully registered `ipywidgets, matplotlib` and 4 other packages to be installed on all cluster nodes.\u001b[0m\n",
-      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_1dp3fa7w5hu3i83ldsi7lqvp9t?workspace-tab=dependencies\u001b[0m\n",
+      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_23ry3pgfn3jgq2jk3e5z25udhz?workspace-tab=dependencies\u001b[0m\n",
       "\u001b[92mSuccessfully registered `doggos` package to be installed on all cluster nodes.\u001b[0m\n",
-      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_1dp3fa7w5hu3i83ldsi7lqvp9t?workspace-tab=dependencies\u001b[0m\n"
+      "\u001b[92mView and update dependencies here: https://console.anyscale.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/workspaces/expwrk_23ry3pgfn3jgq2jk3e5z25udhz?workspace-tab=dependencies\u001b[0m\n"
      ]
     }
    ],
@@ -278,26 +278,43 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 00:51:12,070\tINFO worker.py:1747 -- Connecting to existing Ray cluster at address: 10.0.52.10:6379...\n",
-      "2025-08-22 00:51:12,082\tINFO worker.py:1918 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-466hy7cqu1gzrp8zk8l4byz7l7.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
-      "2025-08-22 00:51:12,091\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_bb1ea558d334a00804951688d29c76ff051341cc.zip' (1.11MiB) to Ray cluster...\n",
-      "2025-08-22 00:51:12,096\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_bb1ea558d334a00804951688d29c76ff051341cc.zip'.\n",
-      "INFO 2025-08-22 00:51:12,153 serve 133557 -- Connecting to existing Serve app in namespace \"serve\". New http options will not be applied.\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:12,275 controller 61167 -- Deploying new version of Deployment(name='ClassPredictor', app='default') (initial target replicas: 1).\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:12,276 controller 61167 -- Deploying new version of Deployment(name='Doggos', app='default') (initial target replicas: 1).\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:12,400 controller 61167 -- Stopping 1 replicas of Deployment(name='ClassPredictor', app='default') with outdated versions.\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:12,401 controller 61167 -- Adding 1 replica to Deployment(name='ClassPredictor', app='default').\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:12,403 controller 61167 -- Stopping 1 replicas of Deployment(name='Doggos', app='default') with outdated versions.\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:12,404 controller 61167 -- Adding 1 replica to Deployment(name='Doggos', app='default').\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:12,489 controller 61167 -- Draining proxy on node '7cf4feced6fe6a3166528c758e7aea63f8414ff9b95e3f69304a0bbb'.\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:14,489 controller 61167 -- Replica(id='m8hm2lqw', deployment='ClassPredictor', app='default') is stopped.\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:14,491 controller 61167 -- Replica(id='r17z6dkp', deployment='Doggos', app='default') is stopped.\n",
-      "\u001b[36m(ServeReplica:default:Doggos pid=133722)\u001b[0m INFO 2025-08-22 00:51:14,611 default_Doggos 0qpk1kw9 -- Direct ingress is disabled, skipping direct ingress server start\n",
-      "\u001b[36m(ServeReplica:default:ClassPredictor pid=30024, ip=10.0.4.102)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
-      "\u001b[36m(ServeController pid=61167)\u001b[0m INFO 2025-08-22 00:51:19,249 controller 61167 -- No longer draining proxy on node '7cf4feced6fe6a3166528c758e7aea63f8414ff9b95e3f69304a0bbb'.\n",
-      "\u001b[36m(ServeReplica:default:ClassPredictor pid=30024, ip=10.0.4.102)\u001b[0m INFO 2025-08-22 00:51:21,500 default_ClassPredictor qtsnu3yv -- Direct ingress is disabled, skipping direct ingress server start\n",
-      "INFO 2025-08-22 00:51:22,301 serve 133557 -- Application 'default' is ready at http://127.0.0.1:8000/.\n",
-      "INFO 2025-08-22 00:51:22,313 serve 133557 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b374e3bef30>.\n"
+      "2025-08-28 05:15:38,455\tINFO worker.py:1771 -- Connecting to existing Ray cluster at address: 10.0.17.148:6379...\n",
+      "2025-08-28 05:15:38,465\tINFO worker.py:1942 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-jhxhj69d6ttkjctcxfnsfe7gwk.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
+      "2025-08-28 05:15:38,471\tINFO packaging.py:588 -- Creating a file package for local module '/home/ray/default/doggos/doggos'.\n",
+      "2025-08-28 05:15:38,475\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_62e649352ce105b6.zip' (0.04MiB) to Ray cluster...\n",
+      "2025-08-28 05:15:38,476\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_62e649352ce105b6.zip'.\n",
+      "2025-08-28 05:15:38,478\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_c3f5a1927d401ecc93333d17727d37c3401aeed9.zip' (1.08MiB) to Ray cluster...\n",
+      "2025-08-28 05:15:38,484\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_c3f5a1927d401ecc93333d17727d37c3401aeed9.zip'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(autoscaler +9s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ProxyActor pid=42150)\u001b[0m INFO 2025-08-28 05:15:42,208 proxy 10.0.17.148 -- Proxy starting on node 524d54fa7a3dfe7fcd55149e6efeaa7a697a4ce87282da72073206b6 (HTTP port: 8000).\n",
+      "INFO 2025-08-28 05:15:42,290 serve 41929 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=42150)\u001b[0m INFO 2025-08-28 05:15:42,286 proxy 10.0.17.148 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=42086)\u001b[0m INFO 2025-08-28 05:15:47,403 controller 42086 -- Deploying new version of Deployment(name='ClassPredictor', app='default') (initial target replicas: 1).\n",
+      "\u001b[36m(ServeController pid=42086)\u001b[0m INFO 2025-08-28 05:15:47,404 controller 42086 -- Deploying new version of Deployment(name='Doggos', app='default') (initial target replicas: 1).\n",
+      "\u001b[36m(ProxyActor pid=42150)\u001b[0m INFO 2025-08-28 05:15:47,423 proxy 10.0.17.148 -- Got updated endpoints: {Deployment(name='Doggos', app='default'): EndpointInfo(route='/', app_is_cross_language=False)}.\n",
+      "\u001b[36m(ProxyActor pid=42150)\u001b[0m WARNING 2025-08-28 05:15:47,430 proxy 10.0.17.148 -- ANYSCALE_RAY_SERVE_GRPC_RUN_PROXY_ROUTER_SEPARATE_LOOP has been deprecated and will be removed in the ray v2.50.0. Please use RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP instead.\n",
+      "\u001b[36m(ProxyActor pid=42150)\u001b[0m INFO 2025-08-28 05:15:47,434 proxy 10.0.17.148 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x79fb040771d0>.\n",
+      "\u001b[36m(ServeController pid=42086)\u001b[0m INFO 2025-08-28 05:15:47,524 controller 42086 -- Adding 1 replica to Deployment(name='ClassPredictor', app='default').\n",
+      "\u001b[36m(ServeController pid=42086)\u001b[0m INFO 2025-08-28 05:15:47,525 controller 42086 -- Adding 1 replica to Deployment(name='Doggos', app='default').\n",
+      "\u001b[36m(ServeReplica:default:ClassPredictor pid=20055, ip=10.0.5.20)\u001b[0m Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n",
+      "\u001b[36m(ProxyActor pid=20172, ip=10.0.5.20)\u001b[0m INFO 2025-08-28 05:15:56,055 proxy 10.0.5.20 -- Proxy starting on node b84e244dca75c40ea981202cae7a1a06df9598ac29ad2b18e1bedb99 (HTTP port: 8000).\n",
+      "\u001b[36m(ProxyActor pid=20172, ip=10.0.5.20)\u001b[0m INFO 2025-08-28 05:15:56,131 proxy 10.0.5.20 -- Got updated endpoints: {Deployment(name='Doggos', app='default'): EndpointInfo(route='/', app_is_cross_language=False)}.\n",
+      "\u001b[36m(ProxyActor pid=20172, ip=10.0.5.20)\u001b[0m WARNING 2025-08-28 05:15:56,137 proxy 10.0.5.20 -- ANYSCALE_RAY_SERVE_GRPC_RUN_PROXY_ROUTER_SEPARATE_LOOP has been deprecated and will be removed in the ray v2.50.0. Please use RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP instead.\n",
+      "\u001b[36m(ProxyActor pid=20172, ip=10.0.5.20)\u001b[0m INFO 2025-08-28 05:15:56,141 proxy 10.0.5.20 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x76c838542d80>.\n",
+      "INFO 2025-08-28 05:15:57,505 serve 41929 -- Application 'default' is ready at http://127.0.0.1:8000/.\n",
+      "INFO 2025-08-28 05:15:57,511 serve 41929 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7955d893cd70>.\n"
      ]
     },
     {
@@ -325,17 +342,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeReplica:default:ClassPredictor pid=30024, ip=10.0.4.102)\u001b[0m /home/ray/anaconda3/lib/python3.12/site-packages/ray/serve/_private/replica.py:1376: UserWarning: Calling sync method 'get_probabilities' directly on the asyncio loop. In a future version, sync methods will be run in a threadpool by default. Ensure your sync methods are thread safe or keep the existing behavior by making them `async def`. Opt into the new behavior by setting RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1.\n",
-      "\u001b[36m(ServeReplica:default:ClassPredictor pid=30024, ip=10.0.4.102)\u001b[0m   warnings.warn(\n",
-      "\u001b[36m(ServeReplica:default:Doggos pid=133722)\u001b[0m INFO 2025-08-22 00:51:22,490 default_Doggos 0qpk1kw9 daf11861-073e-4758-82b7-0b222066b668 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x72f86c539670>.\n"
+      "\u001b[36m(ServeReplica:default:Doggos pid=42244)\u001b[0m INFO 2025-08-28 05:15:57,646 default_Doggos fs1weamq 31c15b70-89a9-4b2d-b4ab-f8424fe6d8d2 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7ba028149fd0>.\n",
+      "\u001b[36m(ServeReplica:default:ClassPredictor pid=20055, ip=10.0.5.20)\u001b[0m /home/ray/anaconda3/lib/python3.12/site-packages/ray/serve/_private/replica.py:1397: UserWarning: Calling sync method 'get_probabilities' directly on the asyncio loop. In a future version, sync methods will be run in a threadpool by default. Ensure your sync methods are thread safe or keep the existing behavior by making them `async def`. Opt into the new behavior by setting RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1.\n",
+      "\u001b[36m(ServeReplica:default:ClassPredictor pid=20055, ip=10.0.5.20)\u001b[0m   warnings.warn(\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[('collie', 0.2292557954788208),\n",
-       " ('border_collie', 0.1228194534778595),\n",
-       " ('german_shepherd', 0.07383470982313156)]"
+       "[('border_collie', 0.1990548074245453),\n",
+       " ('collie', 0.1363961398601532),\n",
+       " ('german_shepherd', 0.07545585185289383)]"
       ]
      },
      "execution_count": null,
@@ -346,15 +363,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeReplica:default:ClassPredictor pid=30024, ip=10.0.4.102)\u001b[0m INFO 2025-08-22 00:51:23,011 default_ClassPredictor qtsnu3yv daf11861-073e-4758-82b7-0b222066b668 -- CALL /predict/ OK 504.9ms\n",
-      "\u001b[36m(ServeReplica:default:Doggos pid=133722)\u001b[0m INFO 2025-08-22 00:51:23,013 default_Doggos 0qpk1kw9 daf11861-073e-4758-82b7-0b222066b668 -- POST /predict/ 200 567.1ms\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(autoscaler +13m35s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n"
+      "\u001b[36m(ServeReplica:default:Doggos pid=42244)\u001b[0m INFO 2025-08-28 05:15:58,150 default_Doggos fs1weamq 31c15b70-89a9-4b2d-b4ab-f8424fe6d8d2 -- POST /predict/ 200 516.2ms\n",
+      "\u001b[36m(ServeReplica:default:ClassPredictor pid=20055, ip=10.0.5.20)\u001b[0m INFO 2025-08-28 05:15:58,148 default_ClassPredictor y7tebd3e 31c15b70-89a9-4b2d-b4ab-f8424fe6d8d2 -- CALL /predict/ OK 491.4ms\n"
      ]
     }
    ],

--- a/release/ray_release/byod/byod_e2e_multimodal_ai_workloads.sh
+++ b/release/ray_release/byod/byod_e2e_multimodal_ai_workloads.sh
@@ -5,7 +5,7 @@ set -exo pipefail
 # Install Python dependencies
 pip3 install --no-cache-dir \
     "matplotlib==3.10.0" \
-    "torch==2.7.0" \
+    "torch==2.7.1" \
     "transformers==4.52.3" \
     "scikit-learn==1.6.0" \
     "mlflow==2.19.0" \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The [e2e multimodal AI workloads example](https://github.com/ray-project/ray/tree/master/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads) was pinned to Ray `2.48.0` and Torch `2.7.0`. Moving to Ray `2.49.0` ensures the example builds/runs on the latest published Anyscale base image and stays consistent with the rest of the docs/release tests. Torch is bumped to `2.7.1` to resolve dependency selection/solver issues observed with `2.7.0` during BYOD installs. I also cleared noisy cell outputs in the notebooks to reduce repo churn and make diffs/reviews readable.

## What changed

- Base container: `anyscale/ray:2.48.0-slim-py312-cu128` → `anyscale/ray:2.49.0-slim-py312-cu128` in [doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/containerfile](https://github.com/ray-project/ray/blob/master/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/containerfile).
- BYOD install script: torch==`2.7.0` → torch==`2.7.1` in [release/ray_release/byod/byod_e2e_multimodal_ai_workloads.sh](https://github.com/ray-project/ray/blob/master/release/ray_release/byod/byod_e2e_multimodal_ai_workloads.sh).
- Notebooks cleaned (outputs removed, code unchanged) to cut noise and shrink diffs:
    - [01-Batch-Inference.ipynb](https://github.com/ray-project/ray/blob/master/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/01-Batch-Inference.ipynb)
    - [02-Distributed-Training.ipynb](https://github.com/ray-project/ray/blob/master/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/02-Distributed-Training.ipynb)
    - [03-Online-Serving.ipynb](https://github.com/ray-project/ray/blob/master/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/03-Online-Serving.ipynb)
- Net diff is mostly output removal: thousands of lines dropped from saved outputs, a few hundred added (markdown/cell metadata and version bumps).

## Rationale / impact
- Ray `2.49.0`: Keeps the example current with latest Ray features and bug fixes while matching the officially published CUDA 12.8 “slim” base image used across docs.
- Torch `2.7.1`: Minor patch that improves dependency resolution over `2.7.0` in clean BYOD environments; no API changes expected for this example.
- Notebook output cleanup: Prevents spurious changes on re-execution and speeds up code review by removing large stored outputs.

## Testing done
- Built the example image from the updated containerfile and validated environment comes up on Ray `2.49.0`.
- Ran the BYOD script to confirm torch==2.7.1 installs alongside the existing pins (transformers==`4.52.3`, mlflow==`2.19.0`, etc.).
- Opened and executed the three notebooks end-to-end on Ray 2.49.0 to confirm no runtime regressions.
- Spot-checked that removed notebook outputs are only display artifacts (no code removals).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
