### PR TITLE
[core] Stabilize & clean up `single_node_oom` release test

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -1183,14 +1183,18 @@ def test_exit_actor_queued(shutdown_only):
     a = RegressionAsync.remote()
     a.f.remote()
     refs = [a.ping.remote() for _ in range(10000)]
-    with pytest.raises(ray.exceptions.RayActorError) as exc_info:
+    with pytest.raises(
+        (ray.exceptions.RayActorError, ray.exceptions.TaskCancelledError)
+    ) as exc_info:
         ray.get(refs)
     assert " Worker unexpectedly exits" not in str(exc_info.value)
 
     # Test a sync case.
     a = RegressionSync.remote()
     a.f.remote()
-    with pytest.raises(ray.exceptions.RayActorError) as exc_info:
+    with pytest.raises(
+        (ray.exceptions.RayActorError, ray.exceptions.TaskCancelledError)
+    ) as exc_info:
         ray.get([a.ping.remote() for _ in range(10000)])
     assert " Worker unexpectedly exits" not in str(exc_info.value)
 

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -1,75 +1,66 @@
-from math import ceil
-import time
+import argparse
 import random
+import time
+from math import ceil
+from typing import Dict
+
+import numpy as np
 
 import ray
 from ray._private.utils import get_system_memory, get_used_memory
 
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--num-tasks",
+    help="number of tasks to process in total",
+    default="20",
+    type=int,
+)
 
-@ray.remote
+parser.add_argument(
+    "--mem-pct-per-task",
+    help="memory to allocate per task as a fraction of the node's available memory",
+    default="0.45",
+    type=float,
+)
+
+@ray.remote(max_retries=-1)
 def allocate_memory(
-    total_allocate_bytes: int,
+    target_bytes: int,
+    *,
     num_chunks: int = 10,
-    allocate_interval_s: float = 0,
-) -> int:
+    allocate_interval_s: float = 1,
+):
     chunks = []
-    # divide by 8 as each element in the array occupies 8 bytes
-    bytes_per_chunk = total_allocate_bytes / 8 / num_chunks
     for _ in range(num_chunks):
-        chunks.append([0] * ceil(bytes_per_chunk))
+        chunk = np.empty(ceil(target_bytes / num_chunks), dtype=np.uint8)
+        chunk.fill(1)
+        chunks.append(chunk)
 
         # If all tasks try to allocate memory at the same time,
         # the memory monitor might not be able to kill them in time.
-        # To avoid this, we introduce a random sleep interval.
-        r = 1 + 5 * random.random()
-        time.sleep(allocate_interval_s * r)
-    return 1
+        # To avoid this, we introduce jitter in the sleep interval.
+        time.sleep(allocate_interval_s * random.random())
 
 
-def get_additional_bytes_to_reach_memory_usage_pct(pct: float) -> int:
-    total = get_system_memory()
-    used = get_used_memory()
-    bytes_needed = total * pct - used
-    assert bytes_needed > 0, "node has less memory than what is requested"
-    return int(bytes_needed)
+def main(*, num_tasks: int, mem_pct_per_task: float):
+    # First run some warmup tasks before estimating the steady state memory consumption.
+    print(f"Running {num_tasks} warm up tasks, each allocating 100 MiB.")
+    # ray.get([allocate_memory.remote(100 * 1024**2, num_chunks=1) for _ in range(num_tasks)])
+    print("Warm up tasks finished.")
 
+    total_bytes, used_bytes = get_system_memory(), get_used_memory()
+    bytes_per_task = int((total_bytes - used_bytes) * mem_pct_per_task)
+    gib_per_task = bytes_per_task / 1024**3
 
-if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--num-tasks",
-        help="number of tasks to process in total",
-        default="20",
-        type=int,
-    )
-
-    parser.add_argument(
-        "--mem-pct-per-task",
-        help="memory to allocate per task as a fraction of the node's available memory",
-        default="0.45",
-        type=float,
-    )
-
-    args = parser.parse_args()
-
-    cpu_per_task = 1
-
-    bytes_per_task = get_additional_bytes_to_reach_memory_usage_pct(
-        args.mem_pct_per_task
-    )
-
-    start = time.time()
-    task_refs = [
-        allocate_memory.options(num_cpus=cpu_per_task).remote(
-            total_allocate_bytes=bytes_per_task, allocate_interval_s=1
-        )
-        for _ in range(args.num_tasks)
-    ]
     # When a task or actor is killed by the memory monitor
     # it will be retried with exponential backoff.
-    results = [ray.get(ref) for ref in task_refs]
+    start = time.time()
+    print(f"Running {num_tasks} tasks, each allocating {gib_per_task:.2f} GiB.")
+    ray.get([allocate_memory.remote(bytes_per_task) for _ in range(num_tasks)])
     end = time.time()
 
