### PR TITLE
[ci] build generated protobuf in ray core binaries

### DIFF
--- a/ci/docker/ray-core.Dockerfile
+++ b/ci/docker/ray-core.Dockerfile
@@ -26,12 +26,13 @@ if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
   echo "build --remote_upload_local_results=false" >> "$HOME/.bazelrc"
 fi
 
-bazelisk build --config=ci //:ray_pkg_zip
+bazelisk build --config=ci //:ray_pkg_zip //:ray_py_proto_zip
 
 cp bazel-bin/ray_pkg.zip /home/forge/ray_pkg.zip
+cp bazel-bin/ray_py_proto.zip /home/forge/ray_py_proto.zip
 
 EOF
 
 FROM scratch
 
-COPY --from=builder /home/forge/ray_pkg.zip /ray_pkg.zip
+COPY --from=builder /home/forge/ray_pkg.zip /home/forge/ray_py_proto.zip /


### PR DESCRIPTION
this avoids the extra calls on bazel build to build the protobuf files, which will load the protobuf compilers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Build and include `ray_py_proto_zip` alongside `ray_pkg_zip` in the ray-core Docker image.
> 
> - **CI/Docker**:
>   - Update `ci/docker/ray-core.Dockerfile` to build `//:ray_py_proto_zip` alongside `//:ray_pkg_zip`.
>   - Copy `bazel-bin/ray_py_proto.zip` to `/home/forge/ray_py_proto.zip` in the builder stage.
>   - Adjust final `COPY` to include both `/home/forge/ray_pkg.zip` and `/home/forge/ray_py_proto.zip` in the output image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afaf423d6527df91a33a79da28f887c69b59bf12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->