### PR TITLE
[Data] - Handle BaseMaskedDtype -> pa type in schema

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6480,6 +6480,9 @@ class Schema:
         ) -> pa.DataType:
             if isinstance(dtype, pd.ArrowDtype):
                 return dtype.pyarrow_dtype
+            elif isinstance(dtype, pd.StringDtype):
+                # StringDtype is not a BaseMaskedDtype, handle separately
+                return pa.string()
             elif isinstance(dtype, BaseMaskedDtype):
                 dtype = dtype.numpy_dtype
             return pa.from_numpy_dtype(dtype)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6471,12 +6471,17 @@ class Schema:
         """
         import pandas as pd
         import pyarrow as pa
+        from pandas.core.dtypes.dtypes import BaseMaskedDtype
 
         from ray.data.extensions import ArrowTensorType, TensorDtype
 
-        def _convert_to_pa_type(dtype: Union[np.dtype, pd.ArrowDtype]) -> pa.DataType:
+        def _convert_to_pa_type(
+            dtype: Union[np.dtype, pd.ArrowDtype, BaseMaskedDtype]
+        ) -> pa.DataType:
             if isinstance(dtype, pd.ArrowDtype):
                 return dtype.pyarrow_dtype
+            elif isinstance(dtype, BaseMaskedDtype):
+                dtype = dtype.numpy_dtype
             return pa.from_numpy_dtype(dtype)
 
         if isinstance(self.base_schema, pa.lib.Schema):

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -258,13 +258,32 @@ def test_strict_schema(ray_start_regular_shared_2_cpus):
     [
         (pd.ArrowDtype(pa.int32()), pa.int32()),
         (np.dtype("int64"), pa.int64()),
+        # Integer nullable types
+        (pd.Int8Dtype(), pa.int8()),
+        (pd.Int16Dtype(), pa.int16()),
+        (pd.Int32Dtype(), pa.int32()),
         (pd.Int64Dtype(), pa.int64()),
+        (pd.UInt8Dtype(), pa.uint8()),
+        (pd.UInt16Dtype(), pa.uint16()),
+        (pd.UInt32Dtype(), pa.uint32()),
+        (pd.UInt64Dtype(), pa.uint64()),
+        # Float nullable types
+        (pd.Float32Dtype(), pa.float32()),
+        (pd.Float64Dtype(), pa.float64()),
+        # Boolean nullable type
+        (pd.BooleanDtype(), pa.bool_()),
+        # String type (default storage)
+        (pd.StringDtype(), pa.string()),
+        # String type with explicit pyarrow storage
+        (pd.StringDtype(storage="pyarrow"), pa.string()),
+        # String type with python storage
+        (pd.StringDtype(storage="python"), pa.string()),
     ],
 )
 def test_schema_types_property(input_dtype, expected_arrow_type):
     """
     Tests that the Schema.types property correctly converts pandas and numpy
-    dtypes to pyarrow types.
+    dtypes to pyarrow types, including BaseMaskedDtype subclasses.
     """
     from ray.data._internal.pandas_block import PandasBlockSchema
 

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -258,6 +258,7 @@ def test_strict_schema(ray_start_regular_shared_2_cpus):
     [
         (pd.ArrowDtype(pa.int32()), pa.int32()),
         (np.dtype("int64"), pa.int64()),
+        (pd.Int64Dtype(), pa.int64()),
     ],
 )
 def test_schema_types_property(input_dtype, expected_arrow_type):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If schema has `pd.Int64Dtype()` then `pa.from_numpy_dtype` fails. So in this change we extract the underlying numpy dtype from pandas then let pyarrow take over from there.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
