### PR TITLE
[ray.data.llm] Fix build_llm_processor for ServeDeploymentProcessor

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1442,12 +1442,6 @@ python/ray/job_config.py
 python/ray/llm/_internal/batch/observability/logging/__init__.py
     DOC201: Function `_setup_logger` does not have a return section in docstring
 --------------------
-python/ray/llm/_internal/batch/processor/base.py
-    DOC101: Method `Processor.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `Processor.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [stages: List[StatefulStage]].
-    DOC101: Method `ProcessorBuilder.build`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `ProcessorBuilder.build`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
---------------------
 python/ray/llm/_internal/batch/stages/base.py
     DOC405: Method `StatefulStageUDF.__call__` has both "return" and "yield" statements. Please use Generator[YieldType, SendType, ReturnType] as the return type annotation, and put your yield type in YieldType and return type in ReturnType. More details in https://jsh9.github.io/pydoclint/notes_generator_vs_iterator.html
 --------------------

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -366,15 +366,14 @@ class ServeDeploymentProcessorConfig(_ServeDeploymentProcessorConfig):
 @PublicAPI(stability="alpha")
 def build_llm_processor(
     config: ProcessorConfig,
-    chat_template_kwargs: Optional[Dict[str, Any]] = None,
     preprocess: Optional[UserDefinedFunction] = None,
     postprocess: Optional[UserDefinedFunction] = None,
+    builder_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Processor:
     """Build a LLM processor using the given config.
 
     Args:
         config: The processor config.
-        chat_template_kwargs: The optional kwargs to pass apply_chat_template.
         preprocess: An optional lambda function that takes a row (dict) as input
             and returns a preprocessed row (dict). The output row must contain the
             required fields for the following processing stages. Each row
@@ -384,12 +383,17 @@ def build_llm_processor(
         postprocess: An optional lambda function that takes a row (dict) as input
             and returns a postprocessed row (dict). To keep all the original columns,
             you can use the `**row` syntax to return all the original columns.
-
+        builder_kwargs: Optional additional kwargs to pass to the processor builder
+            function. These will be passed through to the registered builder and
+            should match the signature of the specific builder being used.
+            For example, vLLM and SGLang processors support `chat_template_kwargs`.
 
     Returns:
         The built processor.
 
-    Example:
+    Examples:
+        Basic usage:
+
         .. testcode::
             :skipif: True
 
@@ -430,17 +434,58 @@ def build_llm_processor(
             ds = processor(ds)
             for row in ds.take_all():
                 print(row)
+
+        Using builder_kwargs to pass chat_template_kwargs:
+
+        .. testcode::
+            :skipif: True
+
+            import ray
+            from ray.data.llm import vLLMEngineProcessorConfig, build_llm_processor
+
+            config = vLLMEngineProcessorConfig(
+                model_source="Qwen/Qwen3-32B",
+                apply_chat_template=True,
+                concurrency=1,
+                batch_size=64,
+            )
+
+            processor = build_llm_processor(
+                config,
+                preprocess=lambda row: dict(
+                    messages=[
+                        {"role": "user", "content": row["prompt"]},
+                    ],
+                ),
+                builder_kwargs=dict(
+                    chat_template_kwargs={"enable_thinking": True},
+                ),
+            )
+
+            ds = ray.data.from_items([{"prompt": "What is 2+2?"}])
+            ds = processor(ds)
+            for row in ds.take_all():
+                print(row)
     """
     from ray.llm._internal.batch.processor import ProcessorBuilder
-    from ray.llm._internal.batch.processor.base import OfflineProcessorConfig
 
     build_kwargs = dict(
         preprocess=preprocess,
         postprocess=postprocess,
     )
 
-    if isinstance(config, OfflineProcessorConfig):
-        build_kwargs["chat_template_kwargs"] = chat_template_kwargs
+    # Pass through any additional builder kwargs
+    if builder_kwargs is not None:
+        # Check for conflicts with explicitly passed arguments
+        reserved_keys = {"preprocess", "postprocess"}
+        conflicting_keys = reserved_keys & builder_kwargs.keys()
+        if conflicting_keys:
+            raise ValueError(
+                f"builder_kwargs cannot contain {conflicting_keys} as these are "
+                "passed as explicit arguments to build_llm_processor. "
+                "Please pass these directly instead of in builder_kwargs."
+            )
+        build_kwargs.update(builder_kwargs)
 
     return ProcessorBuilder.build(config, **build_kwargs)
 

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -432,13 +432,21 @@ def build_llm_processor(
                 print(row)
     """
     from ray.llm._internal.batch.processor import ProcessorBuilder
+    from ray.llm._internal.batch.processor.base import OfflineProcessorConfig
 
-    return ProcessorBuilder.build(
-        config,
-        chat_template_kwargs=chat_template_kwargs,
-        preprocess=preprocess,
-        postprocess=postprocess,
-    )
+    if isinstance(config, OfflineProcessorConfig):
+        return ProcessorBuilder.build(
+            config,
+            chat_template_kwargs=chat_template_kwargs,
+            preprocess=preprocess,
+            postprocess=postprocess,
+        )
+    else:
+        return ProcessorBuilder.build(
+            config,
+            preprocess=preprocess,
+            postprocess=postprocess,
+        )
 
 
 __all__ = [

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -473,6 +473,7 @@ def build_llm_processor(
     """
     from ray.llm._internal.batch.processor import ProcessorBuilder
 
+    ProcessorBuilder.validate_builder_kwargs(builder_kwargs)
     build_kwargs = dict(
         preprocess=preprocess,
         postprocess=postprocess,
@@ -480,15 +481,6 @@ def build_llm_processor(
 
     # Pass through any additional builder kwargs
     if builder_kwargs is not None:
-        # Check for conflicts with explicitly passed arguments
-        reserved_keys = {"preprocess", "postprocess"}
-        conflicting_keys = reserved_keys & builder_kwargs.keys()
-        if conflicting_keys:
-            raise ValueError(
-                f"builder_kwargs cannot contain {conflicting_keys} as these are "
-                "passed as explicit arguments to build_llm_processor. "
-                "Please pass these directly instead of in builder_kwargs."
-            )
         build_kwargs.update(builder_kwargs)
 
     return ProcessorBuilder.build(config, **build_kwargs)

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -444,7 +444,7 @@ def build_llm_processor(
             from ray.data.llm import vLLMEngineProcessorConfig, build_llm_processor
 
             config = vLLMEngineProcessorConfig(
-                model_source="Qwen/Qwen3-32B",
+                model_source="Qwen/Qwen3-0.6B",
                 apply_chat_template=True,
                 concurrency=1,
                 batch_size=64,
@@ -456,6 +456,10 @@ def build_llm_processor(
                     messages=[
                         {"role": "user", "content": row["prompt"]},
                     ],
+                    sampling_params=dict(
+                        temperature=0.6,
+                        max_tokens=100,
+                    ),
                 ),
                 builder_kwargs=dict(
                     chat_template_kwargs={"enable_thinking": True},

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -434,19 +434,15 @@ def build_llm_processor(
     from ray.llm._internal.batch.processor import ProcessorBuilder
     from ray.llm._internal.batch.processor.base import OfflineProcessorConfig
 
+    build_kwargs = dict(
+        preprocess=preprocess,
+        postprocess=postprocess,
+    )
+
     if isinstance(config, OfflineProcessorConfig):
-        return ProcessorBuilder.build(
-            config,
-            chat_template_kwargs=chat_template_kwargs,
-            preprocess=preprocess,
-            postprocess=postprocess,
-        )
-    else:
-        return ProcessorBuilder.build(
-            config,
-            preprocess=preprocess,
-            postprocess=postprocess,
-        )
+        build_kwargs["chat_template_kwargs"] = chat_template_kwargs
+
+    return ProcessorBuilder.build(config, **build_kwargs)
 
 
 __all__ = [

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -352,6 +352,9 @@ class ProcessorBuilder:
         Args:
             config: The processor config.
             override_stage_config_fn: Custom stages configurations.
+            **kwargs: Additional keyword arguments to pass through to the
+                registered builder function. The builder function must accept
+                these kwargs in its signature, otherwise a TypeError will be raised.
 
         Returns:
             The built processor.

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -341,6 +341,34 @@ class ProcessorBuilder:
         cls._registry[type_name] = builder
 
     @classmethod
+    def clear_registry(cls) -> None:
+        """Clear the processor builder registry."""
+        cls._registry.clear()
+
+    @classmethod
+    def validate_builder_kwargs(cls, builder_kwargs: Optional[Dict[str, Any]]) -> None:
+        """Validate builder kwargs for conflicts with reserved keys.
+
+        Args:
+            builder_kwargs: Optional additional kwargs to pass to the processor builder
+                function.
+
+        Raises:
+            ValueError: If builder_kwargs contains reserved keys that conflict with
+                explicit arguments.
+        """
+        if builder_kwargs is not None:
+            # Check for conflicts with explicitly passed arguments
+            reserved_keys = {"preprocess", "postprocess"}
+            conflicting_keys = reserved_keys & builder_kwargs.keys()
+            if conflicting_keys:
+                raise ValueError(
+                    f"builder_kwargs cannot contain {conflicting_keys} as these are "
+                    "passed as explicit arguments to build_llm_processor. "
+                    "Please pass these directly instead of in builder_kwargs."
+                )
+
+    @classmethod
     def build(
         cls,
         config: ProcessorConfig,

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -187,6 +187,7 @@ class Processor:
 
     Args:
         config: The processor config.
+        stages: List of processing stages.
         preprocess: An optional lambda function that takes a row (dict) as input
             and returns a preprocessed row (dict). The output row must contain the
             required fields for the following processing stages.

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -5,6 +5,7 @@ import pydantic
 import pytest
 
 import ray
+from ray.data.llm import build_llm_processor
 from ray.llm._internal.batch.processor import vLLMEngineProcessorConfig
 from ray.llm._internal.batch.processor.base import (
     Processor,
@@ -139,22 +140,24 @@ def test_processor_with_stages(has_extra: bool):
             assert row["result"] == (row["id"] * 2 + extra) * 3 + extra
 
 
+# Common dummy classes for testing
+class DummyStatefulStageUDF(StatefulStageUDF):
+    async def udf(self, batch: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:
+        for row in batch:
+            yield row
+
+
+class DummyStage(StatefulStage):
+    fn: Type[StatefulStageUDF] = DummyStatefulStageUDF
+    fn_constructor_kwargs: Dict[str, Any] = {}
+    map_batches_kwargs: Dict[str, Any] = {}
+
+
+class DummyProcessorConfig(ProcessorConfig):
+    pass
+
+
 def test_builder():
-    class DummyStatefulStageUDF(StatefulStageUDF):
-        async def udf(
-            self, batch: List[Dict[str, Any]]
-        ) -> AsyncIterator[Dict[str, Any]]:
-            for row in batch:
-                yield row
-
-    class DummyStage(StatefulStage):
-        fn: Type[StatefulStageUDF] = DummyStatefulStageUDF
-        fn_constructor_kwargs: Dict[str, Any] = {}
-        map_batches_kwargs: Dict[str, Any] = {}
-
-    class TestBuilderDummyProcessorConfig(ProcessorConfig):
-        pass
-
     def build_processor(config: ProcessorConfig) -> Processor:
         stages = [
             DummyStage(
@@ -165,10 +168,10 @@ def test_builder():
         processor = Processor(config, stages)
         return processor
 
-    ProcessorBuilder.register(TestBuilderDummyProcessorConfig, build_processor)
+    ProcessorBuilder.register(DummyProcessorConfig, build_processor)
 
-    processor = ProcessorBuilder.build(TestBuilderDummyProcessorConfig(batch_size=64))
-    assert isinstance(processor.config, TestBuilderDummyProcessorConfig)
+    processor = ProcessorBuilder.build(DummyProcessorConfig(batch_size=64))
+    assert isinstance(processor.config, DummyProcessorConfig)
     assert processor.list_stage_names() == ["DummyStage"]
     assert (
         processor.get_stage_by_name("DummyStage").map_batches_kwargs["concurrency"] == 1
@@ -179,7 +182,7 @@ def test_builder():
             stage.map_batches_kwargs["concurrency"] = 2
 
     processor = ProcessorBuilder.build(
-        TestBuilderDummyProcessorConfig(batch_size=64),
+        DummyProcessorConfig(batch_size=64),
         override_stage_config_fn=overrider,
     )
     assert processor.list_stage_names() == ["DummyStage"]
@@ -188,108 +191,88 @@ def test_builder():
     )
 
 
-def test_builder_kwargs_passthrough():
-    """Test that builder_kwargs are passed through correctly via build_llm_processor."""
-    from ray.data.llm import build_llm_processor
-
-    class DummyStatefulStageUDF(StatefulStageUDF):
-        async def udf(
-            self, batch: List[Dict[str, Any]]
-        ) -> AsyncIterator[Dict[str, Any]]:
-            for row in batch:
-                yield row
-
-    class DummyStage(StatefulStage):
-        fn: Type[StatefulStageUDF] = DummyStatefulStageUDF
-        fn_constructor_kwargs: Dict[str, Any] = {}
-        map_batches_kwargs: Dict[str, Any] = {}
-
-    class TestBuilderKwargsProcessorConfig(ProcessorConfig):
-        pass
-
-    # Builder that accepts extra kwargs
-    def build_processor_with_kwargs(
-        config: ProcessorConfig,
-        preprocess=None,
-        postprocess=None,
-        custom_kwarg=None,
-        another_kwarg=None,
-    ) -> Processor:
-        stages = [
-            DummyStage(
-                fn_constructor_kwargs=dict(
-                    custom_kwarg=custom_kwarg,
-                    another_kwarg=another_kwarg,
-                ),
-                map_batches_kwargs=dict(concurrency=1),
+class TestBuilderKwargsValidation:
+    @pytest.fixture
+    def build_processor_with_kwargs(self):
+        def build_processor_with_kwargs(
+            config: ProcessorConfig,
+            preprocess=None,
+            postprocess=None,
+            custom_kwarg=None,
+            another_kwarg=None,
+        ) -> Processor:
+            stages = [
+                DummyStage(
+                    fn_constructor_kwargs=dict(
+                        custom_kwarg=custom_kwarg,
+                        another_kwarg=another_kwarg,
+                    ),
+                    map_batches_kwargs=dict(concurrency=1),
+                )
+            ]
+            processor = Processor(
+                config, stages, preprocess=preprocess, postprocess=postprocess
             )
-        ]
-        processor = Processor(
-            config, stages, preprocess=preprocess, postprocess=postprocess
-        )
-        return processor
+            return processor
 
-    ProcessorBuilder.register(
-        TestBuilderKwargsProcessorConfig, build_processor_with_kwargs
-    )
+        return build_processor_with_kwargs
 
-    # Test passing builder_kwargs through build_llm_processor
-    config = TestBuilderKwargsProcessorConfig(batch_size=64)
-    processor = build_llm_processor(
-        config,
-        preprocess=lambda row: {"val": row["id"]},
-        postprocess=lambda row: {"result": row["val"]},
-        builder_kwargs=dict(
-            custom_kwarg="test_value",
-            another_kwarg=42,
-        ),
-    )
-    assert processor.list_stage_names() == ["DummyStage"]
-    stage = processor.get_stage_by_name("DummyStage")
-    assert stage.fn_constructor_kwargs["custom_kwarg"] == "test_value"
-    assert stage.fn_constructor_kwargs["another_kwarg"] == 42
+    @pytest.fixture(autouse=True)
+    def clear_registry(self):
+        ProcessorBuilder.clear_registry()
 
-    # Test that unsupported kwargs raise TypeError
-    class TestBuilderNoKwargsProcessorConfig(ProcessorConfig):
-        pass
+    def test_builder_kwargs_passthrough(self, build_processor_with_kwargs):
+        ProcessorBuilder.register(DummyProcessorConfig, build_processor_with_kwargs)
 
-    def build_processor_no_kwargs(
-        config: ProcessorConfig,
-        preprocess=None,
-        postprocess=None,
-    ) -> Processor:
-        stages = []
-        processor = Processor(
-            config, stages, preprocess=preprocess, postprocess=postprocess
-        )
-        return processor
-
-    ProcessorBuilder.register(
-        TestBuilderNoKwargsProcessorConfig, build_processor_no_kwargs
-    )
-
-    config_no_kwargs = TestBuilderNoKwargsProcessorConfig(batch_size=64)
-    with pytest.raises(TypeError, match="unsupported_kwarg"):
-        build_llm_processor(
-            config_no_kwargs,
-            builder_kwargs=dict(unsupported_kwarg="value"),
-        )
-
-    # Test that passing preprocess/postprocess in builder_kwargs raises ValueError
-    config_conflict = TestBuilderKwargsProcessorConfig(batch_size=64)
-    with pytest.raises(ValueError, match="builder_kwargs cannot contain"):
-        build_llm_processor(
-            config_conflict,
+        config = DummyProcessorConfig(batch_size=64)
+        processor = build_llm_processor(
+            config,
             preprocess=lambda row: {"val": row["id"]},
-            builder_kwargs=dict(preprocess=lambda row: {"other": row["id"]}),
-        )
-
-    with pytest.raises(ValueError, match="builder_kwargs cannot contain"):
-        build_llm_processor(
-            config_conflict,
             postprocess=lambda row: {"result": row["val"]},
-            builder_kwargs=dict(postprocess=lambda row: {"other": row["val"]}),
+            builder_kwargs=dict(
+                custom_kwarg="test_value",
+                another_kwarg=42,
+            ),
         )
+        assert processor.list_stage_names() == ["DummyStage"]
+        stage = processor.get_stage_by_name("DummyStage")
+        assert stage.fn_constructor_kwargs["custom_kwarg"] == "test_value"
+        assert stage.fn_constructor_kwargs["another_kwarg"] == 42
+
+    def test_unsupported_kwargs(self):
+        def build_processor_no_kwargs(
+            config: ProcessorConfig,
+            preprocess=None,
+            postprocess=None,
+        ) -> Processor:
+            stages = []
+            processor = Processor(
+                config, stages, preprocess=preprocess, postprocess=postprocess
+            )
+            return processor
+
+        ProcessorBuilder.register(DummyProcessorConfig, build_processor_no_kwargs)
+
+        config = DummyProcessorConfig(batch_size=64)
+        with pytest.raises(TypeError, match="unsupported_kwarg"):
+            build_llm_processor(
+                config,
+                builder_kwargs=dict(unsupported_kwarg="value"),
+            )
+
+    @pytest.mark.parametrize("conflicting_key", ["preprocess", "postprocess"])
+    def test_error_builder_kwargs_conflict(
+        self, conflicting_key, build_processor_with_kwargs
+    ):
+        ProcessorBuilder.register(DummyProcessorConfig, build_processor_with_kwargs)
+
+        config = DummyProcessorConfig(batch_size=64)
+        with pytest.raises(ValueError, match="builder_kwargs cannot contain"):
+            build_llm_processor(
+                config,
+                preprocess=lambda row: {"val": row["id"]},
+                builder_kwargs={conflicting_key: lambda row: {"other": row["id"]}},
+            )
 
 
 class TestProcessorConfig:

--- a/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
@@ -5,10 +5,8 @@ import pytest
 
 import ray
 from ray import serve
+from ray.data.llm import ServeDeploymentProcessorConfig, build_llm_processor
 from ray.llm._internal.batch.processor import ProcessorBuilder
-from ray.llm._internal.batch.processor.serve_deployment_proc import (
-    ServeDeploymentProcessorConfig,
-)
 from ray.serve.llm.openai_api_models import ChatCompletionRequest, CompletionRequest
 
 
@@ -65,7 +63,7 @@ def test_simple_serve_deployment(serve_cleanup):
         concurrency=1,
     )
 
-    processor = ProcessorBuilder.build(
+    processor = build_llm_processor(
         config,
         preprocess=lambda row: dict(
             method="add",
@@ -100,7 +98,7 @@ def test_completion_model(model_opt_125m, create_model_opt_125m_deployment):
         concurrency=1,
     )
 
-    processor = ProcessorBuilder.build(
+    processor = build_llm_processor(
         config,
         preprocess=lambda row: dict(
             method="completions",
@@ -139,7 +137,7 @@ def test_multi_turn_completion_model(model_opt_125m, create_model_opt_125m_deplo
         concurrency=1,
     )
 
-    processor1 = ProcessorBuilder.build(
+    processor1 = build_llm_processor(
         config1,
         preprocess=lambda row: dict(
             dtype="CompletionRequest",
@@ -165,7 +163,7 @@ def test_multi_turn_completion_model(model_opt_125m, create_model_opt_125m_deplo
         concurrency=1,
     )
 
-    processor2 = ProcessorBuilder.build(
+    processor2 = build_llm_processor(
         config2,
         preprocess=lambda row: dict(
             dtype="CompletionRequest",
@@ -204,7 +202,7 @@ def test_chat_model(model_opt_125m, create_model_opt_125m_deployment):
         concurrency=1,
     )
 
-    processor = ProcessorBuilder.build(
+    processor = build_llm_processor(
         config,
         preprocess=lambda row: dict(
             dtype="ChatCompletionRequest",

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -5,10 +5,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import ray
+from ray.data.llm import SGLangEngineProcessorConfig
 from ray.llm._internal.batch.processor import ProcessorBuilder
-from ray.llm._internal.batch.processor.sglang_engine_proc import (
-    SGLangEngineProcessorConfig,
-)
 
 
 def test_sglang_engine_processor(gpu_type, model_llama_3_2_216M):

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import ray
+from ray.data.llm import build_llm_processor, vLLMEngineProcessorConfig
 from ray.llm._internal.batch.processor import ProcessorBuilder
-from ray.llm._internal.batch.processor.vllm_engine_proc import vLLMEngineProcessorConfig
 
 
 def test_vllm_engine_processor(gpu_type, model_opt_125m):
@@ -137,7 +137,7 @@ def test_generation_model(gpu_type, model_opt_125m, backend):
         detokenize=True,
     )
 
-    processor = ProcessorBuilder.build(
+    processor = build_llm_processor(
         processor_config,
         preprocess=lambda row: dict(
             messages=[
@@ -184,7 +184,7 @@ def test_embedding_model(gpu_type, model_smolvlm_256m):
         detokenize=False,
     )
 
-    processor = ProcessorBuilder.build(
+    processor = build_llm_processor(
         processor_config,
         preprocess=lambda row: dict(
             messages=[
@@ -233,7 +233,7 @@ def test_vision_model(gpu_type, model_smolvlm_256m):
         concurrency=1,
     )
 
-    processor = ProcessorBuilder.build(
+    processor = build_llm_processor(
         processor_config,
         preprocess=lambda row: dict(
             messages=[


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`chat_template_kwargs` was introduced in #56490 and is currently passed through all processors, even though some (e.g., `ServeDeploymentProcessor` and `HttpRequestProcessor`) do not support this field. As a result, constructing a `ServeDeploymentProcessor` via `build_llm_processor` raises errors.

This issue wasn’t caught in tests because they have been using `ProcessorBuilder.build`, which bypasses the layer where `chat_template_kwargs` is passed.

In this PR, we:
- Introduce `builder_kwargs` and delegate their validation to individual processors. The `chat_template_kwargs` will be passed as part of `builder_kwargs` to the `vLLMEngineProcessor`.
- Update tests to rely on public APIs rather than developer APIs, ensuring they reflect end-user usage.

## Related issue number

<!-- For example: "Closes #1234" -->
Resolves #57060 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make build_llm_processor skip chat_template_kwargs for non-offline processors and update processor tests to use public ray.data.llm APIs.
> 
> - **Core (ray.data.llm)**
>   - Adjust `build_llm_processor` to only pass `chat_template_kwargs` when `config` is an `OfflineProcessorConfig`.
> - **Tests**
>   - Switch to public APIs: import processor configs from `ray.data.llm` and use `build_llm_processor` instead of `ProcessorBuilder.build` where applicable.
>   - Update Serve Deployment and vLLM processor tests accordingly; keep behavior/assertions intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb36cc3df97e37a8abc76dca03cdd07fea24cec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->