### PR TITLE
[core][gpu-objects] Fix wrong skipif in test_gpu_objects_gloo

### DIFF
--- a/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
+++ b/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
@@ -517,10 +517,6 @@ def test_fetch_gpu_object_to_driver(ray_start_regular):
     assert result[2] == 7
 
 
-@pytest.mark.skipif(
-    not support_tensordict,
-    reason="tensordict is not supported on this platform",
-)
 def test_invalid_tensor_transport(ray_start_regular):
     with pytest.raises(ValueError, match="Invalid tensor transport"):
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We should not skip it, since it doesn't need the tensordict dependency.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
