### PR TITLE
[core] Don't disconnect worker client on OBOD unless the worker is dead

### DIFF
--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -112,6 +112,7 @@ def test_delete_objects_on_worker_failure(object_spilling_config, shutdown_only)
             # ↓↓↓ make cleanup fast/consistent in CI
             "object_timeout_milliseconds": 200,
             "local_gc_min_interval_s": 1,
+            "core_worker_rpc_server_reconnect_timeout_s": 0,
         },
     )
 

--- a/src/mock/ray/object_manager/object_directory.h
+++ b/src/mock/ray/object_manager/object_directory.h
@@ -23,7 +23,7 @@ class MockObjectDirectory : public IObjectDirectory {
  public:
   MOCK_METHOD(void, HandleNodeRemoved, (const NodeID &node_id), (override));
 
-  MOCK_METHOD(ray::Status,
+  MOCK_METHOD(void,
               SubscribeObjectLocations,
               (const UniqueID &callback_id,
                const ObjectID &object_id,
@@ -31,7 +31,7 @@ class MockObjectDirectory : public IObjectDirectory {
                const OnLocationsFound &callback),
               (override));
 
-  MOCK_METHOD(ray::Status,
+  MOCK_METHOD(void,
               UnsubscribeObjectLocations,
               (const UniqueID &callback_id, const ObjectID &object_id),
               (override));

--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -272,6 +272,7 @@ void ActorTaskSubmitter::CancelDependencyResolution(const TaskID &task_id) {
 
 void ActorTaskSubmitter::DisconnectRpcClient(ClientQueue &queue) {
   queue.client_address_ = std::nullopt;
+  // If the actor on the worker is dead, the worker is also dead.
   core_worker_client_pool_.Disconnect(WorkerID::FromBinary(queue.worker_id_));
   queue.worker_id_.clear();
 }

--- a/src/ray/core_worker_rpc_client/core_worker_client_pool.cc
+++ b/src/ray/core_worker_rpc_client/core_worker_client_pool.cc
@@ -163,7 +163,7 @@ void CoreWorkerClientPool::RemoveIdleClients() {
   }
 }
 
-void CoreWorkerClientPool::Disconnect(ray::WorkerID id) {
+void CoreWorkerClientPool::Disconnect(const WorkerID &id) {
   absl::MutexLock lock(&mu_);
   auto it = worker_client_map_.find(id);
   if (it == worker_client_map_.end()) {
@@ -174,7 +174,7 @@ void CoreWorkerClientPool::Disconnect(ray::WorkerID id) {
   worker_client_map_.erase(it);
 }
 
-void CoreWorkerClientPool::Disconnect(ray::NodeID node_id) {
+void CoreWorkerClientPool::Disconnect(const NodeID &node_id) {
   absl::MutexLock lock(&mu_);
   auto node_client_map_it = node_clients_map_.find(node_id);
   if (node_client_map_it == node_clients_map_.end()) {

--- a/src/ray/core_worker_rpc_client/core_worker_client_pool.h
+++ b/src/ray/core_worker_rpc_client/core_worker_client_pool.h
@@ -55,10 +55,10 @@ class CoreWorkerClientPool {
   /// Removes a connection to the worker from the pool, if one exists. Since the
   /// shared pointer will no longer be retained in the pool, the connection will
   /// be open until it's no longer used, at which time it will disconnect.
-  void Disconnect(ray::WorkerID id);
+  void Disconnect(const WorkerID &id);
 
   /// Removes connections to all workers on a node.
-  void Disconnect(ray::NodeID node_id);
+  void Disconnect(const NodeID &node_id);
 
  private:
   friend void AssertID(WorkerID worker_id,

--- a/src/ray/gcs/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_actor_manager.cc
@@ -1214,7 +1214,7 @@ void GcsActorManager::OnWorkerDead(const ray::NodeID &node_id,
 }
 
 void GcsActorManager::OnNodeDead(std::shared_ptr<const rpc::GcsNodeInfo> node,
-                                 const std::string node_ip_address) {
+                                 const std::string &node_ip_address) {
   const auto node_id = NodeID::FromBinary(node->node_id());
   RAY_LOG(DEBUG).WithField(node_id) << "Node is dead, reconstructing actors.";
   // Kill all children of owner actors on a dead node.

--- a/src/ray/gcs/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_actor_manager.h
@@ -209,7 +209,7 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler {
   /// \param node The specified node id.
   /// \param node_ip_address The ip address of the dead node.
   void OnNodeDead(std::shared_ptr<const rpc::GcsNodeInfo> node,
-                  const std::string node_ip_address);
+                  const std::string &node_ip_address);
 
   /// Handle a worker failure. This will restart the associated actor, if any,
   /// which may be pending or already created. If the worker owned other

--- a/src/ray/gcs/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_actor_scheduler.cc
@@ -204,8 +204,6 @@ std::vector<ActorID> GcsActorScheduler::CancelOnNode(const NodeID &node_id) {
     }
   }
 
-  raylet_client_pool_.Disconnect(node_id);
-
   return actor_ids;
 }
 

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -59,12 +59,12 @@ class IObjectDirectory {
   /// \param callback_id The id associated with the specified callback. This is
   /// needed when UnsubscribeObjectLocations is called.
   /// \param object_id The required object's ObjectID.
-  /// \param success_cb Invoked with non-empty list of node ids and object_id.
-  /// \return Status of whether subscription succeeded.
-  virtual ray::Status SubscribeObjectLocations(const UniqueID &callback_id,
-                                               const ObjectID &object_id,
-                                               const rpc::Address &owner_address,
-                                               const OnLocationsFound &callback) = 0;
+  /// \param owner_address Address of the object owner.
+  /// \param callback Invoked with non-empty set of node ids and object_id.
+  virtual void SubscribeObjectLocations(const UniqueID &callback_id,
+                                        const ObjectID &object_id,
+                                        const rpc::Address &owner_address,
+                                        const OnLocationsFound &callback) = 0;
 
   /// Unsubscribe to object location notifications.
   ///
@@ -72,9 +72,8 @@ class IObjectDirectory {
   /// at subscription time, and unsubscribes the corresponding callback from
   /// further notifications about the given object's location.
   /// \param object_id The object id invoked with Subscribe.
-  /// \return Status of unsubscribing from object location notifications.
-  virtual ray::Status UnsubscribeObjectLocations(const UniqueID &callback_id,
-                                                 const ObjectID &object_id) = 0;
+  virtual void UnsubscribeObjectLocations(const UniqueID &callback_id,
+                                          const ObjectID &object_id) = 0;
 
   /// Report objects added to this node's store to the object directory.
   ///

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -238,8 +238,8 @@ uint64_t ObjectManager::Pull(const std::vector<rpc::ObjectReference> &object_ref
     // be received if the list of locations is empty. The set of node IDs has
     // no ordering guarantee between notifications.
     auto object_id = ObjectRefToId(ref);
-    RAY_CHECK_OK(object_directory_->SubscribeObjectLocations(
-        object_directory_pull_callback_id_, object_id, ref.owner_address(), callback));
+    object_directory_->SubscribeObjectLocations(
+        object_directory_pull_callback_id_, object_id, ref.owner_address(), callback);
   }
 
   return request_id;
@@ -248,8 +248,8 @@ uint64_t ObjectManager::Pull(const std::vector<rpc::ObjectReference> &object_ref
 void ObjectManager::CancelPull(uint64_t request_id) {
   const auto objects_to_cancel = pull_manager_->CancelPull(request_id);
   for (const auto &object_id : objects_to_cancel) {
-    RAY_CHECK_OK(object_directory_->UnsubscribeObjectLocations(
-        object_directory_pull_callback_id_, object_id));
+    object_directory_->UnsubscribeObjectLocations(object_directory_pull_callback_id_,
+                                                  object_id);
   }
 }
 

--- a/src/ray/object_manager/ownership_object_directory.h
+++ b/src/ray/object_manager/ownership_object_directory.h
@@ -49,12 +49,13 @@ class OwnershipBasedObjectDirectory : public IObjectDirectory {
 
   void HandleNodeRemoved(const NodeID &node_id) override;
 
-  ray::Status SubscribeObjectLocations(const UniqueID &callback_id,
-                                       const ObjectID &object_id,
-                                       const rpc::Address &owner_address,
-                                       const OnLocationsFound &callback) override;
-  ray::Status UnsubscribeObjectLocations(const UniqueID &callback_id,
-                                         const ObjectID &object_id) override;
+  void SubscribeObjectLocations(const UniqueID &callback_id,
+                                const ObjectID &object_id,
+                                const rpc::Address &owner_address,
+                                const OnLocationsFound &callback) override;
+
+  void UnsubscribeObjectLocations(const UniqueID &callback_id,
+                                  const ObjectID &object_id) override;
 
   /// Report to the owner that the given object is added to the current node.
   /// This method guarantees ordering and batches requests.

--- a/src/ray/object_manager/tests/ownership_object_directory_test.cc
+++ b/src/ray/object_manager/tests/ownership_object_directory_test.cc
@@ -487,7 +487,6 @@ TEST_F(OwnershipBasedObjectDirectoryTest, TestNotifyOnUpdate) {
   UniqueID callback_id = UniqueID::FromRandom();
   ObjectID obj_id = ObjectID::FromRandom();
   int num_callbacks = 0;
-
   obod_->SubscribeObjectLocations(callback_id,
                                   obj_id,
                                   rpc::Address(),

--- a/src/ray/object_manager/tests/ownership_object_directory_test.cc
+++ b/src/ray/object_manager/tests/ownership_object_directory_test.cc
@@ -487,18 +487,16 @@ TEST_F(OwnershipBasedObjectDirectoryTest, TestNotifyOnUpdate) {
   UniqueID callback_id = UniqueID::FromRandom();
   ObjectID obj_id = ObjectID::FromRandom();
   int num_callbacks = 0;
-  ASSERT_TRUE(
-      obod_
-          ->SubscribeObjectLocations(callback_id,
-                                     obj_id,
-                                     rpc::Address(),
-                                     [&](const ObjectID &object_id,
-                                         const std::unordered_set<NodeID> &client_ids,
-                                         const std::string &spilled_url,
-                                         const NodeID &spilled_node_id,
-                                         bool pending_creation,
-                                         size_t object_size) { num_callbacks++; })
-          .ok());
+
+  obod_->SubscribeObjectLocations(callback_id,
+                                  obj_id,
+                                  rpc::Address(),
+                                  [&](const ObjectID &object_id,
+                                      const std::unordered_set<NodeID> &client_ids,
+                                      const std::string &spilled_url,
+                                      const NodeID &spilled_node_id,
+                                      bool pending_creation,
+                                      size_t object_size) { num_callbacks++; });
   ASSERT_EQ(num_callbacks, 0);
 
   // Object pending, no other metadata. This is the same as the initial state,


### PR DESCRIPTION
## Why are these changes needed?
Previously we could unsubscribe from the object locations channel in the obod and also disconnect the associated worker client.
https://github.com/ray-project/ray/blob/e0313c4220a6f9316a268d5f8e40689fa80a6190/src/ray/object_manager/ownership_object_directory.cc#L435-L440

This means that another pending retry to that worker could fail with Status::Disconnected. We saw that the pubsub could fail with that status due to this disconnect resulting in an OWNER_DIED error even though the owner was still alive, resulting in a critical failure due to a failed rpc.
https://github.com/ray-project/ray/blob/e0313c4220a6f9316a268d5f8e40689fa80a6190/src/ray/object_manager/ownership_object_directory.cc#L347-L350

This fixes that problem by simply removing the disconnect there. The core worker client pool will disconnect the client itself based on the unavailable callback or idle disconnection policy when it needs to, so we don't need this.

Also making some related changes:
- SubscribeObjectLocations and UnsubscribeObjectLocations always return Status::OK, so can just return void.
- Removing another unnecessary disconnect in the UpdateObjectLocationBatch callback. It's retryable now, so the status will only be not ok if the client got disconnected already.
- Removing an unnecessary disconnect in `GcsActorScheduler::CancelOnNode`. It's only called on node death and on node death the gcs disconnects the associated raylet client anyways, so don't need the double disconnect.
