### PR TITLE
[core] Fix HandleRefRemoved thread safety

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3793,15 +3793,15 @@ void CoreWorker::ProcessSubscribeForRefRemoved(
     RAY_LOG(INFO) << "The ProcessSubscribeForRefRemoved message is for worker "
                   << intended_worker_id << ", but the current worker is "
                   << worker_context_->GetWorkerID() << ". The RPC will be no-op.";
-    reference_counter_->HandleRefRemoved(object_id);
+    reference_counter_->PublishRefRemoved(object_id);
     return;
   }
 
   const auto owner_address = message.reference().owner_address();
   ObjectID contained_in_id = ObjectID::FromBinary(message.contained_in_id());
-  // So it will call HandleRefRemovedInternal to publish a message when the requested
+  // So it will call PublishRefRemovedInternal to publish a message when the requested
   // object ID's ref count goes to 0.
-  reference_counter_->SetRefRemovedCallback(object_id, contained_in_id, owner_address);
+  reference_counter_->SubscribeRefRemoved(object_id, contained_in_id, owner_address);
 }
 
 void CoreWorker::HandleRemoteCancelTask(rpc::RemoteCancelTaskRequest request,

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -558,7 +558,7 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
       OnObjectOutOfScopeOrFreed(arg_it);
     }
     if (arg_it->second.ShouldDelete(lineage_pinning_enabled_)) {
-      RAY_CHECK(arg_it->second.on_ref_removed == nullptr);
+      RAY_CHECK(!arg_it->second.call_handle_ref_removed);
       lineage_bytes_evicted += ReleaseLineageReferences(arg_it);
       EraseReference(arg_it);
     }
