### PR TITLE
[core] split out test that needs java

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -379,6 +379,23 @@ py_test_module_list(
 py_test_module_list(
     size = "medium",
     files = [
+        "test_logging_java.py",
+    ],
+    tags = [
+        "exclusive",
+        "medium_size_python_tests_k_to_z",
+        "needs_java",
+        "team:core",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test_module_list(
+    size = "medium",
+    files = [
         "test_multi_node_3.py",
         "test_object_manager.py",
         "test_resource_demand_scheduler.py",

--- a/python/ray/tests/test_logging_java.py
+++ b/python/ray/tests/test_logging_java.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+import ray
+from ray._common.test_utils import wait_for_condition
+from ray.cross_language import java_actor_class
+
+# Source code of MyClass.java
+_MY_CLASS_JAVA = """
+public class MyClass {
+    public int printToLog(String line) {
+        System.err.println(line);
+        return 0;
+    }
+}
+"""
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or sys.platform == "darwin",
+    reason="Does not work on Windows and OSX.",
+)
+def test_log_java_worker_logs(shutdown_only, capsys):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        print("using tmp_dir", tmp_dir)
+        with open(os.path.join(tmp_dir, "MyClass.java"), "w") as f:
+            f.write(_MY_CLASS_JAVA)
+        subprocess.check_call(["javac", "MyClass.java"], cwd=tmp_dir)
+        subprocess.check_call(["jar", "-cf", "myJar.jar", "MyClass.class"], cwd=tmp_dir)
+
+        ray.init(
+            job_config=ray.job_config.JobConfig(code_search_path=[tmp_dir]),
+        )
+
+        handle = java_actor_class("MyClass").remote()
+        ray.get(handle.printToLog.remote("here's my random line!"))
+
+        def check():
+            out, err = capsys.readouterr()
+            out += err
+            with capsys.disabled():
+                print(out)
+            return "here's my random line!" in out
+
+        wait_for_condition(check)
+
+        ray.shutdown()
+
+
+if __name__ == "__main__":
+    # Make subprocess happy in bazel.
+    os.environ["LC_ALL"] = "en_US.UTF-8"
+    os.environ["LANG"] = "en_US.UTF-8"
+    sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
and add `needs_java` tag to the test. this will allow us to run "normal" tests without java jdk and jre, where and running java related tests seperately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts the Java logging test into `test_logging_java.py`, tags it `needs_java`, updates Bazel to run it separately, and adds `no_windows` to a medium test shard.
> 
> - **Tests**:
>   - Split Java logging test out of `test_logging.py` into new `test_logging_java.py` and call `ray.shutdown()` at end.
>   - Removed Java-specific imports and test from `test_logging.py`.
> - **Build/CI (Bazel)**:
>   - Added `py_test_module_list` for `test_logging_java.py` with tags `exclusive`, `medium_size_python_tests_k_to_z`, `needs_java`, `team:core`.
>   - Added `no_windows` tag to `py_test_module_list` containing `test_multi_node_3.py`, `test_object_manager.py`, `test_resource_demand_scheduler.py`, `test_stress.py`, `test_stress_sharded.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44c41b22809ec7a0d68354c7c8e41a53fabfbbba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->