### PR TITLE
[core] Fix bug where inflight requests are not taken into account by retryab…

### DIFF
--- a/src/ray/core_worker_rpc_client/core_worker_client.h
+++ b/src/ray/core_worker_rpc_client/core_worker_client.h
@@ -56,7 +56,8 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   bool IsIdleAfterRPCs() const override {
     return grpc_client_->IsChannelIdleAfterRPCs() &&
-           (retryable_grpc_client_->NumPendingRequests() == 0);
+           retryable_grpc_client_->NumPendingRequests() == 0 &&
+           retryable_grpc_client_->NumInflightRequests() == 0;
   }
 
   VOID_RPC_CLIENT_METHOD(CoreWorkerService,

--- a/src/ray/core_worker_rpc_client/core_worker_client.h
+++ b/src/ray/core_worker_rpc_client/core_worker_client.h
@@ -56,8 +56,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   bool IsIdleAfterRPCs() const override {
     return grpc_client_->IsChannelIdleAfterRPCs() &&
-           retryable_grpc_client_->NumPendingRequests() == 0 &&
-           retryable_grpc_client_->NumInflightRequests() == 0;
+           retryable_grpc_client_->NumActiveRequests() == 0;
   }
 
   VOID_RPC_CLIENT_METHOD(CoreWorkerService,

--- a/src/ray/core_worker_rpc_client/core_worker_client.h
+++ b/src/ray/core_worker_rpc_client/core_worker_client.h
@@ -56,7 +56,8 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   bool IsIdleAfterRPCs() const override {
     return grpc_client_->IsChannelIdleAfterRPCs() &&
-           retryable_grpc_client_->NumPendingRequests() == 0;
+           retryable_grpc_client_->NumPendingRequests() == 0 &&
+           retryable_grpc_client_->NumInflightRequests() == 0;
   }
 
   VOID_RPC_CLIENT_METHOD(CoreWorkerService,

--- a/src/ray/core_worker_rpc_client/core_worker_client.h
+++ b/src/ray/core_worker_rpc_client/core_worker_client.h
@@ -56,8 +56,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   bool IsIdleAfterRPCs() const override {
     return grpc_client_->IsChannelIdleAfterRPCs() &&
-           retryable_grpc_client_->NumPendingRequests() == 0 &&
-           retryable_grpc_client_->NumInflightRequests() == 0;
+           retryable_grpc_client_->NumPendingRequests() == 0;
   }
 
   VOID_RPC_CLIENT_METHOD(CoreWorkerService,

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -16,6 +16,7 @@
 
 #include <grpcpp/grpcpp.h>
 
+#include <atomic>
 #include <boost/asio.hpp>
 #include <memory>
 #include <string>

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -141,14 +141,18 @@ class GrpcClient {
     testing::RpcFailure failure = skip_testing_intra_node_rpc_failure_
                                       ? testing::RpcFailure::None
                                       : testing::GetRpcFailure(call_name);
+    num_inflight_requests_++;
+    call_method_invoked_.store(true);
+
     if (failure == testing::RpcFailure::Request) {
       // Simulate the case where the PRC fails before server receives
       // the request.
       RAY_LOG(INFO) << "Inject RPC request failure for " << call_name;
       client_call_manager_.GetMainService().post(
-          [callback]() {
+          [this, callback]() {
             callback(Status::RpcError("Unavailable", grpc::StatusCode::UNAVAILABLE),
                      Reply());
+            this->num_inflight_requests_--;
           },
           "RpcChaos");
     } else if (failure == testing::RpcFailure::Response) {
@@ -159,9 +163,10 @@ class GrpcClient {
           *stub_,
           prepare_async_function,
           request,
-          [callback](const Status &status, const Reply &) {
+          [this, callback](const Status &status, const Reply &) {
             callback(Status::RpcError("Unavailable", grpc::StatusCode::UNAVAILABLE),
                      Reply());
+            this->num_inflight_requests_--;
           },
           std::move(call_name),
           method_timeout_ms);
@@ -170,13 +175,14 @@ class GrpcClient {
           *stub_,
           prepare_async_function,
           request,
-          callback,
+          [this, callback](const Status &status, Reply &&reply) {
+            callback(status, std::move(reply));
+            this->num_inflight_requests_--;
+          },
           std::move(call_name),
           method_timeout_ms);
       RAY_CHECK(call != nullptr);
     }
-
-    call_method_invoked_.store(true);
   }
 
   std::shared_ptr<grpc::Channel> Channel() const { return channel_; }
@@ -188,7 +194,7 @@ class GrpcClient {
   /// for channel connectivity state machine.
   bool IsChannelIdleAfterRPCs() const {
     return (channel_->GetState(false) == GRPC_CHANNEL_IDLE) &&
-           call_method_invoked_.load();
+           call_method_invoked_.load() && num_inflight_requests_ == 0;
   }
 
  private:
@@ -200,6 +206,8 @@ class GrpcClient {
   /// Whether CallMethod is invoked.
   std::atomic<bool> call_method_invoked_ = false;
   bool skip_testing_intra_node_rpc_failure_ = false;
+  // Total number of inflight requests for this client
+  std::atomic<size_t> num_inflight_requests_ = 0;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -283,10 +283,10 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
           auto current_retryable_grpc_client = weak_retryable_grpc_client.lock();
           if (status.ok() || !IsGrpcRetryableStatus(status) ||
               !current_retryable_grpc_client) {
+            callback(status, std::move(reply));
             if (current_retryable_grpc_client) {
               current_retryable_grpc_client->num_inflight_requests_--;
             }
-            callback(status, std::move(reply));
             return;
           }
           current_retryable_grpc_client->Retry(retryable_grpc_request);

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -270,13 +269,13 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
         request,
         [weak_retryable_grpc_client, retryable_grpc_request, callback](
             const ray::Status &status, Reply &&reply) {
-          auto current_retryable_grpc_client = weak_retryable_grpc_client.lock();
-          if (status.ok() || !IsGrpcRetryableStatus(status) ||
-              !current_retryable_grpc_client) {
+          auto retryable_grpc_client = weak_retryable_grpc_client.lock();
+          if (status.ok() || !IsGrpcRetryableStatus(status) || !retryable_grpc_client) {
             callback(status, std::move(reply));
             return;
           }
-          current_retryable_grpc_client->Retry(retryable_grpc_request);
+
+          retryable_grpc_client->Retry(retryable_grpc_request);
         },
         call_name,
         retryable_grpc_request->GetTimeoutMs());

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -167,7 +167,7 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
   size_t NumPendingRequests() const { return pending_requests_.size(); }
 
   // Return the number of inflight requests.
-  size_t NumInflightRequests() const { return num_inflight_requests_.load(); }
+  size_t NumInflightRequests() const { return num_inflight_requests_; }
 
   ~RetryableGrpcClient();
 

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -281,7 +281,6 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
           if (status.ok() || !IsGrpcRetryableStatus(status) ||
               !current_retryable_grpc_client) {
             callback(status, std::move(reply));
-            current_retryable_grpc_client->num_inflight_requests_--;
             return;
           }
           current_retryable_grpc_client->Retry(retryable_grpc_request);

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -165,6 +165,9 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
   // Return the number of pending requests waiting for retry.
   size_t NumPendingRequests() const { return pending_requests_.size(); }
 
+  // Return the number of inflight requests.
+  size_t NumInflightRequests() const { return num_inflight_requests_; }
+
   ~RetryableGrpcClient();
 
  private:
@@ -222,6 +225,8 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
       pending_requests_;
   // Total number of bytes of pending requests.
   size_t pending_requests_bytes_ = 0;
+  // Total number of inflight requests.
+  size_t num_inflight_requests_ = 0;
 };
 
 template <typename Service, typename Request, typename Reply>
@@ -264,18 +269,23 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
                    request = std::move(request),
                    callback](std::shared_ptr<RetryableGrpcClient::RetryableGrpcRequest>
                                  retryable_grpc_request) {
+    auto retryable_grpc_client = weak_retryable_grpc_client.lock();
+    RAY_CHECK(retryable_grpc_client);
+    retryable_grpc_client->num_inflight_requests_++;
     grpc_client->template CallMethod<Request, Reply>(
         prepare_async_function,
         request,
-        [weak_retryable_grpc_client, retryable_grpc_request, callback](
+        [weak_retryable_grpc_client, retryable_grpc_request, callback, call_name](
             const ray::Status &status, Reply &&reply) {
-          auto retryable_grpc_client = weak_retryable_grpc_client.lock();
-          if (status.ok() || !IsGrpcRetryableStatus(status) || !retryable_grpc_client) {
+          auto current_retryable_grpc_client = weak_retryable_grpc_client.lock();
+          if (status.ok() || !IsGrpcRetryableStatus(status) ||
+              !current_retryable_grpc_client) {
             callback(status, std::move(reply));
+            current_retryable_grpc_client->num_inflight_requests_--;
             return;
           }
-
-          retryable_grpc_client->Retry(retryable_grpc_request);
+          current_retryable_grpc_client->Retry(retryable_grpc_request);
+          current_retryable_grpc_client->num_inflight_requests_--;
         },
         call_name,
         retryable_grpc_request->GetTimeoutMs());

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -275,7 +275,7 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
     grpc_client->template CallMethod<Request, Reply>(
         prepare_async_function,
         request,
-        [weak_retryable_grpc_client, retryable_grpc_request, callback, call_name](
+        [weak_retryable_grpc_client, retryable_grpc_request, callback](
             const ray::Status &status, Reply &&reply) {
           auto current_retryable_grpc_client = weak_retryable_grpc_client.lock();
           if (status.ok() || !IsGrpcRetryableStatus(status) ||


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There seems to be a race where in https://github.com/ray-project/ray/blob/77b1dcfecacf25490d9b22544af8309b9e9b50a4/src/ray/rpc/grpc_client.h#L189-L192
channel_->GetState(...) may return GRPC_CHANNEL_IDLE after you call a RPC method via a RPC handler. 
The race we were seeing for GetObjectStatus (but could affect any core worker RPC using the retryable grpc) is:
- GetObjectStatus RPC request sent
- channel_->GetState(false) == GRPC_CHANNEL_IDLE => IsChannelIdleAfterRPCs() == True
- core worker client pool evicts the client from the pool
- on retry the executor stored in the retryable_grpc_client detects that the client has gone out of scope, so immediately calls the callback with the grpc UNAVAILABLE error

Mitigating this by adding a counter for inflight rpc requests thats also checked in IsChannelIdleAfterRPCs. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