-    print(f"processed {args.num_tasks} tasks in {end-start} seconds")
+    print(f"Tasks completed in {end-start:.2f} seconds.")
+
+if __name__ == "__main__":
+    main(**vars(parser.parse_args()))

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -23,6 +23,7 @@ parser.add_argument(
     type=float,
 )
 
+
 @ray.remote(max_retries=-1)
 def allocate_memory(
     target_bytes: int,
@@ -60,6 +61,7 @@ def main(*, num_tasks: int, mem_pct_per_task: float):
     end = time.time()
 
     print(f"Tasks completed in {end-start:.2f} seconds.")
+
 
 if __name__ == "__main__":
     main(**vars(parser.parse_args()))

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -65,7 +65,9 @@ def main(*, num_tasks: int, mem_pct_per_task: float):
     while len(unready) > 0:
         [ready], unready = ray.wait(unready, num_returns=1)
         assert ray.get(ready) >= bytes_per_task
-        print(f"{num_tasks-len(unready)} / {num_tasks} tasks have completed in {time.time()-start:.2f}s.")
+        print(
+            f"{num_tasks-len(unready)} / {num_tasks} tasks have completed in {time.time()-start:.2f}s."
+        )
 
     end = time.time()
     print(f"All tasks completed in {end-start:.2f} seconds.")

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -46,7 +46,7 @@ def allocate_memory(
     *,
     num_chunks: int = 10,
     allocate_interval_s: float = 5,
-):
+) -> int:
     chunks = []
     total_allocated_bytes = 0
     for _ in range(num_chunks):

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -12,14 +12,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument(
     "--num-tasks",
     help="number of tasks to process in total",
-    default="20",
+    default="10",
     type=int,
 )
 
 parser.add_argument(
     "--mem-pct-per-task",
     help="memory to allocate per task as a fraction of the node's available memory",
-    default="0.45",
+    default="0.4",
     type=float,
 )
 
@@ -29,18 +29,22 @@ def allocate_memory(
     target_bytes: int,
     *,
     num_chunks: int = 10,
-    allocate_interval_s: float = 10,
+    allocate_interval_s: float = 5,
 ):
     chunks = []
+    total_allocated_bytes = 0
     for _ in range(num_chunks):
         chunk = np.empty(ceil(target_bytes / num_chunks), dtype=np.uint8)
         chunk.fill(1)
         chunks.append(chunk)
+        total_allocated_bytes += len(chunk)
 
         # If all tasks try to allocate memory at the same time,
         # the memory monitor might not be able to kill them in time.
         # To avoid this, we introduce jitter in the sleep interval.
         time.sleep(allocate_interval_s * random.random())
+
+    return total_allocated_bytes
 
 
 def main(*, num_tasks: int, mem_pct_per_task: float):
@@ -57,10 +61,14 @@ def main(*, num_tasks: int, mem_pct_per_task: float):
     # it will be retried with exponential backoff.
     start = time.time()
     print(f"Running {num_tasks} tasks, each allocating {gib_per_task:.2f} GiB.")
-    ray.get([allocate_memory.remote(bytes_per_task) for _ in range(num_tasks)])
-    end = time.time()
+    unready = [allocate_memory.remote(bytes_per_task) for _ in range(num_tasks)]
+    while len(unready) > 0:
+        [ready], unready = ray.wait(unready, num_returns=1)
+        assert ray.get(ready) >= bytes_per_task
+        print(f"{num_tasks-len(unready)} / {num_tasks} tasks have completed in {time.time()-start:.2f}s.")
 
-    print(f"Tasks completed in {end-start:.2f} seconds.")
+    end = time.time()
+    print(f"All tasks completed in {end-start:.2f} seconds.")
 
 
 if __name__ == "__main__":

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -24,7 +24,7 @@ parser.add_argument(
 )
 
 
