### PR TITLE
[core][event] clean up ray event buffer

### DIFF
--- a/python/ray/dashboard/modules/aggregator/tests/test_multi_consumer_event_buffer.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_multi_consumer_event_buffer.py
@@ -234,6 +234,37 @@ class TestMultiConsumerEventBuffer:
         assert len(consumed_events) == total_events
         assert consumed_events == produced_events
 
+    @pytest.mark.asyncio
+    async def test_events_are_evicted_once_consumed_by_all_consumers(self):
+        """Test events are evicted from the buffer once they are consumed by all consumers"""
+        buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=2)
+        consumer_name_1 = "test_consumer_1"
+        consumer_name_2 = "test_consumer_2"
+        await buffer.register_consumer(consumer_name_1)
+        await buffer.register_consumer(consumer_name_2)
+
+        # Add events
+        events = []
+        for i in range(10):
+            event = _create_test_event(f"event{i}".encode())
+            events.append(event)
+            await buffer.add_event(event)
+
+        assert await buffer.size() == 10
+        # Consumer 1 reads first batch
+        batch1 = await buffer.wait_for_batch(consumer_name_1, timeout_seconds=0.1)
+        assert batch1 == events[:2]
+
+        # buffer size does not change as consumer 2 is yet to consume these events
+        assert await buffer.size() == 10
+
+        # Consumer 2 reads from beginning
+        batch2 = await buffer.wait_for_batch(consumer_name_2, timeout_seconds=0.1)
+        assert batch2 == events[:2]
+
+        # size reduces by 2 as both consumers have consumed 2 events
+        assert await buffer.size() == 8
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
The PR https://github.com/ray-project/ray/pull/55780
 upgraded the Ray event buffer to a new implementation; however, the new buffer lacks a cleanup function. This change adds logic to clean up the buffer whenever a batch is retrieved. The cleanup targets events that are stale for all consumers.

Test:
- CI
- agent_stress_test.aws is now passing with this change https://buildkite.com/ray-project/release/builds/60705/steps/canvas?sid=019997a8-c766-402a-bf8e-bc6b845ec1e1

AFTER:

Previously `agent_stress_test.aws` was failing because the `agent` process constantly uses 1.5GB. With this change, the memory goes down to 250MB (with a peak at the start up that goes down quickly)

<img width="958" height="312" alt="Screenshot 2025-09-30 at 1 43 42 PM" src="https://github.com/user-attachments/assets/67eb02c3-a2ce-44ed-8a8d-9521471470cc" />

Note that the memory consumption of the `agent` process was about 150MB a short while ago. However, there is also a recent change that bump the export interval from every 0.1s to every 1s, so the higher memory consumption (250MB on a steady state) is expected.

BEFORE:

https://console.anyscale-staging.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_92c7b71w55flm6gv6imv4m6vqg/jobs/prodjob_yxtwz9jebfxu3zztv4idhamj3k?job-logs-section-tabs=application_logs&job-tab=metrics failed with 1.5gb memory consumption for the `agent` process

<img width="954" height="312" alt="Screenshot 2025-09-30 at 1 49 41 PM" src="https://github.com/user-attachments/assets/35a780e8-b522-4fb5-8b25-0b5de68e4a71" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Evicts events consumed by all consumers during batch retrieval and adds a test validating buffer size reduction.
> 
> - **Aggregator / Event Buffer**:
>   - Add `MultiConsumerEventBuffer._evict_old_events` to purge events with index < all consumers' cursors and update consumer cursors.
>   - Invoke eviction after assembling a batch in `wait_for_batch`.
> - **Tests**:
>   - Add `test_events_are_evicted_once_consumed_by_all_consumers` to assert buffer size shrinks after both consumers read the same events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27c44f5caeac64edd2b0477a212f54370b9937fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->