### PR TITLE
[ci] removing python ver check for llm lockfile compile

### DIFF
--- a/ci/raydepsets/pre_hooks/remove-compiled-headers.sh
+++ b/ci/raydepsets/pre_hooks/remove-compiled-headers.sh
@@ -2,13 +2,6 @@
 
 set -euo pipefail
 
-PYTHON_CODE="$(python -c "import sys; v=sys.version_info; print(f'py{v.major}{v.minor}')")"
-if [[ "${PYTHON_CODE}" != "py311" ]]; then
-	echo "--- Python version is not 3.11"
-	echo "--- Current Python version: ${PYTHON_CODE}"
-	exit 1
-fi
-
 mkdir -p /tmp/ray-deps
 
 # Remove the GPU constraints


### PR DESCRIPTION
removing python ver check for llm compilation

already use --python <ver> flag on compilation