### PR TITLE
[core][rdt][cgraphs] Only allocate tensor without initializing/writing on recv

### DIFF
--- a/python/ray/experimental/channel/conftest.py
+++ b/python/ray/experimental/channel/conftest.py
@@ -153,8 +153,8 @@ def start_nccl_mock():
     tensor_patcher = mock.patch("torch.Tensor.is_cuda", True)
     tensor_patcher.start()
     tensor_allocator_patcher = mock.patch(
-        "ray.experimental.channel.torch_tensor_accelerator_channel._torch_zeros_allocator",
-        lambda shape, dtype: torch.zeros(shape, dtype=dtype),
+        "ray.experimental.channel.torch_tensor_accelerator_channel._torch_tensor_allocator",
+        lambda shape, dtype: torch.empty(shape, dtype=dtype),
     )
     tensor_allocator_patcher.start()
 

--- a/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
@@ -362,7 +362,7 @@ def _torch_zeros_allocator(
     import torch
 
     ctx = ChannelContext.get_current()
-    return torch.zeros(shape, dtype=dtype, device=ctx.torch_device)
+    return torch.empty(shape, dtype=dtype, device=ctx.torch_device)
 
 
 class _TorchTensorAcceleratorChannel(ChannelInterface):

--- a/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
@@ -352,12 +352,12 @@ class TorchTensorAcceleratorChannel(ChannelInterface):
             self._local_channel.close()
 
 
-def _torch_zeros_allocator(
+def _torch_tensor_allocator(
     shape: Union[int, Tuple[int]],
     dtype: "torch.dtype",
 ):
     """
-    Allocate a zeros tensor buffer matching the given metadata.
+    Allocate a tensor buffer matching the given metadata.
     """
     import torch
 
@@ -633,7 +633,7 @@ class _TorchTensorAcceleratorChannel(ChannelInterface):
         bufs: List["torch.Tensor"] = []
         for meta in meta_list:
             buf = self._accelerator_group.recv(
-                meta.shape, meta.dtype, self._writer_rank, _torch_zeros_allocator
+                meta.shape, meta.dtype, self._writer_rank, _torch_tensor_allocator
             )
             bufs.append(buf)
         # TODO: Sync CUDA stream after receiving all tensors, instead of after

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -91,7 +91,7 @@ def __ray_recv__(
     tensors = []
     for meta in tensor_meta:
         shape, dtype = meta
-        tensor = torch.zeros(shape, dtype=dtype, device=device)
+        tensor = torch.empty(shape, dtype=dtype, device=device)
         tensors.append(tensor)
 
     tensor_transport_manager = get_tensor_transport_manager(backend)

--- a/release/microbenchmark/experimental/compiled_graph_gpu_microbenchmark.py
+++ b/release/microbenchmark/experimental/compiled_graph_gpu_microbenchmark.py
@@ -105,7 +105,7 @@ class NcclWorker:
                 input_buffer = torch.ones(shape, dtype=dtype, device=self.device) * i
                 self._send(input_buffer, input_buffer.numel(), other_rank)
             else:
-                input_buffer = torch.zeros(shape, dtype=dtype, device=self.device)
+                input_buffer = torch.empty(shape, dtype=dtype, device=self.device)
                 self._recv(input_buffer, input_buffer.numel(), other_rank)
 
             torch.cuda.synchronize()


### PR DESCRIPTION
## Why are these changes needed?
`torch.zeros` allocates memory and then writes zeros to it. `torch.empty` only allocates the memory, so you'll get whatever existed in memory there before but don't pay the cost of writing which is ok because our recv will do the actual writing here. Did some benchmarks on cpu memory and gpu memory on an aws g4dn.12xlarge. Did them 10-20 times, ~2000x on cpu, ~10x on gpu. The gpu benchmarks did need the warmup loop before for empty to actually get the 10x gains.

Making this change for rdt recv's, cgraphs recv's, and the nccl benchmarking recv in our cgraph benchmarks.

### CPU Memory Benchmark
```
start_time = time.perf_counter()
tensor = torch.empty(10000 * 1024 * 1024, dtype=torch.uint8)
# tensor = torch.zeros(10000 * 1024 * 1024, dtype=torch.uint8)
print(time.perf_counter() - start_time)

# Zeros: 0.44489038293249905
# Empty: 0.00016737193800508976
```

### GPU Memory Benchmark
```
# warm up context/allocator
for _ in range(10):
    _ = torch.empty(1, device="cuda")

start_time = time.perf_counter()
tensor = torch.empty(10000 * 1024 * 1024, dtype=torch.uint8, device="cuda")
# tensor = torch.zeros(10000 * 1024 * 1024, dtype=torch.uint8, device="cuda")
print(time.perf_counter() - start_time)

# Zeros: 0.008416594937443733
# Empty: 0.0006318900268524885
```
