### PR TITLE
[RLlib] Add tags to envrunner calls, count in flight requests in ActorManager [2/2]

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1552,7 +1552,7 @@ class Algorithm(Checkpointable, Trainable):
                     )
                 )
 
-                for wid, (env_s, ag_s, metrics, iter) in results:
+                for env_s, ag_s, metrics, iter in results:
                     # Ignore eval results kicked off in an earlier iteration.
                     # (those results would be outdated and thus misleading).
                     if iter != self.iteration:
@@ -1571,7 +1571,7 @@ class Algorithm(Checkpointable, Trainable):
                     )
                 )
 
-                for wid, (batch, metrics, iter) in results:
+                for batch, metrics, iter in results:
                     if iter != self.iteration:
                         continue
                     env_steps += batch.env_steps()
@@ -1688,7 +1688,7 @@ class Algorithm(Checkpointable, Trainable):
                 break
             elif results:
                 t_last_result = time_now
-            for wid, (met, iter) in results:
+            for met, iter in results:
                 if iter != self.iteration:
                     continue
                 all_metrics.append(met)
@@ -1796,7 +1796,7 @@ class Algorithm(Checkpointable, Trainable):
                     break
                 elif results:
                     t_last_result = time_now
-                for wid, (env_s, ag_s, met, iter) in results:
+                for env_s, ag_s, met, iter in results:
                     if iter != self.iteration:
                         continue
                     env_steps += env_s
@@ -1840,7 +1840,7 @@ class Algorithm(Checkpointable, Trainable):
                     break
                 elif results:
                     t_last_result = time_now
-                for wid, (batch, metrics, iter) in results:
+                for batch, metrics, iter in results:
                     if iter != self.iteration:
                         continue
                     env_steps += batch.env_steps()

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -91,7 +91,7 @@ from ray.rllib.offline.offline_evaluator import OfflineEvaluator
 from ray.rllib.policy.policy import Policy, PolicySpec
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch
 from ray.rllib.utils import deep_update, FilterManager, force_list
-from ray.rllib.utils.actor_manager import FaultTolerantActorManager, RemoteCallResults
+from ray.rllib.utils.actor_manager import FaultTolerantActorManager
 from ray.rllib.utils.annotations import (
     DeveloperAPI,
     ExperimentalAPI,
@@ -1544,14 +1544,14 @@ class Algorithm(Checkpointable, Trainable):
                     ),
                 )
 
