### PR TITLE
[tune] improve _PBTTrialState for dev/debugging usage

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -47,7 +47,8 @@ class _PBTTrialState:
             dict[str, object]
         ] = None  # Used for synchronous mode
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
+        # Informative repr for easier debugging.
         return (
             self.__class__.__name__
             + "("
@@ -64,9 +65,6 @@ class _PBTTrialState:
             )
             + ")"
         )
-
-    def __repr__(self) -> str:
-        return self.__class__.__name__ + "(" + self._trial_repr + ")"
 
 
 def _explore(

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -37,7 +37,6 @@ class _PBTTrialState:
     """Internal PBT state tracked per-trial."""
 
     def __init__(self, trial: Trial):
-        self._trial_repr: str = repr(trial)
         self.orig_tag = trial.experiment_tag
         self.last_score: Union[float, MaybeNone] = None  # Set on _save_trial_state
         self.last_checkpoint: Union[TrainCheckpoint, _FutureTrainingResult, None] = None

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -7,7 +7,7 @@ import random
 import shutil
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 from ray.air.constants import TRAINING_ITERATION
 from ray.train._internal.session import _FutureTrainingResult, _TrainingResult
@@ -27,9 +27,6 @@ if TYPE_CHECKING:
     from ray.train import Checkpoint as TrainCheckpoint
     from ray.tune.execution.tune_controller import TuneController
 
-    MaybeNone = Any
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -38,7 +35,7 @@ class _PBTTrialState:
 
     def __init__(self, trial: Trial):
         self.orig_tag = trial.experiment_tag
-        self.last_score: Union[float, MaybeNone] = None  # Set on _save_trial_state
+        self.last_score: Union[float, None] = None  # Set on _save_trial_state
         self.last_checkpoint: Union[TrainCheckpoint, _FutureTrainingResult, None] = None
         self.last_perturbation_time: int = 0
         self.last_train_time: int = 0  # Used for synchronous mode
@@ -969,7 +966,8 @@ class PopulationBasedTraining(FIFOScheduler):
                 logger.debug("Trial {} is finished".format(trial))
             if state.last_score is not None and not trial.is_finished():
                 trials.append(trial)
-        trials.sort(key=lambda t: self._trial_state[t].last_score)
+        # last_score is by construction never None
+        trials.sort(key=lambda t: self._trial_state[t].last_score)  # type: ignore[arg-type,return-value]
 
         if len(trials) <= 1:
             return [], []

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -24,7 +24,7 @@ from ray.util import PublicAPI
 from ray.util.debug import log_once
 
 if TYPE_CHECKING:
-    from ray.train._checkpoint import Checkpoint as TrainCheckpoint
+    from ray.train import Checkpoint as TrainCheckpoint
     from ray.tune.execution.tune_controller import TuneController
 
     MaybeNone = Any


### PR DESCRIPTION
## Why are these changes needed?

I am working with a custom variant of PBT, the when debugging the _PBTTrialState is not very informative; and its printed variant looks like a tuple which is confusing.

This PR improves the usage of the _PBTTrialState by:
- adding type-hints
- more informative repr; usefull during debugging

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

NaN

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] This PR is not tested, cosmetic changes only
