### PR TITLE
[tune][release] Upgrade tune_torch_benchmark to v2

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -119,7 +119,7 @@ def tune_torch(
         "use_gpu": use_gpu,
     }
 
-    param_space["train_loop_config"] = (config or {}) | param_space["train_loop_config"]
+    param_space["train_loop_config"].update(config or {})
 
     tuner = Tuner(
         trainable=train_driver_fn,

--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -8,8 +8,9 @@ import click
 import numpy as np
 
 import ray
-from ray.train import ScalingConfig
+from ray.train import ScalingConfig, RunConfig
 from ray.train.torch import TorchTrainer
+from ray.tune.integration.ray_train import TuneReportCallback
 
 
 CONFIG = {"lr": 1e-3, "batch_size": 64, "epochs": 20}
@@ -21,7 +22,7 @@ def prepare_mnist():
 
     print("Preparing Torch benchmark: Downloading MNIST")
 
-    @ray.remote
+    @ray.remote(num_cpus=0)
     def _download_data():
         import torchvision
 
@@ -31,24 +32,24 @@ def prepare_mnist():
     ray.get(schedule_remote_fn_on_all_nodes(_download_data))
 
 
+def train_loop(config: Dict):
+    from torch_benchmark import train_func
+
+    train_func(use_ray=True, config=config)
+
+
 def get_trainer(
     num_workers: int = 4,
     use_gpu: bool = False,
     config: Optional[Dict] = None,
 ):
     """Get the trainer to be used across train and tune to ensure consistency."""
-    from torch_benchmark import train_func
-
-    def train_loop(config):
-        train_func(use_ray=True, config=config)
-
     # We are using STRICT_PACK here to do an apples to apples comparison.
     # PyTorch defaults to using multithreading, so if the workers are spread,
     # they are able to utilize more resources. We would effectively be comparing
     # X tune runs with 2 CPUs per worker vs. 1 tune run with up to 8 CPUs per
     # worker. Using STRICT_PACK avoids this by forcing all workers to be
     # co-located.
-
     config = config or CONFIG
 
     trainer = TorchTrainer(
@@ -57,9 +58,12 @@ def get_trainer(
         scaling_config=ScalingConfig(
             num_workers=num_workers,
             resources_per_worker={"CPU": 2},
-            trainer_resources={"CPU": 0},
             use_gpu=use_gpu,
             placement_strategy="STRICT_PACK",
+        ),
+        run_config=RunConfig(
+            name="train_torch_benchmark",
+            storage_path="/mnt/cluster_storage/ray-train-results",
         ),
     )
     return trainer
@@ -67,6 +71,27 @@ def get_trainer(
 
 def train_torch(num_workers: int, use_gpu: bool = False, config: Optional[Dict] = None):
     trainer = get_trainer(num_workers=num_workers, use_gpu=use_gpu, config=config)
+    trainer.fit()
+
+
+def train_driver_fn(config: Dict):
+
+    trainer = TorchTrainer(
+        train_loop_per_worker=train_loop,
+        train_loop_config=config["train_loop_config"],
+        run_config=RunConfig(
+            name="tune_torch_benchmark",
+            storage_path="/mnt/cluster_storage/ray-tune-results",
+            callbacks=[TuneReportCallback()],
+        ),
+        scaling_config=ScalingConfig(
+            num_workers=config["num_workers"],
+            resources_per_worker={"CPU": 2},
+            use_gpu=config["use_gpu"],
+            placement_strategy="STRICT_PACK",
+        ),
+    )
+
     trainer.fit()
 
 
@@ -90,11 +115,14 @@ def tune_torch(
         "train_loop_config": {
             "lr": tune.loguniform(1e-4, 1e-1),
         },
+        "num_workers": num_workers,
+        "use_gpu": use_gpu,
     }
 
-    trainer = get_trainer(num_workers=num_workers, use_gpu=use_gpu, config=config)
+    param_space["train_loop_config"] = config | param_space["train_loop_config"]
+
     tuner = Tuner(
-        trainable=trainer,
+        trainable=train_driver_fn,
         param_space=param_space,
         tune_config=TuneConfig(mode="min", metric="loss", num_samples=num_trials),
     )

--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -119,7 +119,7 @@ def tune_torch(
         "use_gpu": use_gpu,
     }
 
-    param_space["train_loop_config"] = config | param_space["train_loop_config"]
+    param_space["train_loop_config"] = (config or {}) | param_space["train_loop_config"]
 
     tuner = Tuner(
         trainable=train_driver_fn,

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -230,7 +230,7 @@
     script: RAY_TRAIN_V2_ENABLED=1 python workloads/tune_torch_benchmark.py --num-runs 1 --num-trials 2 --num-workers 2
 
     wait_for_nodes:
-      num_nodes: 8
+      num_nodes: 4
 
   variations:
     - __suffix__: aws

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -223,11 +223,11 @@
   cluster:
     byod:
       type: gpu
-    cluster_compute: compute_cpu_8_aws.yaml
+    cluster_compute: compute_cpu_4_aws.yaml
 
   run:
     timeout: 3600
-    script: python workloads/tune_torch_benchmark.py --num-runs 3 --num-trials 8 --num-workers 4
+    script: python workloads/tune_torch_benchmark.py --num-runs 1 --num-trials 2 --num-workers 2
 
     wait_for_nodes:
       num_nodes: 8
@@ -238,7 +238,7 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_compute: compute_cpu_8_gce.yaml
+        cluster_compute: compute_cpu_4_gce.yaml
 
   alert: default
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -227,7 +227,7 @@
 
   run:
     timeout: 3600
-    script: python workloads/tune_torch_benchmark.py --num-runs 1 --num-trials 2 --num-workers 2
+    script: RAY_TRAIN_V2_ENABLED=1 python workloads/tune_torch_benchmark.py --num-runs 1 --num-trials 2 --num-workers 2
 
     wait_for_nodes:
       num_nodes: 8


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. In Train V2, tune runs trials of train_driver_fn instead of Trainer instance in V1 into the Tuner, see [latest doc](https://docs.ray.io/en/master/train/user-guides/hyperparameter-optimization.html)
2. Pass in the TuneReportCallback for the trainer that used in Tune for reported results.
3. Reduced the number of runs / trials to make the test run faster
4. example run: https://buildkite.com/ray-project/release/builds/59578#019973ab-dee6-407c-bc0e-702ee9247ced
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
