### PR TITLE
[core] Fixing windows build with cgroups. Broken in cgroups 10/n.

### DIFF
--- a/src/ray/common/cgroup2/BUILD.bazel
+++ b/src/ray/common/cgroup2/BUILD.bazel
@@ -79,7 +79,33 @@ ray_cc_library(
     }),
 )
 
-# Private Targets.
+# Private targets
+#
+# TODO(#54703): This target builds the noop implementations.
+# There's a corressponding test that runs on Linux and Non-Linux
+# CI so breakages are caught in premerge before these targets are
+# cleaned up at the end of the resource isolation milestone 1
+# project.
+ray_cc_library(
+    name = "noop_cgroup_targets",
+    srcs = [
+        "noop_cgroup_manager.cc",
+        "noop_sysfs_cgroup_driver.cc",
+    ],
+    hdrs = [
+        "cgroup_manager.h",
+        "scoped_cgroup_operation.h",
+        "sysfs_cgroup_driver.h",
+    ],
+    visibility = [":__subpackages__"],
+    deps = [
+        ":cgroup_driver_interface",
+        ":cgroup_manager_interface",
+        "//src/ray/common:status",
+        "//src/ray/common:status_or",
+    ],
+)
+
 ray_cc_library(
     name = "fake_cgroup_driver",
     hdrs = [

--- a/src/ray/common/cgroup2/noop_cgroup_manager.cc
+++ b/src/ray/common/cgroup2/noop_cgroup_manager.cc
@@ -36,4 +36,9 @@ StatusOr<std::unique_ptr<CgroupManager>> CgroupManager::Create(
   return std::unique_ptr<CgroupManager>(
       new CgroupManager(base_cgroup_path, node_id, std::move(cgroup_driver)));
 }
+
+Status CgroupManager::AddProcessToSystemCgroup(const std::string &pid) {
+  return Status::OK();
+}
+
 }  // namespace ray

--- a/src/ray/common/cgroup2/noop_sysfs_cgroup_driver.cc
+++ b/src/ray/common/cgroup2/noop_sysfs_cgroup_driver.cc
@@ -71,4 +71,9 @@ StatusOr<std::unordered_set<std::string>> SysFsCgroupDriver::ReadControllerFile(
   return std::unordered_set<std::string>{};
 }
 
+Status SysFsCgroupDriver::AddProcessToCgroup(const std::string &cgroup,
+                                             const std::string &process) {
+  return Status::OK();
+}
+
 }  // namespace ray

--- a/src/ray/common/cgroup2/tests/BUILD.bazel
+++ b/src/ray/common/cgroup2/tests/BUILD.bazel
@@ -48,6 +48,9 @@ ray_cc_test(
 ray_cc_test(
     name = "noop_cgroup_test",
     srcs = ["noop_cgroup_test.cc"],
+    tags = [
+        "team:core",
+    ],
     deps = [
         "//src/ray/common/cgroup2:noop_cgroup_targets",
         "@com_google_googletest//:gtest_main",

--- a/src/ray/common/cgroup2/tests/BUILD.bazel
+++ b/src/ray/common/cgroup2/tests/BUILD.bazel
@@ -39,3 +39,17 @@ ray_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+# TODO(#54703): This target builds the noop implementations.
+# There's a corressponding test that runs on Linux and Non-Linux
+# CI so breakages are caught in premerge before these targets are
+# cleaned up at the end of the resource isolation milestone 1
+# project.
+ray_cc_test(
+    name = "noop_cgroup_test",
+    srcs = ["noop_cgroup_test.cc"],
+    deps = [
+        "//src/ray/common/cgroup2:noop_cgroup_targets",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/common/cgroup2/tests/noop_cgroup_test.cc
+++ b/src/ray/common/cgroup2/tests/noop_cgroup_test.cc
@@ -1,0 +1,31 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "ray/common/cgroup2/cgroup_manager.h"
+#include "ray/common/cgroup2/sysfs_cgroup_driver.h"
+#include "ray/common/status.h"
+namespace ray {
+
+TEST(NoopCgroupTest, NoopCgroupDriverAndManagerBuildSuccessfullyOnAllPlatforms) {
+  std::unique_ptr<SysFsCgroupDriver> sysfs_cgroup_driver =
+      std::make_unique<SysFsCgroupDriver>();
+  auto cgroup_manager =
+      CgroupManager::Create("", "", 1, 1, std::move(sysfs_cgroup_driver));
+}
+
+}  // namespace ray


### PR DESCRIPTION
Broken in #56446. 

This should stop being possible once there's a single cgroups target exported (as highlighted in #54703). 

I've fixed the broken build and I've added a temporary test target that builds the noop implementations as part of Linux CI so it gets caught in premerge. 
