### PR TITLE
[data] Wrong name for Inqueue Panel

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -603,7 +603,7 @@ EXTERNAL_INQUEUE_BYTES_PANEL = Panel(
     unit="bytes",
     targets=[
         Target(
-            expr='sum(ray_data_num_external_inqueue_blocks{{{global_filters}, operator=~"$Operator"}}) by (dataset, operator)',
+            expr='sum(ray_data_num_external_inqueue_bytes{{{global_filters}, operator=~"$Operator"}}) by (dataset, operator)',
             legend="Number of Bytes: {{dataset}}, {{operator}}",
         )
     ],

--- a/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -583,7 +583,7 @@ INTERNAL_OUTQUEUE_BYTES_PANEL = Panel(
 
 EXTERNAL_INQUEUE_BLOCKS_PANEL = Panel(
     id=2,
-    title="Operator External OutQueue Size (Blocks)",
+    title="Operator External InQueue Size (Blocks)",
     description="Number of blocks in operator's external output queue",
     unit="blocks",
     targets=[
@@ -598,7 +598,7 @@ EXTERNAL_INQUEUE_BLOCKS_PANEL = Panel(
 
 EXTERNAL_INQUEUE_BYTES_PANEL = Panel(
     id=27,
-    title="Operator External OutQueue Size (bytes)",
+    title="Operator External InQueue Size (bytes)",
     description="Byte size of blocks in operator's external output queue",
     unit="bytes",
     targets=[

--- a/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -584,7 +584,7 @@ INTERNAL_OUTQUEUE_BYTES_PANEL = Panel(
 EXTERNAL_INQUEUE_BLOCKS_PANEL = Panel(
     id=2,
     title="Operator External InQueue Size (Blocks)",
-    description="Number of blocks in operator's external output queue",
+    description="Number of blocks in operator's external input queue",
     unit="blocks",
     targets=[
         Target(
@@ -599,7 +599,7 @@ EXTERNAL_INQUEUE_BLOCKS_PANEL = Panel(
 EXTERNAL_INQUEUE_BYTES_PANEL = Panel(
     id=27,
     title="Operator External InQueue Size (bytes)",
-    description="Byte size of blocks in operator's external output queue",
+    description="Byte size of blocks in operator's external input queue",
     unit="bytes",
     targets=[
         Target(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
as titled, verified these are the only ones misaligned, it should be inqueue, not outqueue
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
