### PR TITLE
[codeowner] remove aslonnie individual from many ownerships

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,7 +39,7 @@
 
 # Common directory shared by core and the libraries.
 # @edoakes is the czar for now because the pattern is new.
-/python/ray/_common/ @edoakes @aslonnie
+/python/ray/_common/ @edoakes @jjyao
 
 # Ray data.
 /python/ray/data/ @ray-project/ray-data
@@ -78,8 +78,8 @@
 /python/requirements/ml/dl-gpu-requirements.txt @richardliaw @matthewdeng
 
 # Ray symbol export
-/src/ray/ray_version_script.lds @aslonnie
-/src/ray/ray_exported_symbols.lds @aslonnie
+/src/ray/ray_version_script.lds @ray-project/ray-core
+/src/ray/ray_exported_symbols.lds @ray-project/ray-core
 
 # Ray usage stats
 /python/ray/_private/usage/ @edoakes @richardliaw @jjyao
@@ -111,8 +111,8 @@
 # on their own.
 /release/ray_release/byod/*.sh
 
-/.github/ISSUE_TEMPLATE/ @aslonnie
+/.github/ISSUE_TEMPLATE/ @ray-project/ray-ci
 
 /.github/workflows/ @ray-project/ray-ci
 
-/.gemini/ @edoakes @aslonnie
+/.gemini/ @edoakes @ray-project/ray-ci


### PR DESCRIPTION
delegating to ray-core and ray-ci teams

and moving `_common` to core team leads