### PR TITLE
[core] fix windows copts on `task_event_buffer`

### DIFF
--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -231,7 +231,10 @@ ray_cc_library(
     name = "task_event_buffer",
     srcs = ["task_event_buffer.cc"],
     hdrs = ["task_event_buffer.h"],
-    copts = ["-Wno-error=deprecated-declarations"],
+    copts = select({
+        "//conditions:default": ["-Wno-error=deprecated-declarations"],
+        "@platforms//os:windows": [],
+    }),
     visibility = [":__subpackages__"],
     deps = [
         "//src/ray/common:asio",


### PR DESCRIPTION
`-W` is not a valid windows copts arg
