### PR TITLE
[Data] Callback-based stat computation for preprocessors and ValueCounter

### DIFF
--- a/doc/source/data/api/aggregate.rst
+++ b/doc/source/data/api/aggregate.rst
@@ -25,6 +25,7 @@ compute aggregations.
     AbsMax
     Quantile
     Unique
+    ValueCounter
     MissingValuePercentage
     ZeroPercentage
     ApproximateQuantile

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -530,10 +530,38 @@ class ArrowBlockColumnAccessor(BlockColumnAccessor):
 
         return pac.unique(self._column)
 
+    def value_counts(self) -> Optional[Dict[str, List]]:
+        import pyarrow.compute as pac
+
+        value_counts: pyarrow.StructArray = pac.value_counts(self._column)
+        if len(value_counts) == 0:
+            return None
+        return {
+            "values": value_counts.field("values").to_pylist(),
+            "counts": value_counts.field("counts").to_pylist(),
+        }
+
+    def hash(self) -> BlockColumn:
+        import polars as pl
+
+        df = pl.DataFrame({"col": self._column})
+        hashes = df.hash_rows().cast(pl.Int64, wrap_numerical=True)
+        return hashes.to_arrow()
+
     def flatten(self) -> BlockColumn:
         import pyarrow.compute as pac
 
         return pac.list_flatten(self._column)
+
+    def dropna(self) -> BlockColumn:
+        import pyarrow.compute as pac
+
+        return pac.drop_null(self._column)
+
+    def is_composed_of_lists(self, types: Optional[Tuple] = None) -> bool:
+        if not types:
+            types = (pyarrow.lib.ListType, pyarrow.lib.LargeListType)
+        return isinstance(self._column.type, types)
 
     def to_pylist(self) -> List[Any]:
         return self._column.to_pylist()

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -174,8 +174,33 @@ class PandasBlockColumnAccessor(BlockColumnAccessor):
     ) -> Optional[U]:
         return self._column.quantile(q=q)
 
+    def value_counts(self) -> Optional[Dict[str, List]]:
+        value_counts = self._column.value_counts()
+        if len(value_counts) == 0:
+            return None
+        return {
+            "values": value_counts.index.tolist(),
+            "counts": value_counts.values.tolist(),
+        }
+
+    def hash(self) -> BlockColumn:
+
+        from ray.air.util.tensor_extensions.pandas import TensorArrayElement
+
+        first_non_null = next((x for x in self._column if x is not None), None)
+        if isinstance(first_non_null, TensorArrayElement):
+            self._column = self._column.apply(lambda x: x.to_numpy())
+
+        import polars as pl
+
+        df = pl.from_pandas(self._column.to_frame())
+        hashes = df.hash_rows().cast(pl.Int64, wrap_numerical=True)
+        return hashes.to_pandas()
+
     def unique(self) -> BlockColumn:
+
         pd = lazy_import_pandas()
+
         try:
             return pd.Series(self._column.unique())
         except ValueError as e:
@@ -187,7 +212,18 @@ class PandasBlockColumnAccessor(BlockColumnAccessor):
                 raise
 
     def flatten(self) -> BlockColumn:
