### PR TITLE
[core] Mark release tests as stable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2727,6 +2727,7 @@
   group: core-daily-test
   working_dir: nightly_tests
 
+  # TODO: https://github.com/ray-project/ray/issues/47596
   stable: false
 
   frequency: nightly

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2727,6 +2727,8 @@
   group: core-daily-test
   working_dir: nightly_tests
 
+  stable: false
+
   frequency: nightly
   team: core
   env: aws_perf

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2324,8 +2324,6 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: false
-
   cluster:
     byod: {}
     cluster_compute: tpl_64.yaml
@@ -2339,8 +2337,6 @@
   team: core
   frequency: nightly
   working_dir: microbenchmark
-
-  stable: false
 
   cluster:
     byod:
@@ -2357,8 +2353,6 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: false
-
   cluster:
     byod:
       type: gpu
@@ -2373,8 +2367,6 @@
   team: core
   frequency: nightly
   working_dir: microbenchmark
-
-  stable: false
 
   cluster:
     byod:
@@ -2391,8 +2383,6 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: false
-
   cluster:
     byod:
       type: gpu
@@ -2407,8 +2397,6 @@
   team: core
   frequency: nightly
   working_dir: benchmark-worker-startup
-  stable: false
-
 
   cluster:
     byod:
@@ -2437,8 +2425,6 @@
 
   frequency: manual # was nightly
   team: core
-  # https://github.com/ray-project/ray/issues/39165
-  stable: false
 
   cluster:
     byod:
@@ -2498,8 +2484,6 @@
 - name: stress_test_state_api_scale
   group: core-daily-test
   working_dir: nightly_tests
-
-  stable: false
 
   frequency: nightly
   team: core
@@ -2742,9 +2726,6 @@
 - name: single_node_oom
   group: core-daily-test
   working_dir: nightly_tests
-
-  # TODO: https://github.com/ray-project/ray/issues/47596
-  stable: false
 
   frequency: nightly
   team: core
@@ -3714,8 +3695,6 @@
 - name: autoscaler_aws
   group: autoscaler-test
   working_dir: autoscaling_tests
-
-  stable: False
 
   frequency: nightly
   team: core


### PR DESCRIPTION
## Why are these changes needed?

A lot of release tests such as all the gpu objects and compiled graphs ones and other old core ones were marked as `stable: false`. Most of these actually pass https://buildkite.com/ray-project/release/builds/59990#_.

`single_node_oom` is the only one that doesn't pass, keeping it as unstable for now, upgrading this issue to a P0 https://github.com/ray-project/ray/issues/47596 - we should fix it or delete it, a quick look at it makes me think delete. It's trying to run 4 tasks that use up 45% of memory with sleeps in the middle and hoping exponential submission backoff works out in a way where they all eventually finish...

A lot of libraries have release tests with `stable: false`. These release tests will run twice nightly and fail and provide no valuable signals. These should be fixed, deleted, or marked stable too.