### PR TITLE
[runtime env] Integrating Unitrace Profiler into Ray worker process

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -627,6 +627,13 @@ The ``runtime_env`` is a Python dictionary or a Python class :class:`ray.runtime
 
   - Example: ``{"stop-on-exit": "true", "t": "cuda,cublas,cudnn", "ftrace": ""}``
 
+- ``unitrace`` (Union[str, Dict[str, str]]): specifies the config for the unitrace profiler. The value is either (1) "default", which refers to the `default config <https://github.com/ray-project/ray/blob/master/python/ray/_private/runtime_env/unitrace.py#L20>`_, or (2) a dict of unitrace profiler options and their values.
+  See :ref:`here <profiling-unitrace-profiler>` for more details on setup and usage.
+
+  - Example: ``"default"``
+
+  - Example: ``{"chrome-kernel-logging": "", "chrome-call-logging": "", "chrome-ccl-logging": "", "chrome-event-buffer-size": "65536"}``
+
 - ``image_uri`` (dict): Require a given Docker image. The worker process runs in a container with this image.
   - Example: ``{"image_uri": "anyscale/ray:2.31.0-py39-cpu"}``
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -627,8 +627,8 @@ The ``runtime_env`` is a Python dictionary or a Python class :class:`ray.runtime
 
   - Example: ``{"stop-on-exit": "true", "t": "cuda,cublas,cudnn", "ftrace": ""}``
 
-- ``unitrace`` (Union[str, Dict[str, str]]): specifies the config for the unitrace profiler. The value is either (1) "default", which refers to the `default config <https://github.com/ray-project/ray/blob/master/python/ray/_private/runtime_env/unitrace.py#L20>`_, or (2) a dict of unitrace profiler options and their values.
-  See :ref:`here <profiling-unitrace-profiler>` for more details on setup and usage.
+- ``unitrace`` (Union[str, Dict[str, str]]): specifies the config for the unitrace profiler. The value is either (1) "default", which refers to the `unitrace config <https://github.com/ray-project/ray/blob/master/python/ray/_private/runtime_env/unitrace.py#L20>`_, or (2) a dict of unitrace profiler options and their values.
+  See :ref:`unitrace <profiling-unitrace-profiler>` for more details on setup and usage.
 
   - Example: ``"default"``
 

--- a/doc/source/ray-observability/key-concepts.rst
+++ b/doc/source/ray-observability/key-concepts.rst
@@ -77,7 +77,8 @@ Profiling is a way of analyzing the performance of an application by sampling th
 
 - CPU profiling for Driver and Worker processes, including integration with :ref:`py-spy <profiling-pyspy>` and :ref:`cProfile <profiling-cprofile>`
 - Memory profiling for Driver and Worker processes with :ref:`memray <profiling-memray>`
-- GPU profiling with :ref:`Pytorch Profiler <profiling-pytorch-profiler>` and :ref:`Nsight System <profiling-nsight-profiler>`
+- GPU profiling with :ref:`Pytorch Profiler <profiling-pytorch-profiler>`, :ref:`Nsight System <profiling-nsight-profiler>`
+- GPU profiling with :ref:`Unitrace Profiler <profiling-unitrace-profiler>` for Intel(R) GPUs
 - Built in Task and Actor profiling tool called :ref:`Ray Timeline <profiling-timeline>`
 
 View :ref:`Profiling <profiling>` for more details. Note that this list isn't comprehensive and feel free to contribute to it if you find other useful tools.

--- a/doc/source/ray-observability/user-guides/debug-apps/optimize-performance.rst
+++ b/doc/source/ray-observability/user-guides/debug-apps/optimize-performance.rst
@@ -346,9 +346,9 @@ Here are the steps to use PyTorch Profiler during training with Ray Train or bat
 
 * Visualize the results with tools like Tensorboard.
 
-GPU Profiling with Nsight System Profiler
-------------------------------------------
-GPU profiling is critical for ML training and inference. Ray allows users to run Nsight System Profiler with Ray actors and tasks. :ref:`See for details <profiling-nsight-profiler>`.
+GPU Profiling with Nsight System Profiler or Unitrace Profiler
+--------------------------------------------------------------
+GPU profiling is critical for ML training and inference. Ray allows users to run Nsight System Profiler for NVIDIA GPUs and Unitrace Profiler for Intel(R) GPUs with Ray actors and tasks. :ref:`See for details <profiling-nsight-profiler> and <profiling-unitrace-profiler>`.
 
 Profiling for developers
 ------------------------

