### PR TITLE
[Data] - Initialize datacontext after setting `src_fn_name` in actor worker

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -529,9 +529,9 @@ class _MapWorker:
         logical_actor_id: str,
         actor_location_tracker: ActorLocationTracker,
     ):
-        DataContext._set_current(ctx)
         self.src_fn_name: str = src_fn_name
         self._map_transformer = map_transformer
+        DataContext._set_current(ctx)
         # Initialize state for this actor.
         self._map_transformer.init()
         self._logical_actor_id = logical_actor_id

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -531,6 +531,8 @@ class _MapWorker:
     ):
         self.src_fn_name: str = src_fn_name
         self._map_transformer = map_transformer
+        # Initialize the data context for this actor after setting the src_fn_name in order to not
+        # break __repr__. It's possible that logging setup fails.
         DataContext._set_current(ctx)
         # Initialize state for this actor.
         self._map_transformer.init()


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If logging setup fails (triggered by `DataContext._set_current(ctx)`), then the actor worker is only partially initialized and the `__repr__` call will fail. So this change makes sure that `src_fn_name` is set before setting the data context.

## Related issue number

<!-- For example: "Closes #1234" -->

DATA-1496

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize DataContext after setting `src_fn_name` in `_MapWorker` to prevent `__repr__` issues if logging setup fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc95315dabc37b3da06865f840d6ae97b2ce5ca0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->