### PR TITLE
[ci] updating node 14->16 on images

### DIFF
--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -34,7 +34,7 @@ fi
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
 source "$HOME"/.nvm/nvm.sh
 
-NODE_VERSION="16"
+NODE_VERSION="22"
 nvm install "$NODE_VERSION"
 nvm use "$NODE_VERSION"
 

--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -34,7 +34,7 @@ fi
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 source "$HOME"/.nvm/nvm.sh
 
-NODE_VERSION="22"
+NODE_VERSION="16"
 nvm install "$NODE_VERSION"
 nvm use "$NODE_VERSION"
 

--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -31,7 +31,7 @@ if [[ "${RAYCI_DISABLE_JAVA:-false}" != "true" && "${RAY_INSTALL_JAVA:-1}" == "1
 fi
 
 # Install ray dashboard dependencies.
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 source "$HOME"/.nvm/nvm.sh
 
 NODE_VERSION="22"

--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -34,7 +34,7 @@ fi
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
 source "$HOME"/.nvm/nvm.sh
 
-NODE_VERSION="14"
+NODE_VERSION="16"
 nvm install "$NODE_VERSION"
 nvm use "$NODE_VERSION"
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -173,7 +173,7 @@ build_dashboard_front_end() {
       if [ -z "${BUILDKITE-}" ] || [[ "${OSTYPE}" != linux* ]]; then
         set +x  # suppress set -x since it'll get very noisy here
         . "${HOME}/.nvm/nvm.sh"
-        NODE_VERSION="14"
+        NODE_VERSION="16"
         nvm install $NODE_VERSION
         nvm use --silent $NODE_VERSION
       fi

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -173,7 +173,7 @@ build_dashboard_front_end() {
       if [ -z "${BUILDKITE-}" ] || [[ "${OSTYPE}" != linux* ]]; then
         set +x  # suppress set -x since it'll get very noisy here
         . "${HOME}/.nvm/nvm.sh"
-        NODE_VERSION="16"
+        NODE_VERSION="22"
         nvm install $NODE_VERSION
         nvm use --silent $NODE_VERSION
       fi

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -173,7 +173,7 @@ build_dashboard_front_end() {
       if [ -z "${BUILDKITE-}" ] || [[ "${OSTYPE}" != linux* ]]; then
         set +x  # suppress set -x since it'll get very noisy here
         . "${HOME}/.nvm/nvm.sh"
-        NODE_VERSION="22"
+        NODE_VERSION="16"
         nvm install $NODE_VERSION
         nvm use --silent $NODE_VERSION
       fi

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -160,7 +160,7 @@ install_node() {
       fi
     else
       # https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-      curl -sSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+      curl -sSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
       sudo apt-get install -y nodejs
       return
     fi
@@ -170,7 +170,7 @@ install_node() {
   (
     set +x # suppress set -x since it'll get very noisy here.
     . "${HOME}/.nvm/nvm.sh"
-    NODE_VERSION="22"
+    NODE_VERSION="16"
     nvm install $NODE_VERSION
     nvm use --silent $NODE_VERSION
     npm config set loglevel warn  # make NPM quieter

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -154,9 +154,9 @@ install_node() {
   if [[ -n "${BUILDKITE-}" ]] ; then
     if [[ "${OSTYPE}" = darwin* ]]; then
       if [[ "$(uname -m)" == "arm64" ]]; then
-        curl -sSL -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+        curl -sSL -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
       else
-        curl -sSL -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+        curl -sSL -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
       fi
     else
       # https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -170,7 +170,7 @@ install_node() {
   (
     set +x # suppress set -x since it'll get very noisy here.
     . "${HOME}/.nvm/nvm.sh"
-    NODE_VERSION="14"
+    NODE_VERSION="22"
     nvm install $NODE_VERSION
     nvm use --silent $NODE_VERSION
     npm config set loglevel warn  # make NPM quieter

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -160,7 +160,7 @@ install_node() {
       fi
     else
       # https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-      curl -sSL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+      curl -sSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
       sudo apt-get install -y nodejs
       return
     fi

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -133,7 +133,7 @@ To build Ray on Ubuntu, run the following commands:
   # Install Bazelisk.
   ci/env/install-bazel.sh
 
-  # Install node version manager and node 14
+  # Install node version manager and node 22
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
   nvm install 22
   nvm use 22

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -135,8 +135,8 @@ To build Ray on Ubuntu, run the following commands:
 
   # Install node version manager and node 14
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-  nvm install 16
-  nvm use 16
+  nvm install 22
+  nvm use 22
 
 .. note::
   The `install-bazel.sh` script installs `bazelisk` for building Ray.

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -135,8 +135,8 @@ To build Ray on Ubuntu, run the following commands:
 
   # Install node version manager and node 14
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-  nvm install 14
-  nvm use 14
+  nvm install 16
+  nvm use 16
 
 .. note::
   The `install-bazel.sh` script installs `bazelisk` for building Ray.

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -135,8 +135,8 @@ To build Ray on Ubuntu, run the following commands:
 
   # Install node version manager and node 22
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-  nvm install 22
-  nvm use 22
+  nvm install 16
+  nvm use 16
 
 .. note::
   The `install-bazel.sh` script installs `bazelisk` for building Ray.

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -8,7 +8,7 @@ set -x
 
 DOWNLOAD_DIR=python_downloads
 
-NODE_VERSION="22"
+NODE_VERSION="16"
 
 PY_MMS=("3.9" "3.10" "3.11" "3.12" "3.13")
 

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -8,7 +8,7 @@ set -x
 
 DOWNLOAD_DIR=python_downloads
 
-NODE_VERSION="16"
+NODE_VERSION="22"
 
 PY_MMS=("3.9" "3.10" "3.11" "3.12" "3.13")
 

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -8,7 +8,7 @@ set -x
 
 DOWNLOAD_DIR=python_downloads
 
-NODE_VERSION="14"
+NODE_VERSION="16"
 
 PY_MMS=("3.9" "3.10" "3.11" "3.12" "3.13")
 


### PR DESCRIPTION
updating node 14 (EOL support) to node 16


Should save some time on fresh docker builds in ci

```

[2025-08-28T16:36:02Z] #7 77.65 ================================================================================
--
  | [2025-08-28T16:36:02Z] #7 77.65 ================================================================================
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65                               DEPRECATION WARNING
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65   Node.js 14.x is no longer actively supported!
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65   You will not receive security or critical stability updates for this version.
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65   You should migrate to a supported version of Node.js as soon as possible.
  | [2025-08-28T16:36:02Z] #7 77.65   Use the installation script that corresponds to the version of Node.js you
  | [2025-08-28T16:36:02Z] #7 77.65   wish to install. e.g.
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65    * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"
  | [2025-08-28T16:36:02Z] #7 77.65    * https://deb.nodesource.com/setup_18.x — Node.js 18 LTS "Hydrogen" (recommended)
  | [2025-08-28T16:36:02Z] #7 77.65    * https://deb.nodesource.com/setup_19.x — Node.js 19 "Nineteen"
  | [2025-08-28T16:36:02Z] #7 77.65    * https://deb.nodesource.com/setup_20.x — Node.js 20 "Iron" (current)
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65   Please see https://github.com/nodejs/Release for details about which
  | [2025-08-28T16:36:02Z] #7 77.65   version may be appropriate for you.
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65   The NodeSource Node.js distributions repository contains
  | [2025-08-28T16:36:02Z] #7 77.65   information both about supported versions of Node.js and supported Linux
  | [2025-08-28T16:36:02Z] #7 77.65   distributions. To learn more about usage, see the repository:
  | [2025-08-28T16:36:02Z] #7 77.65     https://github.com/nodesource/distributions
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65 ================================================================================
  | [2025-08-28T16:36:02Z] #7 77.65 ================================================================================
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:02Z] #7 77.65 Continuing in 20 seconds ...
  | [2025-08-28T16:36:02Z] #7 77.65
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65 ================================================================================
  | [2025-08-28T16:36:22Z] #7 97.65 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
  | [2025-08-28T16:36:22Z] #7 97.65 ================================================================================
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65                            SCRIPT DEPRECATION WARNING
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65   This script, located at https://deb.nodesource.com/setup_X, used to
  | [2025-08-28T16:36:22Z] #7 97.65   install Node.js is deprecated now and will eventually be made inactive.
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65   Please visit the NodeSource distributions Github and follow the
  | [2025-08-28T16:36:22Z] #7 97.65   instructions to migrate your repo.
  | [2025-08-28T16:36:22Z] #7 97.65   https://github.com/nodesource/distributions
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65   The NodeSource Node.js Linux distributions GitHub repository contains
  | [2025-08-28T16:36:22Z] #7 97.65   information about which versions of Node.js and which Linux distributions
  | [2025-08-28T16:36:22Z] #7 97.65   are supported and how to install it.
  | [2025-08-28T16:36:22Z] #7 97.65   https://github.com/nodesource/distributions
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65                           SCRIPT DEPRECATION WARNING
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65 ================================================================================
  | [2025-08-28T16:36:22Z] #7 97.65 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
  | [2025-08-28T16:36:22Z] #7 97.65 ================================================================================
  | [2025-08-28T16:36:22Z] #7 97.65
  | [2025-08-28T16:36:22Z] #7 97.65 TO AVOID THIS WAIT MIGRATE THE SCRIPT
  | [2025-08-28T16:36:22Z] #7 97.65 Continuing in 60 seconds (press Ctrl-C to abort) ...


```