### PR TITLE
[Data] Fixing more flaky tests

### DIFF
--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1938,8 +1938,11 @@ def test_nowarning_execute_with_cpu(ray_start_cluster):
         mock_logger.assert_not_called()
 
 
-def test_per_task_row_limit_basic(ray_start_regular_shared):
+def test_per_task_row_limit_basic(ray_start_regular_shared, restore_data_context):
     """Test basic per-block limiting functionality."""
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
+
     # Simple test that should work with the existing range datasource
     ds = ray.data.range(1000, override_num_blocks=10).limit(50)
     result = ds.take_all()
@@ -2009,8 +2012,13 @@ def test_per_task_row_limit_multiple_blocks_per_task(ray_start_regular_shared):
     assert all_ids == list(range(70))
 
 
-def test_per_task_row_limit_larger_than_data(ray_start_regular_shared):
+def test_per_task_row_limit_larger_than_data(
+    ray_start_regular_shared, restore_data_context
+):
     """Test per-block limiting when limit is larger than available data."""
+
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
 
     total_rows = 50
     ds = ray.data.range(total_rows, override_num_blocks=5)
@@ -2021,8 +2029,13 @@ def test_per_task_row_limit_larger_than_data(ray_start_regular_shared):
     assert [row["id"] for row in result] == list(range(total_rows))
 
 
-def test_per_task_row_limit_exact_block_boundary(ray_start_regular_shared):
+def test_per_task_row_limit_exact_block_boundary(
+    ray_start_regular_shared, restore_data_context
+):
     """Test per-block limiting when limit exactly matches block boundaries."""
+
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
 
     rows_per_block = 20
     num_blocks = 5
@@ -2037,8 +2050,13 @@ def test_per_task_row_limit_exact_block_boundary(ray_start_regular_shared):
 
 
 @pytest.mark.parametrize("limit", [1, 5, 10, 25, 50, 99])
-def test_per_task_row_limit_various_sizes(ray_start_regular_shared, limit):
+def test_per_task_row_limit_various_sizes(
+    ray_start_regular_shared, limit, restore_data_context
+):
     """Test per-block limiting with various limit sizes."""
+
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
 
     total_rows = 100
     num_blocks = 10
@@ -2052,8 +2070,13 @@ def test_per_task_row_limit_various_sizes(ray_start_regular_shared, limit):
     assert [row["id"] for row in result] == list(range(expected_len))
 
 
-def test_per_task_row_limit_with_transformations(ray_start_regular_shared):
+def test_per_task_row_limit_with_transformations(
+    ray_start_regular_shared, restore_data_context
+):
     """Test that per-block limiting works correctly with transformations."""
+
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
 
     # Test with map operation after limit
     ds = ray.data.range(100, override_num_blocks=10)
@@ -2072,8 +2095,11 @@ def test_per_task_row_limit_with_transformations(ray_start_regular_shared):
     assert [row["doubled"] for row in result] == [i * 2 for i in range(20)]
 
 
-def test_per_task_row_limit_with_filter(ray_start_regular_shared):
+def test_per_task_row_limit_with_filter(ray_start_regular_shared, restore_data_context):
     """Test per-block limiting with filter operations."""
+
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
 
     # Filter before limit - per-block limiting should still work at read level
     ds = ray.data.range(200, override_num_blocks=10)
@@ -2111,8 +2137,11 @@ def test_per_task_row_limit_readtask_properties(ray_start_regular_shared):
     assert task_with_limit.per_task_row_limit == 10
 
 
-def test_per_task_row_limit_edge_cases(ray_start_regular_shared):
+def test_per_task_row_limit_edge_cases(ray_start_regular_shared, restore_data_context):
     """Test per-block limiting edge cases."""
+
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
 
     # Test with single row
     ds = ray.data.range(1, override_num_blocks=1).limit(1)

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -199,7 +199,10 @@ def test_split_small(ray_start_regular_shared_2_cpus):
     assert not fail, fail
 
 
-def test_split_at_indices_simple(ray_start_regular_shared_2_cpus):
+def test_split_at_indices_simple(ray_start_regular_shared_2_cpus, restore_data_context):
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
+
     ds = ray.data.range(10, override_num_blocks=3)
 
     with pytest.raises(ValueError):
@@ -263,6 +266,7 @@ def test_split_at_indices_coverage(
     # Test that split_at_indices() creates the expected splits on a set of partition and
     # indices configurations.
 
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
     DataContext.get_current().execution_options.preserve_order = True
 
     ds = ray.data.range(20, override_num_blocks=num_blocks)
@@ -291,8 +295,11 @@ def test_split_at_indices_coverage(
     ],  # Selected three-split cases
 )
 def test_split_at_indices_coverage_complete(
-    ray_start_regular_shared_2_cpus, num_blocks, indices
+    ray_start_regular_shared_2_cpus, num_blocks, indices, restore_data_context
 ):
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
+
     # Test that split_at_indices() creates the expected splits on a set of partition and
     # indices configurations.
     ds = ray.data.range(10, override_num_blocks=num_blocks)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1159,7 +1159,10 @@ def test_dataset_stats_range(ray_start_regular_shared, tmp_path):
     )
 
 
-def test_dataset_split_stats(ray_start_regular_shared, tmp_path):
+def test_dataset_split_stats(ray_start_regular_shared, tmp_path, restore_data_context):
+    # NOTE: It's critical to preserve ordering for assertions in this test to work
+    DataContext.get_current().execution_options.preserve_order = True
+
     ds = ray.data.range(100, override_num_blocks=10).map(
         column_udf("id", lambda x: x + 1)
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Subject

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes several Ray Data tests by adding restore_data_context and forcing ordered execution (preserve_order=True) before assertions.
> 
> - **Tests**:
>   - **Consumption (`test_consumption.py`)**:
>     - Add `restore_data_context` to multiple `per_task_row_limit*` tests and set `DataContext.get_current().execution_options.preserve_order = True` to ensure deterministic results.
>   - **Split (`test_split.py`)**:
>     - Add `restore_data_context` and set `preserve_order = True` for `split_at_indices` coverage tests to make outputs order-stable.
>     - Update simple and complete coverage tests to include the context fixture.
>   - **Stats (`test_stats.py`)**:
>     - Add `restore_data_context` and set `preserve_order = True` in `test_dataset_split_stats` to avoid flaky ordering.
> - Notes: Only test files updated; no production code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baf38290817e771b1b2fcf2f0523e1a45f49057c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->