### PR TITLE
[ci] install mpi4py from conda-forge channel

### DIFF
--- a/ci/env/install-miniforge.sh
+++ b/ci/env/install-miniforge.sh
@@ -98,7 +98,7 @@ install_miniforge() {
   if [[ "${PYTHON-}" != "3.12" && "${PYTHON-}" != "3.13" ]]; then
     # Install mpi4py as a test dependency for Python <3.12; currently mpi4py is not
     # available for Python 3.12 or 3.13
-    "${WORKSPACE_DIR}"/ci/suppress_output conda install -c anaconda mpi4py -y
+    "${WORKSPACE_DIR}"/ci/suppress_output conda install -c conda-forge --solver=classic mpi4py -y
   fi
 
   command -V python


### PR DESCRIPTION
miniforge works with conda-forge, and can have issues when working with the anaconda channel
