### PR TITLE
[ci] do not install java by default any more

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -390,7 +390,8 @@ steps:
       - if [[ "$${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
           echo "build --remote_upload_local_results=false" >> ~/.bazelrc;
         fi
-      - ci/ci.sh build
+      # cpp worker tests has one that tests cross-language with Java.
+      - RAY_INSTALL_JAVA=1 ci/ci.sh build
       - ci/ci.sh test_cpp
     depends_on: oss-ci-base_build
     job_env: oss-ci-base_build

--- a/ci/docker/base.build.Dockerfile
+++ b/ci/docker/base.build.Dockerfile
@@ -1,8 +1,6 @@
 ARG DOCKER_IMAGE_BASE_TEST=cr.ray.io/rayproject/oss-ci-base_test
 FROM $DOCKER_IMAGE_BASE_TEST
 
-ENV RAY_INSTALL_JAVA=1
-
 COPY . .
 
 RUN <<EOF

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -388,8 +388,8 @@ py_test_module_list(
         "test_logging_java.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
-        "extra_setup",
         "medium_size_python_tests_k_to_z",
         "needs_java",
         "team:core",


### PR DESCRIPTION
tests that require java needs to explicitly use java or multi-lang build type.
