### PR TITLE
[Train] Update Checkpoint Manager to use ray._common.pydantic_compat BaseModel import

### DIFF
--- a/python/ray/train/v2/_internal/execution/checkpoint/checkpoint_manager.py
+++ b/python/ray/train/v2/_internal/execution/checkpoint/checkpoint_manager.py
@@ -20,8 +20,9 @@ from ray.train.v2._internal.execution.worker_group import Worker
 from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint
 
 try:
-    from pydantic import BaseModel
     from pydantic_core import from_json
+
+    from ray._common.pydantic_compat import BaseModel
 except (ImportError, ModuleNotFoundError) as exc:
     raise ImportError(
         "`ray.train.v2` requires the pydantic package, which is missing. "


### PR DESCRIPTION
Currently, Ray Train's Checkpoint Manager requires pydantic v2. This PR replaces CheckpointManager's direct BaseModel import to instead use the BaseModel exported by `ray._common.pydantic_compat` in order to make CheckpointManager agnostic to the pydantic version. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 3f0d2b065c1f882164561b457b55b8a7fa0304b9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->