### PR TITLE
[docs] Update Kueue integration documentation to include RayService & RayCluster support

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayjob-kueue-gang-scheduling.md
+++ b/doc/source/cluster/kubernetes/examples/rayjob-kueue-gang-scheduling.md
@@ -20,7 +20,7 @@ and how jobs consume them. Kueue decides when:
 * To preempt a job, which triggers Kubernetes to delete active Pods.
 
 Kueue has native support for some KubeRay APIs. Specifically, you can use Kueue
-to manage resources that RayJob and RayCluster consume. See the
+to manage resources that RayJob, RayCluster, and RayService consume. See the
 [Kueue documentation](https://kueue.sigs.k8s.io/docs/overview/) to learn more.
 
 ## Why use gang scheduling

--- a/doc/source/cluster/kubernetes/examples/rayjob-kueue-gang-scheduling.md
+++ b/doc/source/cluster/kubernetes/examples/rayjob-kueue-gang-scheduling.md
@@ -69,7 +69,7 @@ The KubeRay operator Pod must be on the CPU node if you set up the taint for the
 
 Install the latest released version of Kueue.
 ```
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.2/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.13.4/manifests.yaml
 ```
 
 See [Kueue Installation](https://kueue.sigs.k8s.io/docs/installation/#install-a-released-version) for more details on installing Kueue.

--- a/doc/source/cluster/kubernetes/examples/rayjob-kueue-priority-scheduling.md
+++ b/doc/source/cluster/kubernetes/examples/rayjob-kueue-priority-scheduling.md
@@ -29,7 +29,7 @@ The KubeRay operator Pod must be on the CPU node if you set up the taint for the
 ## Step 2: Install Kueue
 
 ```bash
-VERSION=v0.8.2
+VERSION=v0.13.4
 kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/$VERSION/manifests.yaml
 ```
 

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/kueue.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/kueue.md
@@ -144,7 +144,6 @@ Note these important points for RayJob custom resources:
 
 ```yaml
 kubectl create -f ray-job.kueue-toy-sample.yaml
-kubectl create -f ray-job.kueue-toy-sample.yaml
 ```
 
 Each RayJob custom resource requests 2 CPUs and 4G of memory in total.

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/kueue.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/kueue.md
@@ -1,18 +1,27 @@
 (kuberay-kueue)=
-# Gang scheduling and priority scheduling for RayJob with Kueue
+# KubeRay Integration with Kueue for Gang scheduling and Priority Scheduling
 
-This guide demonstrates the integration of KubeRay and Kueue for gang and priority scheduling using RayJob on a local Kind cluster.
-Refer to [Priority Scheduling with RayJob and Kueue](kuberay-kueue-priority-scheduling-example) and [Gang Scheduling with RayJob and Kueue](kuberay-kueue-gang-scheduling-example) for real-world use cases.
+This guide demonstrates how to integrate KubeRay with [Kueue](https://kueue.sigs.k8s.io/) to enable advanced scheduling capabilities including gang scheduling and priority scheduling for Ray applications on Kubernetes.
 
-## Kueue
+For real-world use cases with RayJob, see [Priority Scheduling with RayJob and Kueue](kuberay-kueue-priority-scheduling-example) and [Gang Scheduling with RayJob and Kueue](kuberay-kueue-gang-scheduling-example).
 
-[Kueue](https://kueue.sigs.k8s.io/) is a Kubernetes-native job queueing system that manages quotas and how jobs consume them. Kueue decides when:
+## What is Kueue?
+[Kueue](https://kueue.sigs.k8s.io/) is a Kubernetes-native job queueing system that manages resource quotas and job lifecycle. Kueue decides when:
 * To make a job wait.
 * To admit a job to start, which triggers Kubernetes to create pods.
 * To preempt a job, which triggers Kubernetes to delete active pods.
 
-Kueue has native support for some KubeRay APIs. Specifically, you can use Kueue to manage resources consumed by RayJob and RayCluster.
-See the [Kueue documentation](https://kueue.sigs.k8s.io/docs/overview/) to learn more.
+## Supported KubeRay APIs
+Kueue has native support for the following KubeRay APIs:
+- **RayJob**: Ideal for batch processing and model training workloads (covered in this guide)
+- **RayCluster**: Perfect for managing long-running Ray clusters
+- **RayService**: Designed for serving models and applications
+
+*Note: This guide focuses on a detailed RayJob example on a kind cluster. For RayCluster and RayService examples, see the ["Working with RayCluster and RayService"](#working-with-raycluster-and-rayservice) section.*
+
+## Prerequisites
+
+Before you begin, ensure you have a Kubernetes cluster. This guide uses a local Kind cluster.
 
 ## Step 0: Create a Kind cluster
 
@@ -27,14 +36,17 @@ Follow [Deploy a KubeRay operator](kuberay-operator-deploy) to install the lates
 ## Step 2: Install Kueue
 
 ```bash
-VERSION=v0.6.0
+VERSION=v0.13.4
 kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/$VERSION/manifests.yaml
 ```
 
 See [Kueue Installation](https://kueue.sigs.k8s.io/docs/installation/#install-a-released-version) for more details on installing Kueue.
-Some limitations exist between Kueue and RayJob. See the [limitations of Kueue](https://kueue.sigs.k8s.io/docs/tasks/run_rayjobs/#c-limitations) for more details.
+**Note**: Some limitations exist between Kueue and RayJob. See the [limitations of Kueue](https://kueue.sigs.k8s.io/docs/tasks/run_rayjobs/#c-limitations) for more details.
 
-## Step 3: Create Kueue resources
+
+## Step 3: Create Kueue Resources
+
+This manifest creates the necessary Kueue resources to manage scheduling and resource allocation.
 
 ```yaml
 # kueue-resources.yaml
@@ -219,3 +231,12 @@ kubectl create -f ray-job.kueue-toy-sample.yaml
 ```
 
 You can see that KubeRay operator deletes the Pods belonging to the RayJob with the lower priority class `dev-priority` and creates the Pods belonging to the RayJob with the higher priority class `prod-priority`.
+
+## Working with RayCluster and RayService
+
+### RayCluster with Kueue
+For gang scheduling with RayCluster resources, Kueue ensures that all cluster components (head and worker nodes) are provisioned together. This prevents partial cluster creation and resource waste.
+**For detailed RayCluster integration**: See the [Kueue documentation for RayCluster](https://kueue.sigs.k8s.io/docs/tasks/run/rayclusters/).
+### RayService with Kueue
+RayService integration with Kueue enables gang scheduling for model serving workloads, ensuring consistent resource allocation for serving infrastructure.
+**For detailed RayService integration**: See the [Kueue documentation for RayService](https://kueue.sigs.k8s.io/docs/tasks/run/rayservice/).

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/kueue.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/kueue.md
@@ -1,5 +1,5 @@
 (kuberay-kueue)=
-# KubeRay Integration with Kueue for Gang scheduling and Priority Scheduling
+# Gang scheduling and Priority scheduling for KubeRay CRDs with Kueue
 
 This guide demonstrates how to integrate KubeRay with [Kueue](https://kueue.sigs.k8s.io/) to enable advanced scheduling capabilities including gang scheduling and priority scheduling for Ray applications on Kubernetes.
 
@@ -11,7 +11,7 @@ For real-world use cases with RayJob, see [Priority Scheduling with RayJob and K
 * To admit a job to start, which triggers Kubernetes to create pods.
 * To preempt a job, which triggers Kubernetes to delete active pods.
 
-## Supported KubeRay APIs
+## Supported KubeRay CRDs
 Kueue has native support for the following KubeRay APIs:
 - **RayJob**: Ideal for batch processing and model training workloads (covered in this guide)
 - **RayCluster**: Perfect for managing long-running Ray clusters
@@ -239,4 +239,4 @@ For gang scheduling with RayCluster resources, Kueue ensures that all cluster co
 **For detailed RayCluster integration**: See the [Kueue documentation for RayCluster](https://kueue.sigs.k8s.io/docs/tasks/run/rayclusters/).
 ### RayService with Kueue
 RayService integration with Kueue enables gang scheduling for model serving workloads, ensuring consistent resource allocation for serving infrastructure.
-**For detailed RayService integration**: See the [Kueue documentation for RayService](https://kueue.sigs.k8s.io/docs/tasks/run/rayservice/).
+**For detailed RayService integration**: See the [Kueue documentation for RayService](https://kueue.sigs.k8s.io/docs/tasks/run/rayservices/).


### PR DESCRIPTION
## Doc link
https://anyscale-ray--56781.com.readthedocs.build/en/56781/cluster/kubernetes/k8s-ecosystem/kueue.html

## Why are these changes needed?
Updated RayService Support: Kueue recently added [native support for KubeRay RayService](https://kueue.sigs.k8s.io/docs/tasks/run/rayservice/), expanding beyond the previous RayJob and RayCluster support. This documentation update ensures users are aware of the complete range of KubeRay resources that can benefit from Kueue's advanced scheduling capabilities.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands Kueue integration docs to cover RayService and RayCluster and updates install instructions to Kueue v0.13.4.
> 
> - **Docs (Kubernetes/Kueue)**:
>   - **Broadened scope**: Generalize from RayJob-only to KubeRay CRDs, adding support mentions for `RayService` and `RayCluster`.
>   - **New content**:
>     - Added "Supported KubeRay CRDs" listing `RayJob`, `RayCluster`, `RayService`.
>     - Added "Working with RayCluster and RayService" with links to Kueue docs.
>     - Added prerequisites and clarified intro/notes.
>   - **Install instructions**: Update Kueue version to `v0.13.4` in `examples/rayjob-kueue-*` and `k8s-ecosystem/kueue.md`.
>   - **Cleanup**: Minor heading/wording improvements and removal of a duplicate `kubectl create` command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e36bcccfd599ee5dba12651c9c30e22f7cd5c18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->