### PR TITLE
[data] Expose `max_tasks_in_flight_per_actor` in the Dataset and GroupedData API

### DIFF
--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -96,7 +96,7 @@ class ActorPoolStrategy(ComputeStrategy):
         """
         if size is not None:
             if size < 1:
-                raise ValueError("size must be >= 1", size)
+                raise ValueError(f"size must be >= 1, got: {size}")
             if max_size is not None or min_size is not None or initial_size is not None:
                 raise ValueError(
                     "min_size, max_size, and initial_size cannot be set at the same time as `size`"
@@ -105,19 +105,20 @@ class ActorPoolStrategy(ComputeStrategy):
             max_size = size
             initial_size = size
         if min_size is not None and min_size < 1:
-            raise ValueError("min_size must be >= 1", min_size)
+            raise ValueError(f"min_size must be >= 1, got: {min_size}")
         if max_size is not None:
             if min_size is None:
                 min_size = 1  # Legacy default.
             if min_size > max_size:
-                raise ValueError("min_size must be <= max_size", min_size, max_size)
+                raise ValueError(
+                    f"min_size ({min_size}) must be <= max_size ({max_size})"
+                )
         if (
             max_tasks_in_flight_per_actor is not None
             and max_tasks_in_flight_per_actor < 1
         ):
             raise ValueError(
-                "max_tasks_in_flight_per_actor must be >= 1, got: ",
-                max_tasks_in_flight_per_actor,
+                f"max_tasks_in_flight_per_actor must be >= 1, got: {max_tasks_in_flight_per_actor}"
             )
 
         self.min_size = min_size or 1

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -378,11 +378,14 @@ class Dataset:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
-            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
-                send to a single actor worker. Increasing this will increase
-                opportunities for pipelining task dependency prefetching with
-                computation and avoiding actor startup delays, but will also increase
-                queueing delay.
+            max_tasks_in_flight_per_actor: Max number of tasks that could be submitted
+                for execution to individual actor at the same time. Note that only up to
+                `max_concurrency` number of these tasks will be executing concurrently
+                while remaining ones will be waiting in the Actor's queue. Buffering
+                tasks in the queue allows us to overlap pulling of the blocks (which are
+                tasks arguments) with the execution of the prior tasks maximizing
+                individual Actor's utilization. Allows to override this parameter from the
+                :class:`~ray.data.DataContext`
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time prior
@@ -649,11 +652,14 @@ class Dataset:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
-            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
-                send to a single actor worker. Increasing this will increase
-                opportunities for pipelining task dependency prefetching with
-                computation and avoiding actor startup delays, but will also increase
-                queueing delay.
+            max_tasks_in_flight_per_actor: Max number of tasks that could be submitted
+                for execution to individual actor at the same time. Note that only up to
+                `max_concurrency` number of these tasks will be executing concurrently
+                while remaining ones will be waiting in the Actor's queue. Buffering
+                tasks in the queue allows us to overlap pulling of the blocks (which are
+                tasks arguments) with the execution of the prior tasks maximizing
+                individual Actor's utilization. Allows to override this parameter from the
+                :class:`~ray.data.DataContext`
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time prior
@@ -1361,11 +1367,14 @@ class Dataset:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
-            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
-                send to a single actor worker. Increasing this will increase
-                opportunities for pipelining task dependency prefetching with
-                computation and avoiding actor startup delays, but will also increase
-                queueing delay.
+            max_tasks_in_flight_per_actor: Max number of tasks that could be submitted
+                for execution to individual actor at the same time. Note that only up to
+                `max_concurrency` number of these tasks will be executing concurrently
+                while remaining ones will be waiting in the Actor's queue. Buffering
+                tasks in the queue allows us to overlap pulling of the blocks (which are
+                tasks arguments) with the execution of the prior tasks maximizing
+                individual Actor's utilization. Allows to override this parameter from the
+                :class:`~ray.data.DataContext`
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time
@@ -1489,11 +1498,14 @@ class Dataset:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
-            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
-                send to a single actor worker. Increasing this will increase
-                opportunities for pipelining task dependency prefetching with
-                computation and avoiding actor startup delays, but will also increase
-                queueing delay.
+            max_tasks_in_flight_per_actor: Max number of tasks that could be submitted
+                for execution to individual actor at the same time. Note that only up to
+                `max_concurrency` number of these tasks will be executing concurrently
+                while remaining ones will be waiting in the Actor's queue. Buffering
+                tasks in the queue allows us to overlap pulling of the blocks (which are
+                tasks arguments) with the execution of the prior tasks maximizing
+                individual Actor's utilization. Allows to override this parameter from the
+                :class:`~ray.data.DataContext`
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -285,6 +285,7 @@ class Dataset:
         num_gpus: Optional[float] = None,
         memory: Optional[float] = None,
         concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
+        max_tasks_in_flight_per_actor: Optional[int] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -377,6 +378,11 @@ class Dataset:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
+            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
+                send to a single actor worker. Increasing this will increase
+                opportunities for pipelining task dependency prefetching with
+                computation and avoiding actor startup delays, but will also increase
+                queueing delay.
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time prior
@@ -401,6 +407,7 @@ class Dataset:
             fn_constructor_args=fn_constructor_args,
             compute=compute,
             concurrency=concurrency,
+            max_tasks_in_flight_per_actor=max_tasks_in_flight_per_actor,
         )
 
         if num_cpus is not None:
@@ -471,6 +478,7 @@ class Dataset:
         num_gpus: Optional[float] = None,
         memory: Optional[float] = None,
         concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
+        max_tasks_in_flight_per_actor: Optional[int] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -641,6 +649,11 @@ class Dataset:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
+            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
+                send to a single actor worker. Increasing this will increase
+                opportunities for pipelining task dependency prefetching with
+                computation and avoiding actor startup delays, but will also increase
+                queueing delay.
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time prior
@@ -709,6 +722,7 @@ class Dataset:
             num_gpus=num_gpus,
             memory=memory,
             concurrency=concurrency,
+            max_tasks_in_flight_per_actor=max_tasks_in_flight_per_actor,
             ray_remote_args_fn=ray_remote_args_fn,
             **ray_remote_args,
         )
@@ -729,6 +743,7 @@ class Dataset:
         num_gpus: Optional[float],
         memory: Optional[float],
         concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]],
+        max_tasks_in_flight_per_actor: Optional[int],
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]],
         **ray_remote_args,
     ):
@@ -751,6 +766,7 @@ class Dataset:
             fn_constructor_args=fn_constructor_args,
             compute=compute,
             concurrency=concurrency,
+            max_tasks_in_flight_per_actor=max_tasks_in_flight_per_actor,
         )
 
         if num_cpus is not None:
@@ -1258,6 +1274,7 @@ class Dataset:
         num_gpus: Optional[float] = None,
         memory: Optional[float] = None,
         concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
+        max_tasks_in_flight_per_actor: Optional[int] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -1344,6 +1361,11 @@ class Dataset:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
+            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
+                send to a single actor worker. Increasing this will increase
+                opportunities for pipelining task dependency prefetching with
+                computation and avoiding actor startup delays, but will also increase
+                queueing delay.
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time
@@ -1366,6 +1388,7 @@ class Dataset:
             fn_constructor_args=fn_constructor_args,
             compute=compute,
             concurrency=concurrency,
+            max_tasks_in_flight_per_actor=max_tasks_in_flight_per_actor,
         )
 
         if num_cpus is not None:
@@ -1404,6 +1427,7 @@ class Dataset:
         fn_constructor_args: Optional[Iterable[Any]] = None,
         fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
         concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
+        max_tasks_in_flight_per_actor: Optional[int] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -1465,6 +1489,11 @@ class Dataset:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
+            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
+                send to a single actor worker. Increasing this will increase
+                opportunities for pipelining task dependency prefetching with
+                computation and avoiding actor startup delays, but will also increase
+                queueing delay.
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time
@@ -1511,6 +1540,7 @@ class Dataset:
                     fn_constructor_args=fn_constructor_args,
                     compute=compute,
                     concurrency=concurrency,
+                    max_tasks_in_flight_per_actor=max_tasks_in_flight_per_actor,
                 )
             else:
                 raise ValueError(

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -208,11 +208,14 @@ class GroupedData:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
-            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
-                send to a single actor worker. Increasing this will increase
-                opportunities for pipelining task dependency prefetching with
-                computation and avoiding actor startup delays, but will also increase
-                queueing delay.
+            max_tasks_in_flight_per_actor: Max number of tasks that could be submitted
+                for execution to individual actor at the same time. Note that only up to
+                `max_concurrency` number of these tasks will be executing concurrently
+                while remaining ones will be waiting in the Actor's queue. Buffering
+                tasks in the queue allows us to overlap pulling of the blocks (which are
+                tasks arguments) with the execution of the prior tasks maximizing
+                individual Actor's utilization. Allows to override this parameter from the
+                :class:`~ray.data.DataContext`
             ray_remote_args: Additional resource requirements to request from
                 Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
                 :func:`ray.remote` for details.

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -109,6 +109,7 @@ class GroupedData:
         num_gpus: Optional[float] = None,
         memory: Optional[float] = None,
         concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
+        max_tasks_in_flight_per_actor: Optional[int] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -207,6 +208,11 @@ class GroupedData:
                 * If ``fn`` is a class and ``concurrency`` isn't set (default), this
                   method raises an error.
 
+            max_tasks_in_flight_per_actor: The maximum number of tasks to concurrently
+                send to a single actor worker. Increasing this will increase
+                opportunities for pipelining task dependency prefetching with
+                computation and avoiding actor startup delays, but will also increase
+                queueing delay.
             ray_remote_args: Additional resource requirements to request from
                 Ray (e.g., num_gpus=1 to request GPUs for the map tasks). See
                 :func:`ray.remote` for details.
@@ -308,6 +314,7 @@ class GroupedData:
             num_gpus=num_gpus,
             memory=memory,
             concurrency=concurrency,
+            max_tasks_in_flight_per_actor=max_tasks_in_flight_per_actor,
             ray_remote_args_fn=ray_remote_args_fn,
             **ray_remote_args,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, users can config `max_tasks_in_flight_per_actor` with `compute=ray.data.ActorPoolStrategy(...)`.
But after we deprecate the `compute` arg in favor of `concurrency`. We don't have a public API to allow configuring this.

This PR:
- exposes the `max_tasks_in_flight_per_actor` parameter in the Dataset and GroupedData API
- refactors `compute.py` to use f-strings in ValueErrors

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #52667

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
