### PR TITLE
[Data] Added support for projection pushdown into Parquet reads

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -743,6 +743,20 @@ py_test(
 )
 
 py_test(
+    name = "test_projection_fusion",
+    size = "small",
+    srcs = ["tests/test_projection_fusion.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_path_util",
     size = "small",
     srcs = ["tests/test_path_util.py"],

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -277,7 +277,9 @@ class ParquetDatasource(Datasource):
         self._partition_columns = partition_columns
         self._read_schema = schema
         self._file_schema = pq_ds.schema
-        self._partition_schema = _get_partition_columns_schema(partitioning, self._pq_paths)
+        self._partition_schema = _get_partition_columns_schema(
+            partitioning, self._pq_paths
+        )
         self._file_metadata_shuffler = None
         self._include_paths = include_paths
         self._partitioning = partitioning
@@ -869,13 +871,14 @@ def _derive_schema(
     if read_schema is not None:
         target_schema = read_schema
     else:
-        print(f">>> [DBG] _derive_schema: {[type(f) for f in list(file_schema)]=}, {list(partition_schema)=}")
+        print(
+            f">>> [DBG] _derive_schema: {[type(f) for f in list(file_schema)]=}, {list(partition_schema)=}"
+        )
 
         # Otherwise, fallback to file + partitioning schema by default
         target_schema = pa.schema(
-            fields=list(file_schema) + (
-                list(partition_schema) if partition_schema is not None else []
-            ),
+            fields=list(file_schema)
+            + (list(partition_schema) if partition_schema is not None else []),
             metadata=file_schema.metadata,
         )
 

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -876,13 +876,17 @@ def _derive_schema(
         target_schema = read_schema
     else:
         file_schema_fields = list(file_schema)
-        partition_schema_fields = list(partition_schema) if partition_schema is not None else []
+        partition_schema_fields = (
+            list(partition_schema) if partition_schema is not None else []
+        )
 
         # Otherwise, fallback to file + partitioning schema by default
         target_schema = pa.schema(
             fields=(
-                file_schema_fields + [
-                    f for f in partition_schema_fields
+                file_schema_fields
+                + [
+                    f
+                    for f in partition_schema_fields
                     # Ignore fields from partition schema overlapping with
                     # file's schema
                     if file_schema.get_field_index(f.name) == -1

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -837,10 +837,10 @@ def _get_partition_columns_schema(
             field_type = pa.from_numpy_dtype(partitioning.field_types[field_name])
         else:
             field_type = pa.string()
-        if field_name not in schema.names:
-            # Without this check, we would add the same partition field multiple times,
-            # which silently fails when asking for `pa.field()`.
-            fields.append(pa.field(field_name, field_type))
+
+        # Without this check, we would add the same partition field multiple times,
+        # which silently fails when asking for `pa.field()`.
+        fields.append(pa.field(field_name, field_type))
 
     return pa.schema(fields)
 

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -1,4 +1,5 @@
 import logging
+import copy
 import math
 import os
 import warnings

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -419,7 +419,6 @@ class ParquetDatasource(Datasource):
     def supports_distributed_reads(self) -> bool:
         return self._supports_distributed_reads
 
-    @property
     def supports_projection_pushdown(self) -> bool:
         return True
 

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -425,12 +425,12 @@ class ParquetDatasource(Datasource):
 
 
 def read_fragments(
-    block_udf,
-    to_batches_kwargs,
-    default_read_batch_size_rows,
-    data_columns,
-    partition_columns,
-    schema,
+    block_udf: Callable[[Block], Optional[Block]],
+    to_batches_kwargs: Dict[str, Any],
+    default_read_batch_size_rows: Optional[int],
+    data_columns: Optional[List[str]],
+    partition_columns: Optional[List[str]],
+    schema: Optional[Union[type, "pyarrow.lib.Schema"]],
     fragments: List[_ParquetFragment],
     include_paths: bool,
     partitioning: Partitioning,
@@ -685,7 +685,7 @@ def _fetch_file_infos(
     schema: Optional["pyarrow.Schema"],
     local_scheduling: Optional[bool],
 ) -> List[Optional[_ParquetFileInfo]]:
-    fetc_file_info = cached_remote_fn(_fetch_parquet_file_info)
+    fetch_file_info = cached_remote_fn(_fetch_parquet_file_info)
     futures = []
 
     for fragment in sampled_fragments:
@@ -693,7 +693,7 @@ def _fetch_file_infos(
         # Use SPREAD scheduling strategy to avoid packing many sampling tasks on
         # same machine to cause OOM issue, as sampling can be memory-intensive.
         futures.append(
-            fetc_file_info.options(
+            fetch_file_info.options(
                 scheduling_strategy=local_scheduling
                 or DataContext.get_current().scheduling_strategy,
                 # Retry in case of transient errors during sampling.

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -323,6 +323,10 @@ class ParquetDatasource(Datasource):
                     break
 
     def estimate_inmemory_data_size(self) -> int:
+        # In case of empty projections no data will be read
+        if self._data_columns == []:
+            return 0
+
         return self._estimate_in_mem_size(self._pq_fragments)
 
     def get_read_tasks(self, parallelism: int) -> List[ReadTask]:

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -1,5 +1,5 @@
-import logging
 import copy
+import logging
 import math
 import os
 import warnings
@@ -56,7 +56,6 @@ from ray.util.debug import log_once
 
 if TYPE_CHECKING:
     import pyarrow
-    from pyarrow import parquet as pq
     from pyarrow.dataset import ParquetFileFragment
 
 

--- a/python/ray/data/_internal/logical/interfaces/__init__.py
+++ b/python/ray/data/_internal/logical/interfaces/__init__.py
@@ -1,4 +1,4 @@
-from .logical_operator import LogicalOperator, SupportsProjectionPushdown
+from .logical_operator import LogicalOperator, LogicalOperatorSupportsProjectionPushdown
 from .logical_plan import LogicalPlan
 from .operator import Operator
 from .optimizer import Optimizer, Rule
@@ -15,5 +15,5 @@ __all__ = [
     "Plan",
     "Rule",
     "SourceOperator",
-    "SupportsProjectionPushdown",
+    "LogicalOperatorSupportsProjectionPushdown",
 ]

--- a/python/ray/data/_internal/logical/interfaces/__init__.py
+++ b/python/ray/data/_internal/logical/interfaces/__init__.py
@@ -1,4 +1,4 @@
-from .logical_operator import LogicalOperator
+from .logical_operator import LogicalOperator, SupportsProjectionPushdown
 from .logical_plan import LogicalPlan
 from .operator import Operator
 from .optimizer import Optimizer, Rule
@@ -15,4 +15,5 @@ __all__ = [
     "Plan",
     "Rule",
     "SourceOperator",
+    "SupportsProjectionPushdown",
 ]

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -88,7 +88,7 @@ class LogicalOperator(Operator):
         return True
 
 
-class SupportsProjectionPushdown(LogicalOperator):
+class LogicalOperatorSupportsProjectionPushdown(LogicalOperator):
     """Mixin for reading operators supporting projection pushdown"""
 
     def supports_projection_pushdown(self) -> bool:

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -86,3 +86,16 @@ class LogicalOperator(Operator):
         objects aren't available on the deserialized machine.
         """
         return True
+
+
+class SupportsProjectionPushdown(LogicalOperator):
+    """Mixin for reading operators supporting projection pushdown"""
+
+    def supports_projection_pushdown(self) -> bool:
+        return False
+
+    def get_current_projection(self) -> Optional[List[str]]:
+        return None
+
+    def apply_projection(self, columns: Optional[List[str]]) -> LogicalOperator:
+        return self

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Callable, Iterator, List
 
 
@@ -76,12 +77,17 @@ class Operator:
                 new_ops.append(transformed_input_op)
 
         if new_ops:
+            # Make a shallow copy to avoid modifying operators in-place
+            target = copy.copy(self)
+
             # NOTE: Only newly created ops need to have output deps
             #       wired in
-            self._wire_output_deps(new_ops)
-            self._input_dependencies = transformed_input_ops
+            target._wire_output_deps(new_ops)
+            target._input_dependencies = transformed_input_ops
+        else:
+            target = self
 
-        return transform(self)
+        return transform(target)
 
     def _wire_output_deps(self, input_dependencies: List["Operator"]):
         for x in input_dependencies:

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 import functools
 from typing import Any, Dict, Optional, Union, List
 

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -122,7 +122,10 @@ class Read(AbstractMap, SourceOperator, LogicalOperatorSupportsProjectionPushdow
 
     def apply_projection(self, columns: List[str]):
         clone = copy.copy(self)
-        clone._datasource = self._datasource.apply_projection(columns)
+
+        projected_datasource = self._datasource.apply_projection(columns)
+        clone._datasource = projected_datasource
+        clone._datasource_or_legacy_reader = projected_datasource
 
         return clone
 

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -3,8 +3,7 @@ import functools
 from typing import Any, Dict, Optional, Union, List
 
 from ray.data._internal.datasource.parquet_datasource import ParquetDatasource
-from ray.data._internal.logical.interfaces import SourceOperator, \
-    LogicalOperator
+from ray.data._internal.logical.interfaces import SourceOperator, SupportsProjectionPushdown
 from ray.data._internal.logical.operators.map_operator import AbstractMap
 from ray.data.block import (
     BlockMetadata,
@@ -13,20 +12,7 @@ from ray.data.block import (
 from ray.data.datasource.datasource import Datasource, Reader
 
 
-class LogicalOperatorProjectionPushdownMixin(LogicalOperator):
-    """Mixin for reading operators supporting projection pushdown"""
-
-    def supports_projection_pushdown(self) -> bool:
-        return False
-
-    def get_current_projection(self) -> Optional[List[str]]:
-        return None
-
-    def apply_projection(self, columns: Optional[List[str]]) -> LogicalOperator:
-        return self
-
-
-class Read(AbstractMap, SourceOperator, LogicalOperatorProjectionPushdownMixin):
+class Read(AbstractMap, SourceOperator, SupportsProjectionPushdown):
     """Logical operator for read."""
 
     def __init__(

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,10 +1,11 @@
-import abc
 import copy
 import functools
-from typing import Any, Dict, Optional, Union, List
+from typing import Any, Dict, List, Optional, Union
 
-from ray.data._internal.datasource.parquet_datasource import ParquetDatasource
-from ray.data._internal.logical.interfaces import SourceOperator, LogicalOperatorSupportsProjectionPushdown
+from ray.data._internal.logical.interfaces import (
+    LogicalOperatorSupportsProjectionPushdown,
+    SourceOperator,
+)
 from ray.data._internal.logical.operators.map_operator import AbstractMap
 from ray.data.block import (
     BlockMetadata,

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -3,7 +3,7 @@ import functools
 from typing import Any, Dict, Optional, Union, List
 
 from ray.data._internal.datasource.parquet_datasource import ParquetDatasource
-from ray.data._internal.logical.interfaces import SourceOperator, SupportsProjectionPushdown
+from ray.data._internal.logical.interfaces import SourceOperator, LogicalOperatorSupportsProjectionPushdown
 from ray.data._internal.logical.operators.map_operator import AbstractMap
 from ray.data.block import (
     BlockMetadata,
@@ -12,7 +12,7 @@ from ray.data.block import (
 from ray.data.datasource.datasource import Datasource, Reader
 
 
-class Read(AbstractMap, SourceOperator, SupportsProjectionPushdown):
+class Read(AbstractMap, SourceOperator, LogicalOperatorSupportsProjectionPushdown):
     """Logical operator for read."""
 
     def __init__(

--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -16,6 +16,7 @@ from ray.data._internal.logical.rules.inherit_target_max_block_size import (
 )
 from ray.data._internal.logical.rules.limit_pushdown import LimitPushdownRule
 from ray.data._internal.logical.rules.operator_fusion import FuseOperators
+from ray.data._internal.logical.rules.projection_pushdown import ProjectionPushdown
 from ray.data._internal.logical.rules.set_read_parallelism import SetReadParallelismRule
 from ray.data._internal.logical.rules.zero_copy_map_fusion import (
     EliminateBuildOutputBlocks,
@@ -26,6 +27,7 @@ _LOGICAL_RULESET = Ruleset(
     [
         InheritBatchFormatRule,
         LimitPushdownRule,
+        ProjectionPushdown,
     ]
 )
 

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -129,7 +129,8 @@ class ProjectionPushdown(Rule):
 
         logger.debug(
             f"Pushing projection down into read operation "
-            f"(projection columns = {new_spec.cols}, remap = {new_spec.cols_remap})"
+            f"projection columns = {new_spec.cols} (before: {target_op_spec.cols}), "
+            f"remap = {new_spec.cols_remap} (before: {target_op_spec.cols_remap})"
         )
 
         return target_op.apply_projection(new_spec.cols)

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -57,9 +57,8 @@ class ProjectionPushdown(Rule):
     @classmethod
     def _is_projectable_read(cls, op: Project) -> bool:
         # NOTE: Currently only projecting into Parquet is supported
-        return (
-            isinstance(op.input_dependency, Read) and
-            isinstance(op.input_dependency._datasource, ParquetDatasource)
+        return isinstance(op.input_dependency, Read) and isinstance(
+            op.input_dependency._datasource, ParquetDatasource
         )
 
     @staticmethod

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -1,0 +1,308 @@
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ray.data._internal.datasource.parquet_datasource import ParquetDatasource
+from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule
+from ray.data._internal.logical.operators.map_operator import Project
+from ray.data._internal.logical.operators.read_operator import Read
+from ray.data.expressions import Expr
+
+logger = logging.getLogger(__file__)
+
+
+@dataclass(frozen=True)
+class _ProjectSpec:
+    cols: Optional[List[str]]
+    cols_remap: Optional[Dict[str, str]]
+    exprs: Optional[Dict[str, Expr]]
+
+
+class ProjectionPushdown(Rule):
+    """Optimization rule that pushes down projections across the graph.
+
+    This rule looks for `Project` operators that are immediately
+    preceded by a `Read` operator and sets the
+    projected columns on the `Read` operator.
+
+    If there are redundant Project operators, it removes the `Project` operator from
+    the graph.
+    """
+
+    def apply(self, plan: LogicalPlan) -> LogicalPlan:
+        dag = plan.dag
+        new_dag = dag._apply_transform(self._pushdown_project)
+
+        return LogicalPlan(new_dag, plan.context) if dag is not new_dag else plan
+
+    @classmethod
+    def _pushdown_project(cls, op: LogicalOperator) -> LogicalOperator:
+        if isinstance(op, Project):
+            # Push-down projections into read op
+            if cls._is_projectable_read(op):
+                project_op: Project = op
+                read_op: Read = op.input_dependency
+
+                return cls._try_combine(read_op, project_op)
+
+            # Otherwise, fuse projections into a single op
+            elif isinstance(op.input_dependency, Project):
+                outer_op: Project = op
+                inner_op: Project = op.input_dependency
+
+                return cls._fuse(inner_op, outer_op)
+
+        return op
+
+    @classmethod
+    def _is_projectable_read(cls, op: Project) -> bool:
+        # NOTE: Currently only projecting into Parquet is supported
+        return (
+            isinstance(op.input_dependency, Read) and
+            isinstance(op.input_dependency._datasource, ParquetDatasource)
+        )
+
+    @staticmethod
+    def _fuse(inner_op: Project, outer_op: Project) -> Project:
+        # Combine expressions from both operators
+        combined_exprs = _combine_expressions(inner_op.exprs, outer_op.exprs)
+
+        # Only combine projection specs if there are no expressions
+        # When expressions are present, they take precedence
+        if combined_exprs:
+            # When expressions are present, preserve column operations from outer operation
+            # The logical order is: expressions first, then column operations
+            outer_cols = outer_op.cols
+            outer_cols_rename = outer_op.cols_rename
+
+            # If outer operation has no column operations, fall back to inner operation
+            if outer_cols is None and outer_cols_rename is None:
+                outer_cols = inner_op.cols
+                outer_cols_rename = inner_op.cols_rename
+
+            return Project(
+                inner_op.input_dependency,
+                cols=outer_cols,
+                cols_rename=outer_cols_rename,
+                exprs=combined_exprs,
+                # Give precedence to outer operator's ray_remote_args
+                ray_remote_args={
+                    **inner_op._ray_remote_args,
+                    **outer_op._ray_remote_args,
+                },
+            )
+        else:
+            # Fall back to original behavior for column-only projections
+            inner_op_spec = _get_projection_spec(inner_op)
+            outer_op_spec = _get_projection_spec(outer_op)
+
+            new_spec = _combine_projection_specs(
+                prev_spec=inner_op_spec, new_spec=outer_op_spec
+            )
+
+            return Project(
+                inner_op.input_dependency,
+                cols=new_spec.cols,
+                cols_rename=new_spec.cols_remap,
+                exprs=None,
+                ray_remote_args={
+                    **inner_op._ray_remote_args,
+                    **outer_op._ray_remote_args,
+                },
+            )
+
+    @staticmethod
+    def _try_combine(read_op: Read, project_op: Project) -> LogicalOperator:
+        # For now, don't push down expressions into `Read` operators
+        # Only handle traditional column projections
+        if project_op.exprs:
+            # Cannot push expressions into `Read`, return unchanged
+            return project_op
+
+        read_op_spec = _get_projection_spec(read_op)
+        project_op_spec = _get_projection_spec(project_op)
+
+        new_spec = _combine_projection_specs(
+            prev_spec=read_op_spec, new_spec=project_op_spec
+        )
+
+        logger.debug(
+            f"Pushing projection down into read operation "
+            f"(projection columns = {new_spec.cols}, remap = {new_spec.cols_remap})"
+        )
+
+        pqd: ParquetDatasource = read_op._datasource
+
+        # TODO(DATA-843) avoid modifying in-place
+        pqd._data_columns = new_spec.cols
+
+        return read_op
+
+
+def _combine_expressions(
+    inner_exprs: Optional[Dict[str, Expr]], outer_exprs: Optional[Dict[str, Expr]]
+) -> Optional[Dict[str, Expr]]:
+    """Combine expressions from two Project operators.
+
+    Args:
+        inner_exprs: Expressions from the inner (upstream) Project operator
+        outer_exprs: Expressions from the outer (downstream) Project operator
+
+    Returns:
+        Combined dictionary of expressions, or None if no expressions
+    """
+    if not inner_exprs and not outer_exprs:
+        return None
+
+    combined = {}
+
+    # Add expressions from inner operator
+    if inner_exprs:
+        combined.update(inner_exprs)
+
+    # Add expressions from outer operator
+    if outer_exprs:
+        combined.update(outer_exprs)
+
+    return combined if combined else None
+
+
+def _get_projection_spec(op: Union[Project, Read]) -> _ProjectSpec:
+    assert op is not None
+
+    if isinstance(op, Project):
+        return _ProjectSpec(
+            cols=op.cols,
+            cols_remap=op.cols_rename,
+            exprs=op.exprs,
+        )
+    elif isinstance(op, Read):
+        assert isinstance(op._datasource, ParquetDatasource)
+
+        pqd: ParquetDatasource = op._datasource
+
+        return _ProjectSpec(
+            cols=pqd._data_columns,
+            cols_remap=None,
+            exprs=None,
+        )
+    else:
+        raise ValueError(
+            f"Operation doesn't have projection spec (supported Project, "
+            f"Read, got: {op.__class__})"
+        )
+
+
+def _combine_projection_specs(
+    prev_spec: _ProjectSpec, new_spec: _ProjectSpec
+) -> _ProjectSpec:
+    combined_cols_remap = _combine_columns_remap(
+        prev_spec.cols_remap,
+        new_spec.cols_remap,
+    )
+
+    # Validate resulting remapping against existing projection (if any)
+    _validate(combined_cols_remap, prev_spec.cols)
+
+    new_projection_cols: Optional[List[str]]
+
+    if prev_spec.cols is None and new_spec.cols is None:
+        # If both projections are unset, resulting is unset
+        new_projection_cols = None
+    elif prev_spec.cols is not None and new_spec.cols is None:
+        # If previous projection is set, but the new unset -- fallback to
+        # existing projection
+        new_projection_cols = prev_spec.cols
+    else:
+        # If new is set (and previous is either set or not)
+        #   - Reconcile new projection
+        #   - Project combined column remapping
+        assert new_spec.cols is not None
+
+        new_projection_cols = new_spec.cols
+
+        # Remap new projected columns into the schema before remapping (from the
+        # previous spec)
+        if prev_spec.cols_remap and new_projection_cols:
+            # Inverse remapping
+            inv_cols_remap = {v: k for k, v in prev_spec.cols_remap.items()}
+            new_projection_cols = [
+                inv_cols_remap.get(col, col) for col in new_projection_cols
+            ]
+
+        prev_cols_set = set(prev_spec.cols or [])
+        new_cols_set = set(new_projection_cols or [])
+
+        # Validate new projection is a proper subset of the previous one
+        if prev_cols_set and new_cols_set and not new_cols_set.issubset(prev_cols_set):
+            raise ValueError(
+                f"Selected columns '{new_cols_set}' needs to be a subset of "
+                f"'{prev_cols_set}'"
+            )
+
+    # Project remaps to only map relevant columns
+    if new_projection_cols is not None and combined_cols_remap is not None:
+        projected_cols_remap = {
+            k: v for k, v in combined_cols_remap.items() if k in new_projection_cols
+        }
+    else:
+        projected_cols_remap = combined_cols_remap
+
+    # Combine expressions from both specs
+    combined_exprs = _combine_expressions(prev_spec.exprs, new_spec.exprs)
+
+    return _ProjectSpec(
+        cols=new_projection_cols, cols_remap=projected_cols_remap, exprs=combined_exprs
+    )
+
+
+def _combine_columns_remap(
+    prev_remap: Optional[Dict[str, str]], new_remap: Optional[Dict[str, str]]
+) -> Optional[Dict[str, str]]:
+
+    if not new_remap and not prev_remap:
+        return None
+
+    new_remap = new_remap or {}
+    base_remap = prev_remap or {}
+
+    filtered_new_remap = dict(new_remap)
+    # Apply new remapping to the base remap
+    updated_base_remap = {
+        # NOTE: We're removing corresponding chained mapping from the remap
+        k: filtered_new_remap.pop(v, v)
+        for k, v in base_remap.items()
+    }
+
+    resolved_remap = dict(updated_base_remap)
+    resolved_remap.update(filtered_new_remap)
+
+    return resolved_remap
+
+
+def _validate(remap: Optional[Dict[str, str]], projection_cols: Optional[List[str]]):
+    if not remap:
+        return
+
+    # Verify that the remapping is a proper bijection (ie no
+    # columns are renamed into the same new name)
+    prev_names_map = {}
+    for prev_name, new_name in remap.items():
+        if new_name in prev_names_map:
+            raise ValueError(
+                f"Identified projections with conflict in renaming: '{new_name}' "
+                f"is mapped from multiple sources: '{prev_names_map[new_name]}' "
+                f"and '{prev_name}'."
+            )
+
+        prev_names_map[new_name] = prev_name
+
+    # Verify that remapping only references columns available in the projection
+    if projection_cols is not None:
+        invalid_cols = [key for key in remap.keys() if key not in projection_cols]
+
+        if invalid_cols:
+            raise ValueError(
+                f"Identified projections with invalid rename "
+                f"columns: {', '.join(invalid_cols)}"
+            )

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -45,7 +45,9 @@ class ProjectionPushdown(Rule):
             # Push-down projections into read op
             if cls._supports_projection_pushdown(op):
                 project_op: Project = op
-                target_op: LogicalOperatorSupportsProjectionPushdown = op.input_dependency
+                target_op: LogicalOperatorSupportsProjectionPushdown = (
+                    op.input_dependency
+                )
 
                 return cls._try_combine(target_op, project_op)
 
@@ -62,7 +64,10 @@ class ProjectionPushdown(Rule):
     def _supports_projection_pushdown(cls, op: Project) -> bool:
         # NOTE: Currently only projecting into Parquet is supported
         input_op = op.input_dependency
-        return isinstance(input_op, LogicalOperatorSupportsProjectionPushdown) and input_op.supports_projection_pushdown()
+        return (
+            isinstance(input_op, LogicalOperatorSupportsProjectionPushdown)
+            and input_op.supports_projection_pushdown()
+        )
 
     @staticmethod
     def _fuse(inner_op: Project, outer_op: Project) -> Project:

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
@@ -130,9 +131,11 @@ class ProjectionPushdown(Rule):
             f"(projection columns = {new_spec.cols}, remap = {new_spec.cols_remap})"
         )
 
-        pqd: ParquetDatasource = read_op._datasource
+        # Make a sahllow copy of the `Read` and `ParquetDatasource` to avoid
+        # modifying in-place
+        read_op = copy.copy(read_op)
+        pqd: ParquetDatasource = copy.copy(read_op._datasource)
 
-        # TODO(DATA-843) avoid modifying in-place
         pqd._data_columns = new_spec.cols
 
         return read_op

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -1,9 +1,13 @@
-import copy
 import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
-from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule, LogicalOperatorSupportsProjectionPushdown
+from ray.data._internal.logical.interfaces import (
+    LogicalOperator,
+    LogicalOperatorSupportsProjectionPushdown,
+    LogicalPlan,
+    Rule,
+)
 from ray.data._internal.logical.operators.map_operator import Project
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data.expressions import Expr

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -9,7 +9,7 @@ from ray.data._internal.logical.operators.map_operator import Project
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data.expressions import Expr
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3406,7 +3406,7 @@ class Dataset:
 
         plan = self._plan.copy()
 
-        # NOTE: Project the dataset to avoid the need to carrying actual
+        # NOTE: Project the dataset to avoid the need to carry actual
         #       data when we're only interested in the total count
         count_op = Count(Project(self._logical_plan.dag, cols=[]))
         logical_plan = LogicalPlan(count_op, self.context)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1093,9 +1093,6 @@ class Dataset:
                 "select_columns requires 'cols' to be a string or a list of strings."
             )
 
-        if not cols:
-            raise ValueError("select_columns requires at least one column to select.")
-
         if len(cols) != len(set(cols)):
             raise ValueError(
                 "select_columns expected unique column names, "

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Callable, Iterable, List, Optional
 
 import numpy as np
@@ -7,8 +8,24 @@ from ray.data.block import Block, BlockMetadata, Schema
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 
 
+class _DatasourceProjectionPushdownMixin:
+    """Mixin for reading operators supporting projection pushdown"""
+
+    def supports_projection_pushdown(self) -> bool:
+        """Returns ``True`` in case ``Datasource`` supports projection operation
+        being pushed down into the reading layer"""
+        return False
+
+    def get_current_projection(self) -> Optional[List[str]]:
+        """Retrurns current projection"""
+        return None
+
+    def apply_projection(self, columns: List[str]) -> "Datasource":
+        return self
+
+
 @PublicAPI
-class Datasource:
+class Datasource(_DatasourceProjectionPushdownMixin):
     """Interface for defining a custom :class:`~ray.data.Dataset` datasource.
 
     To read a datasource into a dataset, use :meth:`~ray.data.read_datasource`.

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Callable, Iterable, List, Optional
 
 import numpy as np

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -880,7 +880,6 @@ def test_select_columns(
 @pytest.mark.parametrize(
     "cols, expected_exception, expected_error",
     [
-        ([], ValueError, "select_columns requires at least one column to select"),
         (
             None,
             TypeError,

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -635,7 +635,7 @@ def test_projection_pushdown_non_partitioned(ray_start_regular_shared, temp_dir)
 
     summary = ds.materialize()._plan.stats().to_summary()
 
-    assert summary.base_name == "ReadParquet->SplitBlocks(24)"
+    assert "ReadParquet" in summary.base_name
     assert summary.extra_metrics["bytes_task_outputs_generated"] == 0
 
 

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -639,7 +639,6 @@ def test_projection_pushdown_non_partitioned(temp_dir):
     assert summary.extra_metrics["bytes_task_outputs_generated"] == 0
 
 
-
 def test_projection_pushdown_partitioned(temp_dir):
     ds = ray.data.read_parquet("example://iris.parquet").materialize()
 
@@ -670,7 +669,7 @@ def test_projection_pushdown_on_count(temp_dir):
     path = "example://iris.parquet"
 
     # Test reading full dataset
-    #ds = ray.data.read_parquet(path).materialize()
+    # ds = ray.data.read_parquet(path).materialize()
 
     # Test projection from read_parquet
     num_rows = ray.data.read_parquet(path).count()

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -602,11 +602,7 @@ def test_parquet_read_partitioned_explicit(
 
 
 def test_projection_pushdown_non_partitioned(temp_dir):
-    ds = ray.data.read_parquet("example://iris.parquet").materialize()
-
-    # Write out non-partitioned dataset
-    path = f"{temp_dir}/non_partitioned_iris"
-    ds.write_parquet(path)
+    path = "example://iris.parquet"
 
     # Test projection from read_parquet
     ds = ray.data.read_parquet(path, columns=["variety"])

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -657,6 +657,18 @@ def test_projection_pushdown_partitioned(temp_dir):
     assert ds.count() == partitioned_ds.count()
 
 
+def test_projection_pushdown_on_count(temp_dir):
+    path = "example://iris.parquet"
+
+    # Test reading full dataset
+    #ds = ray.data.read_parquet(path).materialize()
+
+    # Test projection from read_parquet
+    num_rows = ray.data.read_parquet(path).count()
+
+    assert num_rows == 150
+
+
 def test_parquet_read_with_udf(
     ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
 ):

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -601,7 +601,7 @@ def test_parquet_read_partitioned_explicit(
     ]
 
 
-def test_projection_pushdown_non_partitioned(temp_dir):
+def test_projection_pushdown_non_partitioned(ray_start_regular_shared, temp_dir):
     path = "example://iris.parquet"
 
     # Test projection from read_parquet
@@ -639,7 +639,7 @@ def test_projection_pushdown_non_partitioned(temp_dir):
     assert summary.extra_metrics["bytes_task_outputs_generated"] == 0
 
 
-def test_projection_pushdown_partitioned(temp_dir):
+def test_projection_pushdown_partitioned(ray_start_regular_shared, temp_dir):
     ds = ray.data.read_parquet("example://iris.parquet").materialize()
 
     partitioned_ds_path = f"{temp_dir}/partitioned_iris"
@@ -665,7 +665,7 @@ def test_projection_pushdown_partitioned(temp_dir):
     assert ds.count() == partitioned_ds.count()
 
 
-def test_projection_pushdown_on_count(temp_dir):
+def test_projection_pushdown_on_count(ray_start_regular_shared, temp_dir):
     path = "example://iris.parquet"
 
     # Test reading full dataset

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -38,7 +38,7 @@ class DependencyTestCase:
     description: str
 
 
-class TestProjectionPushdownTopoSort:
+class TestPorjectionFusion:
     """Test topological sorting in projection pushdown fusion."""
 
     @pytest.fixture(autouse=True)

--- a/python/ray/data/tests/test_projection_pushdown.py
+++ b/python/ray/data/tests/test_projection_pushdown.py
@@ -1,0 +1,678 @@
+from dataclasses import dataclass
+from typing import Dict, List, Set
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
+import pytest
+
+import ray
+from ray.anyscale.data._internal.logical.rules.projection_pushdown import (
+    ProjectionPushdown,
+)
+from ray.data._internal.logical.interfaces import LogicalPlan
+from ray.data._internal.logical.operators.input_data_operator import InputData
+from ray.data._internal.logical.operators.map_operator import Project
+from ray.data.context import DataContext
+from ray.data.expressions import DataType, col, udf
+
+
+@dataclass
+class FusionTestCase:
+    """Test case for projection fusion scenarios."""
+
+    name: str
+    expressions_list: List[Dict[str, str]]  # List of {name: expression_desc}
+    expected_levels: int
+    expected_level_contents: List[Set[str]]  # Expected expressions in each level
+    description: str
+
+
+@dataclass
+class DependencyTestCase:
+    """Test case for dependency analysis."""
+
+    name: str
+    expression_desc: str
+    expected_refs: Set[str]
+    description: str
+
+
+class TestProjectionPushdownTopoSort:
+    """Test topological sorting in projection pushdown fusion."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.context = DataContext.get_current()
+
+        # Create UDFs for testing
+        @udf(return_dtype=DataType.int64())
+        def multiply_by_two(x: pa.Array) -> pa.Array:
+            return pc.multiply(x, 2)
+
+        @udf(return_dtype=DataType.int64())
+        def add_one(x: pa.Array) -> pa.Array:
+            return pc.add(x, 1)
+
+        @udf(return_dtype=DataType.float64())
+        def divide_by_three(x: pa.Array) -> pa.Array:
+            # Convert to float to ensure floating point division
+            return pc.divide(pc.cast(x, pa.float64()), 3.0)
+
+        self.udfs = {
+            "multiply_by_two": multiply_by_two,
+            "add_one": add_one,
+            "divide_by_three": divide_by_three,
+        }
+
+    def _create_input_op(self):
+        """Create a dummy input operator."""
+        return InputData(input_data=[])
+
+    def _parse_expression(self, expr_desc: str):
+        """Parse expression description into actual expression object."""
+        # Enhanced parser for test expressions
+        expr_map = {
+            "col('id')": col("id"),
+            "col('id') + 10": col("id") + 10,
+            "col('id') * 2": col("id") * 2,
+            "col('id') - 5": col("id") - 5,
+            "col('id') + 1": col("id") + 1,
+            "col('id') - 1": col("id") - 1,
+            "col('id') - 3": col("id") - 3,
+            "col('step1') * 2": col("step1") * 2,
+            "col('step2') + 1": col("step2") + 1,
+            "col('a') + col('b')": col("a") + col("b"),
+            "col('c') + col('d')": col("c") + col("d"),
+            "col('e') * 3": col("e") * 3,
+            "col('a') + 1": col("a") + 1,
+            "multiply_by_two(col('id'))": self.udfs["multiply_by_two"](col("id")),
+            "multiply_by_two(col('id')) + col('plus_ten')": (
+                self.udfs["multiply_by_two"](col("id")) + col("plus_ten")
+            ),
+            "col('times_three') > col('plus_ten')": (
+                col("times_three") > col("plus_ten")
+            ),
+            "multiply_by_two(col('x'))": self.udfs["multiply_by_two"](col("x")),
+            "add_one(col('id'))": self.udfs["add_one"](col("id")),
+            "multiply_by_two(col('plus_one'))": self.udfs["multiply_by_two"](
+                col("plus_one")
+            ),
+            "divide_by_three(col('times_two'))": self.udfs["divide_by_three"](
+                col("times_two")
+            ),
+        }
+
+        if expr_desc in expr_map:
+            return expr_map[expr_desc]
+        else:
+            raise ValueError(f"Unknown expression: {expr_desc}")
+
+    def _create_project_chain(self, input_op, expressions_list: List[Dict[str, str]]):
+        """Create a chain of Project operators from expression descriptions."""
+        current_op = input_op
+
+        for expr_dict in expressions_list:
+            exprs = {
+                name: self._parse_expression(desc) for name, desc in expr_dict.items()
+            }
+            current_op = Project(
+                current_op, cols=None, cols_rename=None, exprs=exprs, ray_remote_args={}
+            )
+
+        return current_op
+
+    def _extract_levels_from_plan(self, plan: LogicalPlan) -> List[Set[str]]:
+        """Extract expression levels from optimized plan."""
+        current = plan.dag
+        levels = []
+
+        while isinstance(current, Project):
+            if current.exprs:
+                levels.append(set(current.exprs.keys()))
+            current = current.input_dependency
+
+        return list(reversed(levels))  # Return bottom-up order
+
+    def _count_project_operators(self, plan: LogicalPlan) -> int:
+        """Count the number of Project operators in the plan."""
+        current = plan.dag
+        count = 0
+
+        while current:
+            if isinstance(current, Project):
+                count += 1
+            current = getattr(current, "input_dependency", None)
+
+        return count
+
+    def _describe_plan_structure(self, plan: LogicalPlan) -> str:
+        """Generate a description of the plan structure."""
+        current = plan.dag
+        operators = []
+
+        while current:
+            if isinstance(current, Project):
+                expr_count = len(current.exprs) if current.exprs else 0
+                operators.append(f"Project({expr_count} exprs)")
+            else:
+                operators.append(current.__class__.__name__)
+            current = getattr(current, "input_dependency", None)
+
+        return " -> ".join(operators)
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            FusionTestCase(
+                name="no_dependencies",
+                expressions_list=[
+                    {"doubled": "col('id') * 2", "plus_five": "col('id') + 10"},
+                    {"minus_three": "col('id') - 3"},
+                ],
+                expected_levels=1,
+                expected_level_contents=[{"doubled", "plus_five", "minus_three"}],
+                description="Independent expressions should fuse into single operator",
+            ),
+            FusionTestCase(
+                name="simple_chain",
+                expressions_list=[
+                    {"step1": "col('id') + 10"},
+                    {"step2": "col('step1') * 2"},
+                    {"step3": "col('step2') + 1"},
+                ],
+                expected_levels=1,
+                expected_level_contents=[
+                    {"step1", "step2", "step3"}
+                ],  # All in one level
+                description="All expressions fuse into single operator with OrderedDict preservation",
+            ),
+            FusionTestCase(
+                name="mixed_udf_regular",
+                expressions_list=[
+                    {"plus_ten": "col('id') + 10"},
+                    {"times_three": "multiply_by_two(col('id'))"},
+                    {"minus_five": "col('id') - 5"},
+                    {
+                        "udf_plus_regular": "multiply_by_two(col('id')) + col('plus_ten')"
+                    },
+                    {"comparison": "col('times_three') > col('plus_ten')"},
+                ],
+                expected_levels=1,
+                expected_level_contents=[
+                    {
+                        "plus_ten",
+                        "times_three",
+                        "minus_five",
+                        "udf_plus_regular",
+                        "comparison",
+                    }
+                ],
+                description="All expressions fuse into single operator",
+            ),
+            FusionTestCase(
+                name="complex_graph",
+                expressions_list=[
+                    {"a": "col('id') + 1", "b": "col('id') * 2"},
+                    {"c": "col('a') + col('b')"},
+                    {"d": "col('id') - 1"},
+                    {"e": "col('c') + col('d')"},
+                    {"f": "col('e') * 3"},
+                ],
+                expected_levels=1,
+                expected_level_contents=[{"a", "b", "c", "d", "e", "f"}],
+                description="All expressions fuse into single operator",
+            ),
+            FusionTestCase(
+                name="udf_dependency_chain",
+                expressions_list=[
+                    {"plus_one": "add_one(col('id'))"},
+                    {"times_two": "multiply_by_two(col('plus_one'))"},
+                    {"div_three": "divide_by_three(col('times_two'))"},
+                ],
+                expected_levels=1,  # Changed from 3 to 1
+                expected_level_contents=[{"plus_one", "times_two", "div_three"}],
+                description="All UDF expressions fuse into single operator with preserved order",
+            ),
+        ],
+    )
+    def test_fusion_scenarios(self, test_case: FusionTestCase):
+        """Test various fusion scenarios with simplified single-operator fusion."""
+        input_op = self._create_input_op()
+        final_op = self._create_project_chain(input_op, test_case.expressions_list)
+
+        # Apply projection pushdown
+        plan = LogicalPlan(final_op, self.context)
+        rule = ProjectionPushdown()
+        optimized_plan = rule.apply(plan)
+
+        # Extract levels from optimized plan
+        actual_levels = self._extract_levels_from_plan(optimized_plan)
+
+        # Verify number of levels
+        assert len(actual_levels) == test_case.expected_levels, (
+            f"{test_case.name}: Expected {test_case.expected_levels} operators, "
+            f"got {len(actual_levels)}. Actual operators: {actual_levels}"
+        )
+
+        # Verify level contents (more flexible matching)
+        for i, expected_content in enumerate(test_case.expected_level_contents):
+            assert expected_content.issubset(actual_levels[i]), (
+                f"{test_case.name}: Operator {i} missing expressions. "
+                f"Expected {expected_content} to be subset of {actual_levels[i]}"
+            )
+
+    def test_pairwise_fusion_behavior(self):
+        """Test to understand how pairwise fusion works in practice."""
+        input_data = [{"id": i} for i in range(10)]
+
+        # Test with 2 operations (should fuse to 1)
+        ds2 = ray.data.from_items(input_data)
+        ds2 = ds2.with_column("col1", col("id") + 1)
+        ds2 = ds2.with_column("col2", col("id") * 2)
+
+        count2 = self._count_project_operators(ds2._logical_plan)
+        print(f"2 operations -> {count2} operators")
+
+        # Test with 3 operations
+        ds3 = ray.data.from_items(input_data)
+        ds3 = ds3.with_column("col1", col("id") + 1)
+        ds3 = ds3.with_column("col2", col("id") * 2)
+        ds3 = ds3.with_column("col3", col("id") - 1)
+
+        count3 = self._count_project_operators(ds3._logical_plan)
+        print(f"3 operations -> {count3} operators")
+
+        # Test with 4 operations
+        ds4 = ray.data.from_items(input_data)
+        ds4 = ds4.with_column("col1", col("id") + 1)
+        ds4 = ds4.with_column("col2", col("id") * 2)
+        ds4 = ds4.with_column("col3", col("id") - 1)
+        ds4 = ds4.with_column("col4", col("id") + 5)
+
+        count4 = self._count_project_operators(ds4._logical_plan)
+        print(f"4 operations -> {count4} operators")
+
+        # Verify that fusion is happening (fewer operators than original)
+        assert count2 <= 2, f"2 operations should result in ≤2 operators, got {count2}"
+        assert count3 <= 3, f"3 operations should result in ≤3 operators, got {count3}"
+        assert count4 <= 4, f"4 operations should result in ≤4 operators, got {count4}"
+
+        # Verify correctness
+        result2 = ds2.take(1)[0]
+        result3 = ds3.take(1)[0]
+        result4 = ds4.take(1)[0]
+
+        assert result2 == {"id": 0, "col1": 1, "col2": 0}
+        assert result3 == {"id": 0, "col1": 1, "col2": 0, "col3": -1}
+        assert result4 == {"id": 0, "col1": 1, "col2": 0, "col3": -1, "col4": 5}
+
+    def test_optimal_fusion_with_single_chain(self):
+        """Test fusion when all operations are added in a single chain (ideal case)."""
+        input_data = [{"id": i} for i in range(10)]
+
+        # Create a single Project operator with multiple expressions
+        # This simulates what would happen with perfect fusion
+        ds = ray.data.from_items(input_data)
+
+        # Apply multiple operations that should all be independent
+        expressions = {
+            "col1": col("id") + 1,
+            "col2": col("id") * 2,
+            "col3": col("id") - 1,
+            "col4": col("id") + 5,
+            "col5": col("id") * 3,
+        }
+
+        # Use map_batches to create a single operation that does everything
+        def apply_all_expressions(batch):
+            import pyarrow.compute as pc
+
+            result = batch.to_pydict()
+            result["col1"] = pc.add(batch["id"], 1)
+            result["col2"] = pc.multiply(batch["id"], 2)
+            result["col3"] = pc.subtract(batch["id"], 1)
+            result["col4"] = pc.add(batch["id"], 5)
+            result["col5"] = pc.multiply(batch["id"], 3)
+            return pa.table(result)
+
+        ds_optimal = ds.map_batches(apply_all_expressions, batch_format="pyarrow")
+
+        # Compare with the with_column approach
+        ds_with_column = ds
+        for col_name, expr in expressions.items():
+            ds_with_column = ds_with_column.with_column(col_name, expr)
+
+        # Convert both to pandas for reliable comparison (avoids take() ordering issues)
+        result_optimal_df = (
+            ds_optimal.to_pandas().sort_values("id").reset_index(drop=True)
+        )
+        result_with_column_df = (
+            ds_with_column.to_pandas().sort_values("id").reset_index(drop=True)
+        )
+
+        # Compare using pandas testing
+        pd.testing.assert_frame_equal(
+            result_optimal_df.sort_index(axis=1),
+            result_with_column_df.sort_index(axis=1),
+            check_dtype=False,
+        )
+
+    def test_basic_fusion_works(self):
+        """Test that basic fusion of two independent operations works."""
+        input_data = [{"id": i} for i in range(5)]
+
+        # Create dataset with two independent operations
+        ds = ray.data.from_items(input_data)
+        ds = ds.with_column("doubled", col("id") * 2)
+        ds = ds.with_column("plus_one", col("id") + 1)
+
+        # Check before optimization
+        original_count = self._count_project_operators(ds._logical_plan)
+        print(f"Before optimization: {original_count} operators")
+
+        # Apply optimization
+        rule = ProjectionPushdown()
+        optimized_plan = rule.apply(ds._logical_plan)
+
+        # Check after optimization
+        optimized_count = self._count_project_operators(optimized_plan)
+        print(f"After optimization: {optimized_count} operators")
+
+        # Two independent operations should fuse into one
+        assert (
+            optimized_count == 1
+        ), f"Two independent operations should fuse to 1 operator, got {optimized_count}"
+
+        # Verify correctness using pandas comparison
+        from ray.data.dataset import Dataset
+
+        optimized_ds = Dataset(ds._plan, optimized_plan)
+
+        try:
+            result_df = optimized_ds.to_pandas()
+            print(f"Result: {result_df}")
+
+            expected_df = pd.DataFrame(
+                {
+                    "id": [0, 1, 2, 3, 4],
+                    "doubled": [0, 2, 4, 6, 8],
+                    "plus_one": [1, 2, 3, 4, 5],
+                }
+            )
+            print(f"Expected: {expected_df}")
+
+            # Sort columns for comparison
+            result_sorted = result_df.reindex(sorted(result_df.columns), axis=1)
+            expected_sorted = expected_df.reindex(sorted(expected_df.columns), axis=1)
+
+            pd.testing.assert_frame_equal(
+                result_sorted,
+                expected_sorted,
+                check_dtype=False,
+                check_index_type=False,
+            )
+
+        except Exception as e:
+            print(f"Error in basic fusion test: {e}")
+            # Fallback verification
+            result_list = optimized_ds.take_all()
+            print(f"Result as list: {result_list}")
+
+            expected_list = [
+                {"id": 0, "doubled": 0, "plus_one": 1},
+                {"id": 1, "doubled": 2, "plus_one": 2},
+                {"id": 2, "doubled": 4, "plus_one": 3},
+                {"id": 3, "doubled": 6, "plus_one": 4},
+                {"id": 4, "doubled": 8, "plus_one": 5},
+            ]
+
+            assert len(result_list) == len(expected_list)
+            for actual, expected in zip(result_list, expected_list):
+                for key, expected_val in expected.items():
+                    assert (
+                        actual[key] == expected_val
+                    ), f"Mismatch for key {key}: expected {expected_val}, got {actual[key]}"
+
+    def test_dependency_prevents_fusion(self):
+        """Test that dependencies are handled in single operator with OrderedDict."""
+        input_data = [{"id": i} for i in range(5)]
+
+        # Create dataset with dependency chain
+        ds = ray.data.from_items(input_data)
+        ds = ds.with_column("doubled", col("id") * 2)
+        ds = ds.with_column(
+            "doubled_plus_one", col("doubled") + 1
+        )  # Depends on doubled
+
+        # Check before optimization
+        original_count = self._count_project_operators(ds._logical_plan)
+        print(f"Before optimization: {original_count} operators")
+
+        # Apply optimization
+        rule = ProjectionPushdown()
+        optimized_plan = rule.apply(ds._logical_plan)
+
+        # Check after optimization
+        optimized_count = self._count_project_operators(optimized_plan)
+        print(f"After optimization: {optimized_count} operators")
+
+        # Should have 1 operator now (changed from 2)
+        assert (
+            optimized_count == 1
+        ), f"All operations should fuse into 1 operator, got {optimized_count}"
+
+        # Verify correctness using pandas comparison
+        from ray.data.dataset import Dataset
+
+        optimized_ds = Dataset(ds._plan, optimized_plan)
+        result_df = optimized_ds.to_pandas()
+
+        expected_df = pd.DataFrame(
+            {
+                "id": [0, 1, 2, 3, 4],
+                "doubled": [0, 2, 4, 6, 8],
+                "doubled_plus_one": [1, 3, 5, 7, 9],
+            }
+        )
+
+        pd.testing.assert_frame_equal(
+            result_df.sort_index(axis=1),
+            expected_df.sort_index(axis=1),
+            check_dtype=False,
+        )
+
+    def test_mixed_udf_regular_end_to_end(self):
+        """Test the exact failing scenario from the original issue."""
+        input_data = [{"id": i} for i in range(5)]
+
+        # Create dataset with mixed UDF and regular expressions (the failing test case)
+        ds = ray.data.from_items(input_data)
+        ds = ds.with_column("plus_ten", col("id") + 10)
+        ds = ds.with_column(
+            "times_three", self.udfs["multiply_by_two"](col("id"))
+        )  # Actually multiply by 2
+        ds = ds.with_column("minus_five", col("id") - 5)
+        ds = ds.with_column(
+            "udf_plus_regular",
+            self.udfs["multiply_by_two"](col("id")) + col("plus_ten"),
+        )
+        ds = ds.with_column("comparison", col("times_three") > col("plus_ten"))
+
+        # Apply optimization
+        rule = ProjectionPushdown()
+        optimized_plan = rule.apply(ds._logical_plan)
+
+        # Verify execution correctness
+        from ray.data.dataset import Dataset
+
+        optimized_ds = Dataset(ds._plan, optimized_plan)
+        result_df = optimized_ds.to_pandas()
+
+        expected_df = pd.DataFrame(
+            {
+                "id": [0, 1, 2, 3, 4],
+                "plus_ten": [10, 11, 12, 13, 14],  # id + 10
+                "times_three": [0, 2, 4, 6, 8],  # id * 2 (multiply_by_two UDF)
+                "minus_five": [-5, -4, -3, -2, -1],  # id - 5
+                "udf_plus_regular": [10, 13, 16, 19, 22],  # (id * 2) + (id + 10)
+                "comparison": [
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],  # times_three > plus_ten
+            }
+        )
+
+        pd.testing.assert_frame_equal(
+            result_df.sort_index(axis=1),
+            expected_df.sort_index(axis=1),
+            check_dtype=False,
+        )
+
+        # Verify that we have 1 operator (changed from multiple)
+        optimized_count = self._count_project_operators(optimized_plan)
+        assert (
+            optimized_count == 1
+        ), f"Expected 1 operator with all expressions fused, got {optimized_count}"
+
+    def test_optimal_fusion_comparison(self):
+        """Compare optimized with_column approach against manual map_batches."""
+        input_data = [{"id": i} for i in range(10)]
+
+        # Create dataset using with_column (will be optimized)
+        ds_with_column = ray.data.from_items(input_data)
+        ds_with_column = ds_with_column.with_column("col1", col("id") + 1)
+        ds_with_column = ds_with_column.with_column("col2", col("id") * 2)
+        ds_with_column = ds_with_column.with_column("col3", col("id") - 1)
+        ds_with_column = ds_with_column.with_column("col4", col("id") + 5)
+        ds_with_column = ds_with_column.with_column("col5", col("id") * 3)
+
+        # Apply optimization
+        rule = ProjectionPushdown()
+        optimized_plan = rule.apply(ds_with_column._logical_plan)
+        from ray.data.dataset import Dataset
+
+        optimized_ds = Dataset(ds_with_column._plan, optimized_plan)
+
+        # Create dataset using single map_batches (optimal case)
+        ds_optimal = ray.data.from_items(input_data)
+
+        def apply_all_expressions(batch):
+            import pyarrow.compute as pc
+
+            result = batch.to_pydict()
+            result["col1"] = pc.add(batch["id"], 1)
+            result["col2"] = pc.multiply(batch["id"], 2)
+            result["col3"] = pc.subtract(batch["id"], 1)
+            result["col4"] = pc.add(batch["id"], 5)
+            result["col5"] = pc.multiply(batch["id"], 3)
+            return pa.table(result)
+
+        ds_optimal = ds_optimal.map_batches(
+            apply_all_expressions, batch_format="pyarrow"
+        )
+
+        # Compare results using pandas
+        result_optimized = optimized_ds.to_pandas()
+        result_optimal = ds_optimal.to_pandas()
+
+        pd.testing.assert_frame_equal(
+            result_optimized.sort_index(axis=1),
+            result_optimal.sort_index(axis=1),
+            check_dtype=False,
+        )
+
+    def test_chained_udf_dependencies(self):
+        """Test multiple non-vectorized UDFs in a dependency chain."""
+        input_data = [{"id": i} for i in range(5)]
+
+        # Create dataset with chained UDF dependencies
+        ds = ray.data.from_items(input_data)
+        ds = ds.with_column("plus_one", self.udfs["add_one"](col("id")))
+        ds = ds.with_column("times_two", self.udfs["multiply_by_two"](col("plus_one")))
+        ds = ds.with_column("div_three", self.udfs["divide_by_three"](col("times_two")))
+
+        # Apply optimization
+        rule = ProjectionPushdown()
+        optimized_plan = rule.apply(ds._logical_plan)
+
+        # Verify 1 operator (changed from 3)
+        assert self._count_project_operators(optimized_plan) == 1
+        assert (
+            self._describe_plan_structure(optimized_plan)
+            == "Project(3 exprs) -> FromItems"  # Changed from multiple operators
+        )
+
+        # Verify execution correctness
+        from ray.data.dataset import Dataset
+
+        optimized_ds = Dataset(ds._plan, optimized_plan)
+        result_df = optimized_ds.to_pandas()
+
+        expected_df = pd.DataFrame(
+            {
+                "id": [0, 1, 2, 3, 4],
+                "plus_one": [1, 2, 3, 4, 5],
+                "times_two": [2, 4, 6, 8, 10],
+                "div_three": [2 / 3, 4 / 3, 2.0, 8 / 3, 10 / 3],
+            }
+        )
+
+        pd.testing.assert_frame_equal(
+            result_df.sort_index(axis=1),
+            expected_df.sort_index(axis=1),
+            check_dtype=False,
+        )
+
+    def test_performance_impact_of_udf_chains(self):
+        """Test performance characteristics of UDF dependency chains vs independent UDFs."""
+        input_data = [{"id": i} for i in range(100)]
+
+        # Case 1: Independent UDFs (should fuse)
+        ds_independent = ray.data.from_items(input_data)
+        ds_independent = ds_independent.with_column(
+            "udf1", self.udfs["add_one"](col("id"))
+        )
+        ds_independent = ds_independent.with_column(
+            "udf2", self.udfs["multiply_by_two"](col("id"))
+        )
+        ds_independent = ds_independent.with_column(
+            "udf3", self.udfs["divide_by_three"](col("id"))
+        )
+
+        # Case 2: Chained UDFs (should also fuse now)
+        ds_chained = ray.data.from_items(input_data)
+        ds_chained = ds_chained.with_column("step1", self.udfs["add_one"](col("id")))
+        ds_chained = ds_chained.with_column(
+            "step2", self.udfs["multiply_by_two"](col("step1"))
+        )
+        ds_chained = ds_chained.with_column(
+            "step3", self.udfs["divide_by_three"](col("step2"))
+        )
+
+        # Apply optimization
+        rule = ProjectionPushdown()
+        optimized_independent = rule.apply(ds_independent._logical_plan)
+        optimized_chained = rule.apply(ds_chained._logical_plan)
+
+        # Verify fusion behavior (both should be 1 now)
+        assert self._count_project_operators(optimized_independent) == 1
+        assert (
+            self._count_project_operators(optimized_chained) == 1
+        )  # Changed from 3 to 1
+        assert (
+            self._describe_plan_structure(optimized_independent)
+            == "Project(3 exprs) -> FromItems"
+        )
+        assert (
+            self._describe_plan_structure(optimized_chained)
+            == "Project(3 exprs) -> FromItems"  # Changed from multiple operators
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/ray/data/tests/test_projection_pushdown.py
+++ b/python/ray/data/tests/test_projection_pushdown.py
@@ -7,12 +7,12 @@ import pyarrow.compute as pc
 import pytest
 
 import ray
-from ray.data._internal.logical.rules.projection_pushdown import (
-    ProjectionPushdown,
-)
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators.input_data_operator import InputData
 from ray.data._internal.logical.operators.map_operator import Project
+from ray.data._internal.logical.rules.projection_pushdown import (
+    ProjectionPushdown,
+)
 from ray.data.context import DataContext
 from ray.data.expressions import DataType, col, udf
 

--- a/python/ray/data/tests/test_projection_pushdown.py
+++ b/python/ray/data/tests/test_projection_pushdown.py
@@ -7,7 +7,7 @@ import pyarrow.compute as pc
 import pytest
 
 import ray
-from ray.anyscale.data._internal.logical.rules.projection_pushdown import (
+from ray.data._internal.logical.rules.projection_pushdown import (
     ProjectionPushdown,
 )
 from ray.data._internal.logical.interfaces import LogicalPlan


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adding support for projection pushdown into `Read` ops reading from parquet tables.

Changes
---

 - Adding `ProjectionPushdown` optimization rule
 - Abstracting `LogicalOperatorSupportsProjectionPushdown`, etc interfaces to implement projection pushdown for various Read ops as well as `Datasource`s
 - Added tests for projection push-down

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
