### PR TITLE
[Core] Remove the unnecessary redirection of get_protocols_provider

### DIFF
--- a/python/ray/_private/runtime_env/default_impl.py
+++ b/python/ray/_private/runtime_env/default_impl.py
@@ -3,9 +3,3 @@ from ray._private.runtime_env.image_uri import ImageURIPlugin
 
 def get_image_uri_plugin_cls():
     return ImageURIPlugin
-
-
-def get_protocols_provider():
-    from ray._private.runtime_env.protocol import ProtocolsProvider
-
-    return ProtocolsProvider

--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -1,8 +1,6 @@
 import enum
 import os
 
-from ray._private.runtime_env.default_impl import get_protocols_provider
-
 
 class ProtocolsProvider:
     _MISSING_DEPENDENCIES_WARNING = (
@@ -210,11 +208,9 @@ class ProtocolsProvider:
                 fout.write(fin.read())
 
 
-_protocols_provider = get_protocols_provider()
-
 Protocol = enum.Enum(
     "Protocol",
-    {protocol.upper(): protocol for protocol in _protocols_provider.get_protocols()},
+    {protocol.upper(): protocol for protocol in ProtocolsProvider.get_protocols()},
 )
 
 
@@ -223,7 +219,7 @@ def _remote_protocols(cls):
     # Returns a list of protocols that support remote storage
     # These protocols should only be used with paths that end in ".zip" or ".whl"
     return [
-        cls[protocol.upper()] for protocol in _protocols_provider.get_remote_protocols()
+        cls[protocol.upper()] for protocol in ProtocolsProvider.get_remote_protocols()
     ]
 
 
@@ -231,7 +227,7 @@ Protocol.remote_protocols = _remote_protocols
 
 
 def _download_remote_uri(self, source_uri, dest_file):
-    return _protocols_provider.download_remote_uri(self.value, source_uri, dest_file)
+    return ProtocolsProvider.download_remote_uri(self.value, source_uri, dest_file)
 
 
 Protocol.download_remote_uri = _download_remote_uri


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
