### PR TITLE
[core] Don't need to return status from submitter cancel + cleanup

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2392,8 +2392,8 @@ Status CoreWorker::CancelTask(const ObjectID &object_id,
     RAY_LOG(DEBUG).WithField(object_id)
         << "Request to cancel a task of object to an owner "
         << obj_addr.SerializeAsString();
-    return normal_task_submitter_->CancelRemoteTask(
-        object_id, obj_addr, force_kill, recursive);
+    normal_task_submitter_->CancelRemoteTask(object_id, obj_addr, force_kill, recursive);
+    return Status::OK();
   }
 
   auto task_spec = task_manager_->GetTaskSpec(object_id.TaskId());
@@ -2414,58 +2414,51 @@ Status CoreWorker::CancelTask(const ObjectID &object_id,
       return Status::InvalidArgument("force=True is not supported for actor tasks.");
     }
 
-    return actor_task_submitter_->CancelTask(task_spec.value(), recursive);
+    actor_task_submitter_->CancelTask(task_spec.value(), recursive);
   } else {
-    return normal_task_submitter_->CancelTask(task_spec.value(), force_kill, recursive);
+    normal_task_submitter_->CancelTask(task_spec.value(), force_kill, recursive);
   }
+  return Status::OK();
 }
 
 Status CoreWorker::CancelChildren(const TaskID &task_id, bool force_kill) {
-  std::vector<std::pair<TaskID, Status>> recursive_cancellation_status;
-  bool recursive_success = true;
-  for (const auto &child_id : task_manager_->GetPendingChildrenTasks(task_id)) {
+  absl::flat_hash_set<TaskID> unknown_child_task_ids;
+  auto child_task_ids = task_manager_->GetPendingChildrenTasks(task_id);
+  for (const auto &child_id : child_task_ids) {
     auto child_spec = task_manager_->GetTaskSpec(child_id);
     if (!child_spec.has_value()) {
-      recursive_success = false;
-      recursive_cancellation_status.emplace_back(
-          child_id,
-          Status::UnknownError(
-              "Recursive task cancellation failed--check warning logs."));
+      unknown_child_task_ids.insert(child_id);
     } else if (child_spec->IsActorTask()) {
-      auto result = actor_task_submitter_->CancelTask(child_spec.value(), true);
-      recursive_cancellation_status.emplace_back(child_id, result);
+      actor_task_submitter_->CancelTask(std::move(*child_spec), true);
     } else {
-      auto result =
-          normal_task_submitter_->CancelTask(child_spec.value(), force_kill, true);
-      recursive_cancellation_status.emplace_back(child_id, result);
+      normal_task_submitter_->CancelTask(std::move(*child_spec), force_kill, true);
     }
   }
 
-  if (recursive_success) {
+  if (unknown_child_task_ids.empty()) {
     return Status::OK();
-  } else {
-    auto kMaxFailedTaskSampleSize = 10;
-    std::ostringstream ostr;
-    ostr << "Failed to cancel all the children tasks of " << task_id << " recursively.\n"
-         << "Here are up to " << kMaxFailedTaskSampleSize
-         << " samples tasks that failed to be canceled\n";
-    auto success = 0;
-    auto failures = 0;
-    for (const auto &[child_id, status] : recursive_cancellation_status) {
-      if (status.ok()) {
-        success += 1;
-      } else {
-        // Only record up to sample sizes.
-        if (failures < kMaxFailedTaskSampleSize) {
-          ostr << "\t" << child_id << ", " << status << "\n";
-        }
-        failures += 1;
-      }
-    }
-    ostr << "Total Recursive cancelation success: " << success
-         << ", failures: " << failures;
-    return Status::UnknownError(ostr.str());
   }
+
+  constexpr size_t kMaxFailedTaskSampleSize = 10;
+  std::ostringstream ostr;
+  ostr << "Failed to cancel all the children tasks of " << task_id << " recursively.\n"
+       << "Here are up to " << kMaxFailedTaskSampleSize
+       << " samples tasks that failed to be canceled\n";
+  const auto failure_status_str =
+      Status::UnknownError("Recursive task cancellation failed--check warning logs.")
+          .ToString();
+  size_t failures = 0;
+  for (const auto &child_id : unknown_child_task_ids) {
+    ostr << "\t" << child_id << ", " << failure_status_str << "\n";
+    failures += 1;
+    if (failures >= kMaxFailedTaskSampleSize) {
+      break;
+    }
+  }
+  ostr << "Total Recursive cancelation success: "
+       << (child_task_ids.size() - unknown_child_task_ids.size())
+       << ", failures: " << unknown_child_task_ids.size();
+  return Status::UnknownError(ostr.str());
 }
 
 Status CoreWorker::KillActor(const ActorID &actor_id, bool force_kill, bool no_restart) {

--- a/src/ray/core_worker/task_submission/BUILD.bazel
+++ b/src/ray/core_worker/task_submission/BUILD.bazel
@@ -91,7 +91,7 @@ ray_cc_library(
         "//src/ray/common:lease",
         "//src/ray/core_worker:lease_policy",
         "//src/ray/core_worker:memory_store",
-        "//src/ray/core_worker:task_manager",
+        "//src/ray/core_worker:task_manager_interface",
         "//src/ray/gcs:gcs_pb_util",
         "//src/ray/raylet_client:raylet_client_lib",
         "//src/ray/rpc:core_worker_client",

--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -844,12 +844,12 @@ void ActorTaskSubmitter::RetryCancelTask(TaskSpecification task_spec,
   execute_after(
       io_service_,
       [this, task_spec = std::move(task_spec), recursive] {
-        RAY_UNUSED(CancelTask(task_spec, recursive));
+        CancelTask(task_spec, recursive);
       },
       std::chrono::milliseconds(milliseconds));
 }
 
-Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursive) {
+void ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursive) {
   // We don't support force_kill = true for actor tasks.
   bool force_kill = false;
   RAY_LOG(INFO).WithField(task_spec.TaskId()).WithField(task_spec.ActorId())
@@ -871,7 +871,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
   GetTaskManagerWithoutMu().MarkTaskCanceled(task_id);
   if (!GetTaskManagerWithoutMu().IsTaskPending(task_id)) {
     RAY_LOG(DEBUG).WithField(task_id) << "Task is already finished or canceled";
-    return Status::OK();
+    return;
   }
 
   auto task_queued = false;
@@ -886,7 +886,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
       // No need to decrement cur_pending_calls because it doesn't matter.
       RAY_LOG(DEBUG).WithField(task_id)
           << "Task's actor is already dead. Ignoring the cancel request.";
-      return Status::OK();
+      return;
     }
 
     task_queued = queue->second.actor_submit_queue_->Contains(send_pos);
@@ -916,7 +916,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
     error_info.set_error_type(rpc::ErrorType::TASK_CANCELLED);
     GetTaskManagerWithoutMu().FailOrRetryPendingTask(
         task_id, rpc::ErrorType::TASK_CANCELLED, /*status*/ nullptr, &error_info);
-    return Status::OK();
+    return;
   }
 
   // At this point, the task is in "sent" state and not finished yet.
@@ -934,7 +934,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
     RAY_CHECK(queue != client_queues_.end());
     if (!queue->second.rpc_client_) {
       RetryCancelTask(task_spec, recursive, 1000);
-      return Status::OK();
+      return;
     }
 
     const auto &client = queue->second.rpc_client_;
@@ -964,11 +964,6 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
                          }
                        });
   }
