### PR TITLE
[train] Add hf trainer support for dictionary of datasets

### DIFF
--- a/python/ray/train/huggingface/transformers/_transformers_utils.py
+++ b/python/ray/train/huggingface/transformers/_transformers_utils.py
@@ -2,7 +2,7 @@ import logging
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Iterator, Optional, Type
+from typing import Iterator, Optional, Type, Union
 
 from torch.utils.data import DataLoader, Dataset, IterableDataset
 
@@ -126,12 +126,19 @@ def prepare_trainer(trainer: "Trainer") -> "Trainer":
                 return super().get_train_dataloader()
 
         def get_eval_dataloader(
-            self, eval_dataset: Optional[Dataset] = None
+            self, eval_dataset: Optional[Union[str, Dataset]] = None
         ) -> DataLoader:
             if eval_dataset is None:
                 eval_dataset = self.eval_dataset
 
-            if isinstance(eval_dataset, _IterableFromIterator):
+            if (
+                isinstance(eval_dataset, str)
+                and isinstance(self.eval_dataset, dict)
+                and isinstance(self.eval_dataset[eval_dataset], _IterableFromIterator)
+            ):
+                dataset = RayTorchIterableDataset(self.eval_dataset[eval_dataset])
+                return DataLoader(dataset, batch_size=1, collate_fn=lambda x: x[0])
+            elif isinstance(eval_dataset, _IterableFromIterator):
                 dataset = RayTorchIterableDataset(eval_dataset)
                 return DataLoader(dataset, batch_size=1, collate_fn=lambda x: x[0])
             else:

--- a/python/ray/train/v2/tests/test_torch_transformers_train.py
+++ b/python/ray/train/v2/tests/test_torch_transformers_train.py
@@ -303,6 +303,108 @@ def test_e2e_ray_data(ray_start_6_cpus_2_gpus, config_id):
     assert "eval_loss" in result.metrics
 
 
+@pytest.mark.parametrize("config_id", ["steps_cpu"])
+def test_e2e_dict_eval_ray_data(ray_start_6_cpus_2_gpus, config_id):
+    def train_func(config):
+        # Datasets
+        if config["use_ray_data"]:
+            train_ds_shard = ray.train.get_dataset_shard("train")
+            eval_ds_shard_1 = ray.train.get_dataset_shard("eval_1")
+            eval_ds_shard_2 = ray.train.get_dataset_shard("eval_2")
+
+            train_dataset = train_ds_shard.iter_torch_batches(
+                batch_size=BATCH_SIZE_PER_WORKER
+            )
+            eval_dataset = {
+                "eval_1": eval_ds_shard_1.iter_torch_batches(
+                    batch_size=BATCH_SIZE_PER_WORKER
+                ),
+                "eval_2": eval_ds_shard_2.iter_torch_batches(
+                    batch_size=BATCH_SIZE_PER_WORKER
+                ),
+            }
+        else:
+            train_df = pd.read_json(train_data)
+            validation_df = pd.read_json(validation_data)
+
+            train_dataset = Dataset.from_pandas(train_df)
+            eval_dataset = Dataset.from_pandas(validation_df)
+
+        # Model
+        model_config = AutoConfig.from_pretrained(MODEL_NAME)
+        model = AutoModelForCausalLM.from_config(model_config)
+
+        # HF Transformers Trainer
+        training_args = TrainingArguments(
+            f"{MODEL_NAME}-wikitext2",
+            evaluation_strategy=config["evaluation_strategy"],
+            logging_strategy=config["logging_strategy"],
+            save_strategy=config["save_strategy"],
+            eval_steps=config["eval_steps"],
+            save_steps=config["save_steps"],
+            logging_steps=config["logging_steps"],
+            num_train_epochs=config.get("num_train_epochs", MAX_EPOCHS),
+            max_steps=config.get("max_steps", -1),
+            learning_rate=config.get("learning_rate", 2e-5),
+            per_device_train_batch_size=BATCH_SIZE_PER_WORKER,
+            per_device_eval_batch_size=BATCH_SIZE_PER_WORKER,
+            weight_decay=0.01,
+            disable_tqdm=True,
+            no_cuda=config["no_cuda"],
+            report_to="none",
+        )
+        trainer = Trainer(
+            model=model,
+            args=training_args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+
+        # Report to Ray Train
+        trainer.add_callback(RayTrainReportCallback())
+        trainer = prepare_trainer(trainer)
+
+        # Start Training
+        trainer.train()
+
+    train_loop_config = CONFIGURATIONS[config_id]
+
+    # Must specify `max_steps` for Iterable Dataset
+    train_loop_config["use_ray_data"] = True
+    train_loop_config["max_steps"] = MAX_STEPS
+
+    # Calculate the num of Ray training iterations
+    num_iterations = MAX_STEPS // train_loop_config["save_steps"]
+
+    train_df = pd.read_json(train_data)
+    validation_df = pd.read_json(validation_data)
+
+    ray_train_ds = ray.data.from_pandas(train_df)
+    ray_eval_ds_1 = ray.data.from_pandas(validation_df)
+    ray_eval_ds_2 = ray.data.from_pandas(validation_df)
+
+    use_gpu = not train_loop_config["no_cuda"]
+
+    trainer = TorchTrainer(
+        train_func,
+        train_loop_config=train_loop_config,
+        scaling_config=ScalingConfig(num_workers=NUM_WORKERS, use_gpu=use_gpu),
+        datasets={
+            "train": ray_train_ds,
+            "eval_1": ray_eval_ds_1,
+            "eval_2": ray_eval_ds_2,
+        },
+    )
+    result = trainer.fit()
+
+    assert result.metrics["step"] == MAX_STEPS
+    assert result.checkpoint
+    assert isinstance(result.checkpoint, Checkpoint)
+    assert len(result.best_checkpoints) == num_iterations
+    assert "eval_eval_1_loss" in result.metrics
+    assert "eval_eval_2_loss" in result.metrics
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Use case

To provide support for evaluating model via HuggingFace trainer using a dictionary of Ray datasets. This is to align with the `eval_dataset` argument type in `get_eval_dataloader` in [transformers](https://github.com/huggingface/transformers/blob/v4.56.1/src/transformers/trainer.py#L1196).

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
If users provide a dictionary of Ray datasets as `eval_datasets` to HuggingFace `Trainer`, it will fail during evaluation step because the current dataloader returned is NOT of the type `RayTorchIterableDataset`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(