### PR TITLE
[data] Do not log the content of data block that failed

### DIFF
--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import inspect
+import logging
 import queue
 from threading import Thread
 from types import GeneratorType

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -1,7 +1,6 @@
 import asyncio
 import collections
 import inspect
-import logging
 import queue
 from threading import Thread
 from types import GeneratorType
@@ -154,7 +153,7 @@ def plan_project_op(
 
             return block
         except Exception as e:
-            _try_wrap_udf_exception(e, block)
+            _try_wrap_udf_exception(e)
 
     compute = get_compute(op._compute)
     transform_fn = _generate_transform_fn_for_map_block(fn)
@@ -213,7 +212,7 @@ def plan_filter_op(
             try:
                 return block.filter(expression)
             except Exception as e:
-                _try_wrap_udf_exception(e, block)
+                _try_wrap_udf_exception(e)
 
         transform_fn = _generate_transform_fn_for_map_batches(filter_batch_fn)
         map_transformer = _create_map_transformer_for_map_batches_op(
@@ -353,7 +352,7 @@ def _get_udf(
                         **fn_kwargs,
                     )
                 except Exception as e:
-                    _try_wrap_udf_exception(e, item)
+                    _try_wrap_udf_exception(e)
 
         elif inspect.isasyncgenfunction(udf.__call__):
 
@@ -388,7 +387,7 @@ def _get_udf(
                         **fn_kwargs,
                     )
                 except Exception as e:
-                    _try_wrap_udf_exception(e, item)
+                    _try_wrap_udf_exception(e)
 
     else:
 
@@ -396,7 +395,7 @@ def _get_udf(
             try:
                 return udf(item, *fn_args, **fn_kwargs)
             except Exception as e:
-                _try_wrap_udf_exception(e, item)
+                _try_wrap_udf_exception(e)
 
         def init_fn():
             pass
@@ -408,14 +407,11 @@ def _try_wrap_udf_exception(e: Exception, item: Any = None):
     """If the Ray Debugger is enabled, keep the full stack trace unmodified
     so that the debugger can stop at the initial unhandled exception.
     Otherwise, clear the stack trace to omit noisy internal code path."""
-    error_message = f"Failed to process the following data block: {item}"
-
     ctx = ray.data.DataContext.get_current()
     if _is_ray_debugger_post_mortem_enabled() or ctx.raise_original_map_exception:
-        logger.error(error_message)
         raise e
     else:
-        raise UserCodeException(error_message) from e
+        raise UserCodeException() from e
 
 
 # Following are util functions for converting UDFs to `MapTransformCallable`s.

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -412,7 +412,6 @@ def _try_wrap_udf_exception(e: Exception, item: Any = None):
     if _is_ray_debugger_post_mortem_enabled() or ctx.raise_original_map_exception:
         raise e
     else:
-        raise UserCodeException() from e
         raise UserCodeException("UDF failed to process a data block.") from e
 
 # Following are util functions for converting UDFs to `MapTransformCallable`s.

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -414,6 +414,7 @@ def _try_wrap_udf_exception(e: Exception, item: Any = None):
     else:
         raise UserCodeException("UDF failed to process a data block.") from e
 
+
 # Following are util functions for converting UDFs to `MapTransformCallable`s.
 
 

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -413,7 +413,7 @@ def _try_wrap_udf_exception(e: Exception, item: Any = None):
         raise e
     else:
         raise UserCodeException() from e
-
+        raise UserCodeException("UDF failed to process a data block.") from e
 
 # Following are util functions for converting UDFs to `MapTransformCallable`s.
 

--- a/python/ray/data/tests/test_exceptions.py
+++ b/python/ray/data/tests/test_exceptions.py
@@ -9,22 +9,6 @@ from ray.exceptions import RayTaskError
 from ray.tests.conftest import *  # noqa
 
 
-def test_handle_debugger_exception(ray_start_regular_shared):
-    def _bad(batch):
-        if batch["id"][0] == 5:
-            raise Exception("Test exception")
-
-        return batch
-
-    dataset = ray.data.range(8, override_num_blocks=8).map_batches(_bad)
-
-    with pytest.raises(
-        UserCodeException,
-        match=r"Failed to process the following data block: \{'id': array\(\[5\]\)\}",
-    ):
-        dataset.materialize()
-
-
 @pytest.mark.parametrize("log_internal_stack_trace_to_stdout", [True, False])
 def test_user_exception(
     log_internal_stack_trace_to_stdout,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This reverts PR #52380.

When working with large data blocks, this log can dump entire bock to terminal and can be spammy and insecure.

## Related issue number

Fixes #56092

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
