### PR TITLE
[core] improve metric agent connection log

### DIFF
--- a/src/ray/rpc/metrics_agent_client.cc
+++ b/src/ray/rpc/metrics_agent_client.cc
@@ -37,12 +37,16 @@ void MetricsAgentClientImpl::WaitForServerReadyWithRetry(
     return;
   }
 
+  if (retry_count == 0) {
+    // Only log the first time we start the retry loop.
+    RAY_LOG(INFO) << "Initializing exporter ...";
+  }
   HealthCheck(rpc::HealthCheckRequest(),
-              [this, init_exporter_fn, retry_count, retry_interval_ms](auto &status, auto &&reply) {
+              [this, init_exporter_fn](auto &status, auto &&reply) {
                 if (status.ok() && !exporter_initialized_) {
                   init_exporter_fn(status);
                   exporter_initialized_ = true;
-                  RAY_LOG(INFO) << "Exporter initialized after " << retry_count * retry_interval_ms / 1000 << " seconds.";
+                  RAY_LOG(INFO) << "Exporter initialized.";
                 }
               });
   if (retry_count >= max_retry) {

--- a/src/ray/rpc/metrics_agent_client.cc
+++ b/src/ray/rpc/metrics_agent_client.cc
@@ -37,13 +37,12 @@ void MetricsAgentClientImpl::WaitForServerReadyWithRetry(
     return;
   }
 
-  RAY_LOG(INFO) << "Initializing exporter ...";
   HealthCheck(rpc::HealthCheckRequest(),
-              [this, init_exporter_fn](auto &status, auto &&reply) {
+              [this, init_exporter_fn, retry_count, retry_interval_ms](auto &status, auto &&reply) {
                 if (status.ok() && !exporter_initialized_) {
                   init_exporter_fn(status);
                   exporter_initialized_ = true;
-                  RAY_LOG(INFO) << "Exporter initialized.";
+                  RAY_LOG(INFO) << "Exporter initialized after " << retry_count * retry_interval_ms / 1000 << " seconds.";
                 }
               });
   if (retry_count >= max_retry) {


### PR DESCRIPTION
The log emitted during the metric agent connection is currently noisy because it runs in a loop. Only emit the initialization log once. Keep the log about connection established the same; the log timestamp will give us the information we need regarding how long the connection takes.

Test:
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduce log spam by logging "Initializing exporter ..." only once at the start of the retry loop in `MetricsAgentClientImpl::WaitForServerReadyWithRetry`.
> 
> - **Logging**:
>   - In `src/ray/rpc/metrics_agent_client.cc`, update `MetricsAgentClientImpl::WaitForServerReadyWithRetry` to log `"Initializing exporter ..."` only when `retry_count == 0` (first retry attempt), reducing repeated logs during retries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23ece5752fa5c24cc1aee2732978f4a4fc141b8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->