### PR TITLE
Revert "[ci] use --no-deps to avoid installing dependencies"

### DIFF
--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -64,22 +64,16 @@ echo "--- Build dashboard"
 
 echo "--- Install Ray with -e"
 
-
-# Dependencies are already installed in the base CI images.
-# So we use --no-deps to avoid reinstalling them.
-
-INSTALL_FLAGS=(--no-deps --force-reinstall -v -e)
-
 if [[ "$BUILD_TYPE" == "debug" ]]; then
-  RAY_DEBUG_BUILD=debug pip install "${INSTALL_FLAGS[@]}" python/
+  RAY_DEBUG_BUILD=debug pip install -v -e python/
 elif [[ "$BUILD_TYPE" == "asan" ]]; then
-  pip install "${INSTALL_FLAGS[@]}" python/
+  pip install -v -e python/
   bazel run $(./ci/run/bazel_export_options) --no//:jemalloc_flag //:gen_ray_pkg
 elif [[ "$BUILD_TYPE" == "java" ]]; then
   bash java/build-jar-multiplatform.sh linux
-  RAY_INSTALL_JAVA=1 pip install "${INSTALL_FLAGS[@]}" python/
+  RAY_INSTALL_JAVA=1 pip install -v -e python/
 else
-  pip install "${INSTALL_FLAGS[@]}" python/
+  pip install -v -e python/
 fi
 
 EOF


### PR DESCRIPTION
Reverts ray-project/ray#56979

this is failing minimal install tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores standard editable pip installs (with dependencies) in the CI tests Dockerfile by removing no-deps/force-reinstall flags.
> 
> - **CI**:
>   - Updates `ci/ray_ci/tests.env.Dockerfile` to use `pip install -v -e python/` across all build types (debug, asan, java, default), removing `INSTALL_FLAGS` and the `--no-deps`/`--force-reinstall` flags.
>   - Other steps (dashboard build, Bazel/gen package, Java JAR build) remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32ed4e1e54c107e7e7e326fe14b9d4e0d699334f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->