### PR TITLE
Add perf metrics for 2.49.1

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 102.928384,
+    "_dashboard_memory_usage_mb": 116.87936,
     "_dashboard_test_success": true,
     "_peak_memory": 4.56,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1147\t7.55GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3549\t2.03GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4987\t0.83GiB\tpython distributed/test_many_actors.py\n3056\t0.39GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3751\t0.27GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n584\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4235\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3664\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2979\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4237\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
-    "actors_per_second": 526.6643292032776,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3537\t2.03GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5556\t0.87GiB\tpython distributed/test_many_actors.py\n2945\t0.39GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3735\t0.23GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n582\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n1143\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3652\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4226\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3108\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4228\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "actors_per_second": 566.4200586217125,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 526.6643292032776
+            "perf_metric_value": 566.4200586217125
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.667
+            "perf_metric_value": 10.833
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2841.741
+            "perf_metric_value": 2612.102
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3497.265
+            "perf_metric_value": 3446.344
         }
     ],
     "success": "1",
-    "time": 18.987426042556763
+    "time": 17.654742002487183
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 95.510528,
+    "_dashboard_memory_usage_mb": 96.198656,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.29,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3521\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3063\t0.26GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1069\t0.19GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5012\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3719\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n4200\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3637\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n3019\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5257\t0.09GiB\tray::StateAPIGeneratorActor.start\n4202\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "_peak_memory": 2.28,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3348\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2901\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4907\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3546\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n1091\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4032\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2825\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5133\t0.09GiB\tray::StateAPIGeneratorActor.start\n3464\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n3549\t0.08GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 210.13682904062856
+            "perf_metric_value": 179.67755143550417
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.38
+            "perf_metric_value": 6.935
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13.055
+            "perf_metric_value": 13.338
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 38.335
+            "perf_metric_value": 35.162
         }
     ],
     "success": "1",
-    "tasks_per_second": 210.13682904062856,
-    "time": 304.7588040828705,
+    "tasks_per_second": 179.67755143550417,
+    "time": 305.5655255317688,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 90.968064,
+    "_dashboard_memory_usage_mb": 98.287616,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.88,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1111\t8.31GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3486\t0.98GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2906\t0.4GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5166\t0.39GiB\tpython distributed/test_many_pgs.py\n581\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3690\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n2765\t0.11GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4176\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3039\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4178\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "_peak_memory": 2.78,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1146\t7.94GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3546\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3049\t0.47GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5004\t0.37GiB\tpython distributed/test_many_pgs.py\n581\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3758\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n2816\t0.11GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4241\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3665\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2941\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.799625675009633
+            "perf_metric_value": 13.028153672527967
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.562
+            "perf_metric_value": 4.26
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.012
+            "perf_metric_value": 10.799
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 186.207
+            "perf_metric_value": 188.103
         }
     ],
-    "pgs_per_second": 12.799625675009633,
+    "pgs_per_second": 13.028153672527967,
     "success": "1",
-    "time": 78.12728476524353
+    "time": 76.75684714317322
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 104.685568,
+    "_dashboard_memory_usage_mb": 104.443904,
     "_dashboard_test_success": true,
     "_peak_memory": 3.96,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3526\t1.11GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n8718\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3726\t0.45GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n3040\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3729\t0.15GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s\n1122\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4209\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3641\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2964\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n9009\t0.09GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3538\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5120\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3748\t0.46GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n3008\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3751\t0.19GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s\n1134\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4231\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3653\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n3029\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4233\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 347.0074587793457
+            "perf_metric_value": 388.36439061844453
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.278
+            "perf_metric_value": 5.544
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 542.827
+            "perf_metric_value": 652.763
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 736.395
+            "perf_metric_value": 779.606
         }
     ],
     "success": "1",
