### PR TITLE
[train] Abort reconciliation thread catches ray.util.state.get_actor exception

### DIFF
--- a/python/ray/train/v2/_internal/state/state_actor.py
+++ b/python/ray/train/v2/_internal/state/state_actor.py
@@ -97,12 +97,18 @@ class TrainStateActor:
                 last_poll_run_id = run.id
                 if run.status.is_terminal():
                     continue
-                if not is_actor_alive(
-                    run.controller_actor_id, self._get_actor_timeout_s
-                ):
-                    update_train_run_aborted(run, False)
-                    self.create_or_update_train_run(run)
-                    aborted_run_ids.append(run.id)
+                try:
+                    if not is_actor_alive(
+                        run.controller_actor_id, self._get_actor_timeout_s
+                    ):
+                        update_train_run_aborted(run, False)
+                        self.create_or_update_train_run(run)
+                        aborted_run_ids.append(run.id)
+                except ray.util.state.exception.ServerUnavailable:
+                    logger.exception(
+                        "Server unavailable when checking if actor is alive. "
+                        "Will check again on next poll."
+                    )
                 num_polled_runs += 1
 
         # Abort run attempts.

--- a/python/ray/train/v2/_internal/state/state_actor.py
+++ b/python/ray/train/v2/_internal/state/state_actor.py
@@ -104,9 +104,9 @@ class TrainStateActor:
                         update_train_run_aborted(run, False)
                         self.create_or_update_train_run(run)
                         aborted_run_ids.append(run.id)
-                except ray.util.state.exception.ServerUnavailable:
+                except ray.util.state.exception.RayStateApiException:
                     logger.exception(
-                        "Server unavailable when checking if actor is alive. "
+                        "State API unavailable when checking if actor is alive. "
                         "Will check again on next poll."
                     )
                 num_polled_runs += 1


### PR DESCRIPTION
# Summary

@justinvyu observed that `ray.util.get_actor` in the `TrainStateActor` sometimes raises `ray.util.state.exception.ServerUnavailable`, killing the abort reconciliation thread and causing subsequent train runs to not get marked aborted.

This change catches those errors so the thread stays alive and tries to reconcile the train run on the next poll.

# Testing

Unit test.