### PR TITLE
[core] add "custom_setup" tag for tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -60,7 +60,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/_common/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,runtime_env_container,manual,multi_gpu,spark_on_ray,ray_client,dask
+        --except-tags custom_setup
         --install-mask all-ray-libraries
 
   - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
@@ -74,7 +74,7 @@ steps:
         --install-mask all-ray-libraries
         --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
         --python-version {{matrix.python}}
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,runtime_env_container,manual,multi_gpu,spark_on_ray,ray_client,dask
+        --except-tags custom_setup
     depends_on: corebuild-multipy
     matrix:
       setup:
@@ -103,7 +103,7 @@ steps:
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,runtime_env_container,manual,multi_gpu,spark_on_ray,ray_client,dask
+        --except-tags custom_setup
 
   - label: ":ray: core: memory pressure tests"
     tags:

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -166,6 +166,7 @@ py_test(
     tags = [
         "exclusive",
         "post_wheel_build",
+        "custom_setup",
         "team:core",
     ],
 )
@@ -178,6 +179,7 @@ py_test(
     tags = [
         "exclusive",
         "mem_pressure",
+        "custom_setup",
         "team:core",
     ],
 )
@@ -190,6 +192,7 @@ py_test(
     tags = [
         "exclusive",
         "multi_gpu",
+        "custom_setup",
         "team:core",
     ],
 )
@@ -202,6 +205,7 @@ py_test(
     tags = [
         "exclusive",
         "multi_gpu",
+        "custom_setup",
         "team:core",
     ],
 )
@@ -214,6 +218,7 @@ py_test(
     tags = [
         "exclusive",
         "multi_gpu",
+        "custom_setup",
         "team:core",
     ],
 )
@@ -237,6 +242,7 @@ py_test(
     tags = [
         "exclusive",
         "multi_gpu",
+        "custom_setup",
         "team:core",
     ],
 )
@@ -249,6 +255,7 @@ py_test(
     tags = [
         "exclusive",
         "multi_gpu",
+        "custom_setup",
         "team:core",
     ],
 )
