### PR TITLE
[core] Introduce env var to set rpc failure prob for all rpc's

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -833,6 +833,12 @@ RAY_CONFIG(std::string, testing_asio_delay_us, "")
 ///      RAY_testing_rpc_failure="method1=max_num_failures:req_failure_prob:resp_failure_prob,method2=max_num_failures:req_failure_prob:resp_failure_prob"
 RAY_CONFIG(std::string, testing_rpc_failure, "")
 
+/// To use this:
+///      export RAY_testing_all_rpc_failure=req_failure_prob:resp_failure_prob
+/// NOTE: testing_rpc_failure will be ignored if this is set and only the config from this
+/// will be used.
+RAY_CONFIG(std::string, testing_all_rpc_failure, "")
+
 /// The following are configs for the health check. They are borrowed
 /// from k8s health probe (shorturl.at/jmTY3)
 /// The delay to send the first health check.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -828,16 +828,16 @@ RAY_CONFIG(std::string, REDIS_SERVER_NAME, "")
 //  it will apply to all methods.
 RAY_CONFIG(std::string, testing_asio_delay_us, "")
 
-///  To use this, simply do
-///      export
-///      RAY_testing_rpc_failure="method1=max_num_failures:req_failure_prob:resp_failure_prob,method2=max_num_failures:req_failure_prob:resp_failure_prob"
+/// To use this, simply do
+///     export
+///     RAY_testing_rpc_failure="method1=max_num_failures:req_failure_prob:resp_failure_prob,method2=max_num_failures:req_failure_prob:resp_failure_prob"
+/// If you want to test all rpc failures you can use * as the method name and you can set
+/// -1 max_num_failures to have unlimited failures.
+/// Ex. unlimited failures for all rpc's with 25% request failures and 50% response
+/// failures.
+///     export RAY_testing_rpc_failure="*=-1:25:50"
+/// NOTE: Setting the wildcard will override any configuration for other methods.
 RAY_CONFIG(std::string, testing_rpc_failure, "")
-
-/// To use this:
-///      export RAY_testing_all_rpc_failure=req_failure_prob:resp_failure_prob
-/// NOTE: testing_rpc_failure will be ignored if this is set and only the config from this
-/// will be used.
-RAY_CONFIG(std::string, testing_all_rpc_failure, "")
 
 /// The following are configs for the health check. They are borrowed
 /// from k8s health probe (shorturl.at/jmTY3)

