### PR TITLE
[release] Read test filters from both release-test-filters and release-test-attr-regex-filters

### DIFF
--- a/release/ray_release/buildkite/settings.py
+++ b/release/ray_release/buildkite/settings.py
@@ -193,7 +193,9 @@ def update_settings_from_buildkite(settings: Dict):
     if test_name_filter:
         settings["test_filters"] = get_test_filters("name:" + test_name_filter)
 
-    test_filters = get_buildkite_prompt_value("release-test-filters")
+    test_filters = get_buildkite_prompt_value(
+        "release-test-filters"
+    ) or get_buildkite_prompt_value("release-test-attr-regex-filters")
     if test_filters:
         settings["test_filters"] = get_test_filters(test_filters)
 


### PR DESCRIPTION
`release-test-attr-regex-filters` is the metadata being used in the input box for Release pipeline which we need to make it backward compatible still after adding `release-test-filters`