### PR TITLE
[core] enable open telemetry by default

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -575,7 +575,7 @@ RAY_METRIC_CARDINALITY_LEVEL = os.environ.get("RAY_metric_cardinality_level", "l
 
 # Whether enable OpenTelemetry as the metrics collection backend. The default is
 # using OpenCensus.
-RAY_ENABLE_OPEN_TELEMETRY = env_bool("RAY_enable_open_telemetry", False)
+RAY_ENABLE_OPEN_TELEMETRY = env_bool("RAY_enable_open_telemetry", True)
 
 # How long to wait for a fetch to complete during ray.get before timing out and raising an exception to the user.
 #

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -198,23 +198,8 @@ def enable_grpc_metrics_collection():
     os.environ.pop("RAY_enable_grpc_metrics_collection_for", None)
 
 
-@pytest.fixture
-def enable_open_telemetry(request):
-    """
-    Fixture to enable OpenTelemetry for the test.
-    """
-    if request.param:
-        os.environ["RAY_enable_open_telemetry"] = "true"
-    else:
-        os.environ["RAY_enable_open_telemetry"] = "false"
-    yield
-    os.environ.pop("RAY_enable_open_telemetry", None)
-
-
 @pytest.mark.skipif(prometheus_client is None, reason="prometheus_client not installed")
-@pytest.mark.parametrize("enable_open_telemetry", [True, False], indirect=True)
 def test_prometheus_physical_stats_record(
-    enable_open_telemetry,
     enable_grpc_metrics_collection,
     enable_test_module,
     shutdown_only,

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -84,28 +84,6 @@ py_test_module_list(
 
 py_test_module_list(
     size = "medium",
-    env = {
-        "RAY_enable_open_telemetry": "true",
-    },
-    files = [
-        "test_metric_cardinality.py",
-        "test_metrics_agent.py",
-        "test_task_metrics.py",
-    ],
-    name_suffix = "_otel",
-    tags = [
-        "exclusive",
-        "medium_size_python_tests_a_to_j",
-        "team:core",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test_module_list(
-    size = "medium",
     files = [
         "test_global_gc.py",
         "test_job.py",

--- a/python/ray/tests/test_actor_bounded_threads.py
+++ b/python/ray/tests/test_actor_bounded_threads.py
@@ -7,6 +7,7 @@ from typing import Dict
 import pytest
 
 import ray
+from ray._private.test_utils import wait_for_dashboard_agent_available
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +72,12 @@ def fibonacci(a, i):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="procfs only works on linux.")
-def test_threaded_actor_have_bounded_num_of_threads(shutdown_only):
-    ray.init()
+def test_threaded_actor_have_bounded_num_of_threads(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node()
+    cluster.wait_for_nodes()
+    wait_for_dashboard_agent_available(cluster)
+    ray.init(address=cluster.address)
 
     @ray.remote
     class A:
@@ -97,8 +102,12 @@ def test_threaded_actor_have_bounded_num_of_threads(shutdown_only):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="procfs only works on linux.")
-def test_async_actor_have_bounded_num_of_threads(shutdown_only):
-    ray.init()
+def test_async_actor_have_bounded_num_of_threads(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node()
+    cluster.wait_for_nodes()
+    wait_for_dashboard_agent_available(cluster)
+    ray.init(address=cluster.address)
 
     @ray.remote
     class A:
@@ -123,8 +132,12 @@ def test_async_actor_have_bounded_num_of_threads(shutdown_only):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="procfs only works on linux.")
-def test_async_actor_cg_have_bounded_num_of_threads(shutdown_only):
-    ray.init()
+def test_async_actor_cg_have_bounded_num_of_threads(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node()
+    cluster.wait_for_nodes()
+    wait_for_dashboard_agent_available(cluster)
+    ray.init(address=cluster.address)
 
     @ray.remote(concurrency_groups={"io": 2, "compute": 4})
     class A:

--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -9,7 +9,8 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray._private.test_utils import (
-    raw_metrics,
+    PrometheusTimeseries,
+    raw_metric_timeseries,
     run_string_as_driver,
 )
 from ray._private.worker import RayContext
@@ -20,8 +21,8 @@ _SYSTEM_CONFIG = {
 }
 
 
-def actors_by_state(info: RayContext) -> Dict:
-    res = raw_metrics(info)
+def actors_by_state(info: RayContext, timeseries: PrometheusTimeseries) -> Dict:
+    res = raw_metric_timeseries(info, timeseries)
     actors_info = defaultdict(int)
     if "ray_actors" in res:
         for sample in res["ray_actors"]:
@@ -33,8 +34,8 @@ def actors_by_state(info: RayContext) -> Dict:
     return actors_info
 
 
-def actors_by_name(info: RayContext) -> Dict:
-    res = raw_metrics(info)
+def actors_by_name(info: RayContext, timeseries: PrometheusTimeseries) -> Dict:
+    res = raw_metric_timeseries(info, timeseries)
     actors_info = defaultdict(int)
     if "ray_actors" in res:
         for sample in res["ray_actors"]:
@@ -78,6 +79,7 @@ def test_basic_states(shutdown_only):
     ray.get(b.ping.remote())
     ray.get(c.ping.remote())
     d = Actor.remote()
+    timeseries = PrometheusTimeseries()
 
     # Test creation states.
     expected = {
@@ -86,7 +88,7 @@ def test_basic_states(shutdown_only):
         "PENDING_CREATION": 1,
     }
     wait_for_condition(
-        lambda: actors_by_state(info) == expected,
+        lambda: actors_by_state(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )
@@ -101,7 +103,7 @@ def test_basic_states(shutdown_only):
         "PENDING_CREATION": 1,
     }
     wait_for_condition(
-        lambda: actors_by_state(info) == expected,
+        lambda: actors_by_state(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )
@@ -121,14 +123,14 @@ def test_destroy_actors(shutdown_only):
     c = Actor.remote()
     del a
     del b
-
+    timeseries = PrometheusTimeseries()
     expected = {
         "ALIVE": 1,
         "ALIVE_IDLE": 1,
         "DEAD": 2,
     }
     wait_for_condition(
-        lambda: actors_by_state(info) == expected,
+        lambda: actors_by_state(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )
@@ -154,12 +156,13 @@ ray.get([actor.ready.remote() for actor in actors])
 
         output = run_string_as_driver(driver)
         print(output)
+        timeseries = PrometheusTimeseries()
 
         expected = {
             "DEAD": 10,
         }
         wait_for_condition(
-            lambda: actors_by_state(info) == expected,
+            lambda: expected.items() <= actors_by_state(info, timeseries).items(),
             timeout=20,
             retry_interval_ms=500,
         )
@@ -173,7 +176,7 @@ ray.get([actor.ready.remote() for actor in actors])
         wait_for_condition(lambda: len(list_actors()) == 5)
         # DEAD count shouldn't be changed.
         wait_for_condition(
-            lambda: actors_by_state(info) == expected,
+            lambda: expected.items() <= actors_by_state(info, timeseries).items(),
             timeout=20,
             retry_interval_ms=500,
         )
@@ -192,11 +195,12 @@ def test_dep_wait(shutdown_only):
             pass
 
     a = Actor.remote(sleep.remote())
+    timeseries = PrometheusTimeseries()
     expected = {
         "DEPENDENCIES_UNREADY": 1,
     }
     wait_for_condition(
-        lambda: actors_by_state(info) == expected,
+        lambda: actors_by_state(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )
@@ -220,12 +224,13 @@ def test_async_actor(shutdown_only):
 
     a = AsyncActor.remote()
     a.sleep.remote()
+    timeseries = PrometheusTimeseries()
     expected = {
         "ALIVE": 1,
         "ALIVE_RUNNING_TASKS": 1,
     }
     wait_for_condition(
-        lambda: actors_by_state(info) == expected,
+        lambda: actors_by_state(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )
@@ -238,7 +243,7 @@ def test_async_actor(shutdown_only):
         "ALIVE_RUNNING_TASKS": 1,
     }
     wait_for_condition(
-        lambda: actors_by_state(info) == expected,
+        lambda: actors_by_state(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )
@@ -262,7 +267,7 @@ def test_tracking_by_name(shutdown_only):
 
     a = Actor1.remote()
     b = Actor2.remote()
-
+    timeseries = PrometheusTimeseries()
     expected = {
         # one reported by gcs as ALIVE
         # another reported by core worker as IDLE
@@ -270,7 +275,7 @@ def test_tracking_by_name(shutdown_only):
         "Actor2": 2,
     }
     wait_for_condition(
-        lambda: actors_by_name(info) == expected,
+        lambda: actors_by_name(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -267,7 +267,7 @@ def test_worker_thread_count(monkeypatch, shutdown_only):
         ray.get(actor.get_thread_count.remote())
     # Lowering these numbers in this assert should be celebrated,
     # increasing these numbers should be scrutinized
-    assert ray.get(actor.get_thread_count.remote()) in {24, 25, 26}
+    assert ray.get(actor.get_thread_count.remote()) in {21, 22, 23}
 
 
 # https://github.com/ray-project/ray/issues/7287

--- a/python/ray/tests/test_metric_cardinality.py
+++ b/python/ray/tests/test_metric_cardinality.py
@@ -18,7 +18,6 @@ from ray._private.telemetry.metric_cardinality import (
     TASK_OR_ACTOR_NAME_TAG_KEY,
 )
 
-from ray._private.ray_constants import RAY_ENABLE_OPEN_TELEMETRY
 
 try:
     import prometheus_client
@@ -42,7 +41,6 @@ def _setup_cluster_for_test(request, ray_start_cluster):
             "metrics_report_interval_ms": 1000,
             "enable_metrics_collection": True,
             "metric_cardinality_level": core_metric_cardinality_level,
-            "enable_open_telemetry": RAY_ENABLE_OPEN_TELEMETRY,
         }
     )
     cluster.wait_for_nodes()
@@ -137,7 +135,7 @@ def _cardinality_level_test(_setup_cluster_for_test, cardinality_level, metric):
     "_setup_cluster_for_test,cardinality_level,metric",
     [
         (cardinality, cardinality, metric)
-        for cardinality in ["recommended", "legacy"]
+        for cardinality in ["low", "recommended", "legacy"]
         for metric in _TO_TEST_METRICS
     ],
     indirect=["_setup_cluster_for_test"],
@@ -145,22 +143,6 @@ def _cardinality_level_test(_setup_cluster_for_test, cardinality_level, metric):
 def test_cardinality_recommended_and_legacy_levels(
     _setup_cluster_for_test, cardinality_level, metric
 ):
-    _cardinality_level_test(_setup_cluster_for_test, cardinality_level, metric)
-
-
-# We only enable low cardinality test for open telemetry because the legacy opencensus
-# implementation doesn't support low cardinality.
-@pytest.mark.skipif(prometheus_client is None, reason="Prometheus not installed")
-@pytest.mark.skipif(
-    not RAY_ENABLE_OPEN_TELEMETRY,
-    reason="OpenTelemetry is not enabled",
-)
-@pytest.mark.parametrize(
-    "_setup_cluster_for_test,cardinality_level,metric",
-    [("low", "low", metric) for metric in _TO_TEST_METRICS],
-    indirect=["_setup_cluster_for_test"],
-)
-def test_cardinality_low_levels(_setup_cluster_for_test, cardinality_level, metric):
     _cardinality_level_test(_setup_cluster_for_test, cardinality_level, metric)
 
 

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -6,7 +6,6 @@ import signal
 import sys
 import time
 import warnings
-from collections import defaultdict
 from pprint import pformat
 from unittest.mock import MagicMock
 
@@ -24,7 +23,6 @@ from ray._private.metrics_agent import (
 )
 from ray._private.ray_constants import (
     PROMETHEUS_SERVICE_DISCOVERY_FILE,
-    RAY_ENABLE_OPEN_TELEMETRY,
 )
 from ray._private.test_utils import (
     PrometheusTimeseries,
@@ -207,7 +205,6 @@ def _setup_cluster_for_test(request, ray_start_cluster):
             "event_stats_print_interval_ms": 500,
             "event_stats": True,
             "enable_metrics_collection": enable_metrics_collection,
-            "enable_open_telemetry": RAY_ENABLE_OPEN_TELEMETRY,
         }
     )
     # Add worker nodes.
@@ -316,19 +313,9 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
         # The list of custom or user defined metrics. Open Telemetry backend does not
         # support exporting Counter as Gauge, so we skip some metrics in that case.
         custom_metrics = (
-            [
-                "test_counter",
-                "test_counter_total",
-                "test_driver_counter",
-                "test_driver_counter_total",
-                "test_gauge",
-            ]
-            if not RAY_ENABLE_OPEN_TELEMETRY
-            else [
-                "test_counter_total",
-                "test_driver_counter_total",
-                "test_gauge",
-            ]
+            "test_counter_total",
+            "test_driver_counter_total",
+            "test_gauge",
         )
 
         # Make sure our user defined metrics exist and have the correct types
@@ -743,64 +730,6 @@ def test_histogram(_setup_cluster_for_test):
     except RuntimeError:
         print(f"The components are {pformat(timeseries)}")
         test_cases()  # Should fail assert
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Not working in Windows.")
-@pytest.mark.skipif(
-    RAY_ENABLE_OPEN_TELEMETRY,
-    reason="OpenTelemetry backend does not support Counter exported as gauge.",
-)
-def test_counter_exported_as_gauge(shutdown_only):
-    # Test to make sure Counter emits the right Prometheus metrics
-    context = ray.init()
-    timeseries = PrometheusTimeseries()
-
-    @ray.remote
-    class Actor:
-        def __init__(self):
-            self.counter = Counter("test_counter", description="desc")
-            self.counter.inc(2.0)
-            self.counter.inc(3.0)
-
-            self.counter_with_total_suffix = Counter(
-                "test_counter2_total", description="desc2"
-            )
-            self.counter_with_total_suffix.inc(1.5)
-
-    _ = Actor.remote()
-
-    def check_metrics():
-        metrics_page = "localhost:{}".format(
-            context.address_info["metrics_export_port"]
-        )
-        fetch_prometheus_timeseries([metrics_page], timeseries)
-        metric_descriptors = timeseries.metric_descriptors
-        metric_samples = timeseries.metric_samples.values()
-        metric_samples_by_name = defaultdict(list)
-        for metric_sample in metric_samples:
-            metric_samples_by_name[metric_sample.name].append(metric_sample)
-
-        assert "ray_test_counter" in metric_descriptors
-        assert metric_descriptors["ray_test_counter"].type == "gauge"
-        assert (
-            metric_descriptors["ray_test_counter"].documentation
-            == "(DEPRECATED, use ray_test_counter_total metric instead) desc"
-        )
-        assert metric_samples_by_name["ray_test_counter"][-1].value == 5.0
-
-        assert "ray_test_counter_total" in metric_descriptors
-        assert metric_descriptors["ray_test_counter_total"].type == "counter"
-        assert metric_descriptors["ray_test_counter_total"].documentation == "desc"
-        assert metric_samples_by_name["ray_test_counter_total"][-1].value == 5.0
-
-        assert "ray_test_counter2_total" in metric_descriptors
-        assert metric_descriptors["ray_test_counter2_total"].type == "counter"
-        assert metric_descriptors["ray_test_counter2_total"].documentation == "desc2"
-        assert metric_samples_by_name["ray_test_counter2_total"][-1].value == 1.5
-
-        return True
-
-    wait_for_condition(check_metrics, timeout=60)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not working in Windows.")

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -200,19 +200,19 @@ class Counter(Metric):
         else:
             if env_bool("RAY_enable_open_telemetry", False):
                 """
+                For the previous opencensus implementation, we used Sum to support
+                exporting Counter as a gauge metric. We'll drop that feature in the
+                new opentelemetry implementation.
+                """
+                self._metric = CythonSum(self._name, self._description, self._tag_keys)
+            else:
+                """
                 For the new opentelemetry implementation, we'll correctly use Counter
                 rather than Sum.
                 """
                 self._metric = CythonCount(
                     self._name, self._description, self._tag_keys
                 )
-            else:
-                """
-                For the previous opencensus implementation, we used Sum to support
-                exporting Counter as a gauge metric. We'll drop that feature in the
-                new opentelemetry implementation.
-                """
-                self._metric = CythonSum(self._name, self._description, self._tag_keys)
 
     def __reduce__(self):
         deserializer = self.__class__

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -531,7 +531,7 @@ RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
 
 /// Whether enable OpenTelemetry as the metrics collection backend. The default is
 /// using OpenCensus.
-RAY_CONFIG(bool, enable_open_telemetry, false)
+RAY_CONFIG(bool, enable_open_telemetry, true)
 
 /// Whether to enable Ray Event as the event collection backend. The default is
 /// using the Export API.

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -388,8 +388,7 @@ class Stats {
       open_telemetry_tags[tag_key.name()] = "";
     }
     for (const auto &tag : open_census_tags) {
-      const std::string &key = tag.first.name();
-      auto it = open_telemetry_tags.find(key);
+      auto it = open_telemetry_tags.find(tag.first.name());
       if (it != open_telemetry_tags.end()) {
         it->second = tag.second;
       }

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -388,7 +388,8 @@ class Stats {
       open_telemetry_tags[tag_key.name()] = "";
     }
     for (const auto &tag : open_census_tags) {
-      auto it = open_telemetry_tags.find(tag.first.name());
+      const std::string &key = tag.first.name();
+      auto it = open_telemetry_tags.find(key);
       if (it != open_telemetry_tags.end()) {
         it->second = tag.second;
       }

--- a/src/ray/stats/tests/BUILD.bazel
+++ b/src/ray/stats/tests/BUILD.bazel
@@ -4,9 +4,6 @@ ray_cc_test(
     name = "metric_with_open_telemetry_test",
     size = "small",
     srcs = ["metric_with_open_telemetry_test.cc"],
-    env = {
-        "RAY_enable_open_telemetry": "true",
-    },
     tags = ["team:core"],
     deps = [
         "//src/ray/stats:stats_metric",


### PR DESCRIPTION
This PR enables open telemetry as the default backend for ray metric stack. The bulk of this PR is actually to fix tests that were written with some assumptions that no longer hold true. For ease of reviewing, I inline the reasons for the change together with the change for each tests in the comments.

This PR also depends on a release of vllm (so that we can update the minimal supported version of vllm in ray).

Test:
- CI


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable OpenTelemetry metrics backend by default and refactor metrics/Serve tests to use timeseries APIs and updated `ray_serve_*` metric names.
> 
> - **Core/Config**:
>   - Default-enable OpenTelemetry: set `RAY_enable_open_telemetry` to `true` in `ray_constants.py` and `ray_config_def.h`.
>   - Metrics `Counter`: use `CythonCount` by default; keep legacy `CythonSum` only when OTEL is explicitly disabled.
> - **Serve/Metrics Tests**:
>   - Replace text scraping with `PrometheusTimeseries` and `fetch_prometheus_metric_timeseries` throughout.
>   - Update metric names/tags to `ray_serve_*` and counter suffixes `*_total`; adjust latency metric names and processing/queued gauges.
>   - Reduce ad-hoc HTTP scrapes; plumb a reusable `timeseries` object and pass through helpers.
> - **General Test Fixes**:
>   - Remove OTEL parametrization/fixtures; simplify expectations where counters-as-gauges no longer apply; drop related tests.
>   - Cardinality tests: include `"low"` level and remove OTEL gating; stop injecting `enable_open_telemetry` in system config.
>   - Actor/state/thread tests: migrate to cluster fixtures, wait for dashboard agent, and adjust expected worker thread counts.
> - **Build**:
>   - Remove OTEL-specific Bazel test shard/env overrides; clean OTEL env from C++ stats test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d0190f3dd58d5f0c982fcbdab95fcf5f733553f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->