### PR TITLE
[Data] - schema() handle pd.ArrowDtype -> pyarrow type conversion

### DIFF
--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -2,11 +2,13 @@ from collections import UserDict
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 import ray
 from ray.air.util.tensor_extensions.pandas import TensorDtype
 from ray.data.context import DataContext
+from ray.data.dataset import Schema
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
@@ -249,6 +251,24 @@ def test_strict_schema(ray_start_regular_shared_2_cpus):
     assert schema.base_schema.types == [TensorDtype(shape=(10,), dtype=pa.float64())]
     # NOTE: Schema by default returns Arrow types
     assert schema.types == [expected_arrow_ext_type]
+
+
+@pytest.mark.parametrize(
+    "input_dtype, expected_arrow_type",
+    [
+        (pd.ArrowDtype(pa.int32()), pa.int32()),
+        (np.dtype("int64"), pa.int64()),
+    ],
+)
+def test_schema_types_property(input_dtype, expected_arrow_type):
+    """
+    Tests that the Schema.types property correctly converts pandas and numpy
+    dtypes to pyarrow types.
+    """
+    from ray.data._internal.pandas_block import PandasBlockSchema
+
+    schema = Schema(PandasBlockSchema(names=["a"], types=[input_dtype]))
+    assert schema.types == [expected_arrow_type]
 
 
 def test_use_raw_dicts(ray_start_regular_shared_2_cpus):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the schema contains `pd.ArrowDtype` datatypes, the existing `pa.from_numpy_dtype(dtype)` in the schema function will fail. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Schema.types now converts pandas ArrowDtype to pyarrow types (including within TensorDtype), with unit tests validating dtype conversion.
> 
> - **Schema/types conversion**
>   - Add `_convert_to_pa_type` to map `pandas.ArrowDtype` and `numpy dtype` to `pyarrow` types.
>   - Use helper for both generic column dtypes and `TensorDtype._dtype` (works with ArrowTensorType/ArrowTensorTypeV2).
>   - Import `pandas` to detect `pd.ArrowDtype`.
> - **Tests**
>   - Add parametric test ensuring `Schema.types` returns correct `pyarrow` types for `pd.ArrowDtype` and `numpy` dtypes.
>   - Minor test imports updated (e.g., `pyarrow`, `Schema`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 243cdd6992fe0ede8f0c7bda3c3c8aad8d3ebd4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->