-
-  // NOTE: Currently, ray.cancel is asynchronous.
-  // If we want to have a better guarantee in the cancelation result
-  // we should make it synchronos, but that can regress the performance.
-  return Status::OK();
 }
 
 bool ActorTaskSubmitter::QueueGeneratorForResubmit(const TaskSpecification &spec) {

--- a/src/ray/core_worker/task_submission/actor_task_submitter.h
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.h
@@ -236,11 +236,7 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
   ///
   /// \param task_spec The task spec of a task that will be canceled.
   /// \param recursive If true, it will cancel all child tasks.
-  /// \return True if cancel request is not needed or it will be
-  /// requested. False otherwise. Note that tasks could be "not"
-  /// canceled although the status is true because it is an
-  /// asynchronous API.
-  Status CancelTask(TaskSpecification task_spec, bool recursive);
+  void CancelTask(TaskSpecification task_spec, bool recursive);
 
   /// Retry the CancelTask in milliseconds.
   void RetryCancelTask(TaskSpecification task_spec, bool recursive, int64_t milliseconds);

--- a/src/ray/core_worker/task_submission/normal_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.cc
@@ -678,9 +678,9 @@ bool NormalTaskSubmitter::HandleGetWorkerFailureCause(
                                               fail_immediately);
 }
 
-Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
-                                       bool force_kill,
-                                       bool recursive) {
+void NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
+                                     bool force_kill,
+                                     bool recursive) {
   const auto task_id = task_spec.TaskId();
   RAY_LOG(INFO) << "Cancelling a task: " << task_id << " force_kill: " << force_kill
                 << " recursive: " << recursive;
@@ -695,13 +695,13 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
     // For idempotency.
     if (cancelled_tasks_.contains(task_id)) {
       // The task cancel is already in progress. We don't need to do anything.
-      return Status::OK();
+      return;
     }
 
     task_manager_.MarkTaskCanceled(task_id);
     if (!task_manager_.IsTaskPending(task_id)) {
       // The task is finished or failed so marking the task as cancelled is sufficient.
-      return Status::OK();
+      return;
     }
 
     auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
@@ -714,7 +714,7 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
           scheduling_tasks.erase(spec);
           CancelWorkerLeaseIfNeeded(scheduling_key);
           task_manager_.FailPendingTask(task_id, rpc::ErrorType::TASK_CANCELLED);
-          return Status::OK();
+          return;
         }
       }
     }
@@ -742,7 +742,7 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
         // scheduling_key_entries_ hashmap.
         scheduling_key_entries_.erase(scheduling_key);
       }
-      return Status::OK();
+      return;
     }
     // Looks for an RPC handle for the worker executing the task.
     client = core_worker_client_pool_->GetOrConnect(rpc_client->second);
@@ -792,20 +792,18 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
           }
         }
       });
-  return Status::OK();
 }
 
