### PR TITLE
[core] Clean up / improve GCS EventRecorder + GCS TaskManager

### DIFF
--- a/src/ray/gcs/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_ray_event_converter.cc
@@ -19,80 +19,18 @@
 #include "absl/container/flat_hash_map.h"
 #include "ray/common/grpc_util.h"
 #include "ray/common/id.h"
-#include "ray/util/logging.h"
 
 namespace ray {
 namespace gcs {
 
-std::vector<rpc::AddTaskEventDataRequest>
-GcsRayEventConverter::ConvertToTaskEventDataRequests(
-    rpc::events::AddEventsRequest &&request) {
-  std::vector<rpc::AddTaskEventDataRequest> requests_per_job_id;
-  absl::flat_hash_map<std::string, size_t> job_id_to_index;
-  // convert RayEvents to TaskEvents and group by job id.
-  for (auto &event : *request.mutable_events_data()->mutable_events()) {
-    std::optional<rpc::TaskEvents> task_event = std::nullopt;
-    switch (event.event_type()) {
-    case rpc::events::RayEvent::TASK_DEFINITION_EVENT: {
-      task_event = ConvertToTaskEvents(std::move(*event.mutable_task_definition_event()));
-      break;
-    }
-    case rpc::events::RayEvent::TASK_EXECUTION_EVENT: {
-      task_event = ConvertToTaskEvents(std::move(*event.mutable_task_execution_event()));
-      break;
-    }
-    case rpc::events::RayEvent::TASK_PROFILE_EVENT: {
-      task_event = ConvertToTaskEvents(std::move(*event.mutable_task_profile_events()));
-      break;
-    }
-    case rpc::events::RayEvent::ACTOR_TASK_DEFINITION_EVENT: {
-      task_event =
-          ConvertToTaskEvents(std::move(*event.mutable_actor_task_definition_event()));
-      break;
-    }
-    default:
-      // TODO(can-anyscale): Handle other event types
-      break;
-    }
+namespace {
 
-    // Groups all taskEvents belonging to same jobId into one AddTaskEventDataRequest
-    if (task_event) {
-      AddTaskEventToRequest(std::move(*task_event), requests_per_job_id, job_id_to_index);
-    }
-  }
-
-  //  Groups all taskEventMetadata belonging to same jobId into one
-  //  AddTaskEventDataRequest
-  auto *metadata = request.mutable_events_data()->mutable_task_events_metadata();
-  if (metadata->dropped_task_attempts_size() > 0) {
-    AddDroppedTaskAttemptsToRequest(
-        std::move(*metadata), requests_per_job_id, job_id_to_index);
-  }
-  return requests_per_job_id;
-}
-
-void GcsRayEventConverter::AddTaskEventToRequest(
-    rpc::TaskEvents &&task_event,
-    std::vector<rpc::AddTaskEventDataRequest> &requests_per_job_id,
-    absl::flat_hash_map<std::string, size_t> &job_id_to_index) {
-  const std::string job_id_key = task_event.job_id();
-  auto it = job_id_to_index.find(job_id_key);
-  if (it == job_id_to_index.end()) {
-    // Create new AddTaskEventDataRequest entry and add index to map
-    size_t idx = requests_per_job_id.size();
-    requests_per_job_id.emplace_back();
-    auto *data = requests_per_job_id.back().mutable_data();
-    data->set_job_id(job_id_key);
-    *data->add_events_by_task() = std::move(task_event);
-    job_id_to_index.emplace(job_id_key, idx);
-  } else {
-    // add taskEvent to existing AddTaskEventDataRequest with same job id
-    auto *data = requests_per_job_id[it->second].mutable_data();
-    *data->add_events_by_task() = std::move(task_event);
-  }
-}
-
-void GcsRayEventConverter::AddDroppedTaskAttemptsToRequest(
+/// Add dropped task attempts to the appropriate job-grouped request.
+///
+/// \param metadata The task events metadata containing dropped task attempts.
+/// \param requests_per_job_id The list of requests grouped by job id.
+/// \param job_id_to_index The map from job id to index in requests_per_job_id.
+void AddDroppedTaskAttemptsToRequest(
     rpc::events::TaskEventsMetadata &&metadata,
     std::vector<rpc::AddTaskEventDataRequest> &requests_per_job_id,
     absl::flat_hash_map<std::string, size_t> &job_id_to_index) {
@@ -118,8 +56,58 @@ void GcsRayEventConverter::AddDroppedTaskAttemptsToRequest(
   }
 }
 
-rpc::TaskEvents GcsRayEventConverter::ConvertToTaskEvents(
-    rpc::events::TaskDefinitionEvent &&event) {
+/// Populate the TaskInfoEntry with the given runtime env info, function descriptor,
+/// and required resources. This function is commonly used to convert the task
+/// and actor task definition events to TaskEvents.
+///
+/// \param serialized_runtime_env The serialized runtime environment string.
+/// \param function_descriptor The function descriptor.
+/// \param required_resources The required resources.
+/// \param language The language of the task.
+/// \param task_info The output TaskInfoEntry to populate.
+void PopulateTaskRuntimeAndFunctionInfo(
+    std::string &&serialized_runtime_env,
+    rpc::FunctionDescriptor &&function_descriptor,
+    ::google::protobuf::Map<std::string, double> &&required_resources,
+    rpc::Language language,
+    rpc::TaskInfoEntry *task_info) {
+  task_info->set_language(language);
+  task_info->mutable_runtime_env_info()->set_serialized_runtime_env(
+      std::move(serialized_runtime_env));
+  switch (language) {
+  case rpc::Language::CPP:
+    if (function_descriptor.has_cpp_function_descriptor()) {
+      task_info->set_func_or_class_name(
+          std::move(*function_descriptor.mutable_cpp_function_descriptor()
+                         ->mutable_function_name()));
+    }
+    break;
+  case rpc::Language::PYTHON:
+    if (function_descriptor.has_python_function_descriptor()) {
+      task_info->set_func_or_class_name(
+          std::move(*function_descriptor.mutable_python_function_descriptor()
+                         ->mutable_function_name()));
+    }
+    break;
+  case rpc::Language::JAVA:
+    if (function_descriptor.has_java_function_descriptor()) {
+      task_info->set_func_or_class_name(
+          std::move(*function_descriptor.mutable_java_function_descriptor()
+                         ->mutable_function_name()));
+    }
+    break;
+  default:
+    // Other languages are not handled.
+    break;
+  }
+  task_info->mutable_required_resources()->swap(required_resources);
+}
+
+/// Convert a TaskDefinitionEvent to a TaskEvents.
+///
+/// \param event The TaskDefinitionEvent to convert.
+/// \return The output TaskEvents to populate.
+rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskDefinitionEvent &&event) {
   rpc::TaskEvents task_event;
   task_event.set_task_id(event.task_id());
   task_event.set_attempt_number(event.task_attempt());
@@ -143,8 +131,11 @@ rpc::TaskEvents GcsRayEventConverter::ConvertToTaskEvents(
   return task_event;
 }
 
-rpc::TaskEvents GcsRayEventConverter::ConvertToTaskEvents(
-    rpc::events::TaskExecutionEvent &&event) {
+/// Convert a TaskExecutionEvent to a TaskEvents.
+///
+/// \param event The TaskExecutionEvent to convert.
+/// \return The output TaskEvents to populate.
+rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskExecutionEvent &&event) {
   rpc::TaskEvents task_event;
   task_event.set_task_id(event.task_id());
   task_event.set_attempt_number(event.task_attempt());
@@ -154,7 +145,7 @@ rpc::TaskEvents GcsRayEventConverter::ConvertToTaskEvents(
   task_state_update->set_node_id(event.node_id());
   task_state_update->set_worker_id(event.worker_id());
   task_state_update->set_worker_pid(event.worker_pid());
-  task_state_update->mutable_error_info()->Swap(event.mutable_ray_error_info());
+  *task_state_update->mutable_error_info() = std::move(*event.mutable_ray_error_info());
 
   for (const auto &[state, timestamp] : event.task_state()) {
     int64_t ns = ProtoTimestampToAbslTimeNanos(timestamp);
@@ -163,8 +154,11 @@ rpc::TaskEvents GcsRayEventConverter::ConvertToTaskEvents(
   return task_event;
 }
 
-rpc::TaskEvents GcsRayEventConverter::ConvertToTaskEvents(
-    rpc::events::ActorTaskDefinitionEvent &&event) {
+/// Convert an ActorTaskDefinitionEvent to a TaskEvents.
+///
+/// \param event The ActorTaskDefinitionEvent to convert.
+/// \return The output TaskEvents to populate.
+rpc::TaskEvents ConvertToTaskEvents(rpc::events::ActorTaskDefinitionEvent &&event) {
   rpc::TaskEvents task_event;
   task_event.set_task_id(event.task_id());
   task_event.set_attempt_number(event.task_attempt());
@@ -190,50 +184,81 @@ rpc::TaskEvents GcsRayEventConverter::ConvertToTaskEvents(
   return task_event;
 }
 
-rpc::TaskEvents GcsRayEventConverter::ConvertToTaskEvents(
-    rpc::events::TaskProfileEvents &&event) {
+/// Convert ProfileEvents to a TaskEvents.
+///
+/// \param event TaskProfileEvents object to convert.
+/// \return The output TaskEvents to populate.
+rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskProfileEvents &&event) {
   rpc::TaskEvents task_event;
   task_event.set_task_id(event.task_id());
   task_event.set_attempt_number(event.attempt_number());
   task_event.set_job_id(event.job_id());
 
-  task_event.mutable_profile_events()->Swap(event.mutable_profile_events());
+  *task_event.mutable_profile_events() = std::move(*event.mutable_profile_events());
   return task_event;
 }
 
-void GcsRayEventConverter::PopulateTaskRuntimeAndFunctionInfo(
-    std::string &&serialized_runtime_env,
-    rpc::FunctionDescriptor &&function_descriptor,
-    ::google::protobuf::Map<std::string, double> &&required_resources,
-    rpc::Language language,
-    rpc::TaskInfoEntry *task_info) {
-  task_info->set_language(language);
-  task_info->mutable_runtime_env_info()->set_serialized_runtime_env(
-      std::move(serialized_runtime_env));
-  switch (language) {
-  case rpc::Language::CPP:
-    if (function_descriptor.has_cpp_function_descriptor()) {
-      task_info->set_func_or_class_name(
-          function_descriptor.cpp_function_descriptor().function_name());
+}  // namespace
+
+std::vector<rpc::AddTaskEventDataRequest> ConvertToTaskEventDataRequests(
+    rpc::events::AddEventsRequest &&request) {
+  std::vector<rpc::AddTaskEventDataRequest> requests_per_job_id;
+  absl::flat_hash_map<std::string, size_t> job_id_to_index;
+  // convert RayEvents to TaskEvents and group by job id.
+  for (auto &event : *request.mutable_events_data()->mutable_events()) {
+    std::optional<rpc::TaskEvents> task_event = std::nullopt;
+
+    switch (event.event_type()) {
+    case rpc::events::RayEvent::TASK_DEFINITION_EVENT: {
+      task_event = ConvertToTaskEvents(std::move(*event.mutable_task_definition_event()));
+      break;
     }
-    break;
-  case rpc::Language::PYTHON:
-    if (function_descriptor.has_python_function_descriptor()) {
-      task_info->set_func_or_class_name(
-          function_descriptor.python_function_descriptor().function_name());
+    case rpc::events::RayEvent::TASK_EXECUTION_EVENT: {
+      task_event = ConvertToTaskEvents(std::move(*event.mutable_task_execution_event()));
+      break;
     }
-    break;
-  case rpc::Language::JAVA:
-    if (function_descriptor.has_java_function_descriptor()) {
-      task_info->set_func_or_class_name(
-          function_descriptor.java_function_descriptor().function_name());
+    case rpc::events::RayEvent::TASK_PROFILE_EVENT: {
+      task_event = ConvertToTaskEvents(std::move(*event.mutable_task_profile_events()));
+      break;
     }
-    break;
-  default:
-    // Other languages are not handled.
-    break;
+    case rpc::events::RayEvent::ACTOR_TASK_DEFINITION_EVENT: {
+      task_event =
+          ConvertToTaskEvents(std::move(*event.mutable_actor_task_definition_event()));
+      break;
+    }
+    default:
+      // TODO(can-anyscale): Handle other event types
+      break;
+    }
+
+    // Groups all taskEvents belonging to same jobId into one AddTaskEventDataRequest
+    if (task_event) {
+      const std::string job_id_key = task_event->job_id();
+      auto it = job_id_to_index.find(job_id_key);
+      if (it == job_id_to_index.end()) {
+        // Create new AddTaskEventDataRequest entry and add index to map
+        size_t idx = requests_per_job_id.size();
+        requests_per_job_id.emplace_back();
+        auto *data = requests_per_job_id.back().mutable_data();
+        data->set_job_id(job_id_key);
+        *data->add_events_by_task() = std::move(*task_event);
+        job_id_to_index.emplace(job_id_key, idx);
+      } else {
+        // add taskEvent to existing AddTaskEventDataRequest with same job id
+        auto *data = requests_per_job_id[it->second].mutable_data();
+        *data->add_events_by_task() = std::move(*task_event);
+      }
+    }
   }
-  task_info->mutable_required_resources()->swap(required_resources);
+
+  //  Groups all taskEventMetadata belonging to same jobId into one
+  //  AddTaskEventDataRequest
+  auto *metadata = request.mutable_events_data()->mutable_task_events_metadata();
+  if (metadata->dropped_task_attempts_size() > 0) {
+    AddDroppedTaskAttemptsToRequest(
+        std::move(*metadata), requests_per_job_id, job_id_to_index);
+  }
+  return requests_per_job_id;
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_ray_event_converter.cc
@@ -97,8 +97,7 @@ void PopulateTaskRuntimeAndFunctionInfo(
     }
     break;
   default:
-    // Other languages are not handled.
-    break;
+    RAY_CHECK(false) << "Unsupported language: " << language;
   }
   task_info->mutable_required_resources()->swap(required_resources);
 }
@@ -227,8 +226,7 @@ std::vector<rpc::AddTaskEventDataRequest> ConvertToTaskEventDataRequests(
       break;
     }
     default:
-      // TODO(can-anyscale): Handle other event types
-      break;
+      RAY_CHECK(false) << "Unsupported event type: " << event.event_type();
     }
 
     // Groups all taskEvents belonging to same jobId into one AddTaskEventDataRequest

--- a/src/ray/gcs/gcs_ray_event_converter.h
+++ b/src/ray/gcs/gcs_ray_event_converter.h
@@ -16,92 +16,19 @@
 
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
-#include "gtest/gtest_prod.h"
 #include "src/ray/protobuf/events_event_aggregator_service.pb.h"
 #include "src/ray/protobuf/gcs_service.pb.h"
 
 namespace ray {
 namespace gcs {
 
-/// GcsRayEventConverter converts RayEvents to TaskEvents.
-class GcsRayEventConverter {
- public:
-  GcsRayEventConverter() = default;
-  ~GcsRayEventConverter() = default;
-
-  /// Convert an AddEventsRequest to a list of AddTaskEventDataRequest objects,
-  /// grouping entries by job id.
-  ///
-  /// \param request The AddEventsRequest to convert.
-  /// \return A list of AddTaskEventDataRequest grouped by job id.
-  std::vector<rpc::AddTaskEventDataRequest> ConvertToTaskEventDataRequests(
-      rpc::events::AddEventsRequest &&request);
-
- private:
-  /// Convert a TaskDefinitionEvent to a TaskEvents.
-  ///
-  /// \param event The TaskDefinitionEvent to convert.
-  /// \return The output TaskEvents to populate.
-  rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskDefinitionEvent &&event);
-
-  /// Convert ProfileEvents to a TaskEvents.
-  ///
-  /// \param event TaskProfileEvents object to convert.
-  /// \return The output TaskEvents to populate.
-  rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskProfileEvents &&event);
-
-  /// Convert a TaskExecutionEvent to a TaskEvents.
-  ///
-  /// \param event The TaskExecutionEvent to convert.
-  /// \return The output TaskEvents to populate.
-  rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskExecutionEvent &&event);
-
-  /// Convert an ActorTaskDefinitionEvent to a TaskEvents.
-  ///
-  /// \param event The ActorTaskDefinitionEvent to convert.
-  /// \return The output TaskEvents to populate.
-  rpc::TaskEvents ConvertToTaskEvents(rpc::events::ActorTaskDefinitionEvent &&event);
-
-  /// Populate the TaskInfoEntry with the given runtime env info, function descriptor,
-  /// and required resources. This function is commonly used to convert the task
-  /// and actor task definition events to TaskEvents.
-  ///
-  /// \param serialized_runtime_env The serialized runtime environment string.
-  /// \param function_descriptor The function descriptor.
-  /// \param required_resources The required resources.
-  /// \param language The language of the task.
-  /// \param task_info The output TaskInfoEntry to populate.
-  void PopulateTaskRuntimeAndFunctionInfo(
-      std::string &&serialized_runtime_env,
-      rpc::FunctionDescriptor &&function_descriptor,
-      ::google::protobuf::Map<std::string, double> &&required_resources,
-      rpc::Language language,
-      rpc::TaskInfoEntry *task_info);
-
-  /// Add a task event to the appropriate job-grouped request.
-  ///
-  /// \param task_event The TaskEvents to add.
-  /// \param requests_per_job_id The list of requests grouped by job id.
-  /// \param job_id_to_index The map from job id to index in requests_per_job_id.
-  void AddTaskEventToRequest(
-      rpc::TaskEvents &&task_event,
-      std::vector<rpc::AddTaskEventDataRequest> &requests_per_job_id,
-      absl::flat_hash_map<std::string, size_t> &job_id_to_index);
-
-  /// Add dropped task attempts to the appropriate job-grouped request.
-  ///
-  /// \param metadata The task events metadata containing dropped task attempts.
-  /// \param requests_per_job_id The list of requests grouped by job id.
-  /// \param job_id_to_index The map from job id to index in requests_per_job_id.
-  void AddDroppedTaskAttemptsToRequest(
-      rpc::events::TaskEventsMetadata &&metadata,
-      std::vector<rpc::AddTaskEventDataRequest> &requests_per_job_id,
-      absl::flat_hash_map<std::string, size_t> &job_id_to_index);
-
-  FRIEND_TEST(GcsRayEventConverterTest, TestConvertTaskExecutionEvent);
-  FRIEND_TEST(GcsRayEventConverterTest, TestConvertActorTaskDefinitionEvent);
-};
+/// Convert an AddEventsRequest to a list of AddTaskEventDataRequest objects,
+/// grouping entries by job id.
+///
+/// \param request The AddEventsRequest to convert.
+/// \return A list of AddTaskEventDataRequest grouped by job id.
+std::vector<rpc::AddTaskEventDataRequest> ConvertToTaskEventDataRequests(
+    rpc::events::AddEventsRequest &&request);
 
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_task_manager.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <string>
@@ -25,10 +26,8 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/common/protobuf_utils.h"
-#include "ray/gcs/gcs_ray_event_converter.h"
 #include "ray/gcs/grpc_service_interfaces.h"
 #include "ray/gcs/usage_stats_client.h"
-#include "ray/stats/metric_defs.h"
 #include "ray/util/counter_map.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
@@ -39,7 +38,7 @@ class PeriodicalRunner;
 
 namespace gcs {
 
-enum GcsTaskManagerCounter {
+enum GcsTaskManagerCounter : std::uint8_t {
   kTotalNumTaskEventsReported,
   kTotalNumTaskAttemptsDropped,
   kTotalNumProfileTaskEventsDropped,
@@ -199,7 +198,7 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
     ///
     /// \param job_id Job ID to filter task events.
     /// \return task events of `job_id`.
-    std::vector<rpc::TaskEvents> GetTaskEvents(JobID job_id) const;
+    std::vector<rpc::TaskEvents> GetTaskEvents(const JobID &job_id) const;
 
     /// Get all task events.
     ///
@@ -525,9 +524,6 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
   // Pointer to the underlying task events storage. This is only accessed from
   // the io_service_thread_. Access to it is *not* thread safe.
   std::unique_ptr<GcsTaskManagerStorage> task_event_storage_;
-
-  // Converter for converting RayEvents to TaskEvents.
-  std::unique_ptr<GcsRayEventConverter> ray_event_converter_;
 
   /// The runner to run function periodically.
   std::shared_ptr<PeriodicalRunner> periodical_runner_;


### PR DESCRIPTION
## Why are these changes needed?
Noticed gcs task manager had a good amount of event loop lag on some clusters and was looking at it.
RecordTaskEventData would copy all event data on each iteration so turned that into a ref.

Also cleaning up the gcs ray event recorder. It doesn't need to be a class and only has 1 function that needs to be exposed in the header. It also had a couple friend tests that could be pretty easily tested from the public api.
There's no actual behavior changes there.