### PR TITLE
[core] Fix error handling for plasma put errors

### DIFF
--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -425,14 +425,26 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
       /*put_in_local_plasma_callback=*/
       [this](const RayObject &object, const ObjectID &object_id) {
         auto core_worker = GetCoreWorker();
-        auto put_status =
-            core_worker->PutInLocalPlasmaStore(object, object_id, /*pin_object=*/true);
-        if (!put_status.ok()) {
-          RAY_LOG(WARNING).WithField(object_id)
-              << "Failed to put object in plasma store: " << put_status;
-          return put_status;
+        const int max_retries = 3;
+        int attempt = 0;
+        int64_t backoff_ms = 10;
+        Status put_status;
+        while (true) {
+          put_status =
+              core_worker->PutInLocalPlasmaStore(object, object_id, /*pin_object=*/true);
+          if (put_status.ok()) {
+            return Status::OK();
+          }
+          if (attempt++ >= max_retries) {
+            RAY_LOG(WARNING).WithField(object_id)
+                << "Exhausted plasma put retries (attempts=" << attempt
+                << ") with status: " << put_status;
+            return put_status;
+          }
+          // Backoff before retrying.
+          std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+          backoff_ms *= 2;
         }
-        return Status::OK();
       },
       /* retry_task_callback= */
       [this](TaskSpecification &spec, bool object_recovery, uint32_t delay_ms) {

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1537,9 +1537,7 @@ void TaskManager::MarkTaskReturnObjectsFailed(
     const auto object_id = ObjectID::FromIndex(task_id, /*index=*/i + 1);
     if (store_in_plasma_ids.contains(object_id)) {
       Status s = put_in_local_plasma_callback_(error, object_id);
-      if (s.ok()) {
-        in_memory_store_.Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA), object_id);
-      } else {
+      if (!s.ok()) {
         RAY_LOG(WARNING).WithField(object_id)
             << "Failed to put error object in plasma: " << s;
         in_memory_store_.Put(error, object_id);
@@ -1552,10 +1550,7 @@ void TaskManager::MarkTaskReturnObjectsFailed(
     for (const auto &dynamic_return_id : spec.DynamicReturnIds()) {
       if (store_in_plasma_ids.contains(dynamic_return_id)) {
         Status s = put_in_local_plasma_callback_(error, dynamic_return_id);
-        if (s.ok()) {
-          in_memory_store_.Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
-                               dynamic_return_id);
-        } else {
+        if (!s.ok()) {
           RAY_LOG(WARNING).WithField(dynamic_return_id)
               << "Failed to put error object in plasma: " << s;
           in_memory_store_.Put(error, dynamic_return_id);
@@ -1585,10 +1580,7 @@ void TaskManager::MarkTaskReturnObjectsFailed(
       const auto generator_return_id = spec.StreamingGeneratorReturnId(i);
       if (store_in_plasma_ids.contains(generator_return_id)) {
         Status s = put_in_local_plasma_callback_(error, generator_return_id);
-        if (s.ok()) {
-          in_memory_store_.Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
-                               generator_return_id);
-        } else {
+        if (!s.ok()) {
           RAY_LOG(WARNING).WithField(generator_return_id)
               << "Failed to put error object in plasma: " << s;
           in_memory_store_.Put(error, generator_return_id);

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -614,9 +614,9 @@ class TaskManager : public TaskManagerInterface {
   void MarkTaskNoRetryInternal(const TaskID &task_id, bool canceled)
       ABSL_LOCKS_EXCLUDED(mu_);
 
-  /// Update nested ref count info and store the in-memory value for a task's
-  /// return object. On success, sets direct_return_out to true if the object's value
-  /// was returned directly by value (not stored in plasma).
+  /// Update nested ref count info and store the task's return object.
+  /// Returns StatusOr<bool> where the bool indicates the object was returned
+  /// directly in-memory (not stored in plasma) when true.
   StatusOr<bool> HandleTaskReturn(const ObjectID &object_id,
                                   const rpc::ReturnObject &return_object,
                                   const NodeID &worker_node_id,


### PR DESCRIPTION
## Why are these changes needed?

Followup to https://github.com/ray-project/ray/pull/55367#pullrequestreview-3153215777

- map Status -> ErrorType via MapStatusToErrorType (IOError->LOCAL_RAYLET_DIED, ObjectStoreFull/Transient->OUT_OF_MEMORY, OutOfDisk->OUT_OF_DISK_ERROR; default->WORKER_DIED).
- no longer log‑and‑forget on any HandleTaskReturn error.
- For streaming generator returns we now always put the error into the in‑memory store first (unblocks waiters) and only then best‑effort put to plasma; failures there are just warnings.