### PR TITLE
[core] Skip actor name deletion test on ray client

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1677,6 +1677,10 @@ def test_one_liner_actor_method_invocation(shutdown_only):
     assert result == "ok"
 
 
+@pytest.mark.skipif(
+    client_test_enabled(),
+    reason="Out of scope actor cleanup doesn't work with Ray client.",
+)
 def test_get_actor_after_same_name_actor_dead(shutdown_only):
     ACTOR_NAME = "test_actor"
     NAMESPACE_NAME = "test_namespace"


### PR DESCRIPTION
## Why are these changes needed?
This doesn't work with the ray client and looks like a lot of this doesn't.
This test doesn't work with the ray client and neither do 8 others just in this file.

This seems to be the reason looking at where the test actually fails on the ray client
https://github.com/ray-project/ray/blob/6fdf2cfb821e228eb17147b6c100c5a75e2caa79/python/ray/tests/test_actor.py#L1631-L1632