### PR TITLE
[core] Reapply aggregator refactoring changes + improvements to match existing memory consumption

### DIFF
--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -1,47 +1,38 @@
 import asyncio
-import json
 import logging
 import os
-import queue
-import signal
-import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 
-from requests import Session
-from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
-
-from ray._private.protobuf_compat import message_to_json
-
-try:
-    import prometheus_client
-    from prometheus_client import Counter
-except ImportError:
-    prometheus_client = None
-
 import ray
-import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils
-from ray._common.utils import get_or_create_event_loop
 from ray._private import ray_constants
+from ray._private.telemetry.open_telemetry_metric_recorder import (
+    OpenTelemetryMetricRecorder,
+)
 from ray.core.generated import (
     events_base_event_pb2,
     events_event_aggregator_service_pb2,
     events_event_aggregator_service_pb2_grpc,
+)
+from ray.dashboard.modules.aggregator.constants import AGGREGATOR_AGENT_METRIC_PREFIX
+from ray.dashboard.modules.aggregator.multi_consumer_event_buffer import (
+    MultiConsumerEventBuffer,
+)
+from ray.dashboard.modules.aggregator.publisher.async_publisher_client import (
+    AsyncHttpPublisherClient,
+)
+from ray.dashboard.modules.aggregator.publisher.ray_event_publisher import (
+    NoopPublisher,
+    RayEventPublisher,
 )
 
 logger = logging.getLogger(__name__)
 
 # Environment variables for the aggregator agent
 env_var_prefix = "RAY_DASHBOARD_AGGREGATOR_AGENT"
