### PR TITLE
[ci] supports empty `RAYCI_BUILD_ID` for test container

### DIFF
--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -40,7 +40,7 @@ _DOCKER_ENV = [
     "BUILDKITE_PIPELINE_ID",
     "BUILDKITE_PULL_REQUEST",
 ]
-_RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "unknown")
+_RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")
 
 
 class Container(abc.ABC):
@@ -82,6 +82,8 @@ class Container(abc.ABC):
         """
         Get docker image for a particular commit
         """
+        if not _RAYCI_BUILD_ID:
+            return f"{_DOCKER_ECR_REPO}:{self.docker_tag}"
         return f"{_DOCKER_ECR_REPO}:{_RAYCI_BUILD_ID}-{self.docker_tag}"
 
     @abc.abstractmethod

--- a/ci/ray_ci/test_linux_container.py
+++ b/ci/ray_ci/test_linux_container.py
@@ -8,7 +8,7 @@ from ci.ray_ci.linux_container import LinuxContainer
 def test_get_docker_image() -> None:
     assert (
         LinuxContainer("test")._get_docker_image()
-        == "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:unknown-test"
+        == "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:test"
     )
 
 

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -9,7 +9,7 @@ from unittest import mock
 import pytest
 from ray_release.configs.global_config import get_global_config
 
-from ci.ray_ci.container import _DOCKER_ECR_REPO, _RAYCI_BUILD_ID
+from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
 from ci.ray_ci.tester_container import RUN_PER_FLAKY_TEST
 from ci.ray_ci.utils import chunk_into_n, ci_init
@@ -165,7 +165,7 @@ def test_ray_installation() -> None:
 
     with mock.patch("subprocess.check_call", side_effect=_mock_subprocess):
         LinuxTesterContainer("team", build_type="debug")
-        docker_image = f"{_DOCKER_ECR_REPO}:{_RAYCI_BUILD_ID}-team"
+        docker_image = f"{_DOCKER_ECR_REPO}:team"
         assert install_ray_cmds[-1] == [
             "docker",
             "build",

--- a/ci/ray_ci/test_windows_container.py
+++ b/ci/ray_ci/test_windows_container.py
@@ -25,9 +25,7 @@ def test_install_ray() -> None:
         },
     ):
         WindowsContainer("hi").install_ray()
-        image = (
-            "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:unknown-hi"
-        )
+        image = "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:hi"
         assert install_ray_cmds[-1] == [
             "docker",
             "build",
@@ -66,7 +64,7 @@ def test_get_run_command() -> None:
         "/hi:/hello",
         "--workdir",
         "C:\\rayci",
-        "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:unknown-test",
+        "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:test",
         "bash",
         "-c",
         "hi\nhello",

--- a/ci/ray_ci/test_windows_tester_container.py
+++ b/ci/ray_ci/test_windows_tester_container.py
@@ -16,7 +16,7 @@ def test_init() -> None:
             "docker",
             "build",
             "-t",
-            "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:unknown-hi",
+            "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:hi",
             "-f",
             "c:\\workdir\\ci\\ray_ci\\windows\\tests.env.Dockerfile",
             "c:\\workdir",


### PR DESCRIPTION
getting closer to allowing running scripts locally
