### PR TITLE
[core] fix //src/ray/gcs/tests:gcs_node_manager_test tsan/asan

### DIFF
--- a/src/ray/gcs/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_node_manager.cc
@@ -181,12 +181,13 @@ void GcsNodeManager::HandleUnregisterNode(rpc::UnregisterNodeRequest request,
   node_info_delta->set_state(node->state());
   node_info_delta->set_end_time_ms(node->end_time_ms());
 
-  auto on_put_done = [this, node_id, node_info_delta, node](const Status &status) {
+  auto on_put_done = [this, node_id, node_info_delta, node, send_reply_callback, reply](
+                         const Status &status) {
     gcs_publisher_->PublishNodeInfo(node_id, *node_info_delta);
     WriteNodeExportEvent(*node, /*is_register_event*/ false);
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   };
   gcs_table_storage_->NodeTable().Put(node_id, *node, {on_put_done, io_context_});
-  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }
 
 void GcsNodeManager::HandleDrainNode(rpc::DrainNodeRequest request,

--- a/src/ray/gcs/tests/gcs_node_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_node_manager_test.cc
@@ -52,9 +52,7 @@ class GcsNodeManagerTest : public ::testing::Test {
   std::unique_ptr<observability::FakeRayEventRecorder> fake_ray_event_recorder_;
 };
 
-// TODO(https://github.com/ray-project/ray/pull/56631): Re-enable
-// TestRayEventNodeEvents. It was temporarily disabled to unblock CI.
-TEST_F(GcsNodeManagerTest, DISABLED_TestRayEventNodeEvents) {
+TEST_F(GcsNodeManagerTest, TestRayEventNodeEvents) {
   RayConfig::instance().initialize(
       R"(
 {
@@ -72,11 +70,16 @@ TEST_F(GcsNodeManagerTest, DISABLED_TestRayEventNodeEvents) {
   rpc::RegisterNodeRequest register_request;
   register_request.mutable_node_info()->CopyFrom(*node);
   rpc::RegisterNodeReply register_reply;
-  auto send_reply_callback =
-      [](ray::Status status, std::function<void()> f1, std::function<void()> f2) {};
+  std::promise<bool> register_promise;
+  auto send_register_reply_callback = [&register_promise](ray::Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+    register_promise.set_value(true);
+  };
   // Add a node to the manager
-  node_manager.HandleRegisterNode(register_request, &register_reply, send_reply_callback);
-  io_context_->GetIoService().poll();
+  node_manager.HandleRegisterNode(
+      register_request, &register_reply, send_register_reply_callback);
+  register_promise.get_future().get();
   auto register_events = fake_ray_event_recorder_->FlushBuffer();
 
   // Test the node definition event + alive node lifecycle event
@@ -111,9 +114,15 @@ TEST_F(GcsNodeManagerTest, DISABLED_TestRayEventNodeEvents) {
       rpc::NodeDeathInfo::EXPECTED_TERMINATION);
   unregister_request.mutable_node_death_info()->set_reason_message("mock reason message");
   rpc::UnregisterNodeReply unregister_reply;
+  std::promise<bool> unregister_promise;
+  auto send_unregister_reply_callback = [&unregister_promise](ray::Status status,
+                                                              std::function<void()> f1,
+                                                              std::function<void()> f2) {
+    unregister_promise.set_value(true);
+  };
   node_manager.HandleUnregisterNode(
-      unregister_request, &unregister_reply, send_reply_callback);
-  io_context_->GetIoService().poll();
+      unregister_request, &unregister_reply, send_unregister_reply_callback);
+  unregister_promise.get_future().get();
 
   // Test the dead node lifecycle event
   auto unregister_events = fake_ray_event_recorder_->FlushBuffer();


### PR DESCRIPTION
The test `//src/ray/gcs/tests:gcs_node_manager_test tsan/asan` is failing on the master branch. Thanks to @israbbani for pointing it out. The issue is a race condition during the destruction of `fake_ray_event_recorder_ `and `gcs_node_manager_`.

The io_context_, which runs on a separate thread, might still access `fake_ray_event_recorder_` after they have been destroyed. The issue is that `io_context_.poll` does not really guarantee that the grpc call is fully completed. I changed to use a promise in the grpc callback instead.

This also requires updating HandleUnregisterNode so that it completes its gRPC callback only after finishing its operation (which is a better behavior compared to the current implementation in my opinion). The actual gRPC callback is here: https://github.com/ray-project/ray/blob/master/src/ray/gcs_client/accessor.cc#L511-L520
, and it makes sense for it to remain in sync with GCS rather than being triggered prematurely.

Test:
- CI