### PR TITLE
[serve] fix windows tests

### DIFF
--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -27,14 +27,14 @@ skip_on_windows_node_timeout = pytest.mark.skipif(
     sys.platform == "win32",
     reason="Ray node fails to register with GCS within 30s timeout on Windows. "
     "Cluster has zero CPU resources available: {} after test operations. "
-    "Root cause: Worker crashes (error 10054, SIGSEGV) leave resources allocated.",
+    "Cause: Worker crashes (error 10054, SIGSEGV) leave resources allocated.",
 )
 
 skip_on_windows_cluster_reinit = pytest.mark.skipif(
     sys.platform == "win32",
     reason="Ray.init() fails when cluster from previous test persists on Windows. "
     "ValueError: _system_config cannot be provided when connecting to existing cluster. "
-    "Root cause: Ray cluster cleanup/isolation issues on Windows between tests.",
+    "Cause: Ray cluster cleanup/isolation issues on Windows between tests.",
 )
 
 

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -352,17 +352,8 @@ def test_controller_shutdown_gracefully(
     # On Windows, wait for resources to be available before adding second node
     # to avoid timeout errors when cluster has zero CPU resources
     if sys.platform == "win32":
-
-        def check_resources_available():
-            try:
-                resources = ray.cluster_resources()
-                cpu_available = resources.get("CPU", 0) > 0
-                return cpu_available
-            except Exception:
-                return False
-
         wait_for_condition(
-            check_resources_available,
+            lambda: ray.cluster_resources().get("CPU", 0) > 0,
             timeout=30,
             retry_interval_ms=1000,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re: https://buildkite.com/ray-project/postmerge/builds/13410/steps/canvas?jid=0199a8eb-ea89-41cf-b434-f37a935e14a1#/3739-4823

Tests are failing either due to node startup timeouts or during initialization on windows. This PR adds an extra timeout for the test on windows32 platform.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
