### PR TITLE
[release-test] Disable `drop_last` flag to fix division by zero in torch dataloader baselines

### DIFF
--- a/release/train_tests/benchmark/runner.py
+++ b/release/train_tests/benchmark/runner.py
@@ -201,6 +201,7 @@ class TrainLoopRunner:
             self._metrics["validation/rows_processed"].add(
                 self.benchmark_config.dataloader_config.validation_batch_size
             )
+        assert num_rows > 0, "Validation dataset yielded no batches."
 
         return {"validation/loss": total_loss.item() / num_rows}
 

--- a/release/train_tests/benchmark/torch_dataloader_factory.py
+++ b/release/train_tests/benchmark/torch_dataloader_factory.py
@@ -149,7 +149,7 @@ class TorchDataLoaderFactory(BaseDataLoaderFactory, ABC):
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
             timeout=timeout,
-            drop_last=True,
+            drop_last=False,
             **multiprocessing_args,
         )
         # Add a DistributedSampler to the dataloader if possible (map-style datasets)


### PR DESCRIPTION
## Summary

https://github.com/ray-project/ray/pull/56343 refactored some code for torch dataloader creation but introduced a bug when it came to the validation dataset throughput calculation.

```
File "/.../runner.py", line 205, in _validate_epoch
    return {"validation/loss": total_loss.item() / num_rows}
ZeroDivisionError: float division by zero
```

This happened because `drop_last=True` became the default setting, which would cause the validation dataset to be empty since it's small enough and spread across enough workers so that we couldn't form a single full batch. This PR fixes the issue by setting `drop_last=False`.

```python
Validation dataset size = 50_000
Num train workers * num dataloader workers = 16 * 16 = 256
Num rows per dataloader worker = 50_000 // 256 = 195
Validation batch size = 256

195 < 256 !! Cannot construct a single full batch since each dataloader worker operates on < batch size.
```