### PR TITLE
Add node ip in runtime env error message to improve debug observability

### DIFF
--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -534,7 +534,9 @@ class RuntimeEnvAgent:
                 if successful
                 else runtime_env_agent_pb2.AGENT_RPC_STATUS_FAILED,
                 serialized_runtime_env_context=serialized_context,
-                error_message=f"{self._node_prefix}{error_message}" if not successful else "",
+                error_message=f"{self._node_prefix}{error_message}"
+                if not successful
+                else "",
             )
 
     async def DeleteRuntimeEnvIfPossible(self, request):

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -257,7 +257,8 @@ class RuntimeEnvAgent:
         try:
             self._node_ip = ray.util.get_node_ip_address()
             self._node_prefix = f"[Node {self._node_ip}] "
-        except Exception:
+        except Exception as e:
+            self._logger.warning(f"Failed to get node IP address, using fallback: {e}")
             self._node_prefix = "[Node unknown] "
 
     def uris_parser(self, runtime_env: RuntimeEnv):

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -570,7 +570,7 @@ class RuntimeEnvAgent:
         except Exception as e:
             return runtime_env_agent_pb2.DeleteRuntimeEnvIfPossibleReply(
                 status=runtime_env_agent_pb2.AGENT_RPC_STATUS_FAILED,
-                error_message=f"{self._node_prefix}Fails to decrement reference for runtime env for {str(e)}",
+                error_message=f"{self._node_prefix}Failed to decrement reference for runtime env for {str(e)}",
             )
 
         return runtime_env_agent_pb2.DeleteRuntimeEnvIfPossibleReply(

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -534,7 +534,7 @@ class RuntimeEnvAgent:
                 if successful
                 else runtime_env_agent_pb2.AGENT_RPC_STATUS_FAILED,
                 serialized_runtime_env_context=serialized_context,
-                error_message=f"{self._node_prefix}{error_message}",
+                error_message=f"{self._node_prefix}{error_message}" if not successful else "",
             )
 
     async def DeleteRuntimeEnvIfPossible(self, request):

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -4,14 +4,14 @@ If you need a customized Ray instance (e.g., to change system config or env vars
 put the test in `test_runtime_env_standalone.py`.
 """
 import os
+import re
 import sys
 
 import pytest
 
 import ray
-from ray.runtime_env import RuntimeEnv, RuntimeEnvConfig
 from ray.exceptions import RuntimeEnvSetupError
-import re
+from ray.runtime_env import RuntimeEnv, RuntimeEnvConfig
 
 
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -171,7 +171,6 @@ def test_runtime_env_config(start_cluster_shared):
 
 def test_runtime_env_error_includes_node_ip(shutdown_only):
     """Test that RuntimeEnv errors include node IP information for debugging."""
-    ray.init()
     fast_timeout_config = {"setup_timeout_seconds": 1}
     # Test with invalid pip package to trigger RuntimeEnvSetupError
     @ray.remote(

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -12,6 +12,7 @@ import ray
 from ray.runtime_env import RuntimeEnv, RuntimeEnvConfig
 from ray.exceptions import RuntimeEnvSetupError
 
+
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
 def test_decorator_task(start_cluster_shared, runtime_env_class):
     cluster, address = start_cluster_shared
@@ -180,6 +181,7 @@ def test_runtime_env_error_includes_node_ip(shutdown_only):
     )
     def f():
         return "should not reach here"
+
     # Test pip package error
     with pytest.raises(RuntimeEnvSetupError) as exception_info:
         ray.get(f.remote())

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -11,6 +11,7 @@ import pytest
 import ray
 from ray.runtime_env import RuntimeEnv, RuntimeEnvConfig
 from ray.exceptions import RuntimeEnvSetupError
+import re
 
 
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
@@ -189,12 +190,9 @@ def test_runtime_env_error_includes_node_ip(shutdown_only):
     print(f"Pip error message: {error_message}")
     # Check that error message contains node IP information
     # The format should be like "[Node 192.168.1.100] ..." or "[Node unknown] ..."
-    assert (
-        "[Node " in error_message
-    ), f"Error message should contain node IP: {error_message}"
-    assert (
-        "] " in error_message
-    ), f"Error message should have proper node IP format: {error_message}"
+    assert re.search(
+        r"\[Node ((\d{1,3}\.){3}\d{1,3}|unknown)\] ", error_message
+    ), f"Error message should contain node IP or 'unknown' in proper format: {error_message}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### Problem: 
In multi-node Ray clusters, each node runs a Runtime Env Agent.
When setup errors occur, agents report error messages back to the driver.
Current error messages do not specify which node failed, making debugging in production clusters difficult.

### Solution:
Retrieve node IP from the local context in RuntimeEnvAgent.
Prefix all error messages with the node IP. (Fallback to [Node unknown] if IP detection fails.)
Message format example:
```
[Node 192.168.1.100] Failed to create runtime env: <details...>
[Node unknown] Failed to create runtime env: <details...>   # fallback
```
### Benefits
- Easier debugging of RuntimeEnv failures in distributed environments
- Improved operational visibility for large Ray clusters
- No breaking changes to APIs or user-facing configurations
## Related issue number

Closes #56836

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
