### PR TITLE
docs: Add note about using `uv run --active` to avoid Python version …

### DIFF
--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -139,6 +139,8 @@ cpp/
 
 docker/
 .buildkite/pipeline.build_cpp.yml
+.buildkite/_images.rayci.yml
+.buildkite/release/_images.rayci.yml
 @ docker linux_wheels
 ;
 
@@ -206,6 +208,7 @@ ci/docker/forge.wanda.yaml
 ci/docker/forge.aarch64.wanda.yaml
 .buildkite/pipeline.build.yml
 .buildkite/hooks/post-command
+.buildkite/release/
 .buildkite/release-automation/
 @ tools
 ;

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -308,13 +308,6 @@ Using ``uv`` for package management
 """""""""""""""""""""""""""""""""""
 
 
-.. important::
-
-  When launching Ray applications with `uv run`, **always use the `--active` flag** (i.e., `uv run --active main.py`).
-  Omitting `--active` can result in Python version mismatches between your local environment and Ray worker processes, which may cause runtime errors or segmentation faults.
-  If you encounter errors such as version mismatch exceptions, unexpected crashes, or segmentation faults, check that you are using the `--active` flag.
-
-  Note: Some examples below may not yet reflect this best practice. Please ensure you add the `--active` flag when adapting them.
 
 The recommended approach for package management with `uv` in runtime environments is through `uv run`.
 
@@ -386,7 +379,13 @@ run a Ray Serve application with `uv run serve run app:main`.
 
 **Best Practices and Tips:**
 
-- Use `uv lock` to generate a lockfile and make sure all your dependencies are frozen, so things won't change in uncontrolled ways if a new version of a package gets released.
+- If you are running on a Ray Cluster, the Ray and Python versions of your uv environment must be the same as the Ray and Python versions of your cluster. There are multiple ways to achieve this:
+  1. If you are using ephemeral Ray clusters, run the application on a cluster with the right versions.
+  2. If you need to run on a given cluster, consider modifying the versions of your uv environment by updating the `pyproject.toml` file or by using the `--active` flag with `uv run` (i.e., `uv run --active main.py`).
+  If you encounter errors such as version mismatch exceptions, unexpected crashes, or segmentation faults, check that your Ray and Python versions match, and consider using the `--active` flag.
+  Note: Some examples below may not yet reflect this best practice. Please ensure you add the `--active` flag when adapting them.
+
+-- Use `uv lock` to generate a lockfile and make sure all your dependencies are frozen, so things won't change in uncontrolled ways if a new version of a package gets released.
 
 - If you have a requirements.txt file, you can use `uv add -r requirement.txt` to add the dependencies to your `pyproject.toml` and then use that with uv run.
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -311,7 +311,10 @@ Using ``uv`` for package management
 .. important::
 
   When launching Ray applications with `uv run`, **always use the `--active` flag** (i.e., `uv run --active main.py`).
-  Omitting `--active` can result in Python version mismatches between your local environment and Ray worker processes, leading to runtime errors or segmentation faults. The `--active` flag ensures Ray uses the currently active Python environment, preventing these issues.
+  Omitting `--active` can result in Python version mismatches between your local environment and Ray worker processes, which may cause runtime errors or segmentation faults.
+  If you encounter errors such as version mismatch exceptions, unexpected crashes, or segmentation faults, check that you are using the `--active` flag.
+
+  Note: Some examples below may not yet reflect this best practice. Please ensure you add the `--active` flag when adapting them.
 
 The recommended approach for package management with `uv` in runtime environments is through `uv run`.
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -307,6 +307,12 @@ For details, head to the :ref:`API Reference <runtime-environments-api-ref>`.
 Using ``uv`` for package management
 """""""""""""""""""""""""""""""""""
 
+
+.. important::
+
+  When launching Ray applications with `uv run`, **always use the `--active` flag** (i.e., `uv run --active main.py`).
+  Omitting `--active` can result in Python version mismatches between your local environment and Ray worker processes, leading to runtime errors or segmentation faults. The `--active` flag ensures Ray uses the currently active Python environment, preventing these issues.
+
 The recommended approach for package management with `uv` in runtime environments is through `uv run`.
 
 This method offers several key advantages:

