### PR TITLE
[Data] Add hash and `to_resource_dict` to `ExecutionResources`

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -49,6 +49,15 @@ class ExecutionResources:
             memory=resource_dict.get("memory", None),
         )
 
+    def to_resource_dict(self) -> Dict[str, float]:
+        """Convert this ExecutionResources object to a resource dict."""
+        return {
+            "CPU": self.cpu,
+            "GPU": self.gpu,
+            "object_store_memory": self.object_store_memory,
+            "memory": self.memory,
+        }
+
     @classmethod
     def for_limits(
         cls,
@@ -100,6 +109,16 @@ class ExecutionResources:
             and self.gpu == other.gpu
             and self.object_store_memory == other.object_store_memory
             and self.memory == other.memory
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.cpu,
+                self.gpu,
+                self.object_store_memory,
+                self.memory,
+            )
         )
 
     @classmethod

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -581,6 +581,16 @@ def test_output_splitter_resource_reporting(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_outqueue == 0
 
 
+def test_execution_resources_to_resource_dict():
+    resources = ExecutionResources(cpu=1, gpu=2, object_store_memory=3, memory=4)
+    assert resources.to_resource_dict() == {
+        "CPU": 1,
+        "GPU": 2,
+        "object_store_memory": 3,
+        "memory": 4,
+    }
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR adds two utility methods to `ExecutionResources`:
* `__hash__` – allows `ExecutionResources` to be effectively stored in sets or used as dictionary keys.
* `to_resource_dict` – converts the object into a resource dictionary for interoperability with the autoscaler SDK and other components that expect that resource format.

These improvements make `ExecutionResources` easier to use in scheduling and autoscaling components.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
