### PR TITLE
[core] Make core worker pubsub tolerant to network failures

### DIFF
--- a/src/fakes/ray/pubsub/subscriber.h
+++ b/src/fakes/ray/pubsub/subscriber.h
@@ -22,11 +22,11 @@ namespace pubsub {
 class FakeSubscriberClient : public SubscriberClientInterface {
  public:
   void PubsubLongPolling(
-      const rpc::PubsubLongPollingRequest &request,
+      rpc::PubsubLongPollingRequest &&request,
       const rpc::ClientCallback<rpc::PubsubLongPollingReply> &callback) override {}
 
   void PubsubCommandBatch(
-      const rpc::PubsubCommandBatchRequest &request,
+      rpc::PubsubCommandBatchRequest &&request,
       const rpc::ClientCallback<rpc::PubsubCommandBatchReply> &callback) override {}
 };
 

--- a/src/ray/object_manager/ownership_object_directory.cc
+++ b/src/ray/object_manager/ownership_object_directory.cc
@@ -329,10 +329,10 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     const OnLocationsFound &callback) {
   auto it = listeners_.find(object_id);
   if (it == listeners_.end()) {
-    // Create an object eviction subscription message.
-    auto request = std::make_unique<rpc::WorkerObjectLocationsSubMessage>();
-    request->set_intended_worker_id(owner_address.worker_id());
-    request->set_object_id(object_id.Binary());
+    // Create an object location subscription message.
+    rpc::WorkerObjectLocationsSubMessage request;
+    request.set_intended_worker_id(owner_address.worker_id());
+    request.set_object_id(object_id.Binary());
 
     auto msg_published_callback = [this, object_id](const rpc::PubMessage &pub_message) {
       RAY_CHECK(pub_message.has_worker_object_locations_message());

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -498,11 +498,10 @@ service CoreWorkerService {
   rpc WaitForActorRefDeleted(WaitForActorRefDeletedRequest)
       returns (WaitForActorRefDeletedReply);
 
-  /// The long polling request sent to the core worker for pubsub operations.
-  /// It is replied once there are batch of objects that need to be published to
-  /// the caller (subscriber).
-  /// Failure: Pubsub system handles failures. TODO: all clients need subscribe failure
-  /// callbacks
+  // The long polling request sent to the core worker for pubsub operations.
+  // It is replied once there are batch of objects that need to be published to
+  // the caller (subscriber).
+  // Failure: Retries on failures, see pubsub/README.md for more details.
   rpc PubsubLongPolling(PubsubLongPollingRequest) returns (PubsubLongPollingReply);
 
   // The RPC to report the intermediate task return from the executor worker to the owner
@@ -513,7 +512,7 @@ service CoreWorkerService {
 
   // The pubsub command batch request used by the subscriber.
   // Subscribe / unsubscribe commands to the publisher worker.
-  // Failure: TODO: Does not handle failures.
+  // Failure: Retries on failures, see pubsub/README.md for more details.
   rpc PubsubCommandBatch(PubsubCommandBatchRequest) returns (PubsubCommandBatchReply);
 
   // Update the batched object location information to the ownership-based object

--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -269,6 +269,7 @@ void Subscriber::Subscribe(std::unique_ptr<rpc::SubMessage> sub_message,
   // Batch a subscribe command.
   auto command = std::make_unique<CommandItem>();
   command->cmd.set_channel_type(channel_type);
+
   if (key_id.has_value()) {
     command->cmd.set_key_id(*key_id);
   }
@@ -305,11 +306,12 @@ void Subscriber::MakeLongPollingPubsubConnection(const rpc::Address &publisher_a
   auto subscriber_client = get_client_(publisher_address);
   rpc::PubsubLongPollingRequest long_polling_request;
   long_polling_request.set_subscriber_id(subscriber_id_.Binary());
-  auto &processed_state = processed_sequences_[publisher_id];
-  long_polling_request.set_publisher_id(processed_state.first.Binary());
-  long_polling_request.set_max_processed_sequence_id(processed_state.second);
+  auto &[last_publisher_id, max_processed_sequence_id] =
+      processed_sequences_[publisher_id];
+  long_polling_request.set_publisher_id(last_publisher_id.Binary());
+  long_polling_request.set_max_processed_sequence_id(max_processed_sequence_id);
   subscriber_client->PubsubLongPolling(
-      long_polling_request,
+      std::move(long_polling_request),
       [this, publisher_address](const Status &status,
                                 rpc::PubsubLongPollingReply &&reply) {
         absl::MutexLock lock(&mutex_);
@@ -337,16 +339,15 @@ void Subscriber::HandleLongPollingResponse(const rpc::Address &publisher_address
   } else {
     RAY_CHECK(!reply.publisher_id().empty()) << "publisher_id is empty.";
     auto reply_publisher_id = UniqueID::FromBinary(reply.publisher_id());
-    if (reply_publisher_id != processed_sequences_[publisher_id].first) {
-      if (processed_sequences_[publisher_id].first != kDefaultUniqueID) {
+    const auto &last_publisher_id = processed_sequences_[publisher_id].first;
+    if (reply_publisher_id != last_publisher_id) {
+      if (last_publisher_id != kDefaultUniqueID) {
         RAY_LOG(INFO) << "Received publisher_id " << reply_publisher_id.Hex()
-                      << " is different from last seen publisher_id "
-                      << processed_sequences_[publisher_id].first
+                      << " is different from last seen publisher_id " << last_publisher_id
                       << ", this can only happen when gcs failsover.";
       }
       // reset publisher_id and processed_sequence if the publisher_id changes.
-      processed_sequences_[publisher_id].first = reply_publisher_id;
-      processed_sequences_[publisher_id].second = 0;
+      processed_sequences_[publisher_id] = {reply_publisher_id, 0};
     }
 
     for (int i = 0; i < reply.pub_messages_size(); i++) {
@@ -428,7 +429,7 @@ void Subscriber::SendCommandBatchIfPossible(const rpc::Address &publisher_addres
     command_batch_sent_.emplace(publisher_id);
     auto subscriber_client = get_client_(publisher_address);
     subscriber_client->PubsubCommandBatch(
-        command_batch_request,
+        std::move(command_batch_request),
         [this, publisher_address, publisher_id, done_cb = std::move(done_cb)](
             Status status, const rpc::PubsubCommandBatchReply &reply) {
           {

--- a/src/ray/pubsub/subscriber_interface.h
+++ b/src/ray/pubsub/subscriber_interface.h
@@ -97,12 +97,12 @@ class SubscriberClientInterface {
  public:
   /// Send a long polling request to a publisher.
   virtual void PubsubLongPolling(
-      const rpc::PubsubLongPollingRequest &request,
+      rpc::PubsubLongPollingRequest &&request,
       const rpc::ClientCallback<rpc::PubsubLongPollingReply> &callback) = 0;
 
   /// Send a pubsub command batch to a publisher.
   virtual void PubsubCommandBatch(
-      const rpc::PubsubCommandBatchRequest &request,
+      rpc::PubsubCommandBatchRequest &&request,
       const rpc::ClientCallback<rpc::PubsubCommandBatchReply> &callback) = 0;
 
   virtual ~SubscriberClientInterface() = default;

--- a/src/ray/pubsub/tests/pubsub_integration_test.cc
+++ b/src/ray/pubsub/tests/pubsub_integration_test.cc
@@ -107,7 +107,7 @@ class CallbackSubscriberClient final : public pubsub::SubscriberClientInterface 
   ~CallbackSubscriberClient() final = default;
 
   void PubsubLongPolling(
-      const rpc::PubsubLongPollingRequest &request,
+      rpc::PubsubLongPollingRequest &&request,
       const rpc::ClientCallback<rpc::PubsubLongPollingReply> &callback) final {
     auto *context = new grpc::ClientContext;
     auto *reply = new rpc::PubsubLongPollingReply;
@@ -120,7 +120,7 @@ class CallbackSubscriberClient final : public pubsub::SubscriberClientInterface 
   }
 
   void PubsubCommandBatch(
-      const rpc::PubsubCommandBatchRequest &request,
+      rpc::PubsubCommandBatchRequest &&request,
       const rpc::ClientCallback<rpc::PubsubCommandBatchReply> &callback) final {
     auto *context = new grpc::ClientContext;
     auto *reply = new rpc::PubsubCommandBatchReply;

--- a/src/ray/pubsub/tests/subscriber_test.cc
+++ b/src/ray/pubsub/tests/subscriber_test.cc
@@ -34,7 +34,7 @@ namespace ray {
 class MockWorkerClient : public pubsub::SubscriberClientInterface {
  public:
   void PubsubLongPolling(
-      const rpc::PubsubLongPollingRequest &request,
+      rpc::PubsubLongPollingRequest &&request,
       const rpc::ClientCallback<rpc::PubsubLongPollingReply> &callback) override {
     max_processed_sequence_id_ = request.max_processed_sequence_id();
     publisher_id_ = request.publisher_id();
@@ -42,7 +42,7 @@ class MockWorkerClient : public pubsub::SubscriberClientInterface {
   }
 
   void PubsubCommandBatch(
-      const rpc::PubsubCommandBatchRequest &request,
+      rpc::PubsubCommandBatchRequest &&request,
       const rpc::ClientCallback<rpc::PubsubCommandBatchReply> &callback) override {
     requests_.push(request);
     command_batch_callbacks.push_back(callback);

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -64,17 +64,17 @@ void LocalObjectManager::PinObjectsAndWaitForFree(
     }
 
     // Create a object eviction subscription message.
-    auto wait_request = std::make_unique<rpc::WorkerObjectEvictionSubMessage>();
-    wait_request->set_object_id(object_id.Binary());
-    wait_request->set_intended_worker_id(owner_address.worker_id());
+    rpc::WorkerObjectEvictionSubMessage wait_request;
+    wait_request.set_object_id(object_id.Binary());
+    wait_request.set_intended_worker_id(owner_address.worker_id());
     if (!generator_id.IsNil()) {
-      wait_request->set_generator_id(generator_id.Binary());
+      wait_request.set_generator_id(generator_id.Binary());
     }
     rpc::Address subscriber_address;
     subscriber_address.set_node_id(self_node_id_.Binary());
     subscriber_address.set_ip_address(self_node_address_);
     subscriber_address.set_port(self_node_port_);
-    wait_request->mutable_subscriber_address()->CopyFrom(subscriber_address);
+    *wait_request.mutable_subscriber_address() = std::move(subscriber_address);
 
     // If the subscription succeeds, register the subscription callback.
     // Callback is invoked when the owner publishes the object to evict.
@@ -95,7 +95,7 @@ void LocalObjectManager::PinObjectsAndWaitForFree(
     };
 
     auto sub_message = std::make_unique<rpc::SubMessage>();
-    sub_message->mutable_worker_object_eviction_message()->Swap(wait_request.get());
+    *sub_message->mutable_worker_object_eviction_message() = std::move(wait_request);
 
     core_worker_subscriber_->Subscribe(std::move(sub_message),
                                        rpc::ChannelType::WORKER_OBJECT_EVICTION,

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -118,14 +118,14 @@ class CoreWorkerClientInterface : public pubsub::SubscriberClientInterface {
       const ClientCallback<WaitForActorRefDeletedReply> &callback) {}
 
   /// Send a long polling request to a core worker for pubsub operations.
-  virtual void PubsubLongPolling(const PubsubLongPollingRequest &request,
-                                 const ClientCallback<PubsubLongPollingReply> &callback) {
-  }
+  void PubsubLongPolling(
+      PubsubLongPollingRequest &&request,
+      const ClientCallback<PubsubLongPollingReply> &callback) override {}
 
   /// Send a pubsub command batch request to a core worker for pubsub operations.
-  virtual void PubsubCommandBatch(
-      const PubsubCommandBatchRequest &request,
-      const ClientCallback<PubsubCommandBatchReply> &callback) {}
+  void PubsubCommandBatch(
+      PubsubCommandBatchRequest &&request,
+      const ClientCallback<PubsubCommandBatchReply> &callback) override {}
 
   virtual void UpdateObjectLocationBatch(
       UpdateObjectLocationBatchRequest &&request,
@@ -256,17 +256,19 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
                          /*method_timeout_ms*/ -1,
                          override)
 
-  VOID_RPC_CLIENT_METHOD(CoreWorkerService,
-                         PubsubLongPolling,
-                         grpc_client_,
-                         /*method_timeout_ms*/ -1,
-                         override)
+  VOID_RETRYABLE_RPC_CLIENT_METHOD(retryable_grpc_client_,
+                                   CoreWorkerService,
+                                   PubsubLongPolling,
+                                   grpc_client_,
+                                   /*method_timeout_ms*/ -1,
+                                   override)
 
-  VOID_RPC_CLIENT_METHOD(CoreWorkerService,
-                         PubsubCommandBatch,
-                         grpc_client_,
-                         /*method_timeout_ms*/ -1,
-                         override)
+  VOID_RETRYABLE_RPC_CLIENT_METHOD(retryable_grpc_client_,
+                                   CoreWorkerService,
+                                   PubsubCommandBatch,
+                                   grpc_client_,
+                                   /*method_timeout_ms*/ -1,
+                                   override)
 
   VOID_RETRYABLE_RPC_CLIENT_METHOD(retryable_grpc_client_,
                                    CoreWorkerService,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
