### PR TITLE
[Data] Reuse random state in randomize_block_order

### DIFF
--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -86,7 +86,7 @@ def plan_all_to_all_op(
     input_physical_dag = physical_children[0]
 
     if isinstance(op, RandomizeBlocks):
-        fn = generate_randomize_blocks_fn(op)
+        fn = generate_randomize_blocks_fn(op, data_context)
         # Randomize block order does not actually compute anything, so we
         # want to inherit the upstream op's target max block size.
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -448,6 +448,11 @@ class DataContext:
         enforce_schemas: Whether to enforce schema consistency across dataset operations.
         pandas_block_ignore_metadata: Whether to ignore pandas metadata when converting
             between Arrow and pandas formats for better type inference.
+        always_reset_random_state_for_random_ops: Whether to reset the random state given
+            a seed for random operations. Default to True. Set it to False to initialize
+            the random state only once during lifetime of the Dataset, which is useful for
+            model training with Ray Train. For example, setting it to False with a seed will
+            not reset the random state for each epoch.
     """
 
     # `None` means the block size is infinite.
@@ -581,6 +586,8 @@ class DataContext:
     enforce_schemas: bool = DEFAULT_ENFORCE_SCHEMAS
 
     pandas_block_ignore_metadata: bool = DEFAULT_PANDAS_BLOCK_IGNORE_METADATA
+
+    always_reset_random_state_for_random_ops: bool = True
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to


### PR DESCRIPTION
Currently, when iterating `ds.iter_torch_batches()` multiple times, such as using Ray Train, the random state in each randomize operation is reset to the given seed. This PR adds a flag to set the state only once at the first iteration.

## Related issue number

This PR only updates `randomize_block_order` but we probably needs to update a few more APIs that allow user to set `seed`.

Partially closes https://github.com/ray-project/ray/issues/55275

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
