### PR TITLE
foundation work for aggregating metrics on controller

### DIFF
--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -80,7 +80,7 @@ Ray Serve allows you to fine-tune the backoff behavior of the request router, wh
 The Serve Controller runs on the Ray head node and is responsible for a variety of tasks,
 including receiving autoscaling metrics from other Ray Serve components.
 If the Serve Controller becomes overloaded
-(symptoms might include high CPU usage and a large number of pending `ServeController.record_handle_metrics` tasks),
+(symptoms might include high CPU usage and a large number of pending `ServeController.record_autoscaling_metrics_from_handle` tasks),
 you can increase the interval between cycles of the control loop
 by setting the `RAY_SERVE_CONTROL_LOOP_INTERVAL_S` environment variable (defaults to `0.1` seconds).
 This setting gives the Controller more time to process requests and may help alleviate the overload.

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set
 
 from ray.serve._private.common import (
-    DeploymentHandleSource,
     DeploymentID,
+    HandleMetricReport,
     ReplicaID,
+    ReplicaMetricReport,
     TargetCapacityDirection,
 )
 from ray.serve._private.constants import (
@@ -17,65 +18,6 @@ from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.utils import get_capacity_adjusted_num_replicas
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
-
-
-@dataclass
-class HandleMetricReport:
-    """Report from a deployment handle on queued and ongoing requests.
-
-    Args:
-        actor_id: If the deployment handle (from which this metric was
-            sent) lives on an actor, the actor ID of that actor.
-        handle_source: Describes what kind of entity holds this
-            deployment handle: a Serve proxy, a Serve replica, or
-            unknown.
-        queued_requests: The current number of queued requests at the
-            handle, i.e. requests that haven't been assigned to any
-            replica yet.
-        running_requests: A map of replica ID to the average number of
-            requests, assigned through the handle, running at that
-            replica.
-        timestamp: The time at which this report was received.
-    """
-
-    actor_id: Optional[str]
-    handle_source: DeploymentHandleSource
-    queued_requests: float
-    running_requests: Dict[ReplicaID, float]
-    timestamp: float
-
-    @property
-    def total_requests(self) -> float:
-        """Total number of queued and running requests."""
-        return self.queued_requests + sum(self.running_requests.values())
-
-    @property
-    def is_serve_component_source(self) -> bool:
-        """Whether the handle source is a Serve actor.
-
-        More specifically, this returns whether a Serve actor tracked
-        by the controller holds the deployment handle that sent this
-        report. If the deployment handle lives on a driver, a Ray task,
-        or an actor that's not a Serve replica, then this returns False.
-        """
-        return self.handle_source in [
-            DeploymentHandleSource.PROXY,
-            DeploymentHandleSource.REPLICA,
-        ]
-
-
-@dataclass
-class ReplicaMetricReport:
-    """Report from a replica on ongoing requests.
-
-    Args:
-        running_requests: Average number of running requests at the
-            replica.
-        timestamp: The time at which this report was received.
-    """
-
-    running_requests: float
-    timestamp: float
 
 
 @dataclass
@@ -214,47 +156,36 @@ class AutoscalingState:
         )
 
     def record_request_metrics_for_replica(
-        self, replica_id: ReplicaID, window_avg: Optional[float], send_timestamp: float
+        self, replica_metric_report: ReplicaMetricReport
     ) -> None:
         """Records average number of ongoing requests at a replica."""
 
-        if window_avg is None:
+        if replica_metric_report.avg_running_requests is None:
             return
 
+        replica_id = replica_metric_report.replica_id
+        send_timestamp = replica_metric_report.timestamp
         if (
             replica_id not in self._replica_requests
             or send_timestamp > self._replica_requests[replica_id].timestamp
         ):
