### PR TITLE
[Data] Remove redundant check for initial size of actor pool

### DIFF
--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -125,8 +125,6 @@ class ActorPoolStrategy(ComputeStrategy):
 
         # Validate and set initial_size
         if initial_size is not None:
-            if initial_size < 1:
-                raise ValueError("initial_size must be >= 1", initial_size)
             if initial_size < self.min_size:
                 raise ValueError(
                     f"initial_size ({initial_size}) must be >= min_size ({self.min_size})"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The check is redundant here, since the `initial_size` can't be smaller than `min_size` (which must be bigger that 1)
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/56370#discussion_r2337538808
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
