### PR TITLE
Revert "[core][1ev-debt/02] implement even merge logic at export time"

### DIFF
--- a/src/ray/observability/ray_event_recorder.cc
+++ b/src/ray/observability/ray_event_recorder.cc
@@ -52,22 +52,10 @@ void RayEventRecorder::ExportEvents() {
   }
   rpc::events::AddEventsRequest request;
   rpc::events::RayEventsData ray_event_data;
-  // group the event in the buffer_ by their entity id and type; then for each group,
-  // merge the events into a single event.
-  absl::flat_hash_map<std::pair<std::string, rpc::events::RayEvent::EventType>,
-                      std::vector<std::unique_ptr<RayEventInterface>>>
-      event_groups;
+  // TODO(#56391): To further optimize the performance, we can merge multiple
+  // events with the same resource ID into a single event.
   for (auto &event : buffer_) {
-    event_groups[{event->GetEntityId(), event->GetEventType()}].push_back(
-        std::move(event));
-  }
-  for (auto &[entity_id_type, events] : event_groups) {
-    // merge the later event in the group into the first event, then add the merged
-    // event to the request.
-    for (size_t i = 1; i < events.size(); i++) {
-      events[0]->Merge(std::move(*events[i]));
-    }
-    rpc::events::RayEvent ray_event = std::move(*events[0]).Serialize();
+    rpc::events::RayEvent ray_event = std::move(*event).Serialize();
     *ray_event_data.mutable_events()->Add() = std::move(ray_event);
   }
   *request.mutable_events_data() = std::move(ray_event_data);

--- a/src/ray/observability/tests/ray_event_recorder_test.cc
+++ b/src/ray/observability/tests/ray_event_recorder_test.cc
@@ -79,29 +79,6 @@ class RayEventRecorderTest : public ::testing::Test {
   size_t max_buffer_size_ = 5;
 };
 
-TEST_F(RayEventRecorderTest, TestMergeEvents) {
-  rpc::JobTableData data;
-  data.set_job_id("test_job_id");
-
-  std::vector<std::unique_ptr<RayEventInterface>> events;
-  events.push_back(std::make_unique<RayDriverJobExecutionEvent>(
-      data, rpc::events::DriverJobExecutionEvent::CREATED, "test_session_name"));
-  events.push_back(std::make_unique<RayDriverJobExecutionEvent>(
-      data, rpc::events::DriverJobExecutionEvent::FINISHED, "test_session_name"));
-  recorder_->AddEvents(std::move(events));
-  io_service_.run_one();
-
-  std::vector<rpc::events::RayEvent> recorded_events = fake_client_->GetRecordedEvents();
-  // Only one event should be recorded because the two events are merged into one.
-  ASSERT_EQ(recorded_events.size(), 1);
-  ASSERT_EQ(recorded_events[0].source_type(), rpc::events::RayEvent::GCS);
-  ASSERT_EQ(recorded_events[0].session_name(), "test_session_name");
-  auto states = recorded_events[0].driver_job_execution_event().states();
-  ASSERT_EQ(states.size(), 2);
-  ASSERT_EQ(states[0].state(), rpc::events::DriverJobExecutionEvent::CREATED);
-  ASSERT_EQ(states[1].state(), rpc::events::DriverJobExecutionEvent::FINISHED);
-}
-
 TEST_F(RayEventRecorderTest, TestRecordEvents) {
   rpc::JobTableData data1;
   data1.set_job_id("test_job_id_1");


### PR DESCRIPTION
Reverts ray-project/ray#56558

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove export-time event merging and send individual events; delete the merge-specific test.
> 
> - **Observability**:
>   - `ray_event_recorder.cc`: Remove export-time merging logic; each buffered `RayEvent` is serialized and sent individually. Add TODO for potential future merging by resource ID.
> - **Tests**:
>   - `ray_event_recorder_test.cc`: Remove `TestMergeEvents`; retain other event recording and drop-handling tests unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb4f6f2d709d45011b5d1c00c4c9cf8c8c4e30e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->