--- a/doc/source/ray-observability/user-guides/debug-apps/optimize-performance.rst
+++ b/doc/source/ray-observability/user-guides/debug-apps/optimize-performance.rst
@@ -346,9 +346,13 @@ Here are the steps to use PyTorch Profiler during training with Ray Train or bat
 
 * Visualize the results with tools like Tensorboard.
 
-GPU Profiling with Nsight System Profiler or Unitrace Profiler
---------------------------------------------------------------
-GPU profiling is critical for ML training and inference. Ray allows users to run Nsight System Profiler for NVIDIA GPUs and Unitrace Profiler for Intel(R) GPUs with Ray actors and tasks. :ref:`See for details <profiling-nsight-profiler> and <profiling-unitrace-profiler>`.
+GPU Profiling with Nsight System Profiler for NVIDIA GPUs
+---------------------------------------------------------
+GPU profiling is critical for ML training and inference. Ray allows users to run Nsight System Profiler with Ray actors and tasks. :ref:`See for details <profiling-nsight-profiler>`.
+
+GPU Profiling with Unitrace Profiler for Intel(R) GPUs
+------------------------------------------------------
+If you use Intel(R) GPUs, you need Unitrace to profile Ray actors and tasks. :ref:`Here are the details <profiling-unitrace-profiler>`.
 
 Profiling for developers
 ------------------------

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -20,6 +20,7 @@ from ray._private.runtime_env.image_uri import ContainerPlugin
 from ray._private.runtime_env.java_jars import JavaJarsPlugin
 from ray._private.runtime_env.mpi import MPIPlugin
 from ray._private.runtime_env.nsight import NsightPlugin
+from ray._private.runtime_env.unitrace import UnitracePlugin
 from ray._private.runtime_env.pip import PipPlugin
 from ray._private.runtime_env.plugin import (
     RuntimeEnvPlugin,
@@ -219,6 +220,7 @@ class RuntimeEnvAgent:
         # and unify with nsight and other profilers.
         self._nsight_plugin = NsightPlugin(self._runtime_env_dir)
         self._rocprof_sys_plugin = RocProfSysPlugin(self._runtime_env_dir)
+        self._unitrace_plugin = UnitracePlugin(self._runtime_env_dir)
         self._mpi_plugin = MPIPlugin()
         self._image_uri_plugin = get_image_uri_plugin_cls()(temp_dir)
 
@@ -236,6 +238,7 @@ class RuntimeEnvAgent:
             self._container_plugin,
             self._nsight_plugin,
             self._rocprof_sys_plugin,
+            self._unitrace_plugin,
             self._mpi_plugin,
             self._image_uri_plugin,
         ]

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -20,7 +20,6 @@ from ray._private.runtime_env.image_uri import ContainerPlugin
 from ray._private.runtime_env.java_jars import JavaJarsPlugin
 from ray._private.runtime_env.mpi import MPIPlugin
 from ray._private.runtime_env.nsight import NsightPlugin
