### PR TITLE
[Data] Add descriptive error if user tries to download from invalid column

### DIFF
--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -244,6 +244,13 @@ class PartitionActor:
         return file_sizes
 
     def __call__(self, block: pa.Table) -> Iterator[pa.Table]:
+        if self._uri_column_name not in block.column_names:
+            raise ValueError(
+                "Ray Data tried to download URIs from a column named "
+                f"{self._uri_column_name!r}, but a column with that name doesn't "
+                "exist. Is the specified download column correct?"
+            )
+
         if not isinstance(block, pa.Table):
             block = BlockAccessor.for_block(block).to_arrow()
 

--- a/python/ray/data/tests/test_download_expression.py
+++ b/python/ray/data/tests/test_download_expression.py
@@ -221,7 +221,7 @@ class TestDownloadExpressionErrors:
         ds_with_downloads = ds.with_column("bytes", download("non_existent_column"))
 
         # Should raise error when trying to execute
-        with pytest.raises(Exception):  # Could be KeyError or similar
+        with pytest.raises(ValueError):
             ds_with_downloads.take_all()
 
     def test_download_expression_with_null_uris(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

**Before**

> KeyError: 'Field "eggs" does not exist in schema'

**After**

> ValueError: Ray Data tried to download URIs in a column named 'eggs', but a column with that name doesn't exist. Is the specified download column correct?

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
