### PR TITLE
[RLlib] Add tags to envrunner calls, count in flight requests in ActorManager [1/2]

### DIFF
--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -556,18 +556,13 @@ class EnvRunnerGroup:
             if rl_module_state:
                 env_runner_states.update(rl_module_state)
 
-            self.fetch_ready_async_reqs(
-                tags="sync_env_runner_states_set_states",
-                return_obj_refs=False,
-            )
-
             # Broadcast updated states back to all workers.
-            self.foreach_env_runner_async(
+            self.foreach_env_runner(
                 "set_state",  # Call the `set_state()` remote method.
-                tag="sync_env_runner_states_set_states",
                 kwargs=dict(state=env_runner_states),
                 remote_worker_ids=env_runner_indices_to_update,
                 local_env_runner=False,
+                timeout_seconds=0.0,  # This is a state update -> Fire-and-forget.
             )
 
     def foreach_env_runner_async_fetch_ready(

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -578,7 +578,7 @@ class EnvRunnerGroup:
         local_env_runner: bool = False,
         healthy_only: bool = True,
         remote_worker_ids: List[int] = None,
-    ) -> int:
+    ) -> List[Tuple[int, T]]:
         """Calls the given function asynchronously and returns previous results if any.
 
         This is a convenience function that calls `foreach_env_runner_async()` and `fetch_ready_async_reqs()`.

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -1,4 +1,3 @@
-import functools
 import gymnasium as gym
 import logging
 import importlib.util
@@ -38,7 +37,6 @@ from ray.rllib.policy.policy import Policy, PolicyState
 from ray.rllib.utils.actor_manager import FaultTolerantActorManager
 from ray.rllib.utils.annotations import OldAPIStack
 from ray._common.deprecation import (
-    Deprecated,
     deprecation_warning,
     DEPRECATED_VALUE,
 )
@@ -361,9 +359,9 @@ class EnvRunnerGroup:
         """Returns the number of all healthy workers, including the local worker."""
         return self.num_healthy_env_runners()
 
-    def num_in_flight_async_reqs(self) -> int:
+    def num_in_flight_async_reqs(self, tag: Optional[str] = None) -> int:
         """Returns the number of in-flight async requests."""
-        return self._worker_manager.num_outstanding_async_reqs()
+        return self._worker_manager.num_outstanding_async_reqs(tag=tag)
 
     def num_remote_worker_restarts(self) -> int:
         """Total number of times managed remote workers have been restarted."""
@@ -558,14 +556,55 @@ class EnvRunnerGroup:
             if rl_module_state:
                 env_runner_states.update(rl_module_state)
 
+            self.fetch_ready_async_reqs(
+                tags="sync_env_runner_states_set_states",
+                return_obj_refs=False,
+            )
+
             # Broadcast updated states back to all workers.
-            self.foreach_env_runner(
+            self.foreach_env_runner_async(
                 "set_state",  # Call the `set_state()` remote method.
+                tag="sync_env_runner_states_set_states",
                 kwargs=dict(state=env_runner_states),
                 remote_worker_ids=env_runner_indices_to_update,
                 local_env_runner=False,
-                timeout_seconds=0.0,  # This is a state update -> Fire-and-forget.
             )
+
+    def foreach_env_runner_async_fetch_ready(
+        self,
+        func: Union[
+            Callable[[EnvRunner], T], List[Callable[[EnvRunner], T]], str, List[str]
+        ],
+        kwargs: Optional[Dict[str, Any]] = None,
+        tag: Optional[str] = None,
+        timeout_seconds: Optional[float] = 0.0,
+        return_obj_refs: bool = False,
+        mark_healthy: bool = False,
+        local_env_runner: bool = False,
+        healthy_only: bool = True,
+        remote_worker_ids: List[int] = None,
+    ) -> int:
+        """Calls the given function asynchronously and returns previous results if any.
+
+        This is a convenience function that calls `foreach_env_runner_async()` and `fetch_ready_async_reqs()`.
+
+        """
+        results = self.fetch_ready_async_reqs(
+            tags=tag,
+            timeout_seconds=timeout_seconds,
+            return_obj_refs=return_obj_refs,
+            mark_healthy=mark_healthy,
+        )
+        self.foreach_env_runner_async(
+            func,
+            kwargs=kwargs,
+            tag=tag,
+            local_env_runner=local_env_runner,
+            healthy_only=healthy_only,
+            remote_worker_ids=remote_worker_ids,
+        )
+
+        return results
 
     def sync_weights(
         self,
@@ -859,84 +898,15 @@ class EnvRunnerGroup:
 
         return local_result + remote_results
 
-    # TODO (sven): Deprecate this API. Users can lookup the "worker index" from the
-    #  EnvRunner object directly through `self.worker_index` (besides many other useful
-    #  properties, like `in_evaluation`, `num_env_runners`, etc..).
-    def foreach_env_runner_with_id(
-        self,
-        func: Union[
-            Callable[[int, EnvRunner], T],
-            List[Callable[[int, EnvRunner], T]],
-            str,
-            List[str],
-        ],
-        *,
-        local_env_runner: bool = True,
-        healthy_only: bool = True,
-        remote_worker_ids: List[int] = None,
-        timeout_seconds: Optional[float] = None,
-        return_obj_refs: bool = False,
-        mark_healthy: bool = False,
-    ) -> List[T]:
-        """Calls the given function with each EnvRunner and its ID as its arguments.
-
-        Args:
-            func: The function to call for each EnvRunners. The call arguments are
-                the EnvRunner's index (int) and the respective EnvRunner instance
-                itself.
-            local_env_runner: Whether to apply `func` to the local EnvRunner, too.
-                Default is True.
-            healthy_only: Apply `func` on known-to-be healthy EnvRunners only.
-            remote_worker_ids: Apply `func` on a selected set of remote EnvRunners.
-            timeout_seconds: Time to wait for results. Default is None.
-            return_obj_refs: Whether to return ObjectRef instead of actual results.
-                Note, for fault tolerance reasons, these returned ObjectRefs should
-                never be resolved with ray.get() outside of this EnvRunnerGroup.
-            mark_healthy: Whether to mark all those EnvRunners healthy again that are
-                currently marked unhealthy AND that returned results from the remote
-                call (within the given `timeout_seconds`).
-                Note that workers are NOT set unhealthy, if they simply time out
-                (only if they return a RayActorError).
-                Also note that this setting is ignored if `healthy_only=True` (b/c
-                `mark_healthy` only affects EnvRunners that are currently tagged as
-                unhealthy).
-
-        Returns:
-             The list of return values of all calls to `func([worker, id])`.
-        """
-        local_result = []
-        if local_env_runner and self.local_env_runner is not None:
-            local_result = [func(0, self.local_env_runner)]
-
-        if not remote_worker_ids:
-            remote_worker_ids = self._worker_manager.actor_ids()
-
-        funcs = [functools.partial(func, i) for i in remote_worker_ids]
-
-        remote_results = self._worker_manager.foreach_actor(
-            funcs,
-            healthy_only=healthy_only,
-            remote_actor_ids=remote_worker_ids,
-            timeout_seconds=timeout_seconds,
-            return_obj_refs=return_obj_refs,
-            mark_healthy=mark_healthy,
-        )
-
-        FaultTolerantActorManager.handle_remote_call_result_errors(
-            remote_results,
-            ignore_ray_errors=self._ignore_ray_errors_on_env_runners,
-        )
-
-        remote_results = [r.get() for r in remote_results.ignore_errors()]
-
-        return local_result + remote_results
-
     def foreach_env_runner_async(
         self,
         func: Union[
             Callable[[EnvRunner], T], List[Callable[[EnvRunner], T]], str, List[str]
         ],
+        tag: Optional[str] = None,
         *,
+        kwargs=None,
+        local_env_runner: bool = False,
         healthy_only: bool = True,
         remote_worker_ids: List[int] = None,
     ) -> int:
@@ -948,6 +918,12 @@ class EnvRunnerGroup:
         Args:
             func: The function to call for each EnvRunners. The only call argument is
                 the respective EnvRunner instance.
+            tag: A tag to identify the results from this async call when fetching with
+                `fetch_ready_async_reqs()`.
+            kwargs: An optional kwargs dict to be passed to the remote function calls.
+            local_env_runner: Whether to apply `func` to local EnvRunner, too.
+                Default is False (unlike the sync version, async calls typically don't
+                need the local runner).
             healthy_only: Apply `func` on known-to-be healthy EnvRunners only.
             remote_worker_ids: Apply `func` on a selected set of remote EnvRunners.
 
@@ -956,10 +932,32 @@ class EnvRunnerGroup:
              length of `remote_worker_ids` (or self.num_remote_workers()` if
              `remote_worker_ids` is None) minus the number of requests that were NOT
              made b/c a remote EnvRunner already had its
-             `max_remote_requests_in_flight_per_actor` counter reached.
+             `max_remote_requests_in_flight_per_actor` counter reached for this tag.
         """
