### PR TITLE
[deps] ban click 8.3.0

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -287,7 +287,7 @@ steps:
       - minbuild-core
     matrix:
       - "3.9"
-      # - "3.10" # miniforge Python 3.10 seems to be broken..
+      - "3.10"
       - "3.11"
       - "3.12"
       - "3.13"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,9 @@
 # You can obtain this list from the ray.egg-info/requires.txt
 
 ## setup.py install_requires
-click>=7.0
+# Click 8.3.0 does not work with copy.deepcopy on Python 3.10
+# TODO(aslonnie): https://github.com/ray-project/ray/issues/56747
+click>=7.0, !=8.3.0
 cupy-cuda12x; sys_platform != 'darwin'
 filelock
 jsonschema

--- a/python/setup.py
+++ b/python/setup.py
@@ -395,7 +395,9 @@ if setup_spec.type == SetupType.RAY:
 # new releases candidates.
 if setup_spec.type == SetupType.RAY:
     setup_spec.install_requires = [
-        "click >= 7.0",
+        # Click 8.3.0 does not work with copy.deepcopy on Python 3.10
+        # TODO(aslonnie): https://github.com/ray-project/ray/issues/56747
+        "click>=7.0, !=8.3.0",
         "filelock",
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",


### PR DESCRIPTION
it does not work with `copy.deepcopy` on python 3.10

due to https://github.com/pallets/click/issues/3065

mitigates https://github.com/ray-project/ray/issues/56747 for next release