### PR TITLE
[release] updating passing core long running tests to run on py310

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -777,6 +777,7 @@
 
   variations:
     - __suffix__: aws
+      python: "3.10"
     - __suffix__: gce
       env: gce
       frequency: manual
@@ -902,6 +903,7 @@
 
   variations:
     - __suffix__: aws
+      python: "3.10"
     - __suffix__: gce
       env: gce
       frequency: manual
@@ -913,6 +915,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_drivers
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1032,6 +1035,7 @@
 
   variations:
     - __suffix__: aws
+      python: "3.10"
     - __suffix__: gce
       env: gce
       frequency: manual
@@ -1114,6 +1118,7 @@
 
   variations:
     - __suffix__: aws
+      python: "3.10"
     - __suffix__: gce
       env: gce
       frequency: manual


### PR DESCRIPTION
Updating core long running tests to run on py3.10

Successful release tests on 3.10
https://buildkite.com/ray-project/release/builds/60324#_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins Python 3.10 for AWS variations of several long-running tests and sets test-level Python 3.10 for `long_running_many_drivers`.
> 
> - **Release tests**:
>   - **Long running (AWS variations)**: set `python: "3.10"` for `long_running_actor_deaths`, `long_running_apex`, `long_running_impala`, and `long_running_many_actor_tasks`.
>   - **Test-level**: set `python: "3.10"` for `long_running_many_drivers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f8b66b30501bb59d6100cac1888c5aac62af245. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->