### PR TITLE
[serve] Add a test to ensure calling await multiple times on response doesn't result in multiple calls to replica

### DIFF
--- a/python/ray/serve/tests/test_handle_same_loop.py
+++ b/python/ray/serve/tests/test_handle_same_loop.py
@@ -220,5 +220,27 @@ async def test_request_cancellation_in_same_loop(
     await signal_actor.send.remote(clear=True)
 
 
+@pytest.mark.asyncio
+async def test_multiple_awaits(serve_instance_async):
+    """Test that multiple awaits doesn't call replica multiple times."""
+    a = 0
+
+    @serve.deployment
+    async def foo():
+        nonlocal a
+        a += 1
+        return a
+
+    app = serve.run(foo.bind())
+
+    response = app.remote()
+    assert await response == 1
+    assert await response == 1
+
+    response = app.remote()
+    assert await response == 2
+    assert await response == 2
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
