### PR TITLE
[Data] Support  initial concurrency value

### DIFF
--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -156,6 +156,8 @@ class ActorPoolStrategy(ComputeStrategy):
             f"max_size={self.max_size}, "
             f"initial_size={self.initial_size}, "
             f"max_tasks_in_flight_per_actor={self.max_tasks_in_flight_per_actor})"
+            f"num_workers={self.num_workers}, "
+            f"ready_to_total_workers_ratio={self.ready_to_total_workers_ratio})"
         )
 
 

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -76,6 +76,7 @@ class ActorPoolStrategy(ComputeStrategy):
         size: Optional[int] = None,
         min_size: Optional[int] = None,
         max_size: Optional[int] = None,
+        initial_size: Optional[int] = None,
         max_tasks_in_flight_per_actor: Optional[int] = None,
     ):
         """Construct ActorPoolStrategy for a Dataset transform.
@@ -85,6 +86,8 @@ class ActorPoolStrategy(ComputeStrategy):
                 specify both `size` and `min_size` or `max_size`.
             min_size: The minimum size of the actor pool.
             max_size: The maximum size of the actor pool.
+            initial_size: The initial number of actors to start with. If not specified,
+                defaults to min_size. Must be between min_size and max_size.
             max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
                 send to a single actor worker. Increasing this will increase
                 opportunities for pipelining task dependency prefetching with
@@ -94,12 +97,13 @@ class ActorPoolStrategy(ComputeStrategy):
         if size is not None:
             if size < 1:
                 raise ValueError("size must be >= 1", size)
-            if max_size is not None or min_size is not None:
+            if max_size is not None or min_size is not None or initial_size is not None:
                 raise ValueError(
-                    "min_size and max_size cannot be set at the same time as `size`"
+                    "min_size, max_size, and initial_size cannot be set at the same time as `size`"
                 )
             min_size = size
             max_size = size
+            initial_size = size
         if min_size is not None and min_size < 1:
             raise ValueError("min_size must be >= 1", min_size)
         if max_size is not None:
@@ -115,8 +119,24 @@ class ActorPoolStrategy(ComputeStrategy):
                 "max_tasks_in_flight_per_actor must be >= 1, got: ",
                 max_tasks_in_flight_per_actor,
             )
+
         self.min_size = min_size or 1
         self.max_size = max_size or float("inf")
+
+        # Validate and set initial_size
+        if initial_size is not None:
+            if initial_size < 1:
+                raise ValueError("initial_size must be >= 1", initial_size)
+            if initial_size < self.min_size:
+                raise ValueError(
+                    f"initial_size ({initial_size}) must be >= min_size ({self.min_size})"
+                )
+            if self.max_size != float("inf") and initial_size > self.max_size:
+                raise ValueError(
+                    f"initial_size ({initial_size}) must be <= max_size ({self.max_size})"
+                )
+
+        self.initial_size = initial_size or self.min_size
         self.max_tasks_in_flight_per_actor = max_tasks_in_flight_per_actor
         self.num_workers = 0
         self.ready_to_total_workers_ratio = 0.8
@@ -125,6 +145,7 @@ class ActorPoolStrategy(ComputeStrategy):
         return isinstance(other, ActorPoolStrategy) and (
             self.min_size == other.min_size
             and self.max_size == other.max_size
+            and self.initial_size == other.initial_size
             and self.max_tasks_in_flight_per_actor
             == other.max_tasks_in_flight_per_actor
         )
@@ -133,9 +154,8 @@ class ActorPoolStrategy(ComputeStrategy):
         return (
             f"ActorPoolStrategy(min_size={self.min_size}, "
             f"max_size={self.max_size}, "
+            f"initial_size={self.initial_size}, "
             f"max_tasks_in_flight_per_actor={self.max_tasks_in_flight_per_actor})"
-            f"num_workers={self.num_workers}, "
-            f"ready_to_total_workers_ratio={self.ready_to_total_workers_ratio})"
         )
 
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -752,6 +752,7 @@ class _ActorPool(AutoscalingActorPool):
 
         assert self._min_size >= 1
         assert self._max_size >= self._min_size
+        assert self._initial_size <= self._max_size
         assert self._initial_size >= self._min_size
         assert self._max_tasks_in_flight >= 1
         assert self._create_actor_fn is not None

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -571,7 +571,7 @@ def get_compute_strategy(
     fn: "UserDefinedFunction",
     fn_constructor_args: Optional[Iterable[Any]] = None,
     compute: Optional[Union[str, "ComputeStrategy"]] = None,
-    concurrency: Optional[Union[int, Tuple[int, int]]] = None,
+    concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
 ) -> "ComputeStrategy":
     """Get `ComputeStrategy` based on the function or class, and concurrency
     information.
