### PR TITLE
[ci] raydepsets: single depset compilation with dependencies

### DIFF
--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -104,6 +104,8 @@ class DependencySetManager:
 
     def execute(self, single_depset_name: Optional[str] = None):
         if single_depset_name:
+            # check if the depset exists
+            _get_depset(self.config.depsets, single_depset_name)
             self.subgraph_dependency_nodes(single_depset_name)
 
         for node in topological_sort(self.build_graph):

--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -98,8 +98,8 @@ class DependencySetManager:
                 raise ValueError(f"Invalid operation: {depset.operation}")
 
     def subgraph_dependency_nodes(self, depset_name: str):
-        dependendecy_nodes = networkx_ancestors(self.build_graph, depset_name)
-        nodes = dependendecy_nodes | {depset_name}
+        dependency_nodes = networkx_ancestors(self.build_graph, depset_name)
+        nodes = dependency_nodes | {depset_name}
         self.build_graph = self.build_graph.subgraph(nodes).copy()
 
     def execute(self, single_depset_name: Optional[str] = None):

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -437,6 +437,24 @@ depsets:
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
 
+    def test_execute_single_depset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            manager.execute(single_depset_name="general_depset__py311_cpu")
+            assert (
+                manager.build_graph.nodes["general_depset__py311_cpu"]["operation"]
+                == "compile"
+            )
+            assert len(manager.build_graph.nodes()) == 1
+
+    def test_execute_single_depset_with_subset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            with self.assertRaises(RuntimeError):
+                manager.execute(single_depset_name="subset_general_depset")
+
     def test_expand(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -448,12 +448,12 @@ depsets:
             )
             assert len(manager.build_graph.nodes()) == 1
 
-    def test_execute_single_depset_with_subset(self):
+    def test_execute_single_depset_that_does_not_exist(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             manager = _create_test_manager(tmpdir)
-            with self.assertRaises(RuntimeError):
-                manager.execute(single_depset_name="subset_general_depset")
+            with self.assertRaises(KeyError):
+                manager.execute(single_depset_name="fake_depset")
 
     def test_expand(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Raydepsets has a single depset compilation mode which compiles ONLY the depset referenced by name
In some cases depsets have dependencies (ex. expand and subset depend on source depsets)
To allow for the depset dependencies to be compiled:
Subset the build graph by including the user specified target depset and all ancestors
execute all of the depsets in build graph order

Added unit tests