### PR TITLE
increase timeout for failed task test

### DIFF
--- a/python/ray/serve/tests/test_task_processor.py
+++ b/python/ray/serve/tests/test_task_processor.py
@@ -233,7 +233,7 @@ class TestTaskConsumerWithRayServe:
             else:
                 return False
 
-        wait_for_condition(assert_result, timeout=10)
+        wait_for_condition(assert_result, timeout=20)
 
     def test_task_consumer_persistence_across_restarts(
         self, temp_queue_directory, serve_instance, create_processor_config


### PR DESCRIPTION
we have set the retry backoff as true, and max retries as 3 for this test.
so, actually the task gets consumed 4 times, and the difference between the task consumption time is 1 sec, 2 sec and 4 sec, which makes the total time to complete the test close of 10 seconds, hence the test was flaky

increasing the timeout to 20 seconds