### PR TITLE
[release] Rename custom byod build job

### DIFF
--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -95,4 +95,4 @@ def _get_step_name(image: str, step_key: str, tests: List[Test]) -> str:
     step_name = f":tapioca: build custom: {ecr_repo}:{'-'.join(tag_without_build_id_and_custom_hash)} ({step_key})"
     for test in tests[:2]:
         step_name += f" {test.get_name()}"
-    return step_name[:70]
+    return step_name

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -95,4 +95,4 @@ def _get_step_name(image: str, step_key: str, tests: List[Test]) -> str:
     step_name = f":tapioca: build custom: {ecr_repo}:{'-'.join(tag_without_build_id_and_custom_hash)} ({step_key})"
     for test in tests[:2]:
         step_name += f" {test.get_name()}"
-    return step_name
+    return step_name[:70]

--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -8,6 +8,7 @@ import yaml
 from ray_release.custom_byod_build_init_helper import (
     create_custom_build_yaml,
     get_prerequisite_step,
+    _get_step_name,
 )
 from ray_release.configs.global_config import init_global_config
 from ray_release.bazel import bazel_runfile
@@ -94,6 +95,22 @@ def test_get_prerequisite_step():
     assert (
         get_prerequisite_step("ray-project/ray:abc123-custom")
         == config["release_image_step_ray"]
+    )
+
+
+def test_get_step_name():
+    tests = [
+        Test(name="test_1"),
+        Test(name="test_2"),
+        Test(name="test_3"),
+    ]
+    assert (
+        _get_step_name(
+            "ray-project/ray-ml:a1b2c3d4-py39-cpu-abcdef123456789abc123456789",
+            "abc123",
+            tests,
+        )
+        == ":tapioca: build custom: ray-ml:py39-cpu (abc123) test_1 test_2"
     )
 
 


### PR DESCRIPTION
So it looks more readable... 
It's now in the format of `ecr repo - image variant (step_key) test_1 test_2`