### PR TITLE
[core] Kill debug_state_gcs.txt

### DIFF
--- a/doc/source/ray-contribute/debugging.rst
+++ b/doc/source/ray-contribute/debugging.rst
@@ -67,9 +67,9 @@ If it worked, you should see as the first line in ``raylet.err``:
 
 Backend event stats
 -------------------
-The ``raylet`` process also periodically dumps event stats to the ``debug_state.txt`` log
-file if the ``RAY_event_stats=1`` environment variable is set. To also enable regular
-printing of the stats to log files, you can additionally set ``RAY_event_stats_print_interval_ms=1000``.
+The ``raylet`` process also periodically dumps event stats to ``debug_state.txt`` and its log
+file if ``RAY_event_stats=1`` environment variable is set. To alter the interval at which
+Ray writes stats to log files, you can set ``RAY_event_stats_print_interval_ms``.
 
 Event stats include ASIO event handlers, periodic timers, and RPC handlers. Here is a sample
 of what the event stats look like:

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -835,8 +835,7 @@ def test_logs_list(ray_start_with_dashboard):
         assert result["result"]
         logs = result["data"]["result"]
         assert "gcs_server" in logs
-        assert "internal" in logs
-        assert len(logs) == 2
+        assert len(logs) == 1
         assert "gcs_server.out" in logs["gcs_server"]
         assert "gcs_server.err" in logs["gcs_server"]
         return True

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -839,7 +839,6 @@ def test_logs_list(ray_start_with_dashboard):
         assert len(logs) == 2
         assert "gcs_server.out" in logs["gcs_server"]
         assert "gcs_server.err" in logs["gcs_server"]
-        assert "debug_state_gcs.txt" in logs["internal"]
         return True
 
     wait_for_condition(verify_filter)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -21,6 +21,9 @@
 /// The duration between dumping debug info to logs, or 0 to disable.
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
+/// The duration at which the GCS tries to run global GC.
+RAY_CONFIG(uint64_t, gcs_global_gc_interval_milliseconds, 10000)
+
 /// Whether to enable Ray event stats collection.
 RAY_CONFIG(bool, event_stats, true)
 
@@ -33,8 +36,8 @@ RAY_CONFIG(bool, emit_main_service_metrics, false)
 RAY_CONFIG(bool, enable_cluster_auth, true)
 
 /// The interval of periodic event loop stats print.
-/// -1 means the feature is disabled. In this case, stats are available to
-/// debug_state_*.txt
+/// -1 means the feature is disabled. In this case, stats are available
+/// in the associated process's log file.
 /// NOTE: This requires event_stats=1.
 RAY_CONFIG(int64_t, event_stats_print_interval_ms, 60000)
 

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -288,10 +288,7 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
       "GCSServer.deadline_timer.metrics_report");
 
   periodical_runner_->RunFnPeriodically(
-      [this] {
-        RAY_LOG(INFO) << GetDebugState();
-        PrintAsioStats();
-      },
+      [this] { PrintDebugState(); },
       /*ms*/ RayConfig::instance().event_stats_print_interval_ms(),
       "GCSServer.deadline_timer.debug_state_event_stats_print");
 
@@ -878,29 +875,17 @@ void GcsServer::RecordMetrics() const {
   gcs_job_manager_->RecordMetrics();
 }
 
