### PR TITLE
[Core][Autoscaler] Fixed an issue where the command executed when use_podman=true and run_env=None was not prefixed with podman exec

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -505,7 +505,7 @@ class DockerCommandRunner(CommandRunnerInterface):
         if environment_variables:
             cmd = _with_environment_variables(cmd, environment_variables)
 
-        if run_env == "docker":
+        if run_env == self.docker_cmd:
             cmd = self._docker_expand_user(cmd, any_char=True)
             if is_using_login_shells():
                 cmd = " ".join(_with_interactive(cmd))

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -748,8 +748,8 @@ class AutoscalingTest(unittest.TestCase):
         )
         self.waitForNodes(1)
         runner.assert_has_call("1.2.3.4", "init_cmd")
-        runner.assert_has_call("1.2.3.4", "head_setup_cmd")
-        runner.assert_has_call("1.2.3.4", "start_ray_head")
+        runner.assert_has_call("1.2.3.4", "podman exec .*head_setup_cmd.*")
+        runner.assert_has_call("1.2.3.4", "podman exec .*start_ray_head.*")
         self.assertEqual(self.provider.mock_nodes["0"].node_type, "head")
         runner.assert_has_call("1.2.3.4", pattern="podman run")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/55011

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