+        # Handle local EnvRunner if requested
+        if local_env_runner and self.local_env_runner is not None:
+            # For local runner, we need to execute synchronously and store the result
+            # This is a limitation of the async pattern - local calls can't be truly async
+            if isinstance(func, str):
+                if kwargs is None:
+                    local_result = getattr(self.local_env_runner, func)()
+                else:
+                    local_result = getattr(self.local_env_runner, func)(**kwargs)
+            else:
+                local_result = func(self.local_env_runner)
+
+            # Store the local result with a special local tag for retrieval
+            local_tag = f"{tag}_local" if tag else "local"
+            if not hasattr(self, "_local_async_results"):
+                self._local_async_results = {}
+            self._local_async_results[local_tag] = [
+                (0, local_result)
+            ]  # Use worker ID 0 for local
+
         return self._worker_manager.foreach_actor_async(
             func,
+            tag=tag,
+            kwargs=kwargs,
             healthy_only=healthy_only,
             remote_actor_ids=remote_worker_ids,
         )
@@ -967,13 +965,17 @@ class EnvRunnerGroup:
     def fetch_ready_async_reqs(
         self,
         *,
+        tags: Optional[Union[str, List[str], Tuple[str]]] = None,
         timeout_seconds: Optional[float] = 0.0,
         return_obj_refs: bool = False,
         mark_healthy: bool = False,
     ) -> List[Tuple[int, T]]:
