### PR TITLE
Callback-based stat computation for preprocessors and ValueCounter

### DIFF
--- a/doc/source/data/doc_code/preprocessors.py
+++ b/doc/source/data/doc_code/preprocessors.py
@@ -105,6 +105,7 @@ from ray.data.aggregate import Max
 class CustomPreprocessor(Preprocessor):
     def _fit(self, dataset: Dataset) -> Preprocessor:
         self.stats_ = dataset.aggregate(Max("id"))
+        return self
 
     def _transform_pandas(self, df: DataFrame) -> DataFrame:
         return df * self.stats_["max(id)"]

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -501,10 +501,38 @@ class ArrowBlockColumnAccessor(BlockColumnAccessor):
 
         return pac.unique(self._column)
 
+    def value_counts(self) -> Optional[Dict[str, List]]:
+        import pyarrow.compute as pac
+
+        value_counts: pyarrow.StructArray = pac.value_counts(self._column)
+        if len(value_counts) == 0:
+            return None
+        return {
+            "values": value_counts.field("values").to_pylist(),
+            "counts": value_counts.field("counts").to_pylist(),
+        }
+
+    def hash(self) -> BlockColumn:
+        import polars as pl
+
+        df = pl.DataFrame({"col": self._column})
+        hashes = df.hash_rows().cast(pl.Int64, wrap_numerical=True)
+        return hashes.to_arrow()
+
     def flatten(self) -> BlockColumn:
         import pyarrow.compute as pac
 
         return pac.list_flatten(self._column)
+
+    def dropna(self) -> BlockColumn:
+        import pyarrow.compute as pac
+
+        return pac.drop_null(self._column)
+
+    def is_composed_of_lists(self, types: Optional[Tuple] = None) -> bool:
+        if not types:
+            types = (pyarrow.lib.ListType, pyarrow.lib.LargeListType)
+        return isinstance(self._column.type, types)
 
     def to_pylist(self) -> List[Any]:
         return self._column.to_pylist()

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -663,9 +663,42 @@ class BlockColumnAccessor:
         """Returns new column holding only distinct values of the current one"""
         raise NotImplementedError()
 
+    def value_counts(self) -> Dict[str, List]:
+        raise NotImplementedError()
+
+    def hash(self) -> BlockColumn:
+        """
+        Computes a 64-bit hash value for each row in the column.
+
+        Provides a unified hashing method across supported backends.
+        Handles complex types like lists or nested structures by producing a single hash per row.
+        These hashes are useful for downstream operations such as deduplication, grouping, or partitioning.
+
+        Internally, Polars is used to compute row-level hashes even when the original column
+        is backed by Pandas or PyArrow.
+
+        :return: A column of 64-bit integer hashes, returned in the same format as the underlying backend
+             (e.g., Pandas Series or PyArrow Array).
+        """
+        raise NotImplementedError()
+
     def flatten(self) -> BlockColumn:
         """Flattens nested lists merging them into top-level container"""
 
