### PR TITLE
[core] Fix flaky `ShutdownCoordinator` test under tsan

### DIFF
--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -18,6 +18,7 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/core_worker:shutdown_coordinator",
+        "@com_google_absl//absl/synchronization",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/src/ray/core_worker/tests/shutdown_coordinator_test.cc
+++ b/src/ray/core_worker/tests/shutdown_coordinator_test.cc
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -41,26 +42,36 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
 
   std::string last_exit_type;
   std::string last_detail;
+  mutable std::mutex mu_;
 
   void ExecuteGracefulShutdown(std::string_view exit_type,
                                std::string_view detail,
                                std::chrono::milliseconds timeout_ms) override {
     graceful_calls++;
-    last_exit_type = std::string(exit_type);
-    last_detail = std::string(detail);
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      last_exit_type = std::string(exit_type);
+      last_detail = std::string(detail);
+    }
   }
   void ExecuteForceShutdown(std::string_view exit_type,
                             std::string_view detail) override {
     force_calls++;
-    last_exit_type = std::string(exit_type);
-    last_detail = std::string(detail);
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      last_exit_type = std::string(exit_type);
+      last_detail = std::string(detail);
+    }
   }
   void ExecuteWorkerExit(std::string_view exit_type,
                          std::string_view detail,
                          std::chrono::milliseconds timeout_ms) override {
     worker_exit_calls++;
-    last_exit_type = std::string(exit_type);
-    last_detail = std::string(detail);
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      last_exit_type = std::string(exit_type);
+      last_detail = std::string(detail);
+    }
   }
   void ExecuteExit(std::string_view exit_type,
                    std::string_view detail,
@@ -68,15 +79,21 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
                    const std::shared_ptr<::ray::LocalMemoryBuffer>
                        &creation_task_exception_pb_bytes) override {
     worker_exit_calls++;
-    last_exit_type = std::string(exit_type);
-    last_detail = std::string(detail);
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      last_exit_type = std::string(exit_type);
+      last_detail = std::string(detail);
+    }
   }
   void ExecuteHandleExit(std::string_view exit_type,
                          std::string_view detail,
                          std::chrono::milliseconds timeout_ms) override {
     handle_exit_calls++;
-    last_exit_type = std::string(exit_type);
-    last_detail = std::string(detail);
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      last_exit_type = std::string(exit_type);
+      last_detail = std::string(detail);
+    }
   }
   void KillChildProcessesImmediately() override {}
   bool ShouldWorkerIdleExit() const override { return idle_exit_allowed.load(); }

--- a/src/ray/core_worker/tests/shutdown_coordinator_test.cc
+++ b/src/ray/core_worker/tests/shutdown_coordinator_test.cc
@@ -18,13 +18,13 @@
 
 #include <chrono>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "absl/synchronization/mutex.h"
 #include "ray/common/buffer.h"
 #include "src/ray/protobuf/common.pb.h"
 
@@ -42,15 +42,15 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
 
   std::string last_exit_type;
   std::string last_detail;
-  mutable std::mutex mu_;
+  mutable absl::Mutex mu_;
 
   std::string GetLastExitType() const {
-    std::lock_guard<std::mutex> lk(mu_);
+    absl::MutexLock lk(&mu_);
     return last_exit_type;
   }
 
   std::string GetLastDetail() const {
-    std::lock_guard<std::mutex> lk(mu_);
+    absl::MutexLock lk(&mu_);
     return last_detail;
   }
 
@@ -59,7 +59,7 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
                                std::chrono::milliseconds timeout_ms) override {
     graceful_calls++;
     {
-      std::lock_guard<std::mutex> lk(mu_);
+      absl::MutexLock lk(&mu_);
       last_exit_type = std::string(exit_type);
       last_detail = std::string(detail);
     }
@@ -68,7 +68,7 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
                             std::string_view detail) override {
     force_calls++;
     {
-      std::lock_guard<std::mutex> lk(mu_);
+      absl::MutexLock lk(&mu_);
       last_exit_type = std::string(exit_type);
       last_detail = std::string(detail);
     }
@@ -78,7 +78,7 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
                          std::chrono::milliseconds timeout_ms) override {
     worker_exit_calls++;
     {
-      std::lock_guard<std::mutex> lk(mu_);
+      absl::MutexLock lk(&mu_);
       last_exit_type = std::string(exit_type);
       last_detail = std::string(detail);
     }
@@ -90,7 +90,7 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
                        &creation_task_exception_pb_bytes) override {
     worker_exit_calls++;
     {
-      std::lock_guard<std::mutex> lk(mu_);
+      absl::MutexLock lk(&mu_);
       last_exit_type = std::string(exit_type);
       last_detail = std::string(detail);
     }
@@ -100,7 +100,7 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
                          std::chrono::milliseconds timeout_ms) override {
     handle_exit_calls++;
     {
-      std::lock_guard<std::mutex> lk(mu_);
+      absl::MutexLock lk(&mu_);
       last_exit_type = std::string(exit_type);
       last_detail = std::string(detail);
     }

--- a/src/ray/core_worker/tests/shutdown_coordinator_test.cc
+++ b/src/ray/core_worker/tests/shutdown_coordinator_test.cc
@@ -44,6 +44,16 @@ class FakeShutdownExecutor : public ShutdownExecutorInterface {
   std::string last_detail;
   mutable std::mutex mu_;
 
+  std::string GetLastExitType() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return last_exit_type;
+  }
+
+  std::string GetLastDetail() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return last_detail;
+  }
+
   void ExecuteGracefulShutdown(std::string_view exit_type,
                                std::string_view detail,
                                std::chrono::milliseconds timeout_ms) override {
@@ -383,7 +393,8 @@ TEST_F(ShutdownCoordinatorTest, Concurrent_DoubleForce_ForceExecutesOnce) {
   // Verify that only one forced shutdown was called
   EXPECT_EQ(fake_ptr->force_calls.load(), 1);
   EXPECT_EQ(fake_ptr->graceful_calls.load(), 0);
-  EXPECT_TRUE(fake_ptr->last_detail == "force1" || fake_ptr->last_detail == "force2");
+  EXPECT_TRUE(fake_ptr->GetLastDetail() == "force1" ||
+              fake_ptr->GetLastDetail() == "force2");
 }
 
 }  // namespace core


### PR DESCRIPTION
## Why are these changes needed?

TSAN failure is a data race only in the test's `FakeShutdownExecutor`, not production code. Fake was writing shared `std::string` fields from two threads without synchronization -- https://buildkite.com/ray-project/postmerge/builds/12666#019907c0-3bdd-4401-9aa8-6f13215ce819/176-796

- Added a `std::mutex` to `FakeShutdownExecutor` and guarded assignments to `last_exit_type` and `last_detail` in all `Execute*` methods. No production code changes.
- Added mutex-guarded getters in `FakeShutdownExecutor` and used them in the assertion to eliminate remaining unsynchronized reads in the TSAN test.

## Related issue number

Closes #55801