-            self._replica_requests[replica_id] = ReplicaMetricReport(
-                running_requests=window_avg,
-                timestamp=send_timestamp,
-            )
+            self._replica_requests[replica_id] = replica_metric_report
 
     def record_request_metrics_for_handle(
         self,
-        *,
-        handle_id: str,
-        actor_id: Optional[str],
-        handle_source: DeploymentHandleSource,
-        queued_requests: float,
-        running_requests: Dict[ReplicaID, float],
-        send_timestamp: float,
+        handle_metric_report: HandleMetricReport,
     ) -> None:
         """Records average number of queued and running requests at a handle for this
         deployment.
         """
 
+        handle_id = handle_metric_report.handle_id
+        send_timestamp = handle_metric_report.timestamp
         if (
             handle_id not in self._handle_requests
             or send_timestamp > self._handle_requests[handle_id].timestamp
         ):
-            self._handle_requests[handle_id] = HandleMetricReport(
-                actor_id=actor_id,
-                handle_source=handle_source,
-                queued_requests=queued_requests,
-                running_requests=running_requests,
-                timestamp=send_timestamp,
-            )
+            self._handle_requests[handle_id] = handle_metric_report
 
     def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
         """Drops handle metrics that are no longer valid.
@@ -353,7 +284,7 @@ class AutoscalingState:
 
         for id in self._running_replicas:
             if id in self._replica_requests:
-                total_requests += self._replica_requests[id].running_requests
+                total_requests += self._replica_requests[id].avg_running_requests
 
         metrics_collected_on_replicas = total_requests > 0
         for handle_metric in self._handle_requests.values():
@@ -362,7 +293,7 @@ class AutoscalingState:
             if not metrics_collected_on_replicas:
                 for id in self._running_replicas:
                     if id in handle_metric.running_requests:
-                        total_requests += handle_metric.running_requests[id]
+                        total_requests += handle_metric.avg_running_requests[id]
 
         return total_requests
 
@@ -431,39 +362,26 @@ class AutoscalingStateManager:
         )
 
     def record_request_metrics_for_replica(
-        self, replica_id: ReplicaID, window_avg: Optional[float], send_timestamp: float
+        self, replica_metric_report: ReplicaMetricReport
     ) -> None:
-        deployment_id = replica_id.deployment_id
+        deployment_id = replica_metric_report.replica_id.deployment_id
         # Defensively guard against delayed replica metrics arriving
         # after the deployment's been deleted
         if deployment_id in self._autoscaling_states:
             self._autoscaling_states[deployment_id].record_request_metrics_for_replica(
-                replica_id=replica_id,
-                window_avg=window_avg,
-                send_timestamp=send_timestamp,
+                replica_metric_report
             )
 
     def record_request_metrics_for_handle(
         self,
-        *,
-        deployment_id: str,
-        handle_id: str,
-        actor_id: Optional[str],
-        handle_source: DeploymentHandleSource,
-        queued_requests: float,
-        running_requests: Dict[ReplicaID, float],
-        send_timestamp: float,
+        handle_metric_report: HandleMetricReport,
     ) -> None:
         """Update request metric for a specific handle."""
 
+        deployment_id = handle_metric_report.deployment_id
         if deployment_id in self._autoscaling_states:
             self._autoscaling_states[deployment_id].record_request_metrics_for_handle(
-                handle_id=handle_id,
-                actor_id=actor_id,
-                handle_source=handle_source,
-                queued_requests=queued_requests,
-                running_requests=running_requests,
-                send_timestamp=send_timestamp,
+                handle_metric_report
             )
 
     def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -279,7 +279,6 @@ class AutoscalingState:
 
         total_requests = 0
 
-        # print(f"self._replica_requests: {self._replica_requests}")
         for id in self._running_replicas:
             if id in self._replica_requests:
                 total_requests += self._replica_requests[id].aggregated_metrics.get(

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -754,3 +754,86 @@ OBJ_REF_NOT_SUPPORTED_ERROR = RuntimeError(
     "Converting by-value DeploymentResponses to ObjectRefs is not supported. "
     "Use handle.options(_by_reference=True) to enable it."
 )
+
+
+@dataclass(order=True)
+class TimeStampedValue:
+    timestamp: float
+    value: float = field(compare=False)
+
+
+@dataclass
+class HandleMetricReport:
+    """Report from a deployment handle on queued and ongoing requests.
+
+    Args:
+        deployment_id: The deployment ID of the deployment handle.
+        handle_id: The handle ID of the deployment handle.
+        actor_id: If the deployment handle (from which this metric was
+            sent) lives on an actor, the actor ID of that actor.
+        handle_source: Describes what kind of entity holds this
+            deployment handle: a Serve proxy, a Serve replica, or
+            unknown.
+        queued_requests: The current number of queued requests at the
+            handle, i.e. requests that haven't been assigned to any
+            replica yet.
+        avg_running_requests: A map of replica ID to the average number of
+            requests, assigned through the handle, running at that
+            replica. This is average over the past look_back_period_s seconds.
+            This field will be dropped in the future when fully migrate to
+            doing aggregation on the controller.
+        running_requests: A map of replica ID to the list of number of requests
+            running at that replica over the past look_back_period_s seconds.
+            This is a list because we take multiple measurements over time.
+        timestamp: The time at which this report was created.
+    """
+
+    deployment_id: DeploymentID
+    handle_id: str
+    actor_id: str
+    handle_source: DeploymentHandleSource
+    queued_requests: float
+    avg_running_requests: Dict[ReplicaID, float]
+    running_requests: Dict[ReplicaID, List[TimeStampedValue]]
+    timestamp: float
+
+    @property
+    def total_requests(self) -> float:
+        """Total number of queued and running requests."""
+        return self.queued_requests + sum(self.avg_running_requests.values())
+
+    @property
+    def is_serve_component_source(self) -> bool:
+        """Whether the handle source is a Serve actor.
+
+        More specifically, this returns whether a Serve actor tracked
+        by the controller holds the deployment handle that sent this
+        report. If the deployment handle lives on a driver, a Ray task,
+        or an actor that's not a Serve replica, then this returns False.
+        """
+        return self.handle_source in [
+            DeploymentHandleSource.PROXY,
+            DeploymentHandleSource.REPLICA,
+        ]
+
+
+@dataclass
+class ReplicaMetricReport:
+    """Report from a replica on ongoing requests.
+
+    Args:
+        replica_id: The replica ID of the replica.
+        avg_running_requests: Average number of running requests at the
+            replica. This is average over the past look_back_period_s seconds.
+            This field will be dropped in the future when fully migrate to
+            doing aggregation on the controller.
+        running_requests: A list of number of requests running at that replica
+            over the past look_back_period_s seconds. This is a list because
+            we take multiple measurements over time.
+        timestamp: The time at which this report was created.
+    """
+
+    replica_id: ReplicaID
+    avg_running_requests: Optional[float]
+    running_requests: List[TimeStampedValue]
+    timestamp: float

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -779,14 +779,11 @@ class HandleMetricReport:
         queued_requests: The current number of queued requests at the
             handle, i.e. requests that haven't been assigned to any
             replica yet.
-        avg_running_requests: A map of replica ID to the average number of
-            requests, assigned through the handle, running at that
-            replica. This is average over the past look_back_period_s seconds.
-            This field will be dropped in the future when fully migrate to
-            doing aggregation on the controller.
-        running_requests: A map of replica ID to the list of number of requests
-            running at that replica over the past look_back_period_s seconds.
-            This is a list because we take multiple measurements over time.
+        aggregated_metrics: A map of metric name to the aggregated value over the past
+            look_back_period_s seconds at the handle for each replica.
+        metrics: A map of metric name to the list of values running at that handle for each replica
+            over the past look_back_period_s seconds. This is a list because
+            we take multiple measurements over time.
         timestamp: The time at which this report was created.
     """
 

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -477,3 +477,8 @@ if RAY_SERVE_THROUGHPUT_OPTIMIZED:
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE = 1000
     RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP = False
     RAY_SERVE_LOG_TO_STDERR = False
