### PR TITLE
Add ABFSS support to Ray Tune and Train

### DIFF
--- a/python/ray/train/_checkpoint.py
+++ b/python/ray/train/_checkpoint.py
@@ -14,83 +14,17 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 import pyarrow.fs
 
 from ray.air._internal.filelock import TempFileLock
-from ray.train._internal.storage import _download_from_fs_path, _exists_at_fs_path
+from ray.train._internal.storage import (
+    _create_abfss_filesystem,
+    _download_from_fs_path,
+    _exists_at_fs_path,
+)
 from ray.util.annotations import PublicAPI
 
 logger = logging.getLogger(__name__)
 
 # The filename of the file that stores user metadata set on the checkpoint.
 _METADATA_FILE_NAME = ".metadata.json"
-
-
-def _create_abfss_filesystem(storage_path: str):
-    """Create an ABFSS filesystem for Azure Blob Storage.
-    
-    Args:
-        storage_path: ABFSS URI (abfss://container@account.dfs.core.windows.net/path)
-    
-    Returns:
-        Tuple of (PyArrow FileSystem, path without abfss:// prefix)
-    
-    Raises:
-        ImportError: If required dependencies are not installed.
-        ValueError: If the ABFSS URI format is invalid.
-    """
-    try:
-        import adlfs
-        from azure.identity import DefaultAzureCredential
-    except ImportError:
-        raise ImportError(
-            "You must `pip install adlfs azure-identity` "
-            "to use ABFSS URIs with Ray Train checkpoints. "
-            "Note that these must be preinstalled on all nodes in the Ray cluster."
-        )
-    
-    from urllib.parse import urlparse
-    
-    # Parse and validate the ABFSS URI
-    parsed = urlparse(storage_path)
-    
-    # Validate ABFSS URI format: abfss://container@account.dfs.core.windows.net/path
-    if not parsed.netloc or "@" not in parsed.netloc:
-        raise ValueError(
-            f"Invalid ABFSS URI format - missing container@account: {storage_path}"
-        )
-    
-    container_part, hostname_part = parsed.netloc.split("@", 1)
-    
-    # Validate container name (must be non-empty)
-    if not container_part:
-        raise ValueError(
-            f"Invalid ABFSS URI format - empty container name: {storage_path}"
-        )
-    
-    # Validate hostname format
-    if not hostname_part or not hostname_part.endswith(".dfs.core.windows.net"):
-        raise ValueError(
-            f"Invalid ABFSS URI format - invalid hostname (must end with .dfs.core.windows.net): {storage_path}"
-        )
-    
-    # Extract and validate account name
-    azure_storage_account_name = hostname_part.split(".")[0]
-    if not azure_storage_account_name:
-        raise ValueError(
-            f"Invalid ABFSS URI format - empty account name: {storage_path}"
-        )
-    
-    # Create the adlfs filesystem
-    adlfs_fs = adlfs.AzureBlobFileSystem(
-        account_name=azure_storage_account_name,
-        credential=DefaultAzureCredential(),
-    )
-    
-    # Wrap with PyArrow's PyFileSystem for compatibility
-    fs = pyarrow.fs.PyFileSystem(pyarrow.fs.FSSpecHandler(adlfs_fs))
-    
-    # Return the path without the abfss:// prefix
-    path = f"{container_part}{parsed.path}"
-    
-    return fs, path
 
 # The prefix of the temp checkpoint directory that `to_directory` downloads to
 # on the local filesystem.

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -296,13 +296,13 @@ def _create_directory(fs: pyarrow.fs.FileSystem, fs_path: str) -> None:
 
 def _create_abfss_filesystem(storage_path: str) -> Tuple[pyarrow.fs.FileSystem, str]:
     """Create an ABFSS filesystem for Azure Blob Storage.
-    
+
     Args:
         storage_path: ABFSS URI (abfss://container@account.dfs.core.windows.net/path)
-    
+
     Returns:
         Tuple of (PyArrow FileSystem, path without abfss:// prefix)
-    
+
     Raises:
         ImportError: If required dependencies are not installed.
         ValueError: If the ABFSS URI format is invalid.
@@ -313,54 +313,51 @@ def _create_abfss_filesystem(storage_path: str) -> Tuple[pyarrow.fs.FileSystem, 
     except ImportError:
         raise ImportError(
             "You must `pip install adlfs azure-identity` "
-            "to use ABFSS URIs with Ray Tune. "
+            "to use ABFSS URIs with Ray Train and Tune. "
             "Note that these must be preinstalled on all nodes in the Ray cluster."
         )
-    
+
     from urllib.parse import urlparse
-    
+
     # Parse and validate the ABFSS URI
+    # ABFSS URI format: abfss://container@account.dfs.core.windows.net/path
     parsed = urlparse(storage_path)
-    
-    # Validate ABFSS URI format: abfss://container@account.dfs.core.windows.net/path
-    if not parsed.netloc or "@" not in parsed.netloc:
+
+    # Use urlparse attributes for cleaner extraction
+    container_name = parsed.username  # The part before @ in netloc
+    hostname = parsed.hostname  # The part after @ in netloc
+
+    # Validate container name
+    if not container_name:
         raise ValueError(
-            f"Invalid ABFSS URI format - missing container@account: {storage_path}"
+            f"Invalid ABFSS URI format - missing or empty container name: {storage_path}"
         )
-    
-    container_part, hostname_part = parsed.netloc.split("@", 1)
-    
-    # Validate container name (must be non-empty)
-    if not container_part:
-        raise ValueError(
-            f"Invalid ABFSS URI format - empty container name: {storage_path}"
-        )
-    
+
     # Validate hostname format
-    if not hostname_part or not hostname_part.endswith(".dfs.core.windows.net"):
+    if not hostname or not hostname.endswith(".dfs.core.windows.net"):
         raise ValueError(
             f"Invalid ABFSS URI format - invalid hostname (must end with .dfs.core.windows.net): {storage_path}"
         )
-    
+
     # Extract and validate account name
-    azure_storage_account_name = hostname_part.split(".")[0]
+    azure_storage_account_name = hostname.split(".")[0]
     if not azure_storage_account_name:
         raise ValueError(
             f"Invalid ABFSS URI format - empty account name: {storage_path}"
         )
-    
+
     # Create the adlfs filesystem
     adlfs_fs = adlfs.AzureBlobFileSystem(
         account_name=azure_storage_account_name,
         credential=DefaultAzureCredential(),
     )
-    
+
     # Wrap with PyArrow's PyFileSystem for compatibility
     fs = pyarrow.fs.PyFileSystem(pyarrow.fs.FSSpecHandler(adlfs_fs))
-    
+
     # Return the path without the abfss:// prefix
-    path = f"{container_part}{parsed.path}"
-    
+    path = f"{container_name}{parsed.path}"
+
     return fs, path
 
 
@@ -371,7 +368,7 @@ def get_fs_and_path(
     """Returns the fs and path from a storage path and an optional custom fs.
 
     Args:
