### PR TITLE
[core] Fix autoscaler RAY_CHECK when GcsAutoscalerStateManager is out of sync with NodeManager

### DIFF
--- a/src/ray/gcs/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.cc
@@ -268,6 +268,7 @@ void GcsAutoscalerStateManager::GetClusterResourceConstraints(
 }
 
 void GcsAutoscalerStateManager::OnNodeAdd(const rpc::GcsNodeInfo &node) {
+  RAY_CHECK(thread_checker_.IsOnSameThread());
   NodeID node_id = NodeID::FromBinary(node.node_id());
   if (node_resource_info_.contains(node_id)) {
     // early termination as we already know about this node

--- a/src/ray/gcs/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.cc
@@ -268,8 +268,11 @@ void GcsAutoscalerStateManager::GetClusterResourceConstraints(
 }
 
 void GcsAutoscalerStateManager::OnNodeAdd(const rpc::GcsNodeInfo &node) {
-  RAY_CHECK(thread_checker_.IsOnSameThread());
   NodeID node_id = NodeID::FromBinary(node.node_id());
+  if (node_resource_info_.contains(node_id)) {
+    // early termination as we already know about this node
+    return;
+  }
   auto node_info =
       node_resource_info_
           .emplace(node_id, std::make_pair(absl::Now(), rpc::ResourcesData()))
@@ -343,7 +346,7 @@ void GcsAutoscalerStateManager::GetPendingResourceRequests(
 void GcsAutoscalerStateManager::GetNodeStates(
     rpc::autoscaler::ClusterResourceState *state) {
   RAY_CHECK(thread_checker_.IsOnSameThread());
-  auto populate_node_state = [&](const rpc::GcsNodeInfo &gcs_node_info) {
+  auto populate_node_state = [this, state](const rpc::GcsNodeInfo &gcs_node_info) {
     auto node_state_proto = state->add_node_states();
     node_state_proto->set_node_id(gcs_node_info.node_id());
     node_state_proto->set_instance_id(gcs_node_info.instance_id());
@@ -372,8 +375,18 @@ void GcsAutoscalerStateManager::GetNodeStates(
 
     auto const node_id = NodeID::FromBinary(node_state_proto->node_id());
     // The node is alive. We need to check if the node is idle.
-    auto const node_resource_iter = node_resource_info_.find(node_id);
+    auto node_resource_iter = node_resource_info_.find(node_id);
 
+    if (node_resource_iter == node_resource_info_.end()) {
+      // TODO:(zac)  There exists a possibility that the GcsNodeManager node list is more
+      // up to date then the resource information within this class.  In the future all
+      // state will get updated transactionally together, but for now, we'll utilize this
+      // 'escape hatch' option and in place update the state. See
+      // https://github.com/ray-project/ray/issues/57009 and once resolved we can delete
+      // this logic
+      OnNodeAdd(gcs_node_info);
+      node_resource_iter = node_resource_info_.find(node_id);
+    }
     RAY_CHECK(node_resource_iter != node_resource_info_.end());
 
     auto const &node_resource_item = node_resource_iter->second;

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -391,8 +391,6 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
       [this] {
         for (const auto &alive_node : gcs_node_manager_->GetAllAliveNodes()) {
           std::shared_ptr<ray::RayletClientInterface> raylet_client;
-          // GetOrConnectionByID will not connect to the raylet is it hasn't been
-          // connected.
           if (auto raylet_client_opt = raylet_client_pool_.GetByID(alive_node.first)) {
             raylet_client = raylet_client_opt;
           } else {

--- a/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
@@ -115,6 +115,11 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
     gcs_autoscaler_state_manager_->OnNodeAdd(*node);
   }
 
+  void AddNodeToNodeManagerOnly(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
+    absl::MutexLock lock(&gcs_node_manager_->mutex_);
+    gcs_node_manager_->alive_nodes_[NodeID::FromBinary(node->node_id())] = node;
+  }
+
   void RemoveNode(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
     absl::MutexLock lock(&gcs_node_manager_->mutex_);
     const auto node_id = NodeID::FromBinary(node->node_id());
@@ -455,6 +460,27 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGetClusterStatusBasic) {
     const auto &state = reply.autoscaling_state();
     ASSERT_EQ(state.autoscaler_state_version(), 1);
   }
+}
+
+TEST_F(GcsAutoscalerStateManagerTest, TestHandleGetClusterStatusWithOutOfOrderNodeAdd) {
+  auto node = GenNodeInfo();
+  node->mutable_resources_total()->insert({"CPU", 2});
+  node->set_instance_id("instance_1");
+  AddNodeToNodeManagerOnly(node);
+
+  const auto reply = GetClusterStatusSync();
+
+  // Should have cluster resource state
+  ASSERT_TRUE(reply.has_cluster_resource_state());
+  const auto &state = reply.cluster_resource_state();
+  ASSERT_EQ(state.node_states_size(), 1);
+
+  // Should NOT have autoscaling state when none has been reported
+  ASSERT_FALSE(reply.has_autoscaling_state());
+
+  // Cluster resource state should still be valid
+  ASSERT_GT(state.cluster_resource_state_version(), 0);
+  ASSERT_EQ(state.cluster_session_name(), "fake_cluster");
 }
 
 TEST_F(GcsAutoscalerStateManagerTest, TestNodeDynamicLabelsWithPG) {


### PR DESCRIPTION
## Why are these changes needed?

This is a fix for #56995 which was a regression introduced by change #56351 .  This change rendered it so that listener callbacks were no longer triggered synchronously with node updates.  This means there exists a period of time where node resource information is out of sync with node entries in the GcsNodeManager.  This change introduces an auto repair attempt prior to triggering the ray check.

## Related issue number

Closes #56995 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle out-of-order node additions by populating missing resource state on-the-fly and skip duplicate OnNodeAdd; add test for GetClusterStatus with out-of-order node add.
> 
> - **Autoscaler (GCS)**:
>   - Auto-repair in `GetNodeStates`: if `node_resource_info_` lacks an alive `node`, call `OnNodeAdd` to populate before proceeding.
>   - Prevent duplicate processing in `OnNodeAdd` by early-return when `node_resource_info_` already contains the `node_id`.
> - **Tests**:
>   - Add `AddNodeToNodeManagerOnly` helper and `TestHandleGetClusterStatusWithOutOfOrderNodeAdd` to validate cluster status when node add/order is out-of-sync.
> - **Misc**:
>   - Minor comment cleanup in `gcs_server.cc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eef8ad2088ca9fe64d06ff621a45e8307747660b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->