### PR TITLE
[core] Remove redundant psutil get_cpu_utilzation call from

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -474,6 +474,7 @@ class ReporterAgent(
             thread_name_prefix="reporter_agent_executor",
         )
         self._gcs_pid = None
+        self._gcs_proc = None
 
         self._gpu_profiling_manager = GpuProfilingManager(
             profile_dir_path=self._log_dir, ip_address=self._ip
@@ -1004,10 +1005,10 @@ class ReporterAgent(
 
     def _get_gcs(self):
         if self._gcs_pid:
-            gcs_proc = psutil.Process(self._gcs_pid)
-            if gcs_proc:
-                dictionary = gcs_proc.as_dict(attrs=PSUTIL_PROCESS_ATTRS)
-                dictionary["cpu_percent"] = gcs_proc.cpu_percent(interval=1)
+            if not self._gcs_proc:
+                self._gcs_proc = psutil.Process(self._gcs_pid)
+            if self._gcs_proc:
+                dictionary = self._gcs_proc.as_dict(attrs=PSUTIL_PROCESS_ATTRS)
                 return dictionary
         return {}
 

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1005,7 +1005,7 @@ class ReporterAgent(
 
     def _get_gcs(self):
         if self._gcs_pid:
-            if not self._gcs_proc:
+            if not self._gcs_proc or self._gcs_pid != self._gcs_proc.pid:
                 self._gcs_proc = psutil.Process(self._gcs_pid)
             if self._gcs_proc:
                 dictionary = self._gcs_proc.as_dict(attrs=PSUTIL_PROCESS_ATTRS)


### PR DESCRIPTION
The first call to 'get_cpu_utilization' if you don't pass an interval will always return 0 on the first call. Subsequent calls will have a nonzero number because the sample interval is just assumed to be between successive calls.  There are three separate functions for agent/worker/raylet/gcs.  They all do the exact same thing but differ slightly in terms of how they're written.  Let's look at two.

```
    def _get_gcs(self):
        if self._gcs_pid:
            gcs_proc = psutil.Process(self._gcs_pid)
            if gcs_proc:
                dictionary = gcs_proc.as_dict(attrs=PSUTIL_PROCESS_ATTRS)
                # dictionary["cpu_percent"] = gcs_proc.cpu_percent(interval=1)
                return dictionary
        return {}
```

The above is for gcs

```
    def _get_agent(self):
        # Current proc == agent proc
        if not self._agent_proc:
            self._agent_proc = psutil.Process()
        return self._agent_proc.as_dict(attrs=PSUTIL_PROCESS_ATTRS)
```

The above is for agent.

The important thing to notice is these two lines:

`gcs_proc = psutil.Process(self._gcs_pid)`

and
        
```
if not self._agent_proc:
            self._agent_proc = psutil.Process()
```

The agent function uses a cached Process object while the gcs one makes a new one on each call to get_gcs which means that every call to get_gcs is the first call to this object and as a result will always return zero.  Meanwhile, since the object is cached for the agent version of this function, only the first call will return non zero.

The earlier fix here was just to call it again using the api which allowed one to pass an interval.  This would return non-zero and at least fixed the metric.  However, it's a bit redundant and has the overhead of having to wait for the interval to elapse.  This change removes the extra call and the wait.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
