### PR TITLE
[core] Modify test expectations for test_actor_failures.py::test_exit_actor_queued 

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -1183,14 +1183,18 @@ def test_exit_actor_queued(shutdown_only):
     a = RegressionAsync.remote()
     a.f.remote()
     refs = [a.ping.remote() for _ in range(10000)]
-    with pytest.raises(ray.exceptions.RayActorError) as exc_info:
+    with pytest.raises(
+        (ray.exceptions.RayActorError, ray.exceptions.TaskCancelledError)
+    ) as exc_info:
         ray.get(refs)
     assert " Worker unexpectedly exits" not in str(exc_info.value)
 
     # Test a sync case.
     a = RegressionSync.remote()
     a.f.remote()
-    with pytest.raises(ray.exceptions.RayActorError) as exc_info:
+    with pytest.raises(
+        (ray.exceptions.RayActorError, ray.exceptions.TaskCancelledError)
+    ) as exc_info:
         ray.get([a.ping.remote() for _ in range(10000)])
     assert " Worker unexpectedly exits" not in str(exc_info.value)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Seems like test_actor_failures.py::test_exit_actor_queued need's to have it's test expectation adjusted after #56159 since pending actor tasks are explicilty cancelled with a TaskCancelledError now. RayActorError can still pop up for the ongoing task that was cancelled so need to account for both. 

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #44058 #52130 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update test expectations to accept either RayActorError or TaskCancelledError when queued actor tasks are canceled after exit_actor.
> 
> - **Tests**:
>   - Adjust `python/ray/tests/test_actor_failures.py`
>     - Update `test_exit_actor_queued` to expect `(ray.exceptions.RayActorError, ray.exceptions.TaskCancelledError)` for both async and sync cases when calling `ray.get` on queued `ping` tasks after `exit_actor()`.
>     - Still asserts error message does not contain `" Worker unexpectedly exits"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b67ba3afe82e436a911dd98d6837b056a8054766. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->