### PR TITLE
[CORE][DOC] Fix grammar, spelling, and formatting issues in Ray Core documentation

### DIFF
--- a/doc/source/ray-core/patterns/concurrent-operations-async-actor.rst
+++ b/doc/source/ray-core/patterns/concurrent-operations-async-actor.rst
@@ -22,7 +22,7 @@ With the default actor, the code will look like this:
     :start-after: __sync_actor_start__
     :end-before: __sync_actor_end__
 
-This is problematic because ``TaskExecutor.run`` method runs forever and never yield the control to run other methods.
+This is problematic because ``TaskExecutor.run`` method runs forever and never yields control to run other methods.
 We can solve this problem by using :ref:`async actors <async-actors>` and use ``await`` to yield control:
 
 .. literalinclude:: ../doc_code/pattern_async_actor.py
@@ -30,4 +30,4 @@ We can solve this problem by using :ref:`async actors <async-actors>` and use ``
     :start-after: __async_actor_start__
     :end-before: __async_actor_end__
 
-Here, instead of using the blocking :func:`ray.get() <ray.get>` to get the value of an ObjectRef, we use ``await`` so it can yield the control while we are waiting for the object to be fetched.
+Here, instead of using the blocking :func:`ray.get() <ray.get>` to get the value of an ObjectRef, we use ``await`` so it can yield control while we are waiting for the object to be fetched.

--- a/doc/source/ray-core/patterns/fork-new-processes.rst
+++ b/doc/source/ray-core/patterns/fork-new-processes.rst
@@ -3,7 +3,7 @@
 Anti-pattern: Forking new processes in application code
 ========================================================
 
-**Summary:** Don't fork new processes in Ray application code—for example, in  
+**Summary:** Don't fork new processes in Ray application code—for example, in 
 driver, tasks or actors. Instead, use the "spawn" method to start new processes or use Ray 
 tasks and actors to parallelize your workload
 

--- a/doc/source/ray-core/patterns/fork-new-processes.rst
+++ b/doc/source/ray-core/patterns/fork-new-processes.rst
@@ -14,7 +14,7 @@ any synchronization. This can lead to corrupted messages and unexpected
 behavior.
 
 The solution is to:
-1. use the "spawn" method to start new processes so that parent process's 
+1. use the "spawn" method to start new processes so that the parent process's 
 memory space is not copied to the child processes or
 2. use Ray tasks and 
 actors to parallelize your workload and let Ray manage the lifecycle of the 

--- a/doc/source/ray-core/patterns/fork-new-processes.rst
+++ b/doc/source/ray-core/patterns/fork-new-processes.rst
@@ -3,21 +3,21 @@
 Anti-pattern: Forking new processes in application code
 ========================================================
 
-**Summary:** Don't fork new processes in Ray application code-for example, in  
-driver, tasks or actors. Instead, use "spawn" method to start new processes or use Ray 
+**Summary:** Don't fork new processes in Ray application code—for example, in  
+driver, tasks or actors. Instead, use the "spawn" method to start new processes or use Ray 
 tasks and actors to parallelize your workload
 
 Ray manages the lifecycle of processes for you. Ray Objects, Tasks, and 
-Actors manages sockets to communicate with the Raylet and the GCS. If you fork new 
+Actors manage sockets to communicate with the Raylet and the GCS. If you fork new 
 processes in your application code, the processes could share the same sockets without 
-any synchronization. This can lead to corrupted message and unexpected
+any synchronization. This can lead to corrupted messages and unexpected
 behavior.
 
 The solution is to:
-1. use "spawn" method to start new processes so that parent process's 
-memory space isn't copied to the child processes or
+1. use the "spawn" method to start new processes so that parent process's 
+memory space is not copied to the child processes or
 2. use Ray tasks and 
-actors to parallelize your workload and let Ray to manage the lifecycle of the 
+actors to parallelize your workload and let Ray manage the lifecycle of the 
 processes for you.
 
 Code example

--- a/doc/source/ray-core/patterns/limit-pending-tasks.rst
+++ b/doc/source/ray-core/patterns/limit-pending-tasks.rst
@@ -22,7 +22,7 @@ With ``ray.wait()``, we can apply backpressure and limit the number of pending t
 Example use case
 ----------------
 
-You have a worker actor that process tasks at a rate of X tasks per second and you want to submit tasks to it at a rate lower than X to avoid OOM.
+You have a worker actor that processes tasks at a rate of X tasks per second and you want to submit tasks to it at a rate lower than X to avoid OOM.
 
 For example, Ray Serve uses this pattern to limit the number of pending queries for each worker.
 

--- a/doc/source/ray-core/patterns/out-of-band-object-ref-serialization.rst
+++ b/doc/source/ray-core/patterns/out-of-band-object-ref-serialization.rst
@@ -6,14 +6,14 @@ Anti-pattern: Serialize ray.ObjectRef out of band
 **TLDR:** Avoid serializing ``ray.ObjectRef`` because Ray can't know when to garbage collect the underlying object.
 
 Ray's ``ray.ObjectRef`` is distributed reference counted. Ray pins the underlying object until the reference isn't used by the system anymore.
-When all references are the pinned object gone,  Ray garbage collects the pinned object and cleans it up from the system.
-However, if user code serializes ``ray.objectRef``, Ray can't keep track of the reference.
+When all references to the pinned object are gone, Ray garbage collects the pinned object and cleans it up from the system.
+However, if user code serializes ``ray.ObjectRef``, Ray can't keep track of the reference.
 
