### PR TITLE
shorten env variants name

### DIFF
--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -321,30 +321,30 @@ py_test(
 py_test_module_list_with_env_variants(
     size = "large",
     env_variants = {
-        "with_metr_disab": {
+        "metr_disab": {
             "env": {
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 # Make sure queued metrics are cleared out quickly.
                 "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
             },
-            "name_suffix": "_with_metr_disab",
+            "name_suffix": "_metr_disab",
         },
-        "with_metr_agg_at_controller": {
+        "metr_agg_at_controller": {
             "env": {
                 "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
                 # Make sure queued metrics are cleared out quickly.
                 "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
             },
-            "name_suffix": "_with_metr_agg_at_controller",
+            "name_suffix": "_metr_agg_at_controller",
         },
-        "with_metr_agg_at_controller_and_metr_on_replicas": {
+        "metr_agg_at_controller_and_replicas": {
             "env": {
                 "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 # Make sure queued metrics are cleared out quickly.
                 "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
             },
-            "name_suffix": "_with_metr_agg_at_controller_and_metr_on_replicas",
+            "name_suffix": "_metr_agg_at_controller_and_replicas",
         },
     },
     files = [

--- a/python/ray/serve/tests/unit/BUILD.bazel
+++ b/python/ray/serve/tests/unit/BUILD.bazel
@@ -43,28 +43,28 @@ py_test_module_list(
 
 py_test_module_list_with_env_variants(
     env_variants = {
-        "with_metr_disab": {
+        "metr_disab": {
             "env": {
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
             },
-            "name_suffix": "_with_metr_disab",
+            "name_suffix": "_metr_disab",
         },
-        "with_metr_agg_at_controller": {
+        "metr_agg_at_controller": {
             "env": {
                 "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "1",
                 "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
             },
-            "name_suffix": "_with_metr_agg_at_controller",
+            "name_suffix": "_metr_agg_at_controller",
         },
-        "with_metr_agg_at_controller_and_metr_on_replicas": {
+        "metr_agg_at_controller_and_replicas": {
             "env": {
                 "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
             },
-            "name_suffix": "_with_metr_agg_at_controller_and_metr_on_replicas",
+            "name_suffix": "_metr_agg_at_controller_and_replicas",
         },
     },
     files = [


### PR DESCRIPTION
-  shorten the name for the env var, as the final path were crossing the threshold of 260 in windows, for the earlier used names

<img width="1813" height="249" alt="Screenshot 2025-09-25 at 13 24 22" src="https://github.com/user-attachments/assets/75f4e787-98a8-4908-ae24-50e384c2ac22" />