### PR TITLE
Add metadata to indicate full dashboard embedding is supported

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/default_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_grafana_dashboard_base.json
@@ -163,6 +163,7 @@
       }
     ]
   },
+  "rayMeta": ["supportsFullGrafanaView"],
   "time": {
     "from": "now-30m",
     "to": "now"

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -170,6 +170,7 @@ def _generate_grafana_dashboard(dashboard_config: DashboardConfig) -> str:
     # Ray metadata can be used to put arbitrary metadata
     ray_meta = base_json.get("rayMeta", []) or []
     ray_meta.append("supportsGlobalFilterOverride")
+    # Indicates full dashboard iframe embedding works well. Added after introducing panel grouping.
     ray_meta.append("supportsFullDashboardEmbedding")
     base_json["rayMeta"] = ray_meta
     return json.dumps(base_json, indent=4), uid

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -170,6 +170,7 @@ def _generate_grafana_dashboard(dashboard_config: DashboardConfig) -> str:
     # Ray metadata can be used to put arbitrary metadata
     ray_meta = base_json.get("rayMeta", []) or []
     ray_meta.append("supportsGlobalFilterOverride")
+    ray_meta.append("supportsFullDashboardEmbedding")
     base_json["rayMeta"] = ray_meta
     return json.dumps(base_json, indent=4), uid
 

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -170,8 +170,6 @@ def _generate_grafana_dashboard(dashboard_config: DashboardConfig) -> str:
     # Ray metadata can be used to put arbitrary metadata
     ray_meta = base_json.get("rayMeta", []) or []
     ray_meta.append("supportsGlobalFilterOverride")
-    # Indicates full dashboard iframe embedding works well. Added after introducing panel grouping.
-    ray_meta.append("supportsFullDashboardEmbedding")
     base_json["rayMeta"] = ray_meta
     return json.dumps(base_json, indent=4), uid
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Since we introduced panel groups to Default (https://github.com/ray-project/ray/pull/55620) & Data (https://github.com/ray-project/ray/pull/55495) dashboards, applications consuming Grafana dashboards can comfortably embed the full dashboard on any UI now (and the other dashboards are pretty usable even without them).

Added a `"supportsFullGrafanaView"` tag to the `rayMeta` list in Default Dashboard to indicate to consumers that we support full Grafana dashboard embedding from now on.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
