### PR TITLE
Fix enable_tensor_transport in gpu microbenchmark

### DIFF
--- a/release/microbenchmark/experimental/gpu_object_microbenchmark.py
+++ b/release/microbenchmark/experimental/gpu_object_microbenchmark.py
@@ -27,7 +27,7 @@ class BackendConfig:
 
 BACKEND_CONFIG = {
     "gloo": BackendConfig(
-        init_actor_kwargs={"enable_tensor_transport": True},
+        init_actor_kwargs={},
         send_method_kwargs={"tensor_transport": "gloo"},
         device=torch.device("cpu"),
         collective_group_backend="torch_gloo",
@@ -51,7 +51,7 @@ BACKEND_CONFIG = {
 }
 
 
-@ray.remote
+@ray.remote(enable_tensor_transport=True)
 class Actor:
     def __init__(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Before this pr,
```
results_working_dirs_gpu_object_GPU_multinode_gsocecnfye__anyscale_pkg_30dac47fa1f11f7bf3882f862f2feb3b/experimental/gpu_object_microbenchmark.py", line 118, in _exec_p2p_transfer_multiple_shapes
    temp_results += _exec_p2p_transfer(
  File "/tmp/ray/session_2025-09-03_14-21-10_485677_2685/runtime_resources/working_dir_files/s3_ray-release-automation-results_working_dirs_gpu_object_GPU_multinode_gsocecnfye__anyscale_pkg_30dac47fa1f11f7bf3882f862f2feb3b/experimental/gpu_object_microbenchmark.py", line 102, in _exec_p2p_transfer
    results = timeit(label, _run)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ray_microbenchmark_helpers.py", line 30, in timeit
    fn()
  File "/tmp/ray/session_2025-09-03_14-21-10_485677_2685/runtime_resources/working_dir_files/s3_ray-release-automation-results_working_dirs_gpu_object_GPU_multinode_gsocecnfye__anyscale_pkg_30dac47fa1f11f7bf3882f862f2feb3b/experimental/gpu_object_microbenchmark.py", line 98, in _run
    ref = sender.send.options(**send_method_kwargs).remote()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/actor.py", line 697, in remote
    return func_cls._remote(args=args, kwargs=kwargs, **options)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/util/tracing/tracing_helper.py", line 422, in _start_span
    return method(self, args, kwargs, *_args, **_kwargs)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/actor.py", line 825, in _remote
    raise ValueError(
ValueError: Currently, methods with .options(tensor_transport="GLOO") are not supported when enable_tensor_transport=False. Please set @ray.remote(enable_tensor_transport=True) on the actor class definition.
Subprocess return code: 1
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
