### PR TITLE
[core] Use `start_ray_shared` in `test_runtime_env.py::test_runtime_env_error_includes_node_ip`

### DIFF
--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -169,7 +169,7 @@ def test_runtime_env_config(start_cluster_shared):
         run(runtime_env)
 
 
-def test_runtime_env_error_includes_node_ip(shutdown_only):
+def test_runtime_env_error_includes_node_ip(start_cluster_shared):
     """Test that RuntimeEnv errors include node IP information for debugging."""
     fast_timeout_config = {"setup_timeout_seconds": 1}
     # Test with invalid pip package to trigger RuntimeEnvSetupError

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -171,12 +171,14 @@ def test_runtime_env_config(start_cluster_shared):
 
 def test_runtime_env_error_includes_node_ip(start_cluster_shared):
     """Test that RuntimeEnv errors include node IP information for debugging."""
-    fast_timeout_config = {"setup_timeout_seconds": 1}
-    # Test with invalid pip package to trigger RuntimeEnvSetupError
+    _, address = start_cluster_shared
+    ray.init(address=address)
+
+    # Test with invalid pip package to trigger RuntimeEnvSetupError.
     @ray.remote(
         runtime_env={
             "pip": ["nonexistent-package"],
-            "config": fast_timeout_config,
+            "config": {"setup_timeout_seconds": 1},
         }
     )
     def f():


### PR DESCRIPTION
All of the other tests in this file use shared cluster. I think this is causing redis tests to fail.

Closes https://github.com/ray-project/ray/issues/53509