### PR TITLE
[core] Fix failing ray_event_recorder_test

### DIFF
--- a/src/ray/observability/tests/ray_event_recorder_test.cc
+++ b/src/ray/observability/tests/ray_event_recorder_test.cc
@@ -96,10 +96,10 @@ TEST_F(RayEventRecorderTest, TestMergeEvents) {
   ASSERT_EQ(recorded_events.size(), 1);
   ASSERT_EQ(recorded_events[0].source_type(), rpc::events::RayEvent::GCS);
   ASSERT_EQ(recorded_events[0].session_name(), "test_session_name");
-  auto states = recorded_events[0].driver_job_lifecycle_event().state_transitions();
-  ASSERT_EQ(states.size(), 2);
-  ASSERT_EQ(states[0].state(), rpc::events::DriverJobLifecycleEvent::CREATED);
-  ASSERT_EQ(states[1].state(), rpc::events::DriverJobLifecycleEvent::FINISHED);
+  auto state_transitions = recorded_events[0].driver_job_lifecycle_event().state_transitions();
+  ASSERT_EQ(state_transitions.size(), 2);
+  ASSERT_EQ(state_transitions[0].state(), rpc::events::DriverJobLifecycleEvent::CREATED);
+  ASSERT_EQ(state_transitions[1].state(), rpc::events::DriverJobLifecycleEvent::FINISHED);
 }
 
 TEST_F(RayEventRecorderTest, TestRecordEvents) {

--- a/src/ray/observability/tests/ray_event_recorder_test.cc
+++ b/src/ray/observability/tests/ray_event_recorder_test.cc
@@ -84,10 +84,10 @@ TEST_F(RayEventRecorderTest, TestMergeEvents) {
   data.set_job_id("test_job_id");
 
   std::vector<std::unique_ptr<RayEventInterface>> events;
-  events.push_back(std::make_unique<RayDriverJobExecutionEvent>(
-      data, rpc::events::DriverJobExecutionEvent::CREATED, "test_session_name"));
-  events.push_back(std::make_unique<RayDriverJobExecutionEvent>(
-      data, rpc::events::DriverJobExecutionEvent::FINISHED, "test_session_name"));
+  events.push_back(std::make_unique<RayDriverJobLifecycleEvent>(
+      data, rpc::events::DriverJobLifecycleEvent::CREATED, "test_session_name"));
+  events.push_back(std::make_unique<RayDriverJobLifecycleEvent>(
+      data, rpc::events::DriverJobLifecycleEvent::FINISHED, "test_session_name"));
   recorder_->AddEvents(std::move(events));
   io_service_.run_one();
 
@@ -96,10 +96,10 @@ TEST_F(RayEventRecorderTest, TestMergeEvents) {
   ASSERT_EQ(recorded_events.size(), 1);
   ASSERT_EQ(recorded_events[0].source_type(), rpc::events::RayEvent::GCS);
   ASSERT_EQ(recorded_events[0].session_name(), "test_session_name");
-  auto states = recorded_events[0].driver_job_execution_event().states();
+  auto states = recorded_events[0].driver_job_lifecycle_event().state_transitions();
   ASSERT_EQ(states.size(), 2);
-  ASSERT_EQ(states[0].state(), rpc::events::DriverJobExecutionEvent::CREATED);
-  ASSERT_EQ(states[1].state(), rpc::events::DriverJobExecutionEvent::FINISHED);
+  ASSERT_EQ(states[0].state(), rpc::events::DriverJobLifecycleEvent::CREATED);
+  ASSERT_EQ(states[1].state(), rpc::events::DriverJobLifecycleEvent::FINISHED);
 }
 
 TEST_F(RayEventRecorderTest, TestRecordEvents) {

--- a/src/ray/observability/tests/ray_event_recorder_test.cc
+++ b/src/ray/observability/tests/ray_event_recorder_test.cc
@@ -96,7 +96,8 @@ TEST_F(RayEventRecorderTest, TestMergeEvents) {
   ASSERT_EQ(recorded_events.size(), 1);
   ASSERT_EQ(recorded_events[0].source_type(), rpc::events::RayEvent::GCS);
   ASSERT_EQ(recorded_events[0].session_name(), "test_session_name");
-  auto state_transitions = recorded_events[0].driver_job_lifecycle_event().state_transitions();
+  auto state_transitions =
+      recorded_events[0].driver_job_lifecycle_event().state_transitions();
   ASSERT_EQ(state_transitions.size(), 2);
   ASSERT_EQ(state_transitions[0].state(), rpc::events::DriverJobLifecycleEvent::CREATED);
   ASSERT_EQ(state_transitions[1].state(), rpc::events::DriverJobLifecycleEvent::FINISHED);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
fixes RayEventRecorderTest which is failing in master

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
NA
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors TestMergeEvents to use DriverJobLifecycleEvent and validates merged state_transitions instead of execution states.
> 
> - **Tests (observability)**:
>   - `ray_event_recorder_test.cc`: Replace `RayDriverJobExecutionEvent` with `RayDriverJobLifecycleEvent` in `TestMergeEvents` and update assertions to check `driver_job_lifecycle_event().state_transitions()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b70db7c13923646bfa4ad66b96c053682982725. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->