+
+# The maximum allowed RPC latency in milliseconds.
+# This is used to detect and warn about long RPC latencies
+# between the controller and the replicas.
+RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS = 2000

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -13,9 +13,10 @@ from ray.actor import ActorHandle
 from ray.serve._private.application_state import ApplicationStateManager, StatusOverview
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
-    DeploymentHandleSource,
     DeploymentID,
+    HandleMetricReport,
     NodeId,
+    ReplicaMetricReport,
     RequestProtocol,
     RequestRoutingInfo,
     RunningReplicaInfo,
@@ -25,6 +26,7 @@ from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     CONTROL_LOOP_INTERVAL_S,
     RAY_SERVE_CONTROLLER_CALLBACK_IMPORT_PATH,
+    RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS,
     RECOVERING_LONG_POLL_BROADCAST_TIMEOUT_S,
     SERVE_CONTROLLER_NAME,
     SERVE_DEFAULT_APP_NAME,
@@ -259,38 +261,45 @@ class ServeController:
     def get_pid(self) -> int:
         return os.getpid()
 
-    def record_autoscaling_metrics(
-        self, replica_id: str, window_avg: Optional[float], send_timestamp: float
+    def record_autoscaling_metrics_from_replica(
+        self, replica_metric_report: ReplicaMetricReport
     ):
         logger.debug(
-            f"Received metrics from replica {replica_id}: {window_avg} running requests"
+            f"Received metrics from replica {replica_metric_report.replica_id}: {replica_metric_report.avg_running_requests} running requests"
         )
+        curr_time = time.time()
+        latency = curr_time - replica_metric_report.timestamp
+        latency_ms = latency * 1000
+        if latency_ms > RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS:
+            logger.warning(
+                f"Received autoscaling metrics from replica {replica_metric_report.replica_id} with timestamp {replica_metric_report.timestamp} "
+                f"which is {latency_ms}ms ago. "
+                f"This is greater than the warning threshold RPC latency of {RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS}ms. "
+                f"This may indicate a performance issue with the controller try increasing the RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS environment variable."
+            )
         self.autoscaling_state_manager.record_request_metrics_for_replica(
-            replica_id, window_avg, send_timestamp
+            replica_metric_report
         )
 
-    def record_handle_metrics(
-        self,
-        deployment_id: str,
-        handle_id: str,
-        actor_id: Optional[str],
-        handle_source: DeploymentHandleSource,
-        queued_requests: float,
-        running_requests: Dict[str, float],
-        send_timestamp: float,
+    def record_autoscaling_metrics_from_handle(
+        self, handle_metric_report: HandleMetricReport
     ):
         logger.debug(
-            f"Received metrics from handle {handle_id} for deployment {deployment_id}: "
-            f"{queued_requests} queued requests and {running_requests} running requests"
+            f"Received metrics from handle {handle_metric_report.handle_id} for deployment {handle_metric_report.deployment_id}: "
+            f"{handle_metric_report.queued_requests} queued requests and {handle_metric_report.avg_running_requests} running requests"
         )
+        curr_time = time.time()
+        latency = curr_time - handle_metric_report.timestamp
+        latency_ms = latency * 1000
+        if latency_ms > RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS:
+            logger.warning(
+                f"Received autoscaling metrics from handle {handle_metric_report.handle_id} for deployment {handle_metric_report.deployment_id} with timestamp {handle_metric_report.timestamp} "
+                f"which is {latency_ms}ms ago. "
+                f"This is greater than the warning threshold RPC latency of {RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS}ms. "
+                f"This may indicate a performance issue with the controller try increasing the RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS environment variable."
+            )
         self.autoscaling_state_manager.record_request_metrics_for_handle(
-            deployment_id=deployment_id,
-            handle_id=handle_id,
-            actor_id=actor_id,
-            handle_source=handle_source,
-            queued_requests=queued_requests,
-            running_requests=running_requests,
-            send_timestamp=send_timestamp,
+            handle_metric_report
         )
 
     def _dump_autoscaling_metrics_for_testing(self):

--- a/python/ray/serve/_private/metrics_utils.py
+++ b/python/ray/serve/_private/metrics_utils.py
@@ -3,7 +3,7 @@ import bisect
 import logging
 import statistics
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from itertools import chain
 from typing import (
     Callable,
@@ -16,6 +16,7 @@ from typing import (
     Tuple,
 )
 
+from ray.serve._private.common import TimeStampedValue
 from ray.serve._private.constants import (
     METRICS_PUSHER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
     SERVE_LOGGER_NAME,
@@ -121,12 +122,6 @@ class MetricsPusher:
 
         self._tasks.clear()
         self._async_tasks.clear()
-
-
-@dataclass(order=True)
-class TimeStampedValue:
-    timestamp: float
-    value: float = field(compare=False)
 
 
 class InMemoryMetricsStore:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -39,6 +39,7 @@ from ray.actor import ActorClass, ActorHandle
 from ray.remote_function import RemoteFunction
 from ray.serve import metrics
 from ray.serve._private.common import (
+    RUNNING_REQUESTS_KEY,
     DeploymentID,
     ReplicaID,
     ReplicaMetricReport,
@@ -332,11 +333,16 @@ class ReplicaMetricsManager:
         self._metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
         replica_metric_report = ReplicaMetricReport(
             replica_id=self._replica_id,
-            avg_running_requests=self._metrics_store.aggregate_avg([self._replica_id])[
-                0
-            ],
-            running_requests=self._metrics_store.data.get(self._replica_id, []),
             timestamp=time.time(),
+            aggregated_metrics={
+                RUNNING_REQUESTS_KEY: self._metrics_store.aggregate_avg(
+                    [self._replica_id]
+                )[0]
+                or 0.0
+            },
+            metrics={
+                RUNNING_REQUESTS_KEY: self._metrics_store.data.get(self._replica_id, [])
+            },
         )
         self._controller_handle.record_autoscaling_metrics_from_replica.remote(
             replica_metric_report

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -25,6 +25,7 @@ import ray
 from ray.actor import ActorHandle
 from ray.exceptions import ActorDiedError, ActorUnavailableError, RayError
 from ray.serve._private.common import (
+    RUNNING_REQUESTS_KEY,
     DeploymentHandleSource,
     DeploymentID,
     DeploymentTargetInfo,
@@ -385,7 +386,7 @@ class RouterMetricsManager:
         start_timestamp = time.time() - self.autoscaling_config.look_back_period_s
         self.metrics_store.prune_keys_and_compact_data(start_timestamp)
 
-    def _get_metrics_report(self):
+    def _get_metrics_report(self) -> HandleMetricReport:
         running_requests = dict()
         avg_running_requests = dict()
         timestamp = time.time()
@@ -394,7 +395,6 @@ class RouterMetricsManager:
             self.metrics_store.prune_keys_and_compact_data(
                 time.time() - look_back_period
             )
-            # Combine two loops into one for efficiency
             for replica_id, num_requests in self.num_requests_sent_to_replicas.items():
                 # Calculate avg running requests
                 avg_running_requests[replica_id] = (
@@ -414,8 +414,8 @@ class RouterMetricsManager:
             actor_id=self._self_actor_id,
             handle_source=self._handle_source,
             queued_requests=self.num_queued_requests,
-            avg_running_requests=avg_running_requests,
-            running_requests=running_requests,
+            aggregated_metrics={RUNNING_REQUESTS_KEY: avg_running_requests},
+            metrics={RUNNING_REQUESTS_KEY: running_requests},
             timestamp=timestamp,
         )
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -377,7 +377,7 @@ class TestAutoscalingMetrics:
 
         # Wait for deployment A to scale up
         wait_for_condition(check_num_requests_eq, client=client, id=dep_id, expected=20)
-        wait_for_condition(check_num_replicas_eq, name="A", target=5)
+        wait_for_condition(check_num_replicas_eq, name="A", target=5, timeout=20)
         print("Confirmed deployment scaled to 5 replicas.")
 
         # Kill CallerActor

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -8,6 +8,7 @@ import pytest
 from ray._common.ray_constants import DEFAULT_MAX_CONCURRENCY_ASYNC
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
+    RUNNING_REQUESTS_KEY,
     DeploymentHandleSource,
     DeploymentID,
     DeploymentStatus,
@@ -2823,14 +2824,19 @@ class TestAutoscaling:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=0,
-                avg_running_requests={
-                    replica._actor.replica_id: req_per_replica for replica in replicas
+                aggregated_metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica._actor.replica_id: req_per_replica
+                        for replica in replicas
+                    }
                 },
-                running_requests={
-                    replica._actor.replica_id: [
-                        TimeStampedValue(timer.time(), req_per_replica)
-                    ]
-                    for replica in replicas
+                metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica._actor.replica_id: [
+                            TimeStampedValue(timer.time(), req_per_replica)
+                        ]
+                        for replica in replicas
+                    }
                 },
                 timestamp=timer.time(),
             )
@@ -2839,8 +2845,12 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    avg_running_requests=req_per_replica,
-                    running_requests=[TimeStampedValue(timer.time(), req_per_replica)],
+                    aggregated_metrics={RUNNING_REQUESTS_KEY: req_per_replica},
+                    metrics={
+                        RUNNING_REQUESTS_KEY: [
+                            TimeStampedValue(timer.time(), req_per_replica)
+                        ]
+                    },
                     timestamp=timer.time(),
                 )
                 asm.record_request_metrics_for_replica(replica_metric_report)
@@ -2990,12 +3000,16 @@ class TestAutoscaling:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=0,
-                avg_running_requests={
-                    replica._actor.replica_id: 2 for replica in replicas
+                aggregated_metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica._actor.replica_id: 2 for replica in replicas
+                    }
                 },
-                running_requests={
-                    replica._actor.replica_id: [TimeStampedValue(timer.time(), 2)]
-                    for replica in replicas
+                metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica._actor.replica_id: [TimeStampedValue(timer.time(), 2)]
+                        for replica in replicas
+                    }
                 },
                 timestamp=timer.time(),
             )
