### PR TITLE
[ci] Raydepsets: Enable defining packages in depset configs

### DIFF
--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -240,7 +240,7 @@ class DependencySetManager:
 
 
 def _get_bytes(packages: List[str]) -> bytes:
-    return "\n".join(packages).encode("utf-8")
+    return ("\n".join(packages) + "\n").encode("utf-8")
 
 
 def _get_depset(depsets: List[Depset], name: str) -> Depset:

--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -174,7 +174,7 @@ class DependencySetManager:
                 args.extend([requirement])
         if packages:
             # need to add a dash to process stdin
-            args = ["-"] + args
+            args.append("-")
             stdin = _get_bytes(packages)
         if output:
             args.extend(["-o", output])

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -97,20 +97,12 @@ class TestCli(unittest.TestCase):
         assert result.stderr.decode("utf-8") == ""
 
     def test_compile(self):
-        compiled_file = Path(
-            _runfiles.Rlocation(
-                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test.txt"
-            )
-        )
-        output_file = Path(
-            _runfiles.Rlocation(
-                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled.txt"
-            )
-        )
-        shutil.copy(compiled_file, output_file)
-
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
+            save_file_as(
+                Path(tmpdir) / "requirements_compiled_test.txt",
+                Path(tmpdir) / "requirements_compiled.txt",
+            )
             manager = _create_test_manager(tmpdir)
             manager.compile(
                 constraints=["requirement_constraints_test.txt"],
@@ -560,20 +552,12 @@ depsets:
                 _get_depset(manager.config.depsets, "build_args_test_depset_py311")
 
     def test_compile_with_packages(self):
-        compiled_file = Path(
-            _runfiles.Rlocation(
-                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test.txt"
-            )
-        )
-        output_file = Path(
-            _runfiles.Rlocation(
-                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test_packages.txt"
-            )
-        )
-        shutil.copy(compiled_file, output_file)
-
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
+            save_file_as(
+                Path(tmpdir) / "requirements_compiled_test.txt",
+                Path(tmpdir) / "requirements_compiled_test_packages.txt",
+            )
             manager = _create_test_manager(tmpdir)
             manager.compile(
                 constraints=["requirement_constraints_test.txt"],
@@ -589,20 +573,12 @@ depsets:
             assert output_text == output_text_valid
 
     def test_compile_with_packages_and_requirements(self):
-        compiled_file = Path(
-            _runfiles.Rlocation(
-                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test.txt"
-            )
-        )
-        output_file = Path(
-            _runfiles.Rlocation(
-                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test_packages.txt"
-            )
-        )
-        shutil.copy(compiled_file, output_file)
-
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
+            save_file_as(
+                Path(tmpdir) / "requirements_compiled_test.txt",
+                Path(tmpdir) / "requirements_compiled_test_packages.txt",
+            )
             manager = _create_test_manager(tmpdir)
             manager.compile(
                 constraints=["requirement_constraints_test.txt"],

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -559,6 +559,65 @@ depsets:
             with self.assertRaises(KeyError):
                 _get_depset(manager.config.depsets, "build_args_test_depset_py311")
 
+    def test_compile_with_packages(self):
+        compiled_file = Path(
+            _runfiles.Rlocation(
+                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test.txt"
+            )
+        )
+        output_file = Path(
+            _runfiles.Rlocation(
+                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test_packages.txt"
+            )
+        )
+        shutil.copy(compiled_file, output_file)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                packages=["emoji==2.9.0", "pyperclip==1.6.0"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="packages_test_depset",
+                output="requirements_compiled_test_packages.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_test_packages.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
+            output_text_valid = output_file_valid.read_text()
+            assert output_text == output_text_valid
+
+    def test_compile_with_packages_and_requirements(self):
+        compiled_file = Path(
+            _runfiles.Rlocation(
+                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test.txt"
+            )
+        )
+        output_file = Path(
+            _runfiles.Rlocation(
+                f"{_REPO_NAME}/ci/raydepsets/tests/test_data/requirements_compiled_test_packages.txt"
+            )
+        )
+        shutil.copy(compiled_file, output_file)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                packages=["emoji==2.9.0", "pyperclip==1.6.0"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="packages_test_depset",
+                output="requirements_compiled_test_packages.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_test_packages.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
+            output_text_valid = output_file_valid.read_text()
+            assert output_text == output_text_valid
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -1,4 +1,3 @@
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -127,7 +126,7 @@ class TestCli(unittest.TestCase):
             output_file = Path(
                 _runfiles.Rlocation(f"{tmpdir}/requirements_compiled.txt")
             )
-            shutil.copy(compiled_file, output_file)
+            save_file_as(compiled_file, output_file)
             manager = _create_test_manager(tmpdir)
             manager.compile(
                 constraints=["requirement_constraints_test.txt"],

--- a/ci/raydepsets/workspace.py
+++ b/ci/raydepsets/workspace.py
@@ -15,11 +15,12 @@ class BuildArgSet:
 class Depset:
     name: str
     operation: str
-    requirements: List[str]
-    constraints: List[str]
     output: str
-    override_flags: List[str]
-    append_flags: List[str]
+    constraints: Optional[List[str]] = None
+    override_flags: Optional[List[str]] = None
+    append_flags: Optional[List[str]] = None
+    requirements: Optional[List[str]] = None
+    packages: Optional[List[str]] = None
     source_depset: Optional[str] = None
     depsets: Optional[List[str]] = None
 
@@ -49,6 +50,7 @@ def _dict_to_depset(depset: dict) -> Depset:
         depsets=depset.get("depsets", []),
         override_flags=depset.get("override_flags", []),
         append_flags=depset.get("append_flags", []),
+        packages=depset.get("packages", []),
     )
 
 


### PR DESCRIPTION
Enable defining explicit packages in depset config

- Added unit tests
- Made requirements optional (relying on uv to throw errors if requirements / packages are not present in a depset)
- added stdin var to pass packages as stdin to the uv command

These changes allow a user to define ray[all]==100.0.0-dev as a requirement in the depset config which removes the need to create temporary requirements files and echoing packages into them
