### PR TITLE
[core][gpu objects] Rename GPU objects -> RDT objects in user-facing exceptions

### DIFF
--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -168,8 +168,8 @@ class SerializationContext:
                 and worker.gpu_object_manager.is_managed_object(obj.hex())
             ):
                 raise ValueError(
-                    "Passing GPU ObjectRefs inside data structures is not yet supported. "
-                    "Pass GPU ObjectRefs directly as task arguments instead. For example, use `foo.remote(ref)` instead of `foo.remote([ref])`."
+                    "Passing RDT ObjectRefs inside data structures is not yet supported. "
+                    "Pass RDT ObjectRefs directly as task arguments instead. For example, use `foo.remote(ref)` instead of `foo.remote([ref])`."
                 )
 
             self.add_contained_object_ref(

--- a/python/ray/experimental/collective/collective_tensor_transport.py
+++ b/python/ray/experimental/collective/collective_tensor_transport.py
@@ -62,7 +62,7 @@ class CollectiveTensorTransport(TensorTransportManager):
                 for t in gpu_object:
                     if t.device.type != device.type:
                         raise ValueError(
-                            "All tensors in one GPU object must be the same device type."
+                            "All tensors in an RDT object must be on the same device."
                         )
                     tensor_meta.append((t.shape, t.dtype))
             return CollectiveTransportMetadata(
@@ -105,7 +105,7 @@ class CollectiveTensorTransport(TensorTransportManager):
         elif len(communicators) > 1:
             raise ValueError(
                 f"There are {len(communicators)} possible communicators that contain actors {src_actor} and {dst_actor}. "
-                "Currently, GPU objects only support one communicator. Please make sure only "
+                "Currently, RDT objects only support one communicator. Please make sure only "
                 "one communicator exists."
             )
         communicator = communicators[0]

--- a/python/ray/experimental/collective/collective_tensor_transport.py
+++ b/python/ray/experimental/collective/collective_tensor_transport.py
@@ -62,7 +62,7 @@ class CollectiveTensorTransport(TensorTransportManager):
                 for t in gpu_object:
                     if t.device.type != device.type:
                         raise ValueError(
-                            "All tensors in an RDT object must be on the same device."
+                            "All tensors in an RDT object must have the same device type."
                         )
                     tensor_meta.append((t.shape, t.dtype))
             return CollectiveTransportMetadata(

--- a/python/ray/experimental/collective/nixl_tensor_transport.py
+++ b/python/ray/experimental/collective/nixl_tensor_transport.py
@@ -78,7 +78,7 @@ class NixlTensorTransport(TensorTransportManager):
                 for t in gpu_object:
                     if t.device.type != device.type:
                         raise ValueError(
-                            "All tensors in an RDT object must be on the same device."
+                            "All tensors in an RDT object must have the same device type."
                         )
                     tensor_meta.append((t.shape, t.dtype))
             else:

--- a/python/ray/experimental/collective/nixl_tensor_transport.py
+++ b/python/ray/experimental/collective/nixl_tensor_transport.py
@@ -78,7 +78,7 @@ class NixlTensorTransport(TensorTransportManager):
                 for t in gpu_object:
                     if t.device.type != device.type:
                         raise ValueError(
-                            "All tensors in one GPU object must be the same device type."
+                            "All tensors in an RDT object must be on the same device."
                         )
                     tensor_meta.append((t.shape, t.dtype))
             else:

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -253,7 +253,7 @@ class GPUObjectStore:
                 timeout=timeout,
             ):
                 raise TimeoutError(
-                    f"ObjectRef({obj_id}) not found in GPU object store after {timeout}s, transfer may have failed. Please report this issue on GitHub: https://github.com/ray-project/ray/issues/new/choose"
+                    f"ObjectRef({obj_id}) not found in RDT object store after {timeout}s, transfer may have failed. Please report this issue on GitHub: https://github.com/ray-project/ray/issues/new/choose"
                 )
 
     def pop_object(self, obj_id: str) -> List["torch.Tensor"]:
@@ -283,7 +283,7 @@ class GPUObjectStore:
                 lambda: tensor not in self._tensor_to_object_ids, timeout=timeout
             ):
                 raise TimeoutError(
-                    f"Tensor {tensor} not freed from GPU object store after {timeout}s. The tensor will not be freed until all ObjectRefs containing the tensor have gone out of scope."
+                    f"Tensor {tensor} not freed from RDT object store after {timeout}s. The tensor will not be freed until all ObjectRefs containing the tensor have gone out of scope."
                 )
 
     def get_num_objects(self) -> int:

--- a/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
+++ b/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
@@ -664,7 +664,7 @@ def test_gpu_object_ref_in_list_throws_exception(ray_start_regular):
     # Test: GPU ref inside a list should fail during task submission
     with pytest.raises(
         ValueError,
-        match="Passing GPU ObjectRefs inside data structures is not yet supported",
+        match="Passing RDT ObjectRefs inside data structures is not yet supported",
     ):
         actor.double.remote([gpu_ref])
 
@@ -672,7 +672,7 @@ def test_gpu_object_ref_in_list_throws_exception(ray_start_regular):
     normal_ref = ray.put("normal_data")
     with pytest.raises(
         ValueError,
-        match="Passing GPU ObjectRefs inside data structures is not yet supported",
+        match="Passing RDT ObjectRefs inside data structures is not yet supported",
     ):
         actor.double.remote([gpu_ref, normal_ref])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Rename GPU objects to RDT (Ray Direct Transport) in user-facing error messages.
