### PR TITLE
[wheel] return early on build if no bazel build is required

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -553,30 +553,10 @@ def build(build_python, build_java, build_cpp, build_redis):
         )
         raise OSError(msg)
 
-    bazel_env = os.environ.copy()
-    bazel_env["PYTHON3_BIN_PATH"] = sys.executable
-
-    if is_native_windows_or_msys():
-        SHELL = bazel_env.get("SHELL")
-        if SHELL:
-            bazel_env.setdefault("BAZEL_SH", os.path.normpath(SHELL))
-        BAZEL_SH = bazel_env.get("BAZEL_SH", "")
-        SYSTEMROOT = os.getenv("SystemRoot")
-        wsl_bash = os.path.join(SYSTEMROOT, "System32", "bash.exe")
-        if (not BAZEL_SH) and SYSTEMROOT and os.path.isfile(wsl_bash):
-            msg = (
-                "You appear to have Bash from WSL,"
-                " which Bazel may invoke unexpectedly. "
-                "To avoid potential problems,"
-                " please explicitly set the {name!r}"
-                " environment variable for Bazel."
-            ).format(name="BAZEL_SH")
-            raise RuntimeError(msg)
-
-    # Note: We are passing in sys.executable so that we use the same
-    # version of Python to build packages inside the build.sh script. Note
-    # that certain flags will not be passed along such as --user or sudo.
-    # TODO(rkn): Fix this.
+    # Vendor thirdparty packages.
+    #
+    # TODO(ray-core, ray-ci): the version of these vendored packages should be
+    # pinned, so that the build is reproducible.
     if not os.getenv("SKIP_THIRDPARTY_INSTALL_CONDA_FORGE"):
         pip_packages = ["psutil", "colorama"]
         subprocess.check_call(
@@ -606,6 +586,39 @@ def build(build_python, build_java, build_cpp, build_redis):
             ]
             + runtime_env_agent_pip_packages
         )
+
+    bazel_targets = []
+    if build_python:
+        bazel_targets.append("//:gen_ray_pkg")
+    if build_cpp:
+        bazel_targets.append("//cpp:gen_ray_cpp_pkg")
+    if build_java:
+        bazel_targets.append("//java:gen_ray_java_pkg")
+    if build_redis:
+        bazel_targets.append("//:gen_redis_pkg")
+
+    if not bazel_targets:
+        return
+
+    bazel_env = os.environ.copy()
+    bazel_env["PYTHON3_BIN_PATH"] = sys.executable
+
+    if is_native_windows_or_msys():
+        SHELL = bazel_env.get("SHELL")
+        if SHELL:
+            bazel_env.setdefault("BAZEL_SH", os.path.normpath(SHELL))
+        BAZEL_SH = bazel_env.get("BAZEL_SH", "")
+        SYSTEMROOT = os.getenv("SystemRoot")
+        wsl_bash = os.path.join(SYSTEMROOT, "System32", "bash.exe")
+        if (not BAZEL_SH) and SYSTEMROOT and os.path.isfile(wsl_bash):
+            msg = (
+                "You appear to have Bash from WSL,"
+                " which Bazel may invoke unexpectedly. "
+                "To avoid potential problems,"
+                " please explicitly set the {name!r}"
+                " environment variable for Bazel."
+            ).format(name="BAZEL_SH")
+            raise RuntimeError(msg)
 
     bazel_flags = ["--verbose_failures"]
     if BAZEL_ARGS:
@@ -644,12 +657,6 @@ def build(build_python, build_java, build_cpp, build_redis):
         bazel_precmd_flags = []
         if sys.platform == "win32":
             bazel_precmd_flags = ["--output_user_root=C:/tmp"]
-
-    bazel_targets = []
-    bazel_targets += ["//:gen_ray_pkg"] if build_python else []
-    bazel_targets += ["//cpp:gen_ray_cpp_pkg"] if build_cpp else []
-    bazel_targets += ["//java:gen_ray_java_pkg"] if build_java else []
-    bazel_targets += ["//:gen_redis_pkg"] if build_redis else []
 
     if setup_spec.build_type == BuildType.DEBUG:
         bazel_flags.append("--config=debug")


### PR DESCRIPTION
when running in mode where no bazel build is required, we return early, and avoid running all bazel related logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip all Bazel logic by returning early in `python/setup.py` when no build targets are requested; refactors target computation and ordering of Bazel env setup.
> 
> - **Build system (`python/setup.py`)**:
>   - Early-return from `build()` when no Bazel targets (`//:gen_ray_pkg`, `//cpp:gen_ray_cpp_pkg`, `//java:gen_ray_java_pkg`, `//:gen_redis_pkg`) are requested, skipping all Bazel logic.
>   - Refactor: compute `bazel_targets` before Bazel env setup; switch to explicit `append` construction; move Windows `BAZEL_SH`/WSL checks after target computation.
>   - Preserve third-party vendoring (e.g., `psutil`, `colorama`, `aiohttp`) prior to any Bazel steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 669a821773b283b64a1bda26daa76b27d0ccb613. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->