### PR TITLE
[core][rdt] Fix check crash on gpu obj free if driver knows actor is dead

### DIFF
--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -470,7 +470,8 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
       RayConfig::instance().max_lineage_bytes(),
       *task_event_buffer,
       /*get_actor_rpc_client_callback=*/
-      [this](const ActorID &actor_id) {
+      [this](const ActorID &actor_id)
+          -> std::optional<std::shared_ptr<rpc::CoreWorkerClientInterface>> {
         auto core_worker = GetCoreWorker();
         auto addr = core_worker->actor_task_submitter_->GetActorAddress(actor_id);
         if (!addr.has_value()) {

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -473,8 +473,10 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
       [this](const ActorID &actor_id) {
         auto core_worker = GetCoreWorker();
         auto addr = core_worker->actor_task_submitter_->GetActorAddress(actor_id);
-        RAY_CHECK(addr.has_value()) << "Actor address not found for actor " << actor_id;
-        return core_worker->core_worker_client_pool_->GetOrConnect(addr.value());
+        if (!addr.has_value()) {
+          return std::nullopt;
+        }
+        return core_worker->core_worker_client_pool_->GetOrConnect(*addr);
       },
       gcs_client,
       task_by_state_counter_);

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -183,8 +183,8 @@ class TaskManager : public TaskManagerInterface {
       PushErrorCallback push_error_callback,
       int64_t max_lineage_bytes,
       worker::TaskEventBuffer &task_event_buffer,
-      std::function<std::shared_ptr<ray::rpc::CoreWorkerClientInterface>(const ActorID &)>
-          client_factory,
+      std::function<std::optional<std::shared_ptr<rpc::CoreWorkerClientInterface>>(
+          const ActorID &)> get_actor_rpc_client_callback,
       std::shared_ptr<gcs::GcsClient> gcs_client,
       ray::observability::MetricInterface &task_by_state_counter)
       : in_memory_store_(in_memory_store),
@@ -195,7 +195,7 @@ class TaskManager : public TaskManagerInterface {
         push_error_callback_(std::move(push_error_callback)),
         max_lineage_bytes_(max_lineage_bytes),
         task_event_buffer_(task_event_buffer),
-        get_actor_rpc_client_callback_(std::move(client_factory)),
+        get_actor_rpc_client_callback_(std::move(get_actor_rpc_client_callback)),
         gcs_client_(std::move(gcs_client)),
         task_by_state_counter_(task_by_state_counter) {
     task_counter_.SetOnChangeCallback(
@@ -796,7 +796,7 @@ class TaskManager : public TaskManagerInterface {
   worker::TaskEventBuffer &task_event_buffer_;
 
   /// Callback to get the actor RPC client.
-  std::function<std::shared_ptr<ray::rpc::CoreWorkerClientInterface>(
+  std::function<std::optional<std::shared_ptr<ray::rpc::CoreWorkerClientInterface>>(
       const ActorID &actor_id)>
       get_actor_rpc_client_callback_;
 


### PR DESCRIPTION
## Why are these changes needed?
We could end up with a ray check crash like the one @crypdick ran into in a situation where we try to free a "gpu" object after the ActorTaskSubmitter already knows the actor is dead. This fixes that by just getting an optional from the get client callback.
```
{"asctime":"2025-09-09 17:20:21,067","levelname":"C","message":" An unexpected system state has occurred. You have 
likely discovered a bug in Ray. Please report this issue at https://github.com/ray-project/ray/issues and we'll work with you to 
fix it. Check failed: addr.has_value() Actor address not found for actor e7f2f6dcedde54551ba4cb1c13000000\n*** 
...
StackTrace Information ***\n/home/ray/anaconda3/lib/python3.11/site-packages/ray/_raylet.so(+0x156bbda) 
[0x7945ef274bda] ray::operator<<()\n/home/ray/anaconda3/lib/python3.11/site-
packages/ray/_raylet.so(_ZN3ray6RayLogD1Ev+0x481) [0x7945ef276fc1] 
ray::RayLog::~RayLog()\n/home/ray/anaconda3/lib/python3.11/site-packages/ray/_raylet.so(+0x9a778c) [0x7945ee6b078c] 
ray::core::CoreWorkerProcessImpl::CreateCoreWorker()::{lambda()#15}::operator()
()\n/home/ray/anaconda3/lib/python3.11/site-packages/ray/_raylet.so(+0x9a7885) [0x7945ee6b0885] 
std::_Function_handler<>::_M_invoke()\n/home/ray/anaconda3/lib/python3.11/site-packages/ray/_raylet.so(+0xa2cd17) 
[0x7945ee735d17] std::_Function_handler<>::_M_invoke()\n/home/ray/anaconda3/lib/python3.11/site-
packages/ray/_raylet.so(_ZN3ray4core16ReferenceCounter25OnObjectOutOfScopeOrFreedEN4absl12lts_2023080218cont
ainer_internal12raw_hash_setINS4_17FlatHashMapPolicyINS_8ObjectIDENS1_9ReferenceEEENS3_13hash_internal4HashIS7
_EESt8equal_toIS7_ESaISt4pairIKS7_S8_EEE8iteratorE+0x64) [0x7945ee7e3ee4] 
ray::core::ReferenceCounter::OnObjectOutOfScopeOrFreed()\n/home/ray/anaconda3/lib/python3.11/site-
```