### PR TITLE
fix(data): Prevent TypeError in categorical encoders with mixed-type columns

### DIFF
--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -759,7 +759,7 @@ def _get_unique_value_indices(
         else:
             # Output sorted by column name.
             unique_values_with_indices[key_format.format(column)] = {
-                k: j for j, k in enumerate(sorted(dict(final_counters[column]).keys()))
+                k: j for j, k in enumerate(sorted(dict(final_counters[column]).keys(), key=lambda x: str(x)))
             }
     return unique_values_with_indices
 

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -202,7 +202,7 @@ def test_ordinal_encoder_mixed_types_after_imputation():
     ])
     encoder = OrdinalEncoder(columns=["feature"])
     encoder.fit(ds)
-    # sorted([1, "a", 2, "b"], key=str) -> ["1", "2", "a", "b"]
+    # sorted([1, "a", 2, "b"], key=str) -> [1, 2, "a", "b"]
     expected_stats = {"unique_values(feature)": {1: 0, 2: 1, "a": 2, "b": 3}}
     assert encoder.stats_ == expected_stats
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR resolves a `TypeError` in categorical preprocessors like `OrdinalEncoder` when fitting on a column with mixed data types (e.g., `bool` and `str`, or `bool` and `NoneType`).

---
## The Problem

The helper function `_get_unique_value_indices` sorts a column's unique values to create a stable encoding. The default `sorted()` operation fails when it tries to compare incompatible types, which is a common scenario after imputing missing values in a boolean column.

This results in the following error:
```
TypeError: '<' not supported between instances of 'str' and 'bool'
```
or
```
TypeError: '<' not supported between instances of 'NoneType' and 'bool'
```

---
## The Solution

The sorting logic is made more robust by casting all values to their string representation before comparison. This ensures all elements are of a comparable type, preventing the `TypeError`.

This is achieved by adding a `key` to the `sorted()` function:

```diff
- k: j for j, k in enumerate(sorted(dict(final_counters[column]).keys()))
+ k: j for j, k in enumerate(sorted(dict(final_counters[column]).keys(), key=lambda x: str(x)))
```
---
### How to Reproduce

```python
import ray
from ray.data.preprocessors import SimpleImputer, OrdinalEncoder

# data with a mixed-type column (bool and None)
ds = ray.data.from_items([
    {"feature": True},
    {"feature": False},
    {"feature": None},
])

# imputing None introduces a string, creating a mix of bool and str
imputer = SimpleImputer(columns=["feature"], strategy="constant", fill_value="missing")
ds_imputed = imputer.fit_transform(ds)

# this step previously failed due to the TypeError
encoder = OrdinalEncoder(columns=["feature"])
encoder.fit(ds_imputed)
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
