### PR TITLE
[core] Fix UBSAN errors in object_manager_test

### DIFF
--- a/src/ray/object_manager/tests/object_manager_test.cc
+++ b/src/ray/object_manager/tests/object_manager_test.cc
@@ -26,6 +26,7 @@
 #include "mock/ray/object_manager/object_directory.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/id.h"
+#include "ray/common/ray_config.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/status.h"
 #include "ray/object_manager/common.h"
@@ -45,8 +46,15 @@ class ObjectManagerTest : public ::testing::Test {
     ObjectManagerConfig config_;
     config_.object_manager_address = "127.0.0.1";
     config_.object_manager_port = 0;
+    config_.timer_freq_ms = RayConfig::instance().object_manager_timer_freq_ms();
+    config_.pull_timeout_ms = RayConfig::instance().object_manager_pull_timeout_ms();
+    config_.object_chunk_size = RayConfig::instance().object_manager_default_chunk_size();
+    config_.max_bytes_in_flight =
+        RayConfig::instance().object_manager_max_bytes_in_flight();
     config_.store_socket_name = "test_store_socket";
+    config_.push_timeout_ms = RayConfig::instance().object_manager_push_timeout_ms();
     config_.rpc_service_threads_number = 1;
+    config_.huge_pages = false;
 
     local_node_id_ = NodeID::FromRandom();
     mock_gcs_client_ = std::make_unique<gcs::MockGcsClient>();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Missed UBSAN errors in #56492 addressing them here. The error was that some fields in the ObjectManagerConfig struct weren't initialized in object_manager_test and were accessed in the ObjectManager constructor.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
