### PR TITLE
[core] Modify `RedisDelKeyPrefixSync` to use the Redis `SCAN` command instead of `KEYS` when identifying GCS keys to clean up

### DIFF
--- a/python/ray/_private/gcs_utils.py
+++ b/python/ray/_private/gcs_utils.py
@@ -111,15 +111,14 @@ def cleanup_redis_storage(
     storage_namespace: str,
     username: Optional[str] = None,
 ):
-    """This function is used to cleanup the storage. Before we having
-    a good design for storage backend, it can be used to delete the old
-    data. It support redis cluster and non cluster mode.
+    """This function is used to cleanup the GCS storage in Redis.
+    It supports Redis in cluster and non-cluster modes.
 
     Args:
-       host: The host address of the Redis.
-       port: The port of the Redis.
-       username: The username of the Redis.
-       password: The password of the Redis.
+       host: The Redis host address.
+       port: The Redis port.
+       username: The Redis username.
+       password: The Redis password.
        use_ssl: Whether to encrypt the connection.
        storage_namespace: The namespace of the storage to be deleted.
     """
@@ -147,9 +146,9 @@ def cleanup_redis_storage(
     if not isinstance(storage_namespace, str):
         raise ValueError("storage namespace must be a string")
 
-    # Right now, GCS stores all data into multiple hashes with keys prefixed by
+    # Right now, GCS stores all data in multiple hashes with keys prefixed by
     # storage_namespace. So we only need to delete the specific key prefix to cleanup
-    # the cluster.
+    # the cluster's data.
     # Note this deletes all keys with prefix `RAY{key_prefix}@`, not `{key_prefix}`.
     return del_key_prefix_from_storage(
         host, port, username, password, use_ssl, storage_namespace

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -555,9 +555,9 @@ bool RedisDelKeyPrefixSync(const std::string &host,
     std::vector<std::string> scan_result;
     cursor = reply->ReadAsScanArray(&scan_result);
 
-    for (const auto &key : scan_result) {
-      keys.push_back(key);
-    }
+    keys.insert(keys.end(),
+                std::make_move_iterator(scan_result.begin()),
+                std::make_move_iterator(scan_result.end()));
   } while (cursor != 0);
 
   if (keys.empty()) {

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -540,14 +540,26 @@ bool RedisDelKeyPrefixSync(const std::string &host,
 
   // Delete all such keys by using empty table name.
   RedisKey redis_key{external_storage_namespace, /*table_name=*/""};
-  std::vector<std::string> cmd{"KEYS",
-                               RedisMatchPattern::Prefix(redis_key.ToString()).escaped_};
-  std::promise<std::shared_ptr<CallbackReply>> promise;
-  context->RunArgvAsync(cmd, [&promise](const std::shared_ptr<CallbackReply> &reply) {
-    promise.set_value(reply);
-  });
-  auto reply = promise.get_future().get();
-  const auto &keys = reply->ReadAsStringArray();
+  std::string match_pattern = RedisMatchPattern::Prefix(redis_key.ToString()).escaped_;
+  std::vector<std::optional<std::string>> keys;
+  size_t cursor = 0;
+
+  do {
+    std::vector<std::string> cmd{"SCAN", std::to_string(cursor), "MATCH", match_pattern};
+    std::promise<std::shared_ptr<CallbackReply>> promise;
+    context->RunArgvAsync(cmd, [&promise](const std::shared_ptr<CallbackReply> &reply) {
+      promise.set_value(reply);
+    });
+
+    auto reply = promise.get_future().get();
+    std::vector<std::string> scan_result;
+    cursor = reply->ReadAsScanArray(&scan_result);
+
+    for (const auto &key : scan_result) {
+      keys.push_back(key);
+    }
+  } while (cursor != 0);
+
   if (keys.empty()) {
     RAY_LOG(INFO) << "No keys found for external storage namespace "
                   << external_storage_namespace;


### PR DESCRIPTION
## Why are these changes needed?

When cleaning up GCS data in Redis, we should not use `KEYS`:
* `KEYS` is blocking, and its use is discouraged in production Redis instances
* some modern CSP-managed Redis offerings like AWS Serverless ElastiCache do not support `KEYS` because of its poor performance characteristics; it would be ideal for Ray to attempt to be compatible with these services, so let's stop using `KEYS`, and instead use `SCAN`, which is supported by _eg_ AWS Serverless ElastiCache
* ⚠️ this diff was generated with assistance from Claude Code

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
- [x] I built wheels from my branch and used them to deploy a KubeRay-based Ray Service and Ray Cluster; I then enabled GCS fault tolerance using an AWS Serverless ElastiCache instance as the GCS Redis datastore, and confirmed that the GCS cleanup finalizer worked as expected (by observing which keys got deleted in Redis)
