### PR TITLE
fixing deployment scoped custom autoscaling

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -233,11 +233,10 @@ class AutoscalingConfig(BaseModel):
     _serialized_policy_def: bytes = PrivateAttr(default=b"")
 
     # Autoscaling policy. This policy is deployment scoped. Defaults to the request-based autoscaler.
-    _policy: AutoscalingPolicy = Field(default_factory=AutoscalingPolicy)
-
-    # This is to make `_policy` a normal field until its GA ready.
-    class Config:
-        underscore_attrs_are_private = True
+    policy: AutoscalingPolicy = Field(
+        default_factory=AutoscalingPolicy,
+        description="The autoscaling policy for the deployment. This option is experimental.",
+    )
 
     @validator("max_replicas", always=True)
     def replicas_settings_valid(cls, max_replicas, values):
@@ -286,8 +285,7 @@ class AutoscalingConfig(BaseModel):
         the policy and set `serialized_policy_def` if it's empty.
         """
         values = self.dict()
-        policy = values.get("_policy")
-
+        policy = values.get("policy")
         policy_name = None
         if isinstance(policy, dict):
             policy_name = policy.get("name")
@@ -301,7 +299,7 @@ class AutoscalingConfig(BaseModel):
         if not self._serialized_policy_def:
             self._serialized_policy_def = cloudpickle.dumps(import_attr(policy_name))
 
-        self._policy = AutoscalingPolicy(name=policy_name)
+        self.policy = AutoscalingPolicy(name=policy_name)
 
     @classmethod
     def default(cls):

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -284,17 +284,11 @@ class AutoscalingConfig(BaseModel):
         Import the policy if it's passed in as a string import path. Then cloudpickle
         the policy and set `serialized_policy_def` if it's empty.
         """
-        values = self.dict()
-        policy = values.get("policy")
-        policy_name = None
-        if isinstance(policy, dict):
-            policy_name = policy.get("name")
+        policy = self.policy
+        policy_name = policy.name
 
         if isinstance(policy_name, Callable):
             policy_name = f"{policy_name.__module__}.{policy_name.__name__}"
-
-        if not policy_name:
-            policy_name = DEFAULT_AUTOSCALING_POLICY_NAME
 
         if not self._serialized_policy_def:
             self._serialized_policy_def = cloudpickle.dumps(import_attr(policy_name))

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -15,6 +15,7 @@ import ray
 import ray.util.state as state_api
 from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
+from ray.serve._private.autoscaling_state import AutoscalingContext
 from ray.serve._private.common import (
     DeploymentID,
     DeploymentStatus,
@@ -36,7 +37,7 @@ from ray.serve._private.test_utils import (
     get_num_alive_replicas,
     tlog,
 )
-from ray.serve.config import AutoscalingConfig
+from ray.serve.config import AutoscalingConfig, AutoscalingPolicy
 from ray.serve.handle import DeploymentHandle
 from ray.serve.schema import ApplicationStatus, ServeDeploySchema
 from ray.util.state import list_actors
@@ -1518,6 +1519,64 @@ def test_autoscaling_status_changes(serve_instance):
     )
 
     print("Statuses are as expected.")
