### PR TITLE
move ingress validation for multiple fastapi deployment into client i…

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -487,7 +487,6 @@ class ApplicationState:
             or docs path.
         """
 
-        self._check_ingress_deployments(deployment_infos)
         # Check routes are unique in deployment infos
         self._route_prefix = self._check_routes(deployment_infos)
 
@@ -721,28 +720,6 @@ class ApplicationState:
                 f"'{self._name}': \n{traceback.format_exc()}"
             )
             return None, BuildAppStatus.FAILED, error_msg
-
-    def _check_ingress_deployments(
-        self, deployment_infos: Dict[str, DeploymentInfo]
-    ) -> None:
-        """Check @serve.ingress of deployments in app.
-
-        Raises: RayServeException if more than one @serve.ingress
-            is found among deployments.
-        """
-        num_ingress_deployments = 0
-        for info in deployment_infos.values():
-            if inspect.isclass(info.replica_config.deployment_def) and issubclass(
-                info.replica_config.deployment_def, ASGIAppReplicaWrapper
-            ):
-                num_ingress_deployments += 1
-
-        if num_ingress_deployments > 1:
-            raise RayServeException(
-                f'Found multiple FastAPI deployments in application "{self._name}".'
-                "Please only include one deployment with @serve.ingress"
-                "in your application to avoid this issue."
-            )
 
     def _check_routes(
         self, deployment_infos: Dict[str, DeploymentInfo]


### PR DESCRIPTION
fixes https://github.com/ray-project/ray/issues/55836

### Reasons for moving validation from controller to client in the imperative case:

1. **Access to User Callable Class on the client side**
   In imperative workflows, Since the client already has access to the User Callable Class at this point, FastAPI-related validations can be performed locally rather than delegating them to the controller.

2. **Unsafe deserialization in the controller**
   The controller was deserializing the User Callable Class without using the runtime environment. This posed a risk: if the class closure referenced an uncommon or obscure package, deserialization could fail. Performing validation on the client side avoids this unsafe pattern.

3. **Declarative flows remain unaffected**
   Declarative deployment workflows still perform their validation in the controller. Those validations are already handled in a safe manner, so no changes or concerns are needed there.

This behavior is tested in the following tests
1. `python/ray/serve/tests/test_fastapi.py::test_two_fastapi_in_one_application`
2. `python/ray/serve/tests/test_deploy_app.py::test_two_fastapi_in_one_application`