--- a/src/ray/rpc/rpc_chaos.cc
+++ b/src/ray/rpc/rpc_chaos.cc
@@ -25,15 +25,20 @@
 namespace ray {
 namespace rpc {
 namespace testing {
-namespace {
 
 // RpcFailureManager is a simple chaos testing framework. Before starting ray, users
 // should set up os environment to use this feature for testing purposes.
-// To use this, simply do
+
+// You can use this to set probabilities for specific rpc's.
 //     export RAY_testing_rpc_failure="method1=3:25:50,method2=5:25:25"
 // Key is the RPC call name and value is a three part colon separated structure. It
 // contains the max number of failures to inject + probability of req failure +
 // probability of reply failure.
+
+// You can also use this to set probabilities for all rpc's.
+//     export RAY_testing_all_rpc_failure=25:50
+// This will set the probabilities for all rpc's to 25% for request failures and 50% for
+// reply failures.
 
 class RpcFailureManager {
  public:
@@ -42,9 +47,14 @@ class RpcFailureManager {
   void Init() {
     absl::MutexLock lock(&mu_);
 
-    failable_methods_.clear();
-
-    if (!RayConfig::instance().testing_rpc_failure().empty()) {
+    if (!RayConfig::instance().testing_all_rpc_failure().empty()) {
+      std::vector<std::string> colon_split =
+          absl::StrSplit(RayConfig::instance().testing_all_rpc_failure(), ':');
+      RAY_CHECK_EQ(colon_split.size(), 2UL);
+      req_failure_prob_ = std::stoul(colon_split[0]);
+      resp_failure_prob_ = std::stoul(colon_split[1]);
+      all_rpc_failure_ = true;
+    } else if (!RayConfig::instance().testing_rpc_failure().empty()) {
       for (const auto &item :
            absl::StrSplit(RayConfig::instance().testing_rpc_failure(), ',')) {
         std::vector<std::string> equal_split = absl::StrSplit(item, '=');
@@ -58,16 +68,27 @@ class RpcFailureManager {
         const auto &failable = iter->second;
         RAY_CHECK_LE(failable.req_failure_prob + failable.resp_failure_prob, 100UL);
       }
+    }
 
+    if (all_rpc_failure_ || !failable_methods_.empty()) {
       std::random_device rd;
       auto seed = rd();
       RAY_LOG(INFO) << "Setting RpcFailureManager seed to " << seed;
       gen_.seed(seed);
+      has_failures_ = true;
     }
   }
 
   RpcFailure GetRpcFailure(const std::string &name) {
+    if (!has_failures_) {
+      return RpcFailure::None;
+    }
+
     absl::MutexLock lock(&mu_);
+
+    if (all_rpc_failure_) {
+      return GetFailureTypeFromProbs(req_failure_prob_, resp_failure_prob_);
+    }
 
     auto iter = failable_methods_.find(name);
     if (iter == failable_methods_.end()) {
@@ -78,47 +99,55 @@ class RpcFailureManager {
     if (failable.num_remaining_failures == 0) {
       return RpcFailure::None;
     }
+    return GetFailureTypeFromProbs(failable.req_failure_prob, failable.resp_failure_prob);
+  }
 
+ private:
+  RpcFailure GetFailureTypeFromProbs(size_t req_failure_prob, size_t resp_failure_prob) {
     std::uniform_int_distribution<size_t> dist(1ul, 100ul);
     const size_t random_number = dist(gen_);
-    if (random_number <= failable.req_failure_prob) {
-      failable.num_remaining_failures--;
+    if (random_number <= req_failure_prob) {
       return RpcFailure::Request;
     }
-    if (random_number <= failable.req_failure_prob + failable.resp_failure_prob) {
-      failable.num_remaining_failures--;
+    if (random_number <= req_failure_prob + resp_failure_prob) {
       return RpcFailure::Response;
     }
     return RpcFailure::None;
   }
 
- private:
   absl::Mutex mu_;
   std::mt19937 gen_;
+  std::atomic_bool has_failures_ = false;
+
+  // If we're testing all rpc failures, we'll use these probabilites instead of
+  // failable_methods_
+  bool all_rpc_failure_ = false;
+  size_t req_failure_prob_ = 0;
+  size_t resp_failure_prob_ = 0;
+
+  // call name -> (num_remaining_failures, req_failure_prob, resp_failure_prob)
   struct Failable {
     size_t num_remaining_failures;
     size_t req_failure_prob;
     size_t resp_failure_prob;
   };
-  // call name -> (num_remaining_failures, req_failure_prob, resp_failure_prob)
   absl::flat_hash_map<std::string, Failable> failable_methods_ ABSL_GUARDED_BY(&mu_);
 };
 
-auto &rpc_failure_manager = []() -> RpcFailureManager & {
+namespace {
+
+RpcFailureManager &GetRpcFailureManager() {
   static auto *manager = new RpcFailureManager();
   return *manager;
-}();
+}
 
 }  // namespace
 
 RpcFailure GetRpcFailure(const std::string &name) {
-  if (RayConfig::instance().testing_rpc_failure().empty()) {
-    return RpcFailure::None;
-  }
-  return rpc_failure_manager.GetRpcFailure(name);
+  return GetRpcFailureManager().GetRpcFailure(name);
 }
 
-void Init() { rpc_failure_manager.Init(); }
+void Init() { GetRpcFailureManager().Init(); }
 
 }  // namespace testing
 }  // namespace rpc

--- a/src/ray/rpc/rpc_chaos.cc
+++ b/src/ray/rpc/rpc_chaos.cc
@@ -61,7 +61,7 @@ class RpcFailureManager {
         std::vector<std::string> colon_split = absl::StrSplit(equal_split[1], ':');
         RAY_CHECK_EQ(colon_split.size(), 3UL);
         auto [iter, _] = failable_methods_.emplace(equal_split[0],
-                                                   Failable{std::stoi(colon_split[0]),
+                                                   Failable{std::stol(colon_split[0]),
                                                             std::stoul(colon_split[1]),
                                                             std::stoul(colon_split[2])});
         const auto &failable = iter->second;
@@ -111,7 +111,7 @@ class RpcFailureManager {
 
   // call name -> (num_remaining_failures, req_failure_prob, resp_failure_prob)
   struct Failable {
-    int num_remaining_failures;
+    int64_t num_remaining_failures;
     size_t req_failure_prob;
     size_t resp_failure_prob;
   };

--- a/src/ray/rpc/rpc_chaos.cc
+++ b/src/ray/rpc/rpc_chaos.cc
@@ -35,8 +35,9 @@ namespace testing {
 // contains the max number of failures to inject + probability of req failure +
 // probability of reply failure.
 
-// You can also use this to set probabilities for all rpc's.
-//     export RAY_testing_all_rpc_failure=25:50
+// You can also use a wildcard to set probabilities for all rpc's and -1 as num_failures
+// to have unlimited failures.
+//     export RAY_testing_rpc_failure="*=-1:25:50"
 // This will set the probabilities for all rpc's to 25% for request failures and 50% for
 // reply failures.
 

--- a/src/ray/rpc/rpc_chaos.cc
+++ b/src/ray/rpc/rpc_chaos.cc
@@ -117,6 +117,10 @@ class RpcFailureManager {
   absl::flat_hash_map<std::string, Failable> failable_methods_ ABSL_GUARDED_BY(&mu_);
 
   RpcFailure GetFailureTypeFromFailable(Failable &failable) {
+    if (failable.num_remaining_failures == 0) {
+      // If < 0, unlimited failures.
+      return RpcFailure::None;
+    }
     std::uniform_int_distribution<size_t> dist(1ul, 100ul);
     const size_t random_number = dist(gen_);
     if (random_number <= failable.req_failure_prob) {

--- a/src/ray/rpc/rpc_chaos.cc
+++ b/src/ray/rpc/rpc_chaos.cc
@@ -47,6 +47,13 @@ class RpcFailureManager {
   void Init() {
     absl::MutexLock lock(&mu_);
 
+    // Clear old state
+    failable_methods_.clear();
+    all_rpc_failure_ = false;
+    req_failure_prob_ = 0;
+    resp_failure_prob_ = 0;
+    has_failures_ = false;
+
     if (!RayConfig::instance().testing_all_rpc_failure().empty()) {
       std::vector<std::string> colon_split =
           absl::StrSplit(RayConfig::instance().testing_all_rpc_failure(), ':');
@@ -84,7 +91,7 @@ class RpcFailureManager {
       return RpcFailure::None;
     }
 
-    absl::MutexLock lock(&mu_);
+    absl::ReaderMutexLock lock(&mu_);
 
     if (all_rpc_failure_) {
       return GetFailureTypeFromProbs(req_failure_prob_, resp_failure_prob_);

--- a/src/ray/rpc/rpc_chaos.h
+++ b/src/ray/rpc/rpc_chaos.h
@@ -20,7 +20,7 @@ namespace ray {
 namespace rpc {
 namespace testing {
 
-enum class RpcFailure {
+enum class RpcFailure : uint8_t {
   None,
   // Failure before server receives the request
   Request,

--- a/src/ray/rpc/tests/rpc_chaos_test.cc
+++ b/src/ray/rpc/tests/rpc_chaos_test.cc
@@ -17,53 +17,47 @@
 #include "gtest/gtest.h"
 #include "ray/common/ray_config.h"
 
+namespace ray::rpc::testing {
+
 TEST(RpcChaosTest, MethodRpcFailure) {
-  RayConfig::instance().testing_rpc_failure() = "method1=0:25:25,method2=1:25:25";
-  ray::rpc::testing::Init();
-  ASSERT_EQ(ray::rpc::testing::GetRpcFailure("unknown"),
-            ray::rpc::testing::RpcFailure::None);
-  ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method1"),
-            ray::rpc::testing::RpcFailure::None);
+  RayConfig::instance().testing_rpc_failure() = "method1=0:25:25,method2=1:100:0";
+  Init();
+  ASSERT_EQ(GetRpcFailure("unknown"), RpcFailure::None);
+  ASSERT_EQ(GetRpcFailure("method1"), RpcFailure::None);
   // At most one failure.
-  ASSERT_FALSE(ray::rpc::testing::GetRpcFailure("method2") !=
-                   ray::rpc::testing::RpcFailure::None &&
-               ray::rpc::testing::GetRpcFailure("method2") !=
-                   ray::rpc::testing::RpcFailure::None);
+  ASSERT_TRUE(GetRpcFailure("method2") == RpcFailure::Request);
+  ASSERT_TRUE(GetRpcFailure("method2") == RpcFailure::None);
 }
 
 TEST(RpcChaosTest, MethodRpcFailureEdgeCase) {
   RayConfig::instance().testing_rpc_failure() =
       "method1=1000:100:0,method2=1000:0:100,method3=1000:0:0";
-  ray::rpc::testing::Init();
+  Init();
   for (int i = 0; i < 1000; i++) {
-    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method1"),
-              ray::rpc::testing::RpcFailure::Request);
-    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method2"),
-              ray::rpc::testing::RpcFailure::Response);
-    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method3"),
-              ray::rpc::testing::RpcFailure::None);
+    ASSERT_EQ(GetRpcFailure("method1"), RpcFailure::Request);
+    ASSERT_EQ(GetRpcFailure("method2"), RpcFailure::Response);
+    ASSERT_EQ(GetRpcFailure("method3"), RpcFailure::None);
   }
 }
 
 TEST(RpcChaosTest, WildcardRpcFailure) {
   RayConfig::instance().testing_rpc_failure() = "*=-1:100:0";
-  ray::rpc::testing::Init();
+  Init();
   for (int i = 0; i < 100; i++) {
-    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),
-              ray::rpc::testing::RpcFailure::Request);
+    ASSERT_EQ(GetRpcFailure("method"), RpcFailure::Request);
   }
 
   RayConfig::instance().testing_rpc_failure() = "*=-1:0:100";
-  ray::rpc::testing::Init();
+  Init();
   for (int i = 0; i < 100; i++) {
-    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),
-              ray::rpc::testing::RpcFailure::Response);
+    ASSERT_EQ(GetRpcFailure("method"), RpcFailure::Response);
   }
 
   RayConfig::instance().testing_rpc_failure() = "*=-1:0:0";
-  ray::rpc::testing::Init();
+  Init();
   for (int i = 0; i < 100; i++) {
-    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),
-              ray::rpc::testing::RpcFailure::None);
+    ASSERT_EQ(GetRpcFailure("method"), RpcFailure::None);
   }
 }
+
+}  // namespace ray::rpc::testing

--- a/src/ray/rpc/tests/rpc_chaos_test.cc
+++ b/src/ray/rpc/tests/rpc_chaos_test.cc
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include "ray/common/ray_config.h"
 
-TEST(RpcChaosTest, Basic) {
+TEST(RpcChaosTest, MethodRpcFailure) {
   RayConfig::instance().testing_rpc_failure() = "method1=0:25:25,method2=1:25:25";
   ray::rpc::testing::Init();
   ASSERT_EQ(ray::rpc::testing::GetRpcFailure("unknown"),
@@ -31,7 +31,7 @@ TEST(RpcChaosTest, Basic) {
                    ray::rpc::testing::RpcFailure::None);
 }
 
-TEST(RpcChaosTest, EdgeCaseProbability) {
+TEST(RpcChaosTest, MethodRpcFailureEdgeCase) {
   RayConfig::instance().testing_rpc_failure() =
       "method1=1000:100:0,method2=1000:0:100,method3=1000:0:0";
   ray::rpc::testing::Init();
@@ -41,6 +41,29 @@ TEST(RpcChaosTest, EdgeCaseProbability) {
     ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method2"),
               ray::rpc::testing::RpcFailure::Response);
     ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method3"),
+              ray::rpc::testing::RpcFailure::None);
+  }
+}
+
+TEST(RpcChaosTest, AllRpcFailure) {
+  RayConfig::instance().testing_all_rpc_failure() = "100:0";
+  ray::rpc::testing::Init();
+  for (int i = 0; i < 100; i++) {
+    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),
+              ray::rpc::testing::RpcFailure::Request);
+  }
+
+  RayConfig::instance().testing_all_rpc_failure() = "0:100";
+  ray::rpc::testing::Init();
+  for (int i = 0; i < 100; i++) {
+    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),
+              ray::rpc::testing::RpcFailure::Response);
+  }
+
+  RayConfig::instance().testing_all_rpc_failure() = "0:0";
+  ray::rpc::testing::Init();
+  for (int i = 0; i < 100; i++) {
+    ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),
               ray::rpc::testing::RpcFailure::None);
   }
 }

--- a/src/ray/rpc/tests/rpc_chaos_test.cc
+++ b/src/ray/rpc/tests/rpc_chaos_test.cc
@@ -45,22 +45,22 @@ TEST(RpcChaosTest, MethodRpcFailureEdgeCase) {
   }
 }
 
-TEST(RpcChaosTest, AllRpcFailure) {
-  RayConfig::instance().testing_all_rpc_failure() = "100:0";
+TEST(RpcChaosTest, WildcardRpcFailure) {
+  RayConfig::instance().testing_rpc_failure() = "*=-1:100:0";
   ray::rpc::testing::Init();
   for (int i = 0; i < 100; i++) {
     ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),
               ray::rpc::testing::RpcFailure::Request);
   }
 
-  RayConfig::instance().testing_all_rpc_failure() = "0:100";
+  RayConfig::instance().testing_rpc_failure() = "*=-1:0:100";
   ray::rpc::testing::Init();
   for (int i = 0; i < 100; i++) {
     ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),
               ray::rpc::testing::RpcFailure::Response);
   }
 
-  RayConfig::instance().testing_all_rpc_failure() = "0:0";
+  RayConfig::instance().testing_rpc_failure() = "*=-1:0:0";
   ray::rpc::testing::Init();
   for (int i = 0; i < 100; i++) {
     ASSERT_EQ(ray::rpc::testing::GetRpcFailure("method"),


### PR DESCRIPTION
## Why are these changes needed?
We want an easier way to run chaos tests that inject rpc failures for all rpc's, so this introduces a way you can inject for unlimited failures for all rpc's, using something like this:
```
RAY_testing_rpc_failure=*=-1:25:50
```
to inject failures for all all rpc's, 25% rate for request failures and 50% rate for reply failures.
