### PR TITLE
[core][otel] clear gauge metric cache at export time

### DIFF
--- a/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
+++ b/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
@@ -47,6 +47,8 @@ class OpenTelemetryMetricRecorder:
                 # Take snapshot of current observations.
                 with self._lock:
                     observations = self._observations_by_name[name]
+                    # Clear the observations to avoid emitting dead observations.
+                    self._observations_by_name[name] = {}
                     # Drop high cardinality from tag_set and sum up the value for
                     # same tag set after dropping
                     aggregated_observations = defaultdict(float)

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -270,11 +270,8 @@ def test_prometheus_physical_stats_record(
                 break
         return str(raylet_proc.process.pid) == str(raylet_pid)
 
-    wait_for_condition(
-        lambda: test_case_stats_exist() and test_case_ip_correct(),
-        timeout=30,
-        retry_interval_ms=1000,
-    )
+    wait_for_condition(test_case_stats_exist, timeout=30, retry_interval_ms=1000)
+    wait_for_condition(test_case_ip_correct, timeout=30, retry_interval_ms=1000)
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -195,6 +195,7 @@ def _setup_cluster_for_test(request, ray_start_cluster):
     # Add a head node.
     cluster.add_node(
         _system_config={
+            "metrics_report_interval_ms": 1000,
             "event_stats_print_interval_ms": 500,
             "event_stats": True,
             "enable_metrics_collection": enable_metrics_collection,


### PR DESCRIPTION
`self._observations_by_name` is a mapping of all time series for a given gauge metric to their current values. Currently, we do not clean up this map at each export interval, which can lead to issues where dead time series (e.g., series created by workers that are no longer alive) continue to emit their last value. Since we use sum aggregation for most gauge metrics, the sum ends up including contributions from these dead workers.

This PR introduces cleanup at each export interval, which also improves memory usage. It relies on the active processes to emit the relevant, up-to-date information at every interval.

Test:
- CI
- Test e2e on anyscale platform (previously the number of live actors remained as 6 after resizing, now they go back to 3

<img width="1850" height="610" alt="Screenshot 2025-09-10 at 10 28 57 AM" src="https://github.com/user-attachments/assets/28d7a252-da68-4fbb-bcef-78a8777a7f72" />
