### PR TITLE
[image] allow using explicit base type

### DIFF
--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -172,7 +172,7 @@ def build_anyscale(
     for p in platform:
         RayDockerContainer(
             python_version, p, image_type, architecture, canonical_tag, upload=False
-        ).run(use_base_extra_testdeps=True)
+        ).run(base="base-extra-testdeps")
         AnyscaleDockerContainer(
             python_version, p, image_type, architecture, canonical_tag, upload
         ).run()


### PR DESCRIPTION
this allows using `base-extra` or `base-extra-testdeps` or other base variations for building ray images.
