### PR TITLE
[serve] swap toolz for collections.defaultdict in tests

### DIFF
--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1,8 +1,8 @@
 import asyncio
 import sys
+from collections import defaultdict
 
 import pytest
-from toolz.tests.test_dicttoolz import defaultdict
 
 from ray._common.test_utils import async_wait_for_condition
 from ray.serve._private.metrics_utils import (


### PR DESCRIPTION
## Why are these changes needed?

Use `collections` instead of `toolz` in `test_metrics_utils`

## Related issue number

https://github.com/ray-project/ray/issues/56227
