### PR TITLE
update spdlog to 15.3

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -129,7 +129,7 @@ def ray_deps_setup():
     auto_http_archive(
         name = "com_github_spdlog",
         build_file = "@io_ray//bazel:spdlog.BUILD",
-        urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.zip"],
+        url = "https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.zip",
         sha256 = "b74274c32c8be5dba70b7006c1d41b7d3e5ff0dff8390c8b6390c1189424e094",
         # spdlog rotation filename format conflict with ray, update the format.
         patches = [

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -129,8 +129,8 @@ def ray_deps_setup():
     auto_http_archive(
         name = "com_github_spdlog",
         build_file = "@io_ray//bazel:spdlog.BUILD",
-        urls = ["https://github.com/gabime/spdlog/archive/v1.12.0.zip"],
-        sha256 = "6174bf8885287422a6c6a0312eb8a30e8d22bcfcee7c48a6d02d1835d7769232",
+        urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.zip"],
+        sha256 = "b74274c32c8be5dba70b7006c1d41b7d3e5ff0dff8390c8b6390c1189424e094",
         # spdlog rotation filename format conflict with ray, update the format.
         patches = [
             "@io_ray//thirdparty/patches:spdlog-rotation-file-format.patch",

--- a/src/ray/rpc/rpc_chaos.h
+++ b/src/ray/rpc/rpc_chaos.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace ray {
 namespace rpc {

--- a/src/ray/rpc/rpc_chaos.h
+++ b/src/ray/rpc/rpc_chaos.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace ray {
 namespace rpc {

--- a/thirdparty/patches/spdlog-rotation-file-format.patch
+++ b/thirdparty/patches/spdlog-rotation-file-format.patch
@@ -10,24 +10,25 @@ diff --git a/include/spdlog/sinks/rotating_file_sink-inl.h b/include/spdlog/sink
 index cf8b9d5c..7580c06f 100644
 --- a/include/spdlog/sinks/rotating_file_sink-inl.h
 +++ b/include/spdlog/sinks/rotating_file_sink-inl.h
-@@ -50,7 +50,7 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
+@@ -49,7 +49,7 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
  }
-
+ 
  // calc filename according to index and file extension if exists.
 -// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
 +// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.txt.3".
- template<typename Mutex>
- SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename_t &filename, std::size_t index)
- {
-@@ -58,10 +58,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename
-     {
+ template <typename Mutex>
+ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename_t &filename,
+                                                                   std::size_t index) {
+@@ -57,10 +57,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename
          return filename;
      }
--
--    filename_t basename, ext;
+ 
+-    filename_t basename;
+-    filename_t ext;
 -    std::tie(basename, ext) = details::file_helper::split_by_extension(filename);
--    return fmt_lib::format(SPDLOG_FILENAME_T("{}.{}{}"), basename, index, ext);
-+    return fmt_lib::format(SPDLOG_FILENAME_T("{}.{}"), filename, index);
+-    return fmt_lib::format(SPDLOG_FMT_STRING(SPDLOG_FILENAME_T("{}.{}{}")), basename, index, ext);
++    return fmt_lib::format(SPDLOG_FMT_STRING(SPDLOG_FILENAME_T("{}.{}")), filename, index);
  }
+ 
+ template <typename Mutex>
 
- template<typename Mutex>


### PR DESCRIPTION
Update spdlog from 12.0 (from July 2023) to 15.3 (released May 2025)
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