@@ -3004,8 +3018,8 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    avg_running_requests=2,
-                    running_requests=[TimeStampedValue(timer.time(), 2)],
+                    aggregated_metrics={RUNNING_REQUESTS_KEY: 2},
+                    metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time(), 2)]},
                     timestamp=timer.time(),
                 )
                 asm.record_request_metrics_for_replica(replica_metric_report)
@@ -3078,12 +3092,16 @@ class TestAutoscaling:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=0,
-                avg_running_requests={
-                    replica._actor.replica_id: 1 for replica in replicas
+                aggregated_metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica._actor.replica_id: 1 for replica in replicas
+                    }
                 },
-                running_requests={
-                    replica._actor.replica_id: [TimeStampedValue(timer.time(), 1)]
-                    for replica in replicas
+                metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica._actor.replica_id: [TimeStampedValue(timer.time(), 1)]
+                        for replica in replicas
+                    }
                 },
                 timestamp=timer.time(),
             )
@@ -3092,8 +3110,8 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    avg_running_requests=1,
-                    running_requests=[TimeStampedValue(timer.time(), 1)],
+                    aggregated_metrics={RUNNING_REQUESTS_KEY: 1},
+                    metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time(), 1)]},
                     timestamp=timer.time(),
                 )
                 asm.record_request_metrics_for_replica(replica_metric_report)
