### PR TITLE
[core] split java worker tests out

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -395,6 +395,18 @@ steps:
     depends_on: oss-ci-base_build
     job_env: oss-ci-base_build
 
+  - label: ":ray: core: java worker tests"
+    tags:
+      - java
+      - python
+      - oss
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --build-type java
+        --only-tags needs_java
+    depends_on: corebuild
+
   - label: ":ray: core: HA integration tests"
     tags:
       - python

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -26,7 +26,7 @@ steps:
     instance_type: medium
     commands:
       # Java tests need the C++ API for multi-langauge worker tests.
-      - bazel run //ci/ray_ci:test_in_docker -- //... core --build-type with-cpp --build-only
+      - bazel run //ci/ray_ci:test_in_docker -- //... core --build-type multi-lang --build-only
       - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail
         "./java/test.sh"

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -52,9 +52,6 @@ class LinuxContainer(Container):
         ]
         if mask:
             build_cmd += ["--build-arg", "RAY_INSTALL_MASK=" + mask]
-        if build_type == "with-cpp":
-            # Only set for Java tests because there's multi-language worker tests.
-            build_cmd += ["--build-arg", "RAY_DISABLE_EXTRA_CPP=0"]
         build_cmd += [
             "-f",
             "/ray/ci/ray_ci/tests.env.Dockerfile",

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -162,8 +162,8 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
             "cgroup",
             # java build types
             "java",
-            # with cpp api
-            "with-cpp",
+            # with cpp and java worker support
+            "multi-lang",
             # do not build ray
             "skip",
         ]

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -5,14 +5,14 @@ FROM "$BASE_IMAGE"
 
 ARG BUILD_TYPE
 ARG BUILDKITE_CACHE_READONLY
-ARG RAY_DISABLE_EXTRA_CPP=1
 ARG RAY_INSTALL_MASK=
 
 ENV CC=clang
 ENV CXX=clang++-12
-# Disabling C++ API build to speed up CI
-# Only needed for java tests where we override this.
-ENV RAY_DISABLE_EXTRA_CPP=${RAY_DISABLE_EXTRA_CPP}
+
+# Disable C++ API/worker building by default on CI.
+# To use C++ API/worker, set BUILD_TYPE to "multi-lang".
+ENV RAY_DISABLE_EXTRA_CPP=1
 
 RUN mkdir /rayci
 WORKDIR /rayci
@@ -69,6 +69,8 @@ if [[ "$BUILD_TYPE" == "debug" ]]; then
 elif [[ "$BUILD_TYPE" == "asan" ]]; then
   pip install -v -e python/
   bazel run $(./ci/run/bazel_export_options) --no//:jemalloc_flag //:gen_ray_pkg
+elif [[ "$BUILD_TYPE" == "multi-lang" ]]; then
+  RAY_DISABLE_EXTRA_CPP=0 RAY_INSTALL_JAVA=1 pip install -v -e python/
 elif [[ "$BUILD_TYPE" == "java" ]]; then
   bash java/build-jar-multiplatform.sh linux
   RAY_INSTALL_JAVA=1 pip install -v -e python/

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -389,6 +389,7 @@ py_test_module_list(
     ],
     tags = [
         "exclusive",
+        "extra_setup",
         "medium_size_python_tests_k_to_z",
         "needs_java",
         "team:core",


### PR DESCRIPTION
run in its own test job.

also renames "with-cpp" build type to "multi-lang".