-std::string GcsServer::GetDebugState() const {
-  std::ostringstream stream;
-  stream << "Gcs Debug state:\n\n"
-         << gcs_node_manager_->DebugString() << "\n\n"
-         << gcs_actor_manager_->DebugString() << "\n\n"
-         << gcs_resource_manager_->DebugString() << "\n\n"
-         << gcs_placement_group_manager_->DebugString() << "\n\n"
-         << gcs_publisher_->DebugString() << "\n\n"
-         << runtime_env_manager_->DebugString() << "\n\n"
-         << gcs_task_manager_->DebugString() << "\n\n"
-         << gcs_autoscaler_state_manager_->DebugString() << "\n\n";
-  return stream.str();
-}
+void GcsServer::PrintDebugState() const {
+  RAY_LOG(INFO) << "Gcs Debug state:\n\n"
+                << gcs_node_manager_->DebugString() << "\n\n"
+                << gcs_actor_manager_->DebugString() << "\n\n"
+                << gcs_resource_manager_->DebugString() << "\n\n"
+                << gcs_placement_group_manager_->DebugString() << "\n\n"
+                << gcs_publisher_->DebugString() << "\n\n"
+                << runtime_env_manager_->DebugString() << "\n\n"
+                << gcs_task_manager_->DebugString() << "\n\n"
+                << gcs_autoscaler_state_manager_->DebugString() << "\n\n";
 
-RedisClientOptions GcsServer::GetRedisClientOptions() {
-  return RedisClientOptions{config_.redis_address,
-                            config_.redis_port,
-                            config_.redis_username,
-                            config_.redis_password,
-                            config_.enable_redis_ssl};
-}
-
-void GcsServer::PrintAsioStats() {
   /// If periodic asio stats print is enabled, it will print it.
   const auto event_stats_print_interval_ms =
       RayConfig::instance().event_stats_print_interval_ms();
@@ -913,6 +898,14 @@ void GcsServer::PrintAsioStats() {
                     << io_context->GetIoService().stats().StatsString() << "\n\n";
     }
   }
+}
+
+RedisClientOptions GcsServer::GetRedisClientOptions() {
+  return RedisClientOptions{config_.redis_address,
+                            config_.redis_port,
+                            config_.redis_username,
+                            config_.redis_password,
+                            config_.enable_redis_ssl};
 }
 
 void GcsServer::TryGlobalGC() {

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -200,7 +200,7 @@ class GcsServer {
   StorageType GetStorageType() const;
 
   /// Print debug info periodically.
-  std::string GetDebugState() const;
+  void PrintDebugState() const;
 
   /// Collect stats from each module.
   void RecordMetrics() const;
@@ -210,9 +210,6 @@ class GcsServer {
   /// Expected to be idempotent while server is up.
   /// Makes several InternalKV calls, all in continuation.io_context().
   void GetOrGenerateClusterId(Postable<void(ClusterID cluster_id)> continuation);
-
-  /// Print the asio event loop stats for debugging.
-  void PrintAsioStats();
 
   RedisClientOptions GetRedisClientOptions();
 

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -80,7 +80,7 @@ class GcsPlacementGroupScheduler;
 class GcsPlacementGroupManager;
 class GcsTaskManager;
 class GcsAutoscalerStateManager;
-class RedisClientOptions;
+struct RedisClientOptions;
 
 /// The GcsServer will take over all requests from GcsClient and transparent
 /// transmit the command to the backend reliable storage for the time being.

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -80,6 +80,7 @@ class GcsPlacementGroupScheduler;
 class GcsPlacementGroupManager;
 class GcsTaskManager;
 class GcsAutoscalerStateManager;
+class RedisClientOptions;
 
 /// The GcsServer will take over all requests from GcsClient and transparent
 /// transmit the command to the backend reliable storage for the time being.

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -33,9 +33,6 @@
 #include "ray/gcs/gcs_task_manager.h"
 #include "ray/gcs/pubsub_handler.h"
 #include "ray/gcs/runtime_env_handler.h"
-#include "ray/gcs/store_client/in_memory_store_client.h"
-#include "ray/gcs/store_client/observable_store_client.h"
-#include "ray/gcs/store_client/redis_store_client.h"
 #include "ray/gcs/usage_stats_client.h"
 #include "ray/observability/ray_event_recorder.h"
 #include "ray/pubsub/gcs_publisher.h"
@@ -203,9 +200,6 @@ class GcsServer {
 
   /// Print debug info periodically.
   std::string GetDebugState() const;
-
-  /// Dump the debug info to debug_state_gcs.txt.
-  void DumpDebugStateToFile() const;
 
   /// Collect stats from each module.
   void RecordMetrics() const;


### PR DESCRIPTION
## Why are these changes needed?
We write the latest gcs state to this `debug_state_gcs.txt` file on a periodic timer and delete the old state dump. We don't really need this since this info gets written to the log file too. Also condensing the debug log dump and print asio stats into one print function that just directly goes to ray_log so there isn't an extra "turn the ostream into a string and feed into another ostream"

The raylet also does this and writes to a `debug_state.txt`, but we have a public api that actually reads from it. - local_dump https://github.com/ray-project/ray/blob/6782cbe2fb92c664522c4756f77350ffb298aff4/python/ray/scripts/scripts.py#L2185

Also updated some related docs.
