### PR TITLE
[core] prevent stale GET request being registered if its lease was cleared

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2152,6 +2152,8 @@ void NodeManager::AsyncGetOrWait(const std::shared_ptr<ClientConnection> &client
   std::shared_ptr<WorkerInterface> worker = worker_pool_.GetRegisteredWorker(client);
   if (!worker) {
     worker = worker_pool_.GetRegisteredDriver(client);
+  } else if (worker->GetGrantedLeaseId().IsNil()) {
+    return;  // The worker may have died or is no longer processing the task.
   }
   RAY_CHECK(worker);
 

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -31,6 +31,7 @@
 #include "mock/ray/rpc/worker/core_worker_client.h"
 #include "ray/common/buffer.h"
 #include "ray/common/cgroup2/cgroup_manager_interface.h"
+#include "ray/common/flatbuf_utils.h"
 #include "ray/common/scheduling/cluster_resource_data.h"
 #include "ray/object_manager/plasma/fake_plasma_client.h"
 #include "ray/observability/fake_metric.h"
@@ -864,6 +865,101 @@ TEST_F(NodeManagerTest, TestResizeLocalResourceInstancesClamps) {
   EXPECT_TRUE(callback_called);
   // With 6 used, total should remain 6
   EXPECT_EQ(reply.total_resources().at("CPU"), 6.0);
+}
+
+TEST_F(NodeManagerTest, AsyncGetOrWaitSkipsGetForWorkerWithoutLease) {
+  // Verifies AsyncGetOrWait drops stale GETs for workers whose lease was cleared,
+  // while leaving driver GETs unaffected.
+
+  // Prepare a mock worker returned by GetRegisteredWorker(client).
+  auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 10);
+  EXPECT_TRUE(worker->GetGrantedLeaseId().IsNil());
+
+  EXPECT_CALL(
+      mock_worker_pool_,
+      GetRegisteredWorker(testing::A<const std::shared_ptr<ClientConnection> &>()))
+      .Times(2)  // one in ProcessClientMessage + one in AsyncGetOrWait
+      .WillRepeatedly(Return(worker));
+  EXPECT_CALL(
+      mock_worker_pool_,
+      GetRegisteredDriver(testing::A<const std::shared_ptr<ClientConnection> &>()))
+      .Times(0);
+
+  // Expect no pull to be registered on the ObjectManager for this GET.
+  EXPECT_CALL(*mock_object_manager_, Pull(_, _, _)).Times(0);
+
+  // Build AsyncGetObjectsRequest flatbuffer and invoke the handler.
+  std::vector<ObjectID> object_ids;
+  flatbuffers::FlatBufferBuilder fbb;
+  std::vector<flatbuffers::Offset<protocol::Address>> address_vec;
+  // Add one object and a corresponding (empty) owner address.
+  object_ids.push_back(ObjectID::FromRandom());
+  address_vec.push_back(protocol::CreateAddress(
+      fbb, fbb.CreateString(""), fbb.CreateString(""), 0, fbb.CreateString("")));
+  auto object_ids_message = flatbuf::to_flatbuf(fbb, object_ids);
+  auto message = protocol::CreateAsyncGetObjectsRequest(
+      fbb, object_ids_message, fbb.CreateVector(address_vec));
+  fbb.Finish(message);
+
+  // Create a minimal client connection for ProcessClientMessage.
+  local_stream_socket fake_socket(io_service_);
+  auto client = ClientConnection::Create(
+      [](std::shared_ptr<ClientConnection>, int64_t, const std::vector<uint8_t> &) {},
+      [](std::shared_ptr<ClientConnection>, const boost::system::error_code &) {},
+      std::move(fake_socket),
+      "test-client",
+      std::vector<std::string>{});
+  node_manager_->ProcessClientMessage(
+      client,
+      static_cast<int64_t>(protocol::MessageType::AsyncGetObjectsRequest),
+      fbb.GetBufferPointer());
+}
+
+TEST_F(NodeManagerTest, AsyncGetOrWaitRegistersGetForDriver) {
+  // A driver has no lease id; GET should still be registered.
+
+  // GetRegisteredWorker returns nullptr, driver is returned instead.
+  EXPECT_CALL(
+      mock_worker_pool_,
+      GetRegisteredWorker(testing::A<const std::shared_ptr<ClientConnection> &>()))
+      .Times(2)  // one in ProcessClientMessage + one in AsyncGetOrWait
+      .WillRepeatedly(Return(nullptr));
+  auto driver = std::make_shared<MockWorker>(WorkerID::FromRandom(), 10);
+  EXPECT_CALL(
+      mock_worker_pool_,
+      GetRegisteredDriver(testing::A<const std::shared_ptr<ClientConnection> &>()))
+      .Times(1)
+      .WillOnce(Return(driver));
+
+  // Expect a pull to be registered on the ObjectManager for this GET.
+  EXPECT_CALL(*mock_object_manager_, Pull(_, _, _)).Times(1);
+
+  // Build AsyncGetObjectsRequest flatbuffer and invoke the handler.
+  std::vector<ObjectID> object_ids;
+  flatbuffers::FlatBufferBuilder fbb;
+  std::vector<flatbuffers::Offset<protocol::Address>> address_vec;
+  // Add one object and a corresponding (empty) owner address.
+  object_ids.push_back(ObjectID::FromRandom());
+  address_vec.push_back(protocol::CreateAddress(
+      fbb, fbb.CreateString(""), fbb.CreateString(""), 0, fbb.CreateString("")));
+
+  auto object_ids_message = flatbuf::to_flatbuf(fbb, object_ids);
+  auto message = protocol::CreateAsyncGetObjectsRequest(
+      fbb, object_ids_message, fbb.CreateVector(address_vec));
+  fbb.Finish(message);
+
+  // Create a minimal client connection for ProcessClientMessage.
+  local_stream_socket fake_socket(io_service_);
+  auto client = ClientConnection::Create(
+      [](std::shared_ptr<ClientConnection>, int64_t, const std::vector<uint8_t> &) {},
+      [](std::shared_ptr<ClientConnection>, const boost::system::error_code &) {},
+      std::move(fake_socket),
+      "test-client",
+      std::vector<std::string>{});
+  node_manager_->ProcessClientMessage(
+      client,
+      static_cast<int64_t>(protocol::MessageType::AsyncGetObjectsRequest),
+      fbb.GetBufferPointer());
 }
 
 class NodeManagerReturnWorkerLeaseIdempotentTest

