### PR TITLE
[core] Fix bug in determining whether a lease/task spec is retriable

### DIFF
--- a/cpp/src/ray/runtime/abstract_ray_runtime.cc
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.cc
@@ -302,7 +302,7 @@ bool AbstractRayRuntime::WasCurrentActorRestarted() {
     throw RayException("Received invalid protobuf data from GCS.");
   }
 
-  return actor_table_data.num_restarts() != 0;
+  return actor_table_data.num_actor_restarts() != 0;
 }
 
 ray::PlacementGroup AbstractRayRuntime::CreatePlacementGroup(

--- a/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
+++ b/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
@@ -131,7 +131,7 @@ public class GcsClient {
                 new ActorInfo(
                     ActorId.fromBytes(info.getActorId().toByteArray()),
                     ActorState.fromValue(info.getState().getNumber()),
-                    info.getNumRestarts(),
+                    info.getNumActorRestarts(),
                     new Address(
                         nodeId, info.getAddress().getIpAddress(), info.getAddress().getPort()),
                     info.getName()));
@@ -161,7 +161,7 @@ public class GcsClient {
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException("Received invalid protobuf data from GCS.");
     }
-    return actorTableData.getNumRestarts() != 0;
+    return actorTableData.getNumActorRestarts() != 0;
   }
 
   public JobId nextJobId() {

--- a/src/ray/common/lease/lease_spec.h
+++ b/src/ray/common/lease/lease_spec.h
@@ -36,7 +36,7 @@ class LeaseSpecification : public MessageWrapper<rpc::LeaseSpec> {
  public:
   explicit LeaseSpecification(const rpc::TaskSpec &task_spec);
 
-  /// Construct an empty t  ask specification. This should not be used directly.
+  /// Construct an empty task specification. This should not be used directly.
   LeaseSpecification() { ComputeResources(); }
 
   explicit LeaseSpecification(rpc::LeaseSpec lease_spec)

--- a/src/ray/common/lease/lease_spec.h
+++ b/src/ray/common/lease/lease_spec.h
@@ -36,7 +36,7 @@ class LeaseSpecification : public MessageWrapper<rpc::LeaseSpec> {
  public:
   explicit LeaseSpecification(const rpc::TaskSpec &task_spec);
 
-  /// Construct an empty task specification. This should not be used directly.
+  /// Construct an empty t  ask specification. This should not be used directly.
   LeaseSpecification() { ComputeResources(); }
 
   explicit LeaseSpecification(rpc::LeaseSpec lease_spec)
@@ -71,6 +71,7 @@ class LeaseSpecification : public MessageWrapper<rpc::LeaseSpec> {
   NodeID CallerNodeId() const;
   BundleID PlacementGroupBundleId() const;
   bool IsRetriable() const;
+  bool IsRetry() const;
   TaskID ParentTaskId() const;
   bool IsDetachedActor() const;
   std::string DebugString() const;
@@ -82,10 +83,6 @@ class LeaseSpecification : public MessageWrapper<rpc::LeaseSpec> {
   int64_t GetDepth() const;
   ActorID RootDetachedActorId() const;
   ray::FunctionDescriptor FunctionDescriptor() const;
-  int64_t MaxActorRestarts() const;
-  int32_t MaxRetries() const;
-  uint64_t AttemptNumber() const;
-  bool IsRetry() const;
   std::string GetTaskName() const;
   std::string GetFunctionOrActorName() const;
   std::vector<std::string> DynamicWorkerOptionsOrEmpty() const;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -336,7 +336,9 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   int GetRuntimeEnvHash() const;
 
-  uint64_t AttemptNumber() const;
+  int32_t TaskAttemptNumber() const;
+
+  int64_t ActorRestartNumber() const;
 
   bool IsRetry() const;
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -199,7 +199,7 @@ class TaskSpecBuilder {
       const std::string &serialized_retry_exception_allowlist,
       const rpc::SchedulingStrategy &scheduling_strategy,
       const ActorID root_detached_actor_id) {
-    message_->set_max_retries(max_retries);
+    message_->set_max_task_retries(max_retries);
     message_->set_retry_exceptions(retry_exceptions);
     message_->set_serialized_retry_exception_allowlist(
         serialized_retry_exception_allowlist);
@@ -306,7 +306,7 @@ class TaskSpecBuilder {
       const std::string &serialized_retry_exception_allowlist,
       uint64_t sequence_number) {
     message_->set_type(TaskType::ACTOR_TASK);
-    message_->set_max_retries(max_retries);
+    message_->set_max_task_retries(max_retries);
     message_->set_retry_exceptions(retry_exceptions);
     message_->set_serialized_retry_exception_allowlist(
         serialized_retry_exception_allowlist);

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -219,7 +219,7 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
       << "received notification on actor, state: " << actor_state
       << ", ip address: " << actor_data.address().ip_address()
       << ", port: " << actor_data.address().port()
-      << ", num_restarts: " << actor_data.num_restarts() << ", death context type="
+      << ", num_restarts: " << actor_data.num_actor_restarts() << ", death context type="
       << gcs::GetActorDeathCauseString(actor_data.death_cause());
   if (actor_data.preempted()) {
     actor_task_submitter_.SetPreempted(actor_id);
@@ -227,14 +227,14 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
 
   if (actor_data.state() == rpc::ActorTableData::RESTARTING) {
     actor_task_submitter_.DisconnectActor(actor_id,
-                                          actor_data.num_restarts(),
+                                          actor_data.num_actor_restarts(),
                                           /*dead=*/false,
                                           actor_data.death_cause(),
                                           /*is_restartable=*/true);
   } else if (actor_data.state() == rpc::ActorTableData::DEAD) {
     OnActorKilled(actor_id);
     actor_task_submitter_.DisconnectActor(actor_id,
-                                          actor_data.num_restarts(),
+                                          actor_data.num_actor_restarts(),
                                           /*dead=*/true,
                                           actor_data.death_cause(),
                                           gcs::IsActorRestartable(actor_data));
@@ -243,7 +243,7 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
     // otherwise we crash when bulk unsubscribing all actor handles.
   } else if (actor_data.state() == rpc::ActorTableData::ALIVE) {
     actor_task_submitter_.ConnectActor(
-        actor_id, actor_data.address(), actor_data.num_restarts());
+        actor_id, actor_data.address(), actor_data.num_actor_restarts());
   } else {
     // The actor is being created and not yet ready, just ignore!
   }

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -94,7 +94,7 @@ struct WorkerThreadContext {
   void SetCurrentTask(const TaskSpecification &task_spec) {
     RAY_CHECK(task_index_ == 0);
     RAY_CHECK(put_counter_ == 0);
-    SetCurrentTaskId(task_spec.TaskId(), task_spec.AttemptNumber());
+    SetCurrentTaskId(task_spec.TaskId(), task_spec.TaskAttemptNumber());
     SetCurrentPlacementGroupId(task_spec.PlacementGroupBundleId().first);
     SetPlacementGroupCaptureChildTasks(task_spec.PlacementGroupCaptureChildTasks());
     current_task_ = std::make_shared<const TaskSpecification>(task_spec);

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -281,7 +281,7 @@ class CoreWorker {
 
   int64_t GetCurrentTaskAttemptNumber() const {
     return worker_context_->GetCurrentTask() != nullptr
-               ? worker_context_->GetCurrentTask()->AttemptNumber()
+               ? worker_context_->GetCurrentTask()->TaskAttemptNumber()
                : 0;
   }
 

--- a/src/ray/core_worker/profile_event.cc
+++ b/src/ray/core_worker/profile_event.cc
@@ -43,7 +43,7 @@ ProfileEvent::ProfileEvent(TaskEventBuffer &task_event_buffer,
   event_ = std::make_unique<TaskProfileEvent>(
       worker_context.GetCurrentTaskID(),
       worker_context.GetCurrentJobID(),
-      task_spec == nullptr ? 0 : task_spec->AttemptNumber(),
+      task_spec == nullptr ? 0 : task_spec->TaskAttemptNumber(),
       WorkerTypeString(worker_context.GetWorkerType()),
       worker_context.GetWorkerID().Binary(),
       node_ip_address,

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -610,7 +610,7 @@ std::unique_ptr<rpc::TaskEventData> TaskEventBufferImpl::CreateTaskEventDataToSe
   for (auto &task_attempt : dropped_task_attempts_to_send) {
     rpc::TaskAttempt rpc_task_attempt;
     rpc_task_attempt.set_task_id(task_attempt.first.Binary());
-    rpc_task_attempt.set_attempt_number(task_attempt.second);
+    rpc_task_attempt.set_num_task_attempts(task_attempt.second);
     *(data->add_dropped_task_attempts()) = std::move(rpc_task_attempt);
   }
   size_t num_profile_events_dropped = stats_counter_.Get(
@@ -645,7 +645,7 @@ TaskEventBufferImpl::CreateRayEventsDataToSend(
   for (auto &task_attempt : dropped_task_attempts_to_send) {
     rpc::TaskAttempt rpc_task_attempt;
     rpc_task_attempt.set_task_id(task_attempt.first.Binary());
-    rpc_task_attempt.set_attempt_number(task_attempt.second);
+    rpc_task_attempt.set_num_task_attempts(task_attempt.second);
     *(metadata->add_dropped_task_attempts()) = std::move(rpc_task_attempt);
   }
   return data;

--- a/src/ray/core_worker/task_execution/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/task_execution/actor_scheduling_queue.cc
@@ -99,7 +99,7 @@ void ActorSchedulingQueue::Add(
     RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
         task_id,
         task_spec.JobId(),
-        task_spec.AttemptNumber(),
+        task_spec.TaskAttemptNumber(),
         task_spec,
         rpc::TaskStatus::PENDING_ACTOR_TASK_ARGS_FETCH,
         /* include_task_info */ false));
@@ -122,7 +122,7 @@ void ActorSchedulingQueue::Add(
         RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
             inbound_req_task_spec.TaskId(),
             inbound_req_task_spec.JobId(),
-            inbound_req_task_spec.AttemptNumber(),
+            inbound_req_task_spec.TaskAttemptNumber(),
             inbound_req_task_spec,
             rpc::TaskStatus::PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY,
             /* include_task_info */ false));
@@ -134,7 +134,7 @@ void ActorSchedulingQueue::Add(
     RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
         task_id,
         task_spec.JobId(),
-        task_spec.AttemptNumber(),
+        task_spec.TaskAttemptNumber(),
         task_spec,
         rpc::TaskStatus::PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY,
         /* include_task_info */ false));

--- a/src/ray/core_worker/task_execution/out_of_order_actor_scheduling_queue.cc
+++ b/src/ray/core_worker/task_execution/out_of_order_actor_scheduling_queue.cc
@@ -108,9 +108,10 @@ void OutOfOrderActorSchedulingQueue::Add(
       if (queued_actor_tasks_.contains(task_id)) {
         // There is already an attempt of the same task queued,
         // keep the one with larger attempt number and cancel the other one.
-        RAY_CHECK_NE(queued_actor_tasks_[task_id].AttemptNumber(),
-                     request.AttemptNumber());
-        if (queued_actor_tasks_[task_id].AttemptNumber() > request.AttemptNumber()) {
+        RAY_CHECK_NE(queued_actor_tasks_[task_id].TaskAttemptNumber(),
+                     request.TaskAttemptNumber());
+        if (queued_actor_tasks_[task_id].TaskAttemptNumber() >
+            request.TaskAttemptNumber()) {
           // This can happen if the PushTaskRequest arrives out of order.
           request_to_cancel = request;
         } else {
@@ -180,7 +181,7 @@ void OutOfOrderActorSchedulingQueue::RunRequest(InboundRequest request) {
     RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
         task_spec.TaskId(),
         task_spec.JobId(),
-        task_spec.AttemptNumber(),
+        task_spec.TaskAttemptNumber(),
         task_spec,
         rpc::TaskStatus::PENDING_ACTOR_TASK_ARGS_FETCH,
         /* include_task_info */ false));
@@ -193,7 +194,7 @@ void OutOfOrderActorSchedulingQueue::RunRequest(InboundRequest request) {
       RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
           task.TaskId(),
           task.JobId(),
-          task.AttemptNumber(),
+          task.TaskAttemptNumber(),
           task,
           rpc::TaskStatus::PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY,
           /* include_task_info */ false));
@@ -205,7 +206,7 @@ void OutOfOrderActorSchedulingQueue::RunRequest(InboundRequest request) {
     RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
         task_spec.TaskId(),
         task_spec.JobId(),
-        task_spec.AttemptNumber(),
+        task_spec.TaskAttemptNumber(),
         task_spec,
         rpc::TaskStatus::PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY,
         /* include_task_info */ false));

--- a/src/ray/core_worker/task_execution/scheduling_util.cc
+++ b/src/ray/core_worker/task_execution/scheduling_util.cc
@@ -46,7 +46,9 @@ void InboundRequest::Cancel(const Status &status) {
 
 ray::TaskID InboundRequest::TaskID() const { return task_spec_.TaskId(); }
 
-uint64_t InboundRequest::AttemptNumber() const { return task_spec_.AttemptNumber(); }
+uint64_t InboundRequest::TaskAttemptNumber() const {
+  return task_spec_.TaskAttemptNumber();
+}
 
 const std::string &InboundRequest::ConcurrencyGroupName() const {
   return task_spec_.ConcurrencyGroupName();

--- a/src/ray/core_worker/task_execution/scheduling_util.h
+++ b/src/ray/core_worker/task_execution/scheduling_util.h
@@ -40,7 +40,7 @@ class InboundRequest {
   void Accept();
   void Cancel(const Status &status);
   ray::TaskID TaskID() const;
-  uint64_t AttemptNumber() const;
+  uint64_t TaskAttemptNumber() const;
   const std::string &ConcurrencyGroupName() const;
   ray::FunctionDescriptor FunctionDescriptor() const;
   bool DependenciesResolved() const;

--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -594,7 +594,7 @@ void ActorTaskSubmitter::PushActorTask(ClientQueue &queue,
         HandlePushTaskReply(status, reply, addr, task_spec);
       };
 
-  const TaskAttempt task_attempt = std::make_pair(task_id, task_spec.AttemptNumber());
+  const TaskAttempt task_attempt = std::make_pair(task_id, task_spec.TaskAttemptNumber());
   queue.inflight_task_callbacks_.emplace(task_attempt, std::move(reply_callback));
   rpc::ClientCallback<rpc::PushTaskReply> wrapped_callback =
       [this, task_attempt, actor_id](const Status &status, rpc::PushTaskReply &&reply) {

--- a/src/ray/core_worker/task_submission/tests/actor_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/actor_task_submitter_test.cc
@@ -461,11 +461,11 @@ TEST_P(ActorTaskSubmitterTest, TestActorRestartRetry) {
   ASSERT_EQ(io_context.poll_one(), 1);
   // Tasks 2 and 3 get retried. In the real world, the seq_no of these two tasks should be
   // updated to 4 and 5 by `CoreWorker::InternalHeartbeat`.
-  task2.GetMutableMessage().set_attempt_number(task2.AttemptNumber() + 1);
+  task2.GetMutableMessage().set_attempt_number(task2.TaskAttemptNumber() + 1);
   task2.GetMutableMessage().mutable_actor_task_spec()->set_sequence_number(4);
   ASSERT_TRUE(submitter_.SubmitTask(task2).ok());
   ASSERT_EQ(io_context.poll_one(), 1);
-  task3.GetMutableMessage().set_attempt_number(task2.AttemptNumber() + 1);
+  task3.GetMutableMessage().set_attempt_number(task2.TaskAttemptNumber() + 1);
   task3.GetMutableMessage().mutable_actor_task_spec()->set_sequence_number(5);
   ASSERT_TRUE(submitter_.SubmitTask(task3).ok());
   ASSERT_EQ(io_context.poll_one(), 1);
@@ -524,7 +524,7 @@ TEST_P(ActorTaskSubmitterTest, TestActorRestartOutOfOrderRetry) {
 
   // Upon re-connect, task 2 (failed) should be retried.
   // Retry task 2 manually (simulating task_manager and SendPendingTask's behavior)
-  task2.GetMutableMessage().set_attempt_number(task2.AttemptNumber() + 1);
+  task2.GetMutableMessage().set_attempt_number(task2.TaskAttemptNumber() + 1);
   task2.GetMutableMessage().mutable_actor_task_spec()->set_sequence_number(3);
   ASSERT_TRUE(submitter_.SubmitTask(task2).ok());
   ASSERT_EQ(io_context.poll_one(), 1);
@@ -675,12 +675,12 @@ TEST_P(ActorTaskSubmitterTest, TestActorRestartFailInflightTasks) {
   task2_second_attempt.GetMutableMessage().set_task_id(
       task2_first_attempt.TaskIdBinary());
   task2_second_attempt.GetMutableMessage().set_attempt_number(
-      task2_first_attempt.AttemptNumber() + 1);
+      task2_first_attempt.TaskAttemptNumber() + 1);
   auto task3_second_attempt = CreateActorTaskHelper(actor_id, caller_worker_id, 4);
   task3_second_attempt.GetMutableMessage().set_task_id(
       task3_first_attempt.TaskIdBinary());
   task3_second_attempt.GetMutableMessage().set_attempt_number(
-      task3_first_attempt.AttemptNumber() + 1);
+      task3_first_attempt.TaskAttemptNumber() + 1);
   ASSERT_TRUE(submitter_.SubmitTask(task2_second_attempt).ok());
   ASSERT_EQ(io_context.poll_one(), 1);
   ASSERT_TRUE(submitter_.SubmitTask(task3_second_attempt).ok());

--- a/src/ray/gcs/gcs_server/gcs_actor.h
+++ b/src/ray/gcs/gcs_server/gcs_actor.h
@@ -85,8 +85,9 @@ class GcsActor {
     const auto &actor_creation_task_spec = task_spec_->actor_creation_task_spec();
     actor_table_data_.set_actor_id(actor_creation_task_spec.actor_id());
     actor_table_data_.set_job_id(task_spec_->job_id());
-    actor_table_data_.set_max_restarts(actor_creation_task_spec.max_actor_restarts());
-    actor_table_data_.set_num_restarts(0);
+    actor_table_data_.set_max_actor_restarts(
+        actor_creation_task_spec.max_actor_restarts());
+    actor_table_data_.set_num_actor_restarts(0);
     actor_table_data_.set_num_restarts_due_to_lineage_reconstruction(0);
 
     actor_table_data_.mutable_function_descriptor()->CopyFrom(

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1317,8 +1317,8 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
   auto mutable_actor_table_data = actor->GetMutableActorTableData();
   // If the need_reschedule is set to false, then set the `remaining_restarts` to 0
   // so that the actor will never be rescheduled.
-  int64_t max_restarts = mutable_actor_table_data->max_restarts();
-  uint64_t num_restarts = mutable_actor_table_data->num_restarts();
+  int64_t max_restarts = mutable_actor_table_data->max_actor_restarts();
+  uint64_t num_restarts = mutable_actor_table_data->num_actor_restarts();
   uint64_t num_restarts_due_to_node_preemption =
       mutable_actor_table_data->num_restarts_due_to_node_preemption();
 
@@ -1353,7 +1353,10 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
       mutable_actor_table_data->set_num_restarts_due_to_node_preemption(
           num_restarts_due_to_node_preemption + 1);
     }
-    mutable_actor_table_data->set_num_restarts(num_restarts + 1);
+    mutable_actor_table_data->set_num_actor_restarts(num_restarts + 1);
+    actor->GetMutableTaskSpec()
+        ->mutable_actor_creation_task_spec()
+        ->set_num_actor_restarts(num_restarts + 1);
     actor->UpdateState(rpc::ActorTableData::RESTARTING);
     // Make sure to reset the address before flushing to GCS. Otherwise,
     // GCS will mistakenly consider this lease request succeeds when restarting.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -369,10 +369,10 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler {
     actor_delta.set_state(actor.state());
     actor_delta.mutable_death_cause()->CopyFrom(actor.death_cause());
     actor_delta.mutable_address()->CopyFrom(actor.address());
-    actor_delta.set_num_restarts(actor.num_restarts());
+    actor_delta.set_num_actor_restarts(actor.num_actor_restarts());
     actor_delta.set_num_restarts_due_to_node_preemption(
         actor.num_restarts_due_to_node_preemption());
-    actor_delta.set_max_restarts(actor.max_restarts());
+    actor_delta.set_max_actor_restarts(actor.max_actor_restarts());
     actor_delta.set_timestamp(actor.timestamp());
     actor_delta.set_pid(actor.pid());
     actor_delta.set_start_time(actor.start_time());

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -617,7 +617,7 @@ void GcsTaskManager::GcsTaskManagerStorage::RecordDataLossFromWorker(
     const rpc::TaskEventData &data) {
   for (const auto &dropped_attempt : data.dropped_task_attempts()) {
     const auto task_id = TaskID::FromBinary(dropped_attempt.task_id());
-    auto attempt_number = dropped_attempt.attempt_number();
+    auto attempt_number = dropped_attempt.num_task_attempts();
     auto job_id = task_id.JobId();
     job_task_summary_[job_id].RecordTaskAttemptDropped(
         std::make_pair(task_id, attempt_number));

--- a/src/ray/gcs/gcs_server/tests/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/tests/gcs_placement_group_manager_test.cc
@@ -816,8 +816,7 @@ TEST_F(GcsPlacementGroupManagerTest, TestSchedulerReinitializeAfterGcsRestart) {
       /* cpu_num */ 1.0,
       /* job_id */ job_id);
   auto job_table_data = Mocker::GenJobTableData(job_id);
-  gcs_table_storage_->JobTable().Put(
-      job_id, *job_table_data, {[](auto) {}, io_service_});
+  gcs_table_storage_->JobTable().Put(job_id, *job_table_data, {[](auto) {}, io_service_});
   std::atomic<int> registered_placement_group_count{0};
   RegisterPlacementGroup(request, [&registered_placement_group_count](Status status) {
     ++registered_placement_group_count;
@@ -1244,8 +1243,7 @@ TEST_F(GcsPlacementGroupManagerTest, TestCheckCreatorJobIsDeadWhenGcsRestart) {
       /* job_id */ job_id);
   auto job_table_data = Mocker::GenJobTableData(job_id);
   job_table_data->set_is_dead(true);
-  gcs_table_storage_->JobTable().Put(
-      job_id, *job_table_data, {[](auto) {}, io_service_});
+  gcs_table_storage_->JobTable().Put(job_id, *job_table_data, {[](auto) {}, io_service_});
   std::atomic<int> registered_placement_group_count{0};
   RegisterPlacementGroup(request, [&registered_placement_group_count](Status status) {
     ++registered_placement_group_count;

--- a/src/ray/gcs/gcs_server/tests/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/tests/gcs_placement_group_manager_test.cc
@@ -816,7 +816,8 @@ TEST_F(GcsPlacementGroupManagerTest, TestSchedulerReinitializeAfterGcsRestart) {
       /* cpu_num */ 1.0,
       /* job_id */ job_id);
   auto job_table_data = Mocker::GenJobTableData(job_id);
-  gcs_table_storage_->JobTable().Put(job_id, *job_table_data, {[](auto) {}, io_service_});
+  gcs_table_storage_->JobTable().Put(
+      job_id, *job_table_data, {[](auto) {}, io_service_});
   std::atomic<int> registered_placement_group_count{0};
   RegisterPlacementGroup(request, [&registered_placement_group_count](Status status) {
     ++registered_placement_group_count;
@@ -1243,7 +1244,8 @@ TEST_F(GcsPlacementGroupManagerTest, TestCheckCreatorJobIsDeadWhenGcsRestart) {
       /* job_id */ job_id);
   auto job_table_data = Mocker::GenJobTableData(job_id);
   job_table_data->set_is_dead(true);
-  gcs_table_storage_->JobTable().Put(job_id, *job_table_data, {[](auto) {}, io_service_});
+  gcs_table_storage_->JobTable().Put(
+      job_id, *job_table_data, {[](auto) {}, io_service_});
   std::atomic<int> registered_placement_group_count{0};
   RegisterPlacementGroup(request, [&registered_placement_group_count](Status status) {
     ++registered_placement_group_count;

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -181,12 +181,12 @@ inline bool IsActorRestartable(const rpc::ActorTableData &actor) {
   return actor.death_cause().context_case() == ContextCase::kActorDiedErrorContext &&
          actor.death_cause().actor_died_error_context().reason() ==
              rpc::ActorDiedErrorContext::OUT_OF_SCOPE &&
-         ((actor.max_restarts() == -1) ||
-          (actor.max_restarts() > 0 && actor.preempted()) ||
+         ((actor.max_actor_restarts() == -1) ||
+          (actor.max_actor_restarts() > 0 && actor.preempted()) ||
           // Restarts due to node preemption do not count towards max_restarts.
-          (static_cast<int64_t>(actor.num_restarts() -
+          (static_cast<int64_t>(actor.num_actor_restarts() -
                                 actor.num_restarts_due_to_node_preemption()) <
-           actor.max_restarts()));
+           actor.max_actor_restarts()));
 }
 
 inline std::string RayErrorInfoToString(const ray::rpc::RayErrorInfo &error_info) {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -464,21 +464,20 @@ message LeaseSpec {
   bytes actor_id = 5;
   bool is_detached_actor = 6;
   bytes root_detached_actor_id = 7;
-  int64 max_actor_restarts = 8;
-  map<string, double> required_resources = 9;
-  map<string, double> required_placement_resources = 10;
-  SchedulingStrategy scheduling_strategy = 11;
-  map<string, string> label_selector = 12;
-  int64 depth = 13;
-  RuntimeEnvInfo runtime_env_info = 14;
-  repeated ObjectReference dependencies = 15;
-  bytes parent_task_id = 16;
-  Language language = 17;
-  FunctionDescriptor function_descriptor = 18;
-  repeated string dynamic_worker_options = 19;
-  int32 max_retries = 20;
-  uint64 attempt_number = 21;
-  string task_name = 22;
+  bool is_retriable = 8;
+  bool is_retry = 9;
+  map<string, double> required_resources = 10;
+  map<string, double> required_placement_resources = 11;
+  SchedulingStrategy scheduling_strategy = 12;
+  map<string, string> label_selector = 13;
+  int64 depth = 14;
+  RuntimeEnvInfo runtime_env_info = 15;
+  repeated ObjectReference dependencies = 16;
+  bytes parent_task_id = 17;
+  Language language = 18;
+  FunctionDescriptor function_descriptor = 19;
+  repeated string dynamic_worker_options = 20;
+  string task_name = 21;
 }
 
 /// The task specification encapsulates all immutable information about the
@@ -524,7 +523,7 @@ message TaskSpec {
   // This field is only valid when `type == ACTOR_TASK`.
   ActorTaskSpec actor_task_spec = 16;
   // Number of times this task may be retried on worker failure.
-  int32 max_retries = 17;
+  int32 max_task_retries = 17;
   // Breakpoint if this task should drop into the debugger when it starts executing
   // and "" if the task should not drop into the debugger.
   bytes debugger_breakpoint = 22;
@@ -544,7 +543,7 @@ message TaskSpec {
   SchedulingStrategy scheduling_strategy = 28;
   // A count of the number of times this task has been attempted so far. 0
   // means this is the first execution.
-  uint64 attempt_number = 29;
+  int32 num_task_attempts = 29;
   // This task returns a dynamic number of objects.
   bool returns_dynamic = 30;
   // A list of ObjectIDs that were created by this task but that should be
@@ -644,7 +643,7 @@ message TaskAttempt {
   // The task id of the task attempt.
   bytes task_id = 1;
   // The attempt number of the task attempt.
-  int32 attempt_number = 2;
+  int32 num_task_attempts = 2;
 }
 
 message Bundle {
@@ -774,41 +773,45 @@ message ReturnObject {
 // Task spec of an actor creation task.
 message ActorCreationTaskSpec {
   // ID of the actor that will be created by this task.
-  bytes actor_id = 2;
+  bytes actor_id = 1;
   // The max number of times this actor should be restarted.
   // If this number is 0 the actor won't be restarted.
   // If this number is -1 the actor will be restarted indefinitely.
-  int64 max_actor_restarts = 3;
+  int64 max_actor_restarts = 2;
   // The max number of times tasks submitted on this actor should be retried
   // if the actor fails and is restarted.
   // If this number is 0 the tasks won't be resubmitted.
   // If this number is -1 the tasks will be resubmitted indefinitely.
-  int64 max_task_retries = 4;
+  int64 max_task_retries = 3;
   // The dynamic options used in the worker command when starting a worker process for
   // an actor creation task. If the list isn't empty, the options will be used to replace
   // the placeholder string `RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER` in the worker command.
   // Used by Java workers for JVM options.
-  repeated string dynamic_worker_options = 5;
+  repeated string dynamic_worker_options = 4;
   // The max number of concurrent calls for default concurrency group of this actor.
-  int32 max_concurrency = 6;
+  int32 max_concurrency = 5;
   // Whether the actor is persistent.
-  bool is_detached = 7;
+  bool is_detached = 6;
   // Globally-unique name of the actor. Should only be populated when is_detached is true.
-  string name = 8;
+  string name = 7;
   // The namespace of the actor. Should only be populated when is_detached is true.
-  string ray_namespace = 9;
+  string ray_namespace = 8;
   // Whether the actor use async actor calls.
-  bool is_asyncio = 10;
+  bool is_asyncio = 9;
   // Field used for storing application-level extensions to the actor definition.
-  string extension_data = 11;
+  string extension_data = 10;
   // Serialized bytes of the Handle to the actor that will be created by this task.
-  bytes serialized_actor_handle = 12;
+  bytes serialized_actor_handle = 11;
   // The concurrency groups of this actor.
-  repeated ConcurrencyGroup concurrency_groups = 13;
+  repeated ConcurrencyGroup concurrency_groups = 12;
   // Whether to enable out of order execution.
-  bool allow_out_of_order_execution = 14;
+  bool allow_out_of_order_execution = 13;
   // The max number of pending actor calls.
-  int32 max_pending_calls = 15;
+  int32 max_pending_calls = 14;
+  // Number of restarts that has been tried on this actor.
+  // This will be greater by 1 than what's published before in ALIVE.
+  // ALIVE:0 RESTARTING:1 ALIVE:1 RESTARTING:2, etc
+  int64 num_actor_restarts = 15;
 }
 
 // Task spec of an actor task.
@@ -943,7 +946,7 @@ message ObjectRefInfo {
   TaskStatus task_status = 8;
   // A count of the number of times this task has been attempted so far. 0
   // means this is the first execution.
-  uint64 attempt_number = 9;
+  int32 num_task_attempts = 9;
 }
 
 // Details about the allocation of a given resource. Some resources

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -443,7 +443,7 @@ message ReportGeneratorItemReturnsRequest {
   bytes generator_id = 5;
   // A count of the number of times this task has been attempted so far. 0
   // means this is the first execution.
-  uint64 attempt_number = 6;
+  int32 attempt_number = 6;
 }
 
 message ReportGeneratorItemReturnsReply {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -99,11 +99,11 @@ message ActorTableData {
   ActorState state = 6;
   // Max number of times this actor should be restarted,
   // a value of -1 indicates an infinite number of reconstruction attempts.
-  int64 max_restarts = 7;
+  int64 max_actor_restarts = 7;
   // Number of restarts that has been tried on this actor.
   // This will be greater by 1 than what's published before in ALIVE.
   // ALIVE:0 RESTARTING:1 ALIVE:1 RESTARTING:2, etc
-  uint64 num_restarts = 8;
+  int64 num_actor_restarts = 8;
   // The address of the actor.
   Address address = 9;
   // The address of the actor's owner (parent).


### PR DESCRIPTION
Fixing a bug in task_spec/lease_spec where we don't take into account the current number of task attempts/actor restarts in determining whether the task is retriable. Also includes a couple non functional refactors to improve readability of the task spec/lease spec fields. Also fixed a bug where the type of the task_attempt_number field did not match the max_attempt_number field, same for max_actor_restarts and num_actor_restarts. The fields in the ActorCreationTaskSpec proto also started at 2 for some reason, moved it back to 1. 

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
