### PR TITLE
[core] deflake darwin://python/ray/tests:test_metric_cardinality_otel

### DIFF
--- a/python/ray/tests/test_metric_cardinality.py
+++ b/python/ray/tests/test_metric_cardinality.py
@@ -75,7 +75,7 @@ def _setup_cluster_for_test(request, ray_start_cluster):
     ray.get(obj_refs)
 
 
-def _cardinality_level_test(_setup_cluster_for_test, cardinality_level):
+def _cardinality_level_test(_setup_cluster_for_test, cardinality_level, metric):
     """
     Test that the ray_tasks and ray_actors metric are reported with the expected cardinality level
     """
@@ -84,43 +84,42 @@ def _cardinality_level_test(_setup_cluster_for_test, cardinality_level):
 
     def _validate():
         metric_samples = fetch_prometheus_metrics(prom_addresses)
-        for metric in _TO_TEST_METRICS:
-            samples = metric_samples.get(metric)
-            assert samples, f"Metric {metric} not found in samples"
-            for sample in samples:
-                if cardinality_level == "recommended":
-                    # If the cardinality level is recommended, the WorkerId tag should
-                    # be removed
-                    assert (
-                        sample.labels.get(WORKER_ID_TAG_KEY) is None
-                    ), f"Sample {sample} contains WorkerId tag"
-                elif cardinality_level == "legacy":
-                    # If the cardinality level is legacy, the WorkerId tag should be
-                    # present
-                    assert (
-                        sample.labels.get(WORKER_ID_TAG_KEY) is not None
-                    ), f"Sample {sample} does not contain WorkerId tag"
-                    if metric == "ray_tasks" or metric == "ray_actors":
-                        assert (
-                            sample.labels.get(TASK_OR_ACTOR_NAME_TAG_KEY) is not None
-                        ), f"Sample {sample} does not contain Name tag"
-                elif cardinality_level == "low":
-                    # If the cardinality level is low, the WorkerId and Name tags should
-                    # be removed
-                    assert (
-                        sample.labels.get(WORKER_ID_TAG_KEY) is None
-                    ), f"Sample {sample} contains WorkerId tag"
-                    if metric == "ray_tasks" or metric == "ray_actors":
-                        assert (
-                            sample.labels.get(TASK_OR_ACTOR_NAME_TAG_KEY) is None
-                        ), f"Sample {sample} contains Name tag"
-                else:
-                    raise ValueError(f"Unknown cardinality level: {cardinality_level}")
-
-                # The Component tag should be present on all cardinality levels
+        samples = metric_samples.get(metric)
+        assert samples, f"Metric {metric} not found in samples"
+        for sample in samples:
+            if cardinality_level == "recommended":
+                # If the cardinality level is recommended, the WorkerId tag should
+                # be removed
                 assert (
-                    sample.labels.get(_COMPONENT_TAG_KEY) is not None
-                ), f"Sample {sample} does not contain Component tag"
+                    sample.labels.get(WORKER_ID_TAG_KEY) is None
+                ), f"Sample {sample} contains WorkerId tag"
+            elif cardinality_level == "legacy":
+                # If the cardinality level is legacy, the WorkerId tag should be
+                # present
+                assert (
+                    sample.labels.get(WORKER_ID_TAG_KEY) is not None
+                ), f"Sample {sample} does not contain WorkerId tag"
+                if metric == "ray_tasks" or metric == "ray_actors":
+                    assert (
+                        sample.labels.get(TASK_OR_ACTOR_NAME_TAG_KEY) is not None
+                    ), f"Sample {sample} does not contain Name tag"
+            elif cardinality_level == "low":
+                # If the cardinality level is low, the WorkerId and Name tags should
+                # be removed
+                assert (
+                    sample.labels.get(WORKER_ID_TAG_KEY) is None
+                ), f"Sample {sample} contains WorkerId tag"
+                if metric == "ray_tasks" or metric == "ray_actors":
+                    assert (
+                        sample.labels.get(TASK_OR_ACTOR_NAME_TAG_KEY) is None
+                    ), f"Sample {sample} contains Name tag"
+            else:
+                raise ValueError(f"Unknown cardinality level: {cardinality_level}")
+
+            # The Component tag should be present on all cardinality levels
+            assert (
+                sample.labels.get(_COMPONENT_TAG_KEY) is not None
+            ), f"Sample {sample} does not contain Component tag"
 
     wait_for_assertion(
         _validate,
@@ -131,14 +130,18 @@ def _cardinality_level_test(_setup_cluster_for_test, cardinality_level):
 
 @pytest.mark.skipif(prometheus_client is None, reason="Prometheus not installed")
 @pytest.mark.parametrize(
-    "_setup_cluster_for_test,cardinality_level",
-    [("recommended", "recommended"), ("legacy", "legacy")],
+    "_setup_cluster_for_test,cardinality_level,metric",
+    [
+        (cardinality, cardinality, metric)
+        for cardinality in ["recommended", "legacy"]
+        for metric in _TO_TEST_METRICS
+    ],
     indirect=["_setup_cluster_for_test"],
 )
 def test_cardinality_recommended_and_legacy_levels(
-    _setup_cluster_for_test, cardinality_level
+    _setup_cluster_for_test, cardinality_level, metric
 ):
-    _cardinality_level_test(_setup_cluster_for_test, cardinality_level)
+    _cardinality_level_test(_setup_cluster_for_test, cardinality_level, metric)
 
 
 # We only enable low cardinality test for open telemetry because the legacy opencensus
@@ -149,12 +152,12 @@ def test_cardinality_recommended_and_legacy_levels(
     reason="OpenTelemetry is not enabled",
 )
 @pytest.mark.parametrize(
-    "_setup_cluster_for_test,cardinality_level",
-    [("low", "low")],
+    "_setup_cluster_for_test,cardinality_level,metric",
+    [("low", "low", metric) for metric in _TO_TEST_METRICS],
     indirect=["_setup_cluster_for_test"],
 )
-def test_cardinality_low_levels(_setup_cluster_for_test, cardinality_level):
-    _cardinality_level_test(_setup_cluster_for_test, cardinality_level)
+def test_cardinality_low_levels(_setup_cluster_for_test, cardinality_level, metric):
+    _cardinality_level_test(_setup_cluster_for_test, cardinality_level, metric)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The commit https://github.com/ray-project/ray/commit/ef7169a77d254a3c8e0779f80d61b2ba5c8a0198
 fixed a bug where Ray continued emitting metrics from dead workers. However, this change made the test `darwin://python/ray/tests:test_metric_cardinality_otel` flaky. The test assumed that all metrics would appear in every Prometheus poll, but in reality, data points for different metrics can arrive at different intervals.

This PR fixes the issue by checking for the presence of each metric independently.


Test:
- CI
- Run test locally

Closes https://github.com/ray-project/ray/issues/56449.