### PR TITLE
[serve] Fix wait_for_condition in test_custom_autoscaling_metrics.py

### DIFF
--- a/python/ray/serve/tests/test_custom_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_custom_autoscaling_metrics.py
@@ -53,16 +53,15 @@ class TestCustomServeMetrics:
         # Call deployment 3 times
         [handle.remote() for _ in range(3)]
 
-        # Wait for controller to receive new metrics
-        wait_for_condition(
-            lambda: "counter"
-            in get_autoscaling_metrics_from_controller(serve_instance, dep_id),
-            timeout=15,
-        )
-        metrics = get_autoscaling_metrics_from_controller(serve_instance, dep_id)
+        def check_counter_value():
+            metrics = get_autoscaling_metrics_from_controller(serve_instance, dep_id)
+            return "counter" in metrics and metrics["counter"][-1][0].value == 3
 
         # The final counter value recorded by the controller should be 3
-        assert metrics["counter"][-1][0].value == 3
+        wait_for_condition(
+            check_counter_value,
+            timeout=15,
+        )
 
     def test_custom_serve_timeout(self, serve_instance):
         @serve.deployment(


### PR DESCRIPTION
## Why are these changes needed?

Windows tests are failing because of different env vars controlling the metrics push time interval, causing one of the tests to check for an incorrect value. The test is rewritten to check for the eventual value instead so it's more robust.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update test to wait until the controller reports counter == 3 using wait_for_condition, replacing a presence check and separate assert.
> 
> - **Tests (Serve autoscaling metrics)**:
>   - Update `test_custom_serve_metrics` in `python/ray/serve/tests/test_custom_autoscaling_metrics.py` to wait until the controller reports `counter == 3` via `wait_for_condition`, replacing the prior presence check and subsequent assert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 672dd2fe13a5af5df9206770fa8388ac7a97dabb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->