### PR TITLE
[train] Adds ability to use dictionary of Ray Data Iterables for Huggingface Trainer

### DIFF
--- a/python/ray/train/huggingface/transformers/_transformers_utils.py
+++ b/python/ray/train/huggingface/transformers/_transformers_utils.py
@@ -2,7 +2,7 @@ import logging
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Iterator, Optional, Type
+from typing import Iterator, Optional, Type, Union
 
 from torch.utils.data import DataLoader, Dataset, IterableDataset
 
@@ -126,10 +126,12 @@ def prepare_trainer(trainer: "Trainer") -> "Trainer":
                 return super().get_train_dataloader()
 
         def get_eval_dataloader(
-            self, eval_dataset: Optional[Dataset] = None
+            self, eval_dataset: Optional[Union[str, Dataset]] = None
         ) -> DataLoader:
             if eval_dataset is None:
                 eval_dataset = self.eval_dataset
+            elif isinstance(eval_dataset, str):
+                eval_dataset = self.eval_dataset[eval_dataset]
 
             if isinstance(eval_dataset, _IterableFromIterator):
                 dataset = RayTorchIterableDataset(eval_dataset)

--- a/python/ray/train/v2/tests/test_torch_transformers_train.py
+++ b/python/ray/train/v2/tests/test_torch_transformers_train.py
@@ -62,6 +62,16 @@ CONFIGURATIONS = {
         "logging_steps": 1,
         "no_cuda": True,
     },
+    "steps_cpu_eval_dict": {
+        "evaluation_strategy": "steps",
+        "save_strategy": "steps",
+        "logging_strategy": "steps",
+        "eval_steps": STEPS_PER_EPOCH,
+        "save_steps": STEPS_PER_EPOCH,
+        "logging_steps": 1,
+        "no_cuda": True,
+        "eval_dataset_as_dict": True,
+    },
 }
 
 
@@ -83,6 +93,10 @@ def train_func(config):
 
         train_dataset = Dataset.from_pandas(train_df)
         eval_dataset = Dataset.from_pandas(validation_df)
+
+    # Convert eval_dataset to dictionary if specified
+    if config.get("eval_dataset_as_dict", False):
+        eval_dataset = {"eval": eval_dataset}
 
     # Model
     model_config = AutoConfig.from_pretrained(MODEL_NAME)
@@ -124,7 +138,7 @@ def train_func(config):
 
 # TODO: Re-enable GPU tests. Right now, ray turbo has no GPU CI.
 # @pytest.mark.parametrize("config_id", ["epoch_gpu", "steps_gpu", "steps_cpu"])
-@pytest.mark.parametrize("config_id", ["steps_cpu"])
+@pytest.mark.parametrize("config_id", ["steps_cpu", "steps_cpu_eval_dict"])
 def test_e2e_hf_data(ray_start_6_cpus_2_gpus, config_id):
     def train_func(config):
         # Datasets

--- a/python/ray/train/v2/tests/test_torch_transformers_train.py
+++ b/python/ray/train/v2/tests/test_torch_transformers_train.py
@@ -94,10 +94,6 @@ def train_func(config):
         train_dataset = Dataset.from_pandas(train_df)
         eval_dataset = Dataset.from_pandas(validation_df)
 
-    # Convert eval_dataset to dictionary if specified
-    if config.get("eval_dataset_as_dict", False):
-        eval_dataset = {"eval": eval_dataset}
-
     # Model
     model_config = AutoConfig.from_pretrained(MODEL_NAME)
     model = AutoModelForCausalLM.from_config(model_config)
@@ -158,6 +154,10 @@ def test_e2e_hf_data(ray_start_6_cpus_2_gpus, config_id):
 
             train_dataset = Dataset.from_pandas(train_df)
             eval_dataset = Dataset.from_pandas(validation_df)
+
+    # Convert eval_dataset to dictionary if specified
+    if config.get("eval_dataset_as_dict", False):
+        eval_dataset = {"eval": eval_dataset}
 
         # Model
         model_config = AutoConfig.from_pretrained(MODEL_NAME)


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Huggingface supports the ability to have a dictionary of eval datasets.
https://huggingface.co/docs/transformers/en/main_classes/trainer#transformers.Trainer.eval_dataset

Currently, this isn't supported, as the overridden `get_eval_dataloader` doesn't take a string as an argument - this PR adds the ability to take a string as a dictionary key argument, similar to the overridden code: https://github.com/huggingface/transformers/blob/91393fe4cc3266a05bc0d129e34ff5f761bb46e2/src/transformers/trainer.py#L1196

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
