### PR TITLE
[Data] Use iterator in write ops instead of accumulating all of the blocks in memory instead

### DIFF
--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -2,8 +2,6 @@ import itertools
 import uuid
 from typing import Callable, Iterator, List, Union
 
-from pandas import DataFrame
-
 from ray.data._internal.compute import TaskPoolStrategy
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
@@ -15,7 +13,7 @@ from ray.data._internal.execution.operators.map_transformer import (
 from ray.data._internal.logical.operators.write_operator import Write
 from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
-from ray.data.datasource.datasink import Datasink, WriteResult
+from ray.data.datasource.datasink import Datasink
 from ray.data.datasource.datasource import Datasource
 
 WRITE_UUID_KWARG_NAME = "write_uuid"

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -21,20 +21,6 @@ from ray.data.datasource.datasource import Datasource
 WRITE_UUID_KWARG_NAME = "write_uuid"
 
 
-def gen_datasink_write_result(
-    write_result_blocks: List[Block],
-) -> WriteResult:
-    assert all(
-        isinstance(block, DataFrame) and len(block) == 1
-        for block in write_result_blocks
-    )
-    total_num_rows = sum(result["num_rows"].sum() for result in write_result_blocks)
-    total_size_bytes = sum(result["size_bytes"].sum() for result in write_result_blocks)
-
-    write_returns = [result["write_return"][0] for result in write_result_blocks]
-    return WriteResult(total_num_rows, total_size_bytes, write_returns)
-
-
 def generate_write_fn(
     datasink_or_legacy_datasource: Union[Datasink, Datasource], **write_args
 ) -> Callable[[Iterator[Block], TaskContext], Iterator[Block]]:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -110,7 +110,7 @@ from ray.data.block import (
 )
 from ray.data.context import DataContext
 from ray.data.datasource import Connection, Datasink, FilenameProvider, SaveMode
-from ray.data.datasource.datasink import WriteResult, gen_datasink_write_result
+from ray.data.datasource.datasink import WriteResult, _gen_datasink_write_result
 from ray.data.datasource.file_datasink import _FileDatasink
 from ray.data.iterator import DataIterator
 from ray.data.random_access_dataset import RandomAccessDataset
@@ -4931,7 +4931,7 @@ class Dataset:
             for bundle in iter_:
                 res = ray.get(bundle.block_refs)
                 # Generate write result report
-                write_results.append(gen_datasink_write_result(res))
+                write_results.append(_gen_datasink_write_result(res))
 
             combined_write_result = WriteResult.combine(*write_results)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -86,7 +86,6 @@ from ray.data._internal.logical.operators.write_operator import Write
 from ray.data._internal.pandas_block import PandasBlockBuilder, PandasBlockSchema
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey
-from ray.data._internal.planner.plan_write_op import gen_datasink_write_result
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.split import _get_num_rows, _split_at_indices
 from ray.data._internal.stats import DatasetStats, DatasetStatsSummary, StatsManager
@@ -111,6 +110,7 @@ from ray.data.block import (
 )
 from ray.data.context import DataContext
 from ray.data.datasource import Connection, Datasink, FilenameProvider, SaveMode
+from ray.data.datasource.datasink import WriteResult, gen_datasink_write_result
 from ray.data.datasource.file_datasink import _FileDatasink
 from ray.data.iterator import DataIterator
 from ray.data.random_access_dataset import RandomAccessDataset
@@ -4931,9 +4931,7 @@ class Dataset:
             for bundle in iter_:
                 res = ray.get(bundle.block_refs)
                 # Generate write result report
-                write_results.append(
-                    gen_datasink_write_result(res)
-                )
+                write_results.append(gen_datasink_write_result(res))
 
             combined_write_result = WriteResult.combine(*write_results)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4929,9 +4929,13 @@ class Dataset:
             write_results = []
 
             for bundle in iter_:
-                write_results.extend(ray.get(bundle.block_refs))
+                res = ray.get(bundle.block_refs)
+                # Generate write result report
+                write_results.append(
+                    gen_datasink_write_result(res)
+                )
 
-            combined_write_result = gen_datasink_write_result(write_results)
+            combined_write_result = WriteResult.combine(*write_results)
 
             logger.info(
                 "Data sink %s finished. %d rows and %s data written.",

--- a/python/ray/data/datasource/datasink.py
+++ b/python/ray/data/datasource/datasink.py
@@ -31,9 +31,7 @@ class WriteResult(Generic[WriteReturnType]):
     def combine(cls, *wrs: "WriteResult") -> "WriteResult":
         num_rows = sum(wr.num_rows for wr in wrs)
         size_bytes = sum(wr.size_bytes for wr in wrs)
-        write_returns = list(
-            itertools.chain(*[wr.write_returns for wr in wrs])
-        )
+        write_returns = list(itertools.chain(*[wr.write_returns for wr in wrs]))
 
         return WriteResult(
             num_rows=num_rows,

--- a/python/ray/data/datasource/datasink.py
+++ b/python/ray/data/datasource/datasink.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 from dataclasses import dataclass
 from typing import Generic, Iterable, List, Optional, TypeVar
@@ -25,6 +26,20 @@ class WriteResult(Generic[WriteReturnType]):
     size_bytes: int
     # All returned values of `Datasink.write`.
     write_returns: List[WriteReturnType]
+
+    @classmethod
+    def combine(cls, *wrs: "WriteResult") -> "WriteResult":
+        num_rows = sum(wr.num_rows for wr in wrs)
+        size_bytes = sum(wr.size_bytes for wr in wrs)
+        write_returns = list(
+            itertools.chain(*[wr.write_returns for wr in wrs])
+        )
+
+        return WriteResult(
+            num_rows=num_rows,
+            size_bytes=size_bytes,
+            write_returns=write_returns,
+        )
 
 
 @DeveloperAPI
@@ -162,3 +177,20 @@ class DummyOutputDatasink(Datasink[None]):
 
     def on_write_failed(self, error: Exception) -> None:
         self.num_failed += 1
+
+
+def gen_datasink_write_result(
+    write_result_blocks: List[Block],
+) -> WriteResult:
+    import pandas as pd
+
+    assert all(
+        isinstance(block, pd.DataFrame) and len(block) == 1
+        for block in write_result_blocks
+    )
+
+    total_num_rows = sum(result["num_rows"].sum() for result in write_result_blocks)
+    total_size_bytes = sum(result["size_bytes"].sum() for result in write_result_blocks)
+
+    write_returns = [result["write_return"][0] for result in write_result_blocks]
+    return WriteResult(total_num_rows, total_size_bytes, write_returns)

--- a/python/ray/data/datasource/datasink.py
+++ b/python/ray/data/datasource/datasink.py
@@ -177,7 +177,7 @@ class DummyOutputDatasink(Datasink[None]):
         self.num_failed += 1
 
 
-def gen_datasink_write_result(
+def _gen_datasink_write_result(
     write_result_blocks: List[Block],
 ) -> WriteResult:
     import pandas as pd


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Changes

Execute as a typical iteration writing and releasing resulting blocks incrementally rather than holding on to them until the whole op completes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Write ops now consume results via an iterator and aggregate per-bundle WriteResult using a new combine API, avoiding accumulating all blocks in memory.
> 
> - **Write Path (Dataset.write_datasink)**:
>   - Switch to streaming execution (`_execute_to_iterator`) to process write results incrementally instead of `ray.get` on all blocks.
>   - Accumulate per-bundle results via `_gen_datasink_write_result` and aggregate with `WriteResult.combine`; log and callback use the combined result.
> - **APIs/Utilities**:
>   - Move write-result aggregation helper to `ray.data.datasource.datasink` as `_gen_datasink_write_result`.
>   - Add `WriteResult.combine(...)` for aggregating multiple write results.
> - **Code Cleanup**:
>   - Remove `gen_datasink_write_result` from `planner/plan_write_op.py` and related imports; adjust imports in `dataset.py` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c5a3738a2d42b51f9e23f7978971677b1b634b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->