@@ -683,10 +683,10 @@ void ReferenceCounter::DeleteReferenceInternal(ReferenceTable::iterator it,
                                                std::vector<ObjectID> *deleted) {
   const ObjectID id = it->first;
   RAY_LOG(DEBUG) << "Attempting to delete object " << id;
-  if (it->second.RefCount() == 0 && it->second.on_ref_removed) {
-    RAY_LOG(DEBUG) << "Calling on_ref_removed for object " << id;
-    it->second.on_ref_removed(id);
-    it->second.on_ref_removed = nullptr;
+  if (it->second.RefCount() == 0 && it->second.call_handle_ref_removed) {
+    RAY_LOG(DEBUG) << "Calling HandleRefRemoved for object " << id;
+    HandleRefRemovedInternal(id);
+    it->second.call_handle_ref_removed = false;
   }
 
   PRINT_REF_COUNT(it);
@@ -1254,6 +1254,11 @@ void ReferenceCounter::AddNestedObjectIdsInternal(const ObjectID &object_id,
 }
 
 void ReferenceCounter::HandleRefRemoved(const ObjectID &object_id) {
+  absl::MutexLock lock(&mutex_);
+  HandleRefRemovedInternal(object_id);
+}
+
+void ReferenceCounter::HandleRefRemovedInternal(const ObjectID &object_id) {
   RAY_LOG(DEBUG).WithField(object_id) << "HandleRefRemoved ";
   auto it = object_id_refs_.find(object_id);
   if (it != object_id_refs_.end()) {
@@ -1284,11 +1289,9 @@ void ReferenceCounter::HandleRefRemoved(const ObjectID &object_id) {
   object_info_publisher_->Publish(std::move(pub_message));
 }
 
-void ReferenceCounter::SetRefRemovedCallback(
-    const ObjectID &object_id,
-    const ObjectID &contained_in_id,
-    const rpc::Address &owner_address,
-    const ReferenceCounter::ReferenceRemovedCallback &ref_removed_callback) {
+void ReferenceCounter::SetRefRemovedCallback(const ObjectID &object_id,
+                                             const ObjectID &contained_in_id,
+                                             const rpc::Address &owner_address) {
   absl::MutexLock lock(&mutex_);
   RAY_LOG(DEBUG).WithField(object_id)
       << "Received WaitForRefRemoved object contained in " << contained_in_id;
@@ -1298,6 +1301,8 @@ void ReferenceCounter::SetRefRemovedCallback(
     it = object_id_refs_.emplace(object_id, Reference()).first;
   }
 
+  auto &reference = it->second;
+
   // If we are borrowing the ID because we own an object that contains it, then
   // add the outer object to the inner ID's ref count. We will not respond to
   // the owner of the inner ID until the outer object ID goes out of scope.
@@ -1305,28 +1310,28 @@ void ReferenceCounter::SetRefRemovedCallback(
     AddNestedObjectIdsInternal(contained_in_id, {object_id}, rpc_address_);
   }
 
-  if (it->second.RefCount() == 0) {
+  if (reference.RefCount() == 0) {
     RAY_LOG(DEBUG).WithField(object_id)
         << "Ref count for borrowed object is already 0, responding to WaitForRefRemoved";
     // We already stopped borrowing the object ID. Respond to the owner
     // immediately.
-    ref_removed_callback(object_id);
+    HandleRefRemovedInternal(object_id);
     DeleteReferenceInternal(it, nullptr);
   } else {
     // We are still borrowing the object ID. Respond to the owner once we have
     // stopped borrowing it.
-    if (it->second.on_ref_removed != nullptr) {
+    if (reference.call_handle_ref_removed) {
       // TODO(swang): If the owner of an object dies and and is re-executed, it
       // is possible that we will receive a duplicate request to set
-      // on_ref_removed. If messages are delayed and we overwrite the
+      // call_handle_ref_removed. If messages are delayed and we overwrite the
       // callback here, it's possible we will drop the request that was sent by
       // the more recent owner. We should fix this by setting multiple
       // callbacks or by versioning the owner requests.
       RAY_LOG(WARNING).WithField(object_id)
-          << "on_ref_removed already set for object. The owner task must have died and "
-             "been re-executed.";
+          << "call_handle_ref_removed already set for object. The owner task must have "
+             "died and been re-executed.";
     }
-    it->second.on_ref_removed = ref_removed_callback;
+    reference.call_handle_ref_removed = true;
   }
 }
 

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -345,8 +345,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
                                    const std::function<void(const ObjectID &)> callback)
       override ABSL_LOCKS_EXCLUDED(mutex_);
 
-  /// So we call HandleRefRemovedInternal to publish when we are no longer borrowing
-  /// this object (when our ref count goes to 0).
+  /// So we call PublishRefRemovedInternal when we are no longer borrowing this object
+  /// (when our ref count goes to 0).
   ///
   /// \param[in] object_id The object ID to set the callback for.
   /// \param[in] contained_in_id The object ID that contains object_id, if any.
@@ -354,10 +354,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// submitted. Then, as long as we have contained_in_id in scope, we are
   /// borrowing object_id.
   /// \param[in] owner_address The owner of object_id's address.
-  void SetRefRemovedCallback(const ObjectID &object_id,
-                             const ObjectID &contained_in_id,
-                             const rpc::Address &owner_address)
-      ABSL_LOCKS_EXCLUDED(mutex_);
+  void SubscribeRefRemoved(const ObjectID &object_id,
+                           const ObjectID &contained_in_id,
+                           const rpc::Address &owner_address) ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Set a callback to call whenever a Reference that we own is deleted. A
   /// Reference can only be deleted if:
@@ -368,8 +367,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[in] callback The callback to call.
   void SetReleaseLineageCallback(const LineageReleasedCallback &callback);
 
-  /// Just calls HandleRefRemovedInternal with a lock.
-  void HandleRefRemoved(const ObjectID &object_id) ABSL_LOCKS_EXCLUDED(mutex_);
+  /// Just calls PublishRefRemovedInternal with a lock.
+  void PublishRefRemoved(const ObjectID &object_id) ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Returns the total number of ObjectIDs currently in scope.
   size_t NumObjectIDsInScope() const ABSL_LOCKS_EXCLUDED(mutex_);
@@ -808,9 +807,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// Callback that will be called when the object ref is deleted
     /// from the reference table (all refs including lineage ref count go to 0).
     std::function<void(const ObjectID &)> on_object_ref_delete;
-    /// If this is set, we'll call HandleRefRemovedInternal whenthis process is no longer
-    /// a borrower (RefCount() == 0).
-    bool call_handle_ref_removed = false;
+    /// If this is set, we'll call PublishRefRemovedInternal when this process is no
+    /// longer a borrower (RefCount() == 0).
+    bool publish_ref_removed = false;
 
     /// For objects that have been spilled to external storage, the URL from which
     /// they can be retrieved.
@@ -986,7 +985,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// To respond to the object's owner once we are no longer borrowing it.  The
   /// sender is the owner of the object ID. We will send the reply when our
   /// RefCount() for the object ID goes to 0.
-  void HandleRefRemovedInternal(const ObjectID &object_id)
+  void PublishRefRemovedInternal(const ObjectID &object_id)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Erase the Reference from the table. Assumes that the entry has no more

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -345,8 +345,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
                                    const std::function<void(const ObjectID &)> callback)
       override ABSL_LOCKS_EXCLUDED(mutex_);
 
-  /// Set up a call HandleRefRemovedInternal for when we are no longer borrowing this
-  /// object (when our ref count goes to 0).
+  /// So we call HandleRefRemovedInternal to publish when we are no longer borrowing
+  /// this object (when our ref count goes to 0).
   ///
   /// \param[in] object_id The object ID to set the callback for.
   /// \param[in] contained_in_id The object ID that contains object_id, if any.
@@ -368,7 +368,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[in] callback The callback to call.
   void SetReleaseLineageCallback(const LineageReleasedCallback &callback);
 
-  /// Just calls HandleRefRemovedInternal while locking.
+  /// Just calls HandleRefRemovedInternal with a lock.
   void HandleRefRemoved(const ObjectID &object_id) ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Returns the total number of ObjectIDs currently in scope.
@@ -986,8 +986,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// To respond to the object's owner once we are no longer borrowing it.  The
   /// sender is the owner of the object ID. We will send the reply when our
   /// RefCount() for the object ID goes to 0.
-  ///
-  /// \param[in] object_id The object that we were borrowing.
   void HandleRefRemovedInternal(const ObjectID &object_id)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -345,8 +345,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
                                    const std::function<void(const ObjectID &)> callback)
       override ABSL_LOCKS_EXCLUDED(mutex_);
 
-  /// Set a callback for when we are no longer borrowing this object (when our
-  /// ref count goes to 0).
+  /// Set up a call HandleRefRemovedInternal for when we are no longer borrowing this
+  /// object (when our ref count goes to 0).
   ///
   /// \param[in] object_id The object ID to set the callback for.
   /// \param[in] contained_in_id The object ID that contains object_id, if any.
@@ -354,12 +354,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// submitted. Then, as long as we have contained_in_id in scope, we are
   /// borrowing object_id.
   /// \param[in] owner_address The owner of object_id's address.
-  /// \param[in] ref_removed_callback The callback to call when we are no
-  /// longer borrowing the object.
   void SetRefRemovedCallback(const ObjectID &object_id,
                              const ObjectID &contained_in_id,
-                             const rpc::Address &owner_address,
-                             const ReferenceRemovedCallback &ref_removed_callback)
+                             const rpc::Address &owner_address)
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Set a callback to call whenever a Reference that we own is deleted. A
@@ -371,12 +368,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[in] callback The callback to call.
   void SetReleaseLineageCallback(const LineageReleasedCallback &callback);
 
-  /// Respond to the object's owner once we are no longer borrowing it.  The
-  /// sender is the owner of the object ID. We will send the reply when our
-  /// RefCount() for the object ID goes to 0.
-  ///
-  /// \param[in] object_id The object that we were borrowing.
-  void HandleRefRemoved(const ObjectID &object_id) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  /// Just calls HandleRefRemovedInternal while locking.
+  void HandleRefRemoved(const ObjectID &object_id) ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Returns the total number of ObjectIDs currently in scope.
   size_t NumObjectIDsInScope() const ABSL_LOCKS_EXCLUDED(mutex_);
@@ -815,9 +808,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// Callback that will be called when the object ref is deleted
     /// from the reference table (all refs including lineage ref count go to 0).
     std::function<void(const ObjectID &)> on_object_ref_delete;
-    /// Callback that is called when this process is no longer a borrower
-    /// (RefCount() == 0).
-    std::function<void(const ObjectID &)> on_ref_removed;
+    /// If this is set, we'll call HandleRefRemovedInternal whenthis process is no longer
+    /// a borrower (RefCount() == 0).
+    bool call_handle_ref_removed = false;
 
     /// For objects that have been spilled to external storage, the URL from which
     /// they can be retrieved.
@@ -988,6 +981,14 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// iterator.
   void DeleteReferenceInternal(ReferenceTable::iterator entry,
                                std::vector<ObjectID> *deleted)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// To respond to the object's owner once we are no longer borrowing it.  The
+  /// sender is the owner of the object ID. We will send the reply when our
+  /// RefCount() for the object ID goes to 0.
+  ///
+  /// \param[in] object_id The object that we were borrowing.
+  void HandleRefRemovedInternal(const ObjectID &object_id)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Erase the Reference from the table. Assumes that the entry has no more

--- a/src/ray/core_worker/tests/reference_count_test.cc
+++ b/src/ray/core_worker/tests/reference_count_test.cc
@@ -319,7 +319,7 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
     auto r = num_requests_;
 
     auto borrower_callback = [=]() {
-      rc_.SetRefRemovedCallback(object_id, contained_in_id, owner_address);
+      rc_.SubscribeRefRemoved(object_id, contained_in_id, owner_address);
     };
     borrower_callbacks_[r] = borrower_callback;
 

--- a/src/ray/core_worker/tests/reference_count_test.cc
+++ b/src/ray/core_worker/tests/reference_count_test.cc
@@ -319,10 +319,7 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
     auto r = num_requests_;
 
     auto borrower_callback = [=]() {
-      auto ref_removed_callback =
-          absl::bind_front(&ReferenceCounter::HandleRefRemoved, &rc_);
-      rc_.SetRefRemovedCallback(
-          object_id, contained_in_id, owner_address, ref_removed_callback);
+      rc_.SetRefRemovedCallback(object_id, contained_in_id, owner_address);
     };
     borrower_callbacks_[r] = borrower_callback;
 


### PR DESCRIPTION
## Why are these changes needed?
HandleRefRemoved needs to be called while holding the ReferenceCounter mutex because it accesses the `object_id_refs_` map guarded by the mutex. However here it could be called from CoreWorker without holding the ReferenceCounter mutex. 
https://github.com/ray-project/ray/blob/7d5a29c4c5980b925503146b8e7345a64e671492/src/ray/core_worker/core_worker.cc#L3793-L3801

This bypasses the absl lock annotation on HandleRefRemoved because boost::bind magic circumvents absl's checking.

So the solution is to have a public `HandleRefRemoved` that will acquire the ReferenceCounter mu and a private one with the `ABSL_EXCLUSIVE_LOCKS_REQUIRED` annotation so the caller has to hold the mutex before calling into it. Also instead of needing to pass a callback into `SetRefRemovedCallback`, it will just set a boolean that will tell the ref counter that it needs to call `HandleRefRemovedInternal` later. We never set any callback that wasn't just calling `HandleRefRemoved` anyways.

Also renaming to SubscribeRefRemoved, PublishRefRemoved, publish_ref_removed so it more apparent what it's doing.