### PR TITLE
[ci] raydepsets: adding post hooks to raydepsets

### DIFF
--- a/ci/raydepsets/BUILD.bazel
+++ b/ci/raydepsets/BUILD.bazel
@@ -35,8 +35,8 @@ py_test(
     name = "test_cli",
     srcs = ["tests/test_cli.py"],
     data = [
-        "tests/test_data/pre-hook-error-test.sh",
-        "tests/test_data/pre-hook-test.sh",
+        "tests/test_data/hook-error-test.sh",
+        "tests/test_data/hook-test.sh",
         "tests/test_data/requirement_constraints_test.txt",
         "tests/test_data/requirements_compiled_test.txt",
         "tests/test_data/requirements_compiled_test_expand.txt",

--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -218,10 +218,10 @@ class DependencySetManager:
         return status.stdout
 
     def execute_hook(self, hook: str, node_type: str):
-        status_code = subprocess.call(hook, cwd=self.workspace.dir)
+        status_code = subprocess.run(hook, cwd=self.workspace.dir)
         if status_code != 0:
-            raise RuntimeError(f"Failed to execute {node_type} hook: {hook}")
-        click.echo(f"Executed {node_type} hook: {hook}")
+            raise RuntimeError(f"Failed to execute {node_type}: {hook}")
+        click.echo(f"Executed {node_type} {hook}")
         return status_code
 
     def execute_depset(self, depset: Depset):

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -385,8 +385,8 @@ class TestCli(unittest.TestCase):
             copy_data_to_tmpdir(tmpdir)
             manager = _create_test_manager(tmpdir)
             assert manager.build_graph is not None
-            assert len(manager.build_graph.nodes()) == 8
-            assert len(manager.build_graph.edges()) == 4
+            assert len(manager.build_graph.nodes()) == 10
+            assert len(manager.build_graph.edges()) == 5
             # assert that the compile depsets are first
             assert (
                 manager.build_graph.nodes["general_depset__py311_cpu"]["operation"]
@@ -583,23 +583,45 @@ class TestCli(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             manager = _create_test_manager(tmpdir)
-            manager.execute_pre_hook("pre-hook-test.sh")
+            manager.execute_hook("hook-test.sh", "pre_hook")
 
     def test_execute_single_invalid_pre_hook(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             manager = _create_test_manager(tmpdir)
             with self.assertRaises(RuntimeError):
-                manager.execute_pre_hook("pre-hook-error-test.sh")
+                manager.execute_hook("hook-error-test.sh", "pre_hook")
 
     def test_execute_pre_hooks_failure_in_middle(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             manager = _create_test_manager(tmpdir)
             with self.assertRaises(RuntimeError):
-                manager.execute_pre_hook("pre-hook-test.sh")
-                manager.execute_pre_hook("pre-hook-error-test.sh")
-                manager.execute_pre_hook("pre-hook-test.sh")
+                manager.execute_hook("hook-test.sh", "pre_hook")
+                manager.execute_hook("hook-error-test.sh", "pre_hook")
+                manager.execute_hook("hook-test.sh", "pre_hook")
+
+    def test_execute_single_post_hook(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            manager.execute_hook("hook-test.sh", "post_hook")
+
+    def test_execute_single_invalid_post_hook(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            with self.assertRaises(RuntimeError):
+                manager.execute_hook("hook-error-test.sh", "post_hook")
+
+    def test_execute_post_hooks_failure_in_middle(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            with self.assertRaises(RuntimeError):
+                manager.execute_hook("hook-test.sh", "post_hook")
+                manager.execute_hook("hook-error-test.sh", "post_hook")
+                manager.execute_hook("hook-test.sh", "post_hook")
 
     def test_copy_lock_files_to_temp_dir(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -10,11 +11,20 @@ from click.testing import CliRunner
 from networkx import topological_sort
 
 from ci.raydepsets.cli import (
+    DEFAULT_UV_FLAGS,
     DependencySetManager,
+    _flatten_flags,
+    _get_depset,
+    _override_uv_flags,
+    _uv_binary,
     build,
 )
 from ci.raydepsets.tests.utils import (
+    append_to_file,
     copy_data_to_tmpdir,
+    replace_in_file,
+    save_file_as,
+    save_packages_to_file,
 )
 from ci.raydepsets.workspace import (
     Depset,
@@ -47,7 +57,7 @@ def _invoke_build(tmpdir: str, config_path: str, name: Optional[str] = None):
         "--uv-cache-dir",
         uv_cache_dir.as_posix(),
     ]
-    if name is not None:
+    if name:
         cmd.extend(["--name", name])
     return CliRunner().invoke(
         build,
@@ -76,114 +86,112 @@ class TestCli(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             result = _invoke_build(tmpdir, "fake_path/test.depsets.yaml")
-            print(f"result: {result}")
-            print(f"result.output: {result.exception}")
             assert result.exit_code == 1
             assert isinstance(result.exception, FileNotFoundError)
             assert "No such file or directory" in str(result.exception)
 
-        # def test_dependency_set_manager_init(self):
-        #     with tempfile.TemporaryDirectory() as tmpdir:
-        #         copy_data_to_tmpdir(tmpdir)
-        #         manager = _create_test_manager(tmpdir)
-        #         assert manager is not None
-        #         assert manager.workspace.dir == tmpdir
-        #         assert manager.config.depsets[0].name == "ray_base_test_depset"
-        #         assert manager.config.depsets[0].operation == "compile"
-        #         assert manager.config.depsets[0].requirements == ["requirements_test.txt"]
-        #         assert manager.config.depsets[0].constraints == [
-        #             "requirement_constraints_test.txt"
-        #         ]
-        #         assert manager.config.depsets[0].output == "requirements_compiled.txt"
+    def test_dependency_set_manager_init(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            assert manager is not None
+            assert manager.workspace.dir == tmpdir
+            assert manager.config.depsets[0].name == "ray_base_test_depset"
+            assert manager.config.depsets[0].operation == "compile"
+            assert manager.config.depsets[0].requirements == ["requirements_test.txt"]
+            assert manager.config.depsets[0].constraints == [
+                "requirement_constraints_test.txt"
+            ]
+            assert manager.config.depsets[0].output == "requirements_compiled.txt"
 
-        # def test_get_depset(self):
-        #     with tempfile.TemporaryDirectory() as tmpdir:
-        #         copy_data_to_tmpdir(tmpdir)
-        #         manager = _create_test_manager(tmpdir)
-        #         with self.assertRaises(KeyError):
-        #             _get_depset(manager.config.depsets, "fake_depset")
+    def test_get_depset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            with self.assertRaises(KeyError):
+                _get_depset(manager.config.depsets, "fake_depset")
 
-        # def test_uv_binary_exists(self):
-        #     assert _uv_binary() is not None
+    def test_uv_binary_exists(self):
+        assert _uv_binary() is not None
 
-        # def test_uv_version(self):
-        #     result = subprocess.run(
-        #         [_uv_binary(), "--version"],
-        #         stdout=subprocess.PIPE,
-        #         stderr=subprocess.PIPE,
-        #     )
-        #     assert result.returncode == 0
-        #     assert "uv 0.8.17" in result.stdout.decode("utf-8")
-        #     assert result.stderr.decode("utf-8") == ""
+    def test_uv_version(self):
+        result = subprocess.run(
+            [_uv_binary(), "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert result.returncode == 0
+        assert "uv 0.8.17" in result.stdout.decode("utf-8")
+        assert result.stderr.decode("utf-8") == ""
 
-        # def test_compile(self):
-        #     with tempfile.TemporaryDirectory() as tmpdir:
-        #         copy_data_to_tmpdir(tmpdir)
-        #         save_file_as(
-        #             Path(tmpdir) / "requirements_compiled_test.txt",
-        #             Path(tmpdir) / "requirements_compiled.txt",
-        #         )
-        #         manager = _create_test_manager(tmpdir)
-        #         manager.compile(
-        #             constraints=["requirement_constraints_test.txt"],
-        #             requirements=["requirements_test.txt"],
-        #             append_flags=["--no-annotate", "--no-header"],
-        #             name="ray_base_test_depset",
-        #             output="requirements_compiled.txt",
-        #         )
-        #         output_file = Path(tmpdir) / "requirements_compiled.txt"
-        #         output_text = output_file.read_text()
-        #         output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
-        #         output_text_valid = output_file_valid.read_text()
-        #         assert output_text == output_text_valid
+    def test_compile(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            save_file_as(
+                Path(tmpdir) / "requirements_compiled_test.txt",
+                Path(tmpdir) / "requirements_compiled.txt",
+            )
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="ray_base_test_depset",
+                output="requirements_compiled.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
+            output_text_valid = output_file_valid.read_text()
+            assert output_text == output_text_valid
 
-        # def test_compile_update_package(self):
-        #     with tempfile.TemporaryDirectory() as tmpdir:
-        #         copy_data_to_tmpdir(tmpdir)
-        #         compiled_file = Path(
-        #             _runfiles.Rlocation(f"{tmpdir}/requirement_constraints_test.txt")
-        #         )
-        #         replace_in_file(compiled_file, "emoji==2.9.0", "emoji==2.10.0")
-        #         output_file = Path(
-        #             _runfiles.Rlocation(f"{tmpdir}/requirements_compiled.txt")
-        #         )
-        #         save_file_as(compiled_file, output_file)
-        #         manager = _create_test_manager(tmpdir)
-        #         manager.compile(
-        #             constraints=["requirement_constraints_test.txt"],
-        #             requirements=["requirements_test.txt"],
-        #             append_flags=["--no-annotate", "--no-header"],
-        #             name="ray_base_test_depset",
-        #             output="requirements_compiled.txt",
-        #         )
-        #         output_file = Path(tmpdir) / "requirements_compiled.txt"
-        #         output_text = output_file.read_text()
-        #         output_file_valid = Path(tmpdir) / "requirements_compiled_test_update.txt"
-        #         output_text_valid = output_file_valid.read_text()
-        #         assert output_text == output_text_valid
+    def test_compile_update_package(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            compiled_file = Path(
+                _runfiles.Rlocation(f"{tmpdir}/requirement_constraints_test.txt")
+            )
+            replace_in_file(compiled_file, "emoji==2.9.0", "emoji==2.10.0")
+            output_file = Path(
+                _runfiles.Rlocation(f"{tmpdir}/requirements_compiled.txt")
+            )
+            save_file_as(compiled_file, output_file)
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="ray_base_test_depset",
+                output="requirements_compiled.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test_update.txt"
+            output_text_valid = output_file_valid.read_text()
+            assert output_text == output_text_valid
 
-        # def test_compile_with_append_and_override_flags(self):
-        #     with tempfile.TemporaryDirectory() as tmpdir:
-        #         copy_data_to_tmpdir(tmpdir)
-        #         manager = _create_test_manager(tmpdir)
-        #         manager.compile(
-        #             constraints=["requirement_constraints_test.txt"],
-        #             requirements=["requirements_test.txt"],
-        #             append_flags=["--no-annotate", "--python-version 3.10"],
-        #             override_flags=["--extra-index-url https://dummyurl.com"],
-        #             name="ray_base_test_depset",
-        #             output="requirements_compiled.txt",
-        #         )
-        #         output_file = Path(tmpdir) / "requirements_compiled.txt"
-        #         output_text = output_file.read_text()
-        #         assert "--python-version 3.10" in output_text
-        #         assert "--extra-index-url https://dummyurl.com" in output_text
-        #         assert (
-        #             "--extra-index-url https://download.pytorch.org/whl/cu128"
-        #             not in output_text
-        #         )
+    def test_compile_with_append_and_override_flags(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--python-version 3.10"],
+                override_flags=["--extra-index-url https://dummyurl.com"],
+                name="ray_base_test_depset",
+                output="requirements_compiled.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled.txt"
+            output_text = output_file.read_text()
+            assert "--python-version 3.10" in output_text
+            assert "--extra-index-url https://dummyurl.com" in output_text
+            assert (
+                "--extra-index-url https://download.pytorch.org/whl/cu128"
+                not in output_text
+            )
 
-        # def test_compile_by_depset_name(self):
+    def test_compile_by_depset_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             result = _invoke_build(tmpdir, "test.depsets.yaml", "ray_base_test_depset")
@@ -196,179 +204,179 @@ class TestCli(unittest.TestCase):
                 in result.output
             )
 
-    # def test_subset(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         # Add six to requirements_test_subset.txt
-    #         save_packages_to_file(
-    #             Path(tmpdir) / "requirements_test_subset.txt",
-    #             ["six==1.16.0"],
-    #         )
-    #         manager = _create_test_manager(tmpdir)
-    #         # Compile general_depset with requirements_test.txt and requirements_test_subset.txt
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt", "requirements_test_subset.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="general_depset__py311_cpu",
-    #             output="requirements_compiled_general.txt",
-    #         )
-    #         # Subset general_depset with requirements_test.txt (should lock emoji & pyperclip)
-    #         manager.subset(
-    #             source_depset="general_depset__py311_cpu",
-    #             requirements=["requirements_test.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="subset_general_depset__py311_cpu",
-    #             output="requirements_compiled_subset_general.txt",
-    #         )
-    #         output_file = Path(tmpdir) / "requirements_compiled_subset_general.txt"
-    #         output_text = output_file.read_text()
-    #         output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
-    #         output_text_valid = output_file_valid.read_text()
+    def test_subset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            # Add six to requirements_test_subset.txt
+            save_packages_to_file(
+                Path(tmpdir) / "requirements_test_subset.txt",
+                ["six==1.16.0"],
+            )
+            manager = _create_test_manager(tmpdir)
+            # Compile general_depset with requirements_test.txt and requirements_test_subset.txt
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt", "requirements_test_subset.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="general_depset__py311_cpu",
+                output="requirements_compiled_general.txt",
+            )
+            # Subset general_depset with requirements_test.txt (should lock emoji & pyperclip)
+            manager.subset(
+                source_depset="general_depset__py311_cpu",
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="subset_general_depset__py311_cpu",
+                output="requirements_compiled_subset_general.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_subset_general.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
+            output_text_valid = output_file_valid.read_text()
 
-    #         assert output_text == output_text_valid
+            assert output_text == output_text_valid
 
-    # def test_subset_does_not_exist(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         # Add six to requirements_test_subset.txt
-    #         save_packages_to_file(
-    #             Path(tmpdir) / "requirements_test_subset.txt",
-    #             ["six==1.16.0"],
-    #         )
-    #         manager = _create_test_manager(tmpdir)
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt", "requirements_test_subset.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="general_depset__py311_cpu",
-    #             output="requirements_compiled_general.txt",
-    #         )
+    def test_subset_does_not_exist(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            # Add six to requirements_test_subset.txt
+            save_packages_to_file(
+                Path(tmpdir) / "requirements_test_subset.txt",
+                ["six==1.16.0"],
+            )
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt", "requirements_test_subset.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="general_depset__py311_cpu",
+                output="requirements_compiled_general.txt",
+            )
 
-    #         with self.assertRaises(RuntimeError):
-    #             manager.subset(
-    #                 source_depset="general_depset__py311_cpu",
-    #                 requirements=["requirements_compiled_test.txt"],
-    #                 append_flags=["--no-annotate", "--no-header"],
-    #                 name="subset_general_depset__py311_cpu",
-    #                 output="requirements_compiled_subset_general.txt",
-    #             )
+            with self.assertRaises(RuntimeError):
+                manager.subset(
+                    source_depset="general_depset__py311_cpu",
+                    requirements=["requirements_compiled_test.txt"],
+                    append_flags=["--no-annotate", "--no-header"],
+                    name="subset_general_depset__py311_cpu",
+                    output="requirements_compiled_subset_general.txt",
+                )
 
-    # def test_check_if_subset_exists(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = _create_test_manager(tmpdir)
-    #         source_depset = Depset(
-    #             name="general_depset__py311_cpu",
-    #             operation="compile",
-    #             requirements=["requirements_1.txt", "requirements_2.txt"],
-    #             constraints=["requirement_constraints_1.txt"],
-    #             output="requirements_compiled_general.txt",
-    #             append_flags=[],
-    #             override_flags=[],
-    #         )
-    #         with self.assertRaises(RuntimeError):
-    #             manager.check_subset_exists(
-    #                 source_depset=source_depset,
-    #                 requirements=["requirements_3.txt"],
-    #             )
+    def test_check_if_subset_exists(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            source_depset = Depset(
+                name="general_depset__py311_cpu",
+                operation="compile",
+                requirements=["requirements_1.txt", "requirements_2.txt"],
+                constraints=["requirement_constraints_1.txt"],
+                output="requirements_compiled_general.txt",
+                append_flags=[],
+                override_flags=[],
+            )
+            with self.assertRaises(RuntimeError):
+                manager.check_subset_exists(
+                    source_depset=source_depset,
+                    requirements=["requirements_3.txt"],
+                )
 
-    # def test_compile_bad_requirements(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = _create_test_manager(tmpdir)
-    #         with self.assertRaises(RuntimeError):
-    #             manager.compile(
-    #                 constraints=[],
-    #                 requirements=["requirements_test_bad.txt"],
-    #                 name="general_depset",
-    #                 output="requirements_compiled_general.txt",
-    #             )
+    def test_compile_bad_requirements(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            with self.assertRaises(RuntimeError):
+                manager.compile(
+                    constraints=[],
+                    requirements=["requirements_test_bad.txt"],
+                    name="general_depset",
+                    output="requirements_compiled_general.txt",
+                )
 
-    # def test_get_path(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = _create_test_manager(tmpdir)
-    #         assert (
-    #             manager.get_path("requirements_test.txt")
-    #             == Path(tmpdir) / "requirements_test.txt"
-    #         )
+    def test_get_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            assert (
+                manager.get_path("requirements_test.txt")
+                == Path(tmpdir) / "requirements_test.txt"
+            )
 
-    # def test_append_uv_flags_exist_in_output(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = _create_test_manager(tmpdir)
-    #         manager.compile(
-    #             constraints=[],
-    #             requirements=["requirements_test.txt"],
-    #             name="general_depset",
-    #             output="requirements_compiled_general.txt",
-    #             append_flags=["--python-version=3.10"],
-    #         )
-    #         output_file = Path(tmpdir) / "requirements_compiled_general.txt"
-    #         output_text = output_file.read_text()
-    #         assert "--python-version=3.10" in output_text
+    def test_append_uv_flags_exist_in_output(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=[],
+                requirements=["requirements_test.txt"],
+                name="general_depset",
+                output="requirements_compiled_general.txt",
+                append_flags=["--python-version=3.10"],
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_general.txt"
+            output_text = output_file.read_text()
+            assert "--python-version=3.10" in output_text
 
-    # def test_append_uv_flags_with_space_in_flag(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = _create_test_manager(tmpdir)
-    #         manager.compile(
-    #             constraints=[],
-    #             requirements=["requirements_test.txt"],
-    #             name="general_depset",
-    #             output="requirements_compiled_general.txt",
-    #             append_flags=["--python-version 3.10"],
-    #         )
-    #         output_file = Path(tmpdir) / "requirements_compiled_general.txt"
-    #         output_text = output_file.read_text()
-    #         assert "--python-version 3.10" in output_text
+    def test_append_uv_flags_with_space_in_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=[],
+                requirements=["requirements_test.txt"],
+                name="general_depset",
+                output="requirements_compiled_general.txt",
+                append_flags=["--python-version 3.10"],
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_general.txt"
+            output_text = output_file.read_text()
+            assert "--python-version 3.10" in output_text
 
-    # def test_override_uv_flag_single_flag(self):
-    #     expected_flags = DEFAULT_UV_FLAGS.copy()
-    #     expected_flags.remove("--extra-index-url")
-    #     expected_flags.remove("https://download.pytorch.org/whl/cpu")
-    #     expected_flags.extend(
-    #         ["--extra-index-url", "https://download.pytorch.org/whl/cu128"]
-    #     )
-    #     assert (
-    #         _override_uv_flags(
-    #             ["--extra-index-url https://download.pytorch.org/whl/cu128"],
-    #             DEFAULT_UV_FLAGS.copy(),
-    #         )
-    #         == expected_flags
-    #     )
+    def test_override_uv_flag_single_flag(self):
+        expected_flags = DEFAULT_UV_FLAGS.copy()
+        expected_flags.remove("--extra-index-url")
+        expected_flags.remove("https://download.pytorch.org/whl/cpu")
+        expected_flags.extend(
+            ["--extra-index-url", "https://download.pytorch.org/whl/cu128"]
+        )
+        assert (
+            _override_uv_flags(
+                ["--extra-index-url https://download.pytorch.org/whl/cu128"],
+                DEFAULT_UV_FLAGS.copy(),
+            )
+            == expected_flags
+        )
 
-    # def test_override_uv_flag_multiple_flags(self):
-    #     expected_flags = DEFAULT_UV_FLAGS.copy()
-    #     expected_flags.remove("--unsafe-package")
-    #     expected_flags.remove("setuptools")
-    #     expected_flags.extend(["--unsafe-package", "dummy"])
-    #     assert (
-    #         _override_uv_flags(
-    #             ["--unsafe-package dummy"],
-    #             DEFAULT_UV_FLAGS.copy(),
-    #         )
-    #         == expected_flags
-    #     )
+    def test_override_uv_flag_multiple_flags(self):
+        expected_flags = DEFAULT_UV_FLAGS.copy()
+        expected_flags.remove("--unsafe-package")
+        expected_flags.remove("setuptools")
+        expected_flags.extend(["--unsafe-package", "dummy"])
+        assert (
+            _override_uv_flags(
+                ["--unsafe-package dummy"],
+                DEFAULT_UV_FLAGS.copy(),
+            )
+            == expected_flags
+        )
 
-    # def test_flatten_flags(self):
-    #     assert _flatten_flags(["--no-annotate", "--no-header"]) == [
-    #         "--no-annotate",
-    #         "--no-header",
-    #     ]
-    #     assert _flatten_flags(
-    #         [
-    #             "--no-annotate",
-    #             "--no-header",
-    #             "--extra-index-url https://download.pytorch.org/whl/cu128",
-    #         ]
-    #     ) == [
-    #         "--no-annotate",
-    #         "--no-header",
-    #         "--extra-index-url",
-    #         "https://download.pytorch.org/whl/cu128",
-    #     ]
+    def test_flatten_flags(self):
+        assert _flatten_flags(["--no-annotate", "--no-header"]) == [
+            "--no-annotate",
+            "--no-header",
+        ]
+        assert _flatten_flags(
+            [
+                "--no-annotate",
+                "--no-header",
+                "--extra-index-url https://download.pytorch.org/whl/cu128",
+            ]
+        ) == [
+            "--no-annotate",
+            "--no-header",
+            "--extra-index-url",
+            "https://download.pytorch.org/whl/cu128",
+        ]
 
     def test_build_graph(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -398,184 +406,185 @@ class TestCli(unittest.TestCase):
             assert "general_depset__py311_cpu" in sorted_nodes[:3]
             assert "build_args_test_depset__py311_cpu" in sorted_nodes[:3]
 
-    # def test_build_graph_predecessors(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = _create_test_manager(tmpdir)
-    #         assert manager.build_graph is not None
-    #         assert (
-    #             manager.build_graph.nodes["general_depset__py311_cpu"]["operation"]
-    #             == "compile"
-    #         )
-    #         assert (
-    #             manager.build_graph.nodes["expanded_depset__py311_cpu"]["operation"]
-    #             == "compile"
-    #         )
-    #         assert (
-    #             manager.build_graph.nodes["expand_general_depset__py311_cpu"][
-    #                 "operation"
-    #             ]
-    #             == "expand"
-    #         )
-    #         assert set(
-    #             manager.build_graph.predecessors("expand_general_depset__py311_cpu")
-    #         ) == {"general_depset__py311_cpu", "expanded_depset__py311_cpu"}
+    def test_build_graph_predecessors(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            assert manager.build_graph is not None
+            assert (
+                manager.build_graph.nodes["general_depset__py311_cpu"]["operation"]
+                == "compile"
+            )
+            assert (
+                manager.build_graph.nodes["expanded_depset__py311_cpu"]["operation"]
+                == "compile"
+            )
+            assert (
+                manager.build_graph.nodes["expand_general_depset__py311_cpu"][
+                    "operation"
+                ]
+                == "expand"
+            )
+            assert set(
+                manager.build_graph.predecessors("expand_general_depset__py311_cpu")
+            ) == {"general_depset__py311_cpu", "expanded_depset__py311_cpu"}
 
-    # def test_build_graph_bad_operation(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         depset = Depset(
-    #             name="invalid_op_depset",
-    #             operation="invalid_op",
-    #             requirements=["requirements_test.txt"],
-    #             output="requirements_compiled_invalid_op.txt",
-    #         )
-    #         _overwrite_config_file(tmpdir, depset)
-    #         with self.assertRaises(ValueError):
-    #             _create_test_manager(tmpdir)
+    def test_build_graph_bad_operation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            depset = Depset(
+                name="invalid_op_depset",
+                operation="invalid_op",
+                requirements=["requirements_test.txt"],
+                output="requirements_compiled_invalid_op.txt",
+            )
+            _overwrite_config_file(tmpdir, depset)
+            with self.assertRaises(ValueError):
+                _create_test_manager(tmpdir)
 
-    # def test_execute(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
+    def test_execute(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
 
-    # def test_execute_single_depset(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = _create_test_manager(tmpdir)
-    #         manager.execute(single_depset_name="general_depset__py311_cpu")
-    #         assert (
-    #             manager.build_graph.nodes["general_depset__py311_cpu"]["operation"]
-    #             == "compile"
-    #         )
-    #         assert len(manager.build_graph.nodes()) == 1
+    def test_execute_single_depset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            manager.execute(single_depset_name="general_depset__py311_cpu")
+            assert (
+                manager.build_graph.nodes["general_depset__py311_cpu"]["operation"]
+                == "compile"
+            )
+            assert len(manager.build_graph.nodes()) == 1
 
-    # def test_execute_single_depset_that_does_not_exist(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = _create_test_manager(tmpdir)
-    #         with self.assertRaises(KeyError):
-    #             manager.execute(single_depset_name="fake_depset")
+    def test_execute_single_depset_that_does_not_exist(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            with self.assertRaises(KeyError):
+                manager.execute(single_depset_name="fake_depset")
 
-    # def test_expand(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         save_packages_to_file(
-    #             Path(tmpdir) / "requirements_expanded.txt",
-    #             ["six"],
-    #         )
-    #         save_file_as(
-    #             Path(tmpdir) / "requirement_constraints_test.txt",
-    #             Path(tmpdir) / "requirement_constraints_expand.txt",
-    #         )
-    #         append_to_file(
-    #             Path(tmpdir) / "requirement_constraints_expand.txt",
-    #             "six==1.17.0",
-    #         )
-    #         manager = _create_test_manager(tmpdir)
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="general_depset__py311_cpu",
-    #             output="requirements_compiled_general.txt",
-    #         )
-    #         manager.compile(
-    #             constraints=[],
-    #             requirements=["requirements_expanded.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="expanded_depset__py311_cpu",
-    #             output="requirements_compiled_expanded.txt",
-    #         )
-    #         manager.expand(
-    #             depsets=["general_depset__py311_cpu", "expanded_depset__py311_cpu"],
-    #             constraints=["requirement_constraints_expand.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             requirements=[],
-    #             name="expand_general_depset__py311_cpu",
-    #             output="requirements_compiled_expand_general.txt",
-    #         )
-    #         output_file = Path(tmpdir) / "requirements_compiled_expand_general.txt"
-    #         output_text = output_file.read_text()
-    #         output_file_valid = Path(tmpdir) / "requirements_compiled_test_expand.txt"
-    #         output_text_valid = output_file_valid.read_text()
-    #         assert output_text == output_text_valid
+    def test_expand(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            save_packages_to_file(
+                Path(tmpdir) / "requirements_expanded.txt",
+                ["six"],
+            )
+            save_file_as(
+                Path(tmpdir) / "requirement_constraints_test.txt",
+                Path(tmpdir) / "requirement_constraints_expand.txt",
+            )
+            append_to_file(
+                Path(tmpdir) / "requirement_constraints_expand.txt",
+                "six==1.17.0",
+            )
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="general_depset__py311_cpu",
+                output="requirements_compiled_general.txt",
+            )
+            manager.compile(
+                constraints=[],
+                requirements=["requirements_expanded.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="expanded_depset__py311_cpu",
+                output="requirements_compiled_expanded.txt",
+            )
+            manager.expand(
+                depsets=["general_depset__py311_cpu", "expanded_depset__py311_cpu"],
+                constraints=["requirement_constraints_expand.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                requirements=[],
+                name="expand_general_depset__py311_cpu",
+                output="requirements_compiled_expand_general.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_expand_general.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test_expand.txt"
+            output_text_valid = output_file_valid.read_text()
+            assert output_text == output_text_valid
 
-    # def test_expand_with_requirements(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         save_packages_to_file(
-    #             Path(tmpdir) / "requirements_expanded.txt",
-    #             ["six"],
-    #         )
-    #         save_file_as(
-    #             Path(tmpdir) / "requirement_constraints_test.txt",
-    #             Path(tmpdir) / "requirement_constraints_expand.txt",
-    #         )
-    #         append_to_file(
-    #             Path(tmpdir) / "requirement_constraints_expand.txt",
-    #             "six==1.17.0",
-    #         )
-    #         manager = _create_test_manager(tmpdir)
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="general_depset__py311_cpu",
-    #             output="requirements_compiled_general.txt",
-    #         )
-    #         manager.expand(
-    #             depsets=["general_depset__py311_cpu"],
-    #             requirements=["requirements_expanded.txt"],
-    #             constraints=["requirement_constraints_expand.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="expand_general_depset__py311_cpu",
-    #             output="requirements_compiled_expand_general.txt",
-    #         )
-    #         output_file = Path(tmpdir) / "requirements_compiled_expand_general.txt"
-    #         output_text = output_file.read_text()
-    #         output_file_valid = Path(tmpdir) / "requirements_compiled_test_expand.txt"
-    #         output_text_valid = output_file_valid.read_text()
-    #         assert output_text == output_text_valid
+    def test_expand_with_requirements(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            save_packages_to_file(
+                Path(tmpdir) / "requirements_expanded.txt",
+                ["six"],
+            )
+            save_file_as(
+                Path(tmpdir) / "requirement_constraints_test.txt",
+                Path(tmpdir) / "requirement_constraints_expand.txt",
+            )
+            append_to_file(
+                Path(tmpdir) / "requirement_constraints_expand.txt",
+                "six==1.17.0",
+            )
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="general_depset__py311_cpu",
+                output="requirements_compiled_general.txt",
+            )
+            manager.expand(
+                depsets=["general_depset__py311_cpu"],
+                requirements=["requirements_expanded.txt"],
+                constraints=["requirement_constraints_expand.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="expand_general_depset__py311_cpu",
+                output="requirements_compiled_expand_general.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_expand_general.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test_expand.txt"
+            output_text_valid = output_file_valid.read_text()
+            assert output_text == output_text_valid
 
-    # def test_get_depset_with_build_arg_set(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = DependencySetManager(
-    #             config_path="test.depsets.yaml",
-    #             workspace_dir=tmpdir,
-    #         )
-    #         depset = _get_depset(
-    #             manager.config.depsets, "build_args_test_depset__py311_cpu"
-    #         )
-    #         assert depset.name == "build_args_test_depset__py311_cpu"
+    def test_get_depset_with_build_arg_set(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = DependencySetManager(
+                config_path="test.depsets.yaml",
+                workspace_dir=tmpdir,
+            )
+            depset = _get_depset(
+                manager.config.depsets, "build_args_test_depset__py311_cpu"
+            )
+            assert depset.name == "build_args_test_depset__py311_cpu"
 
-    # def test_get_depset_without_build_arg_set(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = DependencySetManager(
-    #             config_path="test.depsets.yaml",
-    #             workspace_dir=tmpdir,
-    #         )
-    #         depset = _get_depset(manager.config.depsets, "ray_base_test_depset")
-    #         assert depset.name == "ray_base_test_depset"
+    def test_get_depset_without_build_arg_set(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = DependencySetManager(
+                config_path="test.depsets.yaml",
+                workspace_dir=tmpdir,
+            )
+            depset = _get_depset(manager.config.depsets, "ray_base_test_depset")
+            assert depset.name == "ray_base_test_depset"
 
-    # def test_get_depset_with_build_arg_set_and_no_build_arg_set_provided(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         manager = DependencySetManager(
-    #             config_path="test.depsets.yaml",
-    #             workspace_dir=tmpdir,
-    #         )
-    #         with self.assertRaises(KeyError):
-    #             _get_depset(manager.config.depsets, "build_args_test_depset_py311")
+    def test_get_depset_with_build_arg_set_and_no_build_arg_set_provided(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = DependencySetManager(
+                config_path="test.depsets.yaml",
+                workspace_dir=tmpdir,
+            )
+            with self.assertRaises(KeyError):
+                _get_depset(manager.config.depsets, "build_args_test_depset_py311")
 
     def test_execute_single_pre_hook(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             result = _invoke_build(tmpdir, "test.depsets.yaml", "pre_hook_test_depset")
+            assert (Path(tmpdir) / "test.depsets.yaml").exists()
             assert result.exit_code == 0
             assert "pre hook test" in result.output
-            assert "Executed pre_hook pre_hook_test_depset" in result.output
+            assert "Executed pre_hook hook-test.sh pre successfully" in result.output
 
     def test_execute_multiple_pre_hooks(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -587,7 +596,8 @@ class TestCli(unittest.TestCase):
             assert "pre-1 hook test" in result.output
             assert "pre-2 hook test" in result.output
             assert "pre hook test" not in result.output
-            assert "Executed pre_hook multi_pre_hook_test_depset" in result.output
+            assert "Executed pre_hook hook-test.sh pre-1 successfully" in result.output
+            assert "Executed pre_hook hook-test.sh pre-2 successfully" in result.output
 
     def test_execute_single_invalid_pre_hook(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -597,8 +607,7 @@ class TestCli(unittest.TestCase):
             )
             assert result.exit_code == 1
             assert isinstance(result.exception, RuntimeError)
-            assert "pre hook test" in str(result.output)
-            assert "Failed to execute pre_hook: hook-error-test.sh" in str(
+            assert "Failed to execute pre_hook hook-error-test.sh with error:" in str(
                 result.exception
             )
 
@@ -610,41 +619,41 @@ class TestCli(unittest.TestCase):
             )
             assert result.exit_code == 1
             assert isinstance(result.exception, RuntimeError)
-            assert "pre hook test" in str(result.output)
-            assert "Failed to execute pre_hook: hook-error-test.sh" in str(
+            assert "Failed to execute pre_hook hook-error-test.sh with error:" in str(
                 result.exception
             )
 
     def test_execute_single_post_hook(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
-            result = _invoke_build(tmpdir, "test.depsets.yaml", "post_hook_test_depset")
+            result = _invoke_build(
+                tmpdir, "test.depsets.yaml", "post_hook_test_depset_post_hook_1"
+            )
             assert result.exit_code == 0
             assert "post hook test" in result.output
-            assert "Executed post_hook post_hook_test_depset" in result.output
+            assert "Executed post_hook hook-test.sh post successfully" in result.output
 
     def test_execute_multiple_post_hooks(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             result = _invoke_build(
-                tmpdir, "test.depsets.yaml", "multi_post_hook_test_depset"
+                tmpdir, "test.depsets.yaml", "multi_post_hook_test_depset_post_hook_2"
             )
             assert result.exit_code == 0
-            assert "post-1 hook test" in result.output
             assert "post-2 hook test" in result.output
-            assert "post hook test" not in result.output
-            assert "Executed post_hook multi_post_hook_test_depset" in result.output
+            assert (
+                "Executed post_hook hook-test.sh post-2 successfully" in result.output
+            )
 
     def test_execute_single_invalid_post_hook(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             result = _invoke_build(
-                tmpdir, "test.depsets.yaml", "post_hook_invalid_test_depset"
+                tmpdir, "test.depsets.yaml", "post_hook_invalid_test_depset_post_hook_1"
             )
             assert result.exit_code == 1
             assert isinstance(result.exception, RuntimeError)
-            assert "post hook test" in str(result.output)
-            assert "Failed to execute post_hook: hook-error-test.sh" in str(
+            assert "Failed to execute post_hook hook-error-test.sh with error:" in str(
                 result.exception
             )
 
@@ -652,136 +661,137 @@ class TestCli(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             result = _invoke_build(
-                tmpdir, "test.depsets.yaml", "multiple_post_hook_invalid_test_depset"
+                tmpdir,
+                "test.depsets.yaml",
+                "multiple_post_hook_invalid_test_depset_post_hook_2",
             )
             assert result.exit_code == 1
             assert isinstance(result.exception, RuntimeError)
-            assert "post hook test" in str(result.output)
-            assert "Failed to execute post_hook hook: hook-error-test.sh" in str(
+            assert "Failed to execute post_hook hook-error-test.sh with error:" in str(
                 result.exception
             )
 
-    # def test_copy_lock_files_to_temp_dir(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         depset = Depset(
-    #             name="check_depset",
-    #             operation="compile",
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt"],
-    #             output="requirements_compiled_test.txt",
-    #         )
-    #         _overwrite_config_file(tmpdir, depset)
-    #         manager = _create_test_manager(tmpdir, check=True)
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="check_depset",
-    #             output="requirements_compiled_test.txt",
-    #         )
-    #         assert (
-    #             Path(manager.workspace.dir) / "requirements_compiled_test.txt"
-    #         ).exists()
-    #         assert (Path(manager.temp_dir) / "requirements_compiled_test.txt").exists()
+    def test_copy_lock_files_to_temp_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            depset = Depset(
+                name="check_depset",
+                operation="compile",
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                output="requirements_compiled_test.txt",
+            )
+            _overwrite_config_file(tmpdir, depset)
+            manager = _create_test_manager(tmpdir, check=True)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="check_depset",
+                output="requirements_compiled_test.txt",
+            )
+            assert (
+                Path(manager.workspace.dir) / "requirements_compiled_test.txt"
+            ).exists()
+            assert (Path(manager.temp_dir) / "requirements_compiled_test.txt").exists()
 
-    # def test_diff_lock_files_out_of_date(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         depset = Depset(
-    #             name="check_depset",
-    #             operation="compile",
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt"],
-    #             output="requirements_compiled_test.txt",
-    #         )
-    #         _overwrite_config_file(tmpdir, depset)
-    #         manager = _create_test_manager(tmpdir, check=True)
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="check_depset",
-    #             output="requirements_compiled_test.txt",
-    #         )
-    #         replace_in_file(
-    #             Path(manager.workspace.dir) / "requirements_compiled_test.txt",
-    #             "emoji==2.9.0",
-    #             "emoji==2.8.0",
-    #         )
+    def test_diff_lock_files_out_of_date(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            depset = Depset(
+                name="check_depset",
+                operation="compile",
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                output="requirements_compiled_test.txt",
+            )
+            _overwrite_config_file(tmpdir, depset)
+            manager = _create_test_manager(tmpdir, check=True)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="check_depset",
+                output="requirements_compiled_test.txt",
+            )
+            replace_in_file(
+                Path(manager.workspace.dir) / "requirements_compiled_test.txt",
+                "emoji==2.9.0",
+                "emoji==2.8.0",
+            )
 
-    #         with self.assertRaises(RuntimeError) as e:
-    #             manager.diff_lock_files()
-    #         assert (
-    #             "Lock files are not up to date. Please update lock files and push the changes."
-    #             in str(e.exception)
-    #         )
-    #         assert "+emoji==2.8.0" in str(e.exception)
-    #         assert "-emoji==2.9.0" in str(e.exception)
+            with self.assertRaises(RuntimeError) as e:
+                manager.diff_lock_files()
+            assert (
+                "Lock files are not up to date. Please update lock files and push the changes."
+                in str(e.exception)
+            )
+            assert "+emoji==2.8.0" in str(e.exception)
+            assert "-emoji==2.9.0" in str(e.exception)
 
-    # def test_diff_lock_files_up_to_date(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         depset = Depset(
-    #             name="check_depset",
-    #             operation="compile",
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt"],
-    #             output="requirements_compiled_test.txt",
-    #         )
-    #         _overwrite_config_file(tmpdir, depset)
-    #         manager = _create_test_manager(tmpdir, check=True)
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             requirements=["requirements_test.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="check_depset",
-    #             output="requirements_compiled_test.txt",
-    #         )
-    #         manager.diff_lock_files()
+    def test_diff_lock_files_up_to_date(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            depset = Depset(
+                name="check_depset",
+                operation="compile",
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                output="requirements_compiled_test.txt",
+            )
+            _overwrite_config_file(tmpdir, depset)
+            manager = _create_test_manager(tmpdir, check=True)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="check_depset",
+                output="requirements_compiled_test.txt",
+            )
+            manager.diff_lock_files()
 
-    # def test_compile_with_packages(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         save_file_as(
-    #             Path(tmpdir) / "requirements_compiled_test.txt",
-    #             Path(tmpdir) / "requirements_compiled_test_packages.txt",
-    #         )
-    #         manager = _create_test_manager(tmpdir)
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             packages=["emoji==2.9.0", "pyperclip==1.6.0"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="packages_test_depset",
-    #             output="requirements_compiled_test_packages.txt",
-    #         )
-    #         output_file = Path(tmpdir) / "requirements_compiled_test_packages.txt"
-    #         output_text = output_file.read_text()
-    #         output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
-    #         output_text_valid = output_file_valid.read_text()
-    #         assert output_text == output_text_valid
+    def test_compile_with_packages(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            save_file_as(
+                Path(tmpdir) / "requirements_compiled_test.txt",
+                Path(tmpdir) / "requirements_compiled_test_packages.txt",
+            )
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                packages=["emoji==2.9.0", "pyperclip==1.6.0"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="packages_test_depset",
+                output="requirements_compiled_test_packages.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_test_packages.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
+            output_text_valid = output_file_valid.read_text()
+            assert output_text == output_text_valid
 
-    # def test_compile_with_packages_and_requirements(self):
-    #     with tempfile.TemporaryDirectory() as tmpdir:
-    #         copy_data_to_tmpdir(tmpdir)
-    #         save_file_as(
-    #             Path(tmpdir) / "requirements_compiled_test.txt",
-    #             Path(tmpdir) / "requirements_compiled_test_packages.txt",
-    #         )
-    #         manager = _create_test_manager(tmpdir)
-    #         manager.compile(
-    #             constraints=["requirement_constraints_test.txt"],
-    #             packages=["emoji==2.9.0", "pyperclip==1.6.0"],
-    #             requirements=["requirements_test.txt"],
-    #             append_flags=["--no-annotate", "--no-header"],
-    #             name="packages_test_depset",
-    #             output="requirements_compiled_test_packages.txt",
-    #         )
-    #         output_file = Path(tmpdir) / "requirements_compiled_test_packages.txt"
-    #         output_text = output_file.read_text()
-    #         output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
-    #         output_text_valid = output_file_valid.read_text()
-    #         assert output_text == output_text_valid
+    def test_compile_with_packages_and_requirements(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            save_file_as(
+                Path(tmpdir) / "requirements_compiled_test.txt",
+                Path(tmpdir) / "requirements_compiled_test_packages.txt",
+            )
+            manager = _create_test_manager(tmpdir)
+            manager.compile(
+                constraints=["requirement_constraints_test.txt"],
+                packages=["emoji==2.9.0", "pyperclip==1.6.0"],
+                requirements=["requirements_test.txt"],
+                append_flags=["--no-annotate", "--no-header"],
+                name="packages_test_depset",
+                output="requirements_compiled_test_packages.txt",
+            )
+            output_file = Path(tmpdir) / "requirements_compiled_test_packages.txt"
+            output_text = output_file.read_text()
+            output_file_valid = Path(tmpdir) / "requirements_compiled_test.txt"
+            output_text_valid = output_file_valid.read_text()
+            assert output_text == output_text_valid
 
 
 if __name__ == "__main__":

--- a/ci/raydepsets/tests/test_data/hook-error-test.sh
+++ b/ci/raydepsets/tests/test_data/hook-error-test.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-echo "Pre-hook test error"
+echo "Hook test error"
 
 exit 1

--- a/ci/raydepsets/tests/test_data/hook-error-test.sh
+++ b/ci/raydepsets/tests/test_data/hook-error-test.sh
@@ -2,6 +2,4 @@
 
 set -euo pipefail
 
-echo "Hook test error"
-
 exit 1

--- a/ci/raydepsets/tests/test_data/hook-test.sh
+++ b/ci/raydepsets/tests/test_data/hook-test.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-echo "Pre-hook test"
+echo "Hook test"

--- a/ci/raydepsets/tests/test_data/hook-test.sh
+++ b/ci/raydepsets/tests/test_data/hook-test.sh
@@ -2,4 +2,5 @@
 
 set -euo pipefail
 
-echo "Hook test"
+prefix=$1
+echo "$prefix hook test"

--- a/ci/raydepsets/tests/test_data/hook-test.sh
+++ b/ci/raydepsets/tests/test_data/hook-test.sh
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-prefix=$1
+prefix=${1:-}
 echo "$prefix hook test"

--- a/ci/raydepsets/tests/test_data/test.depsets.yaml
+++ b/ci/raydepsets/tests/test_data/test.depsets.yaml
@@ -57,6 +57,30 @@ depsets:
       - requirements_test.txt
     output: requirements_compiled_pre_hook.txt
     pre_hooks:
+      - hook-test.sh pre
+  - name: multi_pre_hook_test_depset
+    operation: compile
+    requirements:
+      - requirements_test.txt
+    output: requirements_compiled_pre_hook.txt
+    pre_hooks:
+      - hook-test.sh pre-1
+      - hook-test.sh pre-2
+  - name: pre_hook_invalid_test_depset
+    operation: compile
+    requirements:
+      - requirements_test.txt
+    output: requirements_compiled_pre_hook.txt
+    pre_hooks:
+      - hook-error-test.sh
+  - name: multiple_pre_hook_invalid_test_depset
+    operation: compile
+    requirements:
+      - requirements_test.txt
+    output: requirements_compiled_pre_hook.txt
+    pre_hooks:
+      - hook-test.sh
+      - hook-error-test.sh
       - hook-test.sh
   - name: post_hook_test_depset
     operation: compile
@@ -64,4 +88,28 @@ depsets:
       - requirements_test.txt
     output: requirements_compiled_post_hook.txt
     post_hooks:
+      - hook-test.sh post
+  - name: multi_post_hook_test_depset
+    operation: compile
+    requirements:
+      - requirements_test.txt
+    output: requirements_compiled_post_hook.txt
+    post_hooks:
+      - hook-test.sh post-1
+      - hook-test.sh post-2
+  - name: post_hook_invalid_test_depset
+    operation: compile
+    requirements:
+      - requirements_test.txt
+    output: requirements_compiled_post_hook.txt
+    post_hooks:
+      - hook-error-test.sh
+  - name: multiple_post_hook_invalid_test_depset
+    operation: compile
+    requirements:
+      - requirements_test.txt
+    output: requirements_compiled_pre_hook.txt
+    post_hooks:
+      - hook-test.sh
+      - hook-error-test.sh
       - hook-test.sh

--- a/ci/raydepsets/tests/test_data/test.depsets.yaml
+++ b/ci/raydepsets/tests/test_data/test.depsets.yaml
@@ -57,7 +57,7 @@ depsets:
       - requirements_test.txt
     output: requirements_compiled_pre_hook.txt
     pre_hooks:
-      - hook-test.sh pre
+      - "hook-test.sh pre"
   - name: multi_pre_hook_test_depset
     operation: compile
     requirements:
@@ -79,9 +79,9 @@ depsets:
       - requirements_test.txt
     output: requirements_compiled_pre_hook.txt
     pre_hooks:
-      - hook-test.sh
+      - hook-test.sh pre-1
       - hook-error-test.sh
-      - hook-test.sh
+      - hook-test.sh pre-3
   - name: post_hook_test_depset
     operation: compile
     requirements:
@@ -110,6 +110,6 @@ depsets:
       - requirements_test.txt
     output: requirements_compiled_pre_hook.txt
     post_hooks:
-      - hook-test.sh
+      - hook-test.sh post-1
       - hook-error-test.sh
-      - hook-test.sh
+      - hook-test.sh post-3

--- a/ci/raydepsets/tests/test_data/test.depsets.yaml
+++ b/ci/raydepsets/tests/test_data/test.depsets.yaml
@@ -57,4 +57,11 @@ depsets:
       - requirements_test.txt
     output: requirements_compiled_pre_hook.txt
     pre_hooks:
-      - pre-hook-test.sh
+      - hook-test.sh
+  - name: post_hook_test_depset
+    operation: compile
+    requirements:
+      - requirements_test.txt
+    output: requirements_compiled_post_hook.txt
+    post_hooks:
+      - hook-test.sh

--- a/ci/raydepsets/tests/test_workspace.py
+++ b/ci/raydepsets/tests/test_workspace.py
@@ -74,7 +74,7 @@ def test_parse_pre_hooks():
         workspace = Workspace(dir=tmpdir)
         config = workspace.load_config(path=Path(tmpdir) / "test.depsets.yaml")
         pre_hook_depset = get_depset_by_name(config.depsets, "pre_hook_test_depset")
-        assert pre_hook_depset.pre_hooks == ["hook-test.sh"]
+        assert pre_hook_depset.pre_hooks == ["hook-test.sh pre"]
 
 
 def test_parse_post_hooks():
@@ -83,7 +83,7 @@ def test_parse_post_hooks():
         workspace = Workspace(dir=tmpdir)
         config = workspace.load_config(path=Path(tmpdir) / "test.depsets.yaml")
         post_hook_depset = get_depset_by_name(config.depsets, "post_hook_test_depset")
-        assert post_hook_depset.post_hooks == ["hook-test.sh"]
+        assert post_hook_depset.post_hooks == ["hook-test.sh post"]
 
 
 if __name__ == "__main__":

--- a/ci/raydepsets/tests/test_workspace.py
+++ b/ci/raydepsets/tests/test_workspace.py
@@ -74,7 +74,16 @@ def test_parse_pre_hooks():
         workspace = Workspace(dir=tmpdir)
         config = workspace.load_config(path=Path(tmpdir) / "test.depsets.yaml")
         pre_hook_depset = get_depset_by_name(config.depsets, "pre_hook_test_depset")
-        assert pre_hook_depset.pre_hooks == ["pre-hook-test.sh"]
+        assert pre_hook_depset.pre_hooks == ["hook-test.sh"]
+
+
+def test_parse_post_hooks():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        copy_data_to_tmpdir(tmpdir)
+        workspace = Workspace(dir=tmpdir)
+        config = workspace.load_config(path=Path(tmpdir) / "test.depsets.yaml")
+        post_hook_depset = get_depset_by_name(config.depsets, "post_hook_test_depset")
+        assert post_hook_depset.post_hooks == ["hook-test.sh"]
 
 
 if __name__ == "__main__":

--- a/ci/raydepsets/workspace.py
+++ b/ci/raydepsets/workspace.py
@@ -24,6 +24,7 @@ class Depset:
     source_depset: Optional[str] = None
     depsets: Optional[List[str]] = None
     pre_hooks: Optional[List[str]] = None
+    post_hooks: Optional[List[str]] = None
 
 
 def _substitute_build_args(obj: Any, build_arg_set: BuildArgSet):
@@ -52,6 +53,7 @@ def _dict_to_depset(depset: dict) -> Depset:
         override_flags=depset.get("override_flags", []),
         append_flags=depset.get("append_flags", []),
         pre_hooks=depset.get("pre_hooks", []),
+        post_hooks=depset.get("post_hooks", []),
         packages=depset.get("packages", []),
     )
 


### PR DESCRIPTION
Adding post hooks for depsets
Necessary for cleanup for some operations (ex. https://github.com/ray-project/ray/blob/master/docker/ray-ml/install-ml-docker-requirements.sh#L41-L55)

Changed from execute_pre_hook -> execute_hook for reusability
Currently no order for hook script execution but will address this in the near future
