### PR TITLE
[release] Use tests that associate with custom images in its build step name

### DIFF
--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -20,7 +20,7 @@ def generate_custom_build_step_key(image: str) -> str:
 
 def get_images_from_tests(
     tests: List[Test], build_id: str
-) -> Tuple[List[Tuple[str, str, str, str]], Dict[str, List[Test]]]:
+) -> Tuple[List[Tuple[str, str, str, str]], Dict[str, List[str]]]:
     """Get a list of custom BYOD images to build from a list of tests."""
     custom_byod_images = set()
     custom_image_test_names_map = {}

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -97,7 +97,6 @@ def get_prerequisite_step(image: str) -> str:
 
 
 def _get_step_name(image: str, step_key: str, test_names: List[str]) -> str:
-    print("Test names: ", test_names)
     ecr, tag = image.split(":")
     ecr_repo = ecr.split("/")[-1]
     tag_without_build_id_and_custom_hash = tag.split("-")[1:-1]

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 import yaml
 import os
 from ray_release.configs.global_config import get_global_config
@@ -20,9 +20,10 @@ def generate_custom_build_step_key(image: str) -> str:
 
 def get_images_from_tests(
     tests: List[Test], build_id: str
-) -> List[Tuple[str, str, str, str]]:
+) -> Tuple[List[Tuple[str, str, str, str]], Dict[str, List[Test]]]:
     """Get a list of custom BYOD images to build from a list of tests."""
     custom_byod_images = set()
+    custom_image_test_names_map = {}
     for test in tests:
         if not test.require_custom_byod_image():
             continue
@@ -32,9 +33,13 @@ def get_images_from_tests(
             test.get_byod_post_build_script(),
             test.get_byod_python_depset(),
         )
-        logger.info(f"To be built: {custom_byod_image_build[0]}")
         custom_byod_images.add(custom_byod_image_build)
-    return list(custom_byod_images)
+        image_tag = custom_byod_image_build[0]
+        logger.info(f"To be built: {image_tag}")
+        if image_tag not in custom_image_test_names_map:
+            custom_image_test_names_map[image_tag] = []
+        custom_image_test_names_map[image_tag].append(test.get_name())
+    return list(custom_byod_images), custom_image_test_names_map
 
 
 def create_custom_build_yaml(destination_file: str, tests: List[Test]) -> None:
@@ -42,7 +47,9 @@ def create_custom_build_yaml(destination_file: str, tests: List[Test]) -> None:
     config = get_global_config()
     if not config or not config.get("byod_ecr_region") or not config.get("byod_ecr"):
         raise ValueError("byod_ecr_region and byod_ecr must be set in the config")
-    custom_byod_images = get_images_from_tests(tests, "$$RAYCI_BUILD_ID")
+    custom_byod_images, custom_image_test_names_map = get_images_from_tests(
+        tests, "$$RAYCI_BUILD_ID"
+    )
     if not custom_byod_images:
         return
     build_config = {"group": "Custom images build", "steps": []}
@@ -54,7 +61,7 @@ def create_custom_build_yaml(destination_file: str, tests: List[Test]) -> None:
         if not post_build_script:
             continue
         step_key = generate_custom_build_step_key(image)
