### PR TITLE
[core] Disable GcsNodeManager:TestRayEventRecorder

### DIFF
--- a/src/ray/gcs/tests/gcs_node_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_node_manager_test.cc
@@ -52,7 +52,9 @@ class GcsNodeManagerTest : public ::testing::Test {
   std::unique_ptr<observability::FakeRayEventRecorder> fake_ray_event_recorder_;
 };
 
-TEST_F(GcsNodeManagerTest, TestRayEventNodeEvents) {
+// TODO(https://github.com/ray-project/ray/pull/56631): Re-enable
+// TestRayEventNodeEvents. It was temporarily disabled to unblock CI.
+TEST_F(GcsNodeManagerTest, DISABLED_TestRayEventNodeEvents) {
   RayConfig::instance().initialize(
       R"(
 {


### PR DESCRIPTION
Remove GcsNodeManager:TestRayEventRecorder — this test is failing on postmerge tsan/asan. The failure is specific to the fake_ray_event_recorder implementation and does not affect production code. I have a fix in progress (https://github.com/ray-project/ray/pull/56631) but need more time to polish it, so I’m putting this up first to unblock others on their PRs.

Test:
- CI