### PR TITLE
Loosen Ray self-dependency check to allow matching versions.

### DIFF
--- a/python/ray/_private/runtime_env/dependency_utils.py
+++ b/python/ray/_private/runtime_env/dependency_utils.py
@@ -65,15 +65,19 @@ with open(r"{ray_version_path}", "wt") as f:
     version, path = await _get_ray_version_and_path()
     yield
     actual_version, actual_path = await _get_ray_version_and_path()
-    if actual_version != version or actual_path != path:
+    if actual_version != version:
         raise RuntimeError(
             "Changing the ray version is not allowed: \n"
             f"  current version: {actual_version}, "
-            f"current path: {actual_path}\n"
             f"  expect version: {version}, "
-            f"expect path: {path}\n"
+            f"  current path: {actual_path}, "
+            f"  expect path: {path}, "
             "Please ensure the dependencies in the runtime_env pip field "
             "do not install a different version of Ray."
+        )
+    if actual_path != path:
+        logger.info(
+            f"Detected new Ray package with the same version at {actual_path} (vs system {path})."
         )
 
 


### PR DESCRIPTION
## Why are these changes needed?

See #56389 -- the version check makes it difficult to use the `uv` package system for Ray with projects that take Ray as a dependency.

## Related issue number

#56389 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
   - [x] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Loosens the runtime env self-dependency check to only fail on Ray version changes and just log when the package path differs but version matches.
> 
> - **Runtime Env** (`python/ray/_private/runtime_env/dependency_utils.py`):
>   - `check_ray` now only raises on Ray version mismatch; path differences no longer cause failure.
>   - Logs an info message when a different Ray package path with the same version is detected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d5b2ca9ef2f7637f58c46d63c4d464fe180b5bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->