### PR TITLE
Fix rdt micro benchmark by ensuring the actor has received the tensor

### DIFF
--- a/release/microbenchmark/experimental/gpu_object_microbenchmark.py
+++ b/release/microbenchmark/experimental/gpu_object_microbenchmark.py
@@ -69,6 +69,8 @@ class Actor:
 
     def recv(self, tensor: torch.Tensor):
         assert tensor.device.type == self.device.type
+        # Return the first element of the tensor to make sure the actor has received the tensor.
+        return tensor[0].item()
 
 
 def _exec_p2p_transfer(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Since nccl transport will do async recv, we need to make sure the actual tensor has been received before the function of recv actor return. Otherwise, it's not a fair comparison.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `Actor.recv` return a scalar from the tensor so the benchmark waits for receiver confirmation via `ray.get`.
> 
> - **GPU Object Microbenchmark** (`release/microbenchmark/experimental/gpu_object_microbenchmark.py`):
>   - Update `Actor.recv` to return `tensor[0].item()` after device assertion, enabling synchronization by awaiting the receiver's return value (`ray.get`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c6f799109a2881ed039286aad436724038dd43e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->