### PR TITLE
[train][release] Attach a quick checkpoint when reporting metrics

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -233,7 +233,7 @@ def train_torch_ray_air(
     use_gpu: bool = False,
 ) -> Tuple[float, float, float]:
     # This function is kicked off by the main() function and runs a full training
-    # run using Ray AIR.
+    # run using Ray Train.
     from ray.train import ScalingConfig, RunConfig
     from ray.train.torch import TorchTrainer
 

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -235,7 +235,7 @@ def train_torch_ray_air(
 ) -> Tuple[float, float, float]:
     # This function is kicked off by the main() function and runs a full training
     # run using Ray AIR.
-    from ray.train import ScalingConfig
+    from ray.train import ScalingConfig, RunConfig
     from ray.train.torch import TorchTrainer
 
     def train_loop(config):
@@ -250,6 +250,7 @@ def train_torch_ray_air(
             resources_per_worker={"CPU": cpus_per_worker},
             use_gpu=use_gpu,
         ),
+        run_config=RunConfig(storage_path="/mnt/cluster_storage"),
     )
     result = trainer.fit()
     time_taken = time.monotonic() - start_time

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -246,7 +246,6 @@ def train_torch_ray_air(
         train_loop_per_worker=train_loop,
         train_loop_config=config,
         scaling_config=ScalingConfig(
-            trainer_resources={"CPU": 0},
             num_workers=num_workers,
             resources_per_worker={"CPU": cpus_per_worker},
             use_gpu=use_gpu,

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -273,8 +273,8 @@ def train_torch_ray_air(
 
     # print(f"Last result: {result.metrics}")
     loss, local_time_taken = 0.0, 0.0
-    if os.path.exists(VANILLA_RESULT_JSON):
-        with open(VANILLA_RESULT_JSON, "r") as f:
+    if os.path.exists(RAY_RESULT_JSON):
+        with open(RAY_RESULT_JSON, "r") as f:
             result = json.load(f)
         loss = result["loss"]
         local_time_taken = result["local_time_taken"]

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -215,10 +215,10 @@ def train_func(use_ray: bool, config: Dict):
                         os.path.join(temp_checkpoint_dir, "model.pt"),
                     )
 
-                    train.report(
-                        dict(loss=loss, local_time_taken=local_time_taken),
-                        checkpoint=train.Checkpoint.from_directory(temp_checkpoint_dir),
-                    )
+                train.report(
+                    dict(loss=loss, local_time_taken=local_time_taken),
+                    checkpoint=train.Checkpoint.from_directory(temp_checkpoint_dir),
+                )
         else:
             print(f"Reporting loss: {loss:.4f}")
             if local_rank == 0:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -248,7 +248,7 @@
 
   run:
     timeout: 4800
-    script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 120 --num-workers 16 --cpus-per-worker 4 --batch-size 1024 --use-gpu
+    script: RAY_TRAIN_V2_ENABLED=1 python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 120 --num-workers 16 --cpus-per-worker 4 --batch-size 1024 --use-gpu
 
     wait_for_nodes:
       num_nodes: 4


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

1. In Train V2, Free-floating metrics without corresponding checkpoint are no longer automatically saved. See context in https://docs.ray.io/en/master/train/user-guides/monitoring-logging.html#deprecated-reporting-free-floating-metrics.
2. By creating a quick checkpoint, we can leverage Train V2 by adding `RAY_TRAIN_V2_ENABLED=1`.
3. Since in V2, we have a 2s polling interval for train.report() and in this test we only care about final loss, move the metrics reporting part out of epoch loop, only report once at the end of training loop.
4. example run: https://buildkite.com/ray-project/release/builds/59517

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
