### PR TITLE
[wheel] build java bits with wanda

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -21,6 +21,16 @@ steps:
     tags: release_wheels
     depends_on: manylinux
 
+  - name: ray-java-build
+    label: "wanda: java build (x86_64)"
+    wanda: ci/docker/ray-java.wanda.yaml
+    tags:
+      - release_wheels
+      - oss
+    env:
+      ARCH_SUFFIX: ""
+    depends_on: manylinux
+
   - label: ":tapioca: build: wheel {{matrix}} (x86_64)"
     key: linux_wheels
     tags:

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -13,6 +13,17 @@ steps:
     wanda: ci/docker/manylinux.aarch64.wanda.yaml
     instance_type: builder-arm64
 
+  - name: ray-java-build-aarch64
+    label: "wanda: java build (aarch64)"
+    wanda: ci/docker/ray-java.wanda.yaml
+    tags:
+      - release_wheels
+      - oss
+    env:
+      ARCH_SUFFIX: "-aarch64"
+    instance_type: builder-arm64
+    depends_on: manylinux-aarch64
+
   - name: raycpubase-aarch64
     label: "wanda: ray.py{{matrix}}.cpu.base (aarch64)"
     tags:

--- a/ci/docker/ray-java.Dockerfile
+++ b/ci/docker/ray-java.Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.3-labs
+ARG ARCH_SUFFIX
+FROM cr.ray.io/rayproject/manylinux$ARCH_SUFFIX AS builder
+
+ARG BUILDKITE_BAZEL_CACHE_URL
+ARG BUILDKITE_CACHE_READONLY
+
+WORKDIR /home/forge/ray
+
+COPY . .
+
+RUN <<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+export RAY_BUILD_ENV="manylinux"
+
+if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+  echo "build --remote_upload_local_results=false" >> "$HOME/.bazelrc"
+fi
+
+bazelisk build --config=ci //java:ray_java_pkg
+
+cp bazel-bin/java/ray_java_pkg.zip /home/forge/ray_java_pkg.zip
+
+EOF
+
+FROM scratch
+
+COPY --from=builder /home/forge/ray_java_pkg.zip /

--- a/ci/docker/ray-java.wanda.yaml
+++ b/ci/docker/ray-java.wanda.yaml
@@ -1,0 +1,20 @@
+name: ray-java-build$ARCH_SUFFIX
+froms: ["cr.ray.io/rayproject/manylinux$ARCH_SUFFIX"]
+dockerfile: ci/docker/ray-java.Dockerfile
+srcs:
+  - .bazelversion
+  - .bazelrc
+  - WORKSPACE
+  - BUILD.bazel
+  - bazel/
+  - thirdparty/
+  - src/
+  - java/
+  - gen_ray_pkg.py
+  - release/BUILD.bazel
+  - release/requirements_buildkite.txt
+build_args:
+  - ARCH_SUFFIX
+  - BUILDKITE_BAZEL_CACHE_URL
+build_hint_args:
+  - BUILDKITE_CACHE_READONLY


### PR DESCRIPTION
these are not used on most of the CI, but will be used on building the final released version wheels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Wanda-driven Java build for both x86_64 and aarch64, with new Dockerfile and Wanda recipe to produce ray_java_pkg.zip and corresponding Buildkite steps.
> 
> - **CI (Buildkite)**:
>   - Add `ray-java-build` (x86_64) step using `ci/docker/ray-java.wanda.yaml`; tags `release_wheels`, `oss`; `ARCH_SUFFIX: ""`; depends on `manylinux`.
>   - Add `ray-java-build-aarch64` step; `ARCH_SUFFIX: "-aarch64"`; `instance_type: builder-arm64`; depends on `manylinux-aarch64`.
> - **Docker/Wanda**:
>   - New `ci/docker/ray-java.Dockerfile` to build `//java:ray_java_pkg` with Bazelisk in manylinux and output `ray_java_pkg.zip`.
>   - New `ci/docker/ray-java.wanda.yaml` referencing manylinux base, wiring sources (`java/`, `bazel/`, etc.), and build args (`ARCH_SUFFIX`, `BUILDKITE_BAZEL_CACHE_URL`, `BUILDKITE_CACHE_READONLY`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aca6fb7d1fcc2a9805af8215af747abfc836b8c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->