### PR TITLE
[core] Renamed legacy NotifyDirectCallTask* methods.

### DIFF
--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -160,7 +160,6 @@ std::string Status::ToString() const {
   return result;
 }
 
-// TODO(irabbani): This supresses all errors.
 Status boost_to_ray_status(const boost::system::error_code &error) {
   switch (error.value()) {
   case boost::system::errc::success:

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -160,6 +160,7 @@ std::string Status::ToString() const {
   return result;
 }
 
+// TODO(irabbani): This supresses all errors.
 Status boost_to_ray_status(const boost::system::error_code &error) {
   switch (error.value()) {
   case boost::system::errc::success:

--- a/src/ray/core_worker/core_worker_shutdown_executor.cc
+++ b/src/ray/core_worker/core_worker_shutdown_executor.cc
@@ -133,7 +133,7 @@ void CoreWorkerShutdownExecutor::ExecuteExit(
           core_worker_->task_receiver_->Stop();
 
           // Release resources only after tasks have stopped executing.
-          auto status = core_worker_->raylet_ipc_client_->NotifyDirectCallTaskBlocked();
+          auto status = core_worker_->raylet_ipc_client_->NotifyWorkerBlocked();
           if (!status.ok()) {
             RAY_LOG(WARNING)
                 << "Failed to notify Raylet. The raylet may have already shut down or "

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -349,7 +349,7 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
       (raylet_ipc_client_ != nullptr && ctx.ShouldReleaseResourcesOnBlockingCalls());
   // Wait for remaining objects (or timeout).
   if (should_notify_raylet) {
-    RAY_CHECK_OK(raylet_ipc_client_->NotifyDirectCallTaskBlocked());
+    RAY_CHECK_OK(raylet_ipc_client_->NotifyWorkerBlocked());
   }
 
   bool done = false;
@@ -380,7 +380,7 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
   }
 
   if (should_notify_raylet) {
-    RAY_CHECK_OK(raylet_ipc_client_->NotifyDirectCallTaskUnblocked());
+    RAY_CHECK_OK(raylet_ipc_client_->NotifyWorkerUnblocked());
   }
 
   {

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -261,7 +261,7 @@ Status UnblockIfNeeded(
     // NOTE: for direct call actors, we still need to issue an unblock IPC to release
     // get subscriptions, even if the worker isn't blocked.
     if (ctx.ShouldReleaseResourcesOnBlockingCalls() || ctx.CurrentActorIsDirectCall()) {
-      return raylet_client->NotifyDirectCallTaskUnblocked();
+      return raylet_client->NotifyWorkerUnblocked();
     } else {
       return Status::OK();  // We don't need to release resources.
     }
@@ -403,7 +403,7 @@ Status CoreWorkerPlasmaStoreProvider::Wait(
     ready->insert(entry);
   }
   if (ctx.CurrentTaskIsDirectCall() && ctx.ShouldReleaseResourcesOnBlockingCalls()) {
-    RAY_RETURN_NOT_OK(raylet_ipc_client_->NotifyDirectCallTaskUnblocked());
+    RAY_RETURN_NOT_OK(raylet_ipc_client_->NotifyWorkerBlocked());
   }
   return Status::OK();
 }

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -403,7 +403,7 @@ Status CoreWorkerPlasmaStoreProvider::Wait(
     ready->insert(entry);
   }
   if (ctx.CurrentTaskIsDirectCall() && ctx.ShouldReleaseResourcesOnBlockingCalls()) {
-    RAY_RETURN_NOT_OK(raylet_ipc_client_->NotifyWorkerBlocked());
+    RAY_RETURN_NOT_OK(raylet_ipc_client_->NotifyWorkerUnblocked());
   }
   return Status::OK();
 }

--- a/src/ray/flatbuffers/node_manager.fbs
+++ b/src/ray/flatbuffers/node_manager.fbs
@@ -43,11 +43,12 @@ enum MessageType:int {
   AsyncGetObjectsRequest,
   // Cancel outstanding get requests from the worker.
   CancelGetRequest,
-  // Notify the current worker is blocked. This is only used by direct task calls;
-  // otherwise the block command is piggybacked on other messages.
-  NotifyDirectCallTaskBlocked,
-  // Notify the current worker is unblocked. This is only used by direct task calls.
-  NotifyDirectCallTaskUnblocked,
+  // Notify the current worker is blocked for objects to become available. The raylet
+  // will release the worker's resources.
+  NotifyWorkerBlocked,
+  // Notify the current worker is unblocked. The raylet will cancel any inflight
+  // pull requests for objects.
+  NotifyWorkerUnblocked,
   // Wait for objects to be ready either from local or remote Plasma stores.
   WaitRequest,
   // The response message to WaitRequest; replies with the objects found and objects
@@ -138,10 +139,10 @@ table AsyncGetObjectsRequest {
 table CancelGetRequest {
 }
 
-table NotifyDirectCallTaskBlocked {
+table NotifyWorkerBlocked {
 }
 
-table NotifyDirectCallTaskUnblocked {
+table NotifyWorkerUnblocked {
 }
 
 table WaitRequest {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1014,11 +1014,11 @@ void NodeManager::ProcessClientMessage(const std::shared_ptr<ClientConnection> &
   case protocol::MessageType::AsyncGetObjectsRequest: {
     HandleAsyncGetObjectsRequest(client, message_data);
   } break;
-  case protocol::MessageType::NotifyDirectCallTaskBlocked: {
-    HandleDirectCallTaskBlocked(registered_worker);
+  case protocol::MessageType::NotifyWorkerBlocked: {
+    HandleNotifyWorkerBlocked(registered_worker);
   } break;
-  case protocol::MessageType::NotifyDirectCallTaskUnblocked: {
-    HandleDirectCallTaskUnblocked(registered_worker);
+  case protocol::MessageType::NotifyWorkerUnblocked: {
+    HandleNotifyWorkerUnblocked(registered_worker);
   } break;
   case protocol::MessageType::CancelGetRequest: {
     CancelGetRequest(client);
@@ -1955,7 +1955,7 @@ void NodeManager::HandleReturnWorkerLease(rpc::ReturnWorkerLeaseRequest request,
     if (worker->IsBlocked()) {
       // Handle the edge case where the worker was returned before we got the
       // unblock RPC by unblocking it immediately (unblock is idempotent).
-      HandleDirectCallTaskUnblocked(worker);
+      HandleNotifyWorkerUnblocked(worker);
     }
     local_lease_manager_.ReleaseWorkerResources(worker);
     // If the worker is exiting, don't add it to our pool. The worker will cleanup
@@ -2121,7 +2121,7 @@ void NodeManager::MarkObjectsAsFailed(
   }
 }
 
-void NodeManager::HandleDirectCallTaskBlocked(
+void NodeManager::HandleNotifyWorkerBlocked(
     const std::shared_ptr<WorkerInterface> &worker) {
   if (!worker || worker->IsBlocked() || worker->GetGrantedLeaseId().IsNil()) {
     return;  // The worker may have died or is no longer processing the task.
@@ -2131,7 +2131,7 @@ void NodeManager::HandleDirectCallTaskBlocked(
   cluster_lease_manager_.ScheduleAndGrantLeases();
 }
 
-void NodeManager::HandleDirectCallTaskUnblocked(
+void NodeManager::HandleNotifyWorkerUnblocked(
     const std::shared_ptr<WorkerInterface> &worker) {
   if (!worker || worker->GetGrantedLeaseId().IsNil()) {
     return;  // The worker may have died or is no longer processing the task.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -400,14 +400,14 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// arrive after the worker lease has been returned to the node manager.
   ///
   /// \param worker Shared ptr to the worker, or nullptr if lost.
-  void HandleDirectCallTaskBlocked(const std::shared_ptr<WorkerInterface> &worker);
+  void HandleNotifyWorkerBlocked(const std::shared_ptr<WorkerInterface> &worker);
 
   /// Handle a task that is unblocked. Note that this callback may
   /// arrive after the worker lease has been returned to the node manager.
   /// However, it is guaranteed to arrive after DirectCallTaskBlocked.
   ///
   /// \param worker Shared ptr to the worker, or nullptr if lost.
-  void HandleDirectCallTaskUnblocked(const std::shared_ptr<WorkerInterface> &worker);
+  void HandleNotifyWorkerUnblocked(const std::shared_ptr<WorkerInterface> &worker);
 
   /// Destroy a worker.
   /// We will disconnect the worker connection first and then kill the worker.

--- a/src/ray/raylet_ipc_client/fake_raylet_ipc_client.h
+++ b/src/ray/raylet_ipc_client/fake_raylet_ipc_client.h
@@ -25,23 +25,23 @@ namespace ipc {
 
 class FakeRayletIpcClient : public RayletIpcClientInterface {
  public:
-  ray::Status RegisterClient(const WorkerID &worker_id,
-                             rpc::WorkerType worker_type,
-                             const JobID &job_id,
-                             int runtime_env_hash,
-                             const rpc::Language &language,
-                             const std::string &ip_address,
-                             const std::string &serialized_job_config,
-                             const StartupToken &startup_token,
-                             NodeID *node_id,
-                             int *assigned_port) override {
+  Status RegisterClient(const WorkerID &worker_id,
+                        rpc::WorkerType worker_type,
+                        const JobID &job_id,
+                        int runtime_env_hash,
+                        const rpc::Language &language,
+                        const std::string &ip_address,
+                        const std::string &serialized_job_config,
+                        const StartupToken &startup_token,
+                        NodeID *node_id,
+                        int *assigned_port) override {
     return Status::OK();
   }
 
-  ray::Status Disconnect(const rpc::WorkerExitType &exit_type,
-                         const std::string &exit_detail,
-                         const std::shared_ptr<LocalMemoryBuffer>
-                             &creation_task_exception_pb_bytes) override {
+  Status Disconnect(const rpc::WorkerExitType &exit_type,
+                    const std::string &exit_detail,
+                    const std::shared_ptr<LocalMemoryBuffer>
+                        &creation_task_exception_pb_bytes) override {
     return Status::OK();
   }
 
@@ -51,14 +51,14 @@ class FakeRayletIpcClient : public RayletIpcClientInterface {
     return Status::OK();
   }
 
-  ray::Status ActorCreationTaskDone() override { return Status::OK(); }
+  Status ActorCreationTaskDone() override { return Status::OK(); }
 
-  ray::Status AsyncGetObjects(const std::vector<ObjectID> &object_ids,
-                              const std::vector<rpc::Address> &owner_addresses) override {
+  Status AsyncGetObjects(const std::vector<ObjectID> &object_ids,
+                         const std::vector<rpc::Address> &owner_addresses) override {
     return Status::OK();
   }
 
-  ray::StatusOr<absl::flat_hash_set<ObjectID>> Wait(
+  StatusOr<absl::flat_hash_set<ObjectID>> Wait(
       const std::vector<ObjectID> &object_ids,
       const std::vector<rpc::Address> &owner_addresses,
       int num_returns,
@@ -66,26 +66,25 @@ class FakeRayletIpcClient : public RayletIpcClientInterface {
     return absl::flat_hash_set<ObjectID>();
   }
 
-  ray::Status CancelGetRequest() override { return Status::OK(); }
+  Status CancelGetRequest() override { return Status::OK(); }
 
-  ray::Status NotifyDirectCallTaskBlocked() override { return Status::OK(); }
+  Status NotifyWorkerBlocked() override { return Status::OK(); }
 
-  ray::Status NotifyDirectCallTaskUnblocked() override { return Status::OK(); }
+  Status NotifyWorkerUnblocked() override { return Status::OK(); }
 
-  ray::Status WaitForActorCallArgs(const std::vector<rpc::ObjectReference> &references,
-                                   int64_t tag) override {
+  Status WaitForActorCallArgs(const std::vector<rpc::ObjectReference> &references,
+                              int64_t tag) override {
     return Status::OK();
   }
 
-  ray::Status PushError(const ray::JobID &job_id,
-                        const std::string &type,
-                        const std::string &error_message,
-                        double timestamp) override {
+  Status PushError(const JobID &job_id,
+                   const std::string &type,
+                   const std::string &error_message,
+                   double timestamp) override {
     return Status::OK();
   }
 
-  ray::Status FreeObjects(const std::vector<ray::ObjectID> &object_ids,
-                          bool local_only) override {
+  Status FreeObjects(const std::vector<ObjectID> &object_ids, bool local_only) override {
     return Status::OK();
   }
 

--- a/src/ray/raylet_ipc_client/raylet_ipc_client.cc
+++ b/src/ray/raylet_ipc_client/raylet_ipc_client.cc
@@ -212,18 +212,18 @@ Status RayletIpcClient::CancelGetRequest() {
   return WriteMessage(MessageType::CancelGetRequest, &fbb);
 }
 
-Status RayletIpcClient::NotifyDirectCallTaskBlocked() {
+Status RayletIpcClient::NotifyWorkerBlocked() {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = protocol::CreateNotifyDirectCallTaskBlocked(fbb);
+  auto message = protocol::CreateNotifyWorkerBlocked(fbb);
   fbb.Finish(message);
-  return WriteMessage(MessageType::NotifyDirectCallTaskBlocked, &fbb);
+  return WriteMessage(MessageType::NotifyWorkerBlocked, &fbb);
 }
 
-Status RayletIpcClient::NotifyDirectCallTaskUnblocked() {
+Status RayletIpcClient::NotifyWorkerUnblocked() {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = protocol::CreateNotifyDirectCallTaskUnblocked(fbb);
+  auto message = protocol::CreateNotifyWorkerUnblocked(fbb);
   fbb.Finish(message);
-  return WriteMessage(MessageType::NotifyDirectCallTaskUnblocked, &fbb);
+  return WriteMessage(MessageType::NotifyWorkerUnblocked, &fbb);
 }
 
 StatusOr<absl::flat_hash_set<ObjectID>> RayletIpcClient::Wait(

--- a/src/ray/raylet_ipc_client/raylet_ipc_client.h
+++ b/src/ray/raylet_ipc_client/raylet_ipc_client.h
@@ -48,67 +48,75 @@ class RayletIpcClient : public RayletIpcClientInterface {
                   int num_retries,
                   int64_t timeout);
 
-  ray::Status RegisterClient(const WorkerID &worker_id,
-                             rpc::WorkerType worker_type,
-                             const JobID &job_id,
-                             int runtime_env_hash,
-                             const rpc::Language &language,
-                             const std::string &ip_address,
-                             const std::string &serialized_job_config,
-                             const StartupToken &startup_token,
-                             NodeID *node_id,
-                             int *assigned_port) override;
+  Status RegisterClient(const WorkerID &worker_id,
+                        rpc::WorkerType worker_type,
+                        const JobID &job_id,
+                        int runtime_env_hash,
+                        const rpc::Language &language,
+                        const std::string &ip_address,
+                        const std::string &serialized_job_config,
+                        const StartupToken &startup_token,
+                        NodeID *node_id,
+                        int *assigned_port) override;
 
-  ray::Status Disconnect(const rpc::WorkerExitType &exit_type,
-                         const std::string &exit_detail,
-                         const std::shared_ptr<LocalMemoryBuffer>
-                             &creation_task_exception_pb_bytes) override;
+  Status Disconnect(const rpc::WorkerExitType &exit_type,
+                    const std::string &exit_detail,
+                    const std::shared_ptr<LocalMemoryBuffer>
+                        &creation_task_exception_pb_bytes) override;
 
   Status AnnounceWorkerPortForWorker(int port) override;
 
   Status AnnounceWorkerPortForDriver(int port, const std::string &entrypoint) override;
 
-  ray::Status ActorCreationTaskDone() override;
+  Status ActorCreationTaskDone() override;
 
-  ray::Status AsyncGetObjects(const std::vector<ObjectID> &object_ids,
-                              const std::vector<rpc::Address> &owner_addresses) override;
+  Status AsyncGetObjects(const std::vector<ObjectID> &object_ids,
+                         const std::vector<rpc::Address> &owner_addresses) override;
 
-  ray::StatusOr<absl::flat_hash_set<ObjectID>> Wait(
+  StatusOr<absl::flat_hash_set<ObjectID>> Wait(
       const std::vector<ObjectID> &object_ids,
       const std::vector<rpc::Address> &owner_addresses,
       int num_returns,
       int64_t timeout_milliseconds) override;
 
-  ray::Status CancelGetRequest() override;
+  Status CancelGetRequest() override;
 
-  ray::Status NotifyDirectCallTaskBlocked() override;
+  /// Notify the raylet that the worker is currently blocked waiting for an object
+  /// to be pulled. The raylet will release the resources used by this worker.
+  ///
+  /// \return Status::OK if no error occurs.
+  /// \return Status::IOError if any error occurs.
+  Status NotifyWorkerBlocked() override;
 
-  ray::Status NotifyDirectCallTaskUnblocked() override;
+  /// Notify the raylet that the worker is unblocked. The raylet will cancel inflight
+  /// pull requests for the worker.
+  ///
+  /// \return Status::OK if no error occurs.
+  /// \return Status::IOError if any error occurs.
+  Status NotifyWorkerUnblocked() override;
 
-  ray::Status WaitForActorCallArgs(const std::vector<rpc::ObjectReference> &references,
-                                   int64_t tag) override;
+  Status WaitForActorCallArgs(const std::vector<rpc::ObjectReference> &references,
+                              int64_t tag) override;
 
-  ray::Status PushError(const ray::JobID &job_id,
-                        const std::string &type,
-                        const std::string &error_message,
-                        double timestamp) override;
+  Status PushError(const JobID &job_id,
+                   const std::string &type,
+                   const std::string &error_message,
+                   double timestamp) override;
 
-  ray::Status FreeObjects(const std::vector<ray::ObjectID> &object_ids,
-                          bool local_only) override;
+  Status FreeObjects(const std::vector<ObjectID> &object_ids, bool local_only) override;
 
   void SubscribePlasmaReady(const ObjectID &object_id,
                             const rpc::Address &owner_address) override;
 
  private:
   /// Send a request to raylet asynchronously.
-  ray::Status WriteMessage(MessageType type,
-                           flatbuffers::FlatBufferBuilder *fbb = nullptr);
+  Status WriteMessage(MessageType type, flatbuffers::FlatBufferBuilder *fbb = nullptr);
 
   /// Send a request to raylet and synchronously wait for the response.
-  ray::Status AtomicRequestReply(MessageType request_type,
-                                 MessageType reply_type,
-                                 std::vector<uint8_t> *reply_message,
-                                 flatbuffers::FlatBufferBuilder *fbb = nullptr);
+  Status AtomicRequestReply(MessageType request_type,
+                            MessageType reply_type,
+                            std::vector<uint8_t> *reply_message,
+                            flatbuffers::FlatBufferBuilder *fbb = nullptr);
 
   /// Protects read operations on the socket.
   std::mutex mutex_;


### PR DESCRIPTION
I renamed `NotifyDirectCallTask{Blocked|Unblocked}` to `NotifyWorker{Blocked|Unblocked}` to make the code make more sense. 

There are no functional changes in this PR. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames NotifyDirectCallTask{Blocked,Unblocked} to NotifyWorker{Blocked,Unblocked} across core worker, raylet, IPC client, and Flatbuffers schema with corresponding handler and message updates.
> 
> - **IPC/Protocol (Flatbuffers)**:
>   - Rename `MessageType` entries and tables: `NotifyDirectCallTaskBlocked/Unblocked` → `NotifyWorkerBlocked/Unblocked` in `src/ray/flatbuffers/node_manager.fbs`.
> - **Raylet (node manager)**:
>   - Switch message handling cases to `NotifyWorkerBlocked/Unblocked` and rename handlers to `HandleNotifyWorkerBlocked/Unblocked`.
> - **Core Worker**:
>   - Update calls to `raylet_ipc_client_` from `NotifyDirectCallTask*` to `NotifyWorker*` in `core_worker_shutdown_executor.cc`, memory store, and plasma store provider.
> - **Raylet IPC Client**:
>   - Rename interface and implementations to `NotifyWorkerBlocked/Unblocked`; adjust writes to new `MessageType`s.
>   - Minor interface cleanups (status aliases/typedef placement) in headers and fake client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af97976bc8bdc4ff769cae9e1ecd468542e27c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->