### PR TITLE
[data] remove metadata for hashing + truncate warning logs

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -188,7 +188,7 @@ def unify_schemas(
             return schemas.pop()
     except Exception as e:
         # Unsure if there are cases where schemas are NOT hashable
-        logger.warning(f"Failed to hash the schemas (for deduplication): {e}")
+        logger.debug(f"Failed to hash the schemas (for deduplication): {e}")
 
     schemas_to_unify = []
     schema_field_overrides = {}

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -179,6 +179,9 @@ def unify_schemas(
         ArrowVariableShapedTensorType,
     )
 
+    # The schema metadata might be unhashable.
+    # We need schemas to be hashable for unification
+    schemas = [schema.remove_metadata() for schema in schemas]
     try:
         if len(set(schemas)) == 1:
             # Early exit because unifying can be expensive

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -63,13 +63,6 @@ class RefBundle:
                     "The size in bytes of the block must be known: {}".format(b)
                 )
 
-        import pyarrow as pa
-
-        # The schema metadata might be unhashable.
-        # We need schemas to be hashable for unification
-        if isinstance(self.schema, pa.lib.Schema):
-            self.schema = self.schema.remove_metadata()
-
     def __setattr__(self, key, value):
         if hasattr(self, key) and key in ["blocks", "owns_blocks"]:
             raise ValueError(f"The `{key}` field of RefBundle cannot be updated.")

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -36,6 +36,7 @@ from ray.data._internal.execution.operators.input_data_buffer import InputDataBu
 from ray.data._internal.execution.resource_manager import (
     ResourceManager,
 )
+from ray.data._internal.metadata_exporter import _add_ellipsis_for_string
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.util import (
     unify_schemas_with_validation,
@@ -790,11 +791,13 @@ def dedupe_schemas_with_validation(
         return bundle, diverged
 
     diverged = True
-    if warn:
+    if warn and not enforce_schemas:
+        old_schema_string = _add_ellipsis_for_string(str(old_schema), 300)
+        new_schema_string = _add_ellipsis_for_string(str(bundle.schema), 300)
         logger.warning(
             f"Operator produced a RefBundle with a different schema "
-            f"than the previous one. Previous schema: {old_schema}, "
-            f"new schema: {bundle.schema}. This may lead to unexpected behavior."
+            f"than the previous one. Previous schema: {old_schema_string}, "
+            f"new schema: {new_schema_string}. This may lead to unexpected behavior."
         )
     if enforce_schemas:
         old_schema = unify_schemas_with_validation([old_schema, bundle.schema])

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -36,7 +36,6 @@ from ray.data._internal.execution.operators.input_data_buffer import InputDataBu
 from ray.data._internal.execution.resource_manager import (
     ResourceManager,
 )
-from ray.data._internal.metadata_exporter import _add_ellipsis_for_string
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.util import (
     unify_schemas_with_validation,

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -791,13 +791,11 @@ def dedupe_schemas_with_validation(
         return bundle, diverged
 
     diverged = True
-    if warn and not enforce_schemas:
-        old_schema_string = _add_ellipsis_for_string(str(old_schema), 300)
-        new_schema_string = _add_ellipsis_for_string(str(bundle.schema), 300)
+    if warn and enforce_schemas:
         logger.warning(
             f"Operator produced a RefBundle with a different schema "
-            f"than the previous one. Previous schema: {old_schema_string}, "
-            f"new schema: {new_schema_string}. This may lead to unexpected behavior."
+            f"than the previous one. Previous schema: {old_schema}, "
+            f"new schema: {bundle.schema}. This may lead to unexpected behavior."
         )
     if enforce_schemas:
         old_schema = unify_schemas_with_validation([old_schema, bundle.schema])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We need schemas to be hashable for schema deduplication. We previously removed metadata in Refbundle Creation, however, it can be called without a refbundle. For example, it can happen in delegating block builder
```
def concat(
    blocks: List["pyarrow.Table"], *, promote_types: bool = False
) -> "pyarrow.Table":
```
or implicity called when calling `count` on a dataset
```
def _cached_output_metadata
# will grab all the metadata(including schema), not just rows 
```
or in `BlockOutputBuffer`

- This PR also reduces the log warning to truncate too.
To centralize, added it in unify_schemas
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
