### PR TITLE
[release] allowing py310 for gpu byod release tests

### DIFF
--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -260,8 +260,8 @@ def validate_test(test: Test, schema: Optional[Dict] = None) -> Optional[str]:
 def validate_byod_type(byod_type: str, python_version: str) -> None:
     if byod_type not in ALLOWED_BYOD_TYPES:
         raise Exception(f"Invalid BYOD type: {byod_type}")
-    if byod_type == "gpu" and python_version != "3.9":
-        raise Exception("GPU BYOD tests must use Python 3.9")
+    if byod_type == "gpu" and python_version not in ["3.9", "3.10"]:
+        raise Exception("GPU BYOD tests must use Python 3.9 or 3.10")
     if byod_type == "llm-cu124" and python_version != "3.11":
         raise Exception("LLM BYOD tests must use Python 3.11")
     if byod_type in ["cpu", "cu123"] and python_version not in [

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -92,6 +92,57 @@ def test_parse_test_definition():
         parse_test_definition([invalid_test_definition])
 
 
+def test_parse_test_definition_with_python_version():
+    """
+    Unit test for the ray_release.config.parse_test_definition function. In particular,
+    we check that the code correctly parse a test definition that have the 'variations' & 'python'
+    field.
+    """
+    test_definitions = yaml.safe_load(
+        """
+        - name: sample_test
+          working_dir: sample_dir
+          frequency: nightly
+          team: sample
+          python: "3.10"
+          cluster:
+            byod:
+              type: gpu
+            cluster_compute: compute.yaml
+          run:
+            timeout: 100
+            script: python script.py
+          variations:
+            - __suffix__: aws
+            - __suffix__: gce
+              cluster:
+                cluster_compute: compute_gce.yaml
+    """
+    )
+    # Check that parsing returns two tests, one for each variation (aws and gce). Check
+    # that both tests are valid, and their fields are populated correctly
+    tests = parse_test_definition(test_definitions)
+    aws_test = tests[0]
+    gce_test = tests[1]
+    schema = load_schema_file()
+    assert not validate_test(aws_test, schema)
+    assert not validate_test(gce_test, schema)
+    assert aws_test["name"] == "sample_test.aws"
+    assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
+    assert gce_test["cluster"]["byod"]["type"] == "gpu"
+    invalid_test_definition = test_definitions[0]
+    # Intentionally make the test definition invalid by create an empty 'variations'
+    # field. Check that the parser throws exception at runtime
+    invalid_test_definition["variations"] = []
+    with pytest.raises(ReleaseTestConfigError):
+        parse_test_definition([invalid_test_definition])
+    # Intentionally make the test definition invalid by making one 'variation' entry
+    # missing the __suffix__ entry. Check that the parser throws exception at runtime
+    invalid_test_definition["variations"] = [{"__suffix__": "aws"}, {}]
+    with pytest.raises(ReleaseTestConfigError):
+        parse_test_definition([invalid_test_definition])
+
+
 def test_parse_test_definition_with_defaults():
     test_definitions = yaml.safe_load(
         """


### PR DESCRIPTION
allowing for gpu tagged byod images to run on python 3.10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Permits `gpu` BYOD tests on Python 3.10 (in addition to 3.9) and adds a unit test covering parsing with a `python` field and variations.
> 
> - **Config/Validation**:
>   - Update `validate_byod_type` in `release/ray_release/config.py` to accept `python` versions `3.9` or `3.10` for `gpu` BYOD; adjust error message accordingly.
> - **Tests**:
>   - Add `test_parse_test_definition_with_python_version` in `release/ray_release/tests/test_config.py` to verify parsing of tests with `variations` and a `python` field, including validation and error handling for malformed variations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25ab457773816b7796f04fcca94b734acbb0caa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->