### PR TITLE
[java] Bazel fixing the all_modules build

### DIFF
--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -22,6 +22,9 @@ all_modules = [
     "api",
     "runtime",
     "serve",
+]
+
+all_modules_with_test = all_modules + [
     "test",
     "performance_test",
 ]
@@ -34,13 +37,29 @@ java_import(
     ] + [
         "libio_ray_ray_" + module + "-src.jar"
         for module in all_modules
+    ],
+    deps = [
+        ":io_ray_ray_" + module
+        for module in all_modules
+    ],
+)
+
+java_import(
+    name = "all_modules_with_test",
+    testonly = 1,
+    jars = [
+        "libio_ray_ray_" + module + ".jar"
+        for module in all_modules_with_test
+    ] + [
+        "libio_ray_ray_" + module + "-src.jar"
+        for module in all_modules_with_test
     ] + [
         "all_tests_deploy.jar",
         "all_tests_deploy-src.jar",
     ],
     deps = [
         ":io_ray_ray_" + module
-        for module in all_modules
+        for module in all_modules_with_test
     ] + [
         ":all_tests",
     ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The PR is adding bazel build fixes for java, previously the bazel build for all_modules were failing due to having a dependency on testonly target in bazel. Moved the all_modules and all_modules_for_test separately so that both can be used whereever required.

## Related issue number
Fixes #56990 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates `all_modules` into non-test modules and a new test-only `all_modules_with_test`, adding a corresponding `java_import` and adjusting JARs and deps accordingly.
> 
> - **Build/Bazel (Java)**:
>   - **Module lists**: Create `all_modules` with production modules (`api`, `runtime`, `serve`); add `all_modules_with_test` extending it with `test` and `performance_test`.
>   - **Targets**:
>     - Add `java_import` `all_modules_with_test` (`testonly = 1`) including test modules and `all_tests` JARs.
>     - Keep `java_import` `all_modules` for non-test modules; add explicit `deps` on `:io_ray_ray_<module>`.
>   - **Deps adjustments**: Loops for JARs/`deps` now reference the appropriate module list; test-only target depends on `:all_tests`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c79a11ec609e122a5dee4ed8bae62241f9ea81c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->