### PR TITLE
Add unified /api/healthz

### DIFF
--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -9,7 +9,7 @@ import sys
 import ray._private.ray_constants as ray_constants
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils
-from ray._common.network_utils import build_address, is_localhost
+from ray._common.network_utils import build_address, is_localhost, parse_address
 from ray._common.utils import get_or_create_event_loop
 from ray._private import logging_utils
 from ray._private.process_watcher import create_check_raylet_task
@@ -174,6 +174,10 @@ class DashboardAgent:
 
     def get_node_id(self) -> str:
         return self.node_id
+
+    @property
+    def is_head(self) -> bool:
+        return self.ip == parse_address(self.gcs_address)[0]
 
     async def run(self):
         # Start a grpc asyncio server.

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -80,7 +80,8 @@ class DashboardAgent:
         node_info = self.gcs_client.get_all_node_info().get(
             NodeID.from_hex(self.node_id)
         )
-        self.is_head = node_info is not None and node_info.is_head_node
+        assert node_info is not None
+        self.is_head = node_info.is_head_node
 
         if not self.minimal:
             self._init_non_minimal()

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -5,6 +5,7 @@ import logging
 import os
 import signal
 import sys
+import time
 
 import ray._private.ray_constants as ray_constants
 import ray.dashboard.consts as dashboard_consts
@@ -77,9 +78,14 @@ class DashboardAgent:
         )
 
         # Fetch node info and save is_head.
-        node_info = self.gcs_client.get_all_node_info().get(
-            NodeID.from_hex(self.node_id)
-        )
+        node_info = None
+        for _ in range(30):
+            node_info = self.gcs_client.get_all_node_info().get(
+                NodeID.from_hex(self.node_id)
+            )
+            if node_info is not None:
+                break
+            time.sleep(1)
         assert node_info is not None
         self.is_head = node_info.is_head_node
 

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -9,7 +9,7 @@ import sys
 import ray._private.ray_constants as ray_constants
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils
-from ray._common.network_utils import build_address, is_localhost, parse_address
+from ray._common.network_utils import build_address, is_localhost
 from ray._common.utils import get_or_create_event_loop
 from ray._private import logging_utils
 from ray._private.process_watcher import create_check_raylet_task
@@ -77,7 +77,9 @@ class DashboardAgent:
         )
 
         # Fetch node info and save is_head.
-        node_info = self.gcs_client.get_all_node_info().get(NodeID.from_hex(self.node_id))
+        node_info = self.gcs_client.get_all_node_info().get(
+            NodeID.from_hex(self.node_id)
+        )
         self.is_head = node_info is not None and node_info.is_head_node
 
         if not self.minimal:

--- a/python/ray/dashboard/modules/reporter/healthz_agent.py
+++ b/python/ray/dashboard/modules/reporter/healthz_agent.py
@@ -52,10 +52,8 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
             content_type="application/text",
         )
 
-    async def local_gcs_health(self) -> Response:
-        # Check GCS health, if we are the head node.
-        if not self._dashboard_agent.is_head:
-            return Response(status=200, text="not head; no local GCS")
+    async def gcs_health(self) -> Response:
+        # Check GCS health.
         try:
             gcs_alive = await self._health_checker.check_gcs_liveness()
             if not gcs_alive:
@@ -65,15 +63,22 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
 
     @routes.get("/api/healthz")
     async def unified_health(self, req: Request) -> Response:
+        checks = {}
         async with asyncio.TaskGroup() as tg:
-            raylet_task = tg.create_task(self.health_check(req))
-            gcs_task = tg.create_task(self.local_gcs_health())
+            checks["raylet"] = tg.create_task(self.health_check(req))
+            if self._dashboard_agent.is_head:
+                checks["gcs"] = tg.create_task(self.gcs_health())
 
-        raylet_resp = raylet_task.result()
-        gcs_resp = gcs_task.result()
+        # Collect health check results and log any failures.
+        for name in checks:
+            result = checks[name].result()
+            checks[name] = result
+            if result.status != 200:
+                logger.warning(f"health check {name} failed: {result.status} {result.text}")
+
         return Response(
-                status=200 if all([ resp.status == 200 for resp in [raylet_resp, gcs_resp] ]) else 503,
-                text=f"raylet: {raylet_resp.text}\ngcs: {gcs_resp.text}"
+                status=200 if all([ resp.status == 200 for resp in checks.values() ]) else 503,
+                text='\n'.join([ f"{name}: {resp.text}" for name, resp in checks.items() ]),
                 content_type="application/text",
         )
 

