### PR TITLE
[ci] rename `docker_login` to `ecr_docker_login`

### DIFF
--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -13,7 +13,7 @@ from ci.ray_ci.builder_container import (
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.docker_container import PLATFORMS_RAY
 from ci.ray_ci.ray_docker_container import RayDockerContainer
-from ci.ray_ci.utils import ci_init, docker_login, logger
+from ci.ray_ci.utils import ci_init, ecr_docker_login, logger
 from ci.ray_ci.windows_builder_container import WindowsBuilderContainer
 
 
@@ -84,7 +84,7 @@ def main(
     """
     Build a wheel or jar artifact
     """
-    docker_login(_DOCKER_ECR_REPO.split("/")[0])
+    ecr_docker_login(_DOCKER_ECR_REPO.split("/")[0])
     ci_init()
     if artifact_type == "wheel":
         logger.info(f"Building wheel for {python_version}")

--- a/ci/ray_ci/test_utils.py
+++ b/ci/ray_ci/test_utils.py
@@ -9,7 +9,7 @@ from ray_release.test import Test
 
 from ci.ray_ci.utils import (
     chunk_into_n,
-    docker_login,
+    ecr_docker_login,
     filter_tests,
     get_flaky_test_names,
 )
@@ -22,7 +22,7 @@ def test_chunk_into_n() -> None:
 
 
 @mock.patch("boto3.client")
-def test_docker_login(mock_client) -> None:
+def test_ecr_docker_login(mock_client) -> None:
     def _mock_subprocess_run(
         cmd: List[str],
         stdin=None,
@@ -39,7 +39,7 @@ def test_docker_login(mock_client) -> None:
     }
 
     with mock.patch("subprocess.run", side_effect=_mock_subprocess_run):
-        docker_login("docker_ecr")
+        ecr_docker_login("docker_ecr")
 
 
 def _make_test(name: str, state: str, team: str) -> Test:

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -16,7 +16,7 @@ from ci.ray_ci.builder_container import (
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
 from ci.ray_ci.tester_container import TesterContainer
-from ci.ray_ci.utils import ci_init, docker_login
+from ci.ray_ci.utils import ci_init, ecr_docker_login
 from ci.ray_ci.windows_tester_container import WindowsTesterContainer
 
 CUDA_COPYRIGHT = """
@@ -226,7 +226,7 @@ def main(
         raise Exception("Please use `bazelisk run //ci/ray_ci`")
     os.chdir(bazel_workspace_dir)
     ci_init()
-    docker_login(_DOCKER_ECR_REPO.split("/")[0])
+    ecr_docker_login(_DOCKER_ECR_REPO.split("/")[0])
 
     if build_type == "wheel" or build_type == "wheel-aarch64":
         # for wheel testing, we first build the wheel and then use it for running tests

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -47,9 +47,9 @@ def shard_tests(
     return bazel_sharding.main(test_targets, index=shard_id, count=shard_count)
 
 
-def docker_login(docker_ecr: str) -> None:
+def ecr_docker_login(docker_ecr: str) -> None:
     """
-    Login to docker with AWS credentials
+    Login to ECR with AWS credentials
     """
     token = boto3.client("ecr", region_name="us-west-2").get_authorization_token()
     user, password = (


### PR DESCRIPTION
it only supports logging in to ecr, not generic docker login