-        """Get esults from outstanding asynchronous requests that are ready.
+        """Get results from outstanding asynchronous requests that are ready.
 
         Args:
+            tags: Tags to identify the results from a specific async call.
+                If None (default), returns results from all ready async requests.
+                If a single string, returns results from all ready async requests with that tag.
             timeout_seconds: Time to wait for results. Default is 0, meaning
                 those requests that are already ready.
             return_obj_refs: Whether to return ObjectRef instead of actual results.
@@ -990,7 +992,21 @@ class EnvRunnerGroup:
             A list of results successfully returned from outstanding remote calls,
             paired with the indices of the callee workers.
         """
+        # Collect results from both remote and local calls
+        all_results = []
+
+        # Handle local results if the tag matches
+        if hasattr(self, "_local_async_results"):
+            local_tag = f"{tags}_local" if tags else "local"
+            if local_tag in self._local_async_results:
+                local_results = self._local_async_results[local_tag]
+                all_results.extend(local_results)
+                # Remove processed local results
+                del self._local_async_results[local_tag]
+
+        # Get remote results
         remote_results = self._worker_manager.fetch_ready_async_reqs(
+            tags=tags,
             timeout_seconds=timeout_seconds,
             return_obj_refs=return_obj_refs,
             mark_healthy=mark_healthy,
@@ -1001,7 +1017,12 @@ class EnvRunnerGroup:
             ignore_ray_errors=self._ignore_ray_errors_on_env_runners,
         )
 
-        return [(r.actor_id, r.get()) for r in remote_results.ignore_errors()]
+        # Add remote results
+        all_results.extend(
+            [(r.actor_id, r.get()) for r in remote_results.ignore_errors()]
+        )
+
+        return all_results
 
     @OldAPIStack
     def foreach_env(self, func: Callable[[EnvType], List[T]]) -> List[List[T]]:
@@ -1323,44 +1344,3 @@ class EnvRunnerGroup:
                     f"input {class_path}"
                 )
         return False
-
-    @Deprecated(new="EnvRunnerGroup.probe_unhealthy_env_runners", error=False)
-    def probe_unhealthy_workers(self, *args, **kwargs):
-        return self.probe_unhealthy_env_runners(*args, **kwargs)
-
-    @Deprecated(new="EnvRunnerGroup.foreach_env_runner", error=False)
-    def foreach_worker(self, *args, **kwargs):
-        return self.foreach_env_runner(*args, **kwargs)
-
-    @Deprecated(new="EnvRunnerGroup.foreach_env_runner_with_id", error=False)
-    def foreach_worker_with_id(self, *args, **kwargs):
-        return self.foreach_env_runner_with_id(*args, **kwargs)
-
-    @Deprecated(new="EnvRunnerGroup.foreach_env_runner_async", error=False)
-    def foreach_worker_async(self, *args, **kwargs):
-        return self.foreach_env_runner_async(*args, **kwargs)
-
-    @Deprecated(new="EnvRunnerGroup.local_env_runner", error=True)
-    def local_worker(self) -> EnvRunner:
-        pass
-
-    @property
-    @Deprecated(
-        old="_remote_workers",
-        new="Use either the `foreach_env_runner()`, `foreach_env_runner_with_id()`, or "
-        "`foreach_env_runner_async()` APIs of `EnvRunnerGroup`, which all handle fault "
-        "tolerance.",
-        error=True,
-    )
-    def _remote_workers(self):
-        pass
-
-    @Deprecated(
-        old="remote_workers()",
-        new="Use either the `foreach_env_runner()`, `foreach_env_runner_with_id()`, or "
-        "`foreach_env_runner_async()` APIs of `EnvRunnerGroup`, which all handle fault "
-        "tolerance.",
-        error=True,
-    )
-    def remote_workers(self):
-        pass

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -1,6 +1,7 @@
 import unittest
 
 import ray
+import time
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.core.rl_module.rl_module import RLModule
 from ray.rllib.env.env_runner_group import EnvRunnerGroup
@@ -90,6 +91,40 @@ class TestEnvRunnerGroup(unittest.TestCase):
             self.assertTrue(p[1])
 
         ws.stop()
+
+    def test_foreach_env_runner_async_fetch_ready(self):
+        """Test to make sure basic asychronous calls to remote workers work."""
+        ws = EnvRunnerGroup(
+            config=(
+                PPOConfig()
+                .environment("CartPole-v1")
+                .env_runners(num_env_runners=2, rollout_fragment_length=1)
+            ),
+        )
+
+        # Sample from both env runners.
+        # First call to foreach_env_runner_async_fetch_ready should not return ready results.
+        self.assertEqual(
+            len(
+                ws.foreach_env_runner_async_fetch_ready(
+                    lambda w: w.sample(),
+                    tag="sample",
+                )
+            ),
+            0,
+        )
+        time.sleep(0.1)
+
+        # Second call to foreach_env_runner_async_fetch_ready should return ready results.
+        self.assertEqual(
+            len(
+                ws.foreach_env_runner_async_fetch_ready(
+                    lambda w: w.sample(),
+                    tag="sample",
+                )
+            ),
+            2,
+        )
 
 
 if __name__ == "__main__":

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -113,7 +113,7 @@ class TestEnvRunnerGroup(unittest.TestCase):
             ),
             0,
         )
-        time.sleep(0.1)
+        time.sleep(1)
 
         # Second call to foreach_env_runner_async_fetch_ready should return ready results.
         self.assertEqual(

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -93,7 +93,7 @@ class TestEnvRunnerGroup(unittest.TestCase):
         ws.stop()
 
     def test_foreach_env_runner_async_fetch_ready(self):
-        """Test to make sure basic asychronous calls to remote workers work."""
+        """Test to make sure that test_foreach_env_runner_async_fetch_ready works."""
         ws = EnvRunnerGroup(
             config=(
                 PPOConfig()

--- a/rllib/evaluation/tests/test_rollout_worker.py
+++ b/rllib/evaluation/tests/test_rollout_worker.py
@@ -218,14 +218,10 @@ class TestRolloutWorker(unittest.TestCase):
         results = algo.env_runner_group.foreach_env_runner(
             lambda w: w.total_rollout_fragment_length
         )
-        results2 = algo.env_runner_group.foreach_env_runner_with_id(
-            lambda i, w: (i, w.total_rollout_fragment_length)
-        )
         results3 = algo.env_runner_group.foreach_env_runner(
             lambda w: w.foreach_env(lambda env: 1)
         )
         self.assertEqual(results, [10, 10, 10])
-        self.assertEqual(results2, [(0, 10), (1, 10), (2, 10)])
         self.assertEqual(results3, [[1, 1], [1, 1], [1, 1]])
         algo.stop()
 

--- a/rllib/utils/actor_manager.py
+++ b/rllib/utils/actor_manager.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 import sys
 import time
@@ -237,10 +237,31 @@ class FaultTolerantActorManager:
     class _ActorState:
         """State of a single actor."""
 
-        # Num of outstanding async requests for this actor.
-        num_in_flight_async_requests: int = 0
+        # Num of outstanding async requests for this actor by tag.
+        num_in_flight_async_requests_by_tag: Dict[Optional[str], int] = field(
+            default_factory=dict
+        )
         # Whether this actor is in a healthy state.
         is_healthy: bool = True
+
+        def get_num_in_flight_requests(self, tag: Optional[str] = None) -> int:
+            """Get number of in-flight requests for a specific tag or all tags."""
+            if tag is None:
+                return sum(self.num_in_flight_async_requests_by_tag.values())
+            return self.num_in_flight_async_requests_by_tag.get(tag, 0)
+
+        def increment_requests(self, tag: Optional[str] = None) -> None:
+            """Increment the count of in-flight requests for a tag."""
+            if tag not in self.num_in_flight_async_requests_by_tag:
+                self.num_in_flight_async_requests_by_tag[tag] = 0
+            self.num_in_flight_async_requests_by_tag[tag] += 1
+
+        def decrement_requests(self, tag: Optional[str] = None) -> None:
+            """Decrement the count of in-flight requests for a tag."""
+            if tag in self.num_in_flight_async_requests_by_tag:
+                self.num_in_flight_async_requests_by_tag[tag] -= 1
+                if self.num_in_flight_async_requests_by_tag[tag] <= 0:
+                    del self.num_in_flight_async_requests_by_tag[tag]
 
     def __init__(
         self,
@@ -339,9 +360,12 @@ class FaultTolerantActorManager:
         return self._num_actor_restarts
 
     @DeveloperAPI
-    def num_outstanding_async_reqs(self) -> int:
+    def num_outstanding_async_reqs(self, tag: Optional[str] = None) -> int:
         """Return the number of outstanding async requests."""
-        return len(self._in_flight_req_to_actor_id)
+        return sum(
+            s.get_num_in_flight_requests(tag)
+            for s in self._remote_actor_states.values()
+        )
 
     @DeveloperAPI
     def is_actor_healthy(self, actor_id: int) -> bool:
@@ -543,18 +567,18 @@ class FaultTolerantActorManager:
             )
 
         num_calls_to_make: Dict[int, int] = defaultdict(lambda: 0)
-        # Drop calls to actors that are too busy.
+        # Drop calls to actors that are too busy for this specific tag.
         if isinstance(func, list):
             assert len(func) == len(remote_actor_ids)
             limited_func = []
             limited_kwargs = []
             limited_remote_actor_ids = []
             for i, (f, raid) in enumerate(zip(func, remote_actor_ids)):
-                num_outstanding_reqs = self._remote_actor_states[
+                num_outstanding_reqs_for_tag = self._remote_actor_states[
                     raid
-                ].num_in_flight_async_requests
+                ].get_num_in_flight_requests(tag)
                 if (
-                    num_outstanding_reqs + num_calls_to_make[raid]
+                    num_outstanding_reqs_for_tag + num_calls_to_make[raid]
                     < self._max_remote_requests_in_flight_per_actor
                 ):
                     num_calls_to_make[raid] += 1
@@ -567,11 +591,11 @@ class FaultTolerantActorManager:
             limited_kwargs = kwargs
             limited_remote_actor_ids = []
             for raid in remote_actor_ids:
-                num_outstanding_reqs = self._remote_actor_states[
+                num_outstanding_reqs_for_tag = self._remote_actor_states[
                     raid
-                ].num_in_flight_async_requests
+                ].get_num_in_flight_requests(tag)
                 if (
-                    num_outstanding_reqs + num_calls_to_make[raid]
+                    num_outstanding_reqs_for_tag + num_calls_to_make[raid]
                     < self._max_remote_requests_in_flight_per_actor
                 ):
                     num_calls_to_make[raid] += 1
@@ -588,7 +612,7 @@ class FaultTolerantActorManager:
 
         # Save these as outstanding requests.
         for id, call in zip(limited_remote_actor_ids, remote_calls):
-            self._remote_actor_states[id].num_in_flight_async_requests += 1
+            self._remote_actor_states[id].increment_requests(tag)
             self._in_flight_req_to_actor_id[call] = (tag, id)
 
         return len(remote_calls)
@@ -643,11 +667,11 @@ class FaultTolerantActorManager:
         )
 
         for obj_ref, result in zip(ready, remote_results):
-            # Decrease outstanding request on this actor by 1.
-            self._remote_actor_states[result.actor_id].num_in_flight_async_requests -= 1
-            # Also, remove this call here from the in-flight list,
-            # obj_refs may have already been removed when we disable an actor.
+            # Get the tag for this request and decrease outstanding request count by 1.
             if obj_ref in self._in_flight_req_to_actor_id:
+                tag, actor_id = self._in_flight_req_to_actor_id[obj_ref]
+                self._remote_actor_states[result.actor_id].decrement_requests(tag)
+                # Remove this call from the in-flight list.
                 del self._in_flight_req_to_actor_id[obj_ref]
 
         return remote_results
@@ -940,12 +964,12 @@ class FaultTolerantActorManager:
         return func, kwargs, remote_actor_ids
 
     def _filter_calls_by_tag(
-        self, tags: Union[str, List[str], Tuple[str]]
+        self, tags: Optional[Union[str, List[str], Tuple[str]]] = None
     ) -> Tuple[List[ray.ObjectRef], List[ActorHandle], List[str]]:
         """Return all the in flight requests that match the given tags, if any.
 
         Args:
