### PR TITLE
[Data] Fix resource reservation by excluding completed operators' usages

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -508,6 +508,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         """
         last_completed_ops = []
         ops_to_exclude_from_reservation = []
+        # Traverse operator tree collecting all operators that have already finished
         for op in self._resource_manager._topology:
             if not op.execution_finished():
                 for dep in op.input_dependencies:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -519,6 +519,9 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         if len(eligible_ops) == 0:
             return
 
+        # Ineligible operators might still consume resources, we need to subtract their usage from the remaining resources.
+        # We only consider operators that have no eligible upstream operators, because ineligible operators that have eligible upstream operators
+        # will be excluded in https://github.com/ray-project/ray/blob/6b703a8a4d5b761365e05f75a1de61625cab248b/python/ray/data/_internal/execution/resource_manager.py#L667
         for op in self.get_ineligible_ops_without_eligible_upstream():
             remaining = remaining.subtract(self._resource_manager.get_op_usage(op))
 

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -508,7 +508,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         return all_ops - visited
 
     def _update_reservation(self):
-        global_limits = self._resource_manager.get_global_limits()
+        global_limits = self._resource_manager.get_global_limits().copy()
         eligible_ops = self._get_eligible_ops()
 
         self._op_reserved.clear()

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -496,7 +496,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
     def find_the_ops_to_exclude_from_reservation(self) -> List[PhysicalOperator]:
         """
         Resource reservation is based on the number of eligible operators.
-        However, there might be completed operators that still have blocks in their output queue, we should exclude them from the reservation.
+        However, there might be completed operators that still have blocks in their output queue, which we need to exclude them from the reservation.
         And we also need to exclude the downstream ineligible operators.
 
         E.g., for the following pipeline:

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -781,7 +781,7 @@ class TestReservationOpResourceAllocator:
 
         assert allocator._op_budgets[o2].gpu == 0
 
-    def test_find_the_ops_to_exclude_from_reservation(self, restore_data_context):
+    def test_get_ineligible_ops_with_usage(self, restore_data_context):
         DataContext.get_current().op_resource_reservation_enabled = True
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -806,13 +806,11 @@ class TestReservationOpResourceAllocator:
 
         allocator = resource_manager._op_resource_allocator
 
-        ops_to_exclude = allocator.find_the_ops_to_exclude_from_reservation()
+        ops_to_exclude = allocator._get_ineligible_ops_with_usage()
         assert len(ops_to_exclude) == 2
         assert set(ops_to_exclude) == {o2, o3}
 
-    def test_find_the_ops_to_exclude_from_reservation_complex_graph(
-        self, restore_data_context
-    ):
+    def test_get_ineligible_ops_with_usage_complex_graph(self, restore_data_context):
         """
         o1 (InputDataBuffer)
                 |
@@ -862,7 +860,7 @@ class TestReservationOpResourceAllocator:
 
         allocator = resource_manager._op_resource_allocator
 
-        ops_to_exclude = allocator.find_the_ops_to_exclude_from_reservation()
+        ops_to_exclude = allocator._get_ineligible_ops_with_usage()
         assert len(ops_to_exclude) == 4
         assert set(ops_to_exclude) == {o2, o3, o5, o7}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Problem
The `ReservationOpResourceAllocator` was incorrectly accounting for resource usage when calculating available resources for reservation. Specifically, it wasn't properly handling completed operators who have blocks in the output queue.

The `ReadFiles` operator below consumes 50 GB of object store memory and should be excluded from reservation, but it is currently not.

<img width="1628" height="281" alt="image" src="https://github.com/user-attachments/assets/8a80902d-7f88-4263-bc97-a3dee519b401" />

## Solution
Added logic to identify and subtract resource usage specifically from completed physical operators:

## Testing results

Before the fix

<img width="958" height="653" alt="image" src="https://github.com/user-attachments/assets/432dc94e-bbe1-4ecb-b1c3-a6e201da724a" />

After the fix

<img width="1567" height="700" alt="image" src="https://github.com/user-attachments/assets/2b780d68-a208-4c6b-a250-dee0823e9083" />


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
