### PR TITLE
[Train] ignore tensorflow test for py312

### DIFF
--- a/python/ray/train/v2/tests/test_local_mode.py
+++ b/python/ray/train/v2/tests/test_local_mode.py
@@ -253,6 +253,10 @@ def test_lightning_trainer_local_mode(ray_start_6_cpus, datasource):
     assert "val_loss" in results.metrics
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Tensorflow is not installed for Python 3.12 because of keras compatibility.",
+)
 def test_tensorflow_linear_local_mode(ray_start_4_cpus):
     """Also tests air Keras callback."""
     epochs = 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Tensorflow is not installed for Python 3.12 because of keras compatibility. Skip the test.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