@@ -638,6 +638,24 @@ def get_compute_strategy(
                 if is_callable_class:
                     return ActorPoolStrategy(
                         min_size=concurrency[0], max_size=concurrency[1]
+                    )
+                else:
+                    raise ValueError(
+                        "``concurrency`` is set as a tuple of integers, but ``fn`` "
+                        f"is not a callable class: {fn}. Use ``concurrency=n`` to "
+                        "control maximum number of workers to use."
+                    )
+            elif (
+                len(concurrency) == 3
+                and isinstance(concurrency[0], int)
+                and isinstance(concurrency[1], int)
+                and isinstance(concurrency[2], int)
+            ):
+                if is_callable_class:
+                    return ActorPoolStrategy(
+                        min_size=concurrency[0],
+                        max_size=concurrency[1],
+                        initial_size=concurrency[2],
                     )
                 else:
                     raise ValueError(

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -630,43 +630,33 @@ def get_compute_strategy(
         return compute
     elif concurrency is not None:
         if isinstance(concurrency, tuple):
-            if (
-                len(concurrency) == 2
-                and isinstance(concurrency[0], int)
-                and isinstance(concurrency[1], int)
+            # Validate tuple length and that all elements are integers
+            if len(concurrency) not in (2, 3) or not all(
+                isinstance(c, int) for c in concurrency
             ):
-                if is_callable_class:
-                    return ActorPoolStrategy(
-                        min_size=concurrency[0], max_size=concurrency[1]
-                    )
-                else:
-                    raise ValueError(
-                        "``concurrency`` is set as a tuple of integers, but ``fn`` "
-                        f"is not a callable class: {fn}. Use ``concurrency=n`` to "
-                        "control maximum number of workers to use."
-                    )
-            elif (
-                len(concurrency) == 3
-                and isinstance(concurrency[0], int)
-                and isinstance(concurrency[1], int)
-                and isinstance(concurrency[2], int)
-            ):
-                if is_callable_class:
-                    return ActorPoolStrategy(
-                        min_size=concurrency[0],
-                        max_size=concurrency[1],
-                        initial_size=concurrency[2],
-                    )
-                else:
-                    raise ValueError(
-                        "``concurrency`` is set as a tuple of integers, but ``fn`` "
-                        f"is not a callable class: {fn}. Use ``concurrency=n`` to "
-                        "control maximum number of workers to use."
-                    )
-            else:
                 raise ValueError(
                     "``concurrency`` is expected to be set as a tuple of "
                     f"integers, but got: {concurrency}."
+                )
+
+            # Check if function is callable class (common validation)
+            if not is_callable_class:
+                raise ValueError(
+                    "``concurrency`` is set as a tuple of integers, but ``fn`` "
+                    f"is not a callable class: {fn}. Use ``concurrency=n`` to "
+                    "control maximum number of workers to use."
+                )
+
+            # Create ActorPoolStrategy based on tuple length
+            if len(concurrency) == 2:
+                return ActorPoolStrategy(
+                    min_size=concurrency[0], max_size=concurrency[1]
+                )
+            else:  # len(concurrency) == 3
+                return ActorPoolStrategy(
+                    min_size=concurrency[0],
+                    max_size=concurrency[1],
+                    initial_size=concurrency[2],
                 )
         elif isinstance(concurrency, int):
             if is_callable_class:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -371,6 +371,9 @@ class Dataset:
                 * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n)``, Ray
                   Data uses an autoscaling actor pool from ``m`` to ``n`` workers.
 
+                * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n, initial)``, Ray
+                  Data uses an autoscaling actor pool from ``m`` to ``n`` workers, with an initial size of ``initial``.
+
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
@@ -631,6 +634,9 @@ class Dataset:
 
                 * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n)``, Ray
                   Data uses an autoscaling actor pool from ``m`` to ``n`` workers.
+
+                * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n, initial)``, Ray
+                  Data uses an autoscaling actor pool from ``m`` to ``n`` workers, with an initial size of ``initial``.
 
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
@@ -1332,6 +1338,9 @@ class Dataset:
                 * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n)``, Ray
                   Data uses an autoscaling actor pool from ``m`` to ``n`` workers.
 
+                * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n, initial)``, Ray
+                  Data uses an autoscaling actor pool from ``m`` to ``n`` workers, with an initial size of ``initial``.
+
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
@@ -1449,6 +1458,9 @@ class Dataset:
 
                 * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n)``, Ray
                   Data uses an autoscaling actor pool from ``m`` to ``n`` workers.
+
+                * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n, initial)``, Ray
+                  Data uses an autoscaling actor pool from ``m`` to ``n`` workers, with an initial size of ``initial``.
 
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -467,7 +467,7 @@ class Dataset:
         num_cpus: Optional[float] = None,
         num_gpus: Optional[float] = None,
         memory: Optional[float] = None,
-        concurrency: Optional[Union[int, Tuple[int, int]]] = None,
+        concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -722,7 +722,7 @@ class Dataset:
         num_cpus: Optional[float],
         num_gpus: Optional[float],
         memory: Optional[float],
-        concurrency: Optional[Union[int, Tuple[int, int]]],
+        concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]],
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]],
         **ray_remote_args,
     ):
@@ -1117,7 +1117,7 @@ class Dataset:
         self,
         names: Union[List[str], Dict[str, str]],
         *,