-To avoid incorrect behavior, if ``ray.cloudpickle`` serializes``ray.ObjectRef``, Ray pins the object for the lifetime of a worker. "Pin" means that object can't be evicted from the object store
-until the corresponding owner worker dies. It's prone to Ray object leaks, which can lead disk spilling. See :ref:`this page <serialize-object-ref>` for more details.
+To avoid incorrect behavior, if ``ray.cloudpickle`` serializes ``ray.ObjectRef``, Ray pins the object for the lifetime of a worker. "Pin" means that object can't be evicted from the object store
+until the corresponding owner worker dies. It's prone to Ray object leaks, which can lead to disk spilling. See :ref:`this page <serialize-object-ref>` for more details.
 
 To detect if this pattern exists in your code, you can set an environment variable ``RAY_allow_out_of_band_object_ref_serialization=0``. If Ray detects
-that ``ray.cloudpickle`` serialized``ray.ObjectRef``, it raises an exception with helpful messages.
+that ``ray.cloudpickle`` serialized ``ray.ObjectRef``, it raises an exception with helpful messages.
 
 Code example
 ------------

--- a/doc/source/ray-core/scheduling/accelerators.rst
+++ b/doc/source/ray-core/scheduling/accelerators.rst
@@ -84,11 +84,11 @@ If you need to, you can :ref:`override <specify-node-resources>` this.
         .. tip::
 
             You can set the ``NEURON_RT_VISIBLE_CORES`` environment variable before starting a Ray node
-            to limit the AWS Neuro Cores that are visible to Ray.
+            to limit the AWS Neuron Cores that are visible to Ray.
             For example, ``NEURON_RT_VISIBLE_CORES=1,3 ray start --head --resources='{"neuron_cores": 2}'``
             lets Ray only see devices 1 and 3.
 
-            See the `Amazon documentation<https://awslabs.github.io/data-on-eks/docs/category/inference-on-eks>` for more examples of Ray on Neuron with EKS as an orchestration substrate.
+            See the `Amazon documentation <https://awslabs.github.io/data-on-eks/docs/category/inference-on-eks>`_ for more examples of Ray on Neuron with EKS as an orchestration substrate.
 
     .. tab-item:: Google TPU
         :sync: Google TPU

--- a/doc/source/ray-core/scheduling/index.rst
+++ b/doc/source/ray-core/scheduling/index.rst
@@ -22,7 +22,7 @@ Given that, a node can be in one of the following states:
 - Infeasible: the node doesn't have the required resources. For example a CPU-only node is infeasible for a GPU task.
 
 Resource requirements are **hard** requirements meaning that only feasible nodes are eligible to run the task or actor.
-If there are feasible nodes, Ray will either choose an available node or wait until a unavailable node to become available
+If there are feasible nodes, Ray will either choose an available node or wait until an unavailable node to become available
 depending on other factors discussed below.
 If all nodes are infeasible, the task or actor cannot be scheduled until feasible nodes are added to the cluster.
 

--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -37,7 +37,7 @@ Create a Placement Group (Reserve Resources)
 You can create a placement group using :func:`ray.util.placement_group`.
 Placement groups take in a list of bundles and a :ref:`placement strategy <pgroup-strategy>`.
 Note that each bundle must be able to fit on a single node on the Ray cluster.
-For example, if you only have a 8 CPU node, and if you have a bundle that requires ``{"CPU": 9}``,
+For example, if you only have an 8 CPU node, and if you have a bundle that requires ``{"CPU": 9}``,
 this bundle cannot be scheduled.
 
 Bundles are specified by a list of dictionaries, e.g., ``[{"CPU": 1}, {"CPU": 1, "GPU": 1}]``).


### PR DESCRIPTION
This PR addresses various documentation issues found during a comprehensive review of Ray Core documentation files in the `patterns`, `scheduling`, and `tasks` directories.

## Changes Made

### Grammar and Language Fixes
- Fixed subject-verb agreement: "Actors manages" → "Actors manage"
- Corrected article usage: "until a unavailable node" → "until an unavailable node" 
- Improved clarity: "yield the control" → "yield control" (removed unnecessary article)
- Fixed verb forms: "never yield the control" → "never yields control"

### Spelling and Terminology Corrections
- Fixed typo: "AWS Neuro Cores" → "AWS Neuron Cores"
- Corrected capitalization: "ray.objectRef" → "ray.ObjectRef"
- Fixed grammar: "all references are the pinned object gone" → "all references to the pinned object are gone"

### Formatting and Syntax Improvements
- Added missing spaces in reStructuredText links
- Fixed spacing around code references: "serializes``ray.ObjectRef``" → "serializes ``ray.ObjectRef``"
- Corrected punctuation and spacing issues

## Files Modified
- **Patterns directory (4/22 files):**
  - `concurrent-operations-async-actor.rst`
  - `fork-new-processes.rst` 
  - `limit-pending-tasks.rst`
  - `out-of-band-object-ref-serialization.rst`

- **Scheduling directory (3/6 files):**
  - `accelerators.rst`
  - `index.rst`
  - `placement-group.rst`

- **Tasks directory (0/2 files):** No issues found

## Review Process
All 30 files were manually reviewed for spelling, grammar, reStructuredText syntax, and formatting consistency. Only necessary corrections were made to preserve the original content structure and meaning.

The majority of files (23/30) were already well-written and required no changes, indicating good overall documentation quality.