### PR TITLE
[fix][dashboard]Fix the card content on the overview page is incomplete.

### DIFF
--- a/python/ray/dashboard/client/src/components/AutoscalerStatusCards.tsx
+++ b/python/ray/dashboard/client/src/components/AutoscalerStatusCards.tsx
@@ -77,7 +77,8 @@ export const NodeStatusCard = ({ clusterStatus }: StatusCardProps) => {
     <Box
       style={{
         overflow: "hidden",
-        overflowY: "scroll",
+        overflowY: "auto",
+        height: "100%",
       }}
     >
       {formatNodeStatus(clusterStatus?.data.clusterStatus)}
@@ -90,7 +91,8 @@ export const ResourceStatusCard = ({ clusterStatus }: StatusCardProps) => {
     <Box
       style={{
         overflow: "hidden",
-        overflowY: "scroll",
+        overflowY: "auto",
+        height: "100%",
       }}
     >
       {formatResourcesStatus(clusterStatus?.data.clusterStatus)}


### PR DESCRIPTION

## Why are these changes needed?

This PR fix the issue of the card content on the overview page is incomplete. When the content of the Node Status card on the Overview page exceeds the fixed height of the card, there is no scroll bar as expected, and the extremely long content cannot be displayed. And when the content height of the Node Status card and Resource Status card is not too long, a scrolling area is also displayed, although it does not need to be scrolled. I recommend that the scroll bar be displayed when the height is insufficient, otherwise it will not be displayed.
I tested this PR against the latest version and resolved the incomplete card content on the page.

## Related issue number

Closes #56923

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
