### PR TITLE
[Core] [Azure] Fix issue where cached config file gets corrupted if cluster config contains path objects

### DIFF
--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -318,11 +318,12 @@ def _configure_key_pair(config):
             private_key_path, ssh_user
         )
 
-    config["auth"]["ssh_private_key"] = private_key_path
-    config["auth"]["ssh_public_key"] = public_key_path
+    # Convert Path objects to strings to ensure JSON serialization works
+    config["auth"]["ssh_private_key"] = str(private_key_path)
+    config["auth"]["ssh_public_key"] = str(public_key_path)
     if "file_mounts" not in config:
         config["file_mounts"] = {}
-    config["file_mounts"]["~/.ssh/id_rsa.pub"] = public_key_path
+    config["file_mounts"]["~/.ssh/id_rsa.pub"] = str(public_key_path)
 
     for node_type in config["available_node_types"].values():
         azure_arm_parameters = node_type["node_config"].setdefault(

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -750,6 +750,7 @@ py_test_module_list(
     files = [
         "test_autoscaler_gcp.py",
         "test_autoscaler_util.py",
+        "test_azure_path_serialization.py",
     ],
     tags = [
         "exclusive",

--- a/python/ray/tests/test_azure_path_serialization.py
+++ b/python/ray/tests/test_azure_path_serialization.py
@@ -1,0 +1,58 @@
+"""Tests for Azure autoscaler Path object serialization.
+
+This test verifies that the Azure autoscaler properly handles Path objects
+by converting them to strings before storing them in the configuration dictionary,
+which ensures that the configuration can be properly serialized to JSON.
+
+The issue was introduced in PR #54596 which added automatic SSH key generation
+for Azure clusters but stored Path objects directly in the configuration,
+which later caused serialization errors.
+"""
+import json
+import sys
+
+import pytest
+
+from ray.autoscaler._private._azure.config import _configure_key_pair
+
+
+def test_azure_key_pair_string_conversion(tmp_path):
+    """Test that Azure key pair configuration converts Path objects to strings."""
+
+    # Create the key files under pytest's temporary path
+    private_key_path = tmp_path / "id_rsa"
+    public_key_path = tmp_path / "id_rsa.pub"
+
+    # Create and write the key files
+    private_key_path.write_text("")
+    public_key_path.write_text("ssh-rsa TEST_KEY user@example.com")
+
+    # Create a test config with Path objects
+    config = {
+        "auth": {
+            "ssh_user": "ubuntu",
+            "ssh_private_key": private_key_path,
+            "ssh_public_key": public_key_path,
+        },
+        "provider": {"location": "westus2", "resource_group": "test-group"},
+        "available_node_types": {"ray.head.default": {"node_config": {}}},
+    }
+
+    # Process the config
+    result_config = _configure_key_pair(config)
+
+    # Verify the paths were converted to strings
+    assert isinstance(result_config["auth"]["ssh_private_key"], str)
+    assert isinstance(result_config["auth"]["ssh_public_key"], str)
+    assert isinstance(result_config["file_mounts"]["~/.ssh/id_rsa.pub"], str)
+
+    # Verify we can serialize the config to JSON without errors
+    json_str = json.dumps(result_config)
+    # If we get here, serialization succeeded
+    # Now try to deserialize to make sure it's valid JSON
+    deserialized = json.loads(json_str)
+    assert isinstance(deserialized, dict)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes an issue in the Azure autoscaler where Path objects in the configuration
couldn't be properly serialized to JSON, leading to errors when trying to bring up clusters in Azure

The issue was introduced in PR #54596 which added automatic SSH key generation for
Azure clusters. That PR changed the Azure autoscaler config to use `pathlib.Path`
objects for SSH key paths, but these Path objects were stored directly in the
configuration dictionary. Later in the code flow, when this configuration needed to
be serialized to JSON, it would fail because Python's standard JSON serializer can't
handle Path objects.
## Related issue number


<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
