### PR TITLE
[core] initialize opentelemetry.metrics once

### DIFF
--- a/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
+++ b/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
@@ -23,16 +23,28 @@ class OpenTelemetryMetricRecorder:
     It uses OpenTelemetry's Prometheus exporter to export metrics.
     """
 
+    _metrics_initialized = False
+    _metrics_initialized_lock = threading.Lock()
+
     def __init__(self):
         self._lock = threading.Lock()
         self._registered_instruments = {}
         self._observations_by_name = defaultdict(dict)
         self._histogram_bucket_midpoints = defaultdict(list)
-
-        prometheus_reader = PrometheusMetricReader()
-        provider = MeterProvider(metric_readers=[prometheus_reader])
-        metrics.set_meter_provider(provider)
+        self._init_metrics()
         self.meter = metrics.get_meter(__name__)
+
+    def _init_metrics(self):
+        # Initialize the global metrics provider and meter. We only do this once on
+        # the first initialization of the class, because re-setting the meter provider
+        # can result in loss of metrics.
+        with self._metrics_initialized_lock:
+            if self._metrics_initialized:
+                return
+            prometheus_reader = PrometheusMetricReader()
+            provider = MeterProvider(metric_readers=[prometheus_reader])
+            metrics.set_meter_provider(provider)
+            self._metrics_initialized = True
 
     def register_gauge_metric(self, name: str, description: str) -> None:
         with self._lock:


### PR DESCRIPTION
The otel-recorder python interface currently might reset opentelemetry.metrics every time it is initialized. This is not correct since later initialization might cause previous initialization to lose metrics.

This PR create class variables to make sure opentelemetry.metrics is only initialized once.

Test:
- CI