### PR TITLE
Small fixes to Metrics Tab for kube-ray clusters

### DIFF
--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -85,6 +85,10 @@ export type GlobalContextType = {
    */
   grafanaOrgId: string;
   /**
+   * The filter for the Cluster variable in grafana dashboards.
+   */
+  grafanaClusterFilter: string | undefined;
+  /**
    * The uids of the dashboards that ray exports that powers the various metrics UIs.
    */
   dashboardUids: DashboardUids | undefined;
@@ -116,6 +120,7 @@ export const GlobalContext = React.createContext<GlobalContextType>({
   metricsContextLoaded: false,
   grafanaHost: undefined,
   grafanaOrgId: "1",
+  grafanaClusterFilter: undefined,
   dashboardUids: undefined,
   prometheusHealth: undefined,
   sessionName: undefined,
@@ -135,6 +140,7 @@ const App = () => {
     metricsContextLoaded: false,
     grafanaHost: undefined,
     grafanaOrgId: "1",
+    grafanaClusterFilter: undefined,
     dashboardUids: undefined,
     prometheusHealth: undefined,
     sessionName: undefined,
@@ -166,6 +172,7 @@ const App = () => {
       const {
         grafanaHost,
         grafanaOrgId,
+        grafanaClusterFilter,
         sessionName,
         prometheusHealth,
         dashboardUids,
@@ -176,6 +183,7 @@ const App = () => {
         metricsContextLoaded: true,
         grafanaHost,
         grafanaOrgId,
+        grafanaClusterFilter,
         dashboardUids,
         sessionName,
         prometheusHealth,

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
@@ -11,6 +11,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         metricsContextLoaded: true,
         grafanaHost: "localhost:3000",
         grafanaOrgId: "1",
+        grafanaClusterFilter: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",
@@ -39,6 +40,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         metricsContextLoaded: true,
         grafanaHost: undefined,
         grafanaOrgId: "1",
+        grafanaClusterFilter: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",
@@ -77,7 +79,7 @@ describe("Metrics", () => {
     ).toBeNull();
   });
 
-  it("renders warning when ", async () => {
+  it("renders warning when grafana is not available", async () => {
     expect.assertions(5);
 
     render(<Metrics />, { wrapper: MetricsDisabledWrapper });
@@ -89,5 +91,80 @@ describe("Metrics", () => {
     expect(screen.queryByText(/Tasks and Actors/)).toBeNull();
     expect(screen.queryByText(/Ray Resource Usage/)).toBeNull();
     expect(screen.queryByText(/Hardware Utilization/)).toBeNull();
+  });
+
+  it("validates iframe query parameters are correctly constructed", async () => {
+    expect.assertions(11);
+
+    render(<Metrics />, { wrapper: Wrapper });
+    await screen.findByText(/View in Grafana/);
+
+    // Get all iframe elements
+    const iframes = document.querySelectorAll("iframe");
+    expect(iframes.length).toBeGreaterThan(0);
+
+    // Test the first iframe to validate query parameters
+    const firstIframe = iframes[0] as HTMLIFrameElement;
+    const iframeSrc = firstIframe.src;
+    const url = new URL(iframeSrc);
+
+    // Validate required iframe query parameters
+    expect(url.searchParams.get("orgId")).toBe("1");
+    expect(url.searchParams.get("theme")).toBe("light");
+    expect(url.searchParams.get("panelId")).toBeTruthy();
+    expect(url.searchParams.get("var-SessionName")).toBe("session-name");
+    expect(url.searchParams.get("var-datasource")).toBe("Prometheus");
+    expect(url.searchParams.get("refresh")).toBe("5s");
+    expect(url.searchParams.get("from")).toBe("now-5m");
+    expect(url.searchParams.get("to")).toBe("now");
+
+    // Validate URL structure
+    expect(iframeSrc).toMatch(/localhost:3000\/d-solo\/rayDefaultDashboard\?/);
+    expect(iframeSrc).toContain("/d-solo/rayDefaultDashboard");
+  });
+
+  it("validates iframe query parameters with cluster filter", async () => {
+    const WrapperWithClusterFilter = ({ children }: PropsWithChildren<{}>) => {
+      return (
+        <GlobalContext.Provider
+          value={{
+            metricsContextLoaded: true,
+            grafanaHost: "localhost:3000",
+            grafanaOrgId: "1",
+            grafanaClusterFilter: "test-cluster",
+            dashboardUids: {
+              default: "rayDefaultDashboard",
+              serve: "rayServeDashboard",
+              serveDeployment: "rayServeDeploymentDashboard",
+              data: "rayDataDashboard",
+            },
+            prometheusHealth: true,
+            sessionName: "session-name",
+            nodeMap: {},
+            nodeMapByIp: {},
+            namespaceMap: {},
+            dashboardDatasource: "Prometheus",
+            serverTimeZone: undefined,
+            currentTimeZone: undefined,
+          }}
+        >
+          <STYLE_WRAPPER>{children}</STYLE_WRAPPER>
+        </GlobalContext.Provider>
+      );
+    };
+
+    expect.assertions(2);
+
+    render(<Metrics />, { wrapper: WrapperWithClusterFilter });
+    await screen.findByText(/View in Grafana/);
+
+    // Get the first iframe and validate cluster filter parameter
+    const iframes = document.querySelectorAll("iframe");
+    const firstIframe = iframes[0] as HTMLIFrameElement;
+    const iframeSrc = firstIframe.src;
+    const url = new URL(iframeSrc);
+
+    expect(url.searchParams.get("var-Cluster")).toBe("test-cluster");
+    expect(iframeSrc).toContain("var-Cluster=test-cluster");
   });
 });

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -17,6 +17,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { BiRefresh, BiTime } from "react-icons/bi";
 import { RiExternalLinkLine } from "react-icons/ri";
 
+import { useLocalStorage } from "usehooks-ts";
 import { GlobalContext } from "../../App";
 import { CollapsibleSection } from "../../common/CollapsibleSection";
 import { ClassNameProps } from "../../common/props";
@@ -391,6 +392,7 @@ export const Metrics = () => {
   const {
     grafanaHost,
     grafanaOrgId,
+    grafanaClusterFilter,
     prometheusHealth,
     dashboardUids,
     dashboardDatasource,
@@ -401,13 +403,30 @@ export const Metrics = () => {
 
   const grafanaOrgIdParam = grafanaOrgId ?? "1";
   const grafanaDefaultDatasource = dashboardDatasource ?? "Prometheus";
+  const grafanaClusterFilterParam = grafanaClusterFilter
+    ? `&var-Cluster=${grafanaClusterFilter}`
+    : "";
+
+  const [cachedRefreshOptionStr, setCachedRefreshOptionStr] = useLocalStorage<
+    string | null
+  >(`Metrics-refreshOption`, null);
+  const cachedRefreshOption = cachedRefreshOptionStr
+    ? (cachedRefreshOptionStr as RefreshOptions)
+    : undefined;
+
+  const [cachedTimeRangeOptionStr, setCachedTimeRangeOptionStr] =
+    useLocalStorage<string | null>(`Metrics-timeRangeOption`, null);
+
+  const cachedTimeRangeOption = cachedTimeRangeOptionStr
+    ? (cachedTimeRangeOptionStr as TimeRangeOptions)
+    : undefined;
 
   const [refreshOption, setRefreshOption] = useState<RefreshOptions>(
-    RefreshOptions.FIVE_SECONDS,
+    cachedRefreshOption ?? RefreshOptions.FIVE_SECONDS,
   );
 
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(
-    TimeRangeOptions.FIVE_MINS,
+    cachedTimeRangeOption ?? TimeRangeOptions.FIVE_MINS,
   );
 
   const [refresh, setRefresh] = useState<string | null>(null);
@@ -483,7 +502,7 @@ export const Metrics = () => {
               >
                 <MenuItem
                   component="a"
-                  href={`${grafanaHost}/d/${grafanaDefaultDashboardUid}/?orgId=${grafanaOrgId}&var-datasource=${grafanaDefaultDatasource}`}
+                  href={`${grafanaHost}/d/${grafanaDefaultDashboardUid}/?orgId=${grafanaOrgId}&var-datasource=${grafanaDefaultDatasource}${grafanaClusterFilterParam}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -493,7 +512,7 @@ export const Metrics = () => {
                   <Tooltip title="The Ray Data dashboard has a dropdown to filter the data metrics by Dataset ID">
                     <MenuItem
                       component="a"
-                      href={`${grafanaHost}/d/${dashboardUids["data"]}/?orgId=${grafanaOrgId}&var-datasource=${grafanaDefaultDatasource}`}
+                      href={`${grafanaHost}/d/${dashboardUids["data"]}/?orgId=${grafanaOrgId}&var-datasource=${grafanaDefaultDatasource}${grafanaClusterFilterParam}`}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -510,6 +529,7 @@ export const Metrics = () => {
               value={refreshOption}
               onChange={({ target: { value } }) => {
                 setRefreshOption(value as RefreshOptions);
+                setCachedRefreshOptionStr(value);
               }}
               variant="standard"
               InputProps={{
@@ -534,6 +554,7 @@ export const Metrics = () => {
               value={timeRangeOption}
               onChange={({ target: { value } }) => {
                 setTimeRangeOption(value as TimeRangeOptions);
+                setCachedTimeRangeOptionStr(value);
               }}
               variant="standard"
               InputProps={{
@@ -567,6 +588,7 @@ export const Metrics = () => {
                 grafanaOrgId={grafanaOrgIdParam}
                 dashboardUid={grafanaDefaultDashboardUid}
                 dashboardDatasource={grafanaDefaultDatasource}
+                grafanaClusterFilterParam={grafanaClusterFilterParam}
               />
             ))}
             {dashboardUids?.["data"] &&
@@ -579,6 +601,7 @@ export const Metrics = () => {
                   grafanaOrgId={grafanaOrgIdParam}
                   dashboardUid={dashboardUids["data"]}
                   dashboardDatasource={grafanaDefaultDatasource}
+                  grafanaClusterFilterParam={grafanaClusterFilterParam}
                 />
               ))}
           </Box>
@@ -593,6 +616,7 @@ type MetricsSectionProps = {
   refreshParams: string;
   timeRangeParams: string;
   grafanaOrgId: string;
+  grafanaClusterFilterParam: string;
   dashboardUid: string;
   dashboardDatasource: string;
 };
@@ -602,11 +626,13 @@ const MetricsSection = ({
   refreshParams,
   timeRangeParams,
   grafanaOrgId,
+  grafanaClusterFilterParam,
   dashboardUid,
   dashboardDatasource,
 }: MetricsSectionProps) => {
   const { grafanaHost, sessionName, currentTimeZone } =
     useContext(GlobalContext);
+
   return (
     <CollapsibleSection
       key={title}
@@ -627,7 +653,7 @@ const MetricsSection = ({
         {contents.map(({ title, pathParams }) => {
           const path =
             `/d-solo/${dashboardUid}?${pathParams}&orgId=${grafanaOrgId}` +
-            `&${refreshParams}&timezone=${currentTimeZone}${timeRangeParams}&var-SessionName=${sessionName}&var-datasource=${dashboardDatasource}`;
+            `${refreshParams}&timezone=${currentTimeZone}${timeRangeParams}&var-SessionName=${sessionName}&var-datasource=${dashboardDatasource}${grafanaClusterFilterParam}`;
           return (
             <Paper
               key={pathParams}

--- a/python/ray/dashboard/client/src/pages/metrics/utils.ts
+++ b/python/ray/dashboard/client/src/pages/metrics/utils.ts
@@ -17,6 +17,7 @@ type GrafanaHealthcheckRsp = {
   data: {
     grafanaHost: string;
     grafanaOrgId: string;
+    grafanaClusterFilter: string | undefined;
     sessionName: string;
     dashboardUids: DashboardUids;
     dashboardDatasource: string;
@@ -44,6 +45,7 @@ const fetchPrometheusHealthcheck = async () => {
 type MetricsInfo = {
   grafanaHost?: string;
   grafanaOrgId: string;
+  grafanaClusterFilter: string | undefined;
   sessionName?: string;
   prometheusHealth?: boolean;
   dashboardUids?: DashboardUids;
@@ -54,6 +56,7 @@ export const getMetricsInfo = async () => {
   const info: MetricsInfo = {
     grafanaHost: undefined,
     grafanaOrgId: "1",
+    grafanaClusterFilter: undefined,
     sessionName: undefined,
     prometheusHealth: undefined,
     dashboardUids: undefined,
@@ -64,6 +67,7 @@ export const getMetricsInfo = async () => {
     if (resp.data.result) {
       info.grafanaHost = resp.data.data.grafanaHost;
       info.grafanaOrgId = resp.data.data.grafanaOrgId;
+      info.grafanaClusterFilter = resp.data.data.grafanaClusterFilter;
       info.sessionName = resp.data.data.sessionName;
       info.dashboardUids = resp.data.data.dashboardUids;
       info.dashboardDatasource = resp.data.data.dashboardDatasource;

--- a/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
@@ -83,6 +83,7 @@ const Wrapper =
                 ? "DISABLED"
                 : "http://localhost:3000",
               grafanaOrgId: "1",
+              grafanaClusterFilter: undefined,
               dashboardUids: {
                 default: "rayDefaultDashboard",
                 serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
@@ -11,6 +11,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         metricsContextLoaded: true,
         grafanaHost: "localhost:3000",
         grafanaOrgId: "1",
+        grafanaClusterFilter: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",
@@ -39,6 +40,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         metricsContextLoaded: true,
         grafanaHost: undefined,
         grafanaOrgId: "1",
+        grafanaClusterFilter: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -15,6 +15,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         metricsContextLoaded: true,
         grafanaHost: "localhost:3000",
         grafanaOrgId: "1",
+        grafanaClusterFilter: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",
@@ -43,6 +44,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         metricsContextLoaded: true,
         grafanaHost: undefined,
         grafanaOrgId: "1",
+        grafanaClusterFilter: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/util/test-utils.tsx
+++ b/python/ray/dashboard/client/src/util/test-utils.tsx
@@ -13,6 +13,7 @@ export const TEST_APP_WRAPPER = ({ children }: PropsWithChildren<{}>) => {
     metricsContextLoaded: true,
     grafanaHost: "localhost:3000",
     grafanaOrgId: "1",
+    grafanaClusterFilter: undefined,
     dashboardUids: {
       default: "rayDefaultDashboard",
       serve: "rayServeDashboard",

--- a/python/ray/dashboard/modules/metrics/dashboards/data_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_grafana_dashboard_base.json
@@ -140,6 +140,7 @@
             "useTags": false
           },
           {
+            "allValue": ".*",
             "current": {
               "selected": false
             },

--- a/python/ray/dashboard/modules/metrics/dashboards/default_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_grafana_dashboard_base.json
@@ -101,6 +101,7 @@
         "useTags": false
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": false
         },

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_deployment_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_deployment_grafana_dashboard_base.json
@@ -165,6 +165,7 @@
         "useTags": false
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": false
         },

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_grafana_dashboard_base.json
@@ -134,6 +134,7 @@
         "useTags": false
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": false
         },

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -46,6 +46,7 @@ DEFAULT_GRAFANA_HOST = "http://localhost:3000"
 GRAFANA_HOST_ENV_VAR = "RAY_GRAFANA_HOST"
 GRAFANA_ORG_ID_ENV_VAR = "RAY_GRAFANA_ORG_ID"
 DEFAULT_GRAFANA_ORG_ID = "1"
+GRAFANA_CLUSTER_FILTER_ENV_VAR = "RAY_GRAFANA_CLUSTER_FILTER"
 GRAFANA_HOST_DISABLED_VALUE = "DISABLED"
 GRAFANA_IFRAME_HOST_ENV_VAR = "RAY_GRAFANA_IFRAME_HOST"
 GRAFANA_DASHBOARD_OUTPUT_DIR_ENV_VAR = "RAY_METRICS_GRAFANA_DASHBOARD_OUTPUT_DIR"
@@ -119,6 +120,7 @@ class MetricsHead(SubprocessModule):
         self._grafana_org_id = os.environ.get(
             GRAFANA_ORG_ID_ENV_VAR, DEFAULT_GRAFANA_ORG_ID
         )
+        self._grafana_cluster_filter = os.environ.get(GRAFANA_CLUSTER_FILTER_ENV_VAR)
 
         # To be set later when dashboards gets generated
         self._dashboard_uids = {}
@@ -166,6 +168,7 @@ class MetricsHead(SubprocessModule):
                     session_name=self.session_name,
                     dashboard_uids=self._dashboard_uids,
                     dashboard_datasource=self._prometheus_name,
+                    grafana_cluster_filter=self._grafana_cluster_filter,
                 )
 
         except Exception as e:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Based on feedback from spotify, we need to do a better job of handling grafana / prometheus instances that are managing metrics for multiple ray clusters.

- fix cluster filter to use regex (`.*`) for customAllValue. Previously, it would try to concatenate all values into a list which could be 100s of clusters in a grafana instance.

- add env var to filter ray dashboard to a specific cluster so the ray dashboard will only show the metrics with the configured cluster name

- cache the refresh value and selected time range in the browser storage so user does not have to reset it between browser refreshes


Manually tested:
- Verified customAllValue is set in final grafana output
- Verified that refresh and time range options are kept around after refresh
- Verified that var-Cluster query param is being set correctly in iframes.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
