### PR TITLE
[core][rdt] Wait on nccl id with event

### DIFF
--- a/python/ray/util/collective/collective_group/nccl_collective_group.py
+++ b/python/ray/util/collective/collective_group/nccl_collective_group.py
@@ -114,7 +114,7 @@ class Rendezvous:
         except ray.exceptions.GetTimeoutError:
             raise RuntimeError(
                 f"Unable to get the NCCLUniqueID from the store within {timeout_s} seconds."
-            )
+            ) from None
         return uid
 
 

--- a/python/ray/util/collective/collective_group/nccl_collective_group.py
+++ b/python/ray/util/collective/collective_group/nccl_collective_group.py
@@ -109,19 +109,12 @@ class Rendezvous:
         """
         if not self._store:
             raise ValueError("Rendezvous store is not setup.")
-        uid = None
-        timeout_delta = datetime.timedelta(seconds=timeout_s)
-        elapsed = datetime.timedelta(seconds=0)
-        start_time = datetime.datetime.now()
-        while elapsed < timeout_delta:
-            uid = ray.get(self._store.get_id.remote())
-            if not uid:
-                time.sleep(1)
-                elapsed = datetime.datetime.now() - start_time
-                continue
-            break
-        if not uid:
-            raise RuntimeError("Unable to get the NCCLUniqueID from the store.")
+        try:
+            uid = ray.get(self._store.wait_and_get_id.remote(), timeout=timeout_s)
+        except ray.exceptions.GetTimeoutError:
+            raise RuntimeError(
+                f"Unable to get the NCCLUniqueID from the store within {timeout_s} seconds."
+            )
         return uid
 
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -293,8 +293,8 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
                 [object_id, actor_id](Status status,
                                       const rpc::FreeActorObjectReply &reply) {
                   if (!status.ok()) {
-                    RAY_LOG(ERROR).WithField(object_id).WithField(actor_id)
-                        << "Failed to free actor object: " << status;
+                    RAY_LOG(INFO).WithField(object_id).WithField(actor_id)
+                        << "Failed to free actor object, the actor may already be dead, status: " << status;
                   }
                 });
           });

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -293,10 +293,8 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
                 [object_id, actor_id](Status status,
                                       const rpc::FreeActorObjectReply &reply) {
                   if (!status.ok()) {
-                    RAY_LOG(INFO).WithField(object_id).WithField(actor_id)
-                        << "Failed to free actor object, the actor may already be dead, "
-                           "status: "
-                        << status;
+                    RAY_LOG(ERROR).WithField(object_id).WithField(actor_id)
+                        << "Failed to free actor object: " << status;
                   }
                 });
           });

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -294,7 +294,9 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
                                       const rpc::FreeActorObjectReply &reply) {
                   if (!status.ok()) {
                     RAY_LOG(INFO).WithField(object_id).WithField(actor_id)
-                        << "Failed to free actor object, the actor may already be dead, status: " << status;
+                        << "Failed to free actor object, the actor may already be dead, "
+                           "status: "
+                        << status;
                   }
                 });
           });


### PR DESCRIPTION
## Why are these changes needed?
I'd see concerning logs saying `The NCCL ID has not been set yet` when running gpu objects code with nccl. Looks like we have a loop with a 1 second sleep to try to get the nccl id. Creating a new `wait_and_get_id` with an asyncio condition so we don't have to have that sleep loop with the scary log.

I'd also see logs that say `Failed to free actor object` but it's always because the actor's often dead by the time the driver tries to free at the end. We're not handling rpc failures right now for gpu objects, so just turning it down to an info log so it doesn't look as scary to a user.