### PR TITLE
[release] Change back to g4dn.12x for 4 GPU

### DIFF
--- a/release/air_tests/air_benchmarks/compute_gpu_4x4_aws.yaml
+++ b/release/air_tests/air_benchmarks/compute_gpu_4x4_aws.yaml
@@ -5,11 +5,11 @@ max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: g4dn.8xlarge
+    instance_type: g4dn.12xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: g4dn.8xlarge
+      instance_type: g4dn.12xlarge
       max_workers: 3
       min_workers: 3
       use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

1. previously when I cleaning up the legacy g3 test, accidentally changed it https://github.com/ray-project/ray/pull/56175 to became g4dn.8xlarge machine which only has 1 GPU per host, this is to change it back.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
