### PR TITLE
[core] Starting log_monitor before starting the raylet.

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1422,9 +1422,10 @@ class Node:
         if self.resource_isolation_config.is_enabled():
             self.resource_isolation_config.add_object_store_memory(object_store_memory)
 
-        self.start_raylet(plasma_directory, fallback_directory, object_store_memory)
         if self._ray_params.include_log_monitor:
             self.start_log_monitor()
+
+        self.start_raylet(plasma_directory, fallback_directory, object_store_memory)
 
     def _kill_process_type(
         self,


### PR DESCRIPTION
As part of #54703, all system processes that are not managed by the raylet need to be started before the the raylet starts. 

I checked with @jjyao and the log monitor can be safely started before the raylet.