### PR TITLE
[serve] Configure proxy logger in generic class

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1041,12 +1041,7 @@ class ProxyActorInterface(ABC):
         self._node_ip_address = node_ip_address
         self._logging_config = logging_config
 
-        configure_component_logger(
-            component_name="proxy",
-            component_id=node_ip_address,
-            logging_config=logging_config,
-            buffer_size=RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
-        )
+        self._update_logging_config(logging_config)
 
     @abstractmethod
     async def ready(self) -> str:

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1041,6 +1041,13 @@ class ProxyActorInterface(ABC):
         self._node_ip_address = node_ip_address
         self._logging_config = logging_config
 
+        configure_component_logger(
+            component_name="proxy",
+            component_id=node_ip_address,
+            logging_config=logging_config,
+            buffer_size=RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
+        )
+
     @abstractmethod
     async def ready(self) -> str:
         """Blocks until the proxy is ready to serve requests.
@@ -1120,6 +1127,14 @@ class ProxyActorInterface(ABC):
         """Get replicas for a route (for testing)."""
         pass
 
+    def _update_logging_config(self, logging_config: LoggingConfig):
+        configure_component_logger(
+            component_name="proxy",
+            component_id=self._node_ip_address,
+            logging_config=logging_config,
+            buffer_size=RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
+        )
+
 
 @ray.remote(num_cpus=0)
 class ProxyActor(ProxyActorInterface):
@@ -1150,13 +1165,6 @@ class ProxyActor(ProxyActorInterface):
                 LongPollNamespace.ROUTE_TABLE: self._update_routes_in_proxies,
             },
             call_in_event_loop=event_loop,
-        )
-
-        configure_component_logger(
-            component_name="proxy",
-            component_id=node_ip_address,
-            logging_config=logging_config,
-            buffer_size=RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
         )
 
         startup_msg = f"Proxy starting on node {self._node_id} (HTTP port: {self._http_options.port}"
@@ -1258,13 +1266,6 @@ class ProxyActor(ProxyActorInterface):
 
     def _update_routes_in_proxies(self, endpoints: Dict[DeploymentID, EndpointInfo]):
         self.proxy_router.update_routes(endpoints)
-
-    def _update_logging_config(self, logging_config: LoggingConfig):
-        configure_component_logger(
-            component_name="proxy",
-            component_id=self._node_ip_address,
-            logging_config=logging_config,
-        )
 
     def _get_logging_config(self) -> Tuple:
         """Get the logging configuration (for testing purposes)."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Configuring the proxy logger should happen in the generic class.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