-                results = self.eval_env_runner_group.fetch_ready_async_reqs(
-                    return_obj_refs=False, timeout_seconds=0.0
+                results = (
+                    self.eval_env_runner_group.foreach_env_runner_async_fetch_ready(
+                        func=_env_runner_remote,
+                        kwargs={"num": _num, "round": _round, "iter": algo_iteration},
+                        tag="_env_runner_remote",
+                    )
                 )
-                self.eval_env_runner_group.foreach_env_runner_async(
-                    func=functools.partial(
-                        _env_runner_remote, num=_num, round=_round, iter=algo_iteration
-                    ),
-                )
+
                 for wid, (env_s, ag_s, metrics, iter) in results:
                     # Ignore eval results kicked off in an earlier iteration.
                     # (those results would be outdated and thus misleading).
@@ -1564,12 +1564,13 @@ class Algorithm(Checkpointable, Trainable):
 
             # Old API stack -> RolloutWorkers return batches.
             else:
-                self.eval_env_runner_group.foreach_env_runner_async(
-                    func=lambda w: (w.sample(), w.get_metrics(), algo_iteration),
+                results = (
+                    self.eval_env_runner_group.foreach_env_runner_async_fetch_ready(
+                        func=lambda w: (w.sample(), w.get_metrics(), algo_iteration),
+                        tag="env_runner_sample_and_get_metrics",
+                    )
                 )
-                results = self.eval_env_runner_group.fetch_ready_async_reqs(
-                    return_obj_refs=False, timeout_seconds=0.01
-                )
+
                 for wid, (batch, metrics, iter) in results:
                     if iter != self.iteration:
                         continue
@@ -1672,15 +1673,14 @@ class Algorithm(Checkpointable, Trainable):
 
             _round += 1
 
-            self.offline_eval_runner_group.foreach_runner_async(
-                func=functools.partial(
-                    _offline_eval_runner_remote,
-                    iter=algo_iteration,
-                ),
+            results = (
+                self.offline_eval_runner_group.foreach_env_runner_async_fetch_ready(
+                    func=_offline_eval_runner_remote,
+                    kwargs={"iter": algo_iteration},
+                    tag="_offline_eval_runner_remote",
+                )
             )
-            results = self.offline_eval_runner_group.fetch_ready_async_reqs(
-                return_obj_refs=False, timeout_seconds=0.01
-            )
+
             # Make sure we properly time out if we have not received any results
             # for more than `time_out` seconds.
             time_now = time.time()
@@ -1775,18 +1775,20 @@ class Algorithm(Checkpointable, Trainable):
                     + bool(i <= (units_left_to_do % num_healthy_workers))
                     for i in range(1, num_workers + 1)
                 ]
-                self.eval_env_runner_group.foreach_env_runner_async(
-                    func=functools.partial(
-                        _env_runner_remote,
-                        num=_num,
-                        round=_round,
-                        iter=algo_iteration,
-                        _force_reset=force_reset,
-                    ),
+
+                results = (
+                    self.eval_env_runner_group.foreach_env_runner_async_fetch_ready(
+                        func=_env_runner_remote,
+                        kwargs={
+                            "num": _num,
+                            "round": _round,
+                            "iter": algo_iteration,
+                            "_force_reset": force_reset,
+                        },
+                        tag="_env_runner_remote",
+                    )
                 )
-                results = self.eval_env_runner_group.fetch_ready_async_reqs(
-                    return_obj_refs=False, timeout_seconds=0.01
-                )
+
                 # Make sure we properly time out if we have not received any results
                 # for more than `time_out` seconds.
                 time_now = time.time()
@@ -1823,12 +1825,13 @@ class Algorithm(Checkpointable, Trainable):
                     )
                     if i * units_per_healthy_remote_worker < units_left_to_do
                 ]
-                self.eval_env_runner_group.foreach_env_runner_async(
-                    func=lambda w: (w.sample(), w.get_metrics(), algo_iteration),
-                    remote_worker_ids=selected_eval_worker_ids,
-                )
-                results = self.eval_env_runner_group.fetch_ready_async_reqs(
-                    return_obj_refs=False, timeout_seconds=0.01
+
+                results = (
+                    self.eval_env_runner_group.foreach_env_runner_async_fetch_ready(
+                        func=lambda w: (w.sample(), w.get_metrics(), algo_iteration),
+                        remote_worker_ids=selected_eval_worker_ids,
+                        tags="env_runner_sample_and_get_metrics",
+                    )
                 )
                 # Make sure we properly time out if we have not received any results
                 # for more than `time_out` seconds.
@@ -3442,16 +3445,11 @@ class Algorithm(Checkpointable, Trainable):
                     )
 
         if self.config.num_aggregator_actors_per_learner:
-            remote_aggregator_metrics: RemoteCallResults = (
-                self._aggregator_actor_manager.fetch_ready_async_reqs(
-                    timeout_seconds=0.0,
-                    return_obj_refs=False,
-                    tags="metrics",
+            remote_aggregator_metrics = (
+                self._aggregator_actor_manager.foreach_env_runner_async_fetch_ready(
+                    func=lambda actor: actor.get_metrics(),
+                    tag="get_metrics",
                 )
-            )
-            self._aggregator_actor_manager.foreach_actor_async(
-                func=lambda actor: actor.get_metrics(),
-                tag="metrics",
             )
 
             FaultTolerantActorManager.handle_remote_call_result_errors(

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -803,6 +803,7 @@ class IMPALA(Algorithm):
                 func="sample_get_state_and_metrics",
                 timeout_seconds=self.config.timeout_s_sampler_manager,
                 return_obj_refs=False,
+                return_actor_ids=True,
             )
             # Get results from the n different async calls and store those EnvRunner
             # indices we should update.

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -645,7 +645,7 @@ class IMPALA(Algorithm):
             ma_batches_refs_remote_results = (
                 self._aggregator_actor_manager.fetch_ready_async_reqs(
                     return_obj_refs=True,
-                    tags="impala_get_batches",
+                    tags="get_batches",
                 )
             )
             ma_batches_refs = []
@@ -667,7 +667,7 @@ class IMPALA(Algorithm):
                 sent = self._aggregator_actor_manager.foreach_actor_async(
                     func="get_batch",
                     kwargs=[dict(episode_refs=p) for p in packs],
-                    tag="impala_get_batches",
+                    tag="get_batches",
                 )
                 self.metrics.log_value(
                     (AGGREGATOR_ACTOR_RESULTS, "num_env_steps_dropped_lifetime"),

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -780,16 +780,15 @@ class IMPALA(Algorithm):
             self.metrics.set_value(
                 NUM_TRAINING_STEP_CALLS_SINCE_LAST_SYNCH_WORKER_WEIGHTS, 0
             )
+            self.metrics.log_value(NUM_SYNCH_WORKER_WEIGHTS, 1, reduce="sum")
             with self.metrics.log_time((TIMERS, SYNCH_WORKER_WEIGHTS_TIMER)):
-                did_sync_weights = self.env_runner_group.sync_env_runner_states(
+                self.env_runner_group.sync_env_runner_states(
                     config=self.config,
                     connector_states=connector_states,
                     rl_module_state=rl_module_state,
                     env_to_module=self.env_to_module_connector,
                     module_to_env=self.module_to_env_connector,
                 )
-                if did_sync_weights:
-                    self.metrics.log_value(NUM_SYNCH_WORKER_WEIGHTS, 1, reduce="sum")
 
     def _sample_and_get_connector_states(self):
         env_runner_indices_to_update = set()

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -556,18 +556,13 @@ class EnvRunnerGroup:
             if rl_module_state:
                 env_runner_states.update(rl_module_state)
 
-            self.fetch_ready_async_reqs(
-                tags="sync_env_runner_states_set_states",
-                return_obj_refs=False,
-            )
-
             # Broadcast updated states back to all workers.
-            self.foreach_env_runner_async(
+            self.foreach_env_runner(
                 "set_state",  # Call the `set_state()` remote method.
-                tag="sync_env_runner_states_set_states",
                 kwargs=dict(state=env_runner_states),
                 remote_worker_ids=env_runner_indices_to_update,
                 local_env_runner=False,
+                timeout_seconds=0.0,  # This is a state update -> Fire-and-forget.
             )
 
     def foreach_env_runner_async_fetch_ready(

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -575,30 +575,26 @@ class EnvRunnerGroup:
         timeout_seconds: Optional[float] = 0.0,
         return_obj_refs: bool = False,
         mark_healthy: bool = False,
-        local_env_runner: bool = False,
         healthy_only: bool = True,
         remote_worker_ids: List[int] = None,
     ) -> List[Union[Tuple[int, T], T]]:
         """Calls the given function asynchronously and returns previous results if any.
 
-        This is a convenience function that calls `foreach_env_runner_async()` and `fetch_ready_async_reqs()`.
+        This is a convenience function that calls the underlying actor manager's
+        `foreach_actor_async_fetch_ready()` method.
 
         """
-        results = self.fetch_ready_async_reqs(
-            tags=tag,
+        return self._worker_manager.foreach_actor_async_fetch_ready(
+            func=func,
+            tag=tag,
+            kwargs=kwargs,
             timeout_seconds=timeout_seconds,
             return_obj_refs=return_obj_refs,
             mark_healthy=mark_healthy,
-        )
-        self.foreach_env_runner_async(
-            func,
-            kwargs=kwargs,
-            tag=tag,
             healthy_only=healthy_only,
-            remote_worker_ids=remote_worker_ids,
+            remote_actor_ids=remote_worker_ids,
+            ignore_ray_errors=self._ignore_ray_errors_on_env_runners,
         )
-
-        return results
 
     def sync_weights(
         self,
@@ -914,9 +910,6 @@ class EnvRunnerGroup:
             tag: A tag to identify the results from this async call when fetching with
                 `fetch_ready_async_reqs()`.
             kwargs: An optional kwargs dict to be passed to the remote function calls.
-            local_env_runner: Whether to apply `func` to local EnvRunner, too.
-                Default is False (unlike the sync version, async calls typically don't
-                need the local runner).
             healthy_only: Apply `func` on known-to-be healthy EnvRunners only.
             remote_worker_ids: Apply `func` on a selected set of remote EnvRunners.
 

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -577,6 +577,7 @@ class EnvRunnerGroup:
         mark_healthy: bool = False,
         healthy_only: bool = True,
         remote_worker_ids: List[int] = None,
+        return_actor_ids: bool = False,
     ) -> List[Union[Tuple[int, T], T]]:
         """Calls the given function asynchronously and returns previous results if any.
 
@@ -594,6 +595,7 @@ class EnvRunnerGroup:
             healthy_only=healthy_only,
             remote_actor_ids=remote_worker_ids,
             ignore_ray_errors=self._ignore_ray_errors_on_env_runners,
+            return_actor_ids=return_actor_ids,
         )
 
     def sync_weights(

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -979,12 +979,7 @@ class EnvRunnerGroup:
             ignore_ray_errors=self._ignore_ray_errors_on_env_runners,
         )
 
-        # Add remote results
-        all_results.extend(
-            [(r.actor_id, r.get()) for r in remote_results.ignore_errors()]
-        )
-
-        return all_results
+        return [(r.actor_id, r.get()) for r in remote_results.ignore_errors()]
 
     @OldAPIStack
     def foreach_env(self, func: Callable[[EnvType], List[T]]) -> List[List[T]]:

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -113,7 +113,7 @@ class TestEnvRunnerGroup(unittest.TestCase):
             ),
             0,
         )
-        time.sleep(1)
+        time.sleep(0.1)
 
         # Second call to foreach_env_runner_async_fetch_ready should return ready results.
         self.assertEqual(

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -113,7 +113,7 @@ class TestEnvRunnerGroup(unittest.TestCase):
             ),
             0,
         )
-        time.sleep(0.1)
+        time.sleep(1)
 
         # Second call to foreach_env_runner_async_fetch_ready should return ready results.
         self.assertEqual(

--- a/rllib/utils/actor_manager.py
+++ b/rllib/utils/actor_manager.py
@@ -885,7 +885,7 @@ class FaultTolerantActorManager:
                 )
         else:
             for raid in remote_actor_ids:
-                calls.append(self._actors[raid].apply.remote(func))
+                calls.append(self._actors[raid].apply.remote(func=func, **kwargs or {}))
 
         return calls
 

--- a/rllib/utils/actor_manager.py
+++ b/rllib/utils/actor_manager.py
@@ -676,6 +676,75 @@ class FaultTolerantActorManager:
 
         return remote_results
 
+    @DeveloperAPI
+    def foreach_actor_async_fetch_ready(
+        self,
+        func: Union[Callable[[Any], Any], List[Callable[[Any], Any]], str, List[str]],
+        tag: Optional[str] = None,
+        *,
+        kwargs: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+        timeout_seconds: Optional[float] = 0.0,
+        return_obj_refs: bool = False,
+        mark_healthy: bool = False,
+        healthy_only: bool = True,
+        remote_actor_ids: Optional[List[int]] = None,
+        ignore_ray_errors: bool = False,
+    ) -> RemoteCallResults:
+        """Calls the given function asynchronously and returns previous results if any.
+
+        This is a convenience function that calls `fetch_ready_async_reqs()` to get
+        previous results and then `foreach_actor_async()` to start new async calls.
+
+        Args:
+            func: A single Callable applied to all specified remote actors or a list
+                of Callables, that get applied on the list of specified remote actors.
+                In the latter case, both list of Callables and list of specified actors
+                must have the same length. Alternatively, you can use the name of the
+                remote method to be called, instead, or a list of remote method names.
+            tag: A tag to identify the results from this async call.
+            kwargs: An optional single kwargs dict or a list of kwargs dict matching the
+                list of provided `func` or `remote_actor_ids`. In the first case (single
+                dict), use `kwargs` on all remote calls. The latter case (list of
+                dicts) allows you to define individualized kwarg dicts per actor.
+            timeout_seconds: Time to wait for results from previous calls. Default is 0,
+                meaning those requests that are already ready.
+            return_obj_refs: Whether to return ObjectRef instead of actual results.
+            mark_healthy: Whether to mark all those actors healthy again that are
+                currently marked unhealthy AND that returned results from the remote
+                call (within the given `timeout_seconds`).
+            healthy_only: Apply `func` on known-to-be healthy actors only.
+            remote_actor_ids: Apply func on a selected set of remote actors.
+            ignore_ray_errors: Whether to ignore RayErrors in results.
+
+        Returns:
+            The results from previous async requests that were ready.
+        """
+        # First fetch any ready results from previous async calls
+        remote_results = self.fetch_ready_async_reqs(
+            tags=tag,
+            timeout_seconds=timeout_seconds,
+            return_obj_refs=return_obj_refs,
+            mark_healthy=mark_healthy,
+        )
+
+        # Then start new async calls
+        self.foreach_actor_async(
+            func,
+            tag=tag,
+            kwargs=kwargs,
+            healthy_only=healthy_only,
+            remote_actor_ids=remote_actor_ids,
+        )
+
+        # Handle errors the same way as fetch_ready_async_reqs does
+        FaultTolerantActorManager.handle_remote_call_result_errors(
+            remote_results,
+            ignore_ray_errors=ignore_ray_errors,
+        )
+
+        # Return the same format as before: list of (actor_id, result) tuples
+        return [(r.actor_id, r.get()) for r in remote_results.ignore_errors()]
+
     @staticmethod
     def handle_remote_call_result_errors(
         results_or_errors: RemoteCallResults,

--- a/rllib/utils/actor_manager.py
+++ b/rllib/utils/actor_manager.py
@@ -856,13 +856,16 @@ class FaultTolerantActorManager:
         if remote_actor_ids is None:
             remote_actor_ids = self.actor_ids()
 
+        calls = []
         if isinstance(func, list):
             assert len(remote_actor_ids) == len(
                 func
             ), "Funcs must have the same number of callables as actor indices."
 
-        calls = []
-        if isinstance(func, list):
+            assert isinstance(
+                kwargs, list
+            ), "If func is a list of functions, kwargs has to be a list of kwargs."
+
             for i, (raid, f) in enumerate(zip(remote_actor_ids, func)):
                 if isinstance(f, str):
                     calls.append(

--- a/rllib/utils/tests/test_actor_manager.py
+++ b/rllib/utils/tests/test_actor_manager.py
@@ -423,6 +423,17 @@ class TestActorManager(unittest.TestCase):
             else:
                 raise ValueError("result is not str or int")
 
+    def test_foreach_actor_async_fetch_ready(self):
+        """Test foreach_actor_async_fetch_ready works."""
+        actors = [Actor.remote(i, maybe_crash=False) for i in range(2)]
+        manager = FaultTolerantActorManager(actors=actors)
+        manager.foreach_actor_async_fetch_ready(lambda w: w.ping(), tag="ping")
+        time.sleep(5)
+        results = manager.foreach_actor_async_fetch_ready(
+            lambda w: w.ping(), tag="ping"
+        )
+        self.assertEqual(len(results), 2)
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
## Why are these changes needed?

After introducing tags for all in-flight async calls and adding foreach_env_runner_async_fetch_ready to the picture, we make broad use of this mechanism in this PR. 

Before merging, we probably want to trigger release tests because of how delicate the dynamics of moving data around in IMPALA can be.

Merge https://github.com/ray-project/ray/pull/56930/files first

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces ad‑hoc async send+fetch with tagged foreach_*_async_fetch_ready across Algorithm/IMPALA, adds the helper to ActorManager, wires it through EnvRunnerGroup, updates tags, and adds tests.
> 
> - **Core Utils**:
>   - Add `FaultTolerantActorManager.foreach_actor_async_fetch_ready(...)` to fetch ready results and kick off new async calls in one step; allow kwargs passthrough in `_call_actors` when using `apply`.
>   - Update `EnvRunnerGroup.foreach_env_runner_async_fetch_ready(...)` to delegate to actor manager (`foreach_actor_async_fetch_ready`), accept `tag`, `kwargs`, and `remote_actor_ids`; propagate `ignore_ray_errors`.
>   - Tests: add coverage for `foreach_actor_async_fetch_ready`.
> - **Algorithms**:
>   - Algorithm evaluation/offline-eval loops now use `foreach_env_runner_async_fetch_ready(...)` (with tags like `"_env_runner_remote"`, `"env_runner_sample_and_get_metrics"`, `"_offline_eval_runner_remote"`); aggregator metrics fetched via `foreach_actor_async_fetch_ready(tag="metrics")` and aggregated directly.
>   - IMPALA switches sampler to `foreach_env_runner_async_fetch_ready("sample_get_state_and_metrics")`; retag aggregator calls from `"batches"` to `"get_batches"` and adjust fetch accordingly.
> - **Minor**:
>   - Remove unused `RemoteCallResults` import; small tag/timeouts tweaks and comment cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eb69b5133f2da0ba19666349895893d0c3b70b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->