### PR TITLE
[Core] [Azure] skip managed identity auth for Azure when not running on Azure

### DIFF
--- a/python/ray/_common/tests/test_usage_stats.py
+++ b/python/ray/_common/tests/test_usage_stats.py
@@ -1554,17 +1554,31 @@ def test_get_cloud_from_metadata_requests(monkeypatch):
             if "gcp" in error_providers:
                 print("raising")
                 raise requests.exceptions.ConnectionError()
-            mock_response.status_code = 200 if provider == "gcp" else 404
+            mock_response.status_code = 200 if provider == "gcp" else 400
         elif url == "http://169.254.169.254/latest/meta-data/":
             # AWS endpoint
             if "aws" in error_providers:
                 raise requests.exceptions.ConnectionError()
-            mock_response.status_code = 200 if provider == "aws" else 404
-        elif url == "http://169.254.169.254/metadata/instance?api-version=2021-02-01":
+            # Azure IMDS returns 400 (not 404) when queried with AWS endpoint format
+            # because Azure requires the "Metadata: true" header (not sent in AWS queries).
+            # See: https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service#errors-and-debugging
+            if provider == "azure":
+                mock_response.status_code = (
+                    400  # Bad Request (missing headers/wrong path)
+                )
+            else:
+                mock_response.status_code = 200 if provider == "aws" else 404
+        elif url == "http://169.254.169.254/metadata/instance?api-version=2021-12-13":
             # Azure endpoint
             if "azure" in error_providers:
                 raise requests.exceptions.ConnectionError()
-            mock_response.status_code = 200 if provider == "azure" else 404
+            # AWS IMDS returns 404 when queried with Azure endpoint format
+            # because Azure's URL path doesn't exist on AWS metadata service.
+            # See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-returns
+            if provider == "aws":
+                mock_response.status_code = 404  # Not Found
+            else:
+                mock_response.status_code = 200 if provider == "azure" else 400
 
         return mock_response
 
@@ -1582,7 +1596,7 @@ def test_get_cloud_from_metadata_requests(monkeypatch):
         assert result == "aws"
 
         mock_get.side_effect = lambda url, **kwargs: create_mock_response(
-            url, "azure", ["gcp"]
+            url, "azure", []
         )
         result = ray_usage_lib.get_cloud_from_metadata_requests()
         assert result == "azure"
@@ -1592,6 +1606,46 @@ def test_get_cloud_from_metadata_requests(monkeypatch):
         )
         result = ray_usage_lib.get_cloud_from_metadata_requests()
         assert result == "unknown"
+
+
+def test_get_cloud_azure_not_detected_as_aws():
+    """Regression test for bug where Azure VMs were incorrectly detected as AWS.
+
+    The bug occurred because:
+    1. AWS endpoint was checked before Azure endpoint
+    2. Both use the same IP (169.254.169.254)
+    3. Azure IMDS returns 400 (not 404) when queried with AWS endpoint
+    4. Old code accepted any non-404 status, so it incorrectly returned "aws"
+
+    This test ensures Azure is checked FIRST and only 200 status is accepted.
+    """
+    with patch("requests.get") as mock_get:
+        # Simulate being on an Azure VM
+        # - Azure endpoint returns 200 (correct provider)
+        # - AWS endpoint returns 400 (Azure IMDS rejecting AWS query)
+        # - GCP endpoint times out (not on GCP)
+        def azure_vm_response(url, **kwargs):
+            mock_response = Mock()
+            if url == "http://169.254.169.254/metadata/instance?api-version=2021-12-13":
+                # Azure endpoint succeeds
+                mock_response.status_code = 200
+            elif url == "http://169.254.169.254/latest/meta-data/":
+                # AWS endpoint fails with 400 on Azure IMDS (the critical bug case)
+                mock_response.status_code = 400
+            elif url == "http://metadata.google.internal/computeMetadata/v1":
+                # GCP times out
+                raise requests.exceptions.ConnectionError()
+            return mock_response
+
+        mock_get.side_effect = azure_vm_response
+        result = ray_usage_lib.get_cloud_from_metadata_requests()
+
+        # Should correctly identify as Azure (not AWS!)
+        assert result == "azure", (
+            "Azure VM incorrectly detected as AWS! "
+            "This is the critical bug where status_code != 404 accepted "
+            "Azure's 400 response to AWS query."
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/_common/tests/test_usage_stats.py
+++ b/python/ray/_common/tests/test_usage_stats.py
@@ -1617,7 +1617,7 @@ def test_get_cloud_azure_not_detected_as_aws():
     3. Azure IMDS returns 400 (not 404) when queried with AWS endpoint
     4. Old code accepted any non-404 status, so it incorrectly returned "aws"
 
-    This test ensures Azure is checked FIRST and only 200 status is accepted.
+    This test ensures only 200 status is accepted.
     """
     with patch("requests.get") as mock_get:
         # Simulate being on an Azure VM

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -83,10 +83,20 @@ class AzureNodeProvider(NodeProvider):
         # Detect cloud environment to optimize Azure credential chain.
         # On non-Azure clouds (AWS, GCP), skip Azure-specific auth methods
         # (managed identity, workload identity) to avoid IMDS timeout delays / failures.
-        on_azure = get_cloud_from_metadata_requests() == "azure"
-        logger.info(
-            f"Detected cloud environment: {'Azure' if on_azure else 'non-Azure'}"
-        )
+        detected_cloud = get_cloud_from_metadata_requests()
+        on_azure = detected_cloud == "azure"
+
+        if on_azure:
+            logger.info(
+                "Initializing Azure node provider for Azure infrastructure "
+                "running on Azure cloud environment"
+            )
+        else:
+            logger.info(
+                f"Initializing Azure node provider for Azure infrastructure "
+                f"but detected this is running on a '{detected_cloud}' environment. "
+                f"Skipping Azure-specific authentication methods to avoid timeouts."
+            )
 
         credential = DefaultAzureCredential(
             exclude_shared_token_cache_credential=True,


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes the issue reported at https://github.com/ray-project/ray/pull/55719#issuecomment-3354243024 by skipping chained credential checks form managed identity / workload identity azure tokens when we detect the machine is not running in Azure

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
