### PR TITLE
[core] Use `absl::mutex` instead of `std::mutex` in `shutdown_coordinator`

### DIFF
--- a/src/ray/core_worker/shutdown_coordinator.cc
+++ b/src/ray/core_worker/shutdown_coordinator.cc
@@ -100,17 +100,17 @@ bool ShutdownCoordinator::TryTransitionToShutdown() {
 }
 
 ShutdownState ShutdownCoordinator::GetState() const {
-  absl::MutexLock lock(&mu_);
+  absl::ReaderMutexLock lock(&mu_);
   return state_;
 }
 
 ShutdownReason ShutdownCoordinator::GetReason() const {
-  absl::MutexLock lock(&mu_);
+  absl::ReaderMutexLock lock(&mu_);
   return reason_;
 }
 
 bool ShutdownCoordinator::ShouldEarlyExit() const {
-  absl::MutexLock lock(&mu_);
+  absl::ReaderMutexLock lock(&mu_);
   return state_ != ShutdownState::kRunning;
 }
 

--- a/src/ray/core_worker/shutdown_coordinator.h
+++ b/src/ray/core_worker/shutdown_coordinator.h
@@ -17,10 +17,10 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <string_view>
 
+#include "absl/synchronization/mutex.h"
 #include "src/ray/protobuf/common.pb.h"
 
 namespace ray {
@@ -258,14 +258,14 @@ class ShutdownCoordinator {
   rpc::WorkerType worker_type_;
 
   // Mutex-guarded shutdown state
-  mutable std::mutex mu_;
-  ShutdownState state_ = ShutdownState::kRunning;
-  ShutdownReason reason_ = ShutdownReason::kNone;
-  bool force_executed_ = false;
-  bool force_started_ = false;
+  mutable absl::Mutex mu_;
+  ShutdownState state_ ABSL_GUARDED_BY(mu_) = ShutdownState::kRunning;
+  ShutdownReason reason_ ABSL_GUARDED_BY(mu_) = ShutdownReason::kNone;
+  bool force_executed_ ABSL_GUARDED_BY(mu_) = false;
+  bool force_started_ ABSL_GUARDED_BY(mu_) = false;
 
   /// Shutdown detail for observability (set once during shutdown initiation)
-  std::string shutdown_detail_;
+  std::string shutdown_detail_ ABSL_GUARDED_BY(mu_);
 };
 }  // namespace core
 }  // namespace ray


### PR DESCRIPTION
Use `absl::mutex` instead of `std::mutex` in `shutdown_coordinator.{h,cc}`