### PR TITLE
[core] Reduce event aggregator memory footprint

### DIFF
--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -20,5 +20,5 @@ PUBLISHER_MAX_BACKOFF_SECONDS = ray_constants.env_float(
 PUBLISHER_JITTER_RATIO = ray_constants.env_float(f"{env_var_prefix}_JITTER_RATIO", 0.1)
 # Maximum sleep time between sending batches of events to the destination, should be greater than 0.0 to avoid busy looping
 PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS = ray_constants.env_float(
-    f"{env_var_prefix}_MAX_BUFFER_SEND_INTERVAL_SECONDS", 1
+    f"{env_var_prefix}_MAX_BUFFER_SEND_INTERVAL_SECONDS", 0.1
 )

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -18,7 +18,11 @@ PUBLISHER_MAX_BACKOFF_SECONDS = ray_constants.env_float(
 )
 # Jitter ratio for publishing events to the destination
 PUBLISHER_JITTER_RATIO = ray_constants.env_float(f"{env_var_prefix}_JITTER_RATIO", 0.1)
-# Maximum sleep time between sending batches of events to the destination, should be greater than 0.0 to avoid busy looping
+# Minimum and maximum sleep interval between sending batches of events to the destination.
+# These are used to adaptively pick an interval based on buffer fullness per consumer.
+PUBLISHER_MIN_BUFFER_SEND_INTERVAL_SECONDS = ray_constants.env_float(
+    f"{env_var_prefix}_MIN_BUFFER_SEND_INTERVAL_SECONDS", 0.1
+)
 PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS = ray_constants.env_float(
-    f"{env_var_prefix}_MAX_BUFFER_SEND_INTERVAL_SECONDS", 0.1
+    f"{env_var_prefix}_MAX_BUFFER_SEND_INTERVAL_SECONDS", 1.0
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
in https://github.com/ray-project/ray/pull/55780 the publish interval was increased from 0.1s to 1s. because of this events remain in buffer longer leading to increase in memory usage. Instead of going back to the old configuration, this pr introduces an adaptive interval selection logic where the interval is picked based on the number of events left to publish.

default setup:
less than 30% of the buffer is full -> publish every 1 second
30- 50% of the buffer is full -> publish every 0.5 seconds
<50% is full -> publish every 0.1 seconds

memory footprint after this change, when running `test agent_stress_test.aws` release test
<img width="1711" height="1071" alt="image" src="https://github.com/user-attachments/assets/dc5c1b2f-a1d5-4587-bbd6-868e760af9e7" />


memory footprint when running test `agent_stress_test.aws` with publish interval hardcoded to 0.1seconds
<img width="720" height="451" alt="image" src="https://github.com/user-attachments/assets/b808032b-81e7-4681-90f9-22e802e04ae4" />


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements per-consumer adaptive publish intervals using buffer fullness, adds buffer size/capacity APIs, and updates configs and tests.
> 
> - **Aggregator Buffer (`multi_consumer_event_buffer.py`)**:
>   - `size()` made sync; added `async size_for_consumer(consumer_name)` and `capacity()`.
>   - Eviction logic verified with new test ensuring events are removed once all consumers consume them.
>   - Tests updated to reflect sync `size()` and to cover `size_for_consumer`/`capacity`.
> - **Publisher Config (`publisher/configs.py`)**:
>   - Introduces `PUBLISHER_MIN_BUFFER_SEND_INTERVAL_SECONDS` (default 0.1s) and updates `PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS` to float (default 1.0s).
> - **Ray Event Publisher (`publisher/ray_event_publisher.py`)**:
>   - Adds adaptive interval selection `_compute_adaptive_interval()` based on buffer fullness.
>   - Constructor accepts min/max send interval; stores buffer capacity.
>   - Worker loop computes per-consumer pending size and passes adaptive interval to `wait_for_batch()`.
>   - New unit tests for interval computation; imports updated to expose interface in tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7228577c08f2492a4de95d7a597a71f66d856520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->