### PR TITLE
[RLlib][release test] Upgrade g3 to g4 machine for aws release test

### DIFF
--- a/release/rllib_tests/2gpus_32cpus.yaml
+++ b/release/rllib_tests/2gpus_32cpus.yaml
@@ -5,7 +5,7 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: g3.8xlarge
+    instance_type: g4dn.8xlarge
 
 worker_node_types: []
 

--- a/release/rllib_tests/2gpus_32cpus.yaml
+++ b/release/rllib_tests/2gpus_32cpus.yaml
@@ -5,7 +5,7 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: g4dn.8xlarge
+    instance_type: g4dn.12xlarge
 
 worker_node_types: []
 

--- a/release/rllib_tests/2gpus_64cpus.yaml
+++ b/release/rllib_tests/2gpus_64cpus.yaml
@@ -5,7 +5,7 @@ max_workers: 1
 
 head_node_type:
     name: head_node
-    instance_type: g3.8xlarge
+    instance_type: g4dn.8xlarge
 
 worker_node_types:
     - name: worker_node

--- a/release/rllib_tests/2gpus_64cpus.yaml
+++ b/release/rllib_tests/2gpus_64cpus.yaml
@@ -5,7 +5,7 @@ max_workers: 1
 
 head_node_type:
     name: head_node
-    instance_type: g4dn.8xlarge
+    instance_type: g4dn.12xlarge
 
 worker_node_types:
     - name: worker_node

--- a/release/rllib_tests/4gpus_544_cpus.yaml
+++ b/release/rllib_tests/4gpus_544_cpus.yaml
@@ -5,7 +5,7 @@ max_workers: 5
 
 head_node_type:
     name: head_node
-    instance_type: g4dn.12xlarge
+    instance_type: g3.16xlarge
 
 worker_node_types:
     - name: worker_node

--- a/release/rllib_tests/4gpus_544_cpus.yaml
+++ b/release/rllib_tests/4gpus_544_cpus.yaml
@@ -5,7 +5,7 @@ max_workers: 5
 
 head_node_type:
     name: head_node
-    instance_type: g3.16xlarge
+    instance_type: g4dn.12xlarge
 
 worker_node_types:
     - name: worker_node


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are a few release test in core daily test that are using g3 machines:
[RLlib rllib_learning_tests_poing_impala_torch](https://github.com/ray-project/ray/blob/master/release/release_tests.yaml#L2754-L2777)

[rllib_learning_tests_pendulum_dreamerv3_torch](https://github.com/ray-project/ray/blob/master/release/release_tests.yaml#L2714C9-L2733)

Since G3 machine are old and have lower availability, update to use newer machine, e.g. g4dn.8xlarge can reduce the stock out flakiness.

A successful RLlib release test run: https://buildkite.com/ray-project/release/builds/56710

## Related issue number

Closes #56178 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
