### PR TITLE
[core] fix typo on java test tag

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -388,8 +388,8 @@ py_test_module_list(
         "test_logging_java.py",
     ],
     tags = [
+        "custom_setup",
         "exclusive",
-        "extra_setup",
         "medium_size_python_tests_k_to_z",
         "needs_java",
         "team:core",


### PR DESCRIPTION
it is `custom_setup`, not `extra_setup`
