### PR TITLE
[core] Fix windows build errors

### DIFF
--- a/src/fakes/ray/rpc/raylet/BUILD.bazel
+++ b/src/fakes/ray/rpc/raylet/BUILD.bazel
@@ -7,6 +7,7 @@ ray_cc_library(
         "//src/ray/common:id",
         "//src/ray/common:status",
         "//src/ray/common/scheduling:scheduling_ids",
+        "//src/ray/rpc:client_call",
         "//src/ray/rpc:raylet_client_interface",
     ],
 )

--- a/src/fakes/ray/rpc/raylet/raylet_client.h
+++ b/src/fakes/ray/rpc/raylet/raylet_client.h
@@ -14,10 +14,18 @@
 
 #pragma once
 
+#include <limits>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/time/clock.h"
+#include "ray/common/id.h"
 #include "ray/common/scheduling/scheduling_ids.h"
+#include "ray/common/status.h"
+#include "ray/rpc/client_call.h"
 #include "ray/rpc/raylet/raylet_client_interface.h"
-#include "src/ray/common/id.h"
-#include "src/ray/common/status.h"
 
 namespace ray {
 
@@ -27,12 +35,12 @@ class FakeRayletClient : public RayletClientInterface {
       const rpc::Address &caller_address,
       const std::vector<ObjectID> &object_ids,
       const ObjectID &generator_id,
-      const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply> &callback) override {}
+      const rpc::ClientCallback<rpc::PinObjectIDsReply> &callback) override {}
 
   void RequestWorkerLease(
       const rpc::LeaseSpec &lease_spec,
       bool grant_or_reject,
-      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply> &callback,
+      const rpc::ClientCallback<rpc::RequestWorkerLeaseReply> &callback,
       const int64_t backlog_size = -1,
       const bool is_selected_based_on_locality = false) override {
     num_workers_requested += 1;
@@ -53,7 +61,7 @@ class FakeRayletClient : public RayletClientInterface {
 
   void PrestartWorkers(
       const rpc::PrestartWorkersRequest &request,
-      const rpc::ClientCallback<ray::rpc::PrestartWorkersReply> &callback) override {}
+      const rpc::ClientCallback<rpc::PrestartWorkersReply> &callback) override {}
 
   void ReleaseUnusedActorWorkers(
       const std::vector<WorkerID> &workers_in_use,
@@ -152,24 +160,21 @@ class FakeRayletClient : public RayletClientInterface {
 
   void PrepareBundleResources(
       const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
-      const ray::rpc::ClientCallback<ray::rpc::PrepareBundleResourcesReply> &callback)
-      override {
+      const rpc::ClientCallback<rpc::PrepareBundleResourcesReply> &callback) override {
     num_lease_requested += 1;
     lease_callbacks.push_back(callback);
   }
 
   void CommitBundleResources(
       const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
-      const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback)
-      override {
+      const rpc::ClientCallback<rpc::CommitBundleResourcesReply> &callback) override {
     num_commit_requested += 1;
     commit_callbacks.push_back(callback);
   }
 
   void CancelResourceReserve(
       const BundleSpecification &bundle_spec,
-      const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback)
-      override {
+      const rpc::ClientCallback<rpc::CancelResourceReserveReply> &callback) override {
     num_return_requested += 1;
     return_callbacks.push_back(callback);
   }
@@ -243,7 +248,7 @@ class FakeRayletClient : public RayletClientInterface {
   void GetWorkerFailureCause(
       const LeaseID &lease_id,
       const rpc::ClientCallback<rpc::GetWorkerFailureCauseReply> &callback) override {
-    ray::rpc::GetWorkerFailureCauseReply reply;
+    rpc::GetWorkerFailureCauseReply reply;
     callback(Status::OK(), std::move(reply));
     num_get_task_failure_causes += 1;
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Seems like prefixing my includes with "src" on windows ended up causing the same file (in this case id.h) to be included twice, one header file in the dependencies was including the non "src/" version while the other was. Not sure if this ended up creating two separate copies in the bazel cache, but I ended up getting multiple redefinition errors. #pragma once doesn't check the contents of the files themselves so seems like two copies with different paths being included can happen. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