-Status NormalTaskSubmitter::CancelRemoteTask(const ObjectID &object_id,
-                                             const rpc::Address &worker_addr,
-                                             bool force_kill,
-                                             bool recursive) {
+void NormalTaskSubmitter::CancelRemoteTask(const ObjectID &object_id,
+                                           const rpc::Address &worker_addr,
+                                           bool force_kill,
+                                           bool recursive) {
   auto client = core_worker_client_pool_->GetOrConnect(worker_addr);
   auto request = rpc::RemoteCancelTaskRequest();
   request.set_force_kill(force_kill);
   request.set_recursive(recursive);
   request.set_remote_object_id(object_id.Binary());
   client->RemoteCancelTask(request, nullptr);
-  return Status::OK();
 }
 
 bool NormalTaskSubmitter::QueueGeneratorForResubmit(const TaskSpecification &spec) {

--- a/src/ray/core_worker/task_submission/normal_task_submitter.h
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.h
@@ -25,11 +25,9 @@
 
 #include "absl/base/thread_annotations.h"
 #include "ray/common/id.h"
-#include "ray/core_worker/actor_manager.h"
-#include "ray/core_worker/context.h"
 #include "ray/core_worker/lease_policy.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
-#include "ray/core_worker/task_manager.h"
+#include "ray/core_worker/task_manager_interface.h"
 #include "ray/core_worker/task_submission/dependency_resolver.h"
 #include "ray/raylet_client/raylet_client.h"
 #include "ray/rpc/node_manager/raylet_client_pool.h"
@@ -123,16 +121,16 @@ class NormalTaskSubmitter {
   ///
   /// \param[in] task_spec The task to kill.
   /// \param[in] force_kill Whether to kill the worker executing the task.
-  Status CancelTask(TaskSpecification task_spec, bool force_kill, bool recursive);
+  void CancelTask(TaskSpecification task_spec, bool force_kill, bool recursive);
 
   /// Request the owner of the object ID to cancel a request.
   /// It is used when a object ID is not owned by the current process.
   /// We cannot cancel the task in this case because we don't have enough
   /// information to cancel a task.
-  Status CancelRemoteTask(const ObjectID &object_id,
-                          const rpc::Address &worker_addr,
-                          bool force_kill,
-                          bool recursive);
+  void CancelRemoteTask(const ObjectID &object_id,
+                        const rpc::Address &worker_addr,
+                        bool force_kill,
+                        bool recursive);
 
   /// Queue the streaming generator up for resubmission.
   /// \return true if the task is still executing and the submitter agrees to resubmit

--- a/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
@@ -690,7 +690,7 @@ TEST_F(NormalTaskSubmitterTest, TestCancellationWhileHandlingTaskFailure) {
   // GetWorkerFailureCause is called.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("oops")));
   // Cancel the task while GetWorkerFailureCause has not been completed.
-  ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
+  submitter.CancelTask(task, true, false);
   // Completing the GetWorkerFailureCause call. Check that the reply runs without error
   // and FailPendingTask is not called.
   ASSERT_TRUE(raylet_client->ReplyGetWorkerFailureCause());
@@ -1738,7 +1738,7 @@ TEST_F(NormalTaskSubmitterTest, TestKillExecutingTask) {
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
 
   // Try force kill, exiting the worker
-  ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
+  submitter.CancelTask(task, true, false);
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(), task.TaskIdBinary());
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("workerdying"), true));
   ASSERT_TRUE(raylet_client->ReplyGetWorkerFailureCause());
@@ -1755,7 +1755,7 @@ TEST_F(NormalTaskSubmitterTest, TestKillExecutingTask) {
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
 
   // Try non-force kill, worker returns normally
-  ASSERT_TRUE(submitter.CancelTask(task, false, false).ok());
+  submitter.CancelTask(task, false, false).ok();
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(), task.TaskIdBinary());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
@@ -1776,7 +1776,7 @@ TEST_F(NormalTaskSubmitterTest, TestKillPendingTask) {
   TaskSpecification task = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
-  ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
+  submitter.CancelTask(task, true, false).ok();
   ASSERT_EQ(worker_client->kill_requests.size(), 0);
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
@@ -1803,7 +1803,7 @@ TEST_F(NormalTaskSubmitterTest, TestKillResolvingTask) {
   task.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(obj1.Binary());
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
   ASSERT_EQ(task_manager->num_inlined_dependencies, 0);
-  ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
+  submitter.CancelTask(task, true, false);
   auto data = GenerateRandomObject();
   store->Put(*data, obj1);
   WaitForObjectIdInMemoryStore(*store, obj1);
@@ -1841,7 +1841,7 @@ TEST_F(NormalTaskSubmitterTest, TestCancelBeforeAfterQueueGeneratorForResubmit) 
   TaskSpecification task = BuildEmptyTaskSpec();
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
-  ASSERT_TRUE(submitter.CancelTask(task, /*force_kill=*/false, /*recursive=*/true).ok());
+  submitter.CancelTask(task, /*force_kill=*/false, /*recursive=*/true);
   ASSERT_FALSE(submitter.QueueGeneratorForResubmit(task));
   worker_client->ReplyCancelTask();
   ASSERT_TRUE(submitter.QueueGeneratorForResubmit(task));
@@ -1859,7 +1859,7 @@ TEST_F(NormalTaskSubmitterTest, TestCancelBeforeAfterQueueGeneratorForResubmit) 
   ASSERT_TRUE(submitter.SubmitTask(task2).ok());
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
   ASSERT_TRUE(submitter.QueueGeneratorForResubmit(task2));
-  ASSERT_TRUE(submitter.CancelTask(task2, /*force_kill=*/false, /*recursive=*/true).ok());
+  submitter.CancelTask(task2, /*force_kill=*/false, /*recursive=*/true);
   ASSERT_TRUE(worker_client->ReplyPushTask());
   worker_client->ReplyCancelTask(Status::OK(),
                                  /*attempt_succeeded=*/true,

--- a/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
@@ -1755,7 +1755,7 @@ TEST_F(NormalTaskSubmitterTest, TestKillExecutingTask) {
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
 
   // Try non-force kill, worker returns normally
-  submitter.CancelTask(task, false, false).ok();
+  submitter.CancelTask(task, false, false);
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(), task.TaskIdBinary());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
@@ -1776,7 +1776,7 @@ TEST_F(NormalTaskSubmitterTest, TestKillPendingTask) {
   TaskSpecification task = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
-  submitter.CancelTask(task, true, false).ok();
+  submitter.CancelTask(task, true, false);
   ASSERT_EQ(worker_client->kill_requests.size(), 0);
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);


### PR DESCRIPTION
## Why are these changes needed?
The submitters' CancelTask functions return a status even though it's always ok. Also cleaning up some related code with cancelling child tasks and cleaning up the includes/deps.