### PR TITLE
[core][rdt] Support tensor transfer from outside owners of actors

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -786,6 +786,7 @@ cdef int prepare_labels(
     if label_dict is None:
         return 0
 
+    label_map[0].reserve(len(label_dict))
     for key, value in label_dict.items():
         if not isinstance(key, str):
             raise ValueError(f"Label key must be string, but got {type(key)}")
@@ -802,6 +803,7 @@ cdef int prepare_label_selector(
     if label_selector_dict is None:
         return 0
 
+    label_selector[0].reserve(len(label_selector_dict))
     for key, value in label_selector_dict.items():
         if not isinstance(key, str):
             raise ValueError(f"Label selector key type must be string, but got {type(key)}")
@@ -829,6 +831,7 @@ cdef int prepare_resources(
     if resource_dict is None:
         raise ValueError("Must provide resource map.")
 
+    resource_map[0].reserve(len(resource_dict))
     for key, value in resource_dict.items():
         if not (isinstance(value, int) or isinstance(value, float)):
             raise ValueError("Resource quantities may only be ints or floats.")
@@ -855,6 +858,7 @@ cdef c_vector[CFunctionDescriptor] prepare_function_descriptors(pyfd_list):
         c_vector[CFunctionDescriptor] fd_list
         CRayFunction ray_function
 
+    fd_list.reserve(len(pyfd_list))
     for pyfd in pyfd_list:
         fd_list.push_back(CFunctionDescriptorBuilder.BuildPython(
             pyfd.module_name, pyfd.class_name, pyfd.function_name, b""))
@@ -866,17 +870,16 @@ cdef int prepare_actor_concurrency_groups(
         c_vector[CConcurrencyGroup] *concurrency_groups):
 
     cdef:
-        CConcurrencyGroup cg
         c_vector[CFunctionDescriptor] c_fd_list
 
     if concurrency_groups_dict is None:
         raise ValueError("Must provide it...")
 
+    concurrency_groups.reserve(len(concurrency_groups_dict))
     for key, value in concurrency_groups_dict.items():
         c_fd_list = prepare_function_descriptors(value["function_descriptors"])
-        cg = CConcurrencyGroup(
-            key.encode("ascii"), value["max_concurrency"], c_fd_list)
-        concurrency_groups.push_back(cg)
+        concurrency_groups.push_back(CConcurrencyGroup(
+            key.encode("ascii"), value["max_concurrency"], move(c_fd_list)))
     return 1
 
 
@@ -3832,6 +3835,7 @@ cdef class CoreWorker:
                      labels,
                      label_selector,
                      c_bool allow_out_of_order_execution,
+                     c_bool enable_tensor_transport,
                      ):
         cdef:
             CRayFunction ray_function
@@ -3886,6 +3890,7 @@ cdef class CoreWorker:
                         c_concurrency_groups,
                         allow_out_of_order_execution,
                         max_pending_calls,
+                        enable_tensor_transport,
                         enable_task_events,
                         c_labels,
                         c_label_selector),
@@ -4165,6 +4170,7 @@ cdef class CoreWorker:
         max_task_retries = dereference(c_actor_handle).MaxTaskRetries()
         enable_task_events = dereference(c_actor_handle).EnableTaskEvents()
         allow_out_of_order_execution = dereference(c_actor_handle).AllowOutOfOrderExecution()
+        enable_tensor_transport = dereference(c_actor_handle).EnableTensorTransport()
         if language == Language.PYTHON:
             assert isinstance(actor_creation_function_descriptor,
                               PythonFunctionDescriptor)
@@ -4188,11 +4194,7 @@ cdef class CoreWorker:
                                          method_meta.retry_exceptions,
                                          method_meta.generator_backpressure_num_objects, # noqa
                                          method_meta.enable_task_events,
-                                         # TODO(swang): Pass
-                                         # enable_tensor_transport when
-                                         # serializing an ActorHandle and
-                                         # sending to another actor.
-                                         False,  # enable_tensor_transport
+                                         enable_tensor_transport,
                                          method_meta.method_name_to_tensor_transport,
                                          actor_method_cpu,
                                          actor_creation_function_descriptor,

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -894,6 +894,7 @@ class ActorMethod:
             "is_generator": self._is_generator,
             "generator_backpressure_num_objects": self._generator_backpressure_num_objects,  # noqa
             "enable_task_events": self._enable_task_events,
+            "_tensor_transport": self._tensor_transport,
         }
 
     def __setstate__(self, state):
@@ -907,6 +908,7 @@ class ActorMethod:
             state["generator_backpressure_num_objects"],
             state["enable_task_events"],
             state["decorator"],
+            state["_tensor_transport"],
         )
 
 
