### PR TITLE
[Data] - Download expr - cast to arrow before checking column

### DIFF
--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -244,15 +244,16 @@ class PartitionActor:
         return file_sizes
 
     def __call__(self, block: pa.Table) -> Iterator[pa.Table]:
+        if not isinstance(block, pa.Table):
+            block = BlockAccessor.for_block(block).to_arrow()
+
+        # Perform the arrow conversion before calling column_names
         if self._uri_column_name not in block.column_names:
             raise ValueError(
                 "Ray Data tried to download URIs from a column named "
                 f"{self._uri_column_name!r}, but a column with that name doesn't "
                 "exist. Is the specified download column correct?"
             )
-
-        if not isinstance(block, pa.Table):
-            block = BlockAccessor.for_block(block).to_arrow()
 
         if self._batch_size_estimate is None:
             # Extract URIs from PyArrow table for sampling


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Call `to_arrow()` before invoking `.column_names`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