-        step_name = _get_step_name(image, step_key, tests)
+        step_name = _get_step_name(image, step_key, custom_image_test_names_map[image])
         step = {
             "label": step_name,
             "key": step_key,
@@ -89,11 +96,12 @@ def get_prerequisite_step(image: str) -> str:
         return config["release_image_step_ray"]
 
 
-def _get_step_name(image: str, step_key: str, tests: List[Test]) -> str:
+def _get_step_name(image: str, step_key: str, test_names: List[str]) -> str:
+    print("Test names: ", test_names)
     ecr, tag = image.split(":")
     ecr_repo = ecr.split("/")[-1]
     tag_without_build_id_and_custom_hash = tag.split("-")[1:-1]
     step_name = f":tapioca: build custom: {ecr_repo}:{'-'.join(tag_without_build_id_and_custom_hash)} ({step_key})"
-    for test in tests[:2]:
-        step_name += f" {test.get_name()}"
+    for test_name in test_names[:2]:
+        step_name += f" {test_name}"
     return step_name

--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -9,6 +9,7 @@ from ray_release.custom_byod_build_init_helper import (
     create_custom_build_yaml,
     get_prerequisite_step,
     _get_step_name,
+    generate_custom_build_step_key,
 )
 from ray_release.configs.global_config import init_global_config
 from ray_release.bazel import bazel_runfile
@@ -25,32 +26,49 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
     config = get_global_config()
     custom_byod_images = [
         (
-            "ray-project/ray-ml:abc123-custom",
+            "ray-project/ray-ml:abc123-custom-123456789abc123456789",
             "ray-project/ray-ml:abc123-base",
             "custom_script.sh",
             None,
         ),
         (
-            "ray-project/ray-ml:abc123-custom",
+            "ray-project/ray-ml:abc123-custom1",
             "ray-project/ray-ml:abc123-base",
             "",
             None,
         ),
         (
-            "ray-project/ray-ml:nightly-py37-cpu-custom-abcdef123456789abc123456789",
-            "ray-project/ray-ml:nightly-py37-cpu-base",
+            "ray-project/ray-ml:abc123-py37-cpu-custom-abcdef123456789abc123456789",
+            "ray-project/ray-ml:abc123-py37-cpu-base",
             "custom_script.sh",
             None,
         ),  # longer than 40 chars
         (
-            "ray-project/ray-ml:nightly-py37-cpu-custom-abcdef123456789abc123456789",
-            "ray-project/ray-ml:nightly-py37-cpu-base",
+            "ray-project/ray-ml:abc123-py37-cpu-custom-abcdef123456789abc987654321",
+            "ray-project/ray-ml:abc123-py37-cpu-base",
             "custom_script.sh",
             "python_depset.lock",
         ),
     ]
-    mock_get_images_from_tests.return_value = custom_byod_images
-
+    custom_image_test_names_map = {
+        "ray-project/ray-ml:abc123-custom-123456789abc123456789": ["test_1"],
+        "ray-project/ray-ml:abc123-custom1": ["test_2"],
+        "ray-project/ray-ml:abc123-py37-cpu-custom-abcdef123456789abc123456789": [
+            "test_1",
+            "test_2",
+        ],
+        "ray-project/ray-ml:abc123-py37-cpu-custom-abcdef123456789abc987654321": [
+            "test_1",
+            "test_2",
+        ],
+    }
+    mock_get_images_from_tests.return_value = (
+        custom_byod_images,
+        custom_image_test_names_map,
+    )
+    step_keys = [
+        generate_custom_build_step_key(image) for image, _, _, _ in custom_byod_images
+    ]
     # List of dummy tests
     tests = [
         Test(
@@ -76,6 +94,18 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
             content = yaml.safe_load(f)
             assert content["group"] == "Custom images build"
             assert len(content["steps"]) == 3
+            assert (
+                content["steps"][0]["label"]
+                == f":tapioca: build custom: ray-ml:custom ({step_keys[0]}) test_1"
+            )
+            assert (
+                content["steps"][1]["label"]
+                == f":tapioca: build custom: ray-ml:py37-cpu-custom ({step_keys[2]}) test_1 test_2"
+            )
+            assert (
+                content["steps"][2]["label"]
+                == f":tapioca: build custom: ray-ml:py37-cpu-custom ({step_keys[3]}) test_1 test_2"
+            )
             assert (
                 "export RAY_WANT_COMMIT_IN_IMAGE=abc123"
                 in content["steps"][0]["commands"][0]
@@ -112,16 +142,16 @@ def test_get_prerequisite_step():
 
 
 def test_get_step_name():
-    tests = [
-        Test(name="test_1"),
-        Test(name="test_2"),
-        Test(name="test_3"),
+    test_names = [
+        "test_1",
+        "test_2",
+        "test_3",
     ]
     assert (
         _get_step_name(
             "ray-project/ray-ml:a1b2c3d4-py39-cpu-abcdef123456789abc123456789",
             "abc123",
-            tests,
+            test_names,
         )
         == ":tapioca: build custom: ray-ml:py39-cpu (abc123) test_1 test_2"
     )


### PR DESCRIPTION
Previously, the custom image build job just lists the first 2 tests overall but didn't filter based on the tests that it's associated with.... 