### PR TITLE
[ci] use --no-deps to avoid installing dependencies

### DIFF
--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -64,16 +64,22 @@ echo "--- Build dashboard"
 
 echo "--- Install Ray with -e"
 
+
+# Dependencies are already installed in the base CI images.
+# So we use --no-deps to avoid reinstalling them.
+
+INSTALL_FLAGS=(--no-deps --force-reinstall -v -e)
+
 if [[ "$BUILD_TYPE" == "debug" ]]; then
-  RAY_DEBUG_BUILD=debug pip install -v -e python/
+  RAY_DEBUG_BUILD=debug pip install "${INSTALL_FLAGS[@]}" python/
 elif [[ "$BUILD_TYPE" == "asan" ]]; then
-  pip install -v -e python/
+  pip install "${INSTALL_FLAGS[@]}" python/
   bazel run $(./ci/run/bazel_export_options) --no//:jemalloc_flag //:gen_ray_pkg
 elif [[ "$BUILD_TYPE" == "java" ]]; then
   bash java/build-jar-multiplatform.sh linux
-  RAY_INSTALL_JAVA=1 pip install -v -e python/
+  RAY_INSTALL_JAVA=1 pip install "${INSTALL_FLAGS[@]}" python/
 else
-  pip install -v -e python/
+  pip install "${INSTALL_FLAGS[@]}" python/
 fi
 
 EOF


### PR DESCRIPTION
python dependencies are already installed in the CI images.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch editable Ray installs in `ci/ray_ci/tests.env.Dockerfile` to a shared `INSTALL_FLAGS` using `--no-deps` to avoid reinstalling dependencies.
> 
> - **CI Dockerfile (`ci/ray_ci/tests.env.Dockerfile`)**:
>   - Define `INSTALL_FLAGS=(--no-deps --force-reinstall -v -e)` and apply to all `pip install` paths (debug/asan/java/default) for editable Ray installs.
>   - Add comment noting dependencies are preinstalled in base CI images to justify `--no-deps`.
>   - Preserve existing `asan` Bazel package generation and Java JAR build steps; only the pip install flags changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd82d9133d9c6576e1feef62621c1269c2fe4870. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->