### PR TITLE
round timestamp to 10ms during time series merge

### DIFF
--- a/python/ray/serve/_private/metrics_utils.py
+++ b/python/ray/serve/_private/metrics_utils.py
@@ -400,13 +400,17 @@ def merge_instantaneous_total(
     Uses a k-way merge algorithm for O(n log k) complexity where k is the number
     of timeseries and n is the total number of events.
 
+    Timestamps are rounded to 1ms precision (3 decimal places) and datapoints
+    with the same rounded timestamp are combined, keeping the most recent value.
+
     Args:
         replicas_timeseries: List of time series, one per replica. Each time series
             is a list of TimeStampedValue objects sorted by timestamp.
 
     Returns:
         A list of TimeStampedValue representing the instantaneous total at event times.
-        Between events, the total remains constant (step function).
+        Between events, the total remains constant (step function). Timestamps are
+        rounded to 1ms precision and duplicate timestamps are combined.
     """
     # Filter out empty timeseries
     active_series = [series for series in replicas_timeseries if series]
@@ -454,7 +458,17 @@ def merge_instantaneous_total(
 
         # Only add a point if the total actually changed
         if value != old_value:  # Equivalent to new_total != old_total
-            merged.append(TimeStampedValue(timestamp, running_total))
+            # Round timestamp to 1ms precision (3 decimal places)
+            rounded_timestamp = round(timestamp, 3)
+
+            # Check if we already have a point with this rounded timestamp
+            # If so, update its value; otherwise, add a new point
+            if merged and merged[-1].timestamp == rounded_timestamp:
+                # Update the last point's value since timestamps match
+                merged[-1] = TimeStampedValue(rounded_timestamp, running_total)
+            else:
+                # Add new point with rounded timestamp
+                merged.append(TimeStampedValue(rounded_timestamp, running_total))
 
     return merged
 

--- a/python/ray/serve/_private/metrics_utils.py
+++ b/python/ray/serve/_private/metrics_utils.py
@@ -400,7 +400,7 @@ def merge_instantaneous_total(
     Uses a k-way merge algorithm for O(n log k) complexity where k is the number
     of timeseries and n is the total number of events.
 
-    Timestamps are rounded to 1ms precision (3 decimal places) and datapoints
+    Timestamps are rounded to 10ms precision (2 decimal places) and datapoints
     with the same rounded timestamp are combined, keeping the most recent value.
 
     Args:
@@ -410,7 +410,7 @@ def merge_instantaneous_total(
     Returns:
         A list of TimeStampedValue representing the instantaneous total at event times.
         Between events, the total remains constant (step function). Timestamps are
-        rounded to 1ms precision and duplicate timestamps are combined.
+        rounded to 10ms precision and duplicate timestamps are combined.
     """
     # Filter out empty timeseries
     active_series = [series for series in replicas_timeseries if series]
@@ -458,8 +458,8 @@ def merge_instantaneous_total(
 
         # Only add a point if the total actually changed
         if value != old_value:  # Equivalent to new_total != old_total
-            # Round timestamp to 1ms precision (3 decimal places)
-            rounded_timestamp = round(timestamp, 3)
+            # Round timestamp to 10ms precision (2 decimal places)
+            rounded_timestamp = round(timestamp, 2)
 
             # Check if we already have a point with this rounded timestamp
             # If so, update its value; otherwise, add a new point

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -555,21 +555,21 @@ class TestInstantaneousMerge:
         print(f"Late period average (20-30s): {late_avg:.2f}")
 
     def test_merge_instantaneous_total_timestamp_rounding(self):
-        """Test that timestamps are rounded to 1ms precision."""
+        """Test that timestamps are rounded to 10ms precision."""
         series1 = [
-            TimeStampedValue(1.0001234, 5.0),  # Should round to 1.000
-            TimeStampedValue(2.0005678, 7.0),  # Should round to 2.001
-            TimeStampedValue(3.0009999, 3.0),  # Should round to 3.001
+            TimeStampedValue(1.001234, 5.0),  # Should round to 1.00
+            TimeStampedValue(2.005678, 7.0),  # Should round to 2.01
+            TimeStampedValue(3.009999, 3.0),  # Should round to 3.01
         ]
         series2 = [
-            TimeStampedValue(1.5004321, 2.0),  # Should round to 1.500
-            TimeStampedValue(2.0008765, 4.0),  # Should round to 2.001
+            TimeStampedValue(1.504321, 2.0),  # Should round to 1.50
+            TimeStampedValue(2.008765, 4.0),  # Should round to 2.01
         ]
 
         result = merge_instantaneous_total([series1, series2])
 
-        # Verify timestamps are rounded to 3 decimal places
-        expected_timestamps = [1.000, 1.500, 2.001, 3.001]
+        # Verify timestamps are rounded to 2 decimal places (10ms precision)
+        expected_timestamps = [1.00, 1.50, 2.01, 3.01]
         actual_timestamps = [point.timestamp for point in result]
 
         assert len(actual_timestamps) == len(expected_timestamps)
@@ -578,12 +578,12 @@ class TestInstantaneousMerge:
 
         # Verify values are correct with rounded timestamps
         expected = [
-            TimeStampedValue(1.000, 5.0),  # series1 starts
-            TimeStampedValue(1.500, 7.0),  # series2 starts: 5+2=7
+            TimeStampedValue(1.00, 5.0),  # series1 starts
+            TimeStampedValue(1.50, 7.0),  # series2 starts: 5+2=7
             TimeStampedValue(
-                2.001, 11.0
+                2.01, 11.0
             ),  # s1 becomes 7, s2 becomes 4. Total: 7 + 4 = 11.0
-            TimeStampedValue(3.001, 7.0),  # series1 changes: 11+(3-7)=7
+            TimeStampedValue(3.01, 7.0),  # series1 changes: 11+(3-7)=7
         ]
         assert_timeseries_equal(result, expected)
 
@@ -591,13 +591,13 @@ class TestInstantaneousMerge:
         """Test that datapoints with same rounded timestamp are combined."""
         # Create series where multiple events round to the same timestamp
         series1 = [
-            TimeStampedValue(1.0001, 5.0),  # Rounds to 1.000
-            TimeStampedValue(1.0004, 7.0),  # Also rounds to 1.000
-            TimeStampedValue(2.0000, 10.0),  # Rounds to 2.000
+            TimeStampedValue(1.001, 5.0),  # Rounds to 1.00
+            TimeStampedValue(1.004, 7.0),  # Also rounds to 1.00
+            TimeStampedValue(2.000, 10.0),  # Rounds to 2.00
         ]
         series2 = [
-            TimeStampedValue(1.0002, 3.0),  # Rounds to 1.000
-            TimeStampedValue(1.0005, 4.0),  # Also rounds to 1.000
+            TimeStampedValue(1.002, 3.0),  # Rounds to 1.00
+            TimeStampedValue(1.005, 4.0),  # Also rounds to 1.00
         ]
 
         result = merge_instantaneous_total([series1, series2])
@@ -605,20 +605,20 @@ class TestInstantaneousMerge:
         # Should only have unique rounded timestamps
         timestamps = [point.timestamp for point in result]
         assert timestamps == [
-            1.000,
-            2.000,
-        ], f"Expected [1.000, 2.000], got {timestamps}"
+            1.00,
+            2.00,
+        ], f"Expected [1.00, 2.00], got {timestamps}"
 
-        # The value at 1.000 should be the final state after all changes at that rounded time
-        # Order of events at rounded timestamp 1.000:
-        # - series1: 0->5 (t=1.0001)
-        # - series2: 0->3 (t=1.0002)
-        # - series1: 5->7 (t=1.0004)
-        # - series2: 3->4 (t=1.0005)
+        # The value at 1.00 should be the final state after all changes at that rounded time
+        # Order of events at rounded timestamp 1.00:
+        # - series1: 0->5 (t=1.001)
+        # - series2: 0->3 (t=1.002)
+        # - series1: 5->7 (t=1.004)
+        # - series2: 3->4 (t=1.005)
         # Final state: series1=7, series2=4, total=11
         expected = [
-            TimeStampedValue(1.000, 11.0),  # Final combined state at rounded timestamp
-            TimeStampedValue(2.000, 14.0),  # series1 changes: 11+(10-7)=14
+            TimeStampedValue(1.00, 11.0),  # Final combined state at rounded timestamp
+            TimeStampedValue(2.00, 14.0),  # series1 changes: 11+(10-7)=14
         ]
         assert_timeseries_equal(result, expected)
 
@@ -626,43 +626,44 @@ class TestInstantaneousMerge:
         """Test edge cases for timestamp rounding and combination."""
         # Test rounding edge cases
         series1 = [
-            TimeStampedValue(1.0004999, 5.0),  # Should round to 1.000
-            TimeStampedValue(
-                1.0005000, 7.0
-            ),  # Should round to 1.000 (round half to even)
-            TimeStampedValue(1.0005001, 9.0),  # Should round to 1.001
+            TimeStampedValue(1.004999, 5.0),  # Should round to 1.0
+            TimeStampedValue(1.005000, 7.0),  # Should round to 1.0 (round half to even)
+            TimeStampedValue(1.005001, 9.0),  # Should round to 1.01
         ]
 
         result = merge_instantaneous_total([series1])
 
         # Should have two distinct rounded timestamps
-        expected_timestamps = [1.000, 1.001]
+        expected_timestamps = [1.0, 1.01]
         actual_timestamps = [point.timestamp for point in result]
         assert actual_timestamps == expected_timestamps
 
         # Values should reflect the changes
+        # Both 1.004999 and 1.005000 round to 1.0, so they get combined
+        # Order: 1.004999 (0->5), then 1.005000 (5->7) - final value at 1.0 is 7.0
+        # Then 1.005001 (7->9) rounds to 1.01 - value at 1.01 is 9.0
         expected = [
             TimeStampedValue(
-                1.000, 7.0
-            ),  # Final state after changes at 1.0004999 and 1.0005000
-            TimeStampedValue(1.001, 9.0),  # State after change at 1.0005001
+                1.0, 7.0
+            ),  # Final state after all changes that round to 1.0 (1.004999: 0->5, 1.005000: 5->7)
+            TimeStampedValue(1.01, 9.0),  # State after change at 1.005001 (7->9)
         ]
         assert_timeseries_equal(result, expected)
 
     def test_merge_instantaneous_total_no_changes_filtered(self):
         """Test that zero-change events are filtered even with rounding."""
         series1 = [
-            TimeStampedValue(1.0001, 5.0),  # Rounds to 1.000
-            TimeStampedValue(1.0004, 5.0),  # Also rounds to 1.000, no change
-            TimeStampedValue(2.0000, 7.0),  # Rounds to 2.000, change
+            TimeStampedValue(1.001, 5.0),  # Rounds to 1.00
+            TimeStampedValue(1.004, 5.0),  # Also rounds to 1.00, no change
+            TimeStampedValue(2.000, 7.0),  # Rounds to 2.00, change
         ]
 
         result = merge_instantaneous_total([series1])
 
         # Should only include points where value actually changed
         expected = [
-            TimeStampedValue(1.000, 5.0),  # Initial value
-            TimeStampedValue(2.000, 7.0),  # Value change
+            TimeStampedValue(1.00, 5.0),  # Initial value
+            TimeStampedValue(2.00, 7.0),  # Value change
         ]
         assert_timeseries_equal(result, expected)
 

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -582,7 +582,7 @@ class TestInstantaneousMerge:
             TimeStampedValue(1.500, 7.0),  # series2 starts: 5+2=7
             TimeStampedValue(
                 2.001, 11.0
-            ),  # series1 changes to 7, series2 changes to 4: 2+(7-5)+(4-2)=9, but series2 change happens at same rounded time
+            ),  # s1 becomes 7, s2 becomes 4. Total: 7 + 4 = 11.0
             TimeStampedValue(3.001, 7.0),  # series1 changes: 11+(3-7)=7
         ]
         assert_timeseries_equal(result, expected)
@@ -629,7 +629,7 @@ class TestInstantaneousMerge:
             TimeStampedValue(1.0004999, 5.0),  # Should round to 1.000
             TimeStampedValue(
                 1.0005000, 7.0
-            ),  # Should round to 1.001 (exactly at 0.5ms)
+            ),  # Should round to 1.000 (round half to even)
             TimeStampedValue(1.0005001, 9.0),  # Should round to 1.001
         ]
 
@@ -644,8 +644,8 @@ class TestInstantaneousMerge:
         expected = [
             TimeStampedValue(
                 1.000, 7.0
-            ),  # Final state after changes at 1.000 (5.0 then 7.0)
-            TimeStampedValue(1.001, 9.0),  # Final state after both changes at 1.001
+            ),  # Final state after changes at 1.0004999 and 1.0005000
+            TimeStampedValue(1.001, 9.0),  # State after change at 1.0005001
         ]
         assert_timeseries_equal(result, expected)
 


### PR DESCRIPTION
handles the case where there are timestamps that are microsecond precision apart. This change would help reduce number of samples in the merged timeseries. I have chosen `1ms` as the precision 