-    "tasks_per_second": 347.0074587793457,
-    "time": 328.8178243637085,
+    "tasks_per_second": 388.36439061844453,
+    "time": 325.74901366233826,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.49.0"}
+{"release_version": "2.49.1"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8382.98999101571,
-        117.79830230521418
+        7925.658042658907,
+        333.79803776770194
     ],
     "1_1_actor_calls_concurrent": [
-        5185.592351945926,
-        90.30753238314676
+        4710.115509639389,
+        60.79075536787328
     ],
     "1_1_actor_calls_sync": [
-        2091.781722688228,
-        16.9518585087781
+        1826.440590474467,
+        30.44826694257455
     ],
     "1_1_async_actor_calls_async": [
-        4261.744798110754,
-        180.0414155637879
+        3645.3291604906276,
+        145.09649825222274
     ],
     "1_1_async_actor_calls_sync": [
-        1440.0280310845594,
-        32.16094111992805
+        1374.047824125402,
+        35.86321385785778
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2842.6446804977995,
-        86.87223380532768
+        2426.398157992012,
+        38.78002524735766
     ],
     "1_n_actor_calls_async": [
-        7753.148948018643,
-        157.64457409741257
+        7563.474741840271,
+        160.3419047539893
     ],
     "1_n_async_actor_calls_async": [
-        7607.418617152194,
-        89.2638829207031
+        6964.257909926722,
+        53.3826400982145
     ],
     "client__1_1_actor_calls_async": [
-        1156.2740440851749,
-        16.48223271213866
+        846.4118553774217,
+        21.74145942353796
     ],
     "client__1_1_actor_calls_concurrent": [
-        1144.7059953730677,
-        4.145550595536418
+        862.8335019710298,
+        5.40969189845287
     ],
     "client__1_1_actor_calls_sync": [
-        564.4854333177283,
-        3.857233665824203
+        488.0060975075199,
+        18.43611203884743
     ],
     "client__get_calls": [
-        1025.614536261544,
-        21.381968599178617
+        983.5607099398597,
+        44.68614802894011
     ],
     "client__put_calls": [
-        869.4133022105747,
-        28.436164429083114
+        769.3648317551028,
+        25.86986897843832
     ],
     "client__put_gigabytes": [
-        0.1011154460629056,
-        0.0022480613263383856
+        0.10294244610916167,
+        0.00021781279103519403
     ],
     "client__tasks_and_get_batch": [
-        1.040122205853533,
-        0.03858532336305511
+        0.8049748278618892,
+        0.0384792096927115
     ],
     "client__tasks_and_put_batch": [
-        13581.806864962535,
-        520.4510627044893
+        10098.586104880465,
+        158.55761529403424
     ],
     "multi_client_put_calls_Plasma_Store": [
-        15560.620089508539,
-        96.2603254838798
+        10922.349171697762,
+        411.8369713180647
     ],
     "multi_client_put_gigabytes": [
-        37.43614465888436,
-        2.1762237421647583
+        27.572292929404366,
+        0.301414736739597
     ],
     "multi_client_tasks_async": [
-        24135.499735285084,
-        1599.8731087846127
+        19294.747670848352,
+        1531.838851224768
     ],
     "n_n_actor_calls_async": [
-        26441.297568592032,
-        1050.529175955539
+        24808.730524179864,
+        580.5120779930962
     ],
     "n_n_actor_calls_with_arg_async": [
-        2704.110675027102,
-        28.368337606599287
+        2564.489147392739,
+        58.242925806948335
     ],
     "n_n_async_actor_calls_async": [
-        23412.17782093146,
-        617.218384004416
+        21602.16598513169,
+        648.5971305332962
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10119.7301338237
+            "perf_metric_value": 9176.686326011131
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5278.091294531883
+            "perf_metric_value": 4795.051007052156
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 15560.620089508539
+            "perf_metric_value": 10922.349171697762
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.71278038275444
+            "perf_metric_value": 20.350152593657818
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.381854147597904
+            "perf_metric_value": 5.261194854317881
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 37.43614465888436
+            "perf_metric_value": 27.572292929404366
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.265651211414822
+            "perf_metric_value": 13.142098493341212
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.952999927332959
+            "perf_metric_value": 4.8129125825624035
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 946.027654634476
+            "perf_metric_value": 900.96738867954
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7958.403181954658
+            "perf_metric_value": 7418.67591750316
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 24135.499735285084
+            "perf_metric_value": 19294.747670848352
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2091.781722688228
+            "perf_metric_value": 1826.440590474467
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8382.98999101571
+            "perf_metric_value": 7925.658042658907
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5185.592351945926
+            "perf_metric_value": 4710.115509639389
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7753.148948018643
+            "perf_metric_value": 7563.474741840271
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26441.297568592032
+            "perf_metric_value": 24808.730524179864
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2704.110675027102
+            "perf_metric_value": 2564.489147392739
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1440.0280310845594
+            "perf_metric_value": 1374.047824125402
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4261.744798110754
+            "perf_metric_value": 3645.3291604906276
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2842.6446804977995
+            "perf_metric_value": 2426.398157992012
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7607.418617152194
+            "perf_metric_value": 6964.257909926722
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23412.17782093146
+            "perf_metric_value": 21602.16598513169
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 755.9481741578835
+            "perf_metric_value": 751.064903521573
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1025.614536261544
+            "perf_metric_value": 983.5607099398597
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 869.4133022105747
+            "perf_metric_value": 769.3648317551028
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.1011154460629056
+            "perf_metric_value": 0.10294244610916167
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13581.806864962535
+            "perf_metric_value": 10098.586104880465
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 564.4854333177283
+            "perf_metric_value": 488.0060975075199
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1156.2740440851749
+            "perf_metric_value": 846.4118553774217
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1144.7059953730677
+            "perf_metric_value": 862.8335019710298
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1.040122205853533
+            "perf_metric_value": 0.8049748278618892
         }
     ],
     "placement_group_create/removal": [
-        755.9481741578835,
-        12.306329174758009
+        751.064903521573,
+        5.332518268184338
     ],
     "single_client_get_calls_Plasma_Store": [
-        10119.7301338237,
-        102.04801817695024
+        9176.686326011131,
+        202.59360315795405
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.265651211414822,
-        0.01756980511554709
+        13.142098493341212,
+        0.280827763090365
     ],
     "single_client_put_calls_Plasma_Store": [
-        5278.091294531883,
-        27.18593982260196
+        4795.051007052156,
+        55.29886971022227
     ],
     "single_client_put_gigabytes": [
-        18.71278038275444,
-        8.13387701917967
+        20.350152593657818,
+        6.284060239581299
     ],
     "single_client_tasks_and_get_batch": [
-        5.381854147597904,
-        3.1676227294432446
+        5.261194854317881,
+        2.8864991514393927
     ],
     "single_client_tasks_async": [
-        7958.403181954658,
-        437.13498052024147
+        7418.67591750316,
+        224.65732622349898
     ],
     "single_client_tasks_sync": [
-        946.027654634476,
-        12.53937510184865
+        900.96738867954,
+        14.441231923805944
     ],
     "single_client_wait_1k_refs": [
-        4.952999927332959,
-        0.036988477470103795
+        4.8129125825624035,
+        0.007111082814526685
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 13.201167912000003,
+    "broadcast_time": 13.41017694899999,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13.201167912000003
+            "perf_metric_value": 13.41017694899999
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 19.17184469900002,
-    "get_time": 23.946038821000002,
+    "args_time": 19.077259766999987,
+    "get_time": 24.000713915999995,
     "large_object_size": 107374182400,
-    "large_object_time": 31.283377702999985,
+    "large_object_time": 31.36117459099995,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.17184469900002
+            "perf_metric_value": 19.077259766999987
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.863585175999987
+            "perf_metric_value": 5.790547841000006
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.946038821000002
+            "perf_metric_value": 24.000713915999995
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 190.35062810999997
+            "perf_metric_value": 179.146127773
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.283377702999985
+            "perf_metric_value": 31.36117459099995
         }
     ],
