### PR TITLE
[data] ignore metadata for pandas block

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -262,9 +262,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
     def to_pandas(self) -> "pandas.DataFrame":
         from ray.air.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
+
         # We specify ignore_metadata=True because pyarrow will use the metadata
-        # to build the pyarrow Table. This can lead to errors for older pyarrow
-        # versions.
+        # to build the Table. This can is handled incorrectly for older pyarrow versions
         df = self._table.to_pandas(ignore_metadata=True)
         ctx = DataContext.get_current()
         if ctx.enable_tensor_extension_casting:

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -264,9 +264,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
         from ray.air.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
 
         # We specify ignore_metadata=True because pyarrow will use the metadata
-        # to build the Table. This can is handled incorrectly for older pyarrow versions
-        df = self._table.to_pandas(ignore_metadata=True)
+        # to build the Table. This is handled incorrectly for older pyarrow versions
         ctx = DataContext.get_current()
+        df = self._table.to_pandas(ignore_metadata=ctx.pandas_block_ignore_metadata)
         if ctx.enable_tensor_extension_casting:
             df = _cast_tensor_columns_to_ndarrays(df)
         return df

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -262,7 +262,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
     def to_pandas(self) -> "pandas.DataFrame":
         from ray.air.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
-
+        # We specify ignore_metadata=True because pyarrow will use the metadata
+        # to build the pyarrow Table. This can lead to errors for older pyarrow
+        # versions.
         df = self._table.to_pandas(ignore_metadata=True)
         ctx = DataContext.get_current()
         if ctx.enable_tensor_extension_casting:

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -263,7 +263,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def to_pandas(self) -> "pandas.DataFrame":
         from ray.air.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
 
-        df = self._table.to_pandas()
+        df = self._table.to_pandas(ignore_metadata=True)
         ctx = DataContext.get_current()
         if ctx.enable_tensor_extension_casting:
             df = _cast_tensor_columns_to_ndarrays(df)

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -70,6 +70,10 @@ DEFAULT_STREAMING_READ_BUFFER_SIZE = 32 * 1024 * 1024
 
 DEFAULT_ENABLE_PANDAS_BLOCK = True
 
+DEFAULT_PANDAS_BLOCK_IGNORE_METADATA = bool(
+    os.environ.get("RAY_DATA_PANDAS_BLOCK_IGNORE_METADATA", 0)
+)
+
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
@@ -540,6 +544,8 @@ class DataContext:
     downstream_capacity_backpressure_max_queued_bundles: int = None
 
     enforce_schemas: bool = DEFAULT_ENFORCE_SCHEMAS
+
+    pandas_block_ignore_metadata: bool = DEFAULT_PANDAS_BLOCK_IGNORE_METADATA
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Consider the following the code
```python
import ray
# Read File (1)
source_path = "file_that_contains_tensor_strings.parquet"
ds = ray.data.read_parquet(source_path)
# Write File (2)
dest_path = "/tmp"
ds.map_batches(..., batch_format="pandas").write_parquet(dest_path)

# Read File Again (3)
new_ds = ray.data.read_parquet(dest_path).map_bataches(..., batch_format="pandas")
```
At a high level we read, write, read. On a lower-level, we convert arrow blocks -> pandas -> arrow blocks -> pandas. We have connectors and registered extension types in `python/ray/air/util/tensor_extensions/`, however we special case handle tensor types by converting them to `TensorArrays` [here](https://github.com/iamjustinhsu/ray/blob/1f7dcec413bf9aba3ac39c0a14d7d4b734a1939f/python/ray/data/_internal/pandas_block.py#L238) when we convert pandas -> arrow. During this process, however, pyarrow will store metadata about the pandas block, which will look something like this:
```json
{
    "name": "feature1",
    "field_name": "feature1",
    "pandas_type": "object",
    "numpy_type": "numpy.ndarray(shape=(8, 2), dtype=<U38)",
    "metadata": null
},
{
    "name": "feature2",
    "field_name": "feature2",
    "pandas_type": "object",
    "numpy_type": "numpy.ndarray(shape=(8,), dtype=float32)",
    "metadata": null
}
```
For the most part this is fine, however, when converting _back_ to pandas, arrow will first attempt to search through the metadata("numpy_type") to restore the schema. This can be troublesome because pandas/numpy doesn't know how to handle those custom types.

In pyarrow==14.0.0, this is an issue, because it surrenders the special casing to numpy/pandas
in pyarrow==21.0.0, it's smarter and DOES handle that (I tested this) 

### NOTE
This has been tested with pyarrow==14.0.0 (ray version 2.45) and this works.

### Solution
To handle older pyarrow versions, we can do `ignore_metadata=True`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
