### PR TITLE
[train][release] Print more timing data in torch_benchmark.py

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -320,6 +320,7 @@ def train_torch_ray_air(
         train_loop_per_worker=train_loop,
         train_loop_config=config,
         scaling_config=ScalingConfig(
+            # TODO: remove this for v2 migration
             trainer_resources={"CPU": 0},
             num_workers=num_workers,
             resources_per_worker={"CPU": cpus_per_worker},

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -321,7 +321,6 @@ def train_torch_ray_air(
         train_loop_config=config,
         scaling_config=ScalingConfig(
             # TODO: remove this for v2 migration
-            trainer_resources={"CPU": 0},
             num_workers=num_workers,
             resources_per_worker={"CPU": cpus_per_worker},
             use_gpu=use_gpu,

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -287,6 +287,7 @@ def train_func(use_ray: bool, config: Dict):
 
         local_time_taken = time.monotonic() - local_start_time
 
+        report_start_time = time.monotonic()
         if use_ray:
             train.report(dict(loss=loss, local_time_taken=local_time_taken))
         else:
@@ -294,6 +295,10 @@ def train_func(use_ray: bool, config: Dict):
             if local_rank == 0:
                 with open(VANILLA_RESULT_JSON, "w") as f:
                     json.dump({"loss": loss, "local_time_taken": local_time_taken}, f)
+        print(
+            f"Time taken to report epoch {epoch} when use_ray = {use_ray} on rank {local_rank}: "
+            f"{time.monotonic() - report_start_time:.2f} seconds"
+        )
 
 
 def train_torch_ray_air(

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -617,8 +617,8 @@ def run(
             f"Training on Ray took an average of {times_local_ray_mean:.2f} seconds, "
             f"which is more than {target_ratio:.2f}x of the average vanilla training "
             f"time of {times_local_vanilla_mean:.2f} seconds ({ratio:.2f}x). "
-            f"Here are some additional metrics from Ray training: {metrics_ray}. "
-            f"Here are some additional metrics from vanilla training: {metrics_vanilla}. "
+            f"Here are some additional metrics from the last epoch of Ray training: {metrics_ray}. "
+            f"Here are some additional metrics from the last epoch of vanilla training: {metrics_vanilla}. "
             "FAILED"
         )
 
@@ -626,8 +626,8 @@ def run(
         f"Training on Ray took an average of {times_local_ray_mean:.2f} seconds, "
         f"which is less than {target_ratio:.2f}x of the average vanilla training "
         f"time of {times_local_vanilla_mean:.2f} seconds ({ratio:.2f}x). "
-        f"Here are some additional metrics from Ray training: {metrics_ray}. "
-        f"Here are some additional metrics from vanilla training: {metrics_vanilla}. "
+        f"Here are some additional metrics from the last epoch of Ray training: {metrics_ray}. "
+        f"Here are some additional metrics from the last epoch of vanilla training: {metrics_vanilla}. "
         "PASSED"
     )
 

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 import json
 import os
 import time
@@ -285,8 +285,8 @@ def train_func(use_ray: bool, config: Dict):
         metrics = {
             "loss": loss,
             "local_time_taken": local_time_taken,
-            "train_epoch_metrics": train_epoch_metrics,
-            "validate_epoch_metrics": validate_epoch_metrics,
+            "train_epoch_metrics": asdict(train_epoch_metrics),
+            "validate_epoch_metrics": asdict(validate_epoch_metrics),
             "prepare_model_time": prepare_model_time,
             "prev_report_time": prev_report_time,
         }

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -291,6 +291,7 @@ def train_func(use_ray: bool, config: Dict):
             "prev_report_time": prev_report_time,
         }
         if use_ray:
+            # TODO: report associated checkpoint for v2 migration
             train.report(metrics=metrics)
         else:
             print(f"Reporting loss: {loss:.4f}")

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -321,6 +321,7 @@ def train_torch_ray_air(
         train_loop_config=config,
         scaling_config=ScalingConfig(
             # TODO: remove this for v2 migration
+            trainer_resources={"CPU": 0},
             num_workers=num_workers,
             resources_per_worker={"CPU": cpus_per_worker},
             use_gpu=use_gpu,

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -217,7 +217,7 @@
 
   run:
     timeout: 3600
-    script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 8
+    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 8
 
     wait_for_nodes:
       num_nodes: 4
@@ -246,7 +246,7 @@
 
   run:
     timeout: 4800
-    script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 120 --num-workers 16 --cpus-per-worker 4 --batch-size 1024 --use-gpu
+    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 120 --num-workers 16 --cpus-per-worker 4 --batch-size 1024 --use-gpu
 
     wait_for_nodes:
       num_nodes: 4
@@ -259,7 +259,7 @@
 
     run:
       timeout: 3600
-      script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 60 --num-workers 4 --cpus-per-worker 4 --batch-size 512 --use-gpu
+      script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 60 --num-workers 4 --cpus-per-worker 4 --batch-size 512 --use-gpu
 
       wait_for_nodes:
         num_nodes: 2
@@ -291,7 +291,7 @@
 
   run:
     timeout: 3600
-    script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
+    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
 
   variations:
     - __suffix__: aws
@@ -318,7 +318,7 @@
 
   run:
     timeout: 5400
-    script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 16 --cpus-per-worker 2
+    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 16 --cpus-per-worker 2
 
     wait_for_nodes:
       num_nodes: 4

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -291,7 +291,7 @@
 
   run:
     timeout: 3600
-    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
+    script: RAY_TRAIN_V2_ENABLED=1 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
 
   variations:
     - __suffix__: aws

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -217,7 +217,7 @@
 
   run:
     timeout: 3600
-    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 8
+    script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 8
 
     wait_for_nodes:
       num_nodes: 4
@@ -246,7 +246,7 @@
 
   run:
     timeout: 4800
-    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 120 --num-workers 16 --cpus-per-worker 4 --batch-size 1024 --use-gpu
+    script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 120 --num-workers 16 --cpus-per-worker 4 --batch-size 1024 --use-gpu
 
     wait_for_nodes:
       num_nodes: 4
@@ -259,7 +259,7 @@
 
     run:
       timeout: 3600
-      script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 60 --num-workers 4 --cpus-per-worker 4 --batch-size 512 --use-gpu
+      script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 60 --num-workers 4 --cpus-per-worker 4 --batch-size 512 --use-gpu
 
       wait_for_nodes:
         num_nodes: 2
@@ -291,7 +291,7 @@
 
   run:
     timeout: 3600
-    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
+    script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
 
   variations:
     - __suffix__: aws
@@ -318,7 +318,7 @@
 
   run:
     timeout: 5400
-    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 16 --cpus-per-worker 2
+    script: RAY_DEDUP_LOGS=0 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 16 --cpus-per-worker 2
 
     wait_for_nodes:
       num_nodes: 4

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -291,7 +291,7 @@
 
   run:
     timeout: 3600
-    script: RAY_TRAIN_V2_ENABLED=1 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
+    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
 
   variations:
     - __suffix__: aws


### PR DESCRIPTION
# Summary

`air_benchmark_torch_mnist_cpu_1x4` has been failing for a while (at least sep7-sep10 and aug 30) because torch + ray train takes 1.56-1.69x as long as vanilla torch with ray actors, when in reality it should take no more than 1.15x. Here's an example log from that benchmark:

```
[2025-09-09T12:01:45Z] RuntimeError: Training on Ray took an average of 368.48 seconds, which is more than 1.15x of the average vanilla training time of 226.60 seconds (1.63x). FAILED
```

This PR adds additional information to the `RuntimeError` `torch_benchmark.py` raises to see exactly where the slowdown is happening. Here is an example from running the release test on this PR:

```
_bk;t=1757640445637RuntimeError: Training on Ray took an average of 355.17 seconds, which is more than 1.15x of the average vanilla training time of 220.66 seconds (1.61x). Here are some additional metrics from Ray training: {'loss': 0.8790386533661253, 'local_time_taken': 356.713914658, 'train_epoch_metrics': {'total_batches': 938, 'total_batch_fetch_time': 2.6287356089976583, 'total_loss_calc_time': 1.4670290079961887, 'total_backprop_time': 12.392292417000817, 'time_to_first_batch': 0.008285198000066885, 'total_time': 16.49196883600007}, 'validate_epoch_metrics': {'total_batches': 157, 'total_batch_fetch_time': 0.48163445099862656, 'total_loss_calc_time': 0.40668433200039544, 'total_backprop_time': 0, 'time_to_first_batch': 0.008011472000134745, 'total_time': 0.8983475850000104}, 'prepare_model_time': 0.0074844230000508105, 'prev_report_time': 0.0009129359998496511, 'timestamp': 1757640150, 'checkpoint_dir_name': None, 'done': True, 'training_iteration': 20, 'trial_id': '187d3_00000', 'date': '2025-09-11_18-22-30', 'time_this_iter_s': 17.378743171691895, 'time_total_s': 362.25269174575806, 'pid': 11067, 'hostname': 'ip-10-0-72-139', 'node_ip': '10.0.72.139', 'config': {'train_loop_config': {'lr': 0.001, 'batch_size': 64, 'epochs': 20}}, 'time_since_restore': 362.25269174575806, 'iterations_since_restore': 20, 'experiment_tag': '0'}. Here are some additional metrics from vanilla training: {'loss': 0.8209158372442433, 'local_time_taken': 221.86214794600005, 'train_epoch_metrics': {'total_batches': 938, 'total_batch_fetch_time': 2.1469374589969448, 'total_loss_calc_time': 1.3130484710020482, 'total_backprop_time': 7.005908396999303, 'time_to_first_batch': 0.0036344410000310745, 'total_time': 10.46939099899987}, 'validate_epoch_metrics': {'total_batches': 157, 'total_batch_fetch_time': 0.25213677600072515, 'total_loss_calc_time': 0.11302342599788062, 'total_backprop_time': 0, 'time_to_first_batch': 0.0020463500000005297, 'total_time': 0.3722619479999594}, 'prepare_model_time': 0.006708746999947834, 'prev_report_time': 0.0003310509998755151}. FAILED
```

In particular, note the following comparisons:
* `RuntimeError: Training on Ray took an average of 355.17 seconds, which is more than 1.15x of the average vanilla training time of 220.66 seconds (1.61x).`
* `prepare_model_time`, `prev_report_time`, and `time_to_first_batch` were negligible in both cases
* Torch operations were slightly slower across the board for `Torchtrainer` compared to vanilla Torch + ray. In particular, for 938 training batches and 157 validation batches:
  * Fetching batches: 2.63s > 2.15 in training, 0.48 > 0.25 in validation
  * Loss calculation: 1.47 > 1.31 in training, 0.41 > 0.11 in validation
  * Backpropagation: 12.39 > 7.00

Since the slow parts are coming from torch operations, I suspect the slowdown is due to how `TorchTrainer` is placing the actors compared to vanilla ray or what `prepare_model`/`prepare_data_loader` are doing. 

We can consider improving this benchmark in the future by:
* Moving to v2 and consolidating with `train_benchmark.py`, which makes timing easy
* Save the metrics somewhere they can be easily surfaced and tracked

Looking at the other torch tests:
* `air_benchmark_torch_mnist_cpu_4x1.aws`: `[2025-09-11T11:41:36Z] Training on Ray took an average of 187.63 seconds, which is less than 1.15x of the average vanilla training time of 197.80 seconds (0.95x). PASSED`
* `air_benchmark_torch_mnist_gpu_4x4.aws`: `[2025-09-11T12:21:15Z] ray_release.exception.TestCommandTimeout: Command timed out after 3600.067270017 seconds.`
* `air_benchmark_torch_mnist_cpu_4x4.aws`: `[2025-09-11T12:06:00Z] Training on Ray took an average of 443.43 seconds, which is less than 1.15x of the average vanilla training time of 406.82 seconds (1.09x). PASSED`

# Testing

Ran release test: https://buildkite.com/ray-project/release/builds/57989#01993b68-6bfa-4977-9161-b94b1ca159dd on commit `f50289dc3ff34517a616aec519b656bfa6ebf51e`