### PR TITLE
[dashboard] fix grafana dashboard generation bug

### DIFF
--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -66,7 +66,10 @@ def _read_configs_for_dashboard(
         )
         or ""
     )
-    global_filters = global_filters_str.split(",")
+    if global_filters_str == "":
+        global_filters = []
+    else:
+        global_filters = global_filters_str.split(",")
 
     return uid, global_filters
 


### PR DESCRIPTION
## Why are these changes needed?

If `global_filters_str` is empty then some queries in the dashboard contain `,,` in their filters, which is invalid.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