@@ -3179,12 +3197,16 @@ class TestAutoscaling:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=0,
-                avg_running_requests={
-                    replica._actor.replica_id: 1 for replica in replicas
+                aggregated_metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica._actor.replica_id: 1 for replica in replicas
+                    }
                 },
-                running_requests={
-                    replica._actor.replica_id: [TimeStampedValue(timer.time(), 1)]
-                    for replica in replicas
+                metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica._actor.replica_id: [TimeStampedValue(timer.time(), 1)]
+                        for replica in replicas
+                    }
                 },
                 timestamp=timer.time(),
             )
@@ -3193,8 +3215,8 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    avg_running_requests=1,
-                    running_requests=[TimeStampedValue(timer.time(), 1)],
+                    aggregated_metrics={RUNNING_REQUESTS_KEY: 1},
+                    metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time(), 1)]},
                     timestamp=timer.time(),
                 )
                 asm.record_request_metrics_for_replica(replica_metric_report)
@@ -3288,8 +3310,8 @@ class TestAutoscaling:
             actor_id="actor_id",
             handle_source=DeploymentHandleSource.UNKNOWN,
             queued_requests=1,
-            avg_running_requests={},
-            running_requests={},
+            aggregated_metrics={},
+            metrics={},
             timestamp=timer.time(),
         )
         asm.record_request_metrics_for_handle(handle_metric_report)
