### PR TITLE
[release] Make run_release_test binary hermetic

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -294,6 +294,7 @@ py_binary(
         ["**/*.py"],
         exclude = ["ray_release/tests/*.py"],
     ),
+    exec_compatible_with = ["//:hermetic_python"],
     deps = [":ray_release"],
 )
 


### PR DESCRIPTION
So it doesn't look for dependencies in the system which can be confusing..