### PR TITLE
[Core] Add S3 public bucket fallback to handle NoCredentialsError

### DIFF
--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -58,21 +58,20 @@ class ProtocolsProvider:
                 "to fetch URIs in s3 bucket. " + cls._MISSING_DEPENDENCIES_WARNING
             )
 
-        def create_s3_client_with_fallback():
-            """Create S3 client, falling back to unsigned for public buckets."""
-            session = boto3.Session()
-            # session.get_credentials() will return None if no credentials can be found.
-            if session.get_credentials():
-                # If credentials are found, use a standard signed client.
-                return session.client("s3")
-            else:
-                # No credentials found, fall back to an unsigned client for public buckets.
-                from botocore import UNSIGNED
-                from botocore.config import Config
+        # Create S3 client, falling back to unsigned for public buckets
+        session = boto3.Session()
+        # session.get_credentials() will return None if no credentials can be found.
+        if session.get_credentials():
+            # If credentials are found, use a standard signed client.
+            s3_client = session.client("s3")
+        else:
+            # No credentials found, fall back to an unsigned client for public buckets.
+            from botocore import UNSIGNED
+            from botocore.config import Config
 
-                return boto3.client("s3", config=Config(signature_version=UNSIGNED))
+            s3_client = boto3.client("s3", config=Config(signature_version=UNSIGNED))
 
-        transport_params = {"client": create_s3_client_with_fallback()}
+        transport_params = {"client": s3_client}
         return open_file, transport_params
 
     @classmethod

--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -69,6 +69,7 @@ class ProtocolsProvider:
                 # No credentials found, fall back to an unsigned client for public buckets.
                 from botocore import UNSIGNED
                 from botocore.config import Config
+
                 return boto3.client("s3", config=Config(signature_version=UNSIGNED))
 
         transport_params = {"client": create_s3_client_with_fallback()}

--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -51,6 +51,7 @@ class ProtocolsProvider:
         """
         try:
             import boto3
+            from botocore.exceptions import NoCredentialsError
             from smart_open import open as open_file
         except ImportError:
             raise ImportError(
@@ -58,7 +59,27 @@ class ProtocolsProvider:
                 "to fetch URIs in s3 bucket. " + cls._MISSING_DEPENDENCIES_WARNING
             )
 
-        transport_params = {"client": boto3.client("s3")}
+        def create_s3_client_with_fallback():
+            """Create S3 client, falling back to unsigned for public buckets."""
+            # First try with default credentials
+            signed_client = boto3.client("s3")
+
+            # Check if we can use credentials by testing a simple operation
+            try:
+                # This will fail with NoCredentialsError if no credentials are available
+                signed_client._make_api_call("ListBuckets", {})
+                return signed_client
+            except NoCredentialsError:
+                # Fall back to unsigned client for public buckets
+                from botocore import UNSIGNED
+                from botocore.config import Config
+                return boto3.client("s3", config=Config(signature_version=UNSIGNED))
+            except Exception:
+                # For any other error (permissions, network, etc.), still use signed client
+                # The actual error will surface when trying to access the specific bucket
+                return signed_client
+
+        transport_params = {"client": create_s3_client_with_fallback()}
         return open_file, transport_params
 
     @classmethod

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -681,8 +681,8 @@ class TestS3Protocol:
 
     def test_s3_client_creation_with_credentials(self):
         """Test S3 client creation when credentials are available."""
-        import unittest.mock as mock
         import sys
+        import unittest.mock as mock
 
         # Mock boto3 and smart_open modules
         mock_boto3 = mock.MagicMock()
@@ -720,8 +720,8 @@ class TestS3Protocol:
 
     def test_s3_client_creation_without_credentials(self):
         """Test S3 client creation falls back to unsigned when no credentials."""
-        import unittest.mock as mock
         import sys
+        import unittest.mock as mock
 
         # Mock boto3 and botocore modules
         mock_boto3 = mock.MagicMock()


### PR DESCRIPTION
When S3 credentials are not available, automatically fall back to using unsigned requests (UNSIGNED signature) to access public S3 buckets.

This fixes the issue where Ray runtime environments fail to download packages from public S3 buckets when AWS credentials are not configured.

The implementation:
- First attempts to create a standard S3 client with credentials
- Tests credential availability with a ListBuckets API call
- Falls back to unsigned client if NoCredentialsError is raised
- Preserves other errors for proper error handling

Fixes: botocore.exceptions.NoCredentialsError when accessing public buckets

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
