### PR TITLE
use default gc frequency for proxy

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -436,6 +436,9 @@ RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS = get_env_bool(
     "RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS", "1"
 )
 
+# Used for gc.set_threshold() when proxy GC optimizations are enabled.
+RAY_SERVE_PROXY_GC_THRESHOLD = get_env_int("RAY_SERVE_PROXY_GC_THRESHOLD", 700)
+
 # Interval at which cached metrics will be exported using the Ray metric API.
 # Set to `0` to disable caching entirely.
 RAY_SERVE_METRICS_EXPORT_INTERVAL_MS = get_env_int(

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -436,9 +436,6 @@ RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS = get_env_bool(
     "RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS", "1"
 )
 
-# Used for gc.set_threshold() when proxy GC optimizations are enabled.
-RAY_SERVE_PROXY_GC_THRESHOLD = get_env_int("RAY_SERVE_PROXY_GC_THRESHOLD", 10_000)
-
 # Interval at which cached metrics will be exported using the Ray metric API.
 # Set to `0` to disable caching entirely.
 RAY_SERVE_METRICS_EXPORT_INTERVAL_MS = get_env_int(

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -29,6 +29,7 @@ from ray.serve._private.constants import (
     HEALTHY_MESSAGE,
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
+    RAY_SERVE_PROXY_GC_THRESHOLD,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     REQUEST_LATENCY_BUCKETS_MS,
     SERVE_CONTROLLER_NAME,
@@ -1258,3 +1259,6 @@ def _configure_gc_options():
     # Collect any objects that exist already and exclude them from future GC.
     gc.collect(2)
     gc.freeze()
+
+    # Tune the GC threshold to run less frequently (default is 700).
+    gc.set_threshold(RAY_SERVE_PROXY_GC_THRESHOLD)

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -29,7 +29,6 @@ from ray.serve._private.constants import (
     HEALTHY_MESSAGE,
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
-    RAY_SERVE_PROXY_GC_THRESHOLD,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     REQUEST_LATENCY_BUCKETS_MS,
     SERVE_CONTROLLER_NAME,
@@ -1259,6 +1258,3 @@ def _configure_gc_options():
     # Collect any objects that exist already and exclude them from future GC.
     gc.collect(2)
     gc.freeze()
-
-    # Tune the GC threshold to run less frequently (default is 700).
-    gc.set_threshold(RAY_SERVE_PROXY_GC_THRESHOLD)


### PR DESCRIPTION
## script used for benchmarking
```python
import time
from typing import Optional
from python.ray._common.test_utils import wait_for_condition
from ray import serve
from ray.util.state import list_actors

import logging

logger = logging.getLogger("ray.serve")

@serve.deployment(max_ongoing_requests=1000)
class MemoryLeakTest:
    async def __call__(self):
        logger.info("MemoryLeakTest")
        return "MemoryLeakTest"

app = serve.run(MemoryLeakTest.bind(), logging_config={
    "encoding": "JSON",
})

def get_replica_pid() -> Optional[int]:
    all_current_actors = list_actors(filters=[("state", "=", "ALIVE")])
    for actor in all_current_actors:
        if "MemoryLeakTest" in actor["name"]:
            return actor["pid"]
    return None


wait_for_condition(get_replica_pid)


print(get_replica_pid())

# track the memory of the replica in a loop in MB
import psutil

def track_memory():
    pid = get_replica_pid()
    if pid is not None:
        process = psutil.Process(pid)
        return process.memory_info().rss / 1024 / 1024
    return None

while True:
    memory_mb = track_memory()
    print(f"\rMemory usage: {memory_mb:.2f} MB", end="", flush=True)
    time.sleep(.1)
```

simulating load using `ab -n 500 -c 1 http://127.0.0.1:8000/`

used [memray](https://bloomberg.github.io/memray/tutorials/1.html) to profile the proxy process. Used instructions from [here](https://docs.ray.io/en/latest/ray-observability/user-guides/debug-apps/debug-memory.html#memory-profiling-ray-tasks-and-actors).

### On master
<img width="1164" height="628" alt="image" src="https://github.com/user-attachments/assets/50d22e10-3206-4aeb-9585-97245523a5cb" />


### With fix
<img width="1161" height="621" alt="image" src="https://github.com/user-attachments/assets/19224538-cbd7-4be7-b830-29e1b468625f" />


When we reduce the garbage collection (GC) frequency to every 10k allocations, proxy memory peaks at **1.3 GB** for my test workload. By contrast, under the default GC frequency (700 allocations), peak RSS memory is **700 MB**.

The higher memory footprint with less frequent GC occurs because this workload involves large object transactions. With GC running only after 10k allocations, these large objects remain in RSS longer, inflating memory usage until a collection cycle is triggered.

Importantly, I found no evidence of a memory leak under sustained load. With the fix, memory stabilizes at around **700 MB**, and even without the fix, usage plateaus at **1.3 GB** rather than growing unbounded.

This feature was added in https://github.com/ray-project/ray/pull/49720 as a performance optimization. So we are taking slight hit in RPS for stable memory usage for larger payloads.