### PR TITLE
[Draft] [serve] Prometheus metrics for AutoscalingConfig

### DIFF
--- a/python/ray/_common/prometheus_utils.py
+++ b/python/ray/_common/prometheus_utils.py
@@ -1,0 +1,283 @@
+"""Prometheus query helpers and a node-local TTL cache for co-located fetches."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover
+    _fcntl = None
+
+DEFAULT_PROMETHEUS_QUERY_CACHE_TTL_S = float(
+    os.environ.get("RAY_SERVE_PROMETHEUS_QUERY_CACHE_TTL_S", "1.0")
+)
+
+
+def normalize_prometheus_address(address: str) -> str:
+    """Return host:port, stripping an optional http(s):// scheme and path."""
+    if not address:
+        return address
+    addr = address.strip()
+    for prefix in ("https://", "http://"):
+        if addr.lower().startswith(prefix):
+            addr = addr[len(prefix) :]
+            break
+    return addr.split("/")[0]
+
+
+def fetch_from_prom_server(
+    address: str,
+    query: str,
+    *,
+    time: Union[str, int, float, None] = None,
+    timeout: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Instant-query Prometheus at address (host:port or URL)."""
+    if not address:
+        raise ValueError("Prometheus address must be non-empty")
+    scheme = "https" if address.strip().lower().startswith("https://") else "http"
+    hostport = normalize_prometheus_address(address)
+    params: Dict[str, Any] = {"query": query}
+    if time is not None:
+        params["time"] = time
+    if timeout is not None:
+        params["timeout"] = str(timeout)
+    request_timeout = timeout if timeout is not None else 10.0
+    response = requests.get(
+        f"{scheme}://{hostport}/api/v1/query",
+        params=params,
+        timeout=request_timeout,
+    )
+    response.raise_for_status()
+    body = response.json()
+    # Prometheus may return HTTP 200 with {"status":"error", ...} for bad PromQL.
+    if isinstance(body, dict) and body.get("status") == "error":
+        raise ValueError(
+            "Prometheus query error: "
+            f"{body.get('errorType', 'unknown')}: {body.get('error', body)}"
+        )
+    return body
+
+
+def extract_instant_query_value(response: Dict[str, Any]) -> Optional[float]:
+    """First sample from a PromQL instant query (vector or scalar), else None."""
+    try:
+        if not response or response.get("status") == "error":
+            return None
+        data = response.get("data") or {}
+        result = data.get("result")
+        if result is None:
+            return None
+        result_type = data.get("resultType")
+        if result_type == "scalar" or (
+            isinstance(result, (list, tuple))
+            and len(result) == 2
+            and not isinstance(result[0], dict)
+        ):
+            value = result[1]
+            return float(value) if value is not None else None
+        if not result:
+            return None
+        value = result[0].get("value", [None, None])[1]
+        return float(value) if value is not None else None
+    except (TypeError, ValueError, IndexError, AttributeError, KeyError):
+        return None
+
+
+class NodeLocalPrometheusQueryCache:
+    """TTL cache shared via memory + on-disk files so co-located processes coalesce."""
+
+    def __init__(
+        self,
+        ttl_s: float = DEFAULT_PROMETHEUS_QUERY_CACHE_TTL_S,
+        cache_dir: Optional[str] = None,
+    ):
+        self._ttl_s = max(0.0, float(ttl_s))
+        self._mem: Dict[Tuple[str, str], Tuple[float, Any]] = {}
+        self._lock = threading.Lock()
+        self._cache_dir = cache_dir or os.path.join(
+            tempfile.gettempdir(), "ray_serve_prometheus_query_cache"
+        )
+        self.hits = 0
+        self.misses = 0
+        self.fetches = 0
+
+    def _key(self, address: str, query: str) -> Tuple[str, str]:
+        return (normalize_prometheus_address(address), query)
+
+    def _disk_path(self, key: Tuple[str, str]) -> str:
+        digest = hashlib.sha256(f"{key[0]}\n{key[1]}".encode("utf-8")).hexdigest()
+        return os.path.join(self._cache_dir, f"{digest}.json")
+
+    def _is_fresh(self, ts: float, now: float) -> bool:
+        # ttl_s <= 0 disables caching (entries never treated as fresh).
+        if self._ttl_s <= 0:
+            return False
+        return (now - ts) <= self._ttl_s
+
+    def _flock(self, fd: int, flags: int) -> None:
+        if _fcntl is not None:
+            _fcntl.flock(fd, flags)
+
+    def _read_mem(self, key: Tuple[str, str], now: float) -> Optional[Any]:
+        entry = self._mem.get(key)
+        if entry is None:
+            return None
+        ts, payload = entry
+        return payload if self._is_fresh(ts, now) else None
+
+    def _write_mem(self, key: Tuple[str, str], payload: Any, now: float) -> None:
+        self._mem[key] = (now, payload)
+
+    def _read_disk(self, key: Tuple[str, str], now: float) -> Optional[Any]:
+        path = self._disk_path(key)
+        if not os.path.isfile(path):
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                self._flock(f.fileno(), _fcntl.LOCK_SH if _fcntl else 0)
+                try:
+                    data = json.load(f)
+                finally:
+                    self._flock(f.fileno(), _fcntl.LOCK_UN if _fcntl else 0)
+            ts = float(data["ts"])
+            return data["payload"] if self._is_fresh(ts, now) else None
+        except Exception as e:
+            logger.debug("Prometheus disk cache read failed: %s", e)
+            return None
+
+    def _write_disk(self, key: Tuple[str, str], payload: Any, now: float) -> None:
+        path = self._disk_path(key)
+        try:
+            os.makedirs(self._cache_dir, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(prefix="promcache_", dir=self._cache_dir)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    self._flock(f.fileno(), _fcntl.LOCK_EX if _fcntl else 0)
+                    json.dump({"ts": now, "payload": payload}, f)
+                    f.flush()
+                    os.fsync(f.fileno())
+                    self._flock(f.fileno(), _fcntl.LOCK_UN if _fcntl else 0)
+                os.replace(tmp_path, path)
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except Exception as e:
+            logger.debug("Prometheus disk cache write failed: %s", e)
+
+    def get_or_fetch(
+        self,
+        address: str,
+        query: str,
+        fetch_fn: Optional[Callable[..., Dict[str, Any]]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Return cached JSON for (address, query), or fetch and store it.
+
+        Args:
+            address: Prometheus host:port or URL.
+            query: PromQL instant query string.
+            fetch_fn: Optional fetcher; defaults to ``fetch_from_prom_server``.
+            timeout: Optional request timeout in seconds.
+
+        Returns:
+            Prometheus ``/api/v1/query`` JSON body.
+        """
+        if fetch_fn is None:
+            fetch_fn = fetch_from_prom_server
+        key = self._key(address, query)
+        now = time.time()
+
+        with self._lock:
+            mem_hit = self._read_mem(key, now)
+            if mem_hit is not None:
+                self.hits += 1
+                return mem_hit
+
+        disk_hit = self._read_disk(key, now)
+        if disk_hit is not None:
+            with self._lock:
+                self._write_mem(key, disk_hit, now)
+                self.hits += 1
+            return disk_hit
+
+        os.makedirs(self._cache_dir, exist_ok=True)
+        lock_path = self._disk_path(key) + ".lock"
+        lock_f = open(lock_path, "a+", encoding="utf-8")
+        try:
+            self._flock(lock_f.fileno(), _fcntl.LOCK_EX if _fcntl else 0)
+            try:
+                now = time.time()
+                disk_hit = self._read_disk(key, now)
+                if disk_hit is not None:
+                    with self._lock:
+                        self._write_mem(key, disk_hit, now)
+                        self.hits += 1
+                    return disk_hit
+                with self._lock:
+                    self.misses += 1
+                    self.fetches += 1
+                payload = fetch_fn(address, query, timeout=timeout)
+                now = time.time()
+                self._write_disk(key, payload, now)
+                with self._lock:
+                    self._write_mem(key, payload, now)
+                return payload
+            finally:
+                self._flock(lock_f.fileno(), _fcntl.LOCK_UN if _fcntl else 0)
+        finally:
+            lock_f.close()
+
+    def clear(self) -> None:
+        with self._lock:
+            self._mem.clear()
+            self.hits = self.misses = self.fetches = 0
+
+
+_DEFAULT_CACHE: Optional[NodeLocalPrometheusQueryCache] = None
+_DEFAULT_CACHE_LOCK = threading.Lock()
+
+
+def get_default_prometheus_query_cache() -> NodeLocalPrometheusQueryCache:
+    global _DEFAULT_CACHE
+    with _DEFAULT_CACHE_LOCK:
+        if _DEFAULT_CACHE is None:
+            _DEFAULT_CACHE = NodeLocalPrometheusQueryCache()
+        return _DEFAULT_CACHE
+
+
+def reset_default_prometheus_query_cache_for_tests(
+    cache: Optional[NodeLocalPrometheusQueryCache] = None,
+) -> NodeLocalPrometheusQueryCache:
+    global _DEFAULT_CACHE
+    with _DEFAULT_CACHE_LOCK:
+        _DEFAULT_CACHE = cache if cache is not None else NodeLocalPrometheusQueryCache()
+        return _DEFAULT_CACHE
+
+
+def cached_fetch_from_prom_server(
+    address: str,
+    query: str,
+    *,
+    timeout: Optional[float] = None,
+    cache: Optional[NodeLocalPrometheusQueryCache] = None,
+    fetch_fn: Optional[Callable[..., Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    c = cache if cache is not None else get_default_prometheus_query_cache()
+    return c.get_or_fetch(address, query, fetch_fn=fetch_fn, timeout=timeout)

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -1264,3 +1264,26 @@ class AutoscalingStateManager:
     def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
         for app_state in self._app_autoscaling_states.values():
             app_state.drop_stale_handle_metrics(alive_serve_actor_ids)
+
+    def _dump_all_autoscaling_metrics_for_testing(
+        self,
+    ) -> Dict[DeploymentID, Dict[str, float]]:
+        """Flatten aggregated custom metrics for tests."""
+        all_metrics: Dict[DeploymentID, Dict[str, float]] = {}
+        for app_state in self._app_autoscaling_states.values():
+            for (
+                dep_id,
+                dep_state,
+            ) in app_state._deployment_autoscaling_states.items():
+                flat: Dict[str, float] = {}
+                for (
+                    name,
+                    replica_vals,
+                ) in dep_state._get_aggregated_custom_metrics().items():
+                    if replica_vals:
+                        flat[name] = sum(replica_vals.values()) / len(replica_vals)
+                total = dep_state.get_total_num_requests()
+                if total > 0:
+                    flat["num_ongoing_requests"] = total
+                all_metrics[dep_id] = flat
+        return all_metrics

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -52,6 +52,8 @@ from ray.serve.generated.serve_pb2 import (
     GangRuntimeFailurePolicy as GangRuntimeFailurePolicyProto,
     GangSchedulingConfig as GangSchedulingConfigProto,
     LoggingConfig as LoggingConfigProto,
+    PrometheusCustomMetrics as PrometheusCustomMetricsProto,
+    PrometheusMetric as PrometheusMetricProto,
     ReplicaConfig as ReplicaConfigProto,
     RequestRouterConfig as RequestRouterConfigProto,
 )
@@ -339,6 +341,20 @@ class DeploymentConfig(BaseModel):
             if self.needs_pickle():
                 data["user_config"] = cloudpickle.dumps(data["user_config"])
         if data.get("autoscaling_config"):
+            ac = data["autoscaling_config"]
+            if "prometheus_metrics" in ac:
+                prom = ac["prometheus_metrics"]
+                if prom is None:
+                    ac.pop("prometheus_metrics")
+                elif isinstance(prom, list):
+                    ac["prometheus_metrics"] = PrometheusCustomMetricsProto(
+                        metrics=[PrometheusMetricProto(metric_name=n) for n in prom]
+                    )
+                else:
+                    raise TypeError(
+                        "prometheus_metrics must be None or List[str], "
+                        f"got {type(prom).__name__}"
+                    )
             # By setting the serialized policy def, on the protobuf level, AutoscalingConfig constructor will not
             # try to import the policy from the string import path when the protobuf is deserialized on the controller side
             data["autoscaling_config"]["policy"][
@@ -508,6 +524,19 @@ class DeploymentConfig(BaseModel):
                         )
                     else:
                         policy_data["policy_kwargs"] = {}
+            prom = data["autoscaling_config"].get("prometheus_metrics", None)
+            if prom is None:
+                data["autoscaling_config"]["prometheus_metrics"] = None
+            elif isinstance(prom, dict):
+                data["autoscaling_config"]["prometheus_metrics"] = [
+                    (m.get("metric_name") if isinstance(m, dict) else m.metric_name)
+                    for m in (prom.get("metrics") or [])
+                ]
+            else:
+                data["autoscaling_config"]["prometheus_metrics"] = [
+                    getattr(m, "metric_name", m)
+                    for m in (getattr(prom, "metrics", []) or [])
+                ]
             data["autoscaling_config"] = AutoscalingConfig(**data["autoscaling_config"])
         if "version" in data:
             if data["version"] == "":

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -442,6 +442,13 @@ RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S = get_env_float(
     "RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S", 10.0
 )
 
+#: Prometheus host:port for replica autoscaling metrics (empty = unset).
+RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST = get_env_str(
+    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST", ""
+)
+# Cache TTL for co-located PromQL: env RAY_SERVE_PROMETHEUS_QUERY_CACHE_TTL_S
+# (read in ray._common.prometheus_utils.DEFAULT_PROMETHEUS_QUERY_CACHE_TTL_S).
+
 # Factor of look_back_period_s for autoscaling metric record interval.
 # Record interval = look_back_period_s * factor. Used by both router and replica.
 RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR = get_env_float(

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -442,6 +442,11 @@ class ServeController:
             deployment_id
         )
 
+    def _dump_all_autoscaling_metrics_for_testing(self):
+        return (
+            self.autoscaling_state_manager._dump_all_autoscaling_metrics_for_testing()
+        )
+
     def _stop_one_running_replica_for_testing(self, deployment_id):
         self.deployment_state_manager._stop_one_running_replica_for_testing(
             deployment_id

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -38,6 +38,11 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 import ray
 from ray import cloudpickle
 from ray._common.filters import CoreContextFilter
+from ray._common.prometheus_utils import (
+    cached_fetch_from_prom_server,
+    extract_instant_query_value,
+    fetch_from_prom_server,
+)
 from ray._common.utils import get_or_create_event_loop
 from ray.actor import ActorClass, ActorHandle
 from ray.dag.py_obj_scanner import _PyObjScanner
@@ -68,6 +73,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
     RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S,
+    RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST,
     RAY_SERVE_REPLICA_GRPC_MAX_MESSAGE_LENGTH,
     RAY_SERVE_REPLICA_MAX_PROCESSING_LATENCY_NUM_BUCKETS,
     RAY_SERVE_REPLICA_MAX_PROCESSING_LATENCY_REPORT_INTERVAL_S,
@@ -199,6 +205,8 @@ from ray.serve.schema import EncodingType, LoggingConfig, ReplicaRank
 from ray.types import ObjectRef
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+default_prometheus_handler = fetch_from_prom_server
 
 SERVE_BUILD_ASGI_APP_METHOD = "__serve_build_asgi_app__"
 
@@ -362,6 +370,7 @@ class ReplicaMetricsManager:
         autoscaling_config: Optional[AutoscalingConfig],
         ingress: bool,
         max_ongoing_requests: int,
+        prometheus_handler: Optional[Callable[..., Any]] = None,
     ):
         self._replica_id = replica_id
         self._deployment_id = replica_id.deployment_id
@@ -381,6 +390,14 @@ class ReplicaMetricsManager:
         # On first call to _fetch_custom_autoscaling_metrics. Failing validation disables _custom_metrics_enabled
         self._checked_custom_metrics = False
         self._record_autoscaling_stats_fn = None
+        self._prometheus_metrics_enabled = False
+        self._prometheus_queries: Optional[List[str]] = None
+        self._prometheus_metric_keys: set = set()
+        self._prometheus_handler = (
+            prometheus_handler
+            if prometheus_handler is not None
+            else default_prometheus_handler
+        )
 
         # Tracks in-flight metrics push to controller. Skip if new one is sent.
         self._pending_metrics_push_ref: Optional[ObjectRef] = None
@@ -699,9 +716,32 @@ class ReplicaMetricsManager:
         """Dynamically update autoscaling config."""
 
         self._autoscaling_config = autoscaling_config
-
-        if self._autoscaling_config and self.should_collect_ongoing_requests():
+        self._prometheus_metrics_enabled = False
+        self._prometheus_queries = None
+        if self._autoscaling_config and self._autoscaling_config.prometheus_metrics:
+            if not RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST:
+                logger.error(
+                    "prometheus_metrics set but "
+                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST is unset."
+                )
+            else:
+                self._prometheus_metrics_enabled = True
+                self._prometheus_queries = list(
+                    self._autoscaling_config.prometheus_metrics
+                )
+        new_prom_keys = set(self._prometheus_queries or [])
+        for stale in self._prometheus_metric_keys - new_prom_keys:
+            self._metrics_store.data.pop(stale, None)
+        self._prometheus_metric_keys = new_prom_keys
+        need_pusher = bool(self._autoscaling_config) and (
+            self.should_collect_ongoing_requests()
+            or self._prometheus_metrics_enabled
+            or self._custom_metrics_enabled
+        )
+        if need_pusher:
             self.start_metrics_pusher()
+        else:
+            self._metrics_pusher.stop_tasks()
 
     def enable_custom_autoscaling_metrics(
         self,
@@ -944,6 +984,34 @@ class ReplicaMetricsManager:
                 )
             )
 
+    async def _fetch_prometheus_metrics(
+        self, metric_names: List[str]
+    ) -> Optional[Dict[str, Union[int, float]]]:
+        """Fetch configured PromQL expressions via the node-local cache."""
+        prom_addr = RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST
+        if not prom_addr or not metric_names:
+            return None
+
+        def _query_all() -> Dict[str, Union[int, float]]:
+            out: Dict[str, Union[int, float]] = {}
+            for query in metric_names:
+                try:
+                    response = cached_fetch_from_prom_server(
+                        prom_addr,
+                        query,
+                        timeout=RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S,
+                        fetch_fn=self._prometheus_handler,
+                    )
+                    value = extract_instant_query_value(response)
+                    if value is not None:
+                        out[query] = value
+                except Exception as e:
+                    logger.error("Error fetching prometheus metric %r: %s", query, e)
+            return out
+
+        result = await asyncio.get_event_loop().run_in_executor(None, _query_all)
+        return result if result else None
+
     async def _fetch_custom_autoscaling_metrics(
         self,
     ) -> Optional[Dict[str, Union[int, float]]]:
@@ -1004,6 +1072,13 @@ class ReplicaMetricsManager:
             custom_metrics = await self._fetch_custom_autoscaling_metrics()
             if custom_metrics:
                 metrics_dict.update(custom_metrics)
+
+        if self._prometheus_metrics_enabled and self._prometheus_queries:
+            prom_metrics = await self._fetch_prometheus_metrics(
+                self._prometheus_queries
+            )
+            if prom_metrics:
+                metrics_dict.update(prom_metrics)
 
         self._metrics_store.add_metrics_point(
             metrics_dict,

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -661,6 +661,14 @@ class AutoscalingConfig(BaseModel):
         default=30.0, description="How long to wait before scaling up replicas."
     )
 
+    prometheus_metrics: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Optional Prometheus metric names / PromQL expressions collected by "
+            "each replica (see RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST)."
+        ),
+    )
+
     aggregation_function: Union[str, AggregationFunction] = Field(
         default=AggregationFunction.MEAN,
         description="Function used to aggregate metrics across a time window.",

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -40,6 +40,7 @@ py_test_module_list_with_env_variants(
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 "RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR": "0.001",
                 "RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S": "3",
+                "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST": "localhost:9090",
             },
             "name_suffix": "_metr_agg_at_controller",
         },
@@ -49,12 +50,14 @@ py_test_module_list_with_env_variants(
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 "RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR": "0.001",
                 "RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S": "3",
+                "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST": "localhost:9090",
             },
             "name_suffix": "_metr_agg_at_replicas",
         },
     },
     files = [
         "test_custom_autoscaling_metrics.py",
+        "test_prometheus_autoscaling_metrics.py",
     ],
     tags = [
         "exclusive",

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -189,6 +189,7 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy_nam
                                     "downscale_delay_s": 600.0,
                                     "downscale_to_zero_delay_s": None,
                                     "upscale_delay_s": 30.0,
+                                    "prometheus_metrics": None,
                                     "aggregation_function": "mean",
                                     "policy": {
                                         "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -321,6 +321,7 @@ def test_num_replicas_auto_api(serve_instance, use_options):
         "downscaling_factor": None,
         "smoothing_factor": 1.0,
         "initial_replicas": None,
+        "prometheus_metrics": None,
         "aggregation_function": "mean",
         "policy": {
             "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",
@@ -388,6 +389,7 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
         "downscaling_factor": None,
         "smoothing_factor": 1.0,
         "initial_replicas": None,
+        "prometheus_metrics": None,
         "aggregation_function": "mean",
         "policy": {
             "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",

--- a/python/ray/serve/tests/test_deploy_app_2.py
+++ b/python/ray/serve/tests/test_deploy_app_2.py
@@ -603,6 +603,7 @@ def test_num_replicas_auto_api(serve_instance):
         "downscaling_factor": None,
         "smoothing_factor": 1.0,
         "initial_replicas": None,
+        "prometheus_metrics": None,
         "aggregation_function": "mean",
         "policy": {
             "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",
@@ -663,6 +664,7 @@ def test_num_replicas_auto_basic(serve_instance):
         "downscaling_factor": None,
         "smoothing_factor": 1.0,
         "initial_replicas": None,
+        "prometheus_metrics": None,
         "aggregation_function": "mean",
         "policy": {
             "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -2548,6 +2548,7 @@ def test_get_serve_instance_details_json_serializable(
                                     "downscale_delay_s": 600.0,
                                     "downscale_to_zero_delay_s": None,
                                     "upscale_delay_s": 30.0,
+                                    "prometheus_metrics": None,
                                     "aggregation_function": "mean",
                                     "policy": {
                                         "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",

--- a/python/ray/serve/tests/test_prometheus_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_prometheus_autoscaling_metrics.py
@@ -1,0 +1,159 @@
+"""Core tests for Prometheus autoscaling metrics + co-located query cache."""
+
+import asyncio
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ray._common.prometheus_utils import (
+    NodeLocalPrometheusQueryCache,
+    extract_instant_query_value,
+    normalize_prometheus_address,
+    reset_default_prometheus_query_cache_for_tests,
+)
+from ray.serve._private.common import DeploymentID, ReplicaID
+from ray.serve._private.replica import ReplicaMetricsManager
+from ray.serve.config import AutoscalingConfig
+
+
+def _rid(i: int):
+    try:
+        return ReplicaID(
+            unique_id=f"replica-{i}",
+            deployment_id=DeploymentID(name="D", app_name="A"),
+        )
+    except TypeError:
+
+        class _Rid:
+            unique_id = f"replica-{i}"
+            deployment_id = DeploymentID(name="D", app_name="A")
+
+        return _Rid()
+
+
+def test_normalize_and_extract():
+    assert normalize_prometheus_address("http://h:9") == "h:9"
+    assert normalize_prometheus_address("https://secure:9090/path") == "secure:9090"
+    assert (
+        extract_instant_query_value({"data": {"result": [{"value": [1, "42"]}]}})
+        == 42.0
+    )
+    assert (
+        extract_instant_query_value(
+            {"data": {"resultType": "scalar", "result": [1, "3"]}}
+        )
+        == 3.0
+    )
+    # Error payloads must not be treated as a numeric sample.
+    assert (
+        extract_instant_query_value(
+            {"status": "error", "errorType": "bad_data", "error": "parse error"}
+        )
+        is None
+    )
+
+
+def test_fetch_raises_on_prometheus_status_error(monkeypatch):
+    from ray._common.prometheus_utils import fetch_from_prom_server
+
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"status": "error", "errorType": "bad_data", "error": "parse error"}
+
+    monkeypatch.setattr(
+        "ray._common.prometheus_utils.requests.get", lambda *a, **k: _Resp()
+    )
+    with pytest.raises(ValueError, match="Prometheus query error"):
+        fetch_from_prom_server("localhost:9090", "up")
+
+
+def test_zero_ttl_never_serves_cache_hits(tmp_path):
+    calls = {"n": 0}
+
+    def fetch(address, query, timeout=None):
+        calls["n"] += 1
+        return {"data": {"result": [{"value": [1, str(calls["n"])]}]}}
+
+    cache = NodeLocalPrometheusQueryCache(ttl_s=0.0, cache_dir=str(tmp_path / "z"))
+    cache.get_or_fetch("localhost:9090", "m", fetch_fn=fetch)
+    cache.get_or_fetch("localhost:9090", "m", fetch_fn=fetch)
+    assert calls["n"] == 2
+
+
+def test_cache_colocated_dedup(tmp_path):
+    calls = {"n": 0}
+
+    def fetch(address, query, timeout=None):
+        calls["n"] += 1
+        time.sleep(0.01)
+        return {"data": {"result": [{"value": [1, "7"]}]}}
+
+    cache = NodeLocalPrometheusQueryCache(ttl_s=5.0, cache_dir=str(tmp_path / "c"))
+    out = []
+
+    def worker():
+        out.append(cache.get_or_fetch("localhost:9090", "m", fetch_fn=fetch))
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert calls["n"] == 1
+    assert len(out) == 4
+
+
+@pytest.mark.asyncio
+async def test_replica_fetch_value_and_colocated_dedup(tmp_path, monkeypatch):
+    import ray.serve._private.replica as replica_mod
+
+    calls = {"n": 0}
+
+    def handler(host, query, timeout=None):
+        calls["n"] += 1
+        return {"data": {"result": [{"value": [1, "42"]}]}}
+
+    monkeypatch.setattr(
+        replica_mod,
+        "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST",
+        "localhost:9090",
+    )
+    reset_default_prometheus_query_cache_for_tests(
+        NodeLocalPrometheusQueryCache(ttl_s=5.0, cache_dir=str(tmp_path / "m"))
+    )
+    cfg = AutoscalingConfig(
+        min_replicas=1,
+        max_replicas=3,
+        target_ongoing_requests=1,
+        prometheus_metrics=["custom_load"],
+    )
+    with patch.object(ReplicaMetricsManager, "start_metrics_pusher"):
+        with patch(
+            "ray.serve._private.replica.ray.get_actor", return_value=MagicMock()
+        ):
+            managers = [
+                ReplicaMetricsManager(
+                    replica_id=_rid(i),
+                    event_loop=asyncio.get_event_loop(),
+                    autoscaling_config=cfg,
+                    ingress=True,
+                    max_ongoing_requests=10,
+                    prometheus_handler=handler,
+                )
+                for i in range(3)
+            ]
+            results = [
+                await m._fetch_prometheus_metrics(["custom_load"]) for m in managers
+            ]
+    assert all(r == {"custom_load": 42.0} for r in results)
+    assert calls["n"] == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -89,6 +89,17 @@ message AutoscalingConfig {
 
   // How metrics are aggregated for autoscaling. One of "mean", "max", "min".
   string aggregation_function = 16;
+
+  // Optional Prometheus metrics for autoscaling (preserves None vs empty list).
+  optional PrometheusCustomMetrics prometheus_metrics = 17;
+}
+
+message PrometheusMetric {
+  string metric_name = 1;
+}
+
+message PrometheusCustomMetrics {
+  repeated PrometheusMetric metrics = 1;
 }
 
 //[Begin] LOGGING CONFIG


### PR DESCRIPTION
Implementation of AutoscalingConfig prometheus_custom_metrics: 
<img width="1335" height="1076" alt="image" src="https://github.com/user-attachments/assets/0df2b7e8-3bd0-406f-a75c-4dee31ad0f1a" />


## Why are these changes needed?

Support collection of Prometheus exporter metrics at each replica, and report them to the controller, if the serve config AutoscalingConfig specifies.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional per-replica Prometheus metric collection for autoscaling, refactors Prometheus helpers into a shared module, and updates proto/config/constants/replica logic and tests.
> 
> - **Serve autoscaling (backend)**:
>   - Enable collecting custom Prometheus metrics per replica when `AutoscalingConfig.prometheus_metrics` is set; fetched at `RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST` and merged into autoscaling reports.
>   - Extend replica metrics manager to asynchronously fetch/filter metrics by `replica` label and include alongside ongoing-requests/custom metrics.
> - **Config/Proto**:
>   - Add `prometheus_metrics` to `AutoscalingConfig` (Python) and new proto messages `PrometheusCustomMetrics`/`PrometheusMetric`; map list<str> ↔ proto on (de)serialization.
>   - Update JSON surfaces and defaults accordingly.
> - **Constants**:
>   - Introduce `RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PROMETHEUS_HOST` env var for exporter host.
> - **Prometheus utilities**:
>   - New `python/ray/_private/prometheus_utils.py` with fetch/parse/filter helpers and async fetch; remove duplicated logic from `test_utils` and update imports across tests/benchmarks.
> - **Tests/BUILD**:
>   - Add `test_prometheus_autoscaling_metrics.py`; adjust existing tests and BUILD to include env and new imports; minor test stability tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a540ce4c277c15ece9b3f2a21d46270f1ebfdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->