-# Max number of threads for the thread pool executor handling gRPC requests
-GRPC_TPE_MAX_WORKERS = ray_constants.env_integer(
-    f"{env_var_prefix}_GRPC_TPE_MAX_WORKERS", 10
-)
-# Number of worker threads that publish events to the external service
-PUBLISH_EVENT_WORKERS = ray_constants.env_integer(
-    f"{env_var_prefix}_PUBLISH_EVENT_WORKERS", 1
+# Max number of threads for the thread pool executor handling CPU intensive tasks
+THREAD_POOL_EXECUTOR_MAX_WORKERS = ray_constants.env_integer(
+    f"{env_var_prefix}_THREAD_POOL_EXECUTOR_MAX_WORKERS", 1
 )
 # Interval to check the main thread liveness
 CHECK_MAIN_THREAD_LIVENESS_INTERVAL_SECONDS = ray_constants.env_float(
@@ -51,28 +42,12 @@ CHECK_MAIN_THREAD_LIVENESS_INTERVAL_SECONDS = ray_constants.env_float(
 MAX_EVENT_BUFFER_SIZE = ray_constants.env_integer(
     f"{env_var_prefix}_MAX_EVENT_BUFFER_SIZE", 1000000
 )
-# Maximum sleep time between sending batches of events to the external service
-MAX_BUFFER_SEND_INTERVAL_SECONDS = ray_constants.env_float(
-    f"{env_var_prefix}_MAX_BUFFER_SEND_INTERVAL_SECONDS", 0.1
-)
-# Maximum number of events to send in a single batch to the external service
+# Maximum number of events to send in a single batch to the destination
 MAX_EVENT_SEND_BATCH_SIZE = ray_constants.env_integer(
     f"{env_var_prefix}_MAX_EVENT_SEND_BATCH_SIZE", 10000
 )
-# Maximum number of retries for sending events to the external service for a single request
-REQUEST_BACKOFF_MAX = ray_constants.env_integer(
-    f"{env_var_prefix}_REQUEST_BACKOFF_MAX", 5
-)
-# Backoff factor for the request retries
-REQUEST_BACKOFF_FACTOR = ray_constants.env_float(
-    f"{env_var_prefix}_REQUEST_BACKOFF_FACTOR", 1.0
-)
 # Address of the external service to send events with format of "http://<ip>:<port>"
 EVENTS_EXPORT_ADDR = os.environ.get(f"{env_var_prefix}_EVENTS_EXPORT_ADDR", "")
-# Interval to update metrics
-METRICS_UPDATE_INTERVAL_SECONDS = ray_constants.env_float(
-    f"{env_var_prefix}_METRICS_UPDATE_INTERVAL_SECONDS", 0.1
-)
 # Event filtering configurations
 # Comma-separated list of event types that are allowed to be exposed to external services
 # Valid values: TASK_DEFINITION_EVENT, TASK_EXECUTION_EVENT, ACTOR_TASK_DEFINITION_EVENT, ACTOR_TASK_EXECUTION_EVENT
@@ -88,46 +63,10 @@ DEFAULT_EXPOSABLE_EVENT_TYPES = (
 EXPOSABLE_EVENT_TYPES = os.environ.get(
     f"{env_var_prefix}_EXPOSABLE_EVENT_TYPES", DEFAULT_EXPOSABLE_EVENT_TYPES
 )
-
-# Metrics
-if prometheus_client:
-    metrics_prefix = "event_aggregator_agent"
-    events_received = Counter(
-        f"{metrics_prefix}_events_received",
-        "Total number of events received from the upstream components from the "
-        "AddEvents gRPC call.",
-        tuple(dashboard_consts.COMPONENT_METRICS_TAG_KEYS),
-        namespace="ray",
-    )
-    events_failed_to_add_to_aggregator = Counter(
-        f"{metrics_prefix}_events_failed_to_add_to_aggregator",
-        "Total number of events failed to add to the event aggregator. The metric "
-        "counts the events received by the aggregator agent from the AddEvents gRPC "
-        "call but failed to add to the buffer due to unexpected errors.",
-        tuple(dashboard_consts.COMPONENT_METRICS_TAG_KEYS),
-        namespace="ray",
-    )
-    events_dropped_at_event_aggregator = Counter(
-        f"{metrics_prefix}_events_dropped_at_event_aggregator",
-        "Total number of events dropped at the event aggregator due to the buffer "
-        "being full.",
-        tuple(dashboard_consts.COMPONENT_METRICS_TAG_KEYS),
-        namespace="ray",
-    )
-    events_published = Counter(
-        f"{metrics_prefix}_events_published",
-        "Total number of events successfully published to the external server.",
-        tuple(dashboard_consts.COMPONENT_METRICS_TAG_KEYS),
-        namespace="ray",
-    )
-    events_filtered_out = Counter(
-        f"{metrics_prefix}_events_filtered_out",
-        "Total number of events filtered out before publishing to external server. The "
-        "metric counts the events that are received by the aggregator agent but are "
-        "not part of the public API yet.",
-        tuple(dashboard_consts.COMPONENT_METRICS_TAG_KEYS),
-        namespace="ray",
-    )
+# flag to enable publishing events to the external HTTP service
+PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE = ray_constants.env_bool(
+    f"{env_var_prefix}_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE", True
+)
 
 
 class AggregatorAgent(
@@ -144,47 +83,29 @@ class AggregatorAgent(
         super().__init__(dashboard_agent)
         self._ip = dashboard_agent.ip
         self._pid = os.getpid()
-        self._event_buffer = queue.Queue(maxsize=MAX_EVENT_BUFFER_SIZE)
-        self._grpc_executor = ThreadPoolExecutor(
-            max_workers=GRPC_TPE_MAX_WORKERS,
-            thread_name_prefix="event_aggregator_agent_grpc_executor",
+
+        # common prometheus labels for aggregator-owned metrics
+        self._common_tags = {
+            "ip": self._ip,
+            "pid": str(self._pid),
+            "Version": ray.__version__,
+            "Component": "aggregator_agent",
+            "SessionName": self.session_name,
+        }
+
+        self._event_buffer = MultiConsumerEventBuffer(
+            max_size=MAX_EVENT_BUFFER_SIZE,
+            max_batch_size=MAX_EVENT_SEND_BATCH_SIZE,
+            common_metric_tags=self._common_tags,
+        )
+        self._executor = ThreadPoolExecutor(
+            max_workers=THREAD_POOL_EXECUTOR_MAX_WORKERS,
+            thread_name_prefix="aggregator_agent_executor",
         )
 
-        self._http_session = Session()
-        retries = Retry(
-            total=REQUEST_BACKOFF_MAX,
-            backoff_factor=REQUEST_BACKOFF_FACTOR,
-            status_forcelist=[500, 502, 503, 504],
-            allowed_methods={"POST"},
-            respect_retry_after_header=True,
-        )
-        self._http_session.mount("http://", HTTPAdapter(max_retries=retries))
-        self._http_session.mount("https://", HTTPAdapter(max_retries=retries))
-
-        self._lock = threading.Lock()
-        self._stop_event = threading.Event()
-        self._publisher_threads = []
-        self._events_received_since_last_metrics_update = 0
-        self._events_failed_to_add_to_aggregator_since_last_metrics_update = 0
-        self._events_dropped_at_event_aggregator_since_last_metrics_update = 0
-        self._events_published_since_last_metrics_update = 0
-        self._events_filtered_out_since_last_metrics_update = 0
         self._events_export_addr = (
             dashboard_agent.events_export_addr or EVENTS_EXPORT_ADDR
         )
-
-        self._event_http_target_enabled = bool(self._events_export_addr)
-        if not self._event_http_target_enabled:
-            logger.info(
-                "Event HTTP target not set, skipping sending events to "
-                f"external http service. events_export_addr: {self._events_export_addr}"
-            )
-
-        self._event_processing_enabled = self._event_http_target_enabled
-        if self._event_processing_enabled:
-            logger.info("Event processing enabled")
-        else:
-            logger.info("Event processing disabled")
 
         self._exposable_event_types = {
             event_type.strip()
@@ -192,26 +113,52 @@ class AggregatorAgent(
             if event_type.strip()
         }
 
-        self._orig_sigterm_handler = signal.signal(
-            signal.SIGTERM, self._sigterm_handler
+        self._event_processing_enabled = False
+        if PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE and self._events_export_addr:
+            logger.info(
+                f"Publishing events to external HTTP service is enabled. events_export_addr: {self._events_export_addr}"
+            )
+            self._event_processing_enabled = True
+            self._http_endpoint_publisher = RayEventPublisher(
+                name="http_publisher",
+                publish_client=AsyncHttpPublisherClient(
+                    endpoint=self._events_export_addr,
+                    executor=self._executor,
+                    events_filter_fn=self._can_expose_event,
+                ),
+                event_buffer=self._event_buffer,
+                common_metric_tags=self._common_tags,
+            )
+        else:
+            logger.info(
+                f"Event HTTP target is not enabled or publishing events to external HTTP service is disabled. Skipping sending events to external HTTP service. events_export_addr: {self._events_export_addr}"
+            )
+            self._http_endpoint_publisher = NoopPublisher()
+
+        # Metrics
+        self._open_telemetry_metric_recorder = OpenTelemetryMetricRecorder()
+
+        # Register counter metrics
+        self._events_received_metric_name = (
+            f"{AGGREGATOR_AGENT_METRIC_PREFIX}_events_received_total"
+        )
+        self._open_telemetry_metric_recorder.register_counter_metric(
+            self._events_received_metric_name,
+            "Total number of events received via AddEvents gRPC.",
         )
 
-        self._is_cleanup = False
-        self._cleanup_finished_event = threading.Event()
+        self._events_failed_to_add_metric_name = (
+            f"{AGGREGATOR_AGENT_METRIC_PREFIX}_events_buffer_add_failures_total"
+        )
+        self._open_telemetry_metric_recorder.register_counter_metric(
+            self._events_failed_to_add_metric_name,
+            "Total number of events that failed to be added to the event buffer.",
+        )
 
     async def AddEvents(self, request, context) -> None:
         """
-        gRPC handler for adding events to the event aggregator
-        """
-        loop = get_or_create_event_loop()
-
-        return await loop.run_in_executor(
-            self._grpc_executor, self._receive_events, request
-        )
-
-    def _receive_events(self, request):
-        """
-        Receives events from the request, adds them to the event buffer,
+        gRPC handler for adding events to the event aggregator. Receives events from the
+        request and adds them to the event buffer.
         """
         if not self._event_processing_enabled:
             return events_event_aggregator_service_pb2.AddEventsReply()
@@ -221,28 +168,20 @@ class AggregatorAgent(
         # downstream
         events_data = request.events_data
         for event in events_data.events:
-            with self._lock:
-                self._events_received_since_last_metrics_update += 1
+            self._open_telemetry_metric_recorder.set_metric_value(
+                self._events_received_metric_name, self._common_tags, 1
+            )
             try:
-                self._event_buffer.put_nowait(event)
-            except queue.Full:
-                # Remove the oldest event to make room for the new event.
-                self._event_buffer.get_nowait()
-                self._event_buffer.put_nowait(event)
-                with self._lock:
-                    self._events_dropped_at_event_aggregator_since_last_metrics_update += (
-                        1
-                    )
+                await self._event_buffer.add_event(event)
             except Exception as e:
                 logger.error(
                     f"Failed to add event with id={event.event_id.decode()} to buffer. "
                     "Error: %s",
                     e,
                 )
-                with self._lock:
-                    self._events_failed_to_add_to_aggregator_since_last_metrics_update += (
-                        1
-                    )
+                self._open_telemetry_metric_recorder.set_metric_value(
+                    self._events_failed_to_add_metric_name, self._common_tags, 1
+                )
 
         return events_event_aggregator_service_pb2.AddEventsReply()
 
@@ -255,193 +194,18 @@ class AggregatorAgent(
             in self._exposable_event_types
         )
 
-    def _send_events_to_external_service(self, event_batch) -> None:
-        """
-        Sends a batch of events to the external service via HTTP POST request
-        """
-        if not event_batch or not self._event_http_target_enabled:
-            return
-
-        filtered_event_batch = [
-            event for event in event_batch if self._can_expose_event(event)
-        ]
-        if not filtered_event_batch:
-            # All events were filtered out, update metrics and return to avoid an empty POST.
-            with self._lock:
-                self._events_filtered_out_since_last_metrics_update += len(event_batch)
-            event_batch.clear()
-            return
-
-        # Convert protobuf objects to JSON dictionaries for HTTP POST
-        filtered_event_batch_json = [
-            json.loads(
-                message_to_json(event, always_print_fields_with_no_presence=True)
-            )
-            for event in filtered_event_batch
-        ]
-
-        try:
-            response = self._http_session.post(
-                f"{self._events_export_addr}", json=filtered_event_batch_json
-            )
-            response.raise_for_status()
-            with self._lock:
-                self._events_published_since_last_metrics_update += len(
-                    filtered_event_batch
-                )
-                self._events_filtered_out_since_last_metrics_update += len(
-                    event_batch
-                ) - len(filtered_event_batch)
-            event_batch.clear()
-        except Exception as e:
-            logger.error("Failed to send events to external service. Error: %s", e)
-
-    def _publish_events(self) -> None:
-        """
-        Continuously publishes events from the event buffer to the external service
-        """
-        event_batch = []
-
-        while True:
-            while len(event_batch) < MAX_EVENT_SEND_BATCH_SIZE:
-                try:
-                    event_proto = self._event_buffer.get(block=False)
-                    event_batch.append(event_proto)
-                except queue.Empty:
-                    break
-
-            if event_batch:
-                # Send the batch of events to the external service.
-                # If failed, event_batch will be reused in the next iteration.
-                # Retry sending with other events in the next iteration.
-                self._send_events_to_external_service(event_batch)
-            else:
-                should_stop = self._stop_event.wait(MAX_BUFFER_SEND_INTERVAL_SECONDS)
-                if should_stop:
-                    # Send any remaining events before stopping.
-                    self._send_events_to_external_service(event_batch)
-                    return
-
-    def _update_metrics(self) -> None:
-        """
-        Updates the Prometheus metrics
-        """
-        if not prometheus_client:
-            return
-
-        with self._lock:
-            _events_received = self._events_received_since_last_metrics_update
-            _events_failed_to_add_to_aggregator = (
-                self._events_failed_to_add_to_aggregator_since_last_metrics_update
-            )
-            _events_dropped_at_event_aggregator = (
-                self._events_dropped_at_event_aggregator_since_last_metrics_update
-            )
-            _events_published = self._events_published_since_last_metrics_update
-            _events_filtered_out = self._events_filtered_out_since_last_metrics_update
-
-            self._events_received_since_last_metrics_update = 0
-            self._events_failed_to_add_to_aggregator_since_last_metrics_update = 0
-            self._events_dropped_at_event_aggregator_since_last_metrics_update = 0
-            self._events_published_since_last_metrics_update = 0
-            self._events_filtered_out_since_last_metrics_update = 0
-
-        labels = {
-            "ip": self._ip,
-            "pid": self._pid,
-            "Version": ray.__version__,
-            "Component": "event_aggregator_agent",
-            "SessionName": self.session_name,
-        }
-        events_received.labels(**labels).inc(_events_received)
-        events_failed_to_add_to_aggregator.labels(**labels).inc(
-            _events_failed_to_add_to_aggregator
-        )
-        events_dropped_at_event_aggregator.labels(**labels).inc(
-            _events_dropped_at_event_aggregator
-        )
-        events_published.labels(**labels).inc(_events_published)
-        events_filtered_out.labels(**labels).inc(_events_filtered_out)
-
-    def _check_main_thread_liveness(self) -> None:
-        """
-        Continuously checks if the main thread is alive. If the main thread is not alive,
-        it sets the stop event to trigger cleanup and shutdown of the agent.
-        """
-        while True:
-            if not threading.main_thread().is_alive():
-                self._stop_event.set()
-            if self._stop_event.is_set():
-                self._cleanup()
-                break
-            time.sleep(CHECK_MAIN_THREAD_LIVENESS_INTERVAL_SECONDS)
-
-    def _cleanup(self) -> None:
-        """
-        Cleans up the aggregator agent by stopping the publisher threads,
-        sending any remaining events in the buffer, and updating metrics.
-        """
-
-        should_wait_cleanup_finished = False
-        with self._lock:
-            if self._is_cleanup:
-                should_wait_cleanup_finished = True
-            self._is_cleanup = True
-
-        if should_wait_cleanup_finished:
-            # If cleanup is already in progress, wait for it to finish.
-            self._cleanup_finished_event.wait()
-            return
-
-        # Send any remaining events in the buffer
-        event_batch = []
-        while True:
-            try:
-                event_proto = self._event_buffer.get(block=False)
-                event_batch.append(event_proto)
-            except:  # noqa: E722
-                break
-
-        self._send_events_to_external_service(event_batch)
-
-        for thread in self._publisher_threads:
-            thread.join()
-
-        # Update metrics immediately
-        self._update_metrics()
-
-        self._cleanup_finished_event.set()
-
-    def _sigterm_handler(self, signum: int, frame) -> None:
-        self._stop_event.set()
-        self._cleanup()
-        self._orig_sigterm_handler(signum, frame)
-
     async def run(self, server) -> None:
         if server:
             events_event_aggregator_service_pb2_grpc.add_EventAggregatorServiceServicer_to_server(
                 self, server
             )
 
-        thread = threading.Thread(
-            target=self._check_main_thread_liveness,
-            name="event_aggregator_agent_check_main_thread_liveness",
-            daemon=False,
-        )
-        thread.start()
-
-        for _ in range(PUBLISH_EVENT_WORKERS):
-            thread = threading.Thread(
-                target=self._publish_events,
-                name="event_aggregator_agent_publish_events",
-                daemon=False,
+        try:
+            await asyncio.gather(
+                self._http_endpoint_publisher.run_forever(),
             )
-            self._publisher_threads.append(thread)
-            thread.start()
-
-        while True:
-            self._update_metrics()
-            await asyncio.sleep(METRICS_UPDATE_INTERVAL_SECONDS)
+        finally:
+            self._executor.shutdown()
 
     @staticmethod
     def is_minimal_module() -> bool:

--- a/python/ray/dashboard/modules/aggregator/constants.py
+++ b/python/ray/dashboard/modules/aggregator/constants.py
@@ -1,0 +1,2 @@
+AGGREGATOR_AGENT_METRIC_PREFIX = "aggregator_agent"
+CONSUMER_TAG_KEY = "consumer"

--- a/python/ray/dashboard/modules/aggregator/multi_consumer_event_buffer.py
+++ b/python/ray/dashboard/modules/aggregator/multi_consumer_event_buffer.py
@@ -1,0 +1,175 @@
+import asyncio
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from ray._private.telemetry.open_telemetry_metric_recorder import (
+    OpenTelemetryMetricRecorder,
+)
+from ray.core.generated import (
+    events_base_event_pb2,
+)
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.dashboard.modules.aggregator.constants import (
+    AGGREGATOR_AGENT_METRIC_PREFIX,
+    CONSUMER_TAG_KEY,
+)
+
+
+@dataclass
+class _ConsumerState:
+    # Index of the next event to be consumed by this consumer
+    cursor_index: int
+
+
+class MultiConsumerEventBuffer:
+    """A buffer which allows adding one event at a time and consuming events in batches.
+    Supports multiple consumers, each with their own cursor index. Tracks the number of events evicted for each consumer.
+
+    Buffer is not thread-safe but is asyncio-friendly. All operations must be called from within the same event loop.
+
+    Arguments:
+        max_size: Maximum number of events to store in the buffer.
+        max_batch_size: Maximum number of events to return in a batch when calling wait_for_batch.
+        common_metric_tags: Tags to add to all metrics.
+    """
+
+    def __init__(
+        self,
+        max_size: int,
+        max_batch_size: int,
+        common_metric_tags: Optional[Dict[str, str]] = None,
+    ):
+        self._buffer = deque(maxlen=max_size)
+        self._max_size = max_size
+        self._lock = asyncio.Lock()
+        self._has_new_events_to_consume = asyncio.Condition(self._lock)
+        self._consumers: Dict[str, _ConsumerState] = {}
+
+        self._max_batch_size = max_batch_size
+
+        self._common_metrics_tags = common_metric_tags or {}
+        self._metric_recorder = OpenTelemetryMetricRecorder()
+        self.evicted_events_metric_name = (
+            f"{AGGREGATOR_AGENT_METRIC_PREFIX}_queue_dropped_events"
+        )
+        self._metric_recorder.register_counter_metric(
+            self.evicted_events_metric_name,
+            "Total number of events dropped because the publish/buffer queue was full.",
+        )
+
+    async def add_event(self, event: events_base_event_pb2.RayEvent) -> None:
+        """Add an event to the buffer.
+
+        If the buffer is full, the oldest event is dropped.
+        """
+        async with self._lock:
+            dropped_event = None
+            if len(self._buffer) >= self._max_size:
+                dropped_event = self._buffer.popleft()
+            self._buffer.append(event)
+
+            if dropped_event is not None:
+                for consumer_name, consumer_state in self._consumers.items():
+                    # Update consumer cursor index and evicted events metric if an event was dropped
+                    if consumer_state.cursor_index == 0:
+                        # The dropped event was the next event this consumer would have consumed, publish eviction metric
+                        self._metric_recorder.set_metric_value(
+                            self.evicted_events_metric_name,
+                            {
+                                **self._common_metrics_tags,
+                                CONSUMER_TAG_KEY: consumer_name,
+                                "event_type": RayEvent.EventType.Name(
+                                    dropped_event.event_type
+                                ),
+                            },
+                            1,
+                        )
+                    else:
+                        # The dropped event was already consumed by the consumer, so we need to adjust the cursor
+                        consumer_state.cursor_index -= 1
+
+            # Signal the consumers that there are new events to consume
+            self._has_new_events_to_consume.notify_all()
+
+    async def wait_for_batch(
+        self, consumer_name: str, timeout_seconds: float = 1.0
+    ) -> List[events_base_event_pb2.RayEvent]:
+        """Wait for batch respecting self.max_batch_size and timeout_seconds.
+
+        Returns a batch of up to self.max_batch_size items. Waits for up to
+        timeout_seconds after receiving the first event that will be in
+        the next batch. After the timeout, returns as many items as are ready.
+
+        Always returns a batch with at least one item - will block
+        indefinitely until an item comes in.
+
+        Arguments:
+            consumer_name: name of the consumer consuming the batch
+            timeout_seconds: maximum time to wait for a batch
+
+        Returns:
+            A list of up to max_batch_size events ready for consumption.
+            The list always contains at least one event.
+        """
+        max_batch = self._max_batch_size
+        batch = []
+        async with self._has_new_events_to_consume:
+            consumer_state = self._consumers.get(consumer_name)
+            if consumer_state is None:
+                raise KeyError(f"unknown consumer '{consumer_name}'")
+
+            # Phase 1: read the first event, wait indefinitely until there is at least one event to consume
+            while consumer_state.cursor_index >= len(self._buffer):
+                await self._has_new_events_to_consume.wait()
+
+            # Add the first event to the batch
+            event = self._buffer[consumer_state.cursor_index]
+            consumer_state.cursor_index += 1
+            batch.append(event)
+
+            # Phase 2: add items to the batch up to timeout or until full
+            deadline = time.monotonic() + max(0.0, float(timeout_seconds))
+            while len(batch) < max_batch:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+
+                # Drain whatever is available
+                while len(batch) < max_batch and consumer_state.cursor_index < len(
+                    self._buffer
+                ):
+                    batch.append(self._buffer[consumer_state.cursor_index])
+                    consumer_state.cursor_index += 1
+
+                if len(batch) >= max_batch:
+                    break
+
+                # There is still room in the batch, but no new events to consume; wait until notified or timeout
+                try:
+                    await asyncio.wait_for(
+                        self._has_new_events_to_consume.wait(), remaining
+                    )
+                except asyncio.TimeoutError:
+                    # Timeout, return the current batch
+                    break
+
+        return batch
+
+    async def register_consumer(self, consumer_name: str) -> None:
+        """Register a new consumer with a name.
+
+        Arguments:
+            consumer_name: A unique name for the consumer.
+
+        """
+        async with self._lock:
+            if self._consumers.get(consumer_name) is not None:
+                raise ValueError(f"consumer '{consumer_name}' already registered")
+
+            self._consumers[consumer_name] = _ConsumerState(cursor_index=0)
+
+    async def size(self) -> int:
+        """Get total number of events in the buffer. Does not take consumer cursors into account."""
+        return len(self._buffer)

--- a/python/ray/dashboard/modules/aggregator/multi_consumer_event_buffer.py
+++ b/python/ray/dashboard/modules/aggregator/multi_consumer_event_buffer.py
@@ -173,7 +173,7 @@ class MultiConsumerEventBuffer:
                     # Timeout, return the current batch
                     break
 
-        self._evict_old_events()
+            self._evict_old_events()
         return batch
 
     async def register_consumer(self, consumer_name: str) -> None:

--- a/python/ray/dashboard/modules/aggregator/multi_consumer_event_buffer.py
+++ b/python/ray/dashboard/modules/aggregator/multi_consumer_event_buffer.py
@@ -93,6 +93,24 @@ class MultiConsumerEventBuffer:
             # Signal the consumers that there are new events to consume
             self._has_new_events_to_consume.notify_all()
 
+    def _evict_old_events(self) -> None:
+        """Clean the buffer by removing events from the buffer who have index lower than
+        all the cursor indexes of all consumers and updating the cursor index of all
+        consumers.
+        """
+        if not self._consumers:
+            return
+
+        min_cursor_index = min(
+            consumer_state.cursor_index for consumer_state in self._consumers.values()
+        )
+        for _ in range(min_cursor_index):
+            self._buffer.popleft()
+
+        # update the cursor index of all consumers
+        for consumer_state in self._consumers.values():
+            consumer_state.cursor_index -= min_cursor_index
+
     async def wait_for_batch(
         self, consumer_name: str, timeout_seconds: float = 1.0
     ) -> List[events_base_event_pb2.RayEvent]:
@@ -155,6 +173,7 @@ class MultiConsumerEventBuffer:
                     # Timeout, return the current batch
                     break
 
+        self._evict_old_events()
         return batch
 
     async def register_consumer(self, consumer_name: str) -> None:

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -1,0 +1,127 @@
+import json
+import logging
+from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Callable
+
+import aiohttp
+
+from ray._common.utils import get_or_create_event_loop
+from ray._private.protobuf_compat import message_to_json
+from ray.core.generated import events_base_event_pb2
+from ray.dashboard.modules.aggregator.publisher.configs import PUBLISHER_TIMEOUT_SECONDS
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PublishStats:
+    """Data class that represents stats of publishing a batch of events."""
+
+    # Whether the publish was successful
+    is_publish_successful: bool
+    # Number of events published
+    num_events_published: int
+    # Number of events filtered out
+    num_events_filtered_out: int
+
+
+@dataclass
+class PublishBatch:
+    """Data class that represents a batch of events to publish."""
+
+    # The list of events to publish
+    events: list[events_base_event_pb2.RayEvent]
+
+
+class PublisherClientInterface(ABC):
+    """Abstract interface for publishing Ray event batches to external destinations.
+
+    Implementations should handle the actual publishing logic, filtering,
+    and format conversion appropriate for their specific destination type.
+    """
+
+    def count_num_events_in_batch(self, batch: PublishBatch) -> int:
+        """Count the number of events in a given batch."""
+        return len(batch.events)
+
+    @abstractmethod
+    async def publish(self, batch: PublishBatch) -> PublishStats:
+        """Publish a batch of events to the destination."""
+        pass
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Clean up any resources used by this client. Should be called when the publisherClient is no longer required"""
+        pass
+
+
+class AsyncHttpPublisherClient(PublisherClientInterface):
+    """Client for publishing ray event batches to an external HTTP service."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        executor: ThreadPoolExecutor,
+        events_filter_fn: Callable[[object], bool],
+        timeout: float = PUBLISHER_TIMEOUT_SECONDS,
+    ) -> None:
+        self._endpoint = endpoint
+        self._executor = executor
+        self._events_filter_fn = events_filter_fn
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session = None
+
+    async def publish(self, batch: PublishBatch) -> PublishStats:
+        events_batch: list[events_base_event_pb2.RayEvent] = batch.events
+        if not events_batch:
+            # Nothing to publish -> success but nothing published
+            return PublishStats(True, 0, 0)
+        filtered = [e for e in events_batch if self._events_filter_fn(e)]
+        num_filtered_out = len(events_batch) - len(filtered)
+        if not filtered:
+            # All filtered out -> success but nothing published
+            return PublishStats(True, 0, num_filtered_out)
+
+        # Convert protobuf objects to python dictionaries for HTTP POST. Run in executor to avoid blocking the event loop.
+        filtered_json = await get_or_create_event_loop().run_in_executor(
+            self._executor,
+            lambda: [
+                json.loads(
+                    message_to_json(e, always_print_fields_with_no_presence=True)
+                )
+                for e in filtered
+            ],
+        )
+
+        try:
+            # Create session on first use (lazy initialization)
+            if not self._session:
+                self._session = aiohttp.ClientSession(timeout=self._timeout)
+
+            return await self._send_http_request(filtered_json, num_filtered_out)
+        except Exception as e:
+            logger.error("Failed to send events to external service. Error: %s", e)
+            return PublishStats(False, 0, 0)
+
+    async def _send_http_request(self, json_data, num_filtered_out) -> PublishStats:
+        async with self._session.post(
+            self._endpoint,
+            json=json_data,
+        ) as resp:
+            resp.raise_for_status()
+            return PublishStats(True, len(json_data), num_filtered_out)
+
+    async def close(self) -> None:
+        """Closes the http session if one was created. Should be called when the publisherClient is no longer required"""
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+    def set_session(self, session) -> None:
+        """Inject an HTTP client session.
+
+        If a session is set explicitly, it will be used and managed by close().
+        """
+        self._session = session

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -1,0 +1,24 @@
+# Environment variables for the aggregator agent publisher component.
+from ray._private import ray_constants
+
+env_var_prefix = "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER"
+# Timeout for the publisher to publish events to the destination
+PUBLISHER_TIMEOUT_SECONDS = ray_constants.env_integer(
+    f"{env_var_prefix}_TIMEOUT_SECONDS", 3
+)
+# Maximum number of retries for publishing events to the destination, if less than 0, will retry indefinitely
+PUBLISHER_MAX_RETRIES = ray_constants.env_integer(f"{env_var_prefix}_MAX_RETRIES", -1)
+# Initial backoff time for publishing events to the destination
+PUBLISHER_INITIAL_BACKOFF_SECONDS = ray_constants.env_float(
+    f"{env_var_prefix}_INITIAL_BACKOFF_SECONDS", 0.01
+)
+# Maximum backoff time for publishing events to the destination
+PUBLISHER_MAX_BACKOFF_SECONDS = ray_constants.env_float(
+    f"{env_var_prefix}_MAX_BACKOFF_SECONDS", 5.0
+)
+# Jitter ratio for publishing events to the destination
+PUBLISHER_JITTER_RATIO = ray_constants.env_float(f"{env_var_prefix}_JITTER_RATIO", 0.1)
+# Maximum sleep time between sending batches of events to the destination, should be greater than 0.0 to avoid busy looping
+PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS = ray_constants.env_float(
+    f"{env_var_prefix}_MAX_BUFFER_SEND_INTERVAL_SECONDS", 1
+)

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -20,5 +20,5 @@ PUBLISHER_MAX_BACKOFF_SECONDS = ray_constants.env_float(
 PUBLISHER_JITTER_RATIO = ray_constants.env_float(f"{env_var_prefix}_JITTER_RATIO", 0.1)
 # Maximum sleep time between sending batches of events to the destination, should be greater than 0.0 to avoid busy looping
 PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS = ray_constants.env_float(
-    f"{env_var_prefix}_MAX_BUFFER_SEND_INTERVAL_SECONDS", 1
+    f"{env_var_prefix}_MAX_BUFFER_SEND_INTERVAL_SECONDS", 0.1
 )

--- a/python/ray/dashboard/modules/aggregator/publisher/metrics.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/metrics.py
@@ -1,0 +1,53 @@
+from ray._private.telemetry.open_telemetry_metric_recorder import (
+    OpenTelemetryMetricRecorder,
+)
+from ray.dashboard.modules.aggregator.constants import (
+    AGGREGATOR_AGENT_METRIC_PREFIX,
+)
+
+# OpenTelemetry metrics setup (registered once at import time)
+metric_recorder = OpenTelemetryMetricRecorder()
+
+# Counter metrics
+published_counter_name = f"{AGGREGATOR_AGENT_METRIC_PREFIX}_published_events"
+metric_recorder.register_counter_metric(
+    published_counter_name,
+    "Total number of events successfully published to the destination.",
+)
+
+filtered_counter_name = f"{AGGREGATOR_AGENT_METRIC_PREFIX}_filtered_events"
+metric_recorder.register_counter_metric(
+    filtered_counter_name,
+    "Total number of events filtered out before publishing to the destination.",
+)
+
+failed_counter_name = f"{AGGREGATOR_AGENT_METRIC_PREFIX}_publish_failures"
+metric_recorder.register_counter_metric(
+    failed_counter_name,
+    "Total number of events that failed to publish after retries.",
+)
+
+# Histogram metric
+publish_latency_hist_name = f"{AGGREGATOR_AGENT_METRIC_PREFIX}_publish_latency_seconds"
+metric_recorder.register_histogram_metric(
+    publish_latency_hist_name,
+    "Duration of publish calls in seconds.",
+    [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+)
+
+# Gauge metrics
+consecutive_failures_gauge_name = (
+    f"{AGGREGATOR_AGENT_METRIC_PREFIX}_consecutive_failures_since_last_success"
+)
+metric_recorder.register_gauge_metric(
+    consecutive_failures_gauge_name,
+    "Number of consecutive failed publish attempts since the last success.",
+)
+
+time_since_last_success_gauge_name = (
+    f"{AGGREGATOR_AGENT_METRIC_PREFIX}_time_since_last_success_seconds"
+)
+metric_recorder.register_gauge_metric(
+    time_since_last_success_gauge_name,
+    "Seconds since the last successful publish to the destination.",
+)

--- a/python/ray/dashboard/modules/aggregator/publisher/ray_event_publisher.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/ray_event_publisher.py
@@ -1,0 +1,275 @@
+import asyncio
+import logging
+import random
+from abc import ABC, abstractmethod
+from typing import Dict, Optional
+
+from ray.dashboard.modules.aggregator.constants import (
+    CONSUMER_TAG_KEY,
+)
+from ray.dashboard.modules.aggregator.multi_consumer_event_buffer import (
+    MultiConsumerEventBuffer,
+)
+from ray.dashboard.modules.aggregator.publisher.async_publisher_client import (
+    PublishBatch,
+    PublisherClientInterface,
+)
+from ray.dashboard.modules.aggregator.publisher.configs import (
+    PUBLISHER_INITIAL_BACKOFF_SECONDS,
+    PUBLISHER_JITTER_RATIO,
+    PUBLISHER_MAX_BACKOFF_SECONDS,
+    PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS,
+    PUBLISHER_MAX_RETRIES,
+)
+from ray.dashboard.modules.aggregator.publisher.metrics import (
+    consecutive_failures_gauge_name,
+    failed_counter_name,
+    filtered_counter_name,
+    metric_recorder,
+    publish_latency_hist_name,
+    published_counter_name,
+    time_since_last_success_gauge_name,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RayEventPublisherInterface(ABC):
+    """Abstract interface for publishing Ray event batches to external destinations."""
+
+    @abstractmethod
+    async def run_forever(self) -> None:
+        """Run the publisher forever until cancellation or process death."""
+        pass
+
+    @abstractmethod
+    async def wait_until_running(self, timeout: Optional[float] = None) -> bool:
+        """Wait until the publisher has started."""
+        pass
+
+
+class RayEventPublisher(RayEventPublisherInterface):
+    """RayEvents publisher that publishes batches of events to a destination by running a worker loop.
+
+    The worker loop continuously pulls batches from the event buffer and publishes them to the destination.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        publish_client: PublisherClientInterface,
+        event_buffer: MultiConsumerEventBuffer,
+        common_metric_tags: Optional[Dict[str, str]] = None,
+        max_retries: int = PUBLISHER_MAX_RETRIES,
+        initial_backoff: float = PUBLISHER_INITIAL_BACKOFF_SECONDS,
+        max_backoff: float = PUBLISHER_MAX_BACKOFF_SECONDS,
+        jitter_ratio: float = PUBLISHER_JITTER_RATIO,
+    ) -> None:
+        """Initialize a RayEventsPublisher.
+
+        Args:
+            name: Name identifier for this publisher instance
+            publish_client: Client for publishing events to the destination
+            event_buffer: Buffer for reading batches of events
+            common_metric_tags: Common labels for all prometheus metrics
+            max_retries: Maximum number of retries for failed publishes
+            initial_backoff: Initial backoff time between retries in seconds
+            max_backoff: Maximum backoff time between retries in seconds
+            jitter_ratio: Random jitter ratio to add to backoff times
+        """
+        self._name = name
+        self._common_metric_tags = dict(common_metric_tags or {})
+        self._common_metric_tags[CONSUMER_TAG_KEY] = name
+        self._max_retries = int(max_retries)
+        self._initial_backoff = float(initial_backoff)
+        self._max_backoff = float(max_backoff)
+        self._jitter_ratio = float(jitter_ratio)
+        self._publish_client = publish_client
+        self._event_buffer = event_buffer
+
+        # Event set once the publisher has registered as a consumer and is ready to publish events
+        self._started_event: asyncio.Event = asyncio.Event()
+
+    async def run_forever(self) -> None:
+        """Run the publisher forever until cancellation or process death.
+
+        Registers as a consumer, starts the worker loop, and handles cleanup on cancellation.
+        """
+        await self._event_buffer.register_consumer(self._name)
+
+        # Signal that the publisher is ready to publish events
+        self._started_event.set()
+
+        try:
+            logger.info(f"Starting publisher {self._name}")
+            while True:
+                batch = await self._event_buffer.wait_for_batch(
+                    self._name,
+                    PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS,
+                )
+                publish_batch = PublishBatch(events=batch)
+                await self._async_publish_with_retries(publish_batch)
+        except asyncio.CancelledError:
+            logger.info(f"Publisher {self._name} cancelled, shutting down gracefully")
+            self._started_event.clear()
+            await self._publish_client.close()
+            raise
+        except Exception as e:
+            logger.error(f"Publisher {self._name} encountered error: {e}")
+            self._started_event.clear()
+            await self._publish_client.close()
+            raise
+
+    async def wait_until_running(self, timeout: Optional[float] = None) -> bool:
+        """Wait until the publisher has started.
+
+        Args:
+            timeout: Maximum time to wait in seconds. If None, waits indefinitely.
+
+        Returns:
+            True if the publisher started before the timeout, False otherwise.
+            If timeout is None, waits indefinitely.
+        """
+        if timeout is None:
+            await self._started_event.wait()
+            return True
+        try:
+            await asyncio.wait_for(self._started_event.wait(), timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    async def _async_publish_with_retries(self, batch) -> None:
+        """Attempts to publish a batch with retries.
+
+        Will retry failed publishes up to max_retries times with increasing delays.
+        """
+        num_events_in_batch = self._publish_client.count_num_events_in_batch(batch)
+        failed_attempts_since_last_success = 0
+        while True:
+            start = asyncio.get_running_loop().time()
+            result = await self._publish_client.publish(batch)
+            duration = asyncio.get_running_loop().time() - start
+
+            if result.is_publish_successful:
+                await self._record_success(
+                    num_published=int(result.num_events_published),
+                    num_filtered=int(result.num_events_filtered_out),
+                    duration=float(duration),
+                )
+                failed_attempts_since_last_success = 0
+                return
+
+            # Failed attempt
+            # case 1: if max retries are exhausted mark as failed and break out, retry indefinitely if max_retries is less than 0
+            if (
+                self._max_retries >= 0
+                and failed_attempts_since_last_success >= self._max_retries
+            ):
+                await self._record_final_failure(
+                    num_failed_events=int(num_events_in_batch),
+                    duration=float(duration),
+                )
+                return
+
+            # case 2: max retries not exhausted, increment failed attempts counter and add latency to failure list, retry publishing batch with backoff
+            failed_attempts_since_last_success += 1
+            await self._record_retry_failure(
+                duration=float(duration),
+                failed_attempts=int(failed_attempts_since_last_success),
+            )
+
+            await self._async_sleep_with_backoff(failed_attempts_since_last_success)
+
+    async def _async_sleep_with_backoff(self, attempt: int) -> None:
+        """Sleep with exponential backoff and optional jitter.
+
+        Args:
+            attempt: The current attempt number (0-based)
+        """
+        delay = min(
+            self._max_backoff,
+            self._initial_backoff * (2**attempt),
+        )
+        if self._jitter_ratio > 0:
+            jitter = delay * self._jitter_ratio
+            delay = max(0.0, random.uniform(delay - jitter, delay + jitter))
+        await asyncio.sleep(delay)
+
+    async def _record_success(
+        self, num_published: int, num_filtered: int, duration: float
+    ) -> None:
+        """Update in-memory stats and Prometheus metrics for a successful publish."""
+        if num_published > 0:
+            metric_recorder.set_metric_value(
+                published_counter_name,
+                self._common_metric_tags,
+                int(num_published),
+            )
+        if num_filtered > 0:
+            metric_recorder.set_metric_value(
+                filtered_counter_name, self._common_metric_tags, int(num_filtered)
+            )
+        metric_recorder.set_metric_value(
+            consecutive_failures_gauge_name, self._common_metric_tags, 0
+        )
+        metric_recorder.set_metric_value(
+            time_since_last_success_gauge_name, self._common_metric_tags, 0
+        )
+        metric_recorder.set_metric_value(
+            publish_latency_hist_name,
+            {**self._common_metric_tags, "Outcome": "success"},
+            float(duration),
+        )
+
+    async def _record_retry_failure(
+        self, duration: float, failed_attempts: int
+    ) -> None:
+        """Update Prometheus metrics for a retryable failure attempt."""
+        metric_recorder.set_metric_value(
+            consecutive_failures_gauge_name,
+            self._common_metric_tags,
+            int(failed_attempts),
+        )
+        metric_recorder.set_metric_value(
+            publish_latency_hist_name,
+            {**self._common_metric_tags, "Outcome": "failure"},
+            float(duration),
+        )
+
+    async def _record_final_failure(
+        self, num_failed_events: int, duration: float
+    ) -> None:
+        """Update in-memory stats and Prometheus metrics for a final (non-retryable) failure."""
+        if num_failed_events > 0:
+            metric_recorder.set_metric_value(
+                failed_counter_name,
+                self._common_metric_tags,
+                int(num_failed_events),
+            )
+        metric_recorder.set_metric_value(
+            consecutive_failures_gauge_name, self._common_metric_tags, 0
+        )
+        metric_recorder.set_metric_value(
+            publish_latency_hist_name,
+            {**self._common_metric_tags, "Outcome": "failure"},
+            float(duration),
+        )
+
+
+class NoopPublisher(RayEventPublisherInterface):
+    """A no-op publisher that adheres to the minimal interface used by AggregatorAgent.
+
+    Used when a destination is disabled. It runs forever but does nothing.
+    """
+
+    async def run_forever(self) -> None:
+        """Run forever doing nothing until cancellation."""
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            logger.info("NoopPublisher cancelled")
+            raise
+
+    async def wait_until_running(self, timeout: Optional[float] = None) -> bool:
+        return True

--- a/python/ray/dashboard/modules/aggregator/publisher/ray_event_publisher.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/ray_event_publisher.py
@@ -111,14 +111,13 @@ class RayEventPublisher(RayEventPublisherInterface):
                 await self._async_publish_with_retries(publish_batch)
         except asyncio.CancelledError:
             logger.info(f"Publisher {self._name} cancelled, shutting down gracefully")
-            self._started_event.clear()
-            await self._publish_client.close()
             raise
         except Exception as e:
             logger.error(f"Publisher {self._name} encountered error: {e}")
+            raise
+        finally:
             self._started_event.clear()
             await self._publish_client.close()
-            raise
 
     async def wait_until_running(self, timeout: Optional[float] = None) -> bool:
         """Wait until the publisher has started.

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -47,6 +47,9 @@ from ray.core.generated.events_task_execution_event_pb2 import (
 from ray.core.generated.events_task_profile_events_pb2 import TaskProfileEvents
 from ray.core.generated.profile_events_pb2 import ProfileEventEntry, ProfileEvents
 from ray.dashboard.modules.aggregator.aggregator_agent import AggregatorAgent
+from ray.dashboard.modules.aggregator.publisher.configs import (
+    PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS,
+)
 from ray.dashboard.tests.conftest import *  # noqa
 
 _EVENT_AGGREGATOR_AGENT_TARGET_PORT = find_free_port()
@@ -125,8 +128,9 @@ def test_aggregator_agent_http_target_not_enabled(
 ):
     dashboard_agent = MagicMock()
     dashboard_agent.events_export_addr = export_addr
+    dashboard_agent.session_name = "test_session"
+    dashboard_agent.ip = "127.0.0.1"
     agent = AggregatorAgent(dashboard_agent)
-    assert agent._event_http_target_enabled == expected_http_target_enabled
     assert agent._event_processing_enabled == expected_event_processing_enabled
 
 
@@ -834,6 +838,58 @@ def test_aggregator_agent_receive_driver_job_lifecycle_event(
         req_json[0]["driverJobLifecycleEvent"]["stateTransitions"][1]["state"]
         == "FINISHED"
     )
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": {
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "False",
+                "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_http_svc_publish_disabled(
+    ray_start_cluster_head_with_env_vars, httpserver, fake_timestamp
+):
+    cluster = ray_start_cluster_head_with_env_vars
+    stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[
+                RayEvent(
+                    event_id=b"10",
+                    source_type=RayEvent.SourceType.CORE_WORKER,
+                    event_type=RayEvent.EventType.TASK_DEFINITION_EVENT,
+                    timestamp=fake_timestamp[0],
+                    severity=RayEvent.Severity.INFO,
+                    message="should not be sent",
+                ),
+            ],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    stub.AddEvents(request)
+
+    with pytest.raises(
+        RuntimeError, match="The condition wasn't met before the timeout expired."
+    ):
+        # Wait for up to 2 seconds (publish interval + 1second buffer) to ensure that the event is never published to the external HTTP service
+        wait_for_condition(
+            lambda: len(httpserver.log) > 0,
+            1 + PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS,
+        )
+
+    assert len(httpserver.log) == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/aggregator/tests/test_multi_consumer_event_buffer.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_multi_consumer_event_buffer.py
@@ -1,0 +1,239 @@
+import asyncio
+import random
+import sys
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.dashboard.modules.aggregator.multi_consumer_event_buffer import (
+    MultiConsumerEventBuffer,
+)
+
+
+def _create_test_event(
+    event_id: bytes = b"test",
+    event_type_enum=RayEvent.EventType.TASK_DEFINITION_EVENT,
+    message: str = "test message",
+):
+    """Helper function to create a test RayEvent."""
+    event = RayEvent()
+    event.event_id = event_id
+    event.source_type = RayEvent.SourceType.CORE_WORKER
+    event.event_type = event_type_enum
+    event.severity = RayEvent.Severity.INFO
+    event.message = message
+    event.session_name = "test_session"
+
+    # Set timestamp
+    timestamp = Timestamp()
+    timestamp.GetCurrentTime()
+    event.timestamp.CopyFrom(timestamp)
+
+    return event
+
+
+class TestMultiConsumerEventBuffer:
+    @pytest.mark.asyncio
+    async def test_add_and_consume_event_basic(self):
+        """Test basic event addition."""
+        buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=5)
+        consumer_name = "test_consumer"
+        await buffer.register_consumer(consumer_name)
+        assert await buffer.size() == 0
+
+        event = _create_test_event(b"event1")
+        await buffer.add_event(event)
+
+        assert await buffer.size() == 1
+
+        batch = await buffer.wait_for_batch(consumer_name, timeout_seconds=0)
+        assert len(batch) == 1
+        assert batch[0] == event
+
+    @pytest.mark.asyncio
+    async def test_add_event_buffer_overflow(self):
+        """Test buffer overflow behavior and eviction logic."""
+        buffer = MultiConsumerEventBuffer(max_size=3, max_batch_size=2)
+        consumer_name = "test_consumer"
+        await buffer.register_consumer(consumer_name)
+
+        # Add events to fill buffer
+        events = []
+        event_types = [
+            RayEvent.EventType.TASK_DEFINITION_EVENT,
+            RayEvent.EventType.TASK_EXECUTION_EVENT,
+            RayEvent.EventType.ACTOR_TASK_DEFINITION_EVENT,
+        ]
+        for i in range(3):
+            event = _create_test_event(f"event{i}".encode(), event_types[i])
+            events.append(event)
+            await buffer.add_event(event)
+
+        assert await buffer.size() == 3
+
+        # Add one more event to trigger eviction
+        overflow_event = _create_test_event(
+            b"overflow", RayEvent.EventType.TASK_PROFILE_EVENT
+        )
+        await buffer.add_event(overflow_event)
+
+        assert await buffer.size() == 3  # Still max size
+
+    @pytest.mark.asyncio
+    async def test_wait_for_batch_multiple_events(self):
+        """Test waiting for batch when multiple events are immediately available and when when not all events are available."""
+        buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=3)
+        consumer_name = "test_consumer"
+        await buffer.register_consumer(consumer_name)
+
+        # Add multiple events
+        events = []
+        for i in range(5):
+            event = _create_test_event(f"event{i}".encode())
+            events.append(event)
+            await buffer.add_event(event)
+
+        # Should get max_batch_size events immediately
+        batch = await buffer.wait_for_batch(consumer_name, timeout_seconds=0.1)
+        assert len(batch) == 3  # max_batch_size
+        assert batch == events[:3]
+        # should now get the leftover events (< max_batch_size)
+        batch = await buffer.wait_for_batch(consumer_name, timeout_seconds=0.1)
+        assert len(batch) == 2
+        assert batch == events[3:]
+
+    @pytest.mark.asyncio
+    async def test_wait_for_batch_unknown_consumer(self):
+        """Test error handling for unknown consumer."""
+        buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=5)
+
+        with pytest.raises(KeyError, match="unknown consumer"):
+            await buffer.wait_for_batch("nonexistent_consumer", timeout_seconds=0)
+
+    @pytest.mark.asyncio
+    async def test_register_consumer_duplicate(self):
+        """Test error handling for duplicate consumer registration."""
+        buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=5)
+        consumer_name = "test_consumer"
+        await buffer.register_consumer(consumer_name)
+        with pytest.raises(
+            ValueError, match="consumer 'test_consumer' already registered"
+        ):
+            await buffer.register_consumer(consumer_name)
+
+    @pytest.mark.asyncio
+    async def test_multiple_consumers_independent_cursors(self):
+        """Test that multiple consumers have independent cursors."""
+        buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=2)
+        consumer_name_1 = "test_consumer_1"
+        consumer_name_2 = "test_consumer_2"
+        await buffer.register_consumer(consumer_name_1)
+        await buffer.register_consumer(consumer_name_2)
+
+        # Add events
+        events = []
+        for i in range(10):
+            event = _create_test_event(f"event{i}".encode())
+            events.append(event)
+            await buffer.add_event(event)
+
+        # Consumer 1 reads first batch
+        batch1 = await buffer.wait_for_batch(consumer_name_1, timeout_seconds=0.1)
+        assert batch1 == events[:2]
+
+        # Consumer 2 reads from beginning
+        batch2 = await buffer.wait_for_batch(consumer_name_2, timeout_seconds=0.1)
+        assert batch2 == events[:2]
+
+        # consumer 1 reads another batch
+        batch3 = await buffer.wait_for_batch(consumer_name_1, timeout_seconds=0.1)
+        assert batch3 == events[2:4]
+
+        # more events are added leading to events not consumed by consumer 2 getting evicted
+        # 4 events get evicted, consumer 1 has processed all 4 evicted events previously
+        # but consumer 2 has only processed 2 out of the 4 evicted events
+        for i in range(4):
+            event = _create_test_event(f"event{i + 10}".encode())
+            events.append(event)
+            await buffer.add_event(event)
+
+        # Just ensure buffer remains at max size
+        assert await buffer.size() == 10
+
+        # consumer 1 will read the next 2 events, not affected by the evictions
+        # consumer 1's cursor is adjusted internally to account for the evicted events
+        batch4 = await buffer.wait_for_batch(consumer_name_1, timeout_seconds=0.1)
+        assert batch4 == events[4:6]
+
+        # consumer 2 will read 2 events, skipping the evicted events
+        batch5 = await buffer.wait_for_batch(consumer_name_2, timeout_seconds=0.1)
+        assert batch5 == events[4:6]  # events[2:4] are lost
+
+    @pytest.mark.asyncio
+    async def test_wait_for_batch_blocks_until_event_available(self):
+        """Test that wait_for_batch blocks until at least one event is available."""
+        buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=5)
+        consumer_name = "test_consumer"
+        await buffer.register_consumer(consumer_name)
+
+        # Start waiting for batch (should block)
+        async def wait_for_batch():
+            return await buffer.wait_for_batch(consumer_name, timeout_seconds=2.0)
+
+        wait_task = asyncio.create_task(wait_for_batch())
+
+        # Wait a bit to ensure the task is waiting
+        await asyncio.sleep(4.0)
+        assert not wait_task.done()
+
+        # Add an event
+        event = _create_test_event(b"event1")
+        await buffer.add_event(event)
+
+        # Now the task should complete
+        batch = await wait_task
+        assert len(batch) == 1
+        assert batch[0] == event
+
+    @pytest.mark.asyncio
+    async def test_concurrent_producer_consumer_random_sleeps_with_overall_timeout(
+        self,
+    ):
+        """Producer with random sleeps and consumer reading until all events are received.
+
+        Uses an overall asyncio timeout to ensure the test fails if it hangs
+        before consuming all events.
+        """
+        total_events = 40
+        max_batch_size = 2
+        buffer = MultiConsumerEventBuffer(max_size=100, max_batch_size=max_batch_size)
+        consumer_name = "test_consumer"
+        await buffer.register_consumer(consumer_name)
+
+        produced_events = []
+        consumed_events = []
+
+        random.seed(0)
+
+        async def producer():
+            for i in range(total_events):
+                event = _create_test_event(f"e{i}".encode())
+                produced_events.append(event)
+                await buffer.add_event(event)
+                await asyncio.sleep(random.uniform(0.0, 0.02))
+
+        async def consumer():
+            while len(consumed_events) < total_events:
+                batch = await buffer.wait_for_batch(consumer_name, timeout_seconds=0.1)
+                consumed_events.extend(batch)
+
+        # The test should fail if this times out before all events are consumed
+        await asyncio.wait_for(asyncio.gather(producer(), consumer()), timeout=5.0)
+
+        assert len(consumed_events) == total_events
+        assert consumed_events == produced_events
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dashboard/modules/aggregator/tests/test_multi_consumer_event_buffer.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_multi_consumer_event_buffer.py
@@ -234,6 +234,37 @@ class TestMultiConsumerEventBuffer:
         assert len(consumed_events) == total_events
         assert consumed_events == produced_events
 
+    @pytest.mark.asyncio
+    async def test_events_are_evicted_once_consumed_by_all_consumers(self):
+        """Test events are evicted from the buffer once they are consumed by all consumers"""
+        buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=2)
+        consumer_name_1 = "test_consumer_1"
+        consumer_name_2 = "test_consumer_2"
+        await buffer.register_consumer(consumer_name_1)
+        await buffer.register_consumer(consumer_name_2)
+
+        # Add events
+        events = []
+        for i in range(10):
+            event = _create_test_event(f"event{i}".encode())
+            events.append(event)
+            await buffer.add_event(event)
+
+        assert await buffer.size() == 10
+        # Consumer 1 reads first batch
+        batch1 = await buffer.wait_for_batch(consumer_name_1, timeout_seconds=0.1)
+        assert batch1 == events[:2]
+
+        # buffer size does not change as consumer 2 is yet to consume these events
+        assert await buffer.size() == 10
+
+        # Consumer 2 reads from beginning
+        batch2 = await buffer.wait_for_batch(consumer_name_2, timeout_seconds=0.1)
+        assert batch2 == events[:2]
+
+        # size reduces by 2 as both consumers have consumed 2 events
+        assert await buffer.size() == 8
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dashboard/modules/aggregator/tests/test_ray_event_publisher.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_ray_event_publisher.py
@@ -1,0 +1,164 @@
+import asyncio
+import sys
+import uuid
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from ray._common.test_utils import async_wait_for_condition
+from ray.core.generated import events_base_event_pb2
+from ray.dashboard.modules.aggregator.multi_consumer_event_buffer import (
+    MultiConsumerEventBuffer,
+)
+from ray.dashboard.modules.aggregator.publisher.async_publisher_client import (
+    PublisherClientInterface,
+    PublishStats,
+)
+from ray.dashboard.modules.aggregator.publisher.ray_event_publisher import (
+    NoopPublisher,
+    RayEventPublisher,
+)
+
+
+class MockPublisherClient(PublisherClientInterface):
+    """Test implementation of PublisherClientInterface."""
+
+    def __init__(
+        self,
+        batch_size: int = 1,
+        side_effect=lambda batch: PublishStats(True, 1, 0),
+    ):
+        self.batch_size = batch_size
+        self.publish_calls = []
+        self._side_effect = side_effect
+
+    async def publish(self, batch) -> PublishStats:
+        self.publish_calls.append(batch)
+        return self._side_effect(batch)
+
+    def count_num_events_in_batch(self, batch) -> int:
+        return self.batch_size
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def base_kwargs():
+    """Common kwargs for publisher initialization."""
+    return {
+        "name": "test",
+        "max_retries": 2,
+        "initial_backoff": 0,
+        "max_backoff": 0,
+        "jitter_ratio": 0,
+        "enable_publisher_stats": True,
+    }
+
+
+class TestRayEventPublisher:
+    """Test the main RayEventsPublisher functionality."""
+
+    @pytest.mark.asyncio
+    async def test_publish_with_retries_failure_then_success(self, base_kwargs):
+        """Test publish that fails then succeeds."""
+        call_count = {"count": 0}
+
+        # fail the first publish call but succeed on retry
+        def side_effect(batch):
+            call_count["count"] += 1
+            if call_count["count"] == 1:
+                return PublishStats(False, 0, 0)
+            return PublishStats(True, 1, 0)
+
+        client = MockPublisherClient(side_effect=side_effect)
+        event_buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=10)
+        publisher = RayEventPublisher(
+            name=base_kwargs["name"] + str(uuid.uuid4()),
+            publish_client=client,
+            event_buffer=event_buffer,
+            max_retries=base_kwargs["max_retries"],
+            initial_backoff=base_kwargs["initial_backoff"],
+            max_backoff=base_kwargs["max_backoff"],
+            jitter_ratio=base_kwargs["jitter_ratio"],
+        )
+
+        task = asyncio.create_task(publisher.run_forever())
+        try:
+            # ensure consumer is registered
+            assert await publisher.wait_until_running(2.0)
+            # Enqueue one event into buffer
+            e = events_base_event_pb2.RayEvent(
+                event_id=b"1",
+                source_type=events_base_event_pb2.RayEvent.SourceType.CORE_WORKER,
+                event_type=events_base_event_pb2.RayEvent.EventType.TASK_DEFINITION_EVENT,
+                timestamp=Timestamp(seconds=123, nanos=0),
+                severity=events_base_event_pb2.RayEvent.Severity.INFO,
+                message="hello",
+            )
+            await event_buffer.add_event(e)
+
+            # wait for two publish attempts (failure then success)
+            await async_wait_for_condition(lambda: len(client.publish_calls) == 2)
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_publish_with_retries_max_retries_exceeded(self, base_kwargs):
+        """Test publish that fails all retries and records failed events."""
+        client = MockPublisherClient(
+            side_effect=lambda batch: PublishStats(False, 0, 0)
+        )
+        event_buffer = MultiConsumerEventBuffer(max_size=10, max_batch_size=10)
+        publisher = RayEventPublisher(
+            name=base_kwargs["name"] + str(uuid.uuid4()),
+            publish_client=client,
+            event_buffer=event_buffer,
+            max_retries=2,  # override to finite retries
+            initial_backoff=0,
+            max_backoff=0,
+            jitter_ratio=0,
+        )
+
+        task = asyncio.create_task(publisher.run_forever())
+        try:
+            # ensure consumer is registered
+            assert await publisher.wait_until_running(2.0)
+            e = events_base_event_pb2.RayEvent(
+                event_id=b"1",
+                source_type=events_base_event_pb2.RayEvent.SourceType.CORE_WORKER,
+                event_type=events_base_event_pb2.RayEvent.EventType.TASK_DEFINITION_EVENT,
+                timestamp=Timestamp(seconds=123, nanos=0),
+                severity=events_base_event_pb2.RayEvent.Severity.INFO,
+                message="hello",
+            )
+            await event_buffer.add_event(e)
+
+            # wait for publish attempts (initial + 2 retries)
+            await async_wait_for_condition(lambda: len(client.publish_calls) == 3)
+            assert len(client.publish_calls) == 3
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+
+class TestNoopPublisher:
+    """Test no-op publisher implementation."""
+
+    @pytest.mark.asyncio
+    async def test_all_methods_noop(self):
+        """Test that run_forever can be cancelled and metrics return expected values."""
+        publisher = NoopPublisher()
+
+        # Start and cancel run_forever
+        task = asyncio.create_task(publisher.run_forever())
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
this pr reapplies https://github.com/ray-project/ray/commit/948a425f05a7d219ab0c2c6a3123c8b4ca180cf3 which was reverted in https://github.com/ray-project/ray/pull/57013. this pr has some improvements to ensure that memory utilisation matches what we see today in master.

memory usage when running release test with this branch: `agent_stress_test.aws `
<img width="1711" height="1071" alt="image" src="https://github.com/user-attachments/assets/3a1aa791-2adc-476e-8eba-a660e8ba028e" />

job: https://buildkite.com/ray-project/release/builds/60997#01999e2c-9566-4ef1-a466-d52ece7f27d6
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the aggregator agent to an async, buffered publisher architecture with OpenTelemetry metrics, new configs, and updated tests.
> 
> - **Aggregator Agent (async redesign)**:
>   - Replace thread/queue-based `AggregatorAgent` with async batching via `MultiConsumerEventBuffer` and a shared `ThreadPoolExecutor` for CPU-bound work.
>   - Add HTTP publishing pipeline using `RayEventPublisher` + `AsyncHttpPublisherClient`; support disabling via `RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE`.
>   - Move to OpenTelemetry metrics; register counters for events received/buffer failures and use common tags.
> - **New components**:
>   - `constants.py`: `AGGREGATOR_AGENT_METRIC_PREFIX`, `CONSUMER_TAG_KEY`.
>   - `multi_consumer_event_buffer.py`: async, multi-consumer buffer with eviction accounting per consumer.
>   - `publisher/`: `configs.py` (timeouts/backoff), `metrics.py` (publish counters/histogram/gauges), `async_publisher_client.py`, `ray_event_publisher.py` (retry/backoff loop, NoopPublisher).
> - **Metrics**:
>   - Update/rename metrics to `ray_aggregator_agent_*` and add per-consumer labels; add latency histogram and failure gauges; queue drop counter.
> - **Configs/Env**:
>   - New envs for publisher timeouts, backoff, retries, send interval; rename thread-pool setting to `THREAD_POOL_EXECUTOR_MAX_WORKERS`.
> - **Tests**:
>   - Update `test_aggregator_agent.py` for new enable/disable behavior and session/ip tags; add test for HTTP publish disabled.
>   - Add unit tests for `MultiConsumerEventBuffer` and `RayEventPublisher`.
>   - Adjust `test_metrics_agent.py` to assert new metric names and per-consumer tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11fead9fece0c113c2cd258cd2a4e63115826f9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->