@@ -1795,6 +1797,7 @@ class ActorClass(Generic[T]):
             labels=actor_options.get("_labels"),
             label_selector=actor_options.get("label_selector"),
             allow_out_of_order_execution=allow_out_of_order_execution,
+            enable_tensor_transport=meta.enable_tensor_transport,
         )
 
         if _actor_launch_hook:
@@ -1892,6 +1895,7 @@ class ActorHandle(Generic[T]):
         _ray_actor_creation_function_descriptor: The function descriptor
             of the actor creation task.
         _ray_allow_out_of_order_execution: Whether the actor can execute tasks out of order.
+        _ray_enable_tensor_transport: Whether tensor transport is enabled for this actor.
     """
 
     def __init__(

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -365,6 +365,7 @@ cdef extern from "ray/core_worker/common.h" nogil:
             const c_vector[CConcurrencyGroup] &concurrency_groups,
             c_bool allow_out_of_order_execution,
             int32_t max_pending_calls,
+            c_bool enable_tensor_transport,
             c_bool enable_task_events,
             const unordered_map[c_string, c_string] &labels,
             const unordered_map[c_string, c_string] &label_selector)
@@ -765,9 +766,9 @@ cdef extern from "src/ray/protobuf/autoscaler.pb.h" nogil:
 cdef extern from "ray/common/task/task_spec.h" nogil:
     cdef cppclass CConcurrencyGroup "ray::ConcurrencyGroup":
         CConcurrencyGroup(
-            const c_string &name,
+            c_string name,
             uint32_t max_concurrency,
-            const c_vector[CFunctionDescriptor] &c_fds)
+            c_vector[CFunctionDescriptor] c_fds)
         CConcurrencyGroup()
         c_string GetName() const
         uint32_t GetMaxConcurrency() const

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -117,6 +117,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         int MaxTaskRetries() const
         c_bool EnableTaskEvents() const
         c_bool AllowOutOfOrderExecution() const
+        c_bool EnableTensorTransport() const
 
     cdef cppclass CCoreWorker "ray::core::CoreWorker":
         CWorkerType GetWorkerType()

--- a/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
+++ b/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
@@ -895,5 +895,25 @@ def test_duplicate_objectref_transfer(ray_start_regular):
     ), f"Results differ: result1={val1}, result2={val2}"
 
 
+def test_transfer_from_not_actor_creator(ray_start_regular):
+    @ray.remote
+    class Actor:
+        @ray.method(tensor_transport="gloo")
+        def create(self):
+            return torch.tensor([1, 2, 3])
+
+        def consume(self, obj):
+            return obj
+
+        def do_transfer(self, a1, a2):
+            create_collective_group([a1, a2], backend="torch_gloo")
+            return ray.get(a1.consume.remote(a2.create.remote()))
+
+    actor = [Actor.remote() for _ in range(3)]
+    assert ray.get(actor[2].do_transfer.remote(actor[0], actor[1])) == pytest.approx(
+        torch.tensor([1, 2, 3])
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -247,10 +247,12 @@ struct ConcurrencyGroup {
 
   ConcurrencyGroup() = default;
 
-  ConcurrencyGroup(const std::string &name,
+  ConcurrencyGroup(std::string name,
                    uint32_t max_concurrency,
-                   const std::vector<ray::FunctionDescriptor> &fds)
-      : name_(name), max_concurrency_(max_concurrency), function_descriptors_(fds) {}
+                   std::vector<ray::FunctionDescriptor> fds)
+      : name_(std::move(name)),
+        max_concurrency_(max_concurrency),
+        function_descriptors_(std::move(fds)) {}
 
   std::string GetName() const { return name_; }
 

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -35,6 +35,7 @@ rpc::ActorHandle CreateInnerActorHandle(
     const std::string &ray_namespace,
     int32_t max_pending_calls,
     bool allow_out_of_order_execution,
+    bool enable_tensor_transport,
     std::optional<bool> enable_task_events,
     const std::unordered_map<std::string, std::string> &labels) {
   rpc::ActorHandle inner;
@@ -50,8 +51,9 @@ rpc::ActorHandle CreateInnerActorHandle(
   inner.set_max_task_retries(max_task_retries);
   inner.set_name(name);
   inner.set_ray_namespace(ray_namespace);
-  inner.set_allow_out_of_order_execution(allow_out_of_order_execution);
   inner.set_max_pending_calls(max_pending_calls);
+  inner.set_allow_out_of_order_execution(allow_out_of_order_execution);
+  inner.set_enable_tensor_transport(enable_tensor_transport);
   inner.set_enable_task_events(enable_task_events.value_or(kDefaultTaskEventEnabled));
   inner.mutable_labels()->insert(labels.begin(), labels.end());
   return inner;
@@ -105,6 +107,7 @@ ActorHandle::ActorHandle(
     const std::string &ray_namespace,
     int32_t max_pending_calls,
     bool allow_out_of_order_execution,
+    bool enable_tensor_transport,
     std::optional<bool> enable_task_events,
     const std::unordered_map<std::string, std::string> &labels)
     : ActorHandle(CreateInnerActorHandle(actor_id,
@@ -120,6 +123,7 @@ ActorHandle::ActorHandle(
                                          ray_namespace,
                                          max_pending_calls,
                                          allow_out_of_order_execution,
+                                         enable_tensor_transport,
                                          enable_task_events,
                                          labels)) {}
 

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -49,6 +49,7 @@ class ActorHandle {
               const std::string &ray_namespace,
               int32_t max_pending_calls,
               bool allow_out_of_order_execution = false,
+              bool enable_tensor_transport = false,
               std::optional<bool> enable_task_events = absl::nullopt,
               const std::unordered_map<std::string, std::string> &labels = {});
 
@@ -109,6 +110,8 @@ class ActorHandle {
   int32_t MaxPendingCalls() const { return inner_.max_pending_calls(); }
 
   bool AllowOutOfOrderExecution() const { return inner_.allow_out_of_order_execution(); }
+
+  bool EnableTensorTransport() const { return inner_.enable_tensor_transport(); }
 
   const ::google::protobuf::Map<std::string, std::string> &GetLabels() const {
     return inner_.labels();

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -114,7 +114,7 @@ struct TaskOptions {
 
 /// Options for actor creation tasks.
 struct ActorCreationOptions {
-  ActorCreationOptions() {}
+  ActorCreationOptions() = default;
   ActorCreationOptions(int64_t max_restarts_p,
                        int64_t max_task_retries_p,
                        int max_concurrency_p,
@@ -130,6 +130,7 @@ struct ActorCreationOptions {
                        std::vector<ConcurrencyGroup> concurrency_groups_p = {},
                        bool allow_out_of_order_execution_p = false,
                        int32_t max_pending_calls_p = -1,
+                       bool enable_tensor_transport_p = false,
                        bool enable_task_events_p = kDefaultTaskEventEnabled,
                        std::unordered_map<std::string, std::string> labels_p = {},
                        std::unordered_map<std::string, std::string> label_selector_p = {})
@@ -148,6 +149,7 @@ struct ActorCreationOptions {
         concurrency_groups(std::move(concurrency_groups_p)),
         allow_out_of_order_execution(allow_out_of_order_execution_p),
         max_pending_calls(max_pending_calls_p),
+        enable_tensor_transport(enable_tensor_transport_p),
         scheduling_strategy(std::move(scheduling_strategy_p)),
         enable_task_events(enable_task_events_p),
         labels(std::move(labels_p)),
@@ -201,6 +203,7 @@ struct ActorCreationOptions {
   const bool allow_out_of_order_execution = false;
   /// The maximum actor call pending count.
   const int max_pending_calls = -1;
+  const bool enable_tensor_transport = false;
   // The strategy about how to schedule this actor.
   rpc::SchedulingStrategy scheduling_strategy;
   /// True if task events (worker::TaskEvent) from this creation task should be reported

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -114,7 +114,7 @@ struct TaskOptions {
 
 /// Options for actor creation tasks.
 struct ActorCreationOptions {
-  ActorCreationOptions() = default;
+  ActorCreationOptions() {}
   ActorCreationOptions(int64_t max_restarts_p,
                        int64_t max_task_retries_p,
                        int max_concurrency_p,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2096,6 +2096,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       ray_namespace,
       actor_creation_options.max_pending_calls,
       actor_creation_options.allow_out_of_order_execution,
+      actor_creation_options.enable_tensor_transport,
       actor_creation_options.enable_task_events,
       actor_creation_options.labels);
   std::string serialized_actor_handle;

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -72,6 +72,8 @@ message ActorHandle {
 
   // The key-value labels for actor.
   map<string, string> labels = 15;
+
+  bool enable_tensor_transport = 16;
 }
 
 message PushTaskRequest {


### PR DESCRIPTION
## Why are these changes needed?
To support something like this
```
    @ray.remote
    class Actor:
        @ray.method(tensor_transport="gloo")
        def create(self):
            return torch.tensor([1, 2, 3])

        def consume(self, obj):
            return obj

        def do_transfer(self, a1, a2):
            create_collective_group([a1, a2], backend="torch_gloo")
            return ray.get(a1.consume.remote(a2.create.remote()))

    actor = [Actor.remote() for _ in range(3)]
    ray.get(actor[2].do_transfer.remote(actor[0], actor[1]))
```
where you do a tensor transfer from somewhere that's not the owner of the actor, we need to have `enable_tensor_transport` go through actor handle serde. This PR does that so that you don't get `Method process has tensor_transport=GLOO but enable_tensor_transport is False` when you do this.

Also have some unrelated reserving + moving on the actor creation path.