--- a/doc/source/ray-observability/ray-distributed-debugger.rst
+++ b/doc/source/ray-observability/ray-distributed-debugger.rst
@@ -64,7 +64,7 @@ Start a Ray cluster
 
         .. code-block:: bash
 
-            sudo apt-get install openssh-server
+            sudo apt-get update && sudo apt-get install -y openssh-server
             sudo mkdir -p /run/sshd
             sudo /usr/sbin/sshd -D
 

--- a/python/ray/data/_internal/execution/autoscaling_requester.py
+++ b/python/ray/data/_internal/execution/autoscaling_requester.py
@@ -114,7 +114,7 @@ _autoscaling_requester_lock: threading.RLock = threading.RLock()
 def get_or_create_autoscaling_requester_actor():
     ctx = DataContext.get_current()
     scheduling_strategy = ctx.scheduling_strategy
-    # Pin the stats actor to the local node so it fate-shares with the driver.
+    # Pin the autoscaling requester actor to the local node so it fate-shares with the driver.
     # Note: for Ray Client, the ray.get_runtime_context().get_node_id() should
     # point to the head node.
     scheduling_strategy = NodeAffinitySchedulingStrategy(

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from ray.data.block import UserDefinedFunction
 from ray.llm._internal.batch.processor import (
@@ -366,6 +366,7 @@ class ServeDeploymentProcessorConfig(_ServeDeploymentProcessorConfig):
 @PublicAPI(stability="alpha")
 def build_llm_processor(
     config: ProcessorConfig,
+    chat_template_kwargs: Optional[Dict[str, Any]] = None,
     preprocess: Optional[UserDefinedFunction] = None,
     postprocess: Optional[UserDefinedFunction] = None,
 ) -> Processor:
@@ -373,6 +374,7 @@ def build_llm_processor(
 
     Args:
         config: The processor config.
+        chat_template_kwargs: The optional kwargs to pass apply_chat_template.
         preprocess: An optional lambda function that takes a row (dict) as input
             and returns a preprocessed row (dict). The output row must contain the
             required fields for the following processing stages. Each row
@@ -382,6 +384,7 @@ def build_llm_processor(
         postprocess: An optional lambda function that takes a row (dict) as input
             and returns a postprocessed row (dict). To keep all the original columns,
             you can use the `**row` syntax to return all the original columns.
+
 
     Returns:
         The built processor.
@@ -432,6 +435,7 @@ def build_llm_processor(
 
     return ProcessorBuilder.build(
         config,
+        chat_template_kwargs=chat_template_kwargs,
         preprocess=preprocess,
         postprocess=postprocess,
     )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2440,6 +2440,7 @@ def read_snowflake(
     sql: str,
     connection_parameters: Dict[str, Any],
     *,
+    parallelism: int = -1,
     shard_keys: Optional[list[str]] = None,
     ray_remote_args: Dict[str, Any] = None,
     concurrency: Optional[int] = None,
@@ -2468,6 +2469,7 @@ def read_snowflake(
         connection_parameters: Keyword arguments to pass to
             ``snowflake.connector.connect``. To view supported parameters, read
             https://docs.snowflake.com/developer-guide/python-connector/python-connector-api#functions.
+        parallelism: This argument is deprecated. Use ``override_num_blocks`` argument.
         shard_keys: The keys to shard the data by.
         ray_remote_args: kwargs passed to :func:`ray.remote` in the read tasks.
         concurrency: The maximum number of Ray tasks to run concurrently. Set this
@@ -2493,6 +2495,7 @@ def read_snowflake(
         connection_factory=snowflake_connection_factory,
         shard_keys=shard_keys,
         shard_hash_fn="hash",
+        parallelism=parallelism,
         ray_remote_args=ray_remote_args,
         concurrency=concurrency,
         override_num_blocks=override_num_blocks,

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -55,6 +55,7 @@ class SGLangEngineProcessorConfig(OfflineProcessorConfig):
 
 def build_sglang_engine_processor(
     config: SGLangEngineProcessorConfig,
+    chat_template_kwargs: Optional[Dict[str, Any]] = None,
     preprocess: Optional[UserDefinedFunction] = None,
     postprocess: Optional[UserDefinedFunction] = None,
     telemetry_agent: Optional[TelemetryAgent] = None,
@@ -62,6 +63,7 @@ def build_sglang_engine_processor(
     """Construct a Processor and configure stages.
     Args:
         config: The configuration for the processor.
+        chat_template_kwargs: The optional kwargs to pass to apply_chat_template.
         preprocess: An optional lambda function that takes a row (dict) as input
             and returns a preprocessed row (dict). The output row must contain the
             required fields for the following processing stages.
@@ -82,6 +84,7 @@ def build_sglang_engine_processor(
                 fn_constructor_kwargs=dict(
                     model=config.model_source,
                     chat_template=config.chat_template,
+                    chat_template_kwargs=chat_template_kwargs,
                 ),
                 map_batches_kwargs=dict(
                     zero_copy_batch=True,

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -68,6 +68,7 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
 
 def build_vllm_engine_processor(
     config: vLLMEngineProcessorConfig,
+    chat_template_kwargs: Optional[Dict[str, Any]] = None,
     preprocess: Optional[UserDefinedFunction] = None,
     postprocess: Optional[UserDefinedFunction] = None,
     telemetry_agent: Optional[TelemetryAgent] = None,
@@ -75,12 +76,14 @@ def build_vllm_engine_processor(
     """Construct a Processor and configure stages.
     Args:
         config: The configuration for the processor.
+        chat_template_kwargs: The optional kwargs to pass to apply_chat_template.
         preprocess: An optional lambda function that takes a row (dict) as input
             and returns a preprocessed row (dict). The output row must contain the
             required fields for the following processing stages.
         postprocess: An optional lambda function that takes a row (dict) as input
             and returns a postprocessed row (dict).
         telemetry_agent: An optional telemetry agent for collecting usage telemetry.
+
 
     Returns:
         The constructed processor.
@@ -105,6 +108,7 @@ def build_vllm_engine_processor(
                 fn_constructor_kwargs=dict(
                     model=config.model_source,
                     chat_template=config.chat_template,
+                    chat_template_kwargs=chat_template_kwargs,
                 ),
                 map_batches_kwargs=dict(
                     zero_copy_batch=True,

--- a/python/ray/llm/_internal/batch/stages/chat_template_stage.py
+++ b/python/ray/llm/_internal/batch/stages/chat_template_stage.py
@@ -19,6 +19,7 @@ class ChatTemplateUDF(StatefulStageUDF):
         expected_input_keys: List[str],
         model: str,
         chat_template: Optional[str] = None,
+        chat_template_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the ChatTemplateUDF.
@@ -30,6 +31,7 @@ class ChatTemplateUDF(StatefulStageUDF):
             chat_template: The chat template in Jinja template format. This is
                            usually not needed if the model checkpoint already contains the
                            chat template.
+            chat_template_kwargs: The optional kwargs to pass apply_chat_template.
         """
         from transformers import AutoProcessor
 
@@ -53,6 +55,7 @@ class ChatTemplateUDF(StatefulStageUDF):
             "PreTrainedTokenizerBase", "ProcessorMixin"
         ] = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
         self.chat_template = chat_template
+        self.chat_template_kwargs = chat_template_kwargs
 
     async def udf(self, batch: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:
         """
@@ -84,6 +87,7 @@ class ChatTemplateUDF(StatefulStageUDF):
                     chat_template=self.chat_template,
                     add_generation_prompt=add_generation_prompt,
                     continue_final_message=continue_final_message,
+                    **(self.chat_template_kwargs or {}),
                 )
             )
         assert len(batch) == len(prompts)

--- a/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
@@ -90,6 +90,76 @@ async def test_chat_template_udf_multiple_messages(mock_tokenizer_setup):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chat_template_kwargs, expected_prompt",
+    [
+        ({"enable_thinking": False}, "Answer without thinking"),
+        ({"enable_thinking": True}, "<think>thinking</think>"),
+        ({}, "<think>thinking</think>"),
+        (
+            {"enable_thinking": True, "custom_param": "test_value", "temperature": 0.7},
+            "<think>thinking</think>",
+        ),
+    ],
+)
+async def test_chat_template_udf_chat_template_kwargs(
+    mock_tokenizer_setup, chat_template_kwargs, expected_prompt
+):
+    mock_tokenizer = mock_tokenizer_setup
+
+    # Store captured kwargs for verification
+    captured_kwargs = {}
+
+    def side_effect_func(conversation, **kwargs):
+        # Capture all kwargs for later verification
+        captured_kwargs.update(kwargs)
+
+        enable_thinking = kwargs.get("enable_thinking", True)
+        if enable_thinking is False:
+            return "Answer without thinking"
+        else:
+            return "<think>thinking</think>"
+
+    mock_tokenizer.apply_chat_template.side_effect = side_effect_func
+
+    udf = ChatTemplateUDF(
+        data_column="__data",
+        expected_input_keys=["messages"],
+        model="test-model",
+        chat_template_kwargs=chat_template_kwargs,
+    )
+
+    # Assert that the chat_template_kwargs were properly stored
+    assert udf.chat_template_kwargs == chat_template_kwargs
+
+    batch = {
+        "__data": [
+            {
+                "messages": MagicMock(
+                    tolist=lambda: [{"role": "user", "content": "Hello AI"}]
+                )
+            }
+        ]
+    }
+
+    results = []
+    async for result in udf(batch):
+        results.extend(result["__data"])
+
+    assert len(results) == 1
+    assert results[0]["prompt"] == expected_prompt
+
+    # Verify that all chat_template_kwargs were passed through to apply_chat_template
+    for key, value in chat_template_kwargs.items():
+        assert (
+            key in captured_kwargs
+        ), f"Expected kwargs key '{key}' not found in captured kwargs"
+        assert (
+            captured_kwargs[key] == value
+        ), f"Expected '{key}': {value}, but got '{key}': {captured_kwargs[key]}"
+
+
+@pytest.mark.asyncio
 async def test_chat_template_udf_assistant_prefill(mock_tokenizer_setup):
     mock_tokenizer = mock_tokenizer_setup
     mock_tokenizer.apply_chat_template.side_effect = [

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -829,22 +829,25 @@ class ApplicationState:
             Whether the target state has changed.
         """
 
-        infos, task_status, msg = self._reconcile_build_app_task()
         target_state_changed = False
-        if task_status == BuildAppStatus.SUCCEEDED:
-            target_state_changed = True
-            self._set_target_state(
-                deployment_infos=infos,
-                code_version=self._build_app_task_info.code_version,
-                api_type=self._target_state.api_type,
-                target_config=self._build_app_task_info.config,
-                target_capacity=self._build_app_task_info.target_capacity,
-                target_capacity_direction=(
-                    self._build_app_task_info.target_capacity_direction
-                ),
-            )
-        elif task_status == BuildAppStatus.FAILED:
-            self._update_status(ApplicationStatus.DEPLOY_FAILED, msg)
+        # If the application is being deleted, ignore any build task results to
+        # avoid flipping the state back to DEPLOYING/RUNNING.
+        if not self._target_state.deleting:
+            infos, task_status, msg = self._reconcile_build_app_task()
+            if task_status == BuildAppStatus.SUCCEEDED:
+                target_state_changed = True
+                self._set_target_state(
+                    deployment_infos=infos,
+                    code_version=self._build_app_task_info.code_version,
+                    api_type=self._target_state.api_type,
+                    target_config=self._build_app_task_info.config,
+                    target_capacity=self._build_app_task_info.target_capacity,
+                    target_capacity_direction=(
+                        self._build_app_task_info.target_capacity_direction
+                    ),
+                )
+            elif task_status == BuildAppStatus.FAILED:
+                self._update_status(ApplicationStatus.DEPLOY_FAILED, msg)
 
         # Only reconcile deployments when the build app task is finished. If
         # it's not finished, we don't know what the target list of deployments

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -74,6 +74,7 @@ def _get_basic_autoscaling_config() -> dict:
         },
         "available_node_types": {
             "headgroup": {
+                "labels": {},
                 "max_workers": 0,
                 "min_workers": 0,
                 "node_config": {},
@@ -85,6 +86,7 @@ def _get_basic_autoscaling_config() -> dict:
                 },
             },
             "small-group": {
+                "labels": {},
                 "max_workers": 300,
                 "min_workers": 0,
                 "node_config": {},
@@ -98,6 +100,7 @@ def _get_basic_autoscaling_config() -> dict:
             # Same as "small-group" with a GPU resource entry added
             # and modified max_workers.
             "gpu-group": {
+                "labels": {},
                 "max_workers": 200,
                 "min_workers": 0,
                 "node_config": {},
@@ -112,6 +115,7 @@ def _get_basic_autoscaling_config() -> dict:
             # Same as "small-group" with a TPU resource entry added
             # and modified max_workers and node_config.
             "tpu-group": {
+                "labels": {},
                 "max_workers": 8,
                 "min_workers": 0,
                 "node_config": {},
@@ -238,6 +242,45 @@ def _get_ray_cr_with_only_requests() -> dict:
     return cr
 
 
+def _get_ray_cr_with_labels() -> dict:
+    """CR with labels in rayStartParams of head and worker groups."""
+    cr = get_basic_ray_cr()
+
+    # Pass invalid labels to the head group to test error handling.
+    cr["spec"]["headGroupSpec"]["rayStartParams"]["labels"] = "!!ray.io/node-group=,"
+    # Pass valid labels to each of the worker groups.
+    cr["spec"]["workerGroupSpecs"][0]["rayStartParams"][
+        "labels"
+    ] = "ray.io/availability-region=us-central2, ray.io/market-type=spot"
+    cr["spec"]["workerGroupSpecs"][1]["rayStartParams"][
+        "labels"
+    ] = "ray.io/accelerator-type=A100"
+    cr["spec"]["workerGroupSpecs"][2]["rayStartParams"][
+        "labels"
+    ] = "ray.io/accelerator-type=TPU-V4"
+    return cr
+
+
+def _get_autoscaling_config_with_labels() -> dict:
+    """Autoscaling config with parsed labels for each group."""
+    config = _get_basic_autoscaling_config()
+
+    # Since we passed invalid labels to the head group `rayStartParams`,
+    # we expect an empty dictionary in the autoscaling config.
+    config["available_node_types"]["headgroup"]["labels"] = {}
+    config["available_node_types"]["small-group"]["labels"] = {
+        "ray.io/availability-region": "us-central2",
+        "ray.io/market-type": "spot",
+    }
+    config["available_node_types"]["gpu-group"]["labels"] = {
+        "ray.io/accelerator-type": "A100"
+    }
+    config["available_node_types"]["tpu-group"]["labels"] = {
+        "ray.io/accelerator-type": "TPU-V4"
+    }
+    return config
+
+
 def _get_autoscaling_config_with_options() -> dict:
     config = _get_basic_autoscaling_config()
     config["upscaling_speed"] = 1
@@ -358,6 +401,14 @@ TEST_DATA = (
             None,
             None,
             id="tpu-k8s-resource-limit-and-custom-resource",
+        ),
+        pytest.param(
+            _get_ray_cr_with_labels(),
+            _get_autoscaling_config_with_labels(),
+            None,
+            None,
+            None,
+            id="groups-with-labels",
         ),
     ]
 )

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -236,7 +236,9 @@
   group: AIR tests
   working_dir: air_tests/air_benchmarks
 
-  frequency: weekly
+  # Failing since Aug 2024
+  # https://github.com/ray-project/ray/issues/46687
+  frequency: manual
   team: ml
 
   cluster:
@@ -252,7 +254,7 @@
       num_nodes: 4
 
   smoke_test:
-    frequency: nightly
+    frequency: manual
 
     cluster:
       cluster_compute: compute_gpu_2x2_aws.yaml
@@ -557,7 +559,9 @@
   group: AIR tests
   working_dir: air_tests/air_benchmarks
 
-  frequency: nightly
+  # Jailed with
+  # https://github.com/ray-project/ray/issues/56282
+  frequency: manual
   team: ml
 
   stable: false
@@ -620,7 +624,9 @@
 
   stable: false
 
-  frequency: nightly
+  # Failing since Aug 2025.
+  # https://github.com/ray-project/ray/issues/52562
+  frequency: manual
 
   team: data
   cluster:
@@ -4094,7 +4100,9 @@
 
   stable: false
 
-  frequency: nightly
+  # Failing since Oct 2024.
+  # https://github.com/ray-project/ray/issues/36190
+  frequency: manual
   team: serve
   cluster:
     byod: {}

--- a/src/ray/common/scheduling/BUILD.bazel
+++ b/src/ray/common/scheduling/BUILD.bazel
@@ -21,6 +21,7 @@ ray_cc_library(
     srcs = ["label_selector.cc"],
     hdrs = ["label_selector.h"],
     deps = [
+        "//src/ray/common:constants",
         "//src/ray/protobuf:common_cc_proto",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings",

--- a/src/ray/common/scheduling/label_selector.h
+++ b/src/ray/common/scheduling/label_selector.h
@@ -14,12 +14,14 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
 #include "google/protobuf/map.h"
+#include "ray/common/constants.h"
 #include "src/ray/protobuf/common.pb.h"
 
 namespace ray {
@@ -102,6 +104,20 @@ H AbslHashValue(H h, const LabelSelector &label_selector) {
     }
   }
   return h;
+}
+
+inline std::optional<absl::flat_hash_set<std::string>> GetHardNodeAffinityValues(
+    const LabelSelector &label_selector) {
+  const std::string hard_affinity_key(kLabelKeyNodeID);
+
+  for (const auto &constraint : label_selector.GetConstraints()) {
+    if (constraint.GetLabelKey() == hard_affinity_key) {
+      if (constraint.GetOperator() == LabelSelectorOperator::LABEL_IN) {
+        return constraint.GetLabelValues();
+      }
+    }
+  }
+  return std::nullopt;
 }
 
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -203,6 +203,7 @@ class ClusterResourceManager {
   FRIEND_TEST(ClusterResourceSchedulerTest, TestForceSpillback);
   FRIEND_TEST(ClusterResourceSchedulerTest, AffinityWithBundleScheduleTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, LabelSelectorIsSchedulableOnNodeTest);
+  FRIEND_TEST(ClusterResourceSchedulerTest, LabelSelectorHardNodeAffinityTest);
 
   friend class raylet::SchedulingPolicyTest;
   friend class raylet_scheduling_policy::HybridSchedulingPolicyTest;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -248,6 +248,7 @@ class ClusterResourceScheduler {
   FRIEND_TEST(ClusterResourceSchedulerTest, TestForceSpillback);
   FRIEND_TEST(ClusterResourceSchedulerTest, AffinityWithBundleScheduleTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, LabelSelectorIsSchedulableOnNodeTest);
+  FRIEND_TEST(ClusterResourceSchedulerTest, LabelSelectorHardNodeAffinityTest);
 };
 
 }  // end namespace ray

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_test.cc
@@ -1867,6 +1867,104 @@ TEST_F(ClusterResourceSchedulerTest, LabelSelectorIsSchedulableOnNodeTest) {
   ASSERT_FALSE(is_infeasible);
 }
 
+TEST_F(ClusterResourceSchedulerTest, LabelSelectorHardNodeAffinityTest) {
+  // Setup scheduler with two nodes.
+  absl::flat_hash_map<ResourceID, double> node_resources_map({{ResourceID::CPU(), 1}});
+  NodeResources node_resources = CreateNodeResources(node_resources_map);
+  auto local_node_id = scheduling::NodeID(NodeID::FromRandom().Binary());
+  instrumented_io_context io_context;
+  ClusterResourceScheduler resource_scheduler(
+      io_context, local_node_id, {{"CPU", 0}}, is_node_available_fn_);
+
+  auto node_0_id_obj = NodeID::FromRandom();
+  auto node_1_id_obj = NodeID::FromRandom();
+  auto node_0 = scheduling::NodeID(node_0_id_obj.Binary());
+  auto node_1 = scheduling::NodeID(node_1_id_obj.Binary());
+  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(node_0, node_resources);
+  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(node_1, node_resources);
+
+  // Set required node labels.
+  absl::flat_hash_map<std::string, std::string> node_0_labels = {
+      {"ray.io/node-id", node_0_id_obj.Hex()},
+  };
+  absl::flat_hash_map<std::string, std::string> node_1_labels = {
+      {"ray.io/node-id", node_1_id_obj.Hex()},
+  };
+  resource_scheduler.GetClusterResourceManager().SetNodeLabels(node_0, node_0_labels);
+  resource_scheduler.GetClusterResourceManager().SetNodeLabels(node_1, node_1_labels);
+
+  ResourceRequest base_resource_request = CreateResourceRequest({{ResourceID::CPU(), 1}});
+  int64_t violations;
+  bool is_infeasible;
+  rpc::SchedulingStrategy scheduling_strategy;
+  scheduling_strategy.mutable_default_scheduling_strategy();
+
+  // Schedule on a single specified node.
+  {
+    LabelSelector selector;
+    selector.AddConstraint(LabelConstraint(
+        "ray.io/node-id", LabelSelectorOperator::LABEL_IN, {node_0_id_obj.Hex()}));
+    ResourceRequest request = base_resource_request;
+    request.SetLabelSelector(selector);
+
+    auto result_node_id = resource_scheduler.GetBestSchedulableNode(request,
+                                                                    scheduling_strategy,
+                                                                    false,
+                                                                    false,
+                                                                    std::string(),
+                                                                    &violations,
+                                                                    &is_infeasible);
+    ASSERT_EQ(result_node_id, node_0);
+    ASSERT_FALSE(is_infeasible);
+  }
+
+  // Schedule on one of two specified nodes (in() operator).
+  {
+    LabelSelector selector;
+    selector.AddConstraint(LabelConstraint("ray.io/node-id",
+                                           LabelSelectorOperator::LABEL_IN,
+                                           {node_0_id_obj.Hex(), node_1_id_obj.Hex()}));
+    ResourceRequest request = base_resource_request;
+    request.SetLabelSelector(selector);
+
+    auto result_node_id = resource_scheduler.GetBestSchedulableNode(request,
+                                                                    scheduling_strategy,
+                                                                    false,
+                                                                    false,
+                                                                    std::string(),
+                                                                    &violations,
+                                                                    &is_infeasible);
+    ASSERT_TRUE(result_node_id == node_0 || result_node_id == node_1);
+    ASSERT_FALSE(is_infeasible);
+  }
+
+  // Scheduling is infeasible when all specified nodes are infeasible..
+  {
+    NodeResources depleted_node_resources = CreateNodeResources({{ResourceID::CPU(), 0}});
+    resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
+        node_0, depleted_node_resources);
+    resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
+        node_1, depleted_node_resources);
+
+    LabelSelector selector;
+    selector.AddConstraint(LabelConstraint("ray.io/node-id",
+                                           LabelSelectorOperator::LABEL_IN,
+                                           {node_0_id_obj.Hex(), node_1_id_obj.Hex()}));
+    ResourceRequest request = base_resource_request;
+    request.SetLabelSelector(selector);
+
+    auto result_node_id = resource_scheduler.GetBestSchedulableNode(request,
+                                                                    scheduling_strategy,
+                                                                    false,
+                                                                    false,
+                                                                    std::string(),
+                                                                    &violations,
+                                                                    &is_infeasible);
+    ASSERT_TRUE(result_node_id.IsNil());
+    ASSERT_TRUE(is_infeasible);
+  }
+}
+
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
**docs: Add important note about using `uv run --active` to avoid Python version mismatch errors**

- Added an important directive in the dependency management docs explaining that omitting `--active` when using `uv run` can cause Python version mismatches and runtime errors.
- Clarifies best practices for launching Ray applications with uv.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change adds a prominent note to the dependency management documentation, warning users to use `uv run --active` to avoid Python version mismatches and related runtime errors when launching Ray applications. This addresses a common pitfall and improves the developer experience.

## Related issue number

Closes #56583

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] This PR only updates documentation; no code changes to test.
