### PR TITLE
[CI] Add text embed benchmark tests to group: data-tests.

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4666,6 +4666,7 @@
   python: "3.11"  # necessary for the llm-cu128 image
   working_dir: nightly_tests
   team: data
+  group: data-tests
 
   cluster:
     byod:
@@ -4688,6 +4689,7 @@
   python: "3.11"
   working_dir: nightly_tests
   team: data
+  group: data-tests
 
   cluster:
     byod:


### PR DESCRIPTION
The text embedding benchmarks are currently ungrouped in buildkite. This PR adds them to the Data group