### PR TITLE
[ci] 2 different pydoclints (1 for ci and 1 for local)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,10 +45,35 @@ repos:
       - id: ruff
         args: [ --select, "I", --fix, --exit-non-zero-on-fix ]
 
+
   - repo: https://github.com/jsh9/pydoclint
     rev: "0.6.6"
     hooks:
       - id: pydoclint
+        name: pydoclintlocal
+        args: [
+          --style=google,
+          --baseline=ci/lint/pydoclint-baseline.txt,
+          --exclude=thirdparty|^python/ray/serve/tests/test_config_files/syntax_error\.py$|^python/ray/_private/parameter\.py$,
+          --auto-regenerate-baseline=False,
+          # Current settings (not because we think they're right, but because we
+          # don't want a baseline the size of the codebase)
+          --arg-type-hints-in-docstring=False,
+          --skip-checking-raises=True,
+          --check-return-types=False,
+          --allow-init-docstring=True,
+          --check-class-attributes=False,
+          # --check-style-mismatch=True, # Bring this back once things are a bit cleaner
+        ]
+        types: [python]
+        files: '^python/ray/'
+
+  - repo: https://github.com/jsh9/pydoclint
+    rev: "0.6.6"
+    hooks:
+      - id: pydoclint
+        name: pydoclintci
+        stages: [manual]
         args: [
           --style=google,
           --baseline=ci/lint/pydoclint-baseline.txt,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,8 @@ repos:
     rev: "0.6.6"
     hooks:
       - id: pydoclint
-        name: pydoclintlocal
+        name: pydoclint-local
+        stages: [pre-commit, pre-push]
         args: [
           --style=google,
           --baseline=ci/lint/pydoclint-baseline.txt,
@@ -72,7 +73,7 @@ repos:
     rev: "0.6.6"
     hooks:
       - id: pydoclint
-        name: pydoclintci
+        name: pydoclint-ci
         stages: [manual]
         args: [
           --style=google,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,8 @@ repos:
       - id: ruff
         args: [ --select, "I", --fix, --exit-non-zero-on-fix ]
 
-
+  # pydoclint-local is for local commits only due to pre-commit-hook only passing
+  # updated files to the hook and overwriting the baseline text file
   - repo: https://github.com/jsh9/pydoclint
     rev: "0.6.6"
     hooks:
@@ -69,6 +70,7 @@ repos:
         types: [python]
         files: '^python/ray/'
 
+  # pydoclint-ci is for CI, overwrites the baseline text file, and is run with the manual stage flag
   - repo: https://github.com/jsh9/pydoclint
     rev: "0.6.6"
     hooks:

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -49,9 +49,6 @@ pre_commit_pydoclint() {
   # Run pre-commit pydoclint on all files
   pip install -c python/requirements_compiled.txt pre-commit clang-format
   pre-commit run pydoclint --hook-stage manual --all-files --show-diff-on-failure
-}
-
-pydoclint_check() {
   git diff --quiet -- ci/lint/pydoclint-baseline.txt || {
   echo "Baseline needs update. Run the CI-style hook: \"pre-commit run pydoclint --hook-stage manual --all-files --show-diff-on-failure\" locally and commit the baseline."
   exit 1

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -48,7 +48,7 @@ pre_commit() {
 pre_commit_pydoclint() {
   # Run pre-commit pydoclint on all files
   pip install -c python/requirements_compiled.txt pre-commit clang-format
-  pre-commit run pydoclint --all-files --show-diff-on-failure
+  pre-commit run "pydoclintci" --all-files --show-diff-on-failure
 }
 
 code_format() {

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -48,7 +48,14 @@ pre_commit() {
 pre_commit_pydoclint() {
   # Run pre-commit pydoclint on all files
   pip install -c python/requirements_compiled.txt pre-commit clang-format
-  pre-commit run "pydoclintci" --all-files --show-diff-on-failure
+  pre-commit run pydoclint --hook-stage manual --all-files --show-diff-on-failure
+}
+
+pydoclint_check() {
+  git diff --quiet -- ci/lint/pydoclint-baseline.txt || {
+  echo "Baseline needs update. Run the CI-style hook: \"pre-commit run pydoclint --hook-stage manual --all-files --show-diff-on-failure\" locally and commit the baseline."
+  exit 1
+  }
 }
 
 code_format() {


### PR DESCRIPTION
creating 2 pydoclint pre-commit jobs due to the following issue: https://anyscaleteam.slack.com/archives/C02J07KKF2A/p1757377523554369

Issue: 
pydoclint-baseline.txt gets overwritten during precommit because pydoclint is only running on updated files

When manually running `pre-commit run pydoclint --all-files --show-diff-on-failure` all files are scanned and the pydoctlint-baseline is respected

Solution:
Create 2 pre-commit jobs
1 for local (**pydoclintlocal**):
setting `--auto-regenerate-baseline=False` so its not overwritten but will surface errors

1 for ci (**pydoclintci**):
Leaving current setup `--auto-regenerate-baseline=True` and adding **manual** stage to manually trigger the hook
This step is manually run in ci and will error out if theres a diff in the baseline