-        concurrency: Optional[Union[int, Tuple[int, int]]] = None,
+        concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
         **ray_remote_args,
     ):
         """Rename columns in the dataset.
@@ -1251,7 +1251,7 @@ class Dataset:
         num_cpus: Optional[float] = None,
         num_gpus: Optional[float] = None,
         memory: Optional[float] = None,
-        concurrency: Optional[Union[int, Tuple[int, int]]] = None,
+        concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -1394,7 +1394,7 @@ class Dataset:
         fn_kwargs: Optional[Dict[str, Any]] = None,
         fn_constructor_args: Optional[Iterable[Any]] = None,
         fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        concurrency: Optional[Union[int, Tuple[int, int]]] = None,
+        concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -284,7 +284,7 @@ class Dataset:
         num_cpus: Optional[float] = None,
         num_gpus: Optional[float] = None,
         memory: Optional[float] = None,
-        concurrency: Optional[Union[int, Tuple[int, int]]] = None,
+        concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -201,6 +201,9 @@ class GroupedData:
                 * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n)``, Ray
                   Data uses an autoscaling actor pool from ``m`` to ``n`` workers.
 
+                * If ``fn`` is a class and  ``concurrency`` is a tuple ``(m, n, initial)``, Ray
+                  Data uses an autoscaling actor pool from ``m`` to ``n`` workers, with an initial size of ``initial``.
+
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -108,7 +108,7 @@ class GroupedData:
         num_cpus: Optional[float] = None,
         num_gpus: Optional[float] = None,
         memory: Optional[float] = None,
-        concurrency: Optional[Union[int, Tuple[int, int]]] = None,
+        concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -16,7 +16,7 @@ from ray._common.test_utils import wait_for_condition
 from ray.actor import ActorHandle
 from ray.data._internal.actor_autoscaler import ActorPoolScalingRequest
 from ray.data._internal.execution.bundle_queue import FIFOBundleQueue
-from ray.data._internal.execution.interfaces import ExecutionResources
+from ray.data._internal.execution.interfaces import ExecutionOptions, ExecutionResources
 from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data._internal.execution.operators.actor_pool_map_operator import (
@@ -591,6 +591,26 @@ class TestActorPool(unittest.TestCase):
         except StopIteration:
             res5 = None
         assert res5 is None
+
+
+def test_setting_initial_size_for_actor_pool():
+    data_context = ray.data.DataContext.get_current()
+    op = ActorPoolMapOperator(
+        map_transformer=MagicMock(),
+        input_op=InputDataBuffer(data_context, input_data=MagicMock()),
+        data_context=data_context,
+        target_max_block_size=None,
+        compute_strategy=ray.data.ActorPoolStrategy(
+            min_size=1, max_size=4, initial_size=2
+        ),
+        ray_remote_args={"num_cpus": 1},
+    )
+
+    op.start(ExecutionOptions())
+
+    assert op._actor_pool.get_actor_info() == _ActorPoolInfo(
+        running=0, pending=2, restarting=0
+    )
 
 
 def test_min_max_resource_requirements(restore_data_context):

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -92,11 +92,13 @@ class TestActorPool(unittest.TestCase):
         self,
         min_size=1,
         max_size=4,
+        initial_size=1,
         max_tasks_in_flight=4,
     ):
         pool = _ActorPool(
             min_size=min_size,
             max_size=max_size,
+            initial_size=initial_size,
             max_actor_concurrency=1,
             max_tasks_in_flight_per_actor=max_tasks_in_flight,
             create_actor_fn=self._create_actor_fn,

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -611,6 +611,7 @@ def test_setting_initial_size_for_actor_pool():
     assert op._actor_pool.get_actor_info() == _ActorPoolInfo(
         running=0, pending=2, restarting=0
     )
+    ray.shutdown()
 
 
 def test_min_max_resource_requirements(restore_data_context):

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -301,8 +301,8 @@ def test_concurrency(shutdown_only, target_max_block_size_infinite_or_default):
     # Test function and class.
     for fn in [udf, UDFClass]:
         # Test concurrency with None, single integer and a tuple of integers.
-        for concurrency in [2, (2, 4)]:
-            if fn == udf and concurrency == (2, 4):
+        for concurrency in [2, (2, 4), (2, 6, 4)]:
+            if fn == udf and (concurrency == (2, 4) or concurrency == (2, 6, 4)):
                 error_message = "``concurrency`` is set as a tuple of integers"
                 with pytest.raises(ValueError, match=error_message):
                     ds.map(fn, concurrency=concurrency).take_all()
@@ -312,7 +312,7 @@ def test_concurrency(shutdown_only, target_max_block_size_infinite_or_default):
 
     # Test concurrency with an illegal value.
     error_message = "``concurrency`` is expected to be set a"
-    for concurrency in ["dummy", (1, 3, 5)]:
+    for concurrency in ["dummy", (1, 3, 5, 7)]:
         with pytest.raises(ValueError, match=error_message):
             ds.map(UDFClass, concurrency=concurrency).take_all()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Support setting the initial actor pool size(concurrency) and update methods that accept tuple of concurrency.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
Closes #54648 
- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
