### PR TITLE
[core] [Rccl]: Add device-agnostic multidevice API for collective operations

### DIFF
--- a/python/ray/util/collective/__init__.py
+++ b/python/ray/util/collective/__init__.py
@@ -20,8 +20,10 @@ from ray.util.collective.collective import (
     reducescatter_multigpu,
     send,
     send_multigpu,
+    send_multidevice,
     recv,
     recv_multigpu,
+    recv_multidevice,
     get_group_handle,
 )
 
@@ -47,7 +49,9 @@ __all__ = [
     "reducescatter_multigpu",
     "send",
     "send_multigpu",
+    "send_multidevice",
     "recv",
     "recv_multigpu",
+    "recv_multidevice",
     "get_group_handle",
 ]

--- a/python/ray/util/collective/collective.py
+++ b/python/ray/util/collective/collective.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import ray
 from ray.util.collective import types
+from ray.util.annotations import Deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -545,7 +546,7 @@ def reducescatter(
     if len(tensor_list) != g.world_size:
         raise RuntimeError(
             "The length of the tensor list operands to reducescatter "
-            "must not be equal to world_size."
+            "must be equal to world_size."
         )
     opts = types.ReduceScatterOptions()
     opts.reduceOp = op
@@ -602,6 +603,7 @@ def send(tensor, dst_rank: int, group_name: str = "default"):
     g.send([tensor], opts)
 
 
+@Deprecated(message="Use the `send_multidevice` interface as the replacement.")
 def send_multigpu(
     tensor,
     dst_rank: int,
@@ -625,21 +627,54 @@ def send_multigpu(
     Returns:
         None
     """
+    send_multidevice(
+        tensor=tensor,
+        dst_rank=dst_rank,
+        dst_device_index=dst_gpu_index,
+        group_name=group_name,
+        n_elements=n_elements,
+    )
+
+
+def send_multidevice(
+    tensor,
+    dst_rank: int,
+    dst_device_index: int,
+    group_name: str = "default",
+    n_elements: int = 0,
+):
+    """Send a tensor to a remote Device synchronously, a Device can be
+    a GPU, Ascend NPU, or any supported accelerators.
+
+    The function assumes each process owns >1 Devices, and the sender
+    process and receiver process has equal number of Devices.
+
+    Args:
+        tensor: the tensor to send, located on a Device.
+        dst_rank: the rank of the destination process.
+        dst_device_index: the destination device index.
+        group_name: the name of the collective group.
+        n_elements: if specified, send the next n elements
+            from the starting address of tensor.
+
+    Returns:
+        None
+    """
     if not types.cupy_available():
-        raise RuntimeError("send_multigpu call requires NCCL.")
+        raise RuntimeError("send_multidevice call requires NCCL.")
     _check_single_tensor_input(tensor)
     g = get_group_handle(group_name)
     _check_rank_valid(g, dst_rank)
     if dst_rank == g.rank:
         raise RuntimeError(
             "The dst_rank '{}' is self. Considering "
-            "doing GPU to GPU memcpy instead?".format(dst_rank)
+            "doing Device to Device memcpy instead?".format(dst_rank)
         )
     if n_elements < 0:
         raise RuntimeError("The n_elements '{}' should >= 0.".format(n_elements))
     opts = types.SendOptions()
     opts.dst_rank = dst_rank
-    opts.dst_gpu_index = dst_gpu_index
+    opts.dst_device_index = dst_device_index
     opts.n_elements = n_elements
     g.send([tensor], opts)
 
@@ -665,6 +700,7 @@ def recv(tensor, src_rank: int, group_name: str = "default"):
     g.recv([tensor], opts)
 
 
+@Deprecated(message="Use the `recv_multidevice` interface as the replacement.")
 def recv_multigpu(
     tensor,
     src_rank: int,
@@ -686,21 +722,54 @@ def recv_multigpu(
     Returns:
         None
     """
+    recv_multidevice(
+        tensor=tensor,
+        src_rank=src_rank,
+        src_device_index=src_gpu_index,
+        group_name=group_name,
+        n_elements=n_elements,
+    )
+
+
+def recv_multidevice(
+    tensor,
+    src_rank: int,
+    src_device_index: int,
+    group_name: str = "default",
+    n_elements: int = 0,
+):
+    """Receive a tensor from a remote Device synchronously, a Device can be
+    a GPU, Ascend NPU, or any supported accelerators.
+
+    The function assumes each process owns >1 Devices, and the sender
+    process and receiver process has equal number of Devices.
+
+    Args:
+        tensor: the received tensor, located on a Device.
+        src_rank: the rank of the source process.
+        src_device_index: the index of the source device on the src process.
+        group_name: the name of the collective group.
+        n_elements: if specified, receive the next n elements
+            from the starting address of tensor.
+
+    Returns:
+        None
+    """
     if not types.cupy_available():
-        raise RuntimeError("recv_multigpu call requires NCCL.")
+        raise RuntimeError("recv_multidevice call requires NCCL.")
     _check_single_tensor_input(tensor)
     g = get_group_handle(group_name)
     _check_rank_valid(g, src_rank)
     if src_rank == g.rank:
         raise RuntimeError(
             "The dst_rank '{}' is self. Considering "
-            "doing GPU to GPU memcpy instead?".format(src_rank)
+            "doing Device to Device memcpy instead?".format(src_rank)
         )
     if n_elements < 0:
         raise RuntimeError("The n_elements '{}' should be >= 0.".format(n_elements))
     opts = types.RecvOptions()
     opts.src_rank = src_rank
-    opts.src_gpu_index = src_gpu_index
+    opts.src_device_index = src_device_index
     opts.n_elements = n_elements
     g.recv([tensor], opts)
 

--- a/python/ray/util/collective/collective_group/nccl_collective_group.py
+++ b/python/ray/util/collective/collective_group/nccl_collective_group.py
@@ -370,7 +370,7 @@ class NCCLGroup(BaseGroup):
             )
 
         self._point2point(
-            tensors, p2p_fn, send_options.dst_rank, send_options.dst_gpu_index
+            tensors, p2p_fn, send_options.dst_rank, send_options.dst_device_index
         )
 
     def recv(self, tensors, recv_options=RecvOptions()):
@@ -396,7 +396,7 @@ class NCCLGroup(BaseGroup):
             )
 
         self._point2point(
-            tensors, p2p_fn, recv_options.src_rank, recv_options.src_gpu_index
+            tensors, p2p_fn, recv_options.src_rank, recv_options.src_device_index
         )
 
     def _get_nccl_collective_communicator(self, comm_key, device_list):

--- a/python/ray/util/collective/types.py
+++ b/python/ray/util/collective/types.py
@@ -176,7 +176,7 @@ class ReduceScatterOptions:
 @dataclass
 class SendOptions:
     dst_rank = 0
-    dst_gpu_index = 0
+    dst_device_index = 0
     n_elements = 0
     timeout_ms = unset_timeout_ms
 
@@ -184,6 +184,6 @@ class SendOptions:
 @dataclass
 class RecvOptions:
     src_rank = 0
-    src_gpu_index = 0
+    src_device_index = 0
     n_elements = 0
     unset_timeout_ms = unset_timeout_ms


### PR DESCRIPTION

This change enables collective communication with various accelerator types (GPU, NPU, etc.) while maintaining backward compatibility with existing GPU-specific APIs.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Add send_multidevice() and recv_multidevice() functions as device-agnostic replacements
- Deprecate send_multigpu() and recv_multigpu() with backward compatibility
- Rename dst_gpu_index/src_gpu_index to dst_device_index/src_device_index in SendOptions/RecvOptions
- Fix typo in reducescatter error message ('must not be equal' -> 'must be equal')
- Export new functions in __init__.py

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
