### PR TITLE
[Data] Fix split_blocks produce empty blocks 

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -814,6 +814,8 @@ def _split_blocks(blocks: Iterable[Block], split_factor: float) -> Iterable[Bloc
         offset = 0
         split_sizes = _splitrange(block.num_rows(), split_factor)
         for size in split_sizes:
+            if size <= 0:
+                continue
             yield block.slice(offset, offset + size, copy=False)
             offset += size
 

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -367,7 +367,7 @@ def test_empty_dataset(ray_start_regular_shared):
     ds = ds.materialize()
     assert (
         str(ds)
-        == "MaterializedDataset(num_blocks=2, num_rows=0, schema=Unknown schema)"
+        == "MaterializedDataset(num_blocks=1, num_rows=0, schema=Unknown schema)"
     )
 
     # Test map on empty dataset.

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -1201,7 +1201,10 @@ def test_map_estimated_blocks_split():
 
     min_rows_per_bundle = 10
     input_op = InputDataBuffer(
-        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+        DataContext.get_current(),
+        make_ref_bundles(
+            [[i, i + 1] for i in range(100)]
+        ),  # create 2-row blocks so split_blocks can split into 2 blocks
     )
 
     def yield_five(block_iter: Iterable[Block], ctx) -> Iterable[Block]:

--- a/python/ray/data/tests/test_splitblocks.py
+++ b/python/ray/data/tests/test_splitblocks.py
@@ -1,8 +1,13 @@
 import numpy as np
+import pyarrow as pa
 import pytest
 
 import ray
-from ray.data._internal.execution.operators.map_operator import _splitrange
+from ray.data._internal.execution.operators.map_operator import (
+    _split_blocks,
+    _splitrange,
+)
+from ray.data.block import BlockAccessor
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.conftest import (
     CoreExecutionMetrics,
@@ -17,6 +22,26 @@ def test_splitrange():
         assert _splitrange(n, k) == [len(a) for a in np.array_split(range(n), k)]
 
     f(0, 1)
+    f(5, 1)
+    f(5, 3)
+    f(5, 5)
+    f(5, 10)
+    f(50, 1)
+    f(50, 2)
+    f(50, 3)
+    f(50, 4)
+    f(50, 5)
+
+
+def test_split_blocks():
+    def f(n, k):
+        table = pa.Table.from_arrays([np.arange(n)], names=["value"])
+        in_blocks = [table]
+        out_blocks = list(_split_blocks(in_blocks, k))
+        sizes = [BlockAccessor.for_block(b).num_rows() for b in out_blocks]
+        expected = [len(a) for a in np.array_split(range(n), min(k, n))]
+        assert sizes == expected
+
     f(5, 1)
     f(5, 3)
     f(5, 5)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The ‎`split_blocks` function didn’t account for cases where the number of rows is smaller than the number of blocks, which resulted in many empty blocks. This change adds a guard to avoid splitting when that would produce empties.
Also added a test for this new behavior.

This will help:
- Reduce the unecessary metadata transfer between operators
- Downstream operators don't need to concern about handling empty blocks
<!-- Please give a short summary of the change and the problem this solves. -->
test script: 
```py
ds1 = ray.data.range(1)
print(ds1.materialize())
```
Before fix : 64 blocks for a row, (which means other 63 block is empty)
```py
MaterializedDataset(num_blocks=64, num_rows=1, schema={id: int64})
```
After fix:
```py
MaterializedDataset(num_blocks=1, num_rows=1, schema={id: int64})
```
## Related issue number
Closes #56879 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoid yield of empty blocks in `_split_blocks`, adjusting expectations and adding tests to validate correct block splitting.
> 
> - **Core**:
>   - `map_operator._split_blocks`: Skip sizes `<= 0` to avoid yielding empty block slices.
> - **Tests**:
>   - `test_splitblocks.py`: Add `test_split_blocks` validating `_split_blocks` matches `np.array_split`; import `pa`, `BlockAccessor`.
>   - `test_consumption.py`: Update empty dataset repr expectation from `num_blocks=2` to `num_blocks=1`.
>   - `test_operators.py`: Adjust `test_map_estimated_blocks_split` to use 2-row input blocks so splitting actually occurs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13c24666e7ad194089651578e6932c8a367a226b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->