### PR TITLE
fix: bug with config key pairs when launching worker nodes

### DIFF
--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -318,12 +318,9 @@ def _configure_key_pair(config):
             private_key_path, ssh_user
         )
 
-    # Convert Path objects to strings to ensure JSON serialization works
     config["auth"]["ssh_private_key"] = str(private_key_path)
-    config["auth"]["ssh_public_key"] = str(public_key_path)
-    if "file_mounts" not in config:
-        config["file_mounts"] = {}
-    config["file_mounts"]["~/.ssh/id_rsa.pub"] = str(public_key_path)
+    # Remove public key path because bootstrap config must only contain paths that exist on head node
+    config["auth"].pop("ssh_public_key", None)
 
     for node_type in config["available_node_types"].values():
         azure_arm_parameters = node_type["node_config"].setdefault(

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -1027,7 +1027,7 @@ def generate_rsa_key_pair():
 
 def generate_ssh_key_paths(key_name):
     public_key_path = os.path.expanduser("~/.ssh/{}.pub".format(key_name))
-    private_key_path = os.path.expanduser("~/.ssh/{}.pem".format(key_name))
+    private_key_path = os.path.expanduser("~/.ssh/{}".format(key_name))
     return public_key_path, private_key_path
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
1. When running `ray up` with automatic key pair generation the head node comes online but worker node VMs are not getting provisioned.
`ray monitor` to look at the auto-scaler logs (from the head node) shows something like:

```bash
2025-09-30 22:33:52,100 ERROR autoscaler.py:215 -- [Errno 2] No such file or directory: '/home/marosset/.ssh/ray-autoscaler_azure_westus2_ray-nightly-cpu-minimal_ubuntu.pub'
Traceback (most recent call last):
  File "/anaconda/envs/ray-env/lib/python3.10/site-packages/ray/autoscaler/v2/autoscaler.py", line 200, in update_autoscaling_state
    return Reconciler.reconcile(
  File "/anaconda/envs/ray-env/lib/python3.10/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 120, in reconcile
    Reconciler._step_next(
  File "/anaconda/envs/ray-env/lib/python3.10/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 275, in _step_next
    Reconciler._scale_cluster(
  File "/anaconda/envs/ray-env/lib/python3.10/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 1112, in _scale_cluster
    node_type_configs=autoscaling_config.get_node_type_configs(),
  File "/anaconda/envs/ray-env/lib/python3.10/site-packages/ray/autoscaler/v2/instance_manager/config.py", line 339, in get_node_type_configs
    launch_config_hash = hash_launch_conf(
  File "/anaconda/envs/ray-env/lib/python3.10/site-packages/ray/autoscaler/_private/util.py", line 442, in hash_launch_conf
    with open(os.path.expanduser(auth[key_type])) as key:
FileNotFoundError: [Errno 2] No such file or directory: '/home/marosset/.ssh/ray-autoscaler_azure_westu

```
Public key is injected into all VMs during creation (Azure ARM template).
Private key is copied to head node for worker SSH access. 
`commands.py` copies everything into bootstrap config except private key. So the bootstrap config must only contain paths that exist on the head node. Since public key path doesn’t exist on head node, we should not add it to config.
This fix stores public key into arm template params and only stores the private key in config which doesn’t get copied onto bootstrap config.


2. Also Azure doesn't utilize .pem.
## Related PR uncovering the bug
https://github.com/ray-project/ray/pull/55719
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
Manually tested this with ray up with the following config and worker nodes come up.
```yaml
# Unique identifier for the head node and workers of this cluster.
cluster_name: nightly-cpu-minimal
max_workers: 2
idle_timeout_minutes: 5

# Cloud-provider specific configuration.
provider:
  type: azure
    # https://azure.microsoft.com/en-us/global-infrastructure/locations
  location: uksouth
  resource_group: ray-keypair-test-uksouth
  cache_stopped_nodes: False

auth:
  ssh_user: ubuntu

available_node_types:
  ray.head.default:
    resources: {"CPU": 2}
    node_config:
      azure_arm_parameters:
        vmSize: Standard_D2s_v3
        imagePublisher: microsoft-dsvm
        imageOffer: ubuntu-2204
        imageSku: 2204-gen2
        imageVersion: latest
  ray.worker.default:
    min_workers: 2
    max_workers: 2
    resources: {"CPU": 2}
    node_config:
      azure_arm_parameters:
        vmSize: Standard_D2s_v3
        imagePublisher: microsoft-dsvm
        imageOffer: ubuntu-2204
        imageSku: 2204-gen2
        imageVersion: latest

# Note: The Ubuntu 20.04 dsvm image has a few venvs already configured but
# they all contain python modules that are not compatible with Ray at the moment.
setup_commands:
    - (which conda && echo 'eval "$(conda shell.bash hook)"' >> ~/.bashrc) || true
    - conda tos accept
    - conda create -n ray-env python=3.10 -y
    - conda activate ray-env && echo 'conda activate ray-env' >> ~/.bashrc
    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl"

file_mounts_sync_continuously: False

file_mounts: {
}

head_setup_commands:
- pip install azure-core==1.35.0 azure-identity==1.23.1 azure-mgmt-compute==35.0.0 azure-mgmt-network==29.0.0 azure-mgmt-resource==24.0.0 azure-common==1.1.28 msrest==0.7.1 msrestazure==0.6.4.post1
```



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `auth.ssh_public_key` from config, injects public key into `azure_arm_parameters`, switches Azure private key path from `*.pem` to no extension, and updates tests.
> 
> - **Azure Autoscaler (SSH keys)**:
>   - Remove `auth["ssh_public_key"]` from config; keep only `auth["ssh_private_key"]` and ensure it is a string.
>   - Inject public key contents into `available_node_types[*].node_config.azure_arm_parameters["publicKey"]`; set `adminUsername`.
>   - Drop adding `~/.ssh/id_rsa.pub` to `file_mounts`.
> - **Key path generation**:
>   - Change private key path from `~/.ssh/<name>.pem` to `~/.ssh/<name>`.
> - **Tests**:
>   - Update Azure path serialization test to assert `ssh_public_key` is removed from `auth`, verify `publicKey` in ARM parameters, and maintain JSON-serializability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca6bf070a83cbf13bdb606d082e4ac92c344bbd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->