### PR TITLE
[core] deflake actor,node and job event tests

### DIFF
--- a/python/ray/dashboard/modules/aggregator/tests/test_ray_actor_events.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_ray_actor_events.py
@@ -57,28 +57,49 @@ def test_ray_actor_events(ray_start_cluster, httpserver):
     a = ray.remote(A).options(name="actor-test").remote()
     ray.get(a.ping.remote())
 
-    # Check that an actor definition and a lifecycle event are published.
+    # Check that an actor definition and lifecycle events are published.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
-    wait_for_condition(lambda: len(httpserver.log) >= 1)
-    req, _ = httpserver.log[0]
-    req_json = json.loads(req.data)
-    # We expect batched events containing definition then lifecycle
-    assert len(req_json) >= 2
-    # Verify event types and IDs exist
+    # Wait until we observe both event types across requests.
+    wait_for_condition(
+        lambda: (
+            any(
+                "actorDefinitionEvent" in item
+                for req, _ in httpserver.log
+                for item in json.loads(req.data)
+            )
+            and any(
+                "actorLifecycleEvent" in item
+                for req, _ in httpserver.log
+                for item in json.loads(req.data)
+            )
+        )
+    )
+    # One definition event and potentially many lifecycle events across requests.
+    definition_event = next(
+        item
+        for req, _ in httpserver.log
+        for item in json.loads(req.data)
+        if "actorDefinitionEvent" in item
+    )
+    lifecycle_events = [
+        item
+        for req, _ in httpserver.log
+        for item in json.loads(req.data)
+        if "actorLifecycleEvent" in item
+    ]
+    # Verify IDs
     assert (
-        base64.b64decode(req_json[0]["actorDefinitionEvent"]["actorId"]).hex()
+        base64.b64decode(definition_event["actorDefinitionEvent"]["actorId"]).hex()
         == a._actor_id.hex()
     )
-    # Verify ActorId and state for ActorLifecycleEvents
+    # Verify lifecycle events
     has_alive_state = False
-    for actorLifeCycleEvent in req_json[1:]:
+    for lifecycle_event in lifecycle_events:
         assert (
-            base64.b64decode(
-                actorLifeCycleEvent["actorLifecycleEvent"]["actorId"]
-            ).hex()
+            base64.b64decode(lifecycle_event["actorLifecycleEvent"]["actorId"]).hex()
             == a._actor_id.hex()
         )
-        for stateTransition in actorLifeCycleEvent["actorLifecycleEvent"][
+        for stateTransition in lifecycle_event["actorLifecycleEvent"][
             "stateTransitions"
         ]:
             assert stateTransition["state"] in [
@@ -99,24 +120,32 @@ def test_ray_actor_events(ray_start_cluster, httpserver):
     # Kill the actor and verify we get a DEAD state with death cause
     ray.kill(a)
 
-    # Wait for the death event to be published
+    # Wait until a lifecycle event with DEAD state is observed in any request.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
-    wait_for_condition(lambda: len(httpserver.log) >= 2)
+    wait_for_condition(
+        lambda: any(
+            any(
+                st.get("state") == "DEAD"
+                for st in item["actorLifecycleEvent"].get("stateTransitions", [])
+            )
+            for req, _ in httpserver.log
+            for item in json.loads(req.data)
+            if "actorLifecycleEvent" in item
+        )
+    )
 
     has_dead_state = False
     for death_req, _ in httpserver.log:
         death_req_json = json.loads(death_req.data)
-
-        for actorLifeCycleEvent in death_req_json:
-            if "actorLifecycleEvent" in actorLifeCycleEvent:
+        for lifecycle_event in death_req_json:
+            if "actorLifecycleEvent" in lifecycle_event:
                 assert (
                     base64.b64decode(
-                        actorLifeCycleEvent["actorLifecycleEvent"]["actorId"]
+                        lifecycle_event["actorLifecycleEvent"]["actorId"]
                     ).hex()
                     == a._actor_id.hex()
                 )
-
-                for stateTransition in actorLifeCycleEvent["actorLifecycleEvent"][
+                for stateTransition in lifecycle_event["actorLifecycleEvent"][
                     "stateTransitions"
                 ]:
                     if stateTransition["state"] == "DEAD":

--- a/python/ray/dashboard/modules/aggregator/tests/test_ray_node_events.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_ray_node_events.py
@@ -36,19 +36,45 @@ def test_ray_node_events(ray_start_cluster, httpserver):
 
     # Check that a node definition and a node lifecycle event are published.
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
-    wait_for_condition(lambda: len(httpserver.log) >= 1)
-    req, _ = httpserver.log[0]
-    req_json = json.loads(req.data)
-    assert len(req_json) == 2
+    # Wait until we observe both event types across requests.
+    wait_for_condition(
+        lambda: (
+            any(
+                "nodeDefinitionEvent" in item
+                for req, _ in httpserver.log
+                for item in json.loads(req.data)
+            )
+            and any(
+                "nodeLifecycleEvent" in item
+                for req, _ in httpserver.log
+                for item in json.loads(req.data)
+            )
+        )
+    )
+    # Find the latest items for each event type across all requests.
+    definition_event = next(
+        item
+        for req, _ in httpserver.log
+        for item in json.loads(req.data)
+        if "nodeDefinitionEvent" in item
+    )
+    lifecycle_event = next(
+        item
+        for req, _ in httpserver.log
+        for item in json.loads(req.data)
+        if "nodeLifecycleEvent" in item
+    )
     assert (
-        base64.b64decode(req_json[0]["nodeDefinitionEvent"]["nodeId"]).hex()
+        base64.b64decode(definition_event["nodeDefinitionEvent"]["nodeId"]).hex()
         == cluster.head_node.node_id
     )
     assert (
-        base64.b64decode(req_json[1]["nodeLifecycleEvent"]["nodeId"]).hex()
+        base64.b64decode(lifecycle_event["nodeLifecycleEvent"]["nodeId"]).hex()
         == cluster.head_node.node_id
     )
-    assert req_json[1]["nodeLifecycleEvent"]["stateTransitions"][0]["state"] == "ALIVE"
+    assert (
+        lifecycle_event["nodeLifecycleEvent"]["stateTransitions"][0]["state"] == "ALIVE"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
these tests assume the ordering of events received by the http server which lead to tests acting flacky. The main reason behind why the ordering is non-deterministic is still unknown, but this pr updates the test so that no such assumptions are made.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
NA
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make event tests resilient to non-deterministic batching/order by scanning all HTTP logs for required events and states.
> 
> - **Tests (dashboard aggregator)**:
>   - **Actor events** (`test_ray_actor_events.py`):
>     - Wait across all HTTP requests for both `actorDefinitionEvent` and `actorLifecycleEvent`.
>     - Extract definition event and aggregate lifecycle events from all logged batches; verify actorId and states, including `ALIVE` node/worker IDs.
>     - On kill, wait until any lifecycle event reports `DEAD` and assert death cause is `RAY_KILL`.
>   - **Node events** (`test_ray_node_events.py`):
>     - Wait across requests for both `nodeDefinitionEvent` and `nodeLifecycleEvent`; validate `nodeId` and first lifecycle state `ALIVE`.
>   - **Job events** (`test_ray_job_events.py`):
>     - Wait across requests for `driverJobDefinitionEvent`; verify `jobId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a638e5710609af638f24f9b4c203ae5bf8ae0d7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->