### PR TITLE
[ci] updating pr template description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 ## Checks
 
 - [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
-- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://pre-commit.com/))
+- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
 - [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
     - [ ] I've added any new APIs to the API Reference. For example, if I added a
            method in Tune, I've added it in `doc/source/tune/api/` under the

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 ## Checks
 
 - [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
-- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
+- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://pre-commit.com/))
 - [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
     - [ ] I've added any new APIs to the API Reference. For example, if I added a
            method in Tune, I've added it in `doc/source/tune/api/` under the


### PR DESCRIPTION
Updating pr template to tell users to run pre-commit instead of `scripts/format.sh`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace the checklist item for running `scripts/format.sh` with running pre-commit jobs (with setup link) in `.github/PULL_REQUEST_TEMPLATE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c7e83d554a3fa2a42f75abec511b30235be34e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->