-    "queued_time": 190.35062810999997,
-    "returns_time": 5.863585175999987,
+    "queued_time": 179.146127773,
+    "returns_time": 5.790547841000006,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.1919621157646179,
-    "max_iteration_time": 3.34515118598938,
-    "min_iteration_time": 0.6364881992340088,
+    "avg_iteration_time": 1.2971700072288512,
+    "max_iteration_time": 5.189502000808716,
+    "min_iteration_time": 0.06091117858886719,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1919621157646179
+            "perf_metric_value": 1.2971700072288512
         }
     ],
     "success": 1,
-    "total_time": 119.196359872818
+    "total_time": 129.71714234352112
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.86789870262146
+            "perf_metric_value": 7.735846281051636
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13.265494346618652
+            "perf_metric_value": 12.93162693977356
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 34.152964401245114
+            "perf_metric_value": 33.983641386032104
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.032559394836426
+            "perf_metric_value": 1.8725192546844482
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1814.6457602977753
+            "perf_metric_value": 1821.4706330299377
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4687484200099014
+            "perf_metric_value": 0.5580154959703073
         }
     ],
-    "stage_0_time": 6.86789870262146,
-    "stage_1_avg_iteration_time": 13.265494346618652,
-    "stage_1_max_iteration_time": 13.843246221542358,
-    "stage_1_min_iteration_time": 11.710993766784668,
-    "stage_1_time": 132.65499782562256,
-    "stage_2_avg_iteration_time": 34.152964401245114,
-    "stage_2_max_iteration_time": 34.738978147506714,
-    "stage_2_min_iteration_time": 33.831342458724976,
-    "stage_2_time": 170.76539039611816,
-    "stage_3_creation_time": 2.032559394836426,
-    "stage_3_time": 1814.6457602977753,
-    "stage_4_spread": 0.4687484200099014,
+    "stage_0_time": 7.735846281051636,
+    "stage_1_avg_iteration_time": 12.93162693977356,
+    "stage_1_max_iteration_time": 13.44619870185852,
+    "stage_1_min_iteration_time": 11.569173812866211,
+    "stage_1_time": 129.31632256507874,
+    "stage_2_avg_iteration_time": 33.983641386032104,
+    "stage_2_max_iteration_time": 34.43809151649475,
+    "stage_2_min_iteration_time": 33.45232319831848,
+    "stage_2_time": 169.91874861717224,
+    "stage_3_creation_time": 1.8725192546844482,
+    "stage_3_time": 1821.4706330299377,
+    "stage_4_spread": 0.5580154959703073,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.544663453452921,
-    "avg_pg_remove_time_ms": 1.3276310030028873,
+    "avg_pg_create_time_ms": 1.5636188018035782,
+    "avg_pg_remove_time_ms": 1.396923734234321,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.544663453452921
+            "perf_metric_value": 1.5636188018035782
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.3276310030028873
+            "perf_metric_value": 1.396923734234321
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 29.81%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 15560.620089508539 to 10922.349171697762 in microbenchmark.json
REGRESSION 26.80%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1156.2740440851749 to 846.4118553774217 in microbenchmark.json
REGRESSION 26.35%: multi_client_put_gigabytes (THROUGHPUT) regresses from 37.43614465888436 to 27.572292929404366 in microbenchmark.json
REGRESSION 25.65%: client__tasks_and_put_batch (THROUGHPUT) regresses from 13581.806864962535 to 10098.586104880465 in microbenchmark.json
REGRESSION 24.62%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1144.7059953730677 to 862.8335019710298 in microbenchmark.json
REGRESSION 22.61%: client__tasks_and_get_batch (THROUGHPUT) regresses from 1.040122205853533 to 0.8049748278618892 in microbenchmark.json
REGRESSION 20.06%: multi_client_tasks_async (THROUGHPUT) regresses from 24135.499735285084 to 19294.747670848352 in microbenchmark.json
REGRESSION 14.64%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2842.6446804977995 to 2426.398157992012 in microbenchmark.json
REGRESSION 14.49%: tasks_per_second (THROUGHPUT) regresses from 210.13682904062856 to 179.67755143550417 in benchmarks/many_nodes.json
REGRESSION 14.46%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4261.744798110754 to 3645.3291604906276 in microbenchmark.json
REGRESSION 13.55%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 564.4854333177283 to 488.0060975075199 in microbenchmark.json
REGRESSION 12.68%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2091.781722688228 to 1826.440590474467 in microbenchmark.json
REGRESSION 11.51%: client__put_calls (THROUGHPUT) regresses from 869.4133022105747 to 769.3648317551028 in microbenchmark.json
REGRESSION 9.32%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10119.7301338237 to 9176.686326011131 in microbenchmark.json
REGRESSION 9.17%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5185.592351945926 to 4710.115509639389 in microbenchmark.json
REGRESSION 9.15%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5278.091294531883 to 4795.051007052156 in microbenchmark.json
REGRESSION 8.45%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7607.418617152194 to 6964.257909926722 in microbenchmark.json
REGRESSION 7.73%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23412.17782093146 to 21602.16598513169 in microbenchmark.json
REGRESSION 6.78%: single_client_tasks_async (THROUGHPUT) regresses from 7958.403181954658 to 7418.67591750316 in microbenchmark.json
REGRESSION 6.17%: n_n_actor_calls_async (THROUGHPUT) regresses from 26441.297568592032 to 24808.730524179864 in microbenchmark.json
REGRESSION 5.46%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8382.98999101571 to 7925.658042658907 in microbenchmark.json
REGRESSION 5.16%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2704.110675027102 to 2564.489147392739 in microbenchmark.json
REGRESSION 4.76%: single_client_tasks_sync (THROUGHPUT) regresses from 946.027654634476 to 900.96738867954 in microbenchmark.json
REGRESSION 4.58%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1440.0280310845594 to 1374.047824125402 in microbenchmark.json
REGRESSION 4.10%: client__get_calls (THROUGHPUT) regresses from 1025.614536261544 to 983.5607099398597 in microbenchmark.json
REGRESSION 2.83%: single_client_wait_1k_refs (THROUGHPUT) regresses from 4.952999927332959 to 4.8129125825624035 in microbenchmark.json
REGRESSION 2.45%: 1_n_actor_calls_async (THROUGHPUT) regresses from 7753.148948018643 to 7563.474741840271 in microbenchmark.json
REGRESSION 2.24%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 5.381854147597904 to 5.261194854317881 in microbenchmark.json
REGRESSION 0.93%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.265651211414822 to 13.142098493341212 in microbenchmark.json
REGRESSION 0.65%: placement_group_create/removal (THROUGHPUT) regresses from 755.9481741578835 to 751.064903521573 in microbenchmark.json
REGRESSION 20.25%: dashboard_p95_latency_ms (LATENCY) regresses from 542.827 to 652.763 in benchmarks/many_tasks.json
REGRESSION 19.04%: stage_4_spread (LATENCY) regresses from 0.4687484200099014 to 0.5580154959703073 in stress_tests/stress_test_many_tasks.json
REGRESSION 12.64%: stage_0_time (LATENCY) regresses from 6.86789870262146 to 7.735846281051636 in stress_tests/stress_test_many_tasks.json
REGRESSION 12.06%: dashboard_p50_latency_ms (LATENCY) regresses from 9.667 to 10.833 in benchmarks/many_actors.json
REGRESSION 8.83%: avg_iteration_time (LATENCY) regresses from 1.1919621157646179 to 1.2971700072288512 in stress_tests/stress_test_dead_actors.json
REGRESSION 8.70%: dashboard_p50_latency_ms (LATENCY) regresses from 6.38 to 6.935 in benchmarks/many_nodes.json
REGRESSION 7.86%: dashboard_p95_latency_ms (LATENCY) regresses from 10.012 to 10.799 in benchmarks/many_pgs.json
REGRESSION 5.87%: dashboard_p99_latency_ms (LATENCY) regresses from 736.395 to 779.606 in benchmarks/many_tasks.json
REGRESSION 5.22%: avg_pg_remove_time_ms (LATENCY) regresses from 1.3276310030028873 to 1.396923734234321 in stress_tests/stress_test_placement_group.json
REGRESSION 2.17%: dashboard_p95_latency_ms (LATENCY) regresses from 13.055 to 13.338 in benchmarks/many_nodes.json
REGRESSION 1.58%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 13.201167912000003 to 13.41017694899999 in scalability/object_store.json
REGRESSION 1.23%: avg_pg_create_time_ms (LATENCY) regresses from 1.544663453452921 to 1.5636188018035782 in stress_tests/stress_test_placement_group.json
REGRESSION 1.02%: dashboard_p99_latency_ms (LATENCY) regresses from 186.207 to 188.103 in benchmarks/many_pgs.json
REGRESSION 0.38%: stage_3_time (LATENCY) regresses from 1814.6457602977753 to 1821.4706330299377 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.25%: 107374182400_large_object_time (LATENCY) regresses from 31.283377702999985 to 31.36117459099995 in scalability/single_node.json
REGRESSION 0.23%: 10000_get_time (LATENCY) regresses from 23.946038821000002 to 24.000713915999995 in scalability/single_node.json
```