+
+
+def custom_autoscaling_policy(ctx: AutoscalingContext):
+    if ctx.total_num_requests > 50:
+        return 3, {}
+    else:
+        return 2, {}
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {"name": "ray.serve.tests.test_autoscaling_policy.custom_autoscaling_policy"},
+        AutoscalingPolicy(
+            name="ray.serve.tests.test_autoscaling_policy.custom_autoscaling_policy"
+        ),
+        AutoscalingPolicy(name=custom_autoscaling_policy),
+    ],
+)
+def test_e2e_scale_up_down_basic_with_custom_policy(serve_instance_with_signal, policy):
+    """Send 100 requests and check that we autoscale up, and then back down."""
+
+    _, signal = serve_instance_with_signal
+
+    @serve.deployment(
+        autoscaling_config={
+            "min_replicas": 1,
+            "max_replicas": 4,
+            "downscale_delay_s": 0.5,
+            "upscale_delay_s": 0,
+            "policy": policy,
+            "metrics_interval_s": 0.1,
+        },
+        # We will send over a lot of queries. This will make sure replicas are
+        # killed quickly during cleanup.
+        graceful_shutdown_timeout_s=1,
+        max_ongoing_requests=1000,
+    )
+    class A:
+        async def __call__(self):
+            await signal.wait.remote()
+
+    handle = serve.run(A.bind())
+    wait_for_condition(
+        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+    )
+
+    [handle.remote() for _ in range(40)]
+
+    # scale up one more replica from min_replicas
+    wait_for_condition(check_num_replicas_eq, name="A", target=2)
+    print("Scaled up to 2 replicas.")
+
+    ray.get(signal.send.remote(clear=True))
+    wait_for_condition(lambda: ray.get(signal.cur_num_waiters.remote()) == 0)
+    [handle.remote() for _ in range(70)]
+    wait_for_condition(check_num_replicas_eq, name="A", target=3)
+    ray.get(signal.send.remote(clear=True))
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -177,6 +177,9 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy_nam
                                     "downscaling_factor": None,
                                     "downscale_delay_s": 600.0,
                                     "upscale_delay_s": 30.0,
+                                    "policy": {
+                                        "name": "ray.serve.autoscaling_policy:default_autoscaling_policy"
+                                    },
                                 },
                                 "graceful_shutdown_wait_loop_s": 2.0,
                                 "graceful_shutdown_timeout_s": 20.0,

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -331,6 +331,7 @@ def test_num_replicas_auto_api(serve_instance, use_options):
         "downscaling_factor": None,
         "smoothing_factor": 1.0,
         "initial_replicas": None,
+        "policy": {"name": "ray.serve.autoscaling_policy:default_autoscaling_policy"},
     }
 
 

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -384,6 +384,7 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
         "downscaling_factor": None,
         "smoothing_factor": 1.0,
         "initial_replicas": None,
+        "policy": {"name": "ray.serve.autoscaling_policy:default_autoscaling_policy"},
     }
 
     for i in range(3):

--- a/python/ray/serve/tests/test_deploy_app_2.py
+++ b/python/ray/serve/tests/test_deploy_app_2.py
@@ -616,6 +616,7 @@ def test_num_replicas_auto_api(serve_instance):
         "downscaling_factor": None,
         "smoothing_factor": 1.0,
         "initial_replicas": None,
+        "policy": {"name": "ray.serve.autoscaling_policy:default_autoscaling_policy"},
     }
 
 

--- a/python/ray/serve/tests/test_deploy_app_2.py
+++ b/python/ray/serve/tests/test_deploy_app_2.py
@@ -668,6 +668,7 @@ def test_num_replicas_auto_basic(serve_instance):
         "downscaling_factor": None,
         "smoothing_factor": 1.0,
         "initial_replicas": None,
+        "policy": {"name": "ray.serve.autoscaling_policy:default_autoscaling_policy"},
     }
 
     h = serve.get_app_handle(SERVE_DEFAULT_APP_NAME)

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -70,7 +70,7 @@ message AutoscalingConfig {
   bytes _serialized_policy_def = 11;
 
   // The autoscaling policy definition.
-  AutoscalingPolicy _policy = 12;
+  AutoscalingPolicy policy = 12;
 
   // Target number of in flight requests per replica. This is the primary configuration
   // knob for replica autoscaler. Lower the number, the more rapidly the replicas


### PR DESCRIPTION
`attrbitutes` that start with `_` in pydantic are not seen by `validator`, `.dict()`, hence the previous implementation always resorted to the default policy. Changing `_policy` to `policy` fixes this problem. Also add a test to ensure this works