### PR TITLE
[data] Download op fusion / removal of interleaved partitioners

### DIFF
--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -136,7 +136,8 @@ def download_bytes_threaded(
     uris = block.column(uri_column_name).to_pylist()
 
     if len(uris) == 0:
-        return block
+        yield block
+        return
 
     paths, fs = _resolve_paths_and_filesystem(uris)
     fs = RetryingPyFileSystem.wrap(fs, retryable_errors=data_context.retried_io_errors)
@@ -168,7 +169,7 @@ def download_bytes_threaded(
     if max_bytes is not None and output_block_size > max_bytes:
         num_blocks = math.ceil(output_block_size / max_bytes)
         num_rows = output_block.num_rows
-        yield from _arrow_batcher(output_block, num_rows // num_blocks)
+        yield from _arrow_batcher(output_block, int(math.ceil(num_rows / num_blocks)))
     else:
         yield output_block
 


### PR DESCRIPTION
## Why are these changes needed?
If we have multiple chained downloads e.g. `ds.with_column("bytes_1", download("uri_1")).with_column("bytes_2", download("uri_2")).with_column("bytes_3", download("uri_3"))`, then we would have an operator structure like `URIPartitioner->URIDownloader->URIPartitioner->URIDownloader->URIPartitioner->URIDownloader`. Each of the `URIPartitioner` operators will be implemented with an ActorPoolMapOperator with concurrency of 1. In these chained downloads, these become bottlenecks and scaling the concurrency of these up will result in additional resource usage that will take resources away from other operators. 

This solves the problem by deferring some of the partitioning to the `URIDownloader` so we can remove the interleaved partitioners. The result is an operator structure like `URIPartitioner->URIDownloader->URIDownloader->URIDownloader` which delivers much better performance for these cases.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
