### PR TITLE
[Data] Refactor `from_torch` unit tests

### DIFF
--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-import torchvision
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileSystem
 
@@ -247,79 +246,6 @@ def test_from_tf(ray_start_regular_shared):
     ):
         tf.debugging.assert_equal(expected_features, actual_features)
         tf.debugging.assert_equal(expected_label, actual_label)
-
-
-@pytest.mark.parametrize("local_read", [True, False])
-def test_from_torch(shutdown_only, local_read, tmp_path):
-    torch_dataset = torchvision.datasets.FashionMNIST(tmp_path, download=True)
-    expected_data = list(torch_dataset)
-
-    ray_dataset = ray.data.from_torch(torch_dataset, local_read=local_read)
-
-    actual_data = extract_values("item", list(ray_dataset.take_all()))
-    assert actual_data == expected_data
-
-    import torch
-
-    class IterFashionMNIST(torch.utils.data.IterableDataset):
-        def __len__(self):
-            return len(torch_dataset)
-
-        def __iter__(self):
-            return iter(torch_dataset)
-
-    iter_torch_dataset = IterFashionMNIST()
-    ray_dataset = ray.data.from_torch(iter_torch_dataset)
-
-    actual_data = extract_values("item", list(ray_dataset.take_all()))
-    assert actual_data == expected_data
-
-
-@pytest.mark.parametrize("local_read", [True, False])
-def test_from_torch_boundary_conditions(shutdown_only, local_read):
-    """
-    Tests that from_torch respects __len__ for map-style datasets
-    """
-    from torch.utils.data import Dataset
-
-    class BoundaryTestMapDataset(Dataset):
-        """A map-style dataset where __len__ is less than the underlying data size."""
-
-        def __init__(self, data, length):
-            super().__init__()
-            self._data = data
-            self._length = length
-            assert self._length <= len(
-                self._data
-            ), "Length must be <= data size to properly test boundary conditions"
-
-        def __len__(self):
-            return self._length
-
-        def __getitem__(self, index):
-            if not (0 <= index < self._length):
-                # Note: don't use IndexError because we want to fail clearly if
-                # Ray Data tries to access beyond __len__ - 1
-                raise RuntimeError(
-                    f"Index {index} out of bounds for dataset with length {self._length}"
-                )
-            return self._data[index]
-
-    source_data = list(range(10))
-    dataset_len = 8  # Intentionally less than len(source_data)
-
-    # --- Test MapDataset ---
-    map_ds = BoundaryTestMapDataset(source_data, dataset_len)
-    # Expected data only includes elements up to dataset_len - 1
-    expected_items = source_data[:dataset_len]
-
-    ray_ds_map = ray.data.from_torch(map_ds, local_read=local_read)
-    actual_items_map = extract_values("item", list(ray_ds_map.take_all()))
-
-    # This assertion verifies that ray_ds_map didn't try to access index 8 or 9,
-    # which would have raised an IndexError in BoundaryTestMapDataset.__getitem__
-    assert actual_items_map == expected_items
-    assert len(actual_items_map) == dataset_len
 
 
 def test_read_s3_file_error(shutdown_only, s3_path):

--- a/python/ray/data/tests/test_torch.py
+++ b/python/ray/data/tests/test_torch.py
@@ -1,10 +1,12 @@
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 
 import ray
 from ray.data.extensions.tensor_extension import TensorArray
 from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.util import extract_values
 from ray.tests.conftest import *  # noqa
 
 
@@ -334,6 +336,86 @@ def test_torch_trainer_crash(ray_start_10_cpus_shared):
         datasets={"train": train_ds},
     )
     my_trainer.fit()
+
+
+@pytest.mark.parametrize("local_read", [True, False])
+def test_from_torch_map_style_dataset(ray_start_10_cpus_shared, local_read):
+    class StubDataset(torch.utils.data.Dataset):
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, index):
+            return index
+
+    torch_dataset = StubDataset()
+
+    ray_dataset = ray.data.from_torch(torch_dataset, local_read=local_read)
+
+    actual_data = ray_dataset.take_all()
+    assert actual_data == [{"item": 0}]
+
+
+def test_from_torch_iterable_style_dataset(ray_start_10_cpus_shared):
+    class StubIterableDataset(torch.utils.data.IterableDataset):
+        def __len__(self):
+            return 1
+
+        def __iter__(self):
+            return iter([0])
+
+    iter_torch_dataset = StubIterableDataset()
+
+    ray_dataset = ray.data.from_torch(iter_torch_dataset)
+
+    actual_data = ray_dataset.take_all()
+    assert actual_data == [{"item": 0}]
+
+
+@pytest.mark.parametrize("local_read", [True, False])
+def test_from_torch_boundary_conditions(ray_start_10_cpus_shared, local_read):
+    """
+    Tests that from_torch respects __len__ for map-style datasets
+    """
+    from torch.utils.data import Dataset
+
+    class BoundaryTestMapDataset(Dataset):
+        """A map-style dataset where __len__ is less than the underlying data size."""
+
+        def __init__(self, data, length):
+            super().__init__()
+            self._data = data
+            self._length = length
+            assert self._length <= len(
+                self._data
+            ), "Length must be <= data size to properly test boundary conditions"
+
+        def __len__(self):
+            return self._length
+
+        def __getitem__(self, index):
+            if not (0 <= index < self._length):
+                # Note: don't use IndexError because we want to fail clearly if
+                # Ray Data tries to access beyond __len__ - 1
+                raise RuntimeError(
+                    f"Index {index} out of bounds for dataset with length {self._length}"
+                )
+            return self._data[index]
+
+    source_data = list(range(10))
+    dataset_len = 8  # Intentionally less than len(source_data)
+
+    # --- Test MapDataset ---
+    map_ds = BoundaryTestMapDataset(source_data, dataset_len)
+    # Expected data only includes elements up to dataset_len - 1
+    expected_items = source_data[:dataset_len]
+
+    ray_ds_map = ray.data.from_torch(map_ds, local_read=local_read)
+    actual_items_map = extract_values("item", list(ray_ds_map.take_all()))
+
+    # This assertion verifies that ray_ds_map didn't try to access index 8 or 9,
+    # which would have raised an IndexError in BoundaryTestMapDataset.__getitem__
+    assert actual_items_map == expected_items
+    assert len(actual_items_map) == dataset_len
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR improves `ray.data.from_torch` tests by:
* Moving them from test_formats.py to test_torch.py for clearer organization
* Using a shared Ray cluster instead of shutdown_only to reduce overhead
* Replacing FashionMNIST with a stub dataset to remove the external dependency
* Splitting test_from_torch into separate map-style and iterable-style tests so each case is isolated

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