-@ray.remote(max_retries=-1)
+@ray.remote
 def allocate_memory(
     target_bytes: int,
     *,

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -69,7 +69,12 @@ def main(*, num_tasks: int, mem_pct_per_task: float):
     # First run some warmup tasks before estimating the steady state memory consumption.
     warm_up_start = time.time()
     print(f"Running {num_tasks} warm up tasks, each allocating 100 MiB.")
-    ray.get([allocate_memory.remote(100 * 1024**2, num_chunks=1) for _ in range(num_tasks)])
+    ray.get(
+        [
+            allocate_memory.remote(100 * 1024**2, num_chunks=1)
+            for _ in range(num_tasks)
+        ]
+    )
     print(f"Warm up tasks finished in {time.time()-warm_up_start:.2f}s.")
 
     total_bytes, used_bytes = get_system_memory(), get_used_memory()

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -66,7 +66,7 @@ def allocate_memory(
 def main(*, num_tasks: int, mem_pct_per_task: float):
     # First run some warmup tasks before estimating the steady state memory consumption.
     print(f"Running {num_tasks} warm up tasks, each allocating 100 MiB.")
-    # ray.get([allocate_memory.remote(100 * 1024**2, num_chunks=1) for _ in range(num_tasks)])
+    ray.get([allocate_memory.remote(100 * 1024**2, num_chunks=1) for _ in range(num_tasks)])
     print("Warm up tasks finished.")
 
     total_bytes, used_bytes = get_system_memory(), get_used_memory()

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -2,7 +2,6 @@ import argparse
 import random
 import time
 from math import ceil
-from typing import Dict
 
 import numpy as np
 
@@ -29,7 +28,7 @@ def allocate_memory(
     target_bytes: int,
     *,
     num_chunks: int = 10,
-    allocate_interval_s: float = 1,
+    allocate_interval_s: float = 10,
 ):
     chunks = []
     for _ in range(num_chunks):

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -64,10 +64,13 @@ def allocate_memory(
 
 
 def main(*, num_tasks: int, mem_pct_per_task: float):
+    ray.init()
+
     # First run some warmup tasks before estimating the steady state memory consumption.
+    warm_up_start = time.time()
     print(f"Running {num_tasks} warm up tasks, each allocating 100 MiB.")
     ray.get([allocate_memory.remote(100 * 1024**2, num_chunks=1) for _ in range(num_tasks)])
-    print("Warm up tasks finished.")
+    print(f"Warm up tasks finished in {time.time()-warm_up_start:.2f}s.")
 
     total_bytes, used_bytes = get_system_memory(), get_used_memory()
     bytes_per_task = int((total_bytes - used_bytes) * mem_pct_per_task)

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2760,18 +2760,21 @@
   working_dir: nightly_tests
 
   # TODO: https://github.com/ray-project/ray/issues/47596
-  stable: false
+  # XXX: CLOSE ISSUE IF FIXED.
+  # stable: false
 
   frequency: nightly
   team: core
   env: aws_perf
   cluster:
-    byod: {}
+    byod:
+      runtime_env:
+        - RAY_memory_usage_threshold=0.7
     cluster_compute: stress_tests/stress_tests_single_node_oom_compute.yaml
 
   run:
     timeout: 1000
-    script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 20
+    script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 10 --mem-pct-per-task .2
 
   variations:
     - __suffix__: aws
@@ -2780,27 +2783,6 @@
       frequency: manual
       cluster:
         cluster_compute: stress_tests/stress_tests_single_node_oom_compute_gce.yaml
-
-
-- name: tune_air_oom
-  group: core-daily-test
-  working_dir: air_tests
-
-  stable: false
-
-  frequency: nightly
-  team: core
-
-  cluster:
-    byod:
-      runtime_env:
-        - RAY_memory_usage_threshold=0.7
-        - RAY_task_oom_retries=-1
-    cluster_compute: oom/stress_tests_tune_air_oom_compute.yaml
-
-  run:
-    timeout: 3600
-    script: bash oom/tune_air_oom.sh
 
 
 - name: dask_on_ray_1tb_sort

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3733,7 +3733,6 @@
     # leave oom disabled as test is marked unstable at the moment.
     byod:
       runtime_env:
-        # XXX: ??????
         - RAY_memory_monitor_refresh_ms=0
       pip:
         - ray[default]

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2778,7 +2778,16 @@
     script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 64 --mem-pct-per-task .5
 
   variations:
-    - __suffix__: aws
+    - __suffix__: aws0
+    - __suffix__: aws1
+    - __suffix__: aws2
+    - __suffix__: aws3
+    - __suffix__: aws4
+    - __suffix__: aws5
+    - __suffix__: aws6
+    - __suffix__: aws7
+    - __suffix__: aws8
+    - __suffix__: aws9
     - __suffix__: gce
       env: gce
       frequency: manual

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2769,15 +2769,25 @@
   cluster:
     byod:
       runtime_env:
+        # XXX: comment.
         - RAY_memory_usage_threshold=0.7
     cluster_compute: stress_tests/stress_tests_single_node_oom_compute.yaml
 
   run:
     timeout: 1000
-    script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 10 --mem-pct-per-task .2
+    script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 10 --mem-pct-per-task .4
 
   variations:
-    - __suffix__: aws
+    - __suffix__: aws0
+    - __suffix__: aws1
+    - __suffix__: aws2
+    - __suffix__: aws3
+    - __suffix__: aws4
+    - __suffix__: aws5
+    - __suffix__: aws6
+    - __suffix__: aws7
+    - __suffix__: aws8
+    - __suffix__: aws9
     - __suffix__: gce
       env: gce
       frequency: manual
@@ -3723,6 +3733,7 @@
     # leave oom disabled as test is marked unstable at the moment.
     byod:
       runtime_env:
+        # XXX: ??????
         - RAY_memory_monitor_refresh_ms=0
       pip:
         - ray[default]

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2795,6 +2795,27 @@
         cluster_compute: stress_tests/stress_tests_single_node_oom_compute_gce.yaml
 
 
+- name: tune_air_oom
+  group: core-daily-test
+  working_dir: air_tests
+
+  stable: false
+
+  frequency: nightly
+  team: core
+
+  cluster:
+    byod:
+      runtime_env:
+        - RAY_memory_usage_threshold=0.7
+        - RAY_task_oom_retries=-1
+    cluster_compute: oom/stress_tests_tune_air_oom_compute.yaml
+
+  run:
+    timeout: 3600
+    script: bash oom/tune_air_oom.sh
+
+
 - name: dask_on_ray_1tb_sort
   group: core-daily-test
   working_dir: nightly_tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2778,16 +2778,7 @@
     script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 64 --mem-pct-per-task .5
 
   variations:
-    - __suffix__: aws0
-    - __suffix__: aws1
-    - __suffix__: aws2
-    - __suffix__: aws3
-    - __suffix__: aws4
-    - __suffix__: aws5
-    - __suffix__: aws6
-    - __suffix__: aws7
-    - __suffix__: aws8
-    - __suffix__: aws9
+    - __suffix__: aws
     - __suffix__: gce
       env: gce
       frequency: manual

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2759,35 +2759,26 @@
   group: core-daily-test
   working_dir: nightly_tests
 
-  # TODO: https://github.com/ray-project/ray/issues/47596
-  # XXX: CLOSE ISSUE IF FIXED.
-  # stable: false
-
   frequency: nightly
   team: core
   env: aws_perf
   cluster:
     byod:
       runtime_env:
-        # XXX: comment.
+        # Lower the memory usage threshold at which the Ray memory monitor will kill
+        # running tasks so that it does not compete with the system OOM killer.
         - RAY_memory_usage_threshold=0.7
     cluster_compute: stress_tests/stress_tests_single_node_oom_compute.yaml
 
   run:
-    timeout: 1000
-    script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 10 --mem-pct-per-task .4
+    # The script parameters are tuned to run for ~30min.
+    timeout: 3600
+    # The memory allocated per task is tuned along with the `RAY_memory_usage_threshold` setting above
+    # to trigger the Ray memory monitor to kick in before the Ray worker cgroup OOMs.
+    script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 64 --mem-pct-per-task .5
 
   variations:
-    - __suffix__: aws0
-    - __suffix__: aws1
-    - __suffix__: aws2
-    - __suffix__: aws3
-    - __suffix__: aws4
-    - __suffix__: aws5
-    - __suffix__: aws6
-    - __suffix__: aws7
-    - __suffix__: aws8
-    - __suffix__: aws9
+    - __suffix__: aws
     - __suffix__: gce
       env: gce
       frequency: manual


### PR DESCRIPTION
The `single_node_oom` test has been marked "unstable" for over a year. The reason the test was failing is because on Anyscale, the Ray container & its worker processes are run inside of a separate container/cgroup that is configured to consume at most 90% of the host's memory. When the test workload allocated memory above this threshold, it caused the kernel OOM killer to kick in and kill worker processes out of band. The intention of the test is for the Ray memory monitor to kick in instead. This exposes a fundamental issue with the Ray memory monitor and its interaction with the Ray worker cgroup.

To stabilize the test, I've configured the memory monitor to kick in at a lower threshold (70% of the host memory). I've tuned the parameters in the test to cause it to run for ~30mins and set the timeout to ~60min.

Some other improvements along the way:

- Fixed a bug in the calculation for the amount of memory to consume per task.
- Adding a warm up run to improve available memory calculation.
- Improved log statements to understand what's happening during the test.
- Using `numpy` to allocate the memory as a byte array instead of depending on implementation details of Python.

Closes https://github.com/ray-project/ray/issues/47596

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites the memory pressure stress test and tunes the single_node_oom release config (env threshold, params, timeout) to stabilize execution.
> 
> - **Stress test script (`release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py`)**:
>   - Rewrite to allocate with `numpy` (`np.uint8`) in chunks; function now takes `target_bytes`, adds jittered sleeps, and returns total allocated bytes.
>   - Add argparse flags `--num-tasks` and `--mem-pct-per-task`; introduce warm-up run; compute per-task bytes from `get_system_memory()`/`get_used_memory()`; progress via `ray.wait` loop; remove `get_additional_bytes_to_reach_memory_usage_pct`.
> - **Release config (`release/release_tests.yaml`)**:
>   - For `single_node_oom`: set `byod.runtime_env` `RAY_memory_usage_threshold=0.7`, increase `run.timeout` to `3600`, and update script to `--num-tasks 64 --mem-pct-per-task .5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e6690403aac222670bff408d76a064c7ebac40c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->