### PR TITLE
Enable ruff lint for `workers/`, `workflow/`, `setup-dev.py`, and `cloudpickle/`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff
         args: [ --select, "I", --fix, --exit-non-zero-on-fix ]
-        files: '^python/ray/serve/|^python/ray/train|^python/ray/data|^python/ray/_private/|^python/ray/llm/|^python/ray/tune/|^python/ray/includes/|^python/ray/internal/|^python/ray/ray_operator/|^python/ray/scripts/|^python/ray/streaming/|^python/ray/dag/|^python/ray/tests/'
+        files: '^python/ray/serve/|^python/ray/train|^python/ray/data|^python/ray/_private/|^python/ray/llm/|^python/ray/tune/|^python/ray/includes/|^python/ray/internal/|^python/ray/ray_operator/|^python/ray/scripts/|^python/ray/streaming/|^python/ray/dag/|^python/ray/tests/|^python/ray/setup-dev.py|^python/ray/cloudpickle/|^python/ray/workers/|^python/ray/workflow/'
 
   - repo: https://github.com/jsh9/pydoclint
     rev: "0.6.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,18 +58,13 @@ afterray = ["psutil", "setproctitle"]
 # python/ray/cloudpickle/*
 # doc/*
 # python/ray/__init__.py
-# python/ray/setup-dev.py
 # For the rest we will gradually remove them from the blacklist as we
 # reformat the code to follow the style guide.
 [tool.ruff.lint.per-file-ignores]
 "doc/*" = ["I"]
 "python/ray/__init__.py" = ["I"]
-"python/ray/setup-dev.py" = ["I"]
-"python/ray/cloudpickle/*" = ["I"]
 "python/ray/dag/__init__.py" = ["I"]
 "python/ray/util/*" = ["I"]
-"python/ray/workers/*" = ["I"]
-"python/ray/workflow/*" = ["I"]
 "rllib/*" = ["I"]
 "release/*" = ["I"]
 

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -16,9 +16,10 @@ if this_dir in sys.path:
     sys.path.append(this_dir)
 
 import argparse
-import click
 import shutil
 import subprocess
+
+import click
 
 import ray
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Sixth split of https://github.com/ray-project/ray/pull/55993

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
