### PR TITLE
[RLlib - Offline RL] Add spaces in case only offline data is used

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -769,14 +769,28 @@ class Algorithm(Checkpointable, Trainable):
             elif self.eval_env_runner_group:
                 spaces.update(self.eval_env_runner_group.get_spaces())
             else:
-                spaces.update(
-                    {
-                        DEFAULT_MODULE_ID: (
-                            self.config.observation_space,
-                            self.config.action_space,
-                        ),
-                    }
-                )
+                if self.config.is_online:
+                    spaces.update(
+                        {
+                            DEFAULT_MODULE_ID: (
+                                self.config.observation_space,
+                                self.config.action_space,
+                            ),
+                        }
+                    )
+                elif self.config.is_offline:
+                    learner_connector = self.config.build_learner_connector(
+                        input_observation_space=spaces[INPUT_ENV_SPACES][0],
+                        input_action_space=spaces[INPUT_ENV_SPACES][1],
+                    )
+                    spaces.update(
+                        {
+                            DEFAULT_MODULE_ID: (
+                                learner_connector.observation_space,
+                                learner_connector.action_space,
+                            ),
+                        }
+                    )
 
             module_spec: MultiRLModuleSpec = self.config.get_multi_rl_module_spec(
                 spaces=spaces,

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -769,6 +769,8 @@ class Algorithm(Checkpointable, Trainable):
             elif self.eval_env_runner_group:
                 spaces.update(self.eval_env_runner_group.get_spaces())
             else:
+                # If the algorithm is online we use the spaces from as they are
+                # provided.
                 if self.config.is_online:
                     spaces.update(
                         {
@@ -778,11 +780,16 @@ class Algorithm(Checkpointable, Trainable):
                             ),
                         }
                     )
+                # Otherwise, when we are offline we need to check, if the learner connector
+                # is transforming the spaces.
                 elif self.config.is_offline:
+                    # Build the learner connector with the input spaces from the environment.
                     learner_connector = self.config.build_learner_connector(
                         input_observation_space=spaces[INPUT_ENV_SPACES][0],
                         input_action_space=spaces[INPUT_ENV_SPACES][1],
                     )
+                    # Update the `spaces` dictionary by using the output spaces of the learner
+                    # connector pipeline.
                     spaces.update(
                         {
                             DEFAULT_MODULE_ID: (


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `spaces` are used to build an `RLModule`. This is in online RL handled by the `EnvRunner`s that check the `EnvToModule` and `ModuleToEnv` spaces. In case of offline RL this is not handled and as soon as a user does use a custom connector that changes observations or actions the `RLModule` cannot be built on the `Learner` anymore.

This PR handles this case and adds spaces - deduced from a local learner connector such that users can use space transformations in custom connectors.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
