### PR TITLE
[Core] Fix ABFSS (Azure Blob File System Secure) protocol support problems during E2E test in Anyscale environment

### DIFF
--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -226,7 +226,7 @@ class ProtocolsProvider:
                 )
 
         with open_file(source_uri, "rb", transport_params=tp) as fin:
-            with open_file(dest_file, "wb") as fout:
+            with open(dest_file, "wb") as fout:
                 fout.write(fin.read())
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Fix ABFSS protocol issues during E2E test in Anyscale Environment 
- Implement _handle_abfss_protocol() using adlfs for native ABFSS support
- Automatically extract storage account name from ABFSS URI (e.g., cloudgangsa from abfss://container@cloudgangsa.dfs.core.windows.net)
- Add comprehensive URI validation to reject malformed ABFSS URLs
- Include comprehensive unit tests for ABFSS URL parsing, validation, and account extraction

This enables Ray runtime environments to use packages stored in Azure Data Lake Storage Gen2 via ABFSS URIs without requiring environment variables.

TODO: https://github.com/ray-project/ray/issues/56206

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
   

Tested both service and job. They can run successfully

https://console.anyscale-staging.com/cld_5nnv7pt2jn2312x2e5v72z53n2/prj_y8syktydl7ltabhz5axdelwnce/services/service2_uh7vmaxcryz6lrzwsyeee271ph?service-tabs=overview

[https://console.anyscale-staging.com/cld_5nnv7pt2jn2312x2e5v72z53n2/prj_y8syktydl7ltabhz5ax[…]ob-tab=overview&job-logs-section-tabs=application_logs](https://console.anyscale-staging.com/cld_5nnv7pt2jn2312x2e5v72z53n2/prj_y8syktydl7ltabhz5axdelwnce/jobs/prodjob_2nr9sj23y3eng4kl63imctd9we?job-tab=overview&job-logs-section-tabs=application_logs)
   
   