@@ -447,6 +454,7 @@ py_test_run_all_subdirectory(
     extra_srcs = [],
     tags = [
         "dask",
+        "custom_setup",
         "exclusive",
         "team:data",
     ],

--- a/python/ray/dag/BUILD.bazel
+++ b/python/ray/dag/BUILD.bazel
@@ -143,6 +143,7 @@ py_test(
     main = "tests/experimental/test_torch_tensor_dag.py",
     tags = [
         "compiled_graphs",
+        "custom_setup",
         "exclusive",
         "multi_gpu",
         "no_windows",
@@ -161,6 +162,7 @@ py_test(
     main = "tests/experimental/test_torch_tensor_transport.py",
     tags = [
         "compiled_graphs",
+        "custom_setup",
         "exclusive",
         "multi_gpu",
         "no_windows",
@@ -182,6 +184,7 @@ py_test(
 #         "compiled_graphs",
 #         "exclusive",
 #         "multi_gpu",
+#         "custom_setup",
 #         "no_windows",
 #         "team:core",
 #     ],

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -536,6 +536,7 @@ py_test(
     size = "small",
     srcs = ["tests/test_ecosystem_dask.py"],
     tags = [
+        "custom_setup",
         "dask",
         "exclusive",
         "team:data",

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -266,6 +266,7 @@ py_test_module_list(
         "test_runtime_env_2.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "post_wheel_build",
         "team:serve",
@@ -304,6 +305,7 @@ py_test(
     size = "medium",
     srcs = ["test_serve_ha.py"],
     tags = [
+        "custom_setup",
         "exclusive",
         "ha_integration",
         "team:serve",

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -147,6 +147,7 @@ py_test_module_list(
         "test_client_reconnect.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "ray_client",
         "team:core",
@@ -167,6 +168,7 @@ py_test_module_list(
         "test_client_warnings.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "ray_client",
         "team:core",
@@ -183,6 +185,7 @@ py_test_module_list(
         "test_client_init.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "no_windows",
         "ray_client",
@@ -225,6 +228,7 @@ py_test_module_list(
     ],
     name_suffix = "_client_mode",
     tags = [
+        "custom_setup",
         "exclusive",
         "ray_client",
         "team:core",
@@ -251,6 +255,7 @@ py_test_module_list(
     ],
     name_suffix = "_client_mode",
     tags = [
+        "custom_setup",
         "exclusive",
         "ray_client",
         "team:core",
@@ -276,6 +281,7 @@ py_test_module_list(
     ],
     name_suffix = "_client_mode",
     tags = [
+        "custom_setup",
         "exclusive",
         "post_wheel_build",
         "ray_client",
@@ -634,6 +640,7 @@ py_test_module_list(
         "gpu_objects/test_gpu_objects_nixl.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "gpu_objects",
         "multi_gpu",
@@ -670,6 +677,7 @@ py_test_module_list(
         "test_gcs_ha_e2e_2.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "ha_integration",
         "team:core",
@@ -686,6 +694,7 @@ py_test_module_list(
         "test_network_failure_e2e.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "ha_integration",
         "no_windows",
@@ -701,6 +710,7 @@ py_test_module_list(
     size = "medium",
     files = ["test_memory_pressure.py"],
     tags = [
+        "custom_setup",
         "exclusive",
         "mem_pressure",
         "team:core",
@@ -949,6 +959,7 @@ py_test_module_list(
         "test_out_of_disk_space.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "team:core",
         "tmpfs",
@@ -1066,6 +1077,7 @@ py_test_module_list(
         "test_runtime_env_uv_run.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "post_wheel_build",
         "team:core",
@@ -1081,6 +1093,7 @@ py_test(
     size = "large",
     srcs = ["test_runtime_env_container.py"],
     tags = [
+        "custom_setup",
         "exclusive",
         "runtime_env_container",
         "team:core",
@@ -1291,6 +1304,7 @@ py_test_module_list(
     ],
     name_suffix = "_debug_mode",
     tags = [
+        "custom_setup",
         "debug_tests",
         "exclusive",
         "team:core",
@@ -1313,6 +1327,7 @@ py_test_module_list(
     name_suffix = "_asan",
     tags = [
         "asan_tests",
+        "custom_setup",
         "exclusive",
         "team:core",
     ],
@@ -1336,6 +1351,7 @@ py_test_module_list(
         "spark/test_utils.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
         "spark_on_ray",
         "team:core",


### PR DESCRIPTION
for tests that require customized setup. the tag makes it easier to filter out when running tests for normal setup.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `custom_setup` tag for special-setup tests and update Buildkite to skip them in standard core test runs.
> 
> - **CI (Buildkite)**:
>   - Replace long `--except-tags` lists with `--except-tags custom_setup` in `core` Python, matrix, and Redis test steps in `.buildkite/core.rayci.yml`.
> - **Test Tagging (`custom_setup`)**:
>   - **Core tests (`python/ray/tests/BUILD.bazel`)**: Tag select suites (e.g., `ray_client`, `ha_integration`, `mem_pressure`, `tmpfs`, `post_wheel_build`, `runtime_env_container`, `debug_tests`, `asan_tests`, `spark_on_ray`, GPU-related) with `custom_setup`.
>   - **Docs (`doc/BUILD.bazel`)**: Tag specific doc code examples (runtime env, OOM prevention, multi-GPU, Dask) with `custom_setup`.
>   - **DAG (`python/ray/dag/BUILD.bazel`)**: Tag multi-GPU tests with `custom_setup`.
>   - **Data (`python/ray/data/BUILD.bazel`)**: Tag `test_ecosystem_dask` with `custom_setup`.
>   - **Serve (`python/ray/serve/tests/BUILD.bazel`)**: Tag runtime env and HA tests with `custom_setup`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22d92f8f70baa498ee30b62695534703b1898fca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->