### PR TITLE
[core] remove parallism for spark_on_ray tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -439,9 +439,7 @@ steps:
         --build-type debug
         --test-env=RAY_ON_SPARK_BACKGROUND_JOB_STARTUP_WAIT=1
         --test-env=RAY_ON_SPARK_RAY_WORKER_NODE_STARTUP_INTERVAL=5
-        --parallelism-per-worker 3
         --only-tags spark_on_ray
-        --except-tags kubernetes
     depends_on:
       - corebuild
 


### PR DESCRIPTION
there is only one bazel test; test worker parallism basically has no effect.