-from ray._private.runtime_env.unitrace import UnitracePlugin
 from ray._private.runtime_env.pip import PipPlugin
 from ray._private.runtime_env.plugin import (
     RuntimeEnvPlugin,
@@ -30,6 +29,7 @@ from ray._private.runtime_env.plugin import (
 from ray._private.runtime_env.py_executable import PyExecutablePlugin
 from ray._private.runtime_env.py_modules import PyModulesPlugin
 from ray._private.runtime_env.rocprof_sys import RocProfSysPlugin
+from ray._private.runtime_env.unitrace import UnitracePlugin
 from ray._private.runtime_env.uv import UvPlugin
 from ray._private.runtime_env.working_dir import WorkingDirPlugin
 from ray._raylet import GcsClient

--- a/python/ray/_private/runtime_env/unitrace.py
+++ b/python/ray/_private/runtime_env/unitrace.py
@@ -1,0 +1,127 @@
+import asyncio
+import copy
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from ray._common.utils import (
+    try_to_create_directory,
+)
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray.exceptions import RuntimeEnvSetupError
+
+default_logger = logging.getLogger(__name__)
+
+# unitrace options used when runtime_env={"_unitrace": "default"}
+UNITRACE_DEFAULT_CONFIG = {
+    "chrome-kernel-logging": "",
+    "teardown-on-signal": "0",
+}
+
+def parse_unitrace_config(unitrace_config: Dict[str, str]) -> List[str]:
+    """
+    Function to convert dictionary of unitrace options into
+    unitrace command line
+
+    The function returns:
+    - List[str]: unitrace profile cmd line split into list of str
+    """
+    unitrace_cmd = ["unitrace"]
+
+    for option, option_val in unitrace_config.items():
+        # option standard based on
+        # https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+        if len(option) > 1:
+            unitrace_cmd.append(f"--{option}")
+        else:
+            unitrace_cmd.append(f"-{option}")
+
+        if (len(option_val) > 0):
+            unitrace_cmd.append(f"{option_val}")
+
+    return unitrace_cmd
+
+
+class UnitracePlugin(RuntimeEnvPlugin):
+    name = "_unitrace"
+
+    def __init__(self, resources_dir: str):
+        self.unitrace_cmd = []
+
+    async def _check_unitrace_script(
+        self, unitrace_config: Dict[str, str]
+    ) -> Tuple[bool, str]:
+        """
+        Function to validate if unitrace_config is a valid unitrace profile options
+        Args:
+            unitrace_config: dictionary mapping unitrace option to it's value
+        Returns:
+            a tuple consists of a boolean indicating if the unitrace_config
+            is valid option and an error message if the unitrace_config is invalid
+        """
+
+        unitrace_cmd = ["unitrace"]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *unitrace_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = await process.communicate()
+            error_msg = stderr.strip() if stderr.strip() != "" else stdout.strip()
+
+            if (process.returncode == 0):
+                if (isinstance(stdout, bytes) and ("--chrome-kernel-logging" in stdout.decode())):
+                    return True, None
+                else:
+                    return True, ("wrong unitrace installed")
+            else:
+                return False, error_msg
+        except FileNotFoundError:
+            return False, ("unitrace is not installed")
+
+    async def create(
+        self,
+        uri: Optional[str],
+        runtime_env: "RuntimeEnv",  # noqa: F821
+        context: RuntimeEnvContext,
+        logger: logging.Logger = default_logger,
+    ) -> int:
+        unitrace_config = runtime_env.unitrace()
+        if not unitrace_config:
+            return 0
+
+        if isinstance(unitrace_config, str):
+            if unitrace_config == "default":
+                unitrace_config = UNITRACE_DEFAULT_CONFIG
+            else:
+                raise RuntimeEnvSetupError(
+                    f"Unsupported unitrace config: {unitrace_config}. "
+                    "The supported config is 'default' or "
+                    "Dictionary of unitrace options"
+                )
+
+        is_valid_unitrace_cmd, error_msg = await self._check_unitrace_script(unitrace_config)
+        if not is_valid_unitrace_cmd:
+            logger.warning(error_msg)
+            raise RuntimeEnvSetupError(
+                "unitrace profile failed to run with the following "
+                f"error message:\n {error_msg}"
+            )
+
+        self.unitrace_cmd = parse_unitrace_config(unitrace_config)
+        return 0
+
+    def modify_context(
+        self,
+        uris: List[str],
+        runtime_env: "RuntimeEnv",  # noqa: F821
+        context: RuntimeEnvContext,
+        logger: Optional[logging.Logger] = default_logger,
+    ):
+        logger.info("Running unitrace profiler")
+        context.py_executable = " ".join(self.unitrace_cmd) + " python"

--- a/python/ray/_private/runtime_env/unitrace.py
+++ b/python/ray/_private/runtime_env/unitrace.py
@@ -9,7 +9,7 @@ from ray.exceptions import RuntimeEnvSetupError
 
 default_logger = logging.getLogger(__name__)
 
-# unitrace options used when runtime_env={"unitrace": "default"}
+# unitrace options used when runtime_env={"_unitrace": "default"}
 UNITRACE_DEFAULT_CONFIG = {
     "chrome-kernel-logging": "",
     "teardown-on-signal": "0",
@@ -41,7 +41,7 @@ def parse_unitrace_config(unitrace_config: Dict[str, str]) -> List[str]:
 
 
 class UnitracePlugin(RuntimeEnvPlugin):
-    name = "unitrace"
+    name = "_unitrace"
 
     def __init__(self, resources_dir: str):
         self.unitrace_cmd = []

--- a/python/ray/_private/runtime_env/unitrace.py
+++ b/python/ray/_private/runtime_env/unitrace.py
@@ -16,7 +16,7 @@ from ray.exceptions import RuntimeEnvSetupError
 
 default_logger = logging.getLogger(__name__)
 
-# unitrace options used when runtime_env={"_unitrace": "default"}
+# unitrace options used when runtime_env={"unitrace": "default"}
 UNITRACE_DEFAULT_CONFIG = {
     "chrome-kernel-logging": "",
     "teardown-on-signal": "0",
@@ -47,7 +47,7 @@ def parse_unitrace_config(unitrace_config: Dict[str, str]) -> List[str]:
 
 
 class UnitracePlugin(RuntimeEnvPlugin):
-    name = "_unitrace"
+    name = "unitrace"
 
     def __init__(self, resources_dir: str):
         self.unitrace_cmd = []

--- a/python/ray/_private/runtime_env/unitrace.py
+++ b/python/ray/_private/runtime_env/unitrace.py
@@ -1,15 +1,8 @@
 import asyncio
-import copy
 import logging
-import os
 import subprocess
-import sys
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from ray._common.utils import (
-    try_to_create_directory,
-)
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray.exceptions import RuntimeEnvSetupError
@@ -21,6 +14,7 @@ UNITRACE_DEFAULT_CONFIG = {
     "chrome-kernel-logging": "",
     "teardown-on-signal": "0",
 }
+
 
 def parse_unitrace_config(unitrace_config: Dict[str, str]) -> List[str]:
     """
@@ -40,7 +34,7 @@ def parse_unitrace_config(unitrace_config: Dict[str, str]) -> List[str]:
         else:
             unitrace_cmd.append(f"-{option}")
 
-        if (len(option_val) > 0):
+        if len(option_val) > 0:
             unitrace_cmd.append(f"{option_val}")
 
     return unitrace_cmd
@@ -74,8 +68,10 @@ class UnitracePlugin(RuntimeEnvPlugin):
             stdout, stderr = await process.communicate()
             error_msg = stderr.strip() if stderr.strip() != "" else stdout.strip()
 
-            if (process.returncode == 0):
-                if (isinstance(stdout, bytes) and ("--chrome-kernel-logging" in stdout.decode())):
+            if process.returncode == 0:
+                if isinstance(stdout, bytes) and (
+                     "--chrome-kernel-logging" in stdout.decode()
+                ):
                     return True, None
                 else:
                     return True, ("wrong unitrace installed")
@@ -105,7 +101,9 @@ class UnitracePlugin(RuntimeEnvPlugin):
                     "Dictionary of unitrace options"
                 )
 
-        is_valid_unitrace_cmd, error_msg = await self._check_unitrace_script(unitrace_config)
+        is_valid_unitrace_cmd, error_msg = await self._check_unitrace_script(
+            unitrace_config
+        )
         if not is_valid_unitrace_cmd:
             logger.warning(error_msg)
             raise RuntimeEnvSetupError(

--- a/python/ray/_private/runtime_env/unitrace.py
+++ b/python/ray/_private/runtime_env/unitrace.py
@@ -70,7 +70,7 @@ class UnitracePlugin(RuntimeEnvPlugin):
 
             if process.returncode == 0:
                 if isinstance(stdout, bytes) and (
-                     "--chrome-kernel-logging" in stdout.decode()
+                    "--chrome-kernel-logging" in stdout.decode()
                 ):
                     return True, None
                 else:

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -104,8 +104,8 @@ class RemoteFunction:
 
         # When gpu is used, set the task non-recyclable by default.
         # https://github.com/ray-project/ray/issues/29624 for more context.
-        # Note: Ray task worker process is not being reused when nsight
-        # profiler is running, as nsight/rocprof-sys generate report
+        # Note: Ray task worker process is not being reused when nsight/rocprof-sys/unitrace
+        # profiler is running, as nsight/rocprof-sys/unitrace generates report
         # once the process exit.
         num_gpus = self._default_options.get("num_gpus") or 0
         if (
@@ -113,7 +113,7 @@ class RemoteFunction:
         ) or any(
             [
                 s in (self._default_options.get(s) or {})
-                for s in ["nsight", "rocprof-sys"]
+                for s in ["nsight", "rocprof-sys", "unitrace"]
             ]
         ):
             self._default_options["max_calls"] = 1

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -112,7 +112,7 @@ class RemoteFunction:
             num_gpus > 0 and self._default_options.get("max_calls", None) is None
         ) or any(
             [
-                s in (self._default_options.get(s) or {})
+                s in (self._default_options.get("runtime_env") or {})
                 for s in ["nsight", "rocprof-sys", "unitrace"]
             ]
         ):

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -274,6 +274,7 @@ class RuntimeEnv(dict):
         nsight: Dictionary mapping nsight profile option name to it's value.
         rocprof_sys: Dictionary mapping rocprof-sys profile option name and environment
                    variables to it's value.
+        unitrace: Dictionary mapping unitrace option name to its value.
         config: config for runtime environment. Either
             a dict or a RuntimeEnvConfig. Field: (1) setup_timeout_seconds, the
             timeout of runtime environment creation,  timeout is in seconds.
@@ -300,6 +301,7 @@ class RuntimeEnv(dict):
         "worker_process_setup_hook",
         "_nsight",
         "_rocprof_sys",
+        "_unitrace",
         "mpi",
         "image_uri",
     }
@@ -323,6 +325,7 @@ class RuntimeEnv(dict):
         worker_process_setup_hook: Optional[Union[Callable, str]] = None,
         nsight: Optional[Union[str, Dict[str, str]]] = None,
         rocprof_sys: Optional[Union[str, Dict[str, Dict[str, str]]]] = None,
+        unitrace: Optional[Union[str, Dict[str, str]]] = None,
         config: Optional[Union[Dict, RuntimeEnvConfig]] = None,
         _validate: bool = True,
         mpi: Optional[Dict] = None,
@@ -349,6 +352,8 @@ class RuntimeEnv(dict):
             runtime_env["_nsight"] = nsight
         if rocprof_sys is not None:
             runtime_env["_rocprof_sys"] = rocprof_sys
+        if unitrace is not None:
+            runtime_env["_unitrace"] = unitrace
         if container is not None:
             runtime_env["container"] = container
         if env_vars is not None:
@@ -537,6 +542,9 @@ class RuntimeEnv(dict):
 
     def rocprof_sys(self) -> Optional[Union[str, Dict[str, Dict[str, str]]]]:
         return self.get("_rocprof_sys", None)
+
+    def unitrace(self) -> Optional[Union[str, Dict[str, str]]]:
+        return self.get("_unitrace", None)
 
     def env_vars(self) -> Dict:
         return self.get("env_vars", {})

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -301,7 +301,7 @@ class RuntimeEnv(dict):
         "worker_process_setup_hook",
         "_nsight",
         "_rocprof_sys",
-        "_unitrace",
+        "unitrace",
         "mpi",
         "image_uri",
     }
@@ -353,7 +353,7 @@ class RuntimeEnv(dict):
         if rocprof_sys is not None:
             runtime_env["_rocprof_sys"] = rocprof_sys
         if unitrace is not None:
-            runtime_env["_unitrace"] = unitrace
+            runtime_env["unitrace"] = unitrace
         if container is not None:
             runtime_env["container"] = container
         if env_vars is not None:
@@ -544,7 +544,7 @@ class RuntimeEnv(dict):
         return self.get("_rocprof_sys", None)
 
     def unitrace(self) -> Optional[Union[str, Dict[str, str]]]:
-        return self.get("_unitrace", None)
+        return self.get("unitrace", None)
 
     def env_vars(self) -> Dict:
         return self.get("env_vars", {})

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -301,7 +301,7 @@ class RuntimeEnv(dict):
         "worker_process_setup_hook",
         "_nsight",
         "_rocprof_sys",
-        "unitrace",
+        "_unitrace",
         "mpi",
         "image_uri",
     }
@@ -353,7 +353,7 @@ class RuntimeEnv(dict):
         if rocprof_sys is not None:
             runtime_env["_rocprof_sys"] = rocprof_sys
         if unitrace is not None:
-            runtime_env["unitrace"] = unitrace
+            runtime_env["_unitrace"] = unitrace
         if container is not None:
             runtime_env["container"] = container
         if env_vars is not None:
@@ -544,7 +544,7 @@ class RuntimeEnv(dict):
         return self.get("_rocprof_sys", None)
 
     def unitrace(self) -> Optional[Union[str, Dict[str, str]]]:
-        return self.get("unitrace", None)
+        return self.get("_unitrace", None)
 
     def env_vars(self) -> Dict:
         return self.get("env_vars", {})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The unitrace (https://github.com/intel/pti-gpu/tree/master/tools/unitrace) is a profiling tool for Intel(R) GPUs.

Currently the Ray worker process can not be profiled on Intel(R) GPU,

This PR integrates unitrace with Ray using runtime_env similar to Nsight (https://github.com/ray-project/ray/pull/39998). We add unitrace to runtime_env to run the worker process with unitrace. The result produced by unitrace once the worker process exists can be visualized in Perfetto.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
