### PR TITLE
[Data] Allow `BlockOutputBuffer` to accept nullable output_block_size_option

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -166,6 +166,10 @@ python/ray/_private/runtime_env/setup_hook.py
 python/ray/_private/runtime_env/utils.py
     DOC103: Function `check_output_cmd`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
 --------------------
+python/ray/_private/serialization.py
+    DOC106: Function `_gpu_object_ref_deserializer`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_gpu_object_ref_deserializer`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
 python/ray/_private/services.py
     DOC201: Function `_build_python_executable_command_memory_profileable` does not have a return section in docstring
     DOC101: Function `get_ray_address_from_environment`: Docstring contains fewer arguments than in function signature.
@@ -2813,8 +2817,4 @@ python/ray/widgets/render.py
 python/ray/widgets/util.py
     DOC103: Function `_has_missing`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*deps: Iterable[Union[str, Optional[str]]]]. Arguments in the docstring but not in the function signature: [deps: ].
     DOC103: Function `repr_with_fallback`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*notebook_deps: Iterable[Union[str, Optional[str]]]]. Arguments in the docstring but not in the function signature: [notebook_deps: ].
---------------------
-python/ray/_private/serialization.py
-    DOC106: Function `_gpu_object_ref_deserializer`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
-    DOC107: Function `_gpu_object_ref_deserializer`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
 --------------------

--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1216,7 +1216,6 @@ python/ray/data/_internal/numpy_support.py
 --------------------
 python/ray/data/_internal/output_buffer.py
     DOC101: Method `BlockOutputBuffer.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BlockOutputBuffer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [output_block_size_option: OutputBlockSizeOption].
 --------------------
 python/ray/data/_internal/plan.py
     DOC101: Method `ExecutionPlan.get_plan_as_string`: Docstring contains fewer arguments than in function signature.

