### PR TITLE
[fix][dashboard]Fix the filtering issue in the Job list

### DIFF
--- a/python/ray/dashboard/client/src/pages/job/hook/useJobList.ts
+++ b/python/ray/dashboard/client/src/pages/job/hook/useJobList.ts
@@ -18,13 +18,11 @@ export const useJobList = () => {
     key: "job_id" | "submission_id" | "status",
     val: string,
   ) => {
-    const f = filter.find((e) => e.key === key);
-    if (f) {
-      f.val = val;
-    } else {
-      filter.push({ key, val });
+    const newFilter = filter.filter((e) => e.key !== key);
+    if (val.trim() !== "") {
+      newFilter.push({ key, val });
     }
-    setFilter([...filter]);
+    setFilter(newFilter);
   };
   const onSwitchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRefresh(event.target.checked);


### PR DESCRIPTION

## Why are these changes needed?

This PR fix filtering issues on the Jobs page. In the Jobs page, when filtering the Job List by entering Job ID/Submission ID, it was found that if there are entries with job_id as null or submission_id as null, even after clearing all filter criteria, the original entries cannot be fully displayed.
I have tested this PR against the latest Ray Data release and it correctly displays all jobs.

## Related issue number

Closes #56925

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
