### PR TITLE
[Data] - Groupby benchmark - sort shuffle pull based

### DIFF
--- a/release/nightly_tests/dataset/groupby_benchmark.py
+++ b/release/nightly_tests/dataset/groupby_benchmark.py
@@ -55,7 +55,7 @@ def main(args):
         )
         override_num_blocks = (
             100
-            if args.shuffle_strategy == ShuffleStrategy.SORT_SHUFFLE_PULL_BASED
+            if args.shuffle_strategy == ShuffleStrategy.SORT_SHUFFLE_PULL_BASED.value
             else None
         )
         grouped_ds = ray.data.read_parquet(

--- a/release/nightly_tests/dataset/groupby_benchmark.py
+++ b/release/nightly_tests/dataset/groupby_benchmark.py
@@ -53,6 +53,7 @@ def main(args):
         DataContext.get_current().shuffle_strategy = ShuffleStrategy(
             args.shuffle_strategy
         )
+        # TODO: Don't override once we fix range-based shuffle
         override_num_blocks = (
             100
             if args.shuffle_strategy == ShuffleStrategy.SORT_SHUFFLE_PULL_BASED.value

--- a/release/nightly_tests/dataset/groupby_benchmark.py
+++ b/release/nightly_tests/dataset/groupby_benchmark.py
@@ -53,8 +53,14 @@ def main(args):
         DataContext.get_current().shuffle_strategy = ShuffleStrategy(
             args.shuffle_strategy
         )
-
-        grouped_ds = ray.data.read_parquet(path).groupby(args.group_by)
+        override_num_blocks = (
+            100
+            if args.shuffle_strategy == ShuffleStrategy.SORT_SHUFFLE_PULL_BASED
+            else None
+        )
+        grouped_ds = ray.data.read_parquet(
+            path, override_num_blocks=override_num_blocks
+        ).groupby(args.group_by)
         consume_fn(grouped_ds)
 
         # Report arguments for the benchmark.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The release test (`aggregate_groups_fixed_size_sort_shuffle_pull_based_column02 column14`) for pull based sort shuffle was OOMing. To address this, I reduced the number of blocks to 100 in the read layer.

## Related issue number

DATA-1399

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally set override_num_blocks=100 for read_parquet when using SORT_SHUFFLE_PULL_BASED in the groupby benchmark.
> 
> - **Benchmarks (nightly)**
>   - `release/nightly_tests/dataset/groupby_benchmark.py`:
>     - When `shuffle_strategy` is `SORT_SHUFFLE_PULL_BASED`, call `ray.data.read_parquet(..., override_num_blocks=100)`; otherwise leave unset.
>     - Subsequent `groupby(args.group_by)` flow unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e567de5a3dca98f2424f9269c703b123613420d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->