### PR TITLE
[Data] - make test_unify_schemas_nested_struct_tensors deterministic

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -175,7 +175,7 @@ def _reconcile_diverging_fields(
     from ray.air.util.object_extensions.arrow import ArrowPythonObjectType
 
     reconciled_fields = {}
-    field_types = defaultdict(list)  # field_name -> set of types seen so far
+    field_types = defaultdict(list)  # field_name -> list of types seen so far
     field_flags = defaultdict(
         lambda: defaultdict(bool)
     )  # field_name -> dict of boolean flags

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -175,7 +175,7 @@ def _reconcile_diverging_fields(
     from ray.air.util.object_extensions.arrow import ArrowPythonObjectType
 
     reconciled_fields = {}
-    field_types = defaultdict(set)  # field_name -> set of types seen so far
+    field_types = defaultdict(list)  # field_name -> set of types seen so far
     field_flags = defaultdict(
         lambda: defaultdict(bool)
     )  # field_name -> dict of boolean flags
@@ -188,7 +188,8 @@ def _reconcile_diverging_fields(
                 continue
 
             field_type = schema.field(field_name).type
-            field_types[field_name].add(field_type)
+            if field_type not in field_types[field_name]:
+                field_types[field_name].append(field_type)
             flags = field_flags[field_name]
 
             # Update flags

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -610,6 +610,12 @@ def test_unify_schemas_objects_and_tensors(unify_schemas_objects_and_tensors_sch
         unify_schemas(unify_schemas_objects_and_tensors_schemas)
 
 
+def _sort_schema_fields(schema):
+    """Helper function to sort schema fields by name for deterministic comparison."""
+    sorted_fields = sorted(schema, key=lambda field: field.name)
+    return pa.schema(sorted_fields)
+
+
 @pytest.mark.skipif(
     get_pyarrow_version() < parse_version("17.0.0"),
     reason="Requires PyArrow version 17 or higher",
@@ -633,7 +639,11 @@ def test_unify_schemas_nested_struct_tensors(
 
     # Should convert nested tensor to variable-shaped
     result = unify_schemas([schemas["with_tensor"], schemas["without_tensor"]])
-    assert result == schemas["expected"]
+
+    # Sort field names for deterministic comparison
+    result_sorted = _sort_schema_fields(result)
+    expected_sorted = _sort_schema_fields(schemas["expected"])
+    assert result_sorted == expected_sorted
 
 
 def test_unify_schemas_edge_cases(unify_schemas_edge_cases_data):

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -633,7 +633,6 @@ def test_unify_schemas_nested_struct_tensors(
 
     # Should convert nested tensor to variable-shaped
     result = unify_schemas([schemas["with_tensor"], schemas["without_tensor"]])
-
     assert result == schemas["expected"]
 
 

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -612,20 +612,25 @@ def test_unify_schemas_objects_and_tensors(unify_schemas_objects_and_tensors_sch
 
 def _sort_schema_fields(schema):
     """Helper function to recursively sort schema fields by name for deterministic comparison."""
+
     def _sort_recursively(data_type):
         if pa.types.is_struct(data_type):
-            return pa.struct([
-                field.with_type(_sort_recursively(field.type))
-                for field in sorted(data_type, key=lambda f: f.name)
-            ])
+            return pa.struct(
+                [
+                    field.with_type(_sort_recursively(field.type))
+                    for field in sorted(data_type, key=lambda f: f.name)
+                ]
+            )
         if pa.types.is_list(data_type):
             return pa.list_(_sort_recursively(data_type.value_type))
         return data_type
 
-    return pa.schema([
-        field.with_type(_sort_recursively(field.type))
-        for field in sorted(schema, key=lambda f: f.name)
-    ])
+    return pa.schema(
+        [
+            field.with_type(_sort_recursively(field.type))
+            for field in sorted(schema, key=lambda f: f.name)
+        ]
+    )
 
 
 @pytest.mark.skipif(

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -611,9 +611,21 @@ def test_unify_schemas_objects_and_tensors(unify_schemas_objects_and_tensors_sch
 
 
 def _sort_schema_fields(schema):
-    """Helper function to sort schema fields by name for deterministic comparison."""
-    sorted_fields = sorted(schema, key=lambda field: field.name)
-    return pa.schema(sorted_fields)
+    """Helper function to recursively sort schema fields by name for deterministic comparison."""
+    def _sort_recursively(data_type):
+        if pa.types.is_struct(data_type):
+            return pa.struct([
+                field.with_type(_sort_recursively(field.type))
+                for field in sorted(data_type, key=lambda f: f.name)
+            ])
+        if pa.types.is_list(data_type):
+            return pa.list_(_sort_recursively(data_type.value_type))
+        return data_type
+
+    return pa.schema([
+        field.with_type(_sort_recursively(field.type))
+        for field in sorted(schema, key=lambda f: f.name)
+    ])
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The arrow v9 tests run twice because `test_unify_schemas_nested_struct_tensors` is not deterministic. Use list for field types instead of set

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
