### PR TITLE
[Data] Move obj_store_mem_internal_outqueue to _mem_op_outputs

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -150,11 +150,11 @@ class ResourceManager:
 
         # Pending task outputs.
         mem_op_internal = op.metrics.obj_store_mem_pending_task_outputs or 0
-        # Op's internal output buffers.
-        mem_op_internal += op.metrics.obj_store_mem_internal_outqueue
 
         # Op's external output buffer.
         mem_op_outputs = state.outqueue_memory_usage()
+        # Op's internal output buffers.
+        mem_op_outputs += op.metrics.obj_store_mem_internal_outqueue
         # Input buffers of the downstream operators.
         for next_op in op.output_dependencies:
             mem_op_outputs += (

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -266,7 +266,7 @@ class TestResourceManager:
             if op != o1:
                 assert (
                     resource_manager._mem_op_internal[op]
-                    == mock_pending_task_outputs[op] + mock_internal_outqueue[op]
+                    == mock_pending_task_outputs[op]
                 )
                 assert (
                     resource_manager._mem_op_outputs[op]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Problem

<img width="1624" height="818" alt="image" src="https://github.com/user-attachments/assets/0261ffaa-d909-4ccc-bd1d-3f08f0cd4da7" />

The current implementation of `reserved_for_outputs` does not account for the object store memory used by `internal_out_queue`. This can lead to over-allocation if blocks are not moved quickly enough from `internal_out_queue` to `external_out_queue`.

## Example (Extreme Case)

If all output blocks remain in `internal_out_queue`, then `mem_op_outputs == 0`.  
In this situation, `reserved_for_outputs - OUTPUT` is still positive, so the operator continues generating new blocks into the internal queue — even though `total_shared` has already dropped below zero.

## Fix

Update `reserved_for_outputs` to include the memory consumed by `internal_out_queue`, ensuring allocation is accurately tracked and preventing over-allocation.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
