### PR TITLE
[core] Make test-only transition methods private in ShutdownCoordinator

### DIFF
--- a/src/ray/core_worker/core_worker_shutdown_executor.cc
+++ b/src/ray/core_worker/core_worker_shutdown_executor.cc
@@ -123,8 +123,6 @@ void CoreWorkerShutdownExecutor::ExecuteExit(
         [this, exit_type, detail, creation_task_exception_pb_bytes]() {
           rpc::DrainServerCallExecutor();
           KillChildProcessesImmediately();
-          // Disconnect should be put close to Shutdown
-          // https://github.com/ray-project/ray/pull/34883
           DisconnectServices(exit_type, detail, creation_task_exception_pb_bytes);
           ExecuteGracefulShutdown(
               exit_type, "Post-exit graceful shutdown", std::chrono::milliseconds{30000});

--- a/src/ray/core_worker/shutdown_coordinator.cc
+++ b/src/ray/core_worker/shutdown_coordinator.cc
@@ -82,11 +82,6 @@ bool ShutdownCoordinator::RequestShutdown(
   return true;
 }
 
-bool ShutdownCoordinator::TryInitiateShutdown(ShutdownReason reason) {
-  // Legacy compatibility - delegate to graceful shutdown by default
-  return RequestShutdown(false, reason, "", kInfiniteTimeout, nullptr);
-}
-
 bool ShutdownCoordinator::TryTransitionToDisconnecting() {
   std::lock_guard<std::mutex> lock(mu_);
   if (state_ != ShutdownState::kShuttingDown) {

--- a/src/ray/core_worker/shutdown_coordinator.h
+++ b/src/ray/core_worker/shutdown_coordinator.h
@@ -214,11 +214,6 @@ class ShutdownCoordinator {
   std::string GetReasonString() const;
 
  private:
-  /// Legacy method for compatibility - delegates to RequestShutdown
-  /// \param reason The reason for shutdown initiation
-  /// \return true if this call initiated shutdown, false if already shutting down
-  bool TryInitiateShutdown(ShutdownReason reason);
-
   /// Attempt to transition to disconnecting state.
   /// Begins the disconnection/cleanup phase (e.g., GCS/raylet disconnect). Only
   /// valid from kShuttingDown.

--- a/src/ray/core_worker/shutdown_coordinator.h
+++ b/src/ray/core_worker/shutdown_coordinator.h
@@ -165,40 +165,6 @@ class ShutdownCoordinator {
                        const std::shared_ptr<::ray::LocalMemoryBuffer>
                            &creation_task_exception_pb_bytes = nullptr);
 
-  /// Legacy method for compatibility - delegates to RequestShutdown
-  /// TODO (codope): This is public for now to ease incremental migration and testing.
-  /// Consider removing or making private once all call sites are wired to
-  /// RequestShutdown directly.
-  /// \param reason The reason for shutdown initiation
-  /// \return true if this call initiated shutdown, false if already shutting down
-  bool TryInitiateShutdown(ShutdownReason reason);
-
-  /// Attempt to transition to disconnecting state.
-  ///
-  /// Begins the disconnection/cleanup phase (e.g., GCS/raylet disconnect). Only
-  /// valid from kShuttingDown.
-  ///
-  /// \return true if transition succeeded, false if invalid state
-  /// TODO (codope): Public-for-now to support targeted tests; make private when tests
-  /// drive behavior exclusively via RequestShutdown.
-  /// TODO (codope): Once private, we can consider removing the internal mutex acquisition
-  /// here and in TryTransitionToShutdown(), since RequestShutdown serializes the
-  /// execution path and only a single thread invokes transitions.
-  bool TryTransitionToDisconnecting();
-
-  /// Attempt to transition to final shutdown state.
-  ///
-  /// Finalizes shutdown. Allowed from kDisconnecting (normal) or kShuttingDown
-  /// (force path).
-  ///
-  /// \return true if transition succeeded, false if invalid state
-  /// TODO (codope): Public-for-now to support targeted tests; make private when tests
-  /// drive behavior exclusively via RequestShutdown.
-  /// TODO (codope): Once private, we can consider removing the internal mutex acquisition
-  /// here and in TryTransitionToDisconnecting(), since RequestShutdown serializes the
-  /// execution path and only a single thread invokes transitions.
-  bool TryTransitionToShutdown();
-
   /// Get the current shutdown state (mutex-protected, fast path safe).
   ///
   /// \return Current shutdown state
@@ -248,6 +214,23 @@ class ShutdownCoordinator {
   std::string GetReasonString() const;
 
  private:
+  /// Legacy method for compatibility - delegates to RequestShutdown
+  /// \param reason The reason for shutdown initiation
+  /// \return true if this call initiated shutdown, false if already shutting down
+  bool TryInitiateShutdown(ShutdownReason reason);
+
+  /// Attempt to transition to disconnecting state.
+  /// Begins the disconnection/cleanup phase (e.g., GCS/raylet disconnect). Only
+  /// valid from kShuttingDown.
+  /// \return true if transition succeeded, false if invalid state
+  bool TryTransitionToDisconnecting();
+
+  /// Attempt to transition to final shutdown state.
+  /// Finalizes shutdown. Allowed from kDisconnecting (normal) or kShuttingDown
+  /// (force path).
+  /// \return true if transition succeeded, false if invalid state
+  bool TryTransitionToShutdown();
+
   /// Execute shutdown sequence based on worker type and mode
   void ExecuteShutdownSequence(
       bool force_shutdown,

--- a/src/ray/core_worker/tests/shutdown_coordinator_test.cc
+++ b/src/ray/core_worker/tests/shutdown_coordinator_test.cc
@@ -148,18 +148,17 @@ TEST_F(ShutdownCoordinatorTest, RequestShutdown_IdempotentBehavior) {
   EXPECT_EQ(coordinator->GetReason(), ShutdownReason::kForcedExit);  // Reason is updated
 }
 
-TEST_F(ShutdownCoordinatorTest,
-       TryInitiateShutdown_DelegatesToGraceful_OnlyFirstSucceeds) {
+TEST_F(ShutdownCoordinatorTest, RequestShutdown_DelegatesToGraceful_OnlyFirstSucceeds) {
   auto coordinator = CreateCoordinator();
 
-  EXPECT_TRUE(coordinator->TryInitiateShutdown(ShutdownReason::kUserError));
+  EXPECT_TRUE(coordinator->RequestShutdown(false, ShutdownReason::kUserError));
   const auto state = coordinator->GetState();
   EXPECT_TRUE(state == ShutdownState::kShuttingDown ||
               state == ShutdownState::kDisconnecting);
   EXPECT_EQ(coordinator->GetReason(), ShutdownReason::kUserError);
 
   // Second call should fail
-  EXPECT_FALSE(coordinator->TryInitiateShutdown(ShutdownReason::kForcedExit));
+  EXPECT_FALSE(coordinator->RequestShutdown(false, ShutdownReason::kForcedExit));
   EXPECT_EQ(coordinator->GetReason(), ShutdownReason::kUserError);  // unchanged
 }
 
@@ -177,24 +176,12 @@ TEST_F(ShutdownCoordinatorTest,
   EXPECT_EQ(coordinator->GetReason(), ShutdownReason::kGracefulExit);
 
   // Disconnecting -> Shutdown
-  EXPECT_TRUE(coordinator->TryTransitionToShutdown());
+  EXPECT_TRUE(coordinator->RequestShutdown(true, ShutdownReason::kForcedExit));
   EXPECT_EQ(coordinator->GetState(), ShutdownState::kShutdown);
 
   // Further transitions are no-ops.
-  EXPECT_FALSE(coordinator->TryTransitionToDisconnecting());
-  EXPECT_FALSE(coordinator->TryTransitionToShutdown());
-}
-
-TEST_F(ShutdownCoordinatorTest, InvalidTransitions_FromRunning_Fail) {
-  auto coordinator = CreateCoordinator();
-
-  // Cannot transition to disconnecting from running
-  EXPECT_FALSE(coordinator->TryTransitionToDisconnecting());
-  EXPECT_EQ(coordinator->GetState(), ShutdownState::kRunning);
-
-  // Cannot transition to shutdown from running
-  EXPECT_FALSE(coordinator->TryTransitionToShutdown());
-  EXPECT_EQ(coordinator->GetState(), ShutdownState::kRunning);
+  EXPECT_FALSE(coordinator->RequestShutdown(false, ShutdownReason::kGracefulExit));
+  EXPECT_FALSE(coordinator->RequestShutdown(true, ShutdownReason::kForcedExit));
 }
 
 TEST_F(ShutdownCoordinatorTest, ForceShutdown_TransitionsDirectlyToShutdown) {
@@ -205,7 +192,7 @@ TEST_F(ShutdownCoordinatorTest, ForceShutdown_TransitionsDirectlyToShutdown) {
                                            ShutdownReason::kForcedExit));
 
   // Already in shutdown state, manual transition should fail
-  EXPECT_FALSE(coordinator->TryTransitionToShutdown());
+  EXPECT_FALSE(coordinator->RequestShutdown(true, ShutdownReason::kForcedExit));
   EXPECT_EQ(coordinator->GetState(), ShutdownState::kShutdown);
 }
 
@@ -291,7 +278,7 @@ TEST_F(ShutdownCoordinatorTest, StringRepresentations_StateAndReason_AreReadable
   EXPECT_EQ(coordinator->GetStateString(), "Disconnecting");
   EXPECT_EQ(coordinator->GetReasonString(), "GracefulExit");
 
-  coordinator->TryTransitionToShutdown();
+  coordinator->RequestShutdown(true, ShutdownReason::kForcedExit);
   EXPECT_EQ(coordinator->GetStateString(), "Shutdown");
 }
 


### PR DESCRIPTION
## Why are these changes needed?

This is a followup from https://github.com/ray-project/ray/pull/54244

- Restrict `TryInitiateShutdown`, `TryTransitionToDisconnecting`, and `TryTransitionToShutdown` to private once all production code calls `RequestShutdown`.
- Minimize API surface and prevent misuse; with a single entry point, internal transitions need not be externally callable.
- Update tests to exercise only `RequestShutdown`

## Related issue number

Closes #55739
