### PR TITLE
[train] expose run_config in ray.train.get_context()

### DIFF
--- a/python/ray/train/v2/api/context.py
+++ b/python/ray/train/v2/api/context.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 from ray.train.v2._internal.execution.context import (
     get_train_context as get_internal_train_context,
 )
+from ray.train.v2.api.config import RunConfig
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 
 
@@ -176,12 +177,17 @@ class TrainContext(ABC):
         """
         pass
 
+    @abstractmethod
+    def get_run_config(self) -> RunConfig:
+        """Returns the :class:`~ray.train.RunConfig` run config"""
+        pass
+
     @DeveloperAPI
     @abstractmethod
     def get_storage(self):
         """Returns the :class:`~ray.train._internal.storage.StorageContext` storage
         context which gives advanced access to the filesystem and paths
-        configured through `RunConfig`.
+        configured through :class:`~ray.train.RunConfig`.
 
         NOTE: This is a DeveloperAPI, and the `StorageContext` interface may change
         without notice between minor versions.
@@ -209,6 +215,9 @@ class DistributedTrainContext(TrainContext):
 
     def get_node_rank(self) -> int:
         return get_internal_train_context().get_node_rank()
+
+    def get_run_config(self) -> RunConfig:
+        return get_internal_train_context().train_run_context.get_run_config()
 
     def get_storage(self):
         return get_internal_train_context().get_storage()
@@ -250,6 +259,9 @@ class LocalTrainContext(TrainContext):
 
     def get_node_rank(self) -> int:
         return self.node_rank
+
+    def get_run_config(self):
+        raise NotImplementedError("Local run config not yet implemented. ")
 
     def get_storage(self):
         raise NotImplementedError("Local storage context not yet implemented. ")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #56996

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
