### PR TITLE
[core] Un-disable memory monitor on autoscaling test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3738,10 +3738,7 @@
   team: core
 
   cluster:
-    # leave oom disabled as test is marked unstable at the moment.
     byod:
-      runtime_env:
-        - RAY_memory_monitor_refresh_ms=0
       pip:
         - ray[default]
     cluster_compute: aws.yaml


### PR DESCRIPTION
Removing the config setting to disable the memory monitor. I don't think this is relevant at all, and was probably a copy-paste error.