### PR TITLE
[serve] deflake test pow 2 router

### DIFF
--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -1918,7 +1918,7 @@ async def test_locality_aware_backoff_skips_sleeps(pow_2_router):
         assert done.pop().result() == r3
 
     # assert that we tried local node, followed by local AZ, followed by all replicas
-    assert len(chosen_replicas) == 3
+    assert len(chosen_replicas) >= 3
     assert set(chosen_replicas[0]) == {r1.replica_id}
     assert set(chosen_replicas[1]) == {r1.replica_id, r2.replica_id}
     # assert intersection of chosen_replicas[2] and {r1.replica_id, r2.replica_id, r3.replica_id} is not empty

--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -1918,7 +1918,7 @@ async def test_locality_aware_backoff_skips_sleeps(pow_2_router):
         assert done.pop().result() == r3
 
     # assert that we tried local node, followed by local AZ, followed by all replicas
-    assert len(chosen_replicas) >= 3
+    assert len(chosen_replicas) in (3, 4)
     assert set(chosen_replicas[0]) == {r1.replica_id}
     assert set(chosen_replicas[1]) == {r1.replica_id, r2.replica_id}
     # assert intersection of chosen_replicas[2] and {r1.replica_id, r2.replica_id, r3.replica_id} is not empty


### PR DESCRIPTION
We only back off after the first "all replica set" has been tried once, aka only after the first retry of the "all replicas set". So the order goes like:
1. replicas on same node
2. replicas in same AZ
3. all replicas -- no backoff after
4. all replicas (first retry) -- backoff after

So r3 could get selected on (3), or (4), or neither (3) or (4) (for this last case we'd run into the 10s timeout which the test swallows bc it's expected to sometimes happen). These 3 cases give that we could have gone through either 3 or 4 sets of chosen replicas.

https://github.com/ray-project/ray/issues/55617