### PR TITLE
[data] refactor download expression to use inheritance from `AbstractOneToOne`

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -360,37 +360,3 @@ class StreamingRepartition(AbstractMap):
 
     def can_modify_num_rows(self) -> bool:
         return False
-
-
-class Download(AbstractMap):
-    """Logical operator for download operation."""
-
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        uri_column_name: str,
-        output_bytes_column_name: str,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        from ray.data._internal.compute import ActorPoolStrategy
-
-        # Download operation uses CallableClass (PartitionActor) so needs ActorPoolStrategy
-        super().__init__(
-            "Download",
-            input_op,
-            ray_remote_args=ray_remote_args,
-            compute=ActorPoolStrategy(size=1),
-        )
-        self._uri_column_name = uri_column_name
-        self._output_bytes_column_name = output_bytes_column_name
-
-    def can_modify_num_rows(self) -> bool:
-        return False
-
-    @property
-    def uri_column_name(self) -> str:
-        return self._uri_column_name
-
-    @property
-    def output_bytes_column_name(self) -> str:
-        return self._output_bytes_column_name

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data.block import BlockMetadata
@@ -83,3 +83,37 @@ class Limit(AbstractOneToOne):
         assert len(self._input_dependencies) == 1, len(self._input_dependencies)
         assert isinstance(self._input_dependencies[0], LogicalOperator)
         return self._input_dependencies[0].infer_metadata().input_files
+
+
+class Download(AbstractOneToOne):
+    """Logical operator for download operation."""
+
+    def __init__(
+        self,
+        input_op: LogicalOperator,
+        uri_column_name: str,
+        output_bytes_column_name: str,
+        ray_remote_args: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(
+            "Download",
+            input_op,
+        )
+        self._uri_column_name = uri_column_name
+        self._output_bytes_column_name = output_bytes_column_name
+        self._ray_remote_args = ray_remote_args or {}
+
+    def can_modify_num_rows(self) -> bool:
+        return False
+
+    @property
+    def uri_column_name(self) -> str:
+        return self._uri_column_name
+
+    @property
+    def output_bytes_column_name(self) -> str:
+        return self._output_bytes_column_name
+
+    @property
+    def ray_remote_args(self) -> Dict[str, Any]:
+        return self._ray_remote_args

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -95,10 +95,7 @@ class Download(AbstractOneToOne):
         output_bytes_column_name: str,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
-        super().__init__(
-            "Download",
-            input_op,
-        )
+        super().__init__("Download", input_op)
         self._uri_column_name = uri_column_name
         self._output_bytes_column_name = output_bytes_column_name
         self._ray_remote_args = ray_remote_args or {}

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -26,13 +26,12 @@ from ray.data._internal.logical.operators.input_data_operator import InputData
 from ray.data._internal.logical.operators.join_operator import Join
 from ray.data._internal.logical.operators.map_operator import (
     AbstractUDFMap,
-    Download,
     Filter,
     Project,
     StreamingRepartition,
 )
 from ray.data._internal.logical.operators.n_ary_operator import Union, Zip
-from ray.data._internal.logical.operators.one_to_one_operator import Limit
+from ray.data._internal.logical.operators.one_to_one_operator import Download, Limit
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.operators.streaming_split_operator import StreamingSplit
 from ray.data._internal.logical.operators.write_operator import Write

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -828,7 +828,8 @@ class Dataset:
             A new dataset with the added column evaluated via the expression.
         """
         # TODO: update schema based on the expression AST.
-        from ray.data._internal.logical.operators.map_operator import Download, Project
+        from ray.data._internal.logical.operators.map_operator import Project
+        from ray.data._internal.logical.operators.one_to_one_operator import Download
 
         # TODO: Once the expression API supports UDFs, we can clean up the code here.
         from ray.data.expressions import DownloadExpr


### PR DESCRIPTION
## Why are these changes needed?
`Download` logical operator isn't really a map, we should use `AbstractOneToOne` as the base class instead.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
