### PR TITLE
[core] Fix `clang-format` pre-commit step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,7 +176,7 @@ repos:
           # 2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting). -- these aren't compatible with macOS's old Bash
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-	# This version should be kept in sync with the version in `ci/lint/format.sh`.
+    # This version should be kept in sync with the version in `ci/lint/format.sh`.
     rev: v12.0.1
     hooks:
       - id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -175,11 +175,11 @@ repos:
           # 1091: Not following {file} due to some error
           # 2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting). -- these aren't compatible with macOS's old Bash
 
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+	# This version should be kept in sync with the version in `ci/lint/format.sh`.
+    rev: v12.0.1
     hooks:
       - id: clang-format
-        args: [--version=12.0.1]
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.11.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,7 +176,8 @@ repos:
           # 2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting). -- these aren't compatible with macOS's old Bash
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    # This version should be kept in sync with the version in `ci/lint/format.sh`.
+    # `rev` specifies a tag on the above repo that mirrors the corresponding clang-format version.
+    # The version should be kept in sync with the version in `ci/lint/format.sh`.
     rev: v12.0.1
     hooks:
       - id: clang-format

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -88,7 +88,7 @@ else
 fi
 
 if command -v clang-format >/dev/null; then
-	# This version should be kept in sync with the version in `.pre-commit-config.yaml`.
+	# This version should be kept in sync with the clang-format version tag in `.pre-commit-config.yaml`.
   CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
   tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "12.0.1"
 else

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -88,6 +88,7 @@ else
 fi
 
 if command -v clang-format >/dev/null; then
+	# This version should be kept in sync with the version in `.pre-commit-config.yaml`.
   CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
   tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "12.0.1"
 else


### PR DESCRIPTION
The existing one seemed to do nothing... swapped to using the recommendation from this [stack overflow post](https://stackoverflow.com/questions/55965712/how-do-i-add-clang-formatting-to-pre-commit-hook).