### PR TITLE
[core] pre-install dependencies for min install tests

### DIFF
--- a/ci/docker/min.build.Dockerfile
+++ b/ci/docker/min.build.Dockerfile
@@ -24,7 +24,7 @@ python -m pip install -U pytest==7.4.4 pip-tools==7.4.1
 
 # install extra dependencies
 if [[ "${EXTRA_DEPENDENCY}" == "core" ]]; then
-  ./ci/env/install-core-prerelease-dependencies.sh
+  pip-compile -o min_requirements.txt python/setup.py
 elif [[ "${EXTRA_DEPENDENCY}" == "ml" ]]; then
   pip-compile -o min_requirements.txt python/setup.py --extra tune
 elif [[ "${EXTRA_DEPENDENCY}" == "default" ]]; then
@@ -36,8 +36,11 @@ elif [[ "${EXTRA_DEPENDENCY}" == "serve" ]]; then
   rm /tmp/min_build_requirements.txt
 fi
 
-if [[ -f min_requirements.txt ]]; then
-  pip install -r min_requirements.txt
+pip install -r min_requirements.txt
+
+# Core wants to eagerly be tested with some of its prerelease dependencies.
+if [[ "${EXTRA_DEPENDENCY}" == "core" ]]; then
+  ./ci/env/install-core-prerelease-dependencies.sh
 fi
 
 EOF


### PR DESCRIPTION
this removes the need to install dependencies again later during the tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Precompiles and always installs minimal requirements in the min.build image, then installs core prerelease deps afterward when EXTRA_DEPENDENCY=core.
> 
> - **CI/Docker** (`ci/docker/min.build.Dockerfile`):
>   - Always compile and install minimal requirements via `pip-compile` -> `min_requirements.txt` (remove conditional install).
>   - For `core`: install compiled minimal reqs first, then run `install-core-prerelease-dependencies.sh`.
>   - Keep `ml`/`default`/`serve` extras via `pip-compile` (with `serve-grpc` and temp requirements for `httpx` and `pytest-asyncio`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d41577e3b96ffd9cd09b7db968a1f9aa67cc0bfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->