### PR TITLE
[Data] - Evaluate Expressions sequentially and upsert columns to block

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -335,6 +335,19 @@ class ArrowBlockAccessor(TableBlockAccessor):
             r = r.append_column(col_name, col)
         return r
 
+    def upsert_column(
+        self, column_name: str, column_data: BlockColumn
+    ) -> "pyarrow.Table":
+        assert isinstance(
+            column_data, (pyarrow.Array, pyarrow.ChunkedArray)
+        ), f"Expected either a pyarrow.Array or pyarrow.ChunkedArray, got: {type(column_data)}"
+
+        column_idx = self._table.schema.get_field_index(column_name)
+        if column_idx == -1:
+            return self._table.append_column(column_name, column_data)
+        else:
+            return self._table.set_column(column_idx, column_name, column_data)
+
     @staticmethod
     def builder() -> ArrowBlockBuilder:
         return ArrowBlockBuilder()

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -317,6 +317,14 @@ class PandasBlockAccessor(TableBlockAccessor):
     def rename_columns(self, columns_rename: Dict[str, str]) -> "pandas.DataFrame":
         return self._table.rename(columns=columns_rename, inplace=False, copy=False)
 
+    def upsert_column(
+        self, column_name: str, column_data: BlockColumn
+    ) -> "pandas.DataFrame":
+        if isinstance(column_data, (pyarrow.Array, pyarrow.ChunkedArray)):
+            column_data = column_data.to_pandas()
+
+        return self._table.assign(**{column_name: column_data})
+
     def random_shuffle(self, random_seed: Optional[int]) -> "pandas.DataFrame":
         table = self._table.sample(frac=1, random_state=random_seed)
         table.reset_index(drop=True, inplace=True)

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -343,6 +343,19 @@ class BlockAccessor:
         """Return the block reflecting the renamed columns."""
         raise NotImplementedError
 
+    def upsert_column(self, column_name: str, column_data: BlockColumn) -> Block:
+        """
+        Upserts a column into the block. If the column already exists, it will be replaced.
+
+        Args:
+            column_name: The name of the column to upsert.
+            column_data: The data to upsert into the column. (Arrow Array/ChunkedArray for Arrow blocks, Series or array-like for Pandas blocks)
+
+        Returns:
+            The updated block.
+        """
+        raise NotImplementedError()
+
     def random_shuffle(self, random_seed: Optional[int]) -> Block:
         """Randomly shuffle this block."""
         raise NotImplementedError


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, the columns were updated after all expressions were evaluated, but this required additional handling in the planner and optimization to handle dependency chaining between columns.

In this implementation, each expression will be evaluated and the column will be upserted to the block within the provided Project operator.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
