### PR TITLE
[data] Add ray_remote_args support to repartition operations

### DIFF
--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -111,6 +111,7 @@ class Repartition(AbstractAllToAll):
         shuffle: bool,
         keys: Optional[List[str]] = None,
         sort: bool = False,
+        ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
         if shuffle:
             sub_progress_bar_names = [
@@ -126,6 +127,7 @@ class Repartition(AbstractAllToAll):
             input_op,
             num_outputs=num_outputs,
             sub_progress_bar_names=sub_progress_bar_names,
+            ray_remote_args=ray_remote_args,
         )
         self._shuffle = shuffle
         self._keys = keys

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -342,16 +342,21 @@ class FlatMap(AbstractUDFMap):
 class StreamingRepartition(AbstractMap):
     """Logical operator for streaming repartition operation.
     Args:
+        input_op: The operator preceding this operator in the plan DAG.
         target_num_rows_per_block: The target number of rows per block granularity for
            streaming repartition.
+        ray_remote_args: Args to provide to :func:`ray.remote`.
     """
 
     def __init__(
         self,
         input_op: LogicalOperator,
         target_num_rows_per_block: int,
+        ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
-        super().__init__("StreamingRepartition", input_op)
+        super().__init__(
+            "StreamingRepartition", input_op, ray_remote_args=ray_remote_args
+        )
         self._target_num_rows_per_block = target_num_rows_per_block
 
     @property

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1552,6 +1552,7 @@ class Dataset:
         shuffle: bool = False,
         keys: Optional[List[str]] = None,
         sort: bool = False,
+        **ray_remote_args,
     ) -> "Dataset":
         """Repartition the :class:`Dataset` into exactly this number of
         :ref:`blocks <dataset_concept>`.
@@ -1611,6 +1612,7 @@ class Dataset:
                 is set to True.
             sort: Whether the blocks should be sorted after repartitioning. Note,
                 that by default blocks will be sorted in the ascending order.
+            **ray_remote_args: Additional arguments to pass to :func:`ray.remote`.
 
         Note that you must set either `num_blocks` or `target_num_rows_per_block`
         but not both.
@@ -1656,6 +1658,7 @@ class Dataset:
             op = StreamingRepartition(
                 self._logical_plan.dag,
                 target_num_rows_per_block=target_num_rows_per_block,
+                ray_remote_args=ray_remote_args,
             )
         else:
             op = Repartition(
@@ -1664,6 +1667,7 @@ class Dataset:
                 shuffle=shuffle,
                 keys=keys,
                 sort=sort,
+                ray_remote_args=ray_remote_args,
             )
 
         logical_plan = LogicalPlan(op, self.context)

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -306,6 +306,24 @@ def test_streaming_repartition_write_no_operator_fusion(
     assert partition_1_ds.count() == 20, "Expected 20 rows in partition 1"
 
 
+def test_repartition_ray_remote_args(ray_start_regular_shared_2_cpus):
+    """Test that repartition operations accept ray_remote_args parameter."""
+    input_ds = ray.data.range(100)
+
+    ds = input_ds.repartition(
+        target_num_rows_per_block=20,
+        num_cpus=1,
+        max_retries=2,
+        retry_exceptions=[OSError],
+    )
+    assert ds.sum() == 4950
+
+    ds = input_ds.repartition(
+        num_blocks=20, num_cpus=1, max_retries=2, retry_exceptions=[OSError]
+    )
+    assert ds.materialize().num_blocks() == 20
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds support for `ray_remote_args` parameter to `Repartition` operations in Ray Data. Currently, users cannot specify resource requirements, scheduling strategies, or other Ray remote task options when performing repartition operations. This limitation prevents users from:

- Controlling CPU/GPU resource allocation for repartition tasks
- Specifying memory requirements for large dataset repartitioning
- Using custom scheduling strategies (SPREAD, DEFAULT, etc.)
- Configuring retry policies and exception handling
- Setting runtime environment options

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested 