@@ -3404,8 +3426,8 @@ class TestAutoscaling:
             actor_id="actor_id",
             handle_source=DeploymentHandleSource.UNKNOWN,
             queued_requests=1,
-            avg_running_requests={},
-            running_requests={},
+            aggregated_metrics={},
+            metrics={},
             timestamp=timer.time(),
         )
         asm.record_request_metrics_for_handle(handle_metric_report)
@@ -3480,11 +3502,15 @@ class TestAutoscaling:
             actor_id="actor_id",
             handle_source=DeploymentHandleSource.UNKNOWN,
             queued_requests=0,
-            avg_running_requests={ds._replicas.get()[0]._actor.replica_id: 2},
-            running_requests={
-                ds._replicas.get()[0]._actor.replica_id: [
-                    TimeStampedValue(timer.time(), 2)
-                ]
+            aggregated_metrics={
+                RUNNING_REQUESTS_KEY: {ds._replicas.get()[0]._actor.replica_id: 2}
+            },
+            metrics={
+                RUNNING_REQUESTS_KEY: {
+                    ds._replicas.get()[0]._actor.replica_id: [
+                        TimeStampedValue(timer.time(), 2)
+                    ]
+                }
             },
             timestamp=timer.time(),
         )
@@ -3572,11 +3598,15 @@ class TestAutoscaling:
             actor_id="d2_replica_actor_id",
             handle_source=DeploymentHandleSource.REPLICA,
             queued_requests=0,
