### PR TITLE
[core][event] add instance type to node event

### DIFF
--- a/python/ray/dashboard/modules/aggregator/tests/test_ray_node_events.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_ray_node_events.py
@@ -12,6 +12,7 @@ from ray._private.test_utils import (
 from ray.dashboard.tests.conftest import *  # noqa
 
 _RAY_EVENT_PORT = 12345
+_INSTANCE_TYPE_NAME = "m4.16xlarge"
 
 
 @pytest.fixture(scope="session")
@@ -25,6 +26,7 @@ def test_ray_node_events(ray_start_cluster, httpserver):
         env_vars={
             "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": f"http://127.0.0.1:{_RAY_EVENT_PORT}",
             "RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES": "NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT",
+            "RAY_CLOUD_INSTANCE_TYPE_NAME": _INSTANCE_TYPE_NAME,
         },
         _system_config={
             "enable_ray_event": True,
@@ -44,6 +46,7 @@ def test_ray_node_events(ray_start_cluster, httpserver):
         base64.b64decode(req_json[0]["nodeDefinitionEvent"]["nodeId"]).hex()
         == cluster.head_node.node_id
     )
+    assert req_json[0]["nodeDefinitionEvent"]["instanceTypeName"] == _INSTANCE_TYPE_NAME
     assert (
         base64.b64decode(req_json[1]["nodeLifecycleEvent"]["nodeId"]).hex()
         == cluster.head_node.node_id

--- a/src/ray/observability/ray_node_definition_event.cc
+++ b/src/ray/observability/ray_node_definition_event.cc
@@ -27,6 +27,7 @@ RayNodeDefinitionEvent::RayNodeDefinitionEvent(const rpc::GcsNodeInfo &data,
           session_name) {
   data_.set_node_id(data.node_id());
   data_.set_node_ip_address(data.node_manager_address());
+  data_.set_instance_type_name(data.instance_type_name());
   data_.mutable_start_timestamp()->CopyFrom(
       AbslTimeNanosToProtoTimestamp(absl::ToInt64Nanoseconds(
           absl::FromUnixMillis(data.start_time_ms()) - absl::UnixEpoch())));

--- a/src/ray/protobuf/public/events_node_definition_event.proto
+++ b/src/ray/protobuf/public/events_node_definition_event.proto
@@ -27,8 +27,8 @@ message NodeDefinitionEvent {
   string node_ip_address = 2;
   map<string, string> labels = 3;
   google.protobuf.Timestamp start_timestamp = 4;
-  // The instance type name of the node if running on a cloud provider and
-  // set through ENV of src/ray/common/constants.h::kNodeCloudInstanceTypeNameEnv
-  // e.g. m4.16xlarge
+  // The instance type name of the node if running on a cloud provider.
+  // This is set via the `RAY_CLOUD_INSTANCE_TYPE_NAME` environment variable.
+  // e.g. "m4.16xlarge"
   string instance_type_name = 5;
 }

--- a/src/ray/protobuf/public/events_node_definition_event.proto
+++ b/src/ray/protobuf/public/events_node_definition_event.proto
@@ -27,4 +27,8 @@ message NodeDefinitionEvent {
   string node_ip_address = 2;
   map<string, string> labels = 3;
   google.protobuf.Timestamp start_timestamp = 4;
+  // The instance type name of the node if running on a cloud provider and
+  // set through ENV of src/ray/common/constants.h::kNodeCloudInstanceTypeNameEnv
+  // e.g. m4.16xlarge
+  string instance_type_name = 5;
 }


### PR DESCRIPTION
As title, as requested by @alanwguo 

Test:
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `instanceTypeName` to `NodeDefinitionEvent`, populates it from `GcsNodeInfo`, and updates tests to validate it via `RAY_CLOUD_INSTANCE_TYPE_NAME`.
> 
> - **Observability / Protobuf**:
>   - Extend `rpc.events.NodeDefinitionEvent` with `string instance_type_name` (field `5`).
> - **Core**:
>   - In `ray_node_definition_event.cc`, set `instance_type_name` from `GcsNodeInfo::instance_type_name()` when emitting node definition events.
> - **Tests**:
>   - Update `python/ray/.../test_ray_node_events.py` to:
>     - Pass `RAY_CLOUD_INSTANCE_TYPE_NAME` when starting a node.
>     - Assert `nodeDefinitionEvent.instanceTypeName` matches the provided value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faef277ae3b64f76d4a91ef97b4432737a130f14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->