### PR TITLE
[Data] Rebased `get_eligible_operators` onto `has_pending_bundles`

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler.py
@@ -60,8 +60,7 @@ class DefaultClusterAutoscaler(ClusterAutoscaler):
             for _, op_state in self._topology.items()
         )
         any_has_input = any(
-            op_state._pending_dispatch_input_bundles_count() > 0
-            for _, op_state in self._topology.items()
+            op_state.has_pending_bundles() for _, op_state in self._topology.items()
         )
         if not (no_runnable_op and any_has_input):
             return
@@ -86,7 +85,7 @@ class DefaultClusterAutoscaler(ClusterAutoscaler):
             resource_request.extend([task_bundle] * op.num_active_tasks())
             # Only include incremental resource usage for ops that are ready for
             # dispatch.
-            if state._pending_dispatch_input_bundles_count() > 0:
+            if state.has_pending_bundles():
                 # TODO(Clark): Scale up more aggressively by adding incremental resource
                 # usage for more than one bundle in the queue for this op?
                 resource_request.append(task_bundle)

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -102,11 +102,6 @@ class OpBufferQueue:
             with self._lock:
                 return self._num_per_split[output_split_idx] > 0
 
-    def has_valid_next(self) -> bool:
-        """Whether next RefBundle is available and valid."""
-        with self._lock:
-            return self._queue.has_next()
-
     def append(self, ref: RefBundle):
         """Append a RefBundle to the queue."""
         with self._lock:
@@ -276,9 +271,8 @@ class OpState:
         operator across (external) input queues"""
         return sum(len(q) for q in self.input_queues)
 
-    def has_valid_input_bundle(self) -> bool:
-        """Check if the operator has a valid bundle in its input queue."""
-        return any(queue.has_valid_next() for queue in self.input_queues)
+    def has_pending_bundles(self) -> bool:
+        return self._pending_dispatch_input_bundles_count() > 0
 
     def add_output(self, ref: RefBundle) -> None:
         """Move a bundle produced by the operator to its outqueue."""
@@ -289,6 +283,7 @@ class OpState:
             warn=not self._warned_on_schema_divergence,
             enforce_schemas=self.op.data_context.enforce_schemas,
         )
+
         self._schema = ref.schema
         self._warned_on_schema_divergence |= diverged
 
@@ -645,11 +640,7 @@ def get_eligible_operators(
         #   - It's not completed
         #   - It can accept at least one input
         #   - Its input queue has a valid bundle
-        if (
-            not op.completed()
-            and op.should_add_input()
-            and state.has_valid_input_bundle()
-        ):
+        if not op.completed() and op.should_add_input() and state.has_pending_bundles():
             if not in_backpressure:
                 op_runnable = True
                 eligible_ops.append(op)

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -217,7 +217,7 @@ def test_cluster_scaling():
         num_active_tasks=MagicMock(return_value=1),
     )
     op_state1 = MagicMock(
-        _pending_dispatch_input_bundles_count=MagicMock(return_value=0),
+        has_pending_bundles=MagicMock(return_value=False),
         _scheduling_status=MagicMock(
             runnable=False,
         ),
@@ -230,7 +230,7 @@ def test_cluster_scaling():
         num_active_tasks=MagicMock(return_value=1),
     )
     op_state2 = MagicMock(
-        _pending_dispatch_input_bundles_count=MagicMock(return_value=1),
+        has_pending_bundles=MagicMock(return_value=True),
         _scheduling_status=MagicMock(
             runnable=False,
         ),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cleaning up `get_eligible_ops` onto `has_pending_bundles` method.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