-            avg_running_requests={ds1._replicas.get()[0]._actor.replica_id: 2},
-            running_requests={
-                ds1._replicas.get()[0]._actor.replica_id: [
-                    TimeStampedValue(timer.time(), 2)
-                ]
+            aggregated_metrics={
+                RUNNING_REQUESTS_KEY: {ds1._replicas.get()[0]._actor.replica_id: 2}
+            },
+            metrics={
+                RUNNING_REQUESTS_KEY: {
+                    ds1._replicas.get()[0]._actor.replica_id: [
+                        TimeStampedValue(timer.time(), 2)
+                    ]
+                }
             },
             timestamp=timer.time(),
         )

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -14,6 +14,7 @@ from ray.serve._private.common import (
     DeploymentStatusTrigger,
     HandleMetricReport,
     ReplicaID,
+    ReplicaMetricReport,
     ReplicaState,
     TargetCapacityDirection,
     TimeStampedValue,
@@ -2836,11 +2837,13 @@ class TestAutoscaling:
             asm.record_request_metrics_for_handle(handle_metric_report)
         else:
             for replica in replicas:
-                asm.record_request_metrics_for_replica(
+                replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    window_avg=req_per_replica,
-                    send_timestamp=timer.time(),
+                    avg_running_requests=req_per_replica,
+                    running_requests=[TimeStampedValue(timer.time(), req_per_replica)],
+                    timestamp=timer.time(),
                 )
+                asm.record_request_metrics_for_replica(replica_metric_report)
 
         # status=UPSCALING/DOWNSCALING, status_trigger=AUTOSCALE
         dsm.update()
@@ -2999,9 +3002,13 @@ class TestAutoscaling:
             asm.record_request_metrics_for_handle(handle_metric_report)
         else:
             for replica in replicas:
-                asm.record_request_metrics_for_replica(
-                    replica._actor.replica_id, 2, timer.time()
+                replica_metric_report = ReplicaMetricReport(
+                    replica_id=replica._actor.replica_id,
+                    avg_running_requests=2,
+                    running_requests=[TimeStampedValue(timer.time(), 2)],
+                    timestamp=timer.time(),
                 )
+                asm.record_request_metrics_for_replica(replica_metric_report)
 
         # status=UPSCALING, status_trigger=AUTOSCALE
         dsm.update()
@@ -3083,9 +3090,13 @@ class TestAutoscaling:
             asm.record_request_metrics_for_handle(handle_metric_report)
         else:
             for replica in replicas:
-                asm.record_request_metrics_for_replica(
-                    replica._actor.replica_id, 1, timer.time()
+                replica_metric_report = ReplicaMetricReport(
+                    replica_id=replica._actor.replica_id,
+                    avg_running_requests=1,
+                    running_requests=[TimeStampedValue(timer.time(), 1)],
+                    timestamp=timer.time(),
                 )
+                asm.record_request_metrics_for_replica(replica_metric_report)
 
         # status=DOWNSCALING, status_trigger=AUTOSCALE
         dsm.update()
@@ -3180,9 +3191,13 @@ class TestAutoscaling:
             asm.record_request_metrics_for_handle(handle_metric_report)
         else:
             for replica in replicas:
-                asm.record_request_metrics_for_replica(
-                    replica._actor.replica_id, 1, timer.time()
+                replica_metric_report = ReplicaMetricReport(
+                    replica_id=replica._actor.replica_id,
+                    avg_running_requests=1,
+                    running_requests=[TimeStampedValue(timer.time(), 1)],
+                    timestamp=timer.time(),
                 )
+                asm.record_request_metrics_for_replica(replica_metric_report)
 
         check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, None)])
         assert ds.curr_status_info.status == DeploymentStatus.HEALTHY

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -1006,14 +1006,9 @@ class TestRouterMetricsManager:
 
             # Check metrics are pushed correctly
             metrics_manager.push_autoscaling_metrics_to_controller()
-            mock_controller_handle.record_handle_metrics.remote.assert_called_with(
-                deployment_id=deployment_id,
-                handle_id=handle_id,
-                actor_id=self_actor_id,
-                handle_source=DeploymentHandleSource.PROXY,
-                queued_requests=n,
-                running_requests=running_requests,
-                send_timestamp=start,
+            handle_metric_report = metrics_manager._get_metrics_report()
+            mock_controller_handle.record_autoscaling_metrics_from_handle.remote.assert_called_with(
+                handle_metric_report
             )
 
     @pytest.mark.skipif(


### PR DESCRIPTION
This PR is part of the larger plan outlined [[here](https://gist.github.com/abrarsheikh/ac23e10a61925e0db04097c59e694add)].

### Scope of this PR

* **No functional changes introduced.**
* Begin transition toward controller-side aggregation by sending **unaggregated `num_ongoing_requests`** from both replica and handle to the controller, **in addition to** existing aggregated values.

  * In future PRs, pre-aggregated values will be removed once controller-side aggregation is fully enabled.
* **Refactor `HandleMetricReport` and `ReplicaMetricReport`:**

  * Moved from `autoscaling_state` to `commons`.
  * Objects are now created at the source instead of in `autoscaling_state`, simplifying code and avoiding passing individual attributes through the controller.
  * These reports will be extended in the future to carry **custom metrics**.
* **Controller method renames** for improved clarity.
* **New feature flag:** `RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS`

  * Emits warnings when replicas/handles are slow to send metrics to the controller.
  * Helps users operating large clusters identify and debug RPC communication issues earlier.

### Next Steps (Future PRs)

1. Introduce `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER`.
2. Add user-defined aggregation functions in autoscaling config.
3. Perform aggregation on the controller (replacing pre-aggregated values from handle/replica), gated by the new flag.

https://github.com/ray-project/ray/pull/56306
https://github.com/ray-project/ray/pull/56311