-        return self._column.list.flatten()
+        from ray.air.util.tensor_extensions.pandas import TensorArrayElement
+
+        first_non_null = next((x for x in self._column if x is not None), None)
+        if isinstance(first_non_null, TensorArrayElement):
+            self._column = self._column.apply(
+                lambda x: x.to_numpy() if isinstance(x, TensorArrayElement) else x
+            )
+
+        return self._column.explode(ignore_index=True)
+
+    def dropna(self) -> BlockColumn:
+        return self._column.dropna()
 
     def sum_of_squared_diffs_from_mean(
         self,
@@ -218,6 +254,14 @@ class PandasBlockColumnAccessor(BlockColumnAccessor):
 
     def _is_all_null(self):
         return not self._column.notna().any()
+
+    def is_composed_of_lists(self, types: Optional[Tuple] = None) -> bool:
+        from ray.air.util.tensor_extensions.pandas import TensorArrayElement
+
+        if not types:
+            types = (list, np.ndarray, TensorArrayElement)
+        first_non_null = next((x for x in self._column if x is not None), None)
+        return isinstance(first_non_null, types)
 
 
 class PandasBlockBuilder(TableBlockBuilder):

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -889,7 +889,7 @@ class Unique(AggregateFnV2):
             return {x}
 
 
-@PublicAPI(stability="beta")
+@PublicAPI
 class ValueCounter(AggregateFnV2):
     """Counts the number of times each value appears in a column.
 

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1,6 +1,6 @@
 import abc
 import math
-from typing import TYPE_CHECKING, Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import numpy as np
 import pyarrow.compute as pc
@@ -887,6 +887,50 @@ class Unique(AggregateFnV2):
             return set(x)
         else:
             return {x}
+
+
+class ValueCounter(AggregateFnV2):
+    """Counts the number of times each value appears in a column."""
+
+    def __init__(
+        self,
+        on: str,
+        alias_name: Optional[str] = None,
+    ):
+        super().__init__(
+            alias_name if alias_name else f"value_counter({str(on)})",
+            on=on,
+            ignore_nulls=True,
+            zero_factory=lambda: {},
+        )
+
+    def aggregate_block(self, block: Block) -> Dict[str, List]:
+
+        col_accessor = BlockColumnAccessor.for_column(block[self._target_col_name])
+        return col_accessor.value_counts()
+
+    def combine(
+        self,
+        current_accumulator: Dict[str, List],
+        new_accumulator: Dict[str, List],
+    ) -> Dict[str, List]:
+
+        values = current_accumulator["values"]
+        counts = current_accumulator["counts"]
+
+        # Build a value → index map once (avoid repeated lookups)
+        value_to_index = {v: i for i, v in enumerate(values)}
+
+        for v_new, c_new in zip(new_accumulator["values"], new_accumulator["counts"]):
+            if v_new in value_to_index:
+                idx = value_to_index[v_new]
+                counts[idx] += c_new
+            else:
+                value_to_index[v_new] = len(values)
+                values.append(v_new)
+                counts.append(c_new)
+
+        return current_accumulator
 
 
 def _null_safe_zero_factory(zero_factory, ignore_nulls: bool):

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -889,6 +889,7 @@ class Unique(AggregateFnV2):
             return {x}
 
 
+@PublicAPI(stability="beta")
 class ValueCounter(AggregateFnV2):
     """Counts the number of times each value appears in a column."""
 

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -901,7 +901,7 @@ class ValueCounter(AggregateFnV2):
             alias_name if alias_name else f"value_counter({str(on)})",
             on=on,
             ignore_nulls=True,
-            zero_factory=lambda: {},
+            zero_factory=lambda: {"values": [], "counts": []},
         )
 
     def aggregate_block(self, block: Block) -> Dict[str, List]:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -685,9 +685,42 @@ class BlockColumnAccessor:
         """Returns new column holding only distinct values of the current one"""
         raise NotImplementedError()
 
+    def value_counts(self) -> Dict[str, List]:
+        raise NotImplementedError()
+
+    def hash(self) -> BlockColumn:
+        """
+        Computes a 64-bit hash value for each row in the column.
+
+        Provides a unified hashing method across supported backends.
+        Handles complex types like lists or nested structures by producing a single hash per row.
+        These hashes are useful for downstream operations such as deduplication, grouping, or partitioning.
+
+        Internally, Polars is used to compute row-level hashes even when the original column
+        is backed by Pandas or PyArrow.
+
+        :return: A column of 64-bit integer hashes, returned in the same format as the underlying backend
+             (e.g., Pandas Series or PyArrow Array).
+        """
+        raise NotImplementedError()
+
     def flatten(self) -> BlockColumn:
         """Flattens nested lists merging them into top-level container"""
 
+        raise NotImplementedError()
+
+    def dropna(self) -> BlockColumn:
+        raise NotImplementedError()
+
+    def is_composed_of_lists(self, types: Optional[Tuple] = None) -> bool:
+        """
+        Checks whether the column is composed of list-like elements.
+
+        :param types: Optional tuple of backend-specific types to check against.
+                      If not provided, defaults to list-like types appropriate
+                      for the underlying backend (e.g., PyArrow list types).
+        :return: True if the column is made up of list-like values; False otherwise.
+        """
         raise NotImplementedError()
 
     def sum_of_squared_diffs_from_mean(

--- a/python/ray/data/preprocessors/chain.py
+++ b/python/ray/data/preprocessors/chain.py
@@ -66,6 +66,7 @@ class Chain(Preprocessor):
             return Preprocessor.FitStatus.NOT_FITTABLE
 
     def __init__(self, *preprocessors: Preprocessor):
+        super().__init__()
         self.preprocessors = preprocessors
 
     def _fit(self, ds: "Dataset") -> Preprocessor:

--- a/python/ray/data/preprocessors/discretizer.py
+++ b/python/ray/data/preprocessors/discretizer.py
@@ -342,24 +342,25 @@ class UniformKBinsDiscretizer(_AbstractKBinsDiscretizer):
         self.stats_ = post_fit_processor(stats, self.bins, self.right)
         return self
 
-    def post_fit_processor(aggregate_stats: dict, bins: Union[str, Dict], right: bool):
-        mins, maxes, stats = {}, {}, {}
-        for key, value in aggregate_stats.items():
-            column_name = key[4:-1]  # min(column) -> column
-            if key.startswith("min"):
-                mins[column_name] = value
-            if key.startswith("max"):
-                maxes[column_name] = value
 
-        for column in mins.keys():
-            stats[column] = _translate_min_max_number_of_bins_to_bin_edges(
-                mn=mins[column],
-                mx=maxes[column],
-                bins=bins[column] if isinstance(bins, dict) else bins,
-                right=right,
-            )
+def post_fit_processor(aggregate_stats: dict, bins: Union[str, Dict], right: bool):
+    mins, maxes, stats = {}, {}, {}
+    for key, value in aggregate_stats.items():
+        column_name = key[4:-1]  # min(column) -> column
+        if key.startswith("min"):
+            mins[column_name] = value
+        if key.startswith("max"):
+            maxes[column_name] = value
 
-        return stats
+    for column in mins.keys():
+        stats[column] = _translate_min_max_number_of_bins_to_bin_edges(
+            mn=mins[column],
+            mx=maxes[column],
+            bins=bins[column] if isinstance(bins, dict) else bins,
+            right=right,
+        )
+
+    return stats
 
 
 # Copied from

--- a/python/ray/data/preprocessors/discretizer.py
+++ b/python/ray/data/preprocessors/discretizer.py
@@ -297,6 +297,7 @@ class UniformKBinsDiscretizer(_AbstractKBinsDiscretizer):
         ] = None,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.bins = bins
         self.right = right
@@ -309,21 +310,40 @@ class UniformKBinsDiscretizer(_AbstractKBinsDiscretizer):
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
         self._validate_on_fit()
-        stats = {}
-        aggregates = []
+
         if isinstance(self.bins, dict):
             columns = self.bins.keys()
         else:
             columns = self.columns
 
         for column in columns:
-            aggregates.extend(
-                self._fit_uniform_covert_bin_to_aggregate_if_needed(column)
-            )
+            bins = self.bins[column] if isinstance(self.bins, dict) else self.bins
+            if not isinstance(bins, int):
+                raise TypeError(
+                    f"`bins` must be an integer or a dict of integers, got {bins}"
+                )
 
-        aggregate_stats = dataset.aggregate(*aggregates)
-        mins = {}
-        maxes = {}
+        self.stat_computation_plan.add_aggregator(
+            aggregator_fn=Min,
+            columns=columns,
+        )
+        self.stat_computation_plan.add_aggregator(
+            aggregator_fn=Max,
+            columns=columns,
+        )
+
+        return self
+
+    def _validate_on_fit(self):
+        self._validate_bins_columns()
+
+    def _fit_execute(self, dataset: "Dataset"):
+        stats = self.stat_computation_plan.compute(dataset)
+        self.stats_ = post_fit_processor(stats, self.bins, self.right)
+        return self
+
+    def post_fit_processor(aggregate_stats: dict, bins: Union[str, Dict], right: bool):
+        mins, maxes, stats = {}, {}, {}
         for key, value in aggregate_stats.items():
             column_name = key[4:-1]  # min(column) -> column
             if key.startswith("min"):
@@ -332,25 +352,14 @@ class UniformKBinsDiscretizer(_AbstractKBinsDiscretizer):
                 maxes[column_name] = value
 
         for column in mins.keys():
-            bins = self.bins[column] if isinstance(self.bins, dict) else self.bins
             stats[column] = _translate_min_max_number_of_bins_to_bin_edges(
-                mins[column], maxes[column], bins, self.right
+                mn=mins[column],
+                mx=maxes[column],
+                bins=bins[column] if isinstance(bins, dict) else bins,
+                right=right,
             )
 
-        self.stats_ = stats
-        return self
-
-    def _validate_on_fit(self):
-        self._validate_bins_columns()
-
-    def _fit_uniform_covert_bin_to_aggregate_if_needed(self, column: str):
-        bins = self.bins[column] if isinstance(self.bins, dict) else self.bins
-        if isinstance(bins, int):
-            return (Min(column), Max(column))
-        else:
-            raise TypeError(
-                f"`bins` must be an integer or a dict of integers, got {bins}"
-            )
+        return stats
 
 
 # Copied from

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -1,6 +1,6 @@
-from collections import Counter, OrderedDict
+from collections import Counter
 from functools import partial
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, List, Optional, Set
 
 import numpy as np
 import pandas as pd
@@ -8,6 +8,7 @@ import pandas.api.types
 
 from ray.air.util.data_batch_conversion import BatchFormat
 from ray.data.preprocessor import Preprocessor, PreprocessorNotFittedException
+from ray.data.preprocessors.utils import make_post_processor
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
@@ -108,6 +109,7 @@ class OrdinalEncoder(Preprocessor):
         encode_lists: bool = True,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         # TODO: allow user to specify order of values within each column.
         self.columns = columns
         self.encode_lists = encode_lists
@@ -116,8 +118,17 @@ class OrdinalEncoder(Preprocessor):
         )
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self.stats_ = _get_unique_value_indices(
-            dataset, self.columns, encode_lists=self.encode_lists
+        self.stat_computation_plan.add_callable_stat(
+            stat_fn=lambda key_gen: compute_unique_value_indices(
+                dataset=dataset,
+                columns=self.columns,
+                encode_lists=self.encode_lists,
+                key_gen=key_gen,
+            ),
+            post_process_fn=unique_post_fn(),
+            stat_key_fn=lambda col: f"unique({col})",
+            post_key_fn=lambda col: f"unique_values({col})",
+            columns=self.columns,
         )
         return self
 
@@ -132,11 +143,9 @@ class OrdinalEncoder(Preprocessor):
                 if self.encode_lists:
                     return s.map(partial(encode_list, name=s.name))
 
-                # cannot simply use map here due to pandas thinking
-                # tuples are to be used for indices
                 def list_as_category(element):
-                    element = tuple(element)
-                    return self.stats_[f"unique_values({s.name})"].get(element)
+                    key = tuple(element)
+                    return self.stats_[f"unique_values({s.name})"].get(key)
 
                 return s.apply(list_as_category)
 
@@ -252,43 +261,48 @@ class OneHotEncoder(Preprocessor):
         max_categories: Optional[Dict[str, int]] = None,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         # TODO: add `drop` parameter.
         self.columns = columns
-        self.max_categories = max_categories
+        self.max_categories = max_categories or {}
         self.output_columns = Preprocessor._derive_and_validate_output_columns(
             columns, output_columns
         )
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self.stats_ = _get_unique_value_indices(
-            dataset,
-            self.columns,
-            max_categories=self.max_categories,
-            encode_lists=False,
+        self.stat_computation_plan.add_callable_stat(
+            stat_fn=lambda key_gen: compute_unique_value_indices(
+                dataset=dataset,
+                columns=self.columns,
+                encode_lists=False,
+                key_gen=key_gen,
+                max_categories=self.max_categories,
+            ),
+            post_process_fn=unique_post_fn(),
+            stat_key_fn=lambda col: f"unique({col})",
+            post_key_fn=lambda col: f"unique_values({col})",
+            columns=self.columns,
         )
         return self
+
+    def safe_get(self, v: Any, stats: Dict[str, int]):
+        if isinstance(v, (list, np.ndarray)):
+            v = tuple(v)
+        if isinstance(v, Hashable):
+            return stats.get(v, -1)
+        else:
+            return -1  # Unhashable type treated as a missing category
 
     def _transform_pandas(self, df: pd.DataFrame):
         _validate_df(df, *self.columns)
 
-        def safe_get(v: Any, stats: Dict[str, int]):
-            from collections.abc import Hashable
-
-            if isinstance(v, Hashable):
-                return stats.get(v, -1)
-            else:
-                return -1  # Unhashable type treated as a missing category
-
         # Compute new one-hot encoded columns
         for column, output_column in zip(self.columns, self.output_columns):
-            if _is_series_composed_of_lists(df[column]):
-                df[column] = df[column].map(tuple)
-
             stats = self.stats_[f"unique_values({column})"]
             num_categories = len(stats)
             one_hot = np.zeros((len(df), num_categories), dtype=np.uint8)
             # Integer indices for each category in the column
-            codes = df[column].apply(lambda v: safe_get(v, stats)).to_numpy()
+            codes = df[column].apply(lambda v: self.safe_get(v, stats)).to_numpy()
             # Filter to only the rows that have a valid category
             valid_category_mask = codes != -1
             # Dimension should be (num_rows, ) - 1D boolean array
@@ -399,19 +413,27 @@ class MultiHotEncoder(Preprocessor):
         max_categories: Optional[Dict[str, int]] = None,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         # TODO: add `drop` parameter.
         self.columns = columns
-        self.max_categories = max_categories
+        self.max_categories = max_categories or {}
         self.output_columns = Preprocessor._derive_and_validate_output_columns(
             columns, output_columns
         )
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self.stats_ = _get_unique_value_indices(
-            dataset,
-            self.columns,
-            max_categories=self.max_categories,
-            encode_lists=True,
+        self.stat_computation_plan.add_callable_stat(
+            stat_fn=lambda key_gen: compute_unique_value_indices(
+                dataset=dataset,
+                columns=self.columns,
+                encode_lists=True,
+                key_gen=key_gen,
+                max_categories=self.max_categories,
+            ),
+            post_process_fn=unique_post_fn(),
+            stat_key_fn=lambda col: f"unique({col})",
+            post_key_fn=lambda col: f"unique_values({col})",
+            columns=self.columns,
         )
         return self
 
@@ -507,11 +529,22 @@ class LabelEncoder(Preprocessor):
     """
 
     def __init__(self, label_column: str, *, output_column: Optional[str] = None):
+        super().__init__()
         self.label_column = label_column
         self.output_column = output_column or label_column
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self.stats_ = _get_unique_value_indices(dataset, [self.label_column])
+        self.stat_computation_plan.add_callable_stat(
+            stat_fn=lambda key_gen: compute_unique_value_indices(
+                dataset=dataset,
+                columns=[self.label_column],
+                key_gen=key_gen,
+            ),
+            post_process_fn=unique_post_fn(),
+            stat_key_fn=lambda col: f"unique({col})",
+            post_key_fn=lambda col: f"unique_values({col})",
+            columns=[self.label_column],
+        )
         return self
 
     def _transform_pandas(self, df: pd.DataFrame):
@@ -637,6 +670,7 @@ class Categorizer(Preprocessor):
         dtypes: Optional[Dict[str, pd.CategoricalDtype]] = None,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         if not dtypes:
             dtypes = {}
 
@@ -648,20 +682,29 @@ class Categorizer(Preprocessor):
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
         columns_to_get = [
-            column for column in self.columns if column not in set(self.dtypes)
+            column for column in self.columns if column not in self.dtypes
         ]
-        if columns_to_get:
-            unique_indices = _get_unique_value_indices(
-                dataset, columns_to_get, drop_na_values=True, key_format="{0}"
-            )
-            unique_indices = {
-                column: pd.CategoricalDtype(values_indices.keys())
-                for column, values_indices in unique_indices.items()
-            }
-        else:
-            unique_indices = {}
-        unique_indices = {**self.dtypes, **unique_indices}
-        self.stats_: Dict[str, pd.CategoricalDtype] = unique_indices
+        self.stats_ |= self.dtypes
+        if not columns_to_get:
+            return self
+
+        def callback(unique_indices: Dict[str, Dict]) -> pd.CategoricalDtype:
+            return pd.CategoricalDtype(unique_indices.keys())
+
+        self.stat_computation_plan.add_callable_stat(
+            stat_fn=lambda key_gen: compute_unique_value_indices(
+                dataset=dataset,
+                columns=columns_to_get,
+                key_gen=key_gen,
+            ),
+            post_process_fn=make_post_processor(
+                base_fn=unique_post_fn(drop_na_values=True),
+                callbacks=[callback],
+            ),
+            stat_key_fn=lambda col: f"unique({col})",
+            post_key_fn=lambda col: col,
+            columns=columns_to_get,
+        )
         return self
 
     def _transform_pandas(self, df: pd.DataFrame):
@@ -675,16 +718,14 @@ class Categorizer(Preprocessor):
         )
 
 
