### PR TITLE
[release-test][data][train] Preload a subset of modules for torch dataloader forkserver multiprocessing

### DIFF
--- a/release/train_tests/benchmark/torch_dataloader_factory.py
+++ b/release/train_tests/benchmark/torch_dataloader_factory.py
@@ -201,17 +201,22 @@ class TorchDataLoaderFactory(BaseDataLoaderFactory, ABC):
             f"timeout={timeout}, batch_size={batch_size}"
         )
 
+        multiprocessing_args = {}
+        if num_workers > 0:
+            multiprocessing_args = dict(
+                multiprocessing_context=self._create_multiprocessing_context(),
+                worker_init_fn=self.worker_init_fn,
+                persistent_workers=persistent_workers,
+            )
         dataloader = torch.utils.data.DataLoader(
             dataset=val_ds,
             batch_size=batch_size,
             num_workers=num_workers,
             pin_memory=pin_memory,
-            persistent_workers=persistent_workers,
             prefetch_factor=prefetch_factor,
             timeout=timeout,
             drop_last=False,
-            worker_init_fn=self.worker_init_fn if num_workers > 0 else None,
-            multiprocessing_context=self._create_multiprocessing_context(),
+            **multiprocessing_args,
         )
         dataloader = ray.train.torch.prepare_data_loader(
             dataloader, move_to_device=False

--- a/release/train_tests/benchmark/torch_dataloader_factory.py
+++ b/release/train_tests/benchmark/torch_dataloader_factory.py
@@ -1,7 +1,6 @@
 from typing import Dict, Iterator, Tuple
 import logging
 from abc import ABC, abstractmethod
-import sys
 import multiprocessing
 
 import torch
@@ -100,10 +99,10 @@ class TorchDataLoaderFactory(BaseDataLoaderFactory, ABC):
 
     def _create_multiprocessing_context(self):
         # Importing libs in torch dataloader worker subprocesses is very slow.
-        # Preload all imported modules to speed up subprocess forking.
-        imported_modules = list(sys.modules.keys())
+        # Preload some modules to speed up subprocess forking.
         ctx = multiprocessing.get_context("forkserver")
-        ctx.set_forkserver_preload(imported_modules)
+        modules = ["torch", "torchvision", "pandas", "numpy", "boto3", "fsspec"]
+        ctx.set_forkserver_preload(modules)
         return ctx
 
     def get_train_dataloader(self) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:

--- a/release/train_tests/benchmark/torch_dataloader_factory.py
+++ b/release/train_tests/benchmark/torch_dataloader_factory.py
@@ -105,20 +105,14 @@ class TorchDataLoaderFactory(BaseDataLoaderFactory, ABC):
         ctx.set_forkserver_preload(modules)
         return ctx
 
-    def get_train_dataloader(self) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
-        """Create a DataLoader for training data.
-
-        Returns:
-            An iterator that yields (image, label) tensors for training
-        """
+    def _create_dataloader(self, dataset_key: DatasetKey, batch_size: int):
         worker_rank = ray.train.get_context().get_world_rank()
-        logger.info(f"Worker {worker_rank}: Creating train dataloader")
-
         dataloader_config = self.get_dataloader_config()
-        device = self._get_device()
 
         # Create dataset and dataloader
-        train_ds = self.get_iterable_datasets()[DatasetKey.TRAIN]
+        ds = self.get_iterable_datasets()[dataset_key]
+
+        device = self._get_device()
 
         # Adjust worker settings for 0 workers case
         num_workers = max(0, self.num_torch_workers)
@@ -133,68 +127,9 @@ class TorchDataLoaderFactory(BaseDataLoaderFactory, ABC):
         timeout = (
             dataloader_config.torch_dataloader_timeout_seconds if num_workers > 0 else 0
         )
-        batch_size = dataloader_config.train_batch_size
 
         logger.info(
             f"Worker {worker_rank}: Creating train DataLoader with "
-            f"num_workers={num_workers}, pin_memory={pin_memory}, "
-            f"persistent_workers={persistent_workers}, prefetch_factor={prefetch_factor}, "
-            f"timeout={timeout}, batch_size={batch_size}"
-        )
-
-        dataloader = torch.utils.data.DataLoader(
-            dataset=train_ds,
-            batch_size=batch_size,
-            num_workers=num_workers,
-            pin_memory=pin_memory,
-            persistent_workers=persistent_workers,
-            prefetch_factor=prefetch_factor,
-            timeout=timeout,
-            drop_last=True,
-            worker_init_fn=self.worker_init_fn if num_workers > 0 else None,
-            multiprocessing_context=self._create_multiprocessing_context(),
-        )
-        # Add a DistributedSampler to the dataloader if possible (map-style datasets)
-        dataloader = ray.train.torch.prepare_data_loader(
-            dataloader, move_to_device=False
-        )
-
-        return self.create_batch_iterator(dataloader, device)
-
-    def get_val_dataloader(self) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
-        """Create a DataLoader for validation data.
-
-        Returns:
-            An iterator that yields (image, label) tensors for validation
-        """
-        worker_rank = ray.train.get_context().get_world_rank()
-        logger.info(f"Worker {worker_rank}: Creating validation dataloader")
-
-        dataloader_config = self.get_dataloader_config()
-        device = self._get_device()
-
-        # Create dataset and dataloader with row limits
-        val_ds = self.get_iterable_datasets()[DatasetKey.VALID]
-
-        # Adjust worker settings for 0 workers case
-        num_workers = max(0, self.num_torch_workers)
-        persistent_workers = num_workers > 0
-        pin_memory = (
-            dataloader_config.torch_pin_memory and torch.cuda.is_available()
-        )  # Use config setting
-
-        if dataloader_config.torch_prefetch_factor >= 0:
-            prefetch_factor = dataloader_config.torch_prefetch_factor
-        else:
-            prefetch_factor = None
-
-        timeout = (
-            dataloader_config.torch_dataloader_timeout_seconds if num_workers > 0 else 0
-        )
-        batch_size = dataloader_config.validation_batch_size
-
-        logger.info(
-            f"Worker {worker_rank}: Creating validation DataLoader with "
             f"num_workers={num_workers}, pin_memory={pin_memory}, "
             f"persistent_workers={persistent_workers}, prefetch_factor={prefetch_factor}, "
             f"timeout={timeout}, batch_size={batch_size}"
@@ -208,16 +143,44 @@ class TorchDataLoaderFactory(BaseDataLoaderFactory, ABC):
                 persistent_workers=persistent_workers,
             )
         dataloader = torch.utils.data.DataLoader(
-            dataset=val_ds,
+            dataset=ds,
             batch_size=batch_size,
             num_workers=num_workers,
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
             timeout=timeout,
-            drop_last=False,
+            drop_last=True,
             **multiprocessing_args,
         )
+        # Add a DistributedSampler to the dataloader if possible (map-style datasets)
         dataloader = ray.train.torch.prepare_data_loader(
             dataloader, move_to_device=False
         )
+
         return self.create_batch_iterator(dataloader, device)
+
+    def get_train_dataloader(self) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
+        """Create a DataLoader for training data.
+
+        Returns:
+            An iterator that yields (image, label) tensors for training
+        """
+        worker_rank = ray.train.get_context().get_world_rank()
+        logger.info(f"Worker {worker_rank}: Creating train dataloader")
+
+        return self._create_dataloader(
+            DatasetKey.TRAIN, self.get_dataloader_config().train_batch_size
+        )
+
+    def get_val_dataloader(self) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
+        """Create a DataLoader for validation data.
+
+        Returns:
+            An iterator that yields (image, label) tensors for validation
+        """
+        worker_rank = ray.train.get_context().get_world_rank()
+        logger.info(f"Worker {worker_rank}: Creating validation dataloader")
+
+        return self._create_dataloader(
+            DatasetKey.VALID, self.get_dataloader_config().validation_batch_size
+        )


### PR DESCRIPTION
## Summary

For the training ingest release test baseline using torch dataloader multiprocessing, we preload all imported modules and submodules. This can be brittle and run into issues if any of the imported modules cannot be forked safely. For example, see the following release test error:

```python
Traceback (most recent call last):
File "/tmp/ray/session_2025-09-04_05-22-53_048164_2379/runtime_resources/working_dir_files/s3_runtime-release-test-artifacts_working_dirs_training_ingest_benchmark-task=image_classification_full_training_parquet_torch_dataloader_doiardvjgz__anyscale_pkg_339c386192dfee395b1179753d3efecc/train_benchmark.py", line 35, in train_fn_per_worker
File "/tmp/ray/session_2025-09-04_05-22-53_048164_2379/runtime_resources/working_dir_files/_ray_pkg_b43ef8c2034973b4/runner.py", line 313, in run
self._train_epoch()
File "/tmp/ray/session_2025-09-04_05-22-53_048164_2379/runtime_resources/working_dir_files/_ray_pkg_b43ef8c2034973b4/runner.py", line 154, in _train_epoch
for batch in train_dataloader:
File "/tmp/ray/session_2025-09-04_05-22-53_048164_2379/runtime_resources/working_dir_files/_ray_pkg_b43ef8c2034973b4/runner.py", line 105, in dataloader_with_timers
batch = next(dataloader_iter)
File "/tmp/ray/session_2025-09-04_05-22-53_048164_2379/runtime_resources/working_dir_files/_ray_pkg_b43ef8c2034973b4/image_classification/factory.py", line 117, in create_batch_iterator
for batch_idx, batch in enumerate(dataloader):
File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 434, in __iter__
self._iterator = self._get_iterator()
File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 387, in _get_iterator
return _MultiProcessingDataLoaderIter(self)
File "/home/ray/anaconda3/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 1040, in __init__
w.start()
File "/home/ray/anaconda3/lib/python3.9/multiprocessing/process.py", line 121, in start
self._popen = self._Popen(self)
File "/home/ray/anaconda3/lib/python3.9/multiprocessing/context.py", line 291, in _Popen
return Popen(process_obj)
File "/home/ray/anaconda3/lib/python3.9/multiprocessing/popen_forkserver.py", line 35, in __init__
super().__init__(process_obj)
File "/home/ray/anaconda3/lib/python3.9/multiprocessing/popen_fork.py", line 19, in __init__
self._launch(process_obj)
File "/home/ray/anaconda3/lib/python3.9/multiprocessing/popen_forkserver.py", line 59, in _launch
self.pid = forkserver.read_signed(self.sentinel)
File "/home/ray/anaconda3/lib/python3.9/multiprocessing/forkserver.py", line 328, in read_signed
raise EOFError('unexpected EOF')
EOFError: unexpected EOF 
```

I found that excluding all `ray` submodule imports from the preload list can fix the issue. To make this more robust, I only preload modules in an allowlist of a few heavy imports that take a long time.