+        raise NotImplementedError()
+
+    def dropna(self) -> BlockColumn:
+        raise NotImplementedError()
+
+    def is_composed_of_lists(self, types: Optional[Tuple] = None) -> bool:
+        """
+        Checks whether the column is composed of list-like elements.
+
+        :param types: Optional tuple of backend-specific types to check against.
+                      If not provided, defaults to list-like types appropriate
+                      for the underlying backend (e.g., PyArrow list types).
+        :return: True if the column is made up of list-like values; False otherwise.
+        """
         raise NotImplementedError()
 
     def sum_of_squared_diffs_from_mean(

--- a/python/ray/data/preprocessors/chain.py
+++ b/python/ray/data/preprocessors/chain.py
@@ -66,6 +66,7 @@ class Chain(Preprocessor):
             return Preprocessor.FitStatus.NOT_FITTABLE
 
     def __init__(self, *preprocessors: Preprocessor):
+        super().__init__()
         self.preprocessors = preprocessors
 
     def _fit(self, ds: Dataset) -> Preprocessor:

--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from numbers import Number
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -107,6 +107,7 @@ class SimpleImputer(Preprocessor):
         *,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.strategy = strategy
         self.fill_value = fill_value
@@ -131,10 +132,19 @@ class SimpleImputer(Preprocessor):
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
         if self.strategy == "mean":
-            aggregates = [Mean(col) for col in self.columns]
-            self.stats_ = dataset.aggregate(*aggregates)
+            self.stat_computation_plan.add_aggregator(
+                aggregator_fn=Mean, columns=self.columns
+            )
         elif self.strategy == "most_frequent":
-            self.stats_ = _get_most_frequent_values(dataset, *self.columns)
+            self.stat_computation_plan.add_callable_stat(
+                stat_fn=lambda key_gen: _get_most_frequent_values(
+                    dataset=dataset,
+                    columns=self.columns,
+                    key_gen=key_gen,
+                ),
+                stat_key_fn=lambda col: f"most_frequent({col})",
+                columns=self.columns,
+            )
 
         return self
 
@@ -192,11 +202,11 @@ class SimpleImputer(Preprocessor):
 
 
 def _get_most_frequent_values(
-    dataset: Dataset, *columns: str
+    dataset: Dataset,
+    columns: List[str],
+    key_gen: Callable[[str], str],
 ) -> Dict[str, Union[str, Number]]:
-    columns = list(columns)
-
-    def get_pd_value_counts(df: pd.DataFrame) -> List[Dict[str, Counter]]:
+    def get_pd_value_counts(df: pd.DataFrame) -> Dict[str, List[Counter]]:
         return {col: [Counter(df[col].value_counts().to_dict())] for col in columns}
 
     value_counts = dataset.map_batches(get_pd_value_counts, batch_format="pandas")
@@ -207,6 +217,6 @@ def _get_most_frequent_values(
                 final_counters[col] += counter
 
     return {
-        f"most_frequent({column})": final_counters[column].most_common(1)[0][0]
+        key_gen(column): final_counters[column].most_common(1)[0][0]  # noqa
         for column in columns
     }

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -79,15 +79,21 @@ class StandardScaler(Preprocessor):
     """
 
     def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
+        super().__init__()
         self.columns = columns
         self.output_columns = Preprocessor._derive_and_validate_output_columns(
             columns, output_columns
         )
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
-        mean_aggregates = [Mean(col) for col in self.columns]
-        std_aggregates = [Std(col, ddof=0) for col in self.columns]
-        self.stats_ = dataset.aggregate(*mean_aggregates, *std_aggregates)
+        self.stat_computation_plan.add_aggregator(
+            aggregator_fn=Mean,
+            columns=self.columns,
+        )
+        self.stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Std(col, ddof=0),
+            columns=self.columns,
+        )
         return self
 
     def _transform_pandas(self, df: pd.DataFrame):
@@ -179,6 +185,7 @@ class MinMaxScaler(Preprocessor):
     """
 
     def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
+        super().__init__()
         self.columns = columns
         self.output_columns = Preprocessor._derive_and_validate_output_columns(
             columns, output_columns
@@ -271,6 +278,7 @@ class MaxAbsScaler(Preprocessor):
     """
 
     def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
+        super().__init__()
         self.columns = columns
         self.output_columns = Preprocessor._derive_and_validate_output_columns(
             columns, output_columns
@@ -375,6 +383,7 @@ class RobustScaler(Preprocessor):
         quantile_range: Tuple[float, float] = (0.25, 0.75),
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.quantile_range = quantile_range
 

--- a/python/ray/data/preprocessors/utils.py
+++ b/python/ray/data/preprocessors/utils.py
@@ -1,6 +1,9 @@
 import hashlib
-from typing import List
+from collections import deque
+from typing import Any, Callable, Deque, Dict, List, Optional, Union
 
+from ray.data import Dataset
+from ray.data.aggregate import AggregateFnV2
 from ray.util.annotations import DeveloperAPI
 
 
@@ -17,3 +20,207 @@ def simple_hash(value: object, num_features: int) -> int:
     hashed_value = hashlib.sha1(encoded_value)
     hashed_value_int = int(hashed_value.hexdigest(), 16)
     return hashed_value_int % num_features
+
+
+class BaseStatSpec:
+    """Encapsulates a statistical computation with optional post-processing."""
+
+    def __init__(
+        self,
+        *,
+        stat_fn: Union[AggregateFnV2, Callable],
+        post_process_fn: Callable = lambda x: x,
+        post_key_fn: Callable[[str], str],
+    ):
+        self.stat_fn = stat_fn
+        self.post_process_fn = post_process_fn
+        self.post_key_fn = post_key_fn
+
+
+class AggregateStatSpec(BaseStatSpec):
+    """Represents an AggregateFnV2 spec for a single column."""
+
+    def __init__(
+        self,
+        *,
+        aggregator_fn: Union[AggregateFnV2, Callable[[str], AggregateFnV2]],
+        post_process_fn: Callable = lambda x: x,
+        post_key_fn: Callable[[str], str],
+        column: Optional[str] = None,
+    ):
+        super().__init__(
+            stat_fn=aggregator_fn,
+            post_process_fn=post_process_fn,
+            post_key_fn=post_key_fn,
+        )
+        self.column = column
+
+
+class CallableStatSpec(BaseStatSpec):
+    """Represents a user-defined stat function that operates outside Dataset.aggregate."""
+
+    def __init__(
+        self,
+        *,
+        stat_fn: Callable,
+        stat_key_fn: Optional[Callable[[str], str]],
+        post_key_fn: Optional[Callable[[str], str]],
+        post_process_fn: Callable = lambda x: x,
+        columns: List[str],
+    ):
+        super().__init__(
+            stat_fn=stat_fn, post_process_fn=post_process_fn, post_key_fn=post_key_fn
+        )
+        self.columns = columns
+        self.stat_key_fn = stat_key_fn
+
+
+class StatComputationPlan:
+    """
+    Encapsulates a set of aggregators (AggregateFnV2) and legacy stat functions
+    to compute statistics over a Ray dataset.
+
+    Supports two types of aggregations:
+    1. AggregateFnV2-based aggregators, which are batch-executed using `Dataset.aggregate(...)`.
+    2. Callable-based stat functions, executed sequentially (legacy use case).
+    """
+
+    def __init__(self):
+        self._aggregators: Deque[BaseStatSpec] = deque()
+
+    def reset(self):
+        self._aggregators.clear()
+
+    def add_aggregator(
+        self,
+        *,
+        aggregator_fn: Callable[[str], AggregateFnV2],
+        post_process_fn: Callable = lambda x: x,
+        post_key_fn: Optional[Callable[[str], str]] = None,
+        columns: List[str],
+    ) -> None:
+        """
+        Registers an AggregateFnV2 factory for one or more columns.
+
+        Args:
+            aggregator_fn: A callable (typically a lambda or class) that accepts a column name and returns an instance of AggregateFnV2.
+            post_process_fn: Function to post-process the aggregated result.
+            post_key_fn: Optional key generator to use to save aggregation results after post-processing.
+            columns: List of column names to aggregate.
+        """
+        for column in columns:
+            agg_instance = aggregator_fn(column)
+            self._aggregators.append(
+                AggregateStatSpec(
+                    aggregator_fn=agg_instance,
+                    post_process_fn=post_process_fn,
+                    post_key_fn=post_key_fn,
+                    column=column,
+                )
+            )
+
+    def add_callable_stat(
+        self,
+        *,
+        stat_fn: Callable[[], Any],
+        post_process_fn: Callable = lambda x: x,
+        stat_key_fn: Callable[[str], str],
+        post_key_fn: Optional[Callable[[str], str]] = None,
+        columns: List[str],
+    ) -> None:
+        """
+        Registers a custom stat function to be run sequentially.
+
+        This supports legacy use cases where arbitrary callables are needed
+        and cannot be run via Dataset.aggregate().
+
+        :param post_key_fn:
+        :param stat_fn: A zero-argument callable that returns the stat.
+        :param post_process_fn: Function to apply to the result.
+        :param columns:
+        :param stat_key_fn:
+        """
+        self._aggregators.append(
+            CallableStatSpec(
+                stat_fn=stat_fn,
+                post_process_fn=post_process_fn,
+                columns=columns,
+                stat_key_fn=stat_key_fn,
+                post_key_fn=post_key_fn or stat_key_fn,
+            )
+        )
+
+    def compute(self, dataset: Dataset) -> Dict[str, Any]:
+        """
+        Executes all registered aggregators and stat functions.
+
+        AggregateFnV2-based aggregators are batched and executed via Dataset.aggregate().
+        Callable-based stat functions are run sequentially.
+
+        Args:
+            dataset: The Ray Dataset to compute statistics on.
+
+        Returns:
+            A dictionary of computed statistics.
+        """
+        stats = {}
+        # Run batched aggregators (AggregateFnV2)
+        aggregators = self._get_aggregate_fn_list()
+        if aggregators:
+            raw_result = dataset.aggregate(*aggregators)
+            for spec in self._get_aggregate_specs():
+                stat_key = spec.stat_fn.name
+                post_key = (
+                    spec.post_key_fn(spec.column)
+                    if spec.post_key_fn is not None
+                    else stat_key
+                )
+                stats[post_key] = spec.post_process_fn(raw_result[stat_key])
+
+        # Run sequential stat functions
+        for spec in self._get_custom_stat_fn_specs():
+            result = spec.stat_fn(spec.stat_key_fn)
+            for col in spec.columns:
+                stat_key = spec.stat_key_fn(col)
+                post_key = spec.post_key_fn(col)
+                stats[post_key] = spec.post_process_fn(result[stat_key])
+
+        return stats
+
+    def _get_aggregate_fn_list(self) -> List[AggregateFnV2]:
+        return [
+            spec.stat_fn
+            for spec in self._aggregators
+            if isinstance(spec, AggregateStatSpec)
+        ]
+
+    def _get_aggregate_specs(self) -> List[AggregateStatSpec]:
+        return [
+            spec for spec in self._aggregators if isinstance(spec, AggregateStatSpec)
+        ]
+
+    def _get_custom_stat_fn_specs(self) -> List[CallableStatSpec]:
+        return [
+            spec for spec in self._aggregators if isinstance(spec, CallableStatSpec)
+        ]
+
+    def __iter__(self):
+        """
+        Iterates over all AggregatorSpecs.
+        """
+        return iter(self._get_aggregate_specs())
+
+
+def make_post_processor(base_fn, callbacks: List[Callable]):
+    """
+    Wraps a base post-processing function with a sequence of callback functions.
+    Useful when multiple post-processing steps need to be applied in order.
+    """
+
+    def wrapper(result):
+        processed = base_fn(result)
+        for cb in callbacks:
+            processed = cb(processed)
+        return processed
+
+    return wrapper

--- a/python/ray/data/tests/preprocessors/test_chain.py
+++ b/python/ray/data/tests/preprocessors/test_chain.py
@@ -22,6 +22,10 @@ def test_chain():
 
     # Fit data.
     chain.fit(ds)
+    # Transform data.
+    transformed = chain.transform(ds)
+    out_df = transformed.to_pandas()
+
     assert imputer.stats_ == {
         "mean(B)": 0.0,
     }
@@ -34,10 +38,6 @@ def test_chain():
     assert encoder.stats_ == {
         "unique_values(C)": {"monday": 0, "sunday": 1, "tuesday": 2}
     }
-
-    # Transform data.
-    transformed = chain.transform(ds)
-    out_df = transformed.to_pandas()
 
     processed_col_a = [-1.0, -1.0, 1.0, 1.0]
     processed_col_b = [0.0, 0.0, 0.0, 0.0]
@@ -119,6 +119,10 @@ def test_nested_chain():
 
     # Fit data.
     chain.fit(ds)
+    # Transform data.
+    transformed = chain.transform(ds)
+    out_df = transformed.to_pandas()
+
     assert imputer.stats_ == {
         "mean(B)": 0.0,
     }
@@ -131,10 +135,6 @@ def test_nested_chain():
     assert encoder.stats_ == {
         "unique_values(C)": {"monday": 0, "sunday": 1, "tuesday": 2}
     }
-
-    # Transform data.
-    transformed = chain.transform(ds)
-    out_df = transformed.to_pandas()
 
     processed_col_a = [-1.0, -1.0, 1.0, 1.0]
     processed_col_b = [0.0, 0.0, 0.0, 0.0]

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -117,7 +117,7 @@ def test_fitted_preprocessor_without_stats():
 
     class FittablePreprocessor(Preprocessor):
         def _fit(self, ds):
-            return ds
+            return self
 
     preprocessor = FittablePreprocessor()
     ds = ray.data.from_items([1])

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -2281,7 +2281,7 @@ def test_map_names(target_max_block_size_infinite_or_default):
     ds = ray.data.from_items(["a", "b", "c", "a", "b", "c"])
     enc = OneHotEncoder(columns=["item"])
     r = enc.fit_transform(ds).__repr__()
-    assert r.startswith("OneHotEncoder"), r
+    assert "OneHotEncoder" in r, r
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
* Updated preprocessors to use a callback-based approach for stat computation. This improves code organization and reduces duplication.

* Added ValueCounter aggregator and value_counts method to BlockColumnAccessor. Includes implementations for both Arrow and Pandas backends.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
