### PR TITLE
[core][otel] fix default value for missing metric tags

### DIFF
--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -116,15 +116,16 @@ void Metric::Record(double value, TagsType tags) {
   if (::RayConfig::instance().enable_open_telemetry()) {
     // Collect tags from both the metric-specific tags and the global tags.
     absl::flat_hash_map<std::string, std::string> open_telemetry_tags;
-    std::unordered_set<std::string> tag_keys_set;
+    // Add default values for missing tag keys.
     for (const auto &tag_key : tag_keys_) {
-      tag_keys_set.insert(tag_key.name());
+      open_telemetry_tags[tag_key.name()] = "";
     }
     // Insert metric-specific tags that match the expected keys.
     for (const auto &tag : tags) {
       const std::string &key = tag.first.name();
-      if (tag_keys_set.count(key)) {
-        open_telemetry_tags[key] = tag.second;
+      auto it = open_telemetry_tags.find(key);
+      if (it != open_telemetry_tags.end()) {
+        it->second = tag.second;
       }
     }
     // Add global tags, overwriting any existing tag keys.

--- a/src/ray/stats/tests/metric_with_open_telemetry_test.cc
+++ b/src/ray/stats/tests/metric_with_open_telemetry_test.cc
@@ -176,14 +176,15 @@ INSTANTIATE_TEST_SUITE_P(
     GaugeMetricTest,
     ::testing::Values(
         // Gauge metric without global tags
-        GaugeMetricCase{/*metric_name=*/"metric_gauge_test",
-                        /*record_value=*/42.0,
-                        /*record_tags=*/
-                        {{stats::TagKeyType::Register("Tag1"), "Value1"},
-                         {stats::TagKeyType::Register("Tag2"), "Value1"}},
-                        /*global_tags=*/{},  // no global tags
-                        /*expected_tags=*/{{"Tag1", "Value1"}, {"Tag2", "Value1"}},
-                        /*expected_value=*/42.0},
+        GaugeMetricCase{
+            /*metric_name=*/"metric_gauge_test",
+            /*record_value=*/42.0,
+            /*record_tags=*/
+            {{stats::TagKeyType::Register("Tag1"), "Value1"},
+             {stats::TagKeyType::Register("Tag2"), "Value1"}},
+            /*global_tags=*/{},  // no global tags
+            /*expected_tags=*/{{"Tag1", "Value1"}, {"Tag2", "Value1"}, {"Tag3", ""}},
+            /*expected_value=*/42.0},
         // Gauge metric with a single global tag that is metric-specific
         GaugeMetricCase{/*metric_name=*/"metric_gauge_test",
                         /*record_value=*/52.0,
@@ -195,19 +196,20 @@ INSTANTIATE_TEST_SUITE_P(
                         {{"Tag1", "Value2"}, {"Tag2", "Value2"}, {"Tag3", "Global"}},
                         /*expected_value=*/52.0},
         // Gauge metric with a non-metric-specific global tag
-        GaugeMetricCase{/*metric_name=*/"metric_gauge_test",
-                        /*record_value=*/62.0,
-                        /*record_tags=*/
-                        {{stats::TagKeyType::Register("Tag1"), "Value3"},
-                         {stats::TagKeyType::Register("Tag2"), "Value3"}},
-                        /*global_tags=*/
-                        {
-                            {stats::TagKeyType::Register("Tag4"),
-                             "Global"}  // Tag4 not registered in metric definition
-                        },
-                        /*expected_tags=*/
-                        {{"Tag1", "Value3"}, {"Tag2", "Value3"}, {"Tag4", "Global"}},
-                        /*expected_value=*/62.0},
+        GaugeMetricCase{
+            /*metric_name=*/"metric_gauge_test",
+            /*record_value=*/62.0,
+            /*record_tags=*/
+            {{stats::TagKeyType::Register("Tag1"), "Value3"},
+             {stats::TagKeyType::Register("Tag2"), "Value3"}},
+            /*global_tags=*/
+            {
+                {stats::TagKeyType::Register("Tag4"),
+                 "Global"}  // Tag4 not registered in metric definition
+            },
+            /*expected_tags=*/
+            {{"Tag1", "Value3"}, {"Tag2", "Value3"}, {"Tag3", ""}, {"Tag4", "Global"}},
+            /*expected_value=*/62.0},
         // Gauge metric where global tags overwrite record tags
         GaugeMetricCase{/*metric_name=*/"metric_gauge_test",
                         /*record_value=*/72.0,
@@ -230,7 +232,8 @@ INSTANTIATE_TEST_SUITE_P(
                         /*global_tags=*/{},  // no global tags
                         /*expected_tags=*/
                         {{"Tag1", "Value5"},  // unsupported tag dropped
-                         {"Tag2", "Value5"}},
+                         {"Tag2", "Value5"},
+                         {"Tag3", ""}},
                         /*expected_value=*/82.0}));
 
 }  // namespace observability


### PR DESCRIPTION
When a metric emits a data point with a missing tag, the existing OpenCensus implementation records the tag value as an empty string, whereas the new OpenTelemetry implementation omits the tag entirely.

Update the OpenTelemetry implementation to default missing tags to an empty string, ensuring consistent behavior between the two systems.

Test:
- CI with the test_task_metrics.py test