### PR TITLE
[Data] Make operator `target_max_block_size` optional and rename as override

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1098,8 +1098,6 @@ python/ray/data/_internal/execution/interfaces/task_context.py
 python/ray/data/_internal/execution/operators/base_physical_operator.py
     DOC101: Method `OneToOneOperator.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `OneToOneOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext].
-    DOC101: Method `AllToAllOperator.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `AllToAllOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, target_max_block_size: Optional[int]].
     DOC103: Method `NAryOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*input_ops: LogicalOperator, data_context: DataContext]. Arguments in the docstring but not in the function signature: [input_op: , name: ].
 --------------------
 python/ray/data/_internal/execution/operators/hash_shuffle.py

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -251,7 +251,7 @@ class PhysicalOperator(Operator):
         name: str,
         input_dependencies: List["PhysicalOperator"],
         data_context: DataContext,
-        target_max_block_size: Optional[int],
+        target_max_block_size_override: Optional[int] = None,
     ):
         super().__init__(name, input_dependencies)
 
@@ -259,7 +259,7 @@ class PhysicalOperator(Operator):
             assert isinstance(x, PhysicalOperator), x
         self._inputs_complete = not input_dependencies
         self._output_block_size_option = None
-        self.set_target_max_block_size(target_max_block_size)
+        self.override_target_max_block_size(target_max_block_size_override)
         self._started = False
         self._shutdown = False
         self._in_task_submission_backpressure = False
@@ -307,15 +307,15 @@ class PhysicalOperator(Operator):
         self._logical_operators = list(logical_ops)
 
     @property
-    def target_max_block_size(self) -> Optional[int]:
+    def target_max_block_size_override(self) -> Optional[int]:
         """
         Target max block size output by this operator. If this returns None,
         then the default from DataContext should be used.
         """
-        if self._output_block_size_option is None:
+        if self._output_block_size_option_override is None:
             return None
         else:
-            return self._output_block_size_option.target_max_block_size
+            return self._output_block_size_option_override.target_max_block_size
 
     @property
     def actual_target_max_block_size(self) -> Optional[int]:
@@ -330,13 +330,13 @@ class PhysicalOperator(Operator):
             target_max_block_size = self.data_context.target_max_block_size
         return target_max_block_size
 
-    def set_target_max_block_size(self, target_max_block_size: Optional[int]):
+    def override_target_max_block_size(self, target_max_block_size: Optional[int]):
         if target_max_block_size is not None:
-            self._output_block_size_option = OutputBlockSizeOption(
+            self._output_block_size_option_override = OutputBlockSizeOption(
                 target_max_block_size=target_max_block_size
             )
-        elif self._output_block_size_option is not None:
-            self._output_block_size_option = None
+        elif self._output_block_size_option_override is not None:
+            self._output_block_size_option_override = None
 
     def mark_execution_finished(self):
         """Manually mark that this operator has finished execution."""

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -325,8 +325,11 @@ class PhysicalOperator(Operator):
             `None` if the target max block size is not set, otherwise the target max block size.
             `None` means the block size is infinite.
         """
-        target_max_block_size = self.target_max_block_size
-        if target_max_block_size is None:
+        if self._output_block_size_option_override is not None:
+            target_max_block_size = (
+                self._output_block_size_option_override.target_max_block_size
+            )
+        else:
             target_max_block_size = self.data_context.target_max_block_size
         return target_max_block_size
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -258,7 +258,7 @@ class PhysicalOperator(Operator):
         for x in input_dependencies:
             assert isinstance(x, PhysicalOperator), x
         self._inputs_complete = not input_dependencies
-        self._output_block_size_option = None
+        self._output_block_size_option_override = None
         self.override_target_max_block_size(target_max_block_size_override)
         self._started = False
         self._shutdown = False

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -325,11 +325,8 @@ class PhysicalOperator(Operator):
             `None` if the target max block size is not set, otherwise the target max block size.
             `None` means the block size is infinite.
         """
-        if self._output_block_size_option_override is not None:
-            target_max_block_size = (
-                self._output_block_size_option_override.target_max_block_size
-            )
-        else:
+        target_max_block_size = self.target_max_block_size_override
+        if target_max_block_size is None:
             target_max_block_size = self.data_context.target_max_block_size
         return target_max_block_size
 

--- a/python/ray/data/_internal/execution/interfaces/task_context.py
+++ b/python/ray/data/_internal/execution/interfaces/task_context.py
@@ -44,8 +44,8 @@ class TaskContext:
     # This should be set if upstream_map_transformer is set.
     upstream_map_ray_remote_args: Optional[Dict[str, Any]] = None
 
-    # The target maximum number of bytes to include in the task's output block.
-    target_max_block_size: Optional[int] = None
+    # Override of the target max-block-size for the task
+    target_max_block_size_override: Optional[int] = None
 
     # Additional keyword arguments passed to the task.
     kwargs: Dict[str, Any] = field(default_factory=dict)

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -65,7 +65,6 @@ class ActorPoolMapOperator(MapOperator):
         map_transformer: MapTransformer,
         input_op: PhysicalOperator,
         data_context: DataContext,
-        target_max_block_size: Optional[int],
         compute_strategy: ActorPoolStrategy,
         name: str = "ActorPoolMap",
         min_rows_per_bundle: Optional[int] = None,
@@ -73,6 +72,7 @@ class ActorPoolMapOperator(MapOperator):
         map_task_kwargs: Optional[Dict[str, Any]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        target_max_block_size_override: Optional[int] = None,
     ):
         """Create an ActorPoolMapOperator instance.
 
@@ -81,8 +81,6 @@ class ActorPoolMapOperator(MapOperator):
                 to each ref bundle input.
             input_op: Operator generating input data for this op.
             data_context: The DataContext instance containing configuration settings.
-            target_max_block_size: The target maximum number of bytes to
-                include in an output block.
             compute_strategy: `ComputeStrategy` used for this operator.
             name: The name of this operator.
             min_rows_per_bundle: The number of rows to gather per batch passed to the
@@ -100,13 +98,15 @@ class ActorPoolMapOperator(MapOperator):
                 advanced, experimental feature.
             ray_remote_args: Customize the ray remote args for this op's tasks.
                 See :func:`ray.remote` for details.
+            target_max_block_size_override: The target maximum number of bytes to
+                include in an output block.
         """
         super().__init__(
             map_transformer,
             input_op,
             data_context,
             name,
-            target_max_block_size,
+            target_max_block_size_override,
             min_rows_per_bundle,
             supports_fusion,
             map_task_kwargs,
@@ -301,7 +301,7 @@ class ActorPoolMapOperator(MapOperator):
             ctx = TaskContext(
                 task_idx=self._next_data_task_idx,
                 op_name=self.name,
-                target_max_block_size=self.actual_target_max_block_size,
+                target_max_block_size_override=self.actual_target_max_block_size,
             )
             gen = actor.submit.options(
                 num_returns="streaming",

--- a/python/ray/data/_internal/execution/operators/aggregate_num_rows.py
+++ b/python/ray/data/_internal/execution/operators/aggregate_num_rows.py
@@ -23,7 +23,6 @@ class AggregateNumRows(PhysicalOperator):
             "AggregateNumRows",
             input_dependencies,
             data_context,
-            target_max_block_size=None,
         )
 
         self._column_name = column_name

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -31,16 +31,16 @@ class OneToOneOperator(PhysicalOperator):
         name: str,
         input_op: PhysicalOperator,
         data_context: DataContext,
-        target_max_block_size: Optional[int],
+        target_max_block_size_override: Optional[int] = None,
     ):
         """Create a OneToOneOperator.
         Args:
             input_op: Operator generating input data for this op.
             name: The name of this operator.
-            target_max_block_size: The target maximum number of bytes to
+            target_max_block_size_override: The target maximum number of bytes to
                 include in an output block.
         """
-        super().__init__(name, [input_op], data_context, target_max_block_size)
+        super().__init__(name, [input_op], data_context, target_max_block_size_override)
 
     @property
     def input_dependency(self) -> PhysicalOperator:
@@ -58,7 +58,7 @@ class AllToAllOperator(InternalQueueOperatorMixin, PhysicalOperator):
         bulk_fn: AllToAllTransformFn,
         input_op: PhysicalOperator,
         data_context: DataContext,
-        target_max_block_size: Optional[int],
+        target_max_block_size_override: Optional[int] = None,
         num_outputs: Optional[int] = None,
         sub_progress_bar_names: Optional[List[str]] = None,
         name: str = "AllToAll",
@@ -69,6 +69,9 @@ class AllToAllOperator(InternalQueueOperatorMixin, PhysicalOperator):
                 list of input ref bundles, and the outputs are the output ref bundles
                 and a stats dict.
             input_op: Operator generating input data for this op.
+            data_context: The DataContext instance containing configuration settings.
+            target_max_block_size_override: The target maximum number of bytes to
+                include in an output block.
             num_outputs: The number of expected output bundles for progress bar.
             sub_progress_bar_names: The names of internal sub progress bars.
             name: The name of this operator.
@@ -82,7 +85,7 @@ class AllToAllOperator(InternalQueueOperatorMixin, PhysicalOperator):
         self._input_buffer: List[RefBundle] = []
         self._output_buffer: List[RefBundle] = []
         self._stats: StatsDict = {}
-        super().__init__(name, [input_op], data_context, target_max_block_size)
+        super().__init__(name, [input_op], data_context, target_max_block_size_override)
 
     def num_outputs_total(self) -> Optional[int]:
         return (
@@ -112,7 +115,7 @@ class AllToAllOperator(InternalQueueOperatorMixin, PhysicalOperator):
             task_idx=self._next_task_index,
             op_name=self.name,
             sub_progress_bar_dict=self._sub_progress_bar_dict,
-            target_max_block_size=self.actual_target_max_block_size,
+            target_max_block_size_override=self.actual_target_max_block_size,
         )
         # NOTE: We don't account object store memory use from intermediate `bulk_fn`
         # outputs (e.g., map outputs for map-reduce).
@@ -191,6 +194,4 @@ class NAryOperator(PhysicalOperator):
         """
         input_names = ", ".join([op._name for op in input_ops])
         op_name = f"{self.__class__.__name__}({input_names})"
-        super().__init__(
-            op_name, list(input_ops), data_context, target_max_block_size=None
-        )
+        super().__init__(op_name, list(input_ops), data_context)

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -426,7 +426,6 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
             name=name,
             input_dependencies=input_ops,
             data_context=data_context,
-            target_max_block_size=None,
         )
 
         if shuffle_progress_bar_name is None:

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -33,7 +33,7 @@ class InputDataBuffer(PhysicalOperator):
             num_output_blocks: The number of output blocks. If not specified, progress
                 bars total will be set based on num output bundles instead.
         """
-        super().__init__("Input", [], data_context, target_max_block_size=None)
+        super().__init__("Input", [], data_context)
         if input_data is not None:
             assert input_data_factory is None
             # Copy the input data to avoid mutating the original list.

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -29,7 +29,7 @@ class LimitOperator(OneToOneOperator):
         self._name = f"limit={limit}"
         self._output_blocks_stats: List[BlockStats] = []
         self._cur_output_bundles = 0
-        super().__init__(self._name, input_op, data_context, target_max_block_size=None)
+        super().__init__(self._name, input_op, data_context)
         if self._limit <= 0:
             self.mark_execution_finished()
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -239,7 +239,7 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
                 map_transformer,
                 input_op,
                 data_context,
-                target_max_block_size=target_max_block_size,
+                target_max_block_size_override=target_max_block_size,
                 compute_strategy=compute_strategy,
                 name=name,
                 min_rows_per_bundle=min_rows_per_bundle,
@@ -551,7 +551,7 @@ def _map_task(
     ctx.kwargs.update(kwargs)
     TaskContext.set_current(ctx)
     stats = BlockExecStats.builder()
-    map_transformer.set_target_max_block_size(ctx.target_max_block_size)
+    map_transformer.override_target_max_block_size(ctx.target_max_block_size_override)
     with MemoryProfiler(data_context.memory_usage_poll_interval_s) as profiler:
         for b_out in map_transformer.apply_transform(iter(blocks), ctx):
             # TODO(Clark): Add input file propagation from input blocks.

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -163,7 +163,7 @@ class MapTransformer:
         """Get the transform functions."""
         return self._transform_fns
 
-    def set_target_max_block_size(self, target_max_block_size: int):
+    def override_target_max_block_size(self, target_max_block_size: Optional[int]):
         if target_max_block_size is not None:
             self._output_block_size_option = OutputBlockSizeOption(
                 target_max_block_size=target_max_block_size

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -89,7 +89,7 @@ class MapTransformFn:
     def output_block_size_option(self):
         return self._output_block_size_option
 
-    def set_target_max_block_size(self, target_max_block_size: Optional[int]):
+    def override_target_max_block_size(self, target_max_block_size: Optional[int]):
         self._output_block_size_option = OutputBlockSizeOption(
             target_max_block_size=target_max_block_size
         )
@@ -221,7 +221,7 @@ class MapTransformer:
         """Apply the transform functions to the input blocks."""
         for transform_fn in self._transform_fns:
             if not transform_fn.output_block_size_option:
-                transform_fn.set_target_max_block_size(self.target_max_block_size)
+                transform_fn.override_target_max_block_size(self.target_max_block_size)
 
         iter = input_blocks
         # Apply the transform functions sequentially to the input iterable.
@@ -251,7 +251,7 @@ class MapTransformer:
 
         fused_transform_fns = self._transform_fns + other._transform_fns
         transformer = MapTransformer(fused_transform_fns, init_fn=fused_init_fn)
-        transformer.set_target_max_block_size(target_max_block_size)
+        transformer.override_target_max_block_size(target_max_block_size)
         return transformer
 
     def udf_time(self) -> float:

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -47,7 +47,6 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
             f"split({n}, equal={equal})",
             [input_op],
             data_context,
-            target_max_block_size=None,
         )
         self._equal = equal
         # Buffer of bundles not yet assigned to output splits.

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -85,7 +85,7 @@ class TaskPoolMapOperator(MapOperator):
         ctx = TaskContext(
             task_idx=self._next_data_task_idx,
             op_name=self.name,
-            target_max_block_size=self.actual_target_max_block_size,
+            target_max_block_size_override=self.actual_target_max_block_size,
         )
 
         dynamic_ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -52,7 +52,6 @@ class ZipOperator(InternalQueueOperatorMixin, PhysicalOperator):
             "Zip",
             [left_input_op, right_input_op],
             data_context,
-            target_max_block_size=None,
         )
 
     def num_outputs_total(self) -> Optional[int]:

--- a/python/ray/data/_internal/logical/rules/inherit_target_max_block_size.py
+++ b/python/ray/data/_internal/logical/rules/inherit_target_max_block_size.py
@@ -16,13 +16,13 @@ class InheritTargetMaxBlockSizeRule(Rule):
     def _propagate_target_max_block_size_to_upstream_ops(
         self, dag: PhysicalOperator, target_max_block_size: Optional[int] = None
     ):
-        if dag.target_max_block_size is not None:
+        if dag.target_max_block_size_override is not None:
             # Set the target block size to inherit for
             # upstream ops.
-            target_max_block_size = dag.target_max_block_size
+            target_max_block_size = dag.target_max_block_size_override
         elif target_max_block_size is not None:
             # Inherit from downstream op.
-            dag.set_target_max_block_size(target_max_block_size)
+            dag.override_target_max_block_size(target_max_block_size)
 
         for upstream_op in dag.input_dependencies:
             self._propagate_target_max_block_size_to_upstream_ops(

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -212,8 +212,8 @@ class FuseOperators(Rule):
             return False
 
         if not self._can_merge_target_max_block_size(
-            up_op.target_max_block_size,
-            down_op.target_max_block_size,
+            up_op.target_max_block_size_override,
+            down_op.target_max_block_size_override,
             up_op.data_context,
         ):
             return False
@@ -302,7 +302,7 @@ class FuseOperators(Rule):
         )
 
         target_max_block_size = self._get_merged_target_max_block_size(
-            up_op.target_max_block_size, down_op.target_max_block_size
+            up_op.target_max_block_size_override, down_op.target_max_block_size_override
         )
 
         compute = self._fuse_compute_strategy(
@@ -436,7 +436,7 @@ class FuseOperators(Rule):
         input_op = input_deps[0]
 
         target_max_block_size = self._get_merged_target_max_block_size(
-            up_op.target_max_block_size, down_op.target_max_block_size
+            up_op.target_max_block_size_override, down_op.target_max_block_size_override
         )
 
         assert up_op.data_context is down_op.data_context
@@ -444,7 +444,7 @@ class FuseOperators(Rule):
             fused_all_to_all_transform_fn,
             input_op,
             up_op.data_context,
-            target_max_block_size=target_max_block_size,
+            target_max_block_size_override=target_max_block_size,
             num_outputs=down_op._num_outputs,
             # Transfer over the existing sub-progress bars from
             # the AllToAllOperator (if any) into the fused operator.

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -161,7 +161,6 @@ def plan_all_to_all_op(
         fn,
         input_physical_dag,
         data_context,
-        target_max_block_size=None,
         num_outputs=op._num_outputs,
         sub_progress_bar_names=op._sub_progress_bar_names,
         name=op.name,

--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -54,7 +54,7 @@ def generate_random_shuffle_fn(
             # overhead. This can be removed once dynamic block splitting is
             # supported for all-to-all ops.
             # See https://github.com/ray-project/ray/issues/40518.
-            map_transformer.set_target_max_block_size(float("inf"))
+            map_transformer.override_target_max_block_size(float("inf"))
 
             def upstream_map_fn(blocks):
                 return map_transformer.apply_transform(blocks, ctx)
@@ -64,7 +64,7 @@ def generate_random_shuffle_fn(
             ray_remote_args = ctx.upstream_map_ray_remote_args
 
         shuffle_spec = ShuffleTaskSpec(
-            ctx.target_max_block_size,
+            ctx.target_max_block_size_override,
             random_shuffle=True,
             random_seed=seed,
             upstream_map_fn=upstream_map_fn,

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -48,13 +48,13 @@ def generate_repartition_fn(
             # overhead. This can be removed once dynamic block splitting is
             # supported for all-to-all ops.
             # See https://github.com/ray-project/ray/issues/40518.
-            map_transformer.set_target_max_block_size(float("inf"))
+            map_transformer.override_target_max_block_size(float("inf"))
 
             def upstream_map_fn(blocks):
                 return map_transformer.apply_transform(blocks, ctx)
 
         shuffle_spec = ShuffleTaskSpec(
-            ctx.target_max_block_size,
+            ctx.target_max_block_size_override,
             random_shuffle=False,
             upstream_map_fn=upstream_map_fn,
         )
@@ -77,7 +77,9 @@ def generate_repartition_fn(
         refs: List[RefBundle],
         ctx: TaskContext,
     ) -> AllToAllTransformFnResult:
-        shuffle_spec = ShuffleTaskSpec(ctx.target_max_block_size, random_shuffle=False)
+        shuffle_spec = ShuffleTaskSpec(
+            ctx.target_max_block_size_override, random_shuffle=False
+        )
         scheduler = SplitRepartitionTaskScheduler(shuffle_spec)
         return scheduler.execute(refs, num_outputs, ctx)
 

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -599,7 +599,6 @@ def test_setting_initial_size_for_actor_pool():
         map_transformer=MagicMock(),
         input_op=InputDataBuffer(data_context, input_data=MagicMock()),
         data_context=data_context,
-        target_max_block_size=None,
         compute_strategy=ray.data.ActorPoolStrategy(
             min_size=1, max_size=4, initial_size=2
         ),
@@ -620,7 +619,6 @@ def test_min_max_resource_requirements(restore_data_context):
         map_transformer=MagicMock(),
         input_op=InputDataBuffer(data_context, input_data=MagicMock()),
         data_context=data_context,
-        target_max_block_size=None,
         compute_strategy=ray.data.ActorPoolStrategy(
             min_size=1,
             max_size=2,

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -121,7 +121,7 @@ def test_all_to_all_operator():
         dummy_all_transform,
         input_op,
         DataContext.get_current(),
-        target_max_block_size=DataContext.get_current().target_max_block_size,
+        target_max_block_size_override=DataContext.get_current().target_max_block_size,
         num_outputs=2,
         sub_progress_bar_names=["Test1", "Test2"],
         name="TestAll",
@@ -172,7 +172,7 @@ def test_num_outputs_total():
         dummy_all_transform,
         input_op=op1,
         data_context=DataContext.get_current(),
-        target_max_block_size=DataContext.get_current().target_max_block_size,
+        target_max_block_size_override=DataContext.get_current().target_max_block_size,
         name="TestAll",
     )
     assert op2.num_outputs_total() is None

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -142,7 +142,6 @@ def test_disallow_non_unique_operators():
         "test_combine",
         [o2, o3],
         DataContext.get_current(),
-        target_max_block_size=None,
     )
     with pytest.raises(ValueError):
         build_streaming_topology(o4, ExecutionOptions(verbose_progress=True))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR:
* Makes the `target_max_block_size` parameter of physical operators optional
* Renames them to `target_max_block_size_override`

No behavior changes are introduced. This is purely renaming and removing unnecessary keyword arguments.

The goal is to clarify the parameter’s intent and simplify constructor calls.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
