### PR TITLE
[core][event] add timed-out+ retry for event_aggregator_client

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -688,6 +688,12 @@ RAY_CONFIG(int64_t, core_worker_internal_heartbeat_ms, 1000)
 /// Timeout for core worker grpc server reconnection in seconds.
 RAY_CONFIG(int32_t, core_worker_rpc_server_reconnect_timeout_s, 60)
 
+/// Timeout for event aggregator grpc server reconnection in seconds.
+RAY_CONFIG(int32_t, event_aggregator_rpc_server_reconnect_timeout_s, 60)
+
+/// Timeout for event aggregator grpc request in seconds.
+RAY_CONFIG(int32_t, event_aggregator_rpc_request_timeout_s, 60)
+
 /// Maximum amount of memory that will be used by running tasks' args.
 RAY_CONFIG(float, max_task_args_memory_fraction, 0.7)
 

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -822,7 +822,7 @@ void TaskEventBufferImpl::SendRayEventsToAggregator(
 
   rpc::events::AddEventsRequest request;
   *request.mutable_events_data() = std::move(*data);
-  event_aggregator_client_->AddEvents(request, on_complete);
+  event_aggregator_client_->AddEvents(std::move(request), on_complete);
 }
 
 void TaskEventBufferImpl::FlushEvents(bool forced) {

--- a/src/ray/rpc/BUILD.bazel
+++ b/src/ray/rpc/BUILD.bazel
@@ -70,6 +70,7 @@ ray_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":grpc_client",
+        ":retryable_grpc_client",
         "//src/ray/protobuf:events_event_aggregator_service_cc_grpc",
         "//src/ray/util:logging",
         "@com_github_grpc_grpc//:grpc++",

--- a/src/ray/rpc/event_aggregator_client.h
+++ b/src/ray/rpc/event_aggregator_client.h
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "ray/rpc/grpc_client.h"
+#include "ray/rpc/retryable_grpc_client.h"
 #include "ray/util/logging.h"
 #include "src/ray/protobuf/events_event_aggregator_service.grpc.pb.h"
 #include "src/ray/protobuf/events_event_aggregator_service.pb.h"
@@ -36,7 +37,7 @@ class EventAggregatorClient {
  public:
   virtual ~EventAggregatorClient() = default;
 
-  virtual void AddEvents(const rpc::events::AddEventsRequest &request,
+  virtual void AddEvents(AddEventsRequest &&request,
                          const ClientCallback<rpc::events::AddEventsReply> &callback) = 0;
 };
 
@@ -48,19 +49,34 @@ class EventAggregatorClientImpl : public EventAggregatorClient {
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
   EventAggregatorClientImpl(const int port, ClientCallManager &client_call_manager) {
     RAY_LOG(INFO) << "Initiating the local event aggregator client with port: " << port;
-    grpc_client_ = std::make_unique<GrpcClient<rpc::events::EventAggregatorService>>(
+    grpc_client_ = std::make_shared<GrpcClient<rpc::events::EventAggregatorService>>(
         "127.0.0.1", port, client_call_manager);
+    retryable_grpc_client_ = RetryableGrpcClient::Create(
+        grpc_client_->Channel(),
+        client_call_manager.GetMainService(),
+        /*max_pending_requests_bytes=*/std::numeric_limits<uint64_t>::max(),
+        /*check_channel_status_interval_milliseconds=*/
+        ::RayConfig::instance()
+            .grpc_client_check_connection_status_interval_milliseconds(),
+        /*server_unavailable_timeout_seconds=*/
+        ::RayConfig::instance().event_aggregator_rpc_server_reconnect_timeout_s(),
+        /*server_unavailable_timeout_callback=*/[]() {},
+        /*server_name=*/"EventAggregator");
   };
 
-  VOID_RPC_CLIENT_METHOD(rpc::events::EventAggregatorService,
-                         AddEvents,
-                         grpc_client_,
-                         /*method_timeout_ms*/ -1,
-                         override)
+  VOID_RETRYABLE_RPC_CLIENT_METHOD(
+      retryable_grpc_client_,
+      rpc::events::EventAggregatorService,
+      AddEvents,
+      grpc_client_,
+      ::RayConfig::instance().event_aggregator_rpc_request_timeout_s() * 1000,
+      override)
 
  private:
   // The RPC client.
-  std::unique_ptr<GrpcClient<rpc::events::EventAggregatorService>> grpc_client_;
+  std::shared_ptr<GrpcClient<rpc::events::EventAggregatorService>> grpc_client_;
+  // The retryable RPC client.
+  std::shared_ptr<RetryableGrpcClient> retryable_grpc_client_;
 };
 
 }  // namespace rpc


### PR DESCRIPTION
As a follow up in https://github.com/ray-project/ray/pull/55065, add timed-out + retry for `event_aggregator_client`. Add logic for the `AddEvents` endpoint so that it will reject potential duplicated events due to retries.

Test:
- CI