### PR TITLE
[serve] Fix buffered logging reusing request context (Fixes #55851)

### DIFF
--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -305,7 +305,7 @@ def redirected_print(*objects, sep=" ", end="\n", file=None, flush=False):
     serve_logger.log(logging.INFO, message, stacklevel=2)
 
 
-def wrap_logger_for_buffering(logger: logging.Logger = None):
+def wrap_logger_for_buffering(logger: logging.Logger):
     """
     Wraps the logger with context for the buffering case.
     """

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -1377,7 +1377,7 @@ def test_request_id_uniqueness_with_buffering(buffer_size, monkeypatch):
 
     serve.run(TestApp.bind())
 
-    for _ in range(150 if buffer_size > 1 else 20):
+    for _ in range(150):
         httpx.get("http://127.0.0.1:8000/")
     logs_dir = get_serve_logs_dir()
 

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -1361,11 +1361,17 @@ def test_configure_default_serve_logger_with_stderr_redirect(
     assert not isinstance(sys.stderr, StreamToLogger)
 
 
-@pytest.mark.parametrize("buffer_size", [1, 100])
-def test_request_id_uniqueness_with_buffering(buffer_size, monkeypatch):
+@pytest.mark.parametrize(
+    "ray_instance",
+    [
+        {"RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE": "1"},
+        {"RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE": "100"},
+    ],
+    indirect=True,
+)
+def test_request_id_uniqueness_with_buffering(ray_instance):
     """Test request IDs are unique when buffering is enabled."""
 
-    monkeypatch.setenv("RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE", str(buffer_size))
     logger = logging.getLogger("ray.serve")
 
     @serve.deployment(logging_config={"encoding": "JSON"})
@@ -1376,9 +1382,9 @@ def test_request_id_uniqueness_with_buffering(buffer_size, monkeypatch):
             return "OK"
 
     serve.run(TestApp.bind())
-
-    for _ in range(150):
+    for _ in range(200):
         httpx.get("http://127.0.0.1:8000/")
+
     logs_dir = get_serve_logs_dir()
 
     for log_file in os.listdir(logs_dir):
@@ -1388,14 +1394,14 @@ def test_request_id_uniqueness_with_buffering(buffer_size, monkeypatch):
                 for line in f:
                     log_entry = json.loads(line)
                     request_id = log_entry.get("request_id", None)
+                    message = log_entry.get("message", None)
                     if request_id:
-                        log_request_ids.append(request_id)
-                # Verify no excessive duplication
+                        # Append the (request_id, message) pairs to the list
+                        log_request_ids.append((request_id, message))
+                # Check that there are no duplicate (request_id, message) pairs
                 request_id_counts = Counter(log_request_ids)
-                for request_id, count in request_id_counts.items():
-                    assert (
-                        count <= 5
-                    ), f"Request ids duplicated with buffer size {buffer_size}"
+                for _, count in request_id_counts.items():
+                    assert count == 1, "Request ID duplicates when buffering"
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -1387,26 +1387,25 @@ def test_request_id_uniqueness_with_buffering(ray_instance):
 
     logs_dir = get_serve_logs_dir()
 
-def check_logs():
-    for log_file in os.listdir(logs_dir):
-        if log_file.startswith("replica"):
-            with open(os.path.join(logs_dir, log_file)) as f:
-                log_request_ids = []
-                for line in f:
-                    log_entry = json.loads(line)
-                    request_id = log_entry.get("request_id", None)
-                    message = log_entry.get("message", None)
-                    if request_id:
-                        # Append the (request_id, message) pairs to the list
-                        log_request_ids.append((request_id, message))
-                # Check that there are no duplicate (request_id, message) pairs
-                request_id_counts = Counter(log_request_ids)
-                for _, count in request_id_counts.items():
-                    assert count == 1, "Request ID duplicates when buffering"
-  return True
+    def check_logs():
+        for log_file in os.listdir(logs_dir):
+            if log_file.startswith("replica"):
+                with open(os.path.join(logs_dir, log_file)) as f:
+                    log_request_ids = []
+                    for line in f:
+                        log_entry = json.loads(line)
+                        request_id = log_entry.get("request_id", None)
+                        message = log_entry.get("message", None)
+                        if request_id:
+                            # Append the (request_id, message) pairs to the list
+                            log_request_ids.append((request_id, message))
+                    # Check that there are no duplicate (request_id, message) pairs
+                    request_id_counts = Counter(log_request_ids)
+                    for _, count in request_id_counts.items():
+                        assert count == 1, "Request ID duplicates when buffering"
+        return True
 
-wait_for_condition(check_logs)
-
+    wait_for_condition(check_logs)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -1387,6 +1387,7 @@ def test_request_id_uniqueness_with_buffering(ray_instance):
 
     logs_dir = get_serve_logs_dir()
 
+def check_logs():
     for log_file in os.listdir(logs_dir):
         if log_file.startswith("replica"):
             with open(os.path.join(logs_dir, log_file)) as f:
@@ -1402,6 +1403,10 @@ def test_request_id_uniqueness_with_buffering(ray_instance):
                 request_id_counts = Counter(log_request_ids)
                 for _, count in request_id_counts.items():
                     assert count == 1, "Request ID duplicates when buffering"
+  return True
+
+wait_for_condition(check_logs)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when Serve file logs are buffered via a `MemoryHandler`, `ServeContextFilter` fetches the serve request context at flush time instead of when the log record is emitted. As a result, many log records flushed together can share the same request context, breaking per request tracing.
This PR captures the request context at emit time when buffering is enabled and makes the filter idempotent so it won’t overwrite pre populated fields. This preserves correct per record context for buffered file logs without changing non buffered behavior.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #55851 

## Performance Testing
Manual Verification -  Benchmarked both buffered and non buffered cases with and without the fix.
Performance- Used Locust with 100 users for a duration of 3-4 mins

Without buffering:
With fix: `Avg: 396.69(ms), P99: 580(ms), RPS: 228.4`
Without fix:  `391.29(ms), P99: 560(ms), RPS: 239`

With buffering:
set `RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE` = 1000
With fix: `Avg(ms): 400.83, P99(ms): 620, RPS: 230.5`
Without fix: `Avg(ms): 373.25, P99(ms): 610, RPS: 249.4`


<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