--- a/python/ray/dashboard/modules/reporter/healthz_agent.py
+++ b/python/ray/dashboard/modules/reporter/healthz_agent.py
@@ -1,6 +1,7 @@
-from aiohttp.web import Request, Response
-
 import asyncio
+import logging
+
+from aiohttp.web import Request, Response
 
 import ray.dashboard.optional_utils as optional_utils
 import ray.dashboard.utils as dashboard_utils
@@ -9,6 +10,8 @@ from ray._raylet import NodeID
 from ray.dashboard.modules.reporter.utils import HealthChecker
 
 routes = optional_utils.DashboardAgentRouteTable
+
+logger = logging.getLogger(__name__)
 
 
 class HealthzAgent(dashboard_utils.DashboardAgentModule):

--- a/python/ray/dashboard/modules/reporter/healthz_agent.py
+++ b/python/ray/dashboard/modules/reporter/healthz_agent.py
@@ -74,12 +74,16 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
             result = checks[name].result()
             checks[name] = result
             if result.status != 200:
-                logger.warning(f"health check {name} failed: {result.status} {result.text}")
+                logger.warning(
+                    f"health check {name} failed: {result.status} {result.text}"
+                )
 
         return Response(
-                status=200 if all([ resp.status == 200 for resp in checks.values() ]) else 503,
-                text='\n'.join([ f"{name}: {resp.text}" for name, resp in checks.items() ]),
-                content_type="application/text",
+            status=(
+                200 if all([resp.status == 200 for resp in checks.values()]) else 503
+            ),
+            text="\n".join([f"{name}: {resp.text}" for name, resp in checks.items()]),
+            content_type="application/text",
         )
 
     async def run(self, server):

--- a/python/ray/dashboard/modules/reporter/healthz_agent.py
+++ b/python/ray/dashboard/modules/reporter/healthz_agent.py
@@ -56,7 +56,7 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
     async def unified_health(self, req: Request) -> Response:
         # Check Raylet health.
         raylet_resp = await self.health_check(req)
-        if raylet_resp.status is not 200:
+        if raylet_resp.status != 200:
             return raylet_resp
 
         # Check GCS health.

--- a/python/ray/dashboard/modules/reporter/healthz_agent.py
+++ b/python/ray/dashboard/modules/reporter/healthz_agent.py
@@ -36,7 +36,7 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
     @routes.get("/api/local_raylet_healthz")
     async def health_check(self, req: Request) -> Response:
         try:
-            self.raylet_health()
+            await self.raylet_health()
         except Exception as e:
             return Response(status=503, text=str(e), content_type="application/text")
 
@@ -87,9 +87,7 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
         for name, result in checks.items():
             if isinstance(result, Exception):
                 status = 503
-                logger.warning(
-                    f"health check {name} failed: {result.status} {result.text}"
-                )
+                logger.warning(f"health check {name} failed: {result}")
 
         return Response(
             status=status,

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -25,7 +25,6 @@ import ray
 import ray._private.prometheus_exporter as prometheus_exporter
 import ray.dashboard.modules.reporter.reporter_consts as reporter_consts
 import ray.dashboard.utils as dashboard_utils
-from ray._common.network_utils import parse_address
 from ray._common.utils import (
     get_or_create_event_loop,
     get_user_temp_dir,
@@ -424,7 +423,7 @@ class ReporterAgent(
         self._gcs_client = dashboard_agent.gcs_client
         self._ip = dashboard_agent.ip
         self._log_dir = dashboard_agent.log_dir
-        self._is_head_node = self._ip == parse_address(dashboard_agent.gcs_address)[0]
+        self._is_head_node = dashboard_agent.is_head
         self._hostname = socket.gethostname()
         # (pid, created_time) -> psutil.Process
         self._workers = {}


### PR DESCRIPTION
## Why are these changes needed?

This new endpoint on the HealthzAgent class combines the status of /api/local_raylet_healthz and /api/gcs_healthz into one endpoint for use with Kubernetes.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

 See #56204.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