-def _get_unique_value_indices(
+def compute_unique_value_indices(
+    *,
     dataset: "Dataset",
     columns: List[str],
-    drop_na_values: bool = False,
-    key_format: str = "unique_values({0})",
-    max_categories: Optional[Dict[str, int]] = None,
+    key_gen: Callable,
     encode_lists: bool = True,
-) -> Dict[str, Dict[str, int]]:
-    """If drop_na_values is True, will silently drop NA values."""
-
+    max_categories: Optional[Dict[str, int]] = None,
+):
     if max_categories is None:
         max_categories = {}
     columns_set = set(columns)
@@ -695,7 +736,7 @@ def _get_unique_value_indices(
                 f"{columns}."
             )
 
-    def get_pd_value_counts_per_column(col: pd.Series):
+    def get_pd_value_counts_per_column(col: pd.Series) -> Dict:
         # special handling for lists
         if _is_series_composed_of_lists(col):
             if encode_lists:
@@ -712,7 +753,8 @@ def _get_unique_value_indices(
                 col = col.map(lambda x: tuple(x))
         return Counter(col.value_counts(dropna=False).to_dict())
 
-    def get_pd_value_counts(df: pd.DataFrame) -> List[Dict[str, Counter]]:
+    def get_pd_value_counts(df: pd.DataFrame) -> Dict[str, List[Dict]]:
+
         df_columns = df.columns.tolist()
         result = {}
         for col in columns:
@@ -724,44 +766,47 @@ def _get_unique_value_indices(
                 )
         return result
 
-    value_counts = dataset.map_batches(get_pd_value_counts, batch_format="pandas")
-    final_counters = {col: Counter() for col in columns}
-    for batch in value_counts.iter_batches(batch_size=None):
+    value_counts_ds = dataset.map_batches(get_pd_value_counts, batch_format="pandas")
+    unique_values_by_col: Dict[str, Set] = {key_gen(col): set() for col in columns}
+    for batch in value_counts_ds.iter_batches(batch_size=None):
         for col, counters in batch.items():
             for counter in counters:
-                counter = {k: v for k, v in counter.items() if v is not None}
-                final_counters[col] += Counter(counter)
+                counter: Dict[Any, int] = {
+                    k: v for k, v in counter.items() if v is not None
+                }
+                if col in max_categories:
+                    counter: Dict[Any, int] = dict(
+                        Counter(counter).most_common(max_categories[col])
+                    )
+                # add only column values since frequencies are needed beyond this point
+                unique_values_by_col[key_gen(col)].update(counter.keys())
 
-    # Inspect if there is any NA values.
-    for col in columns:
+    return unique_values_by_col
+
+
+def unique_post_fn(drop_na_values: bool = False) -> Callable[[Set], Dict[str, int]]:
+    """
+    Returns a post-processing function that generates an encoding map by
+    sorting the unique values produced during aggregation or stats computation.
+
+    :param drop_na_values: If True, NA/null values will be silently dropped from the encoding map.
+                           If False, raises an error if any NA/null values are present.
+    :return: A callable that takes a set of unique values and returns a dictionary
+             mapping each value to a unique integer index.
+    """
+
+    def gen_value_index(values: Set) -> Dict[str, int]:
         if drop_na_values:
-            counter = final_counters[col]
-            counter_dict = dict(counter)
-            sanitized_dict = {k: v for k, v in counter_dict.items() if not pd.isnull(k)}
-            final_counters[col] = Counter(sanitized_dict)
+            values = {k for k in values if not pd.isnull(k)}
         else:
-            if any(pd.isnull(k) for k in final_counters[col]):
+            if any(pd.isnull(k) for k in values):
                 raise ValueError(
-                    f"Unable to fit column '{col}' because it contains null"
-                    f" values. Consider imputing missing values first."
+                    "Unable to fit column because it contains null"
+                    " values. Consider imputing missing values first."
                 )
+        return {k: j for j, k in enumerate(sorted(values))}
 
-    unique_values_with_indices = OrderedDict()
-    for column in columns:
-        if column in max_categories:
-            # Output sorted by freq.
-            unique_values_with_indices[key_format.format(column)] = {
-                k[0]: j
-                for j, k in enumerate(
-                    final_counters[column].most_common(max_categories[column])
-                )
-            }
-        else:
-            # Output sorted by column name.
-            unique_values_with_indices[key_format.format(column)] = {
-                k: j for j, k in enumerate(sorted(dict(final_counters[column]).keys()))
-            }
-    return unique_values_with_indices
+    return gen_value_index
 
 
 def _validate_df(df: pd.DataFrame, *columns: str) -> None:

--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from numbers import Number
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -109,6 +109,7 @@ class SimpleImputer(Preprocessor):
         *,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.strategy = strategy
         self.fill_value = fill_value
@@ -133,10 +134,19 @@ class SimpleImputer(Preprocessor):
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
         if self.strategy == "mean":
-            aggregates = [Mean(col) for col in self.columns]
-            self.stats_ = dataset.aggregate(*aggregates)
+            self.stat_computation_plan.add_aggregator(
+                aggregator_fn=Mean, columns=self.columns
+            )
         elif self.strategy == "most_frequent":
-            self.stats_ = _get_most_frequent_values(dataset, *self.columns)
+            self.stat_computation_plan.add_callable_stat(
+                stat_fn=lambda key_gen: _get_most_frequent_values(
+                    dataset=dataset,
+                    columns=self.columns,
+                    key_gen=key_gen,
+                ),
+                stat_key_fn=lambda col: f"most_frequent({col})",
+                columns=self.columns,
+            )
 
         return self
 
@@ -194,11 +204,12 @@ class SimpleImputer(Preprocessor):
 
 
 def _get_most_frequent_values(
-    dataset: "Dataset", *columns: str
+    dataset: Dataset,
+    columns: List[str],
+    key_gen: Callable[[str], str],
 ) -> Dict[str, Union[str, Number]]:
-    columns = list(columns)
 
-    def get_pd_value_counts(df: pd.DataFrame) -> List[Dict[str, Counter]]:
+    def get_pd_value_counts(df: pd.DataFrame) -> Dict[str, List[Counter]]:
         return {col: [Counter(df[col].value_counts().to_dict())] for col in columns}
 
     value_counts = dataset.map_batches(get_pd_value_counts, batch_format="pandas")
@@ -209,6 +220,6 @@ def _get_most_frequent_values(
                 final_counters[col] += counter
 
     return {
-        f"most_frequent({column})": final_counters[column].most_common(1)[0][0]
+        key_gen(column): final_counters[column].most_common(1)[0][0]  # noqa
         for column in columns
     }

--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -204,7 +204,7 @@ class SimpleImputer(Preprocessor):
 
 
 def _get_most_frequent_values(
-    dataset: Dataset,
+    dataset: "Dataset",
     columns: List[str],
     key_gen: Callable[[str], str],
 ) -> Dict[str, Union[str, Number]]:

--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -208,7 +208,6 @@ def _get_most_frequent_values(
     columns: List[str],
     key_gen: Callable[[str], str],
 ) -> Dict[str, Union[str, Number]]:
-
     def get_pd_value_counts(df: pd.DataFrame) -> Dict[str, List[Counter]]:
         return {col: [Counter(df[col].value_counts().to_dict())] for col in columns}
 

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -81,15 +81,21 @@ class StandardScaler(Preprocessor):
     """
 
     def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
+        super().__init__()
         self.columns = columns
         self.output_columns = Preprocessor._derive_and_validate_output_columns(
             columns, output_columns
         )
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        mean_aggregates = [Mean(col) for col in self.columns]
-        std_aggregates = [Std(col, ddof=0) for col in self.columns]
-        self.stats_ = dataset.aggregate(*mean_aggregates, *std_aggregates)
+        self.stat_computation_plan.add_aggregator(
+            aggregator_fn=Mean,
+            columns=self.columns,
+        )
+        self.stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Std(col, ddof=0),
+            columns=self.columns,
+        )
         return self
 
     def _transform_pandas(self, df: pd.DataFrame):
@@ -181,6 +187,7 @@ class MinMaxScaler(Preprocessor):
     """
 
     def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
+        super().__init__()
         self.columns = columns
         self.output_columns = Preprocessor._derive_and_validate_output_columns(
             columns, output_columns
@@ -273,6 +280,7 @@ class MaxAbsScaler(Preprocessor):
     """
 
     def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
+        super().__init__()
         self.columns = columns
         self.output_columns = Preprocessor._derive_and_validate_output_columns(
             columns, output_columns
@@ -377,6 +385,7 @@ class RobustScaler(Preprocessor):
         quantile_range: Tuple[float, float] = (0.25, 0.75),
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.quantile_range = quantile_range
 

--- a/python/ray/data/preprocessors/utils.py
+++ b/python/ray/data/preprocessors/utils.py
@@ -1,6 +1,9 @@
 import hashlib
-from typing import List
+from collections import deque
+from typing import Any, Callable, Deque, Dict, List, Optional, Union
 
+from ray.data import Dataset
+from ray.data.aggregate import AggregateFnV2
 from ray.util.annotations import DeveloperAPI
 
 
@@ -17,3 +20,207 @@ def simple_hash(value: object, num_features: int) -> int:
     hashed_value = hashlib.sha1(encoded_value)
     hashed_value_int = int(hashed_value.hexdigest(), 16)
     return hashed_value_int % num_features
+
+
+class BaseStatSpec:
+    """Encapsulates a statistical computation with optional post-processing."""
+
+    def __init__(
+        self,
+        *,
+        stat_fn: Union[AggregateFnV2, Callable],
+        post_process_fn: Callable = lambda x: x,
+        post_key_fn: Callable[[str], str],
+    ):
+        self.stat_fn = stat_fn
+        self.post_process_fn = post_process_fn
+        self.post_key_fn = post_key_fn
+
+
+class AggregateStatSpec(BaseStatSpec):
+    """Represents an AggregateFnV2 spec for a single column."""
+
+    def __init__(
+        self,
+        *,
+        aggregator_fn: Union[AggregateFnV2, Callable[[str], AggregateFnV2]],
+        post_process_fn: Callable = lambda x: x,
+        post_key_fn: Callable[[str], str],
+        column: Optional[str] = None,
+    ):
+        super().__init__(
+            stat_fn=aggregator_fn,
+            post_process_fn=post_process_fn,
+            post_key_fn=post_key_fn,
+        )
+        self.column = column
+
+
+class CallableStatSpec(BaseStatSpec):
+    """Represents a user-defined stat function that operates outside Dataset.aggregate."""
+
+    def __init__(
+        self,
+        *,
+        stat_fn: Callable,
+        stat_key_fn: Optional[Callable[[str], str]],
+        post_key_fn: Optional[Callable[[str], str]],
+        post_process_fn: Callable = lambda x: x,
+        columns: List[str],
+    ):
+        super().__init__(
+            stat_fn=stat_fn, post_process_fn=post_process_fn, post_key_fn=post_key_fn
+        )
+        self.columns = columns
+        self.stat_key_fn = stat_key_fn
+
+
+class StatComputationPlan:
+    """
+    Encapsulates a set of aggregators (AggregateFnV2) and legacy stat functions
+    to compute statistics over a Ray dataset.
+
+    Supports two types of aggregations:
+    1. AggregateFnV2-based aggregators, which are batch-executed using `Dataset.aggregate(...)`.
+    2. Callable-based stat functions, executed sequentially (legacy use case).
+    """
+
+    def __init__(self):
+        self._aggregators: Deque[BaseStatSpec] = deque()
+
+    def reset(self):
+        self._aggregators.clear()
+
+    def add_aggregator(
+        self,
+        *,
+        aggregator_fn: Callable[[str], AggregateFnV2],
+        post_process_fn: Callable = lambda x: x,
+        post_key_fn: Optional[Callable[[str], str]] = None,
+        columns: List[str],
+    ) -> None:
+        """
+        Registers an AggregateFnV2 factory for one or more columns.
+
+        Args:
+            aggregator_fn: A callable (typically a lambda or class) that accepts a column name and returns an instance of AggregateFnV2.
+            post_process_fn: Function to post-process the aggregated result.
+            post_key_fn: Optional key generator to use to save aggregation results after post-processing.
+            columns: List of column names to aggregate.
+        """
+        for column in columns:
+            agg_instance = aggregator_fn(column)
+            self._aggregators.append(
+                AggregateStatSpec(
+                    aggregator_fn=agg_instance,
+                    post_process_fn=post_process_fn,
+                    post_key_fn=post_key_fn,
+                    column=column,
+                )
+            )
+
+    def add_callable_stat(
+        self,
+        *,
+        stat_fn: Callable[[], Any],
+        post_process_fn: Callable = lambda x: x,
+        stat_key_fn: Callable[[str], str],
+        post_key_fn: Optional[Callable[[str], str]] = None,
+        columns: List[str],
+    ) -> None:
+        """
+        Registers a custom stat function to be run sequentially.
+
+        This supports legacy use cases where arbitrary callables are needed
+        and cannot be run via Dataset.aggregate().
+
+        :param post_key_fn:
+        :param stat_fn: A zero-argument callable that returns the stat.
+        :param post_process_fn: Function to apply to the result.
+        :param columns:
+        :param stat_key_fn:
+        """
+        self._aggregators.append(
+            CallableStatSpec(
+                stat_fn=stat_fn,
+                post_process_fn=post_process_fn,
+                columns=columns,
+                stat_key_fn=stat_key_fn,
+                post_key_fn=post_key_fn or stat_key_fn,
+            )
+        )
+
+    def compute(self, dataset: Dataset) -> Dict[str, Any]:
+        """
+        Executes all registered aggregators and stat functions.
+
+        AggregateFnV2-based aggregators are batched and executed via Dataset.aggregate().
+        Callable-based stat functions are run sequentially.
+
+        Args:
+            dataset: The Ray Dataset to compute statistics on.
+
+        Returns:
+            A dictionary of computed statistics.
+        """
+        stats = {}
+        # Run batched aggregators (AggregateFnV2)
+        aggregators = self._get_aggregate_fn_list()
+        if aggregators:
+            raw_result = dataset.aggregate(*aggregators)
+            for spec in self._get_aggregate_specs():
+                stat_key = spec.stat_fn.name
+                post_key = (
+                    spec.post_key_fn(spec.column)
+                    if spec.post_key_fn is not None
+                    else stat_key
+                )
+                stats[post_key] = spec.post_process_fn(raw_result[stat_key])
+
+        # Run sequential stat functions
+        for spec in self._get_custom_stat_fn_specs():
+            result = spec.stat_fn(spec.stat_key_fn)
+            for col in spec.columns:
+                stat_key = spec.stat_key_fn(col)
+                post_key = spec.post_key_fn(col)
+                stats[post_key] = spec.post_process_fn(result[stat_key])
+
+        return stats
+
+    def _get_aggregate_fn_list(self) -> List[AggregateFnV2]:
+        return [
+            spec.stat_fn
+            for spec in self._aggregators
+            if isinstance(spec, AggregateStatSpec)
+        ]
+
+    def _get_aggregate_specs(self) -> List[AggregateStatSpec]:
+        return [
+            spec for spec in self._aggregators if isinstance(spec, AggregateStatSpec)
+        ]
+
+    def _get_custom_stat_fn_specs(self) -> List[CallableStatSpec]:
+        return [
+            spec for spec in self._aggregators if isinstance(spec, CallableStatSpec)
+        ]
+
+    def __iter__(self):
+        """
+        Iterates over all AggregatorSpecs.
+        """
+        return iter(self._get_aggregate_specs())
+
+
+def make_post_processor(base_fn, callbacks: List[Callable]):
+    """
+    Wraps a base post-processing function with a sequence of callback functions.
+    Useful when multiple post-processing steps need to be applied in order.
+    """
+
+    def wrapper(result):
+        processed = base_fn(result)
+        for cb in callbacks:
+            processed = cb(processed)
+        return processed
+
+    return wrapper

--- a/python/ray/data/preprocessors/vectorizer.py
+++ b/python/ray/data/preprocessors/vectorizer.py
@@ -248,6 +248,7 @@ class CountVectorizer(Preprocessor):
         *,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.tokenization_fn = tokenization_fn or simple_split_tokenizer
         self.max_features = max_features
@@ -256,32 +257,42 @@ class CountVectorizer(Preprocessor):
         )
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        def get_pd_value_counts(df: pd.DataFrame) -> List[Counter]:
-            def get_token_counts(col):
-                token_series = df[col].apply(self.tokenization_fn)
-                tokens = token_series.sum()
-                return Counter(tokens)
+        def stat_fn(key_gen):
+            def get_pd_value_counts(df: pd.DataFrame) -> List[Counter]:
+                def get_token_counts(col):
+                    token_series = df[col].apply(self.tokenization_fn)
+                    tokens = token_series.sum()
+                    return Counter(tokens)
 
-            return {col: [get_token_counts(col)] for col in self.columns}
+                return {col: [get_token_counts(col)] for col in self.columns}
 
-        value_counts = dataset.map_batches(get_pd_value_counts, batch_format="pandas")
-        total_counts = {col: Counter() for col in self.columns}
-        for batch in value_counts.iter_batches(batch_size=None):
-            for col, counters in batch.items():
-                for counter in counters:
-                    total_counts[col].update(counter)
+            value_counts = dataset.map_batches(
+                get_pd_value_counts, batch_format="pandas"
+            )
+            total_counts = {col: Counter() for col in self.columns}
+            for batch in value_counts.iter_batches(batch_size=None):
+                for col, counters in batch.items():
+                    for counter in counters:
+                        total_counts[col].update(counter)
 
-        def most_common(counter: Counter, n: int):
-            return Counter(dict(counter.most_common(n)))
+            def most_common(counter: Counter, n: int):
+                return Counter(dict(counter.most_common(n)))
 
-        top_counts = [
-            most_common(counter, self.max_features) for counter in total_counts.values()
-        ]
+            top_counts = [
+                most_common(counter, self.max_features)
+                for counter in total_counts.values()
+            ]
 
-        self.stats_ = {
-            f"token_counts({col})": counts
-            for (col, counts) in zip(self.columns, top_counts)
-        }
+            return {
+                key_gen(col): counts  # noqa
+                for (col, counts) in zip(self.columns, top_counts)
+            }
+
+        self.stat_computation_plan.add_callable_stat(
+            stat_fn=lambda key_gen: stat_fn(key_gen),
+            stat_key_fn=lambda col: f"token_counts({col})",
+            columns=self.columns,
+        )
 
         return self
 

--- a/python/ray/data/tests/preprocessors/test_chain.py
+++ b/python/ray/data/tests/preprocessors/test_chain.py
@@ -22,6 +22,10 @@ def test_chain():
 
     # Fit data.
     chain.fit(ds)
+    # Transform data.
+    transformed = chain.transform(ds)
+    out_df = transformed.to_pandas()
+
     assert imputer.stats_ == {
         "mean(B)": 0.0,
     }
@@ -34,10 +38,6 @@ def test_chain():
     assert encoder.stats_ == {
         "unique_values(C)": {"monday": 0, "sunday": 1, "tuesday": 2}
     }
-
-    # Transform data.
-    transformed = chain.transform(ds)
-    out_df = transformed.to_pandas()
 
     processed_col_a = [-1.0, -1.0, 1.0, 1.0]
     processed_col_b = [0.0, 0.0, 0.0, 0.0]
@@ -119,6 +119,10 @@ def test_nested_chain():
 
     # Fit data.
     chain.fit(ds)
+    # Transform data.
+    transformed = chain.transform(ds)
+    out_df = transformed.to_pandas()
+
     assert imputer.stats_ == {
         "mean(B)": 0.0,
     }
@@ -131,10 +135,6 @@ def test_nested_chain():
     assert encoder.stats_ == {
         "unique_values(C)": {"monday": 0, "sunday": 1, "tuesday": 2}
     }
-
-    # Transform data.
-    transformed = chain.transform(ds)
-    out_df = transformed.to_pandas()
 
     processed_col_a = [-1.0, -1.0, 1.0, 1.0]
     processed_col_b = [0.0, 0.0, 0.0, 0.0]

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -117,7 +117,7 @@ def test_fitted_preprocessor_without_stats():
 
     class FittablePreprocessor(Preprocessor):
         def _fit(self, ds):
-            return ds
+            return self
 
     preprocessor = FittablePreprocessor()
     ds = ray.data.from_items([1])

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -1390,7 +1390,7 @@ def test_map_names(target_max_block_size_infinite_or_default):
     ds = ray.data.from_items(["a", "b", "c", "a", "b", "c"])
     enc = OneHotEncoder(columns=["item"])
     r = enc.fit_transform(ds).__repr__()
-    assert r.startswith("OneHotEncoder"), r
+    assert "OneHotEncoder" in r, r
 
 
 def test_map_with_max_calls():


### PR DESCRIPTION
* Updated preprocessors to use a callback-based approach for stat computation. This improves code organization and reduces duplication.
* Added ValueCounter aggregator and value_counts method to BlockColumnAccessor. Includes implementations for both Arrow and Pandas backends.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
