### PR TITLE
[core] Task state to differentiate between running and pinning args

### DIFF
--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -909,18 +909,20 @@ enum TaskStatus {
   PENDING_ACTOR_TASK_ARGS_FETCH = 6;
   // The actor task is waiting due to ordering or concurrency constraints.
   PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY = 7;
+  // The task is in GetAndPinArgsForExecutor and trying to pin or re-retrieve arguments.
+  GETTING_AND_PINNING_ARGS = 8;
   // The task is running on a worker.
-  RUNNING = 8;
+  RUNNING = 9;
   // The task is running on a worker, but is blocked in a ray.get() call.
   // This state is a sub-state of RUNNING and used for metrics only.
-  RUNNING_IN_RAY_GET = 9;
+  RUNNING_IN_RAY_GET = 10;
   // The task is running on a worker, but is blocked in a ray.wait() call.
   // This state is a sub-state of RUNNING and used for metrics only.
-  RUNNING_IN_RAY_WAIT = 10;
+  RUNNING_IN_RAY_WAIT = 11;
   // The task has finished.
-  FINISHED = 11;
+  FINISHED = 13;
   // The task has finished but failed with an Exception or system error.
-  FAILED = 12;
+  FAILED = 14;
 }
 
 // Debug info for a referenced object.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
