### PR TITLE
[Data] Add `max_task_concurrency`, `min_scheduling_resources`, and `per_task_resource_allocation`

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -402,6 +402,40 @@ class PhysicalOperator(Operator):
             res[logical_op_id] = logical_op._get_args()
         return res
 
+    # TODO(@balaji): Disambiguate this with `incremental_resource_usage`.
+    def per_task_resource_allocation(
+        self: "PhysicalOperator",
+    ) -> ExecutionResources:
+        """The amount of logical resources used by each task.
+
+        For regular tasks, these are the resources required to schedule a task. For
+        actor tasks, these are the resources required to schedule an actor divided by
+        the number of actor threads (i.e., `max_concurrency`).
+
+        Returns:
+            The resource requirement per task.
+        """
+        return ExecutionResources.zero()
+
+    def max_task_concurrency(self: "PhysicalOperator") -> Optional[int]:
+        """The maximum number of tasks that can be run concurrently.
+
+        Some operators manually configure a maximum concurrency. For example, if you
+        specify `concurrency` in `map_batches`.
+        """
+        return None
+
+    # TODO(@balaji): Disambiguate this with `base_resource_usage`.
+    def min_scheduling_resources(
+        self: "PhysicalOperator",
+    ) -> ExecutionResources:
+        """The minimum resource bundle required to schedule a worker.
+
+        For regular tasks, this is the resources required to schedule a task. For actor
+        tasks, this is the resources required to schedule an actor.
+        """
+        return ExecutionResources.zero()
+
     def progress_str(self) -> str:
         """Return any extra status to be displayed in the operator progress bar.
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -483,13 +483,7 @@ class ActorPoolMapOperator(MapOperator):
     ) -> ExecutionResources:
         max_concurrency = self._ray_remote_args.get("max_concurrency", 1)
         per_actor_resource_usage = self._actor_pool.per_actor_resource_usage()
-        return ExecutionResources(
-            cpu=per_actor_resource_usage.cpu / max_concurrency,
-            gpu=per_actor_resource_usage.gpu / max_concurrency,
-            memory=per_actor_resource_usage.memory / max_concurrency,
-            object_store_memory=per_actor_resource_usage.object_store_memory
-            / max_concurrency,
-        )
+        return per_actor_resource_usage.scale(1 / max_concurrency)
 
     def max_task_concurrency(self: "PhysicalOperator") -> Optional[int]:
         max_concurrency = self._ray_remote_args.get("max_concurrency", 1)

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -140,6 +140,19 @@ class TaskPoolMapOperator(MapOperator):
             or 0,
         )
 
+    def per_task_resource_allocation(
+        self: "PhysicalOperator",
+    ) -> ExecutionResources:
+        return self.incremental_resource_usage()
+
+    def max_task_concurrency(self: "PhysicalOperator") -> Optional[int]:
+        return self._concurrency
+
+    def min_scheduling_resources(
+        self: "PhysicalOperator",
+    ) -> ExecutionResources:
+        return self.incremental_resource_usage()
+
     def get_concurrency(self) -> Optional[int]:
         return self._concurrency
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Adds three new methods to the PhysicalOperator interface to clarify resource usage and scheduling semantics:
* `per_task_resource_allocation` – logical resources required per task (task-level granularity).
* `max_task_concurrency` – maximum number of tasks allowed to run concurrently, if the operator enforces one.
* `min_scheduling_resources` – minimum resource bundle required to schedule a worker (e.g., task vs. actor).

These methods provide a clearer contract for how operators declare resource requirements, making scheduling behavior easier to reason about and extend.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
