### PR TITLE
Fix build with GCC 15

### DIFF
--- a/src/ray/observability/open_telemetry_metric_recorder.h
+++ b/src/ray/observability/open_telemetry_metric_recorder.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <opentelemetry/metrics/meter.h>
 #include <opentelemetry/metrics/observer_result.h>
 #include <opentelemetry/metrics/sync_instruments.h>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently building ray from source fails when using GCC 15.

Ideally, this should be fixed in opentelemetry-cpp like they did [here](https://github.com/open-telemetry/opentelemetry-cpp/pull/3240) (or perhaps it's already fixed in newer versions?) but this workaround is just an extra include here and allows to build on systems with newer versions of GCC.

## Related issue number

Fixes #56242

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.

That script would move the include after all the `opentelemetry` includes, which is precisely what we don't want here.

- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