-            tags: A str or a list/tuple of str. If tags is empty, return all the in
+            tags: A str or a list/tuple of str. If tags is empty or None, return all the in
                 flight requests.
 
         Returns:
@@ -953,7 +977,9 @@ class FaultTolerantActorManager:
             a list of the corresponding remote actor IDs for these calls (same length),
             and a list of the tags corresponding to these calls (same length).
         """
-        if isinstance(tags, str):
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
         elif isinstance(tags, (list, tuple)):
             tags = set(tags)
@@ -985,9 +1011,15 @@ class FaultTolerantActorManager:
         # Remove any outstanding async requests for this actor.
         # Use `list` here to not change a looped generator while we mutate the
         # underlying dict.
-        for id, req in list(self._in_flight_req_to_actor_id.items()):
+        for req, (tag, id) in list(self._in_flight_req_to_actor_id.items()):
             if id == actor_id:
                 del self._in_flight_req_to_actor_id[req]
+
+        # Clear all tag-based request counts for this actor
+        if actor_id in self._remote_actor_states:
+            self._remote_actor_states[
+                actor_id
+            ].num_in_flight_async_requests_by_tag.clear()
 
     def actors(self):
         # TODO(jungong) : remove this API once EnvRunnerGroup.remote_workers()


### PR DESCRIPTION
## Why are these changes needed?

This is the first of two PRs. The end goal is to me able to track in flight requests per tag when applying more functions to env runners. Today, we only track in flight requests for sample() calls. Tomorrow, we want to track in flight requests for other calls separately, like updating weights. 

We want to track them separately because otherwise tasks can block each other by sending too many requests and clogging the shared number of in flight requests.

The next step after this PR will be a follow up PR which introduces tags inside of `sync_env_runner_states` to limit the number of weight updates that are in flight at any given time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce per-tag async request accounting and tagging across EnvRunnerGroup/ActorManager, add foreach_env_runner_async_fetch_ready helper, and remove deprecated worker alias APIs/tests.
> 
> - **EnvRunnerGroup**:
>   - Add tag support to async APIs: `num_in_flight_async_reqs(tag)`, `foreach_env_runner_async(func, tag, kwargs=...)`, and `fetch_ready_async_reqs(tags=...)`.
>   - New convenience API: `foreach_env_runner_async_fetch_ready(...)` to fetch ready results (by tag) and immediately enqueue new async calls.
>   - Remove deprecated worker alias APIs (`probe_unhealthy_workers`, `foreach_worker*`, `local_worker`, `_remote_workers`, `remote_workers`).
> - **ActorManager**:
>   - Track in-flight async requests per tag via `_ActorState.num_in_flight_async_requests_by_tag`; add helpers to increment/decrement and query by tag.
>   - Enforce per-tag limits in `foreach_actor_async`; maintain `(tag, actor_id)` mapping for in-flight calls; support `num_outstanding_async_reqs(tag)`.
>   - `fetch_ready_async_reqs(tags=...)` and `_filter_calls_by_tag(tags)` accept None/strings/lists and update per-tag counters on completion; clear per-tag state on actor removal.
> - **Tests**:
>   - Add `test_foreach_env_runner_async_fetch_ready` validating tagged async fetch helper.
>   - Update rollout worker tests to stop using removed `foreach_env_runner_with_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 172f9acb0b8533c2d2ac9ffe59eaeb5aed24552c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->