--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1220,6 +1220,7 @@ python/ray/data/_internal/numpy_support.py
 --------------------
 python/ray/data/_internal/output_buffer.py
     DOC101: Method `BlockOutputBuffer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BlockOutputBuffer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [output_block_size_option: Optional[OutputBlockSizeOption]].
 --------------------
 python/ray/data/_internal/plan.py
     DOC101: Method `ExecutionPlan.get_plan_as_string`: Docstring contains fewer arguments than in function signature.

--- a/python/ray/data/_internal/output_buffer.py
+++ b/python/ray/data/_internal/output_buffer.py
@@ -41,11 +41,11 @@ class BlockOutputBuffer:
         ...     yield output.next() # doctest: +SKIP
     """
 
-    def __init__(self, output_block_size_option: OutputBlockSizeOption):
+    def __init__(self, output_block_size_option: Optional[OutputBlockSizeOption]):
         self._output_block_size_option = output_block_size_option
         self._buffer = DelegatingBlockBuilder()
-        self._returned_at_least_one_block = False
         self._finalized = False
+        self._has_yielded_blocks = False
 
     def add(self, item: Any) -> None:
         """Add a single item to this output buffer."""
@@ -69,36 +69,57 @@ class BlockOutputBuffer:
 
     def _exceeded_buffer_row_limit(self) -> bool:
         return (
-            self._output_block_size_option.target_num_rows_per_block is not None
-            and self._buffer.num_rows()
-            > self._output_block_size_option.target_num_rows_per_block
+            self._max_num_rows_per_block() is not None
+            and self._buffer.num_rows() > self._max_num_rows_per_block()
         )
 
     def _exceeded_buffer_size_limit(self) -> bool:
         return (
-            self._output_block_size_option.target_max_block_size is not None
-            and self._buffer.get_estimated_memory_usage()
-            > self._output_block_size_option.target_max_block_size
+            self._max_bytes_per_block() is not None
+            and self._buffer.get_estimated_memory_usage() > self._max_bytes_per_block()
+        )
+
+    def _max_num_rows_per_block(self) -> Optional[int]:
+        return (
+            self._output_block_size_option.target_num_rows_per_block
+            if self._output_block_size_option is not None
+            else None
+        )
+
+    def _max_bytes_per_block(self) -> Optional[int]:
+        return (
+            self._output_block_size_option.target_max_block_size
+            if self._output_block_size_option is not None
+            else None
         )
 
     def has_next(self) -> bool:
         """Returns true when a complete output block is produced."""
+
+        # NOTE: Output buffer should yield immediately in either of 2 cases
+        #   - When it's finalized and buffer is non-empty (or no blocks been emitted)
+        #   - When block-sizing is disabled and buffer is non-empty
+        #
+        # TODO remove emitting empty blocks
         if self._finalized:
-            return not self._returned_at_least_one_block or self._buffer.num_rows() > 0
-        else:
-            return (
-                self._exceeded_buffer_row_limit() or self._exceeded_buffer_size_limit()
-            )
+            return not self._has_yielded_blocks or self._buffer.num_rows() > 0
+        elif self._output_block_size_option is None:
+            # NOTE: When block sizing is disabled, buffer won't be producing
+            #       incrementally, until the whole sequence is ingested. This
+            #       is required to align it with semantic of producing 1 block
+            #       from 1 block of the input
+            return False
+
+        return self._exceeded_buffer_row_limit() or self._exceeded_buffer_size_limit()
 
     def _exceeded_block_size_slice_limit(self, block: BlockAccessor) -> bool:
         # Slice a block to respect the target max block size. We only do this if we are
         # more than 50% above the target block size, because this ensures that the last
         # block produced will be at least half the target block size.
         return (
-            self._output_block_size_option.target_max_block_size is not None
+            self._max_bytes_per_block() is not None
             and block.size_bytes()
-            >= MAX_SAFE_BLOCK_SIZE_FACTOR
-            * self._output_block_size_option.target_max_block_size
+            >= MAX_SAFE_BLOCK_SIZE_FACTOR * self._max_bytes_per_block()
         )
 
     def _exceeded_block_row_slice_limit(self, block: BlockAccessor) -> bool:
@@ -106,32 +127,31 @@ class BlockOutputBuffer:
         # are more than 50% above the target rows per block, because this ensures that
         # the last block produced will be at least half the target row count.
         return (
-            self._output_block_size_option.target_num_rows_per_block is not None
+            self._max_num_rows_per_block() is not None
             and block.num_rows()
-            >= MAX_SAFE_ROWS_PER_BLOCK_FACTOR
-            * self._output_block_size_option.target_num_rows_per_block
+            >= MAX_SAFE_ROWS_PER_BLOCK_FACTOR * self._max_num_rows_per_block()
         )
 
     def next(self) -> Block:
         """Returns the next complete output block."""
         assert self.has_next()
 
-        block_to_yield = self._buffer.build()
-        block_remainder = None
-        block = BlockAccessor.for_block(block_to_yield)
+        block = self._buffer.build()
 
+        accessor = BlockAccessor.for_block(block)
+        block_remainder = None
         target_num_rows = None
-        if self._exceeded_block_row_slice_limit(block):
-            target_num_rows = self._output_block_size_option.target_num_rows_per_block
-        elif self._exceeded_block_size_slice_limit(block):
-            num_bytes_per_row = block.size_bytes() // block.num_rows()
+
+        if self._exceeded_block_row_slice_limit(accessor):
+            target_num_rows = self._max_num_rows_per_block()
+        elif self._exceeded_block_size_slice_limit(accessor):
+            num_bytes_per_row = accessor.size_bytes() // accessor.num_rows()
             target_num_rows = max(
                 1,
-                self._output_block_size_option.target_max_block_size
-                // num_bytes_per_row,
+                self._max_bytes_per_block() // num_bytes_per_row,
             )
 
-        if target_num_rows is not None and target_num_rows < block.num_rows():
+        if target_num_rows is not None and target_num_rows < accessor.num_rows():
             # NOTE: We're maintaining following protocol of slicing underlying block
             #       into appropriately sized ones:
             #
@@ -143,12 +163,15 @@ class BlockOutputBuffer:
             #           copied, where N is the total number of bytes in the original
             #           block and M is the number of blocks that will be produced by
             #           this iterator
-            block_to_yield = block.slice(0, target_num_rows, copy=True)
-            block_remainder = block.slice(target_num_rows, block.num_rows(), copy=False)
+            block = accessor.slice(0, target_num_rows, copy=True)
+            block_remainder = accessor.slice(
+                target_num_rows, accessor.num_rows(), copy=False
+            )
 
         self._buffer = DelegatingBlockBuilder()
         if block_remainder is not None:
             self._buffer.add_block(block_remainder)
 
-        self._returned_at_least_one_block = True
-        return block_to_yield
+        self._has_yielded_blocks = True
+
+        return block

--- a/python/ray/data/_internal/output_buffer.py
+++ b/python/ray/data/_internal/output_buffer.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -145,10 +146,11 @@ class BlockOutputBuffer:
         if self._exceeded_block_row_slice_limit(accessor):
             target_num_rows = self._max_num_rows_per_block()
         elif self._exceeded_block_size_slice_limit(accessor):
-            num_bytes_per_row = accessor.size_bytes() // accessor.num_rows()
+            assert accessor.num_rows() > 0, "Block may not be empty"
+            num_bytes_per_row = accessor.size_bytes() / accessor.num_rows()
             target_num_rows = max(
                 1,
-                self._max_bytes_per_block() // num_bytes_per_row,
+                math.ceil(self._max_bytes_per_block() / num_bytes_per_row)
             )
 
         if target_num_rows is not None and target_num_rows < accessor.num_rows():

--- a/python/ray/data/_internal/output_buffer.py
+++ b/python/ray/data/_internal/output_buffer.py
@@ -149,8 +149,7 @@ class BlockOutputBuffer:
             assert accessor.num_rows() > 0, "Block may not be empty"
             num_bytes_per_row = accessor.size_bytes() / accessor.num_rows()
             target_num_rows = max(
-                1,
-                math.ceil(self._max_bytes_per_block() / num_bytes_per_row)
+                1, math.ceil(self._max_bytes_per_block() / num_bytes_per_row)
             )
 
         if target_num_rows is not None and target_num_rows < accessor.num_rows():

--- a/python/ray/data/_internal/output_buffer.py
+++ b/python/ray/data/_internal/output_buffer.py
@@ -97,10 +97,6 @@ class BlockOutputBuffer:
     def has_next(self) -> bool:
         """Returns true when a complete output block is produced."""
 
-        # NOTE: Output buffer should yield immediately in either of 2 cases
-        #   - When it's finalized and buffer is non-empty (or no blocks been emitted)
-        #   - When block-sizing is disabled and buffer is non-empty
-        #
         # TODO remove emitting empty blocks
         if self._finalized:
             return not self._has_yielded_blocks or self._buffer.num_rows() > 0

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -450,7 +450,7 @@ TEST_CASES = [
         target_max_block_size=1024,
         batch_size=int(1024 * 10.125),
         num_batches=1,
-        expected_num_blocks=11,
+        expected_num_blocks=10,
     ),
     # Different batch sizes but same total size should produce a similar number
     # of blocks.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Subject

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