-        storage_path: A storage path or URI. (ex: s3://bucket/path, 
+        storage_path: A storage path or URI. (ex: s3://bucket/path,
             abfss://container@account.dfs.core.windows.net/path, or /tmp/ray_results)
         storage_filesystem: A custom filesystem to use. If not provided,
             this will be auto-resolved by pyarrow. If provided, the storage_path
@@ -382,7 +379,7 @@ def get_fs_and_path(
 
     if storage_filesystem:
         return storage_filesystem, storage_path
-    
+
     # Handle ABFSS URIs specially since PyArrow doesn't natively support them
     if storage_path.startswith("abfss://"):
         return _create_abfss_filesystem(storage_path)

--- a/python/ray/train/tests/test_new_persistence.py
+++ b/python/ray/train/tests/test_new_persistence.py
@@ -124,7 +124,12 @@ def _get_local_inspect_dir(
         if storage_filesystem:
             fs, storage_fs_path = storage_filesystem, storage_path
         else:
-            fs, storage_fs_path = pyarrow.fs.FileSystem.from_uri(storage_path)
+            # Handle ABFSS URIs specially since PyArrow doesn't natively support them
+            if storage_path.startswith("abfss://"):
+                from ray.train._internal.storage import _create_abfss_filesystem
+                fs, storage_fs_path = _create_abfss_filesystem(storage_path)
+            else:
+                fs, storage_fs_path = pyarrow.fs.FileSystem.from_uri(storage_path)
         _download_from_fs_path(
             fs=fs, fs_path=storage_fs_path, local_path=str(local_inspect_dir)
         )

--- a/python/ray/train/tests/test_new_persistence.py
+++ b/python/ray/train/tests/test_new_persistence.py
@@ -121,15 +121,12 @@ def _get_local_inspect_dir(
     """
     local_inspect_dir = root_local_path / "inspect"
     if storage_path:
+        from ray.train._internal.storage import get_fs_and_path
+
         if storage_filesystem:
             fs, storage_fs_path = storage_filesystem, storage_path
         else:
-            # Handle ABFSS URIs specially since PyArrow doesn't natively support them
-            if storage_path.startswith("abfss://"):
-                from ray.train._internal.storage import _create_abfss_filesystem
-                fs, storage_fs_path = _create_abfss_filesystem(storage_path)
-            else:
-                fs, storage_fs_path = pyarrow.fs.FileSystem.from_uri(storage_path)
+            fs, storage_fs_path = get_fs_and_path(storage_path, storage_filesystem)
         _download_from_fs_path(
             fs=fs, fs_path=storage_fs_path, local_path=str(local_inspect_dir)
         )

--- a/python/ray/train/tests/test_result.py
+++ b/python/ray/train/tests/test_result.py
@@ -92,12 +92,9 @@ def test_result_restore(ray_start_4_cpus, tmpdir, mock_s3_bucket_uri, storage, m
 
     # Find the trial directory to restore
     exp_dir = str(URI(storage_path) / exp_name)
-    # Handle ABFSS URIs specially since PyArrow doesn't natively support them
-    if exp_dir.startswith("abfss://"):
-        from ray.train._internal.storage import _create_abfss_filesystem
-        fs, fs_exp_dir = _create_abfss_filesystem(exp_dir)
-    else:
-        fs, fs_exp_dir = pyarrow.fs.FileSystem.from_uri(exp_dir)
+    from ray.train._internal.storage import get_fs_and_path
+
+    fs, fs_exp_dir = get_fs_and_path(exp_dir)
     for item in fs.get_file_info(pyarrow.fs.FileSelector(fs_exp_dir)):
         if item.type == pyarrow.fs.FileType.Directory and item.base_name.startswith(
             "TorchTrainer"

--- a/python/ray/train/v2/_internal/execution/storage.py
+++ b/python/ray/train/v2/_internal/execution/storage.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Type, Union
 
 from ray.air._internal.filelock import TempFileLock
+from ray.train._internal.storage import _create_abfss_filesystem
 from ray.train.constants import _get_ray_train_session_dir
 from ray.train.v2._internal.constants import (
     CHECKPOINT_MANAGER_SNAPSHOT_FILENAME,
@@ -287,76 +288,6 @@ def _create_directory(fs: pyarrow.fs.FileSystem, fs_path: str) -> None:
         )
 
 
-def _create_abfss_filesystem(storage_path: str) -> Tuple[pyarrow.fs.FileSystem, str]:
-    """Create an ABFSS filesystem for Azure Blob Storage.
-    
-    Args:
-        storage_path: ABFSS URI (abfss://container@account.dfs.core.windows.net/path)
-    
-    Returns:
-        Tuple of (PyArrow FileSystem, path without abfss:// prefix)
-    
-    Raises:
-        ImportError: If required dependencies are not installed.
-        ValueError: If the ABFSS URI format is invalid.
-    """
-    try:
-        import adlfs
-        from azure.identity import DefaultAzureCredential
-    except ImportError:
-        raise ImportError(
-            "You must `pip install adlfs azure-identity` "
-            "to use ABFSS URIs with Ray Tune. "
-            "Note that these must be preinstalled on all nodes in the Ray cluster."
-        )
-    
-    from urllib.parse import urlparse
-    
-    # Parse and validate the ABFSS URI
-    parsed = urlparse(storage_path)
-    
-    # Validate ABFSS URI format: abfss://container@account.dfs.core.windows.net/path
-    if not parsed.netloc or "@" not in parsed.netloc:
-        raise ValueError(
-            f"Invalid ABFSS URI format - missing container@account: {storage_path}"
-        )
-    
-    container_part, hostname_part = parsed.netloc.split("@", 1)
-    
-    # Validate container name (must be non-empty)
-    if not container_part:
-        raise ValueError(
-            f"Invalid ABFSS URI format - empty container name: {storage_path}"
-        )
-    
-    # Validate hostname format
-    if not hostname_part or not hostname_part.endswith(".dfs.core.windows.net"):
-        raise ValueError(
-            f"Invalid ABFSS URI format - invalid hostname (must end with .dfs.core.windows.net): {storage_path}"
-        )
-    
-    # Extract and validate account name
-    azure_storage_account_name = hostname_part.split(".")[0]
-    if not azure_storage_account_name:
-        raise ValueError(
-            f"Invalid ABFSS URI format - empty account name: {storage_path}"
-        )
-    
-    # Create the adlfs filesystem
-    adlfs_fs = adlfs.AzureBlobFileSystem(
-        account_name=azure_storage_account_name,
-        credential=DefaultAzureCredential(),
-    )
-    
-    # Wrap with PyArrow's PyFileSystem for compatibility
-    fs = pyarrow.fs.PyFileSystem(pyarrow.fs.FSSpecHandler(adlfs_fs))
-    
-    # Return the path without the abfss:// prefix
-    path = f"{container_part}{parsed.path}"
-    
-    return fs, path
-
-
 def get_fs_and_path(
     storage_path: Union[str, os.PathLike],
     storage_filesystem: Optional[pyarrow.fs.FileSystem] = None,
@@ -364,7 +295,7 @@ def get_fs_and_path(
     """Returns the fs and path from a storage path and an optional custom fs.
 
     Args:
-        storage_path: A storage path or URI. (ex: s3://bucket/path, 
+        storage_path: A storage path or URI. (ex: s3://bucket/path,
             abfss://container@account.dfs.core.windows.net/path, or /tmp/ray_results)
         storage_filesystem: A custom filesystem to use. If not provided,
             this will be auto-resolved by pyarrow. If provided, the storage_path
@@ -375,7 +306,7 @@ def get_fs_and_path(
 
     if storage_filesystem:
         return storage_filesystem, storage_path
-    
+
     # Handle ABFSS URIs specially since PyArrow doesn't natively support them
     if storage_path.startswith("abfss://"):
         return _create_abfss_filesystem(storage_path)

--- a/python/ray/train/v2/_internal/execution/storage.py
+++ b/python/ray/train/v2/_internal/execution/storage.py
@@ -287,6 +287,76 @@ def _create_directory(fs: pyarrow.fs.FileSystem, fs_path: str) -> None:
         )
 
 
+def _create_abfss_filesystem(storage_path: str) -> Tuple[pyarrow.fs.FileSystem, str]:
+    """Create an ABFSS filesystem for Azure Blob Storage.
+    
+    Args:
+        storage_path: ABFSS URI (abfss://container@account.dfs.core.windows.net/path)
+    
+    Returns:
+        Tuple of (PyArrow FileSystem, path without abfss:// prefix)
+    
+    Raises:
+        ImportError: If required dependencies are not installed.
+        ValueError: If the ABFSS URI format is invalid.
+    """
+    try:
+        import adlfs
+        from azure.identity import DefaultAzureCredential
+    except ImportError:
+        raise ImportError(
+            "You must `pip install adlfs azure-identity` "
+            "to use ABFSS URIs with Ray Tune. "
+            "Note that these must be preinstalled on all nodes in the Ray cluster."
+        )
+    
+    from urllib.parse import urlparse
+    
+    # Parse and validate the ABFSS URI
+    parsed = urlparse(storage_path)
+    
+    # Validate ABFSS URI format: abfss://container@account.dfs.core.windows.net/path
+    if not parsed.netloc or "@" not in parsed.netloc:
+        raise ValueError(
+            f"Invalid ABFSS URI format - missing container@account: {storage_path}"
+        )
+    
+    container_part, hostname_part = parsed.netloc.split("@", 1)
+    
+    # Validate container name (must be non-empty)
+    if not container_part:
+        raise ValueError(
+            f"Invalid ABFSS URI format - empty container name: {storage_path}"
+        )
+    
+    # Validate hostname format
+    if not hostname_part or not hostname_part.endswith(".dfs.core.windows.net"):
+        raise ValueError(
+            f"Invalid ABFSS URI format - invalid hostname (must end with .dfs.core.windows.net): {storage_path}"
+        )
+    
+    # Extract and validate account name
+    azure_storage_account_name = hostname_part.split(".")[0]
+    if not azure_storage_account_name:
+        raise ValueError(
+            f"Invalid ABFSS URI format - empty account name: {storage_path}"
+        )
+    
+    # Create the adlfs filesystem
+    adlfs_fs = adlfs.AzureBlobFileSystem(
+        account_name=azure_storage_account_name,
+        credential=DefaultAzureCredential(),
+    )
+    
+    # Wrap with PyArrow's PyFileSystem for compatibility
+    fs = pyarrow.fs.PyFileSystem(pyarrow.fs.FSSpecHandler(adlfs_fs))
+    
+    # Return the path without the abfss:// prefix
+    path = f"{container_part}{parsed.path}"
+    
+    return fs, path
+
+
 def get_fs_and_path(
     storage_path: Union[str, os.PathLike],
     storage_filesystem: Optional[pyarrow.fs.FileSystem] = None,
@@ -294,7 +364,8 @@ def get_fs_and_path(
     """Returns the fs and path from a storage path and an optional custom fs.
 
     Args:
-        storage_path: A storage path or URI. (ex: s3://bucket/path or /tmp/ray_results)
+        storage_path: A storage path or URI. (ex: s3://bucket/path, 
+            abfss://container@account.dfs.core.windows.net/path, or /tmp/ray_results)
         storage_filesystem: A custom filesystem to use. If not provided,
             this will be auto-resolved by pyarrow. If provided, the storage_path
             is assumed to be prefix-stripped already, and must be a valid path
@@ -304,6 +375,10 @@ def get_fs_and_path(
 
     if storage_filesystem:
         return storage_filesystem, storage_path
+    
+    # Handle ABFSS URIs specially since PyArrow doesn't natively support them
+    if storage_path.startswith("abfss://"):
+        return _create_abfss_filesystem(storage_path)
 
     return pyarrow.fs.FileSystem.from_uri(storage_path)
 

--- a/python/ray/train/v2/tests/test_persistence.py
+++ b/python/ray/train/v2/tests/test_persistence.py
@@ -125,7 +125,12 @@ def _get_local_inspect_dir(
         if storage_filesystem:
             fs, storage_fs_path = storage_filesystem, storage_path
         else:
-            fs, storage_fs_path = pyarrow.fs.FileSystem.from_uri(storage_path)
+            # Handle ABFSS URIs specially since PyArrow doesn't natively support them
+            if storage_path.startswith("abfss://"):
+                from ray.train.v2._internal.execution.storage import _create_abfss_filesystem
+                fs, storage_fs_path = _create_abfss_filesystem(storage_path)
+            else:
+                fs, storage_fs_path = pyarrow.fs.FileSystem.from_uri(storage_path)
         _download_from_fs_path(
             fs=fs, fs_path=storage_fs_path, local_path=str(local_inspect_dir)
         )

--- a/python/ray/train/v2/tests/test_persistence.py
+++ b/python/ray/train/v2/tests/test_persistence.py
@@ -122,15 +122,12 @@ def _get_local_inspect_dir(
     """
     local_inspect_dir = root_local_path / "inspect"
     if storage_path:
+        from ray.train.v2._internal.execution.storage import get_fs_and_path
+
         if storage_filesystem:
             fs, storage_fs_path = storage_filesystem, storage_path
         else:
-            # Handle ABFSS URIs specially since PyArrow doesn't natively support them
-            if storage_path.startswith("abfss://"):
-                from ray.train.v2._internal.execution.storage import _create_abfss_filesystem
-                fs, storage_fs_path = _create_abfss_filesystem(storage_path)
-            else:
-                fs, storage_fs_path = pyarrow.fs.FileSystem.from_uri(storage_path)
+            fs, storage_fs_path = get_fs_and_path(storage_path, storage_filesystem)
         _download_from_fs_path(
             fs=fs, fs_path=storage_fs_path, local_path=str(local_inspect_dir)
         )


### PR DESCRIPTION
- Add _create_abfss_filesystem() helper function to handle Azure Blob File System Secure URIs
- Update get_fs_and_path() in both storage modules to detect and handle abfss:// URIs
- Integrate adlfs.AzureBlobFileSystem with PyArrow's PyFileSystem for compatibility
- Update checkpoint module to support ABFSS URIs in Checkpoint.from_uri()
- Update test files to handle ABFSS URIs when inspecting storage paths
- Fixes NotADirectoryError when using abfss:// storage paths with Ray Tune

Requires: pip install adlfs azure-identity

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add ABFSS (abfss://) support by integrating adlfs with PyArrow, updating path resolution, and adapting checkpoints/tests to handle Azure Blob Storage (ADLS Gen2).
> 
> - **Storage**:
>   - Add `'_create_abfss_filesystem'` to parse/validate `abfss://` URIs and return a PyArrow `FileSystem` via `adlfs.AzureBlobFileSystem`.
>   - Update `get_fs_and_path` in `ray.train._internal.storage` and `ray.train.v2._internal.execution.storage` to detect `abfss://` and use the new helper.
> - **Checkpoint**:
>   - Update `ray.train._checkpoint.Checkpoint.__init__` to resolve `abfss://` using `'_create_abfss_filesystem'`.
> - **Tests**:
>   - Replace direct `pyarrow.fs.FileSystem.from_uri` calls with `get_fs_and_path` where appropriate.
>   - Adjust inspection helpers in tests to work with `abfss://` paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44345859129df0ecc9002d75df5c96df78b9a1a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->