--- a/src/ray/raylet/tests/util.h
+++ b/src/ray/raylet/tests/util.h
@@ -85,10 +85,7 @@ class MockWorker : public WorkerInterface {
   }
 
   void MarkDead() override { RAY_CHECK(false) << "Method unused"; }
-  bool IsDead() const override {
-    RAY_CHECK(false) << "Method unused";
-    return killing_.load(std::memory_order_acquire);
-  }
+  bool IsDead() const override { return killing_.load(std::memory_order_acquire); }
   void KillAsync(instrumented_io_context &io_service, bool force) override {
     bool expected = false;
     killing_.compare_exchange_strong(expected, true, std::memory_order_acq_rel);


### PR DESCRIPTION
## Why are these changes needed?

### The problem:

In the flaky `test_spill_objects_on_object_transfer` test, we found that there could always be 1 get bundle request hanging indefinitely in the pull manager. And due to the designated memory quota used in the test, no other pull requests could be activated, so that the test would time out. That is why the test is flaky.

However, when taking a closer look, all objects requested by the hanging get bundle request were actually pulled locally already! It turned out that the get bundle request was registered *AFTER* the lease of the worker was cleared.

The `test_spill_objects_on_object_transfer` test is flaky due to the race between the following handles:
1. `NodeManager::CleanupLease`
2. `Nodemanager::HandleAsyncGetObjectsRequest`

For example, consider a task T taking a remote Object A reference as its task argument:

```python
@ray.remote
def T(a_ref):
    pass

T.remote(ray.put(A))
```

The following sequence can happen:

1. Before task T being assigned to a core worker, Object A is pulled to the local raylet by an activated `task arg` bundle request first (`LeaseDependencyManager::RequestLeaseDependencies`).
2. A core worker is leased to run task T, and it submits a `get` bundle request to pull the remote object A via (`CoreWorkerPlasmaStoreProvider::PullObjectsAndGetFromPlasmaStore`).
3. The core worker finds that object A is pulled already right after submitting the `get` bundle request (still in `CoreWorkerPlasmaStoreProvider::PullObjectsAndGetFromPlasmaStore`) and `raylet_client->NotifyDirectCallTaskUnblocked()` is invoked.
4. The core worker finishes the task and returns to the raylet.
5. `NodeManager::CleanupLease` is invoked, and the lease id on the worker is cleared.
6. `Nodemanager::HandleAsyncGetObjectsRequest` is invoked by step 2 to register the `get` bundle request.
7. `Nodemanager::HandleDirectCallTaskUnblocked` is invoked by step 3 to cancel the `get` bundle registered in the previous step, but since the lease id on the worker is cleared, [this step does nothing](https://github.com/ray-project/ray/blob/3a60beec28c1f9a2d132b6dba40cc5fc5c3aa879/src/ray/raylet/node_manager.cc#L2135). Therefore, the `get` bundle hangs indefinitely.

This PR solves the issue by applying the same lease id check in step 7 to step 6 as well, preventing a stale get bundle request (step 6) from being registered.

This fixes the flaky `test_spill_objects_on_object_transfer` test. I never saw it time out with this fix.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
