### PR TITLE
[ci] avoid install dependencies in tests.env.Dockerfile

### DIFF
--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -64,18 +64,23 @@ echo "--- Build dashboard"
 
 echo "--- Install Ray with -e"
 
+
+# Dependencies are already installed in the base CI images.
+# So we use --no-deps to avoid reinstalling them.
+INSTALL_FLAGS=(--no-deps --force-reinstall -v)
+
 if [[ "$BUILD_TYPE" == "debug" ]]; then
-  RAY_DEBUG_BUILD=debug pip install -v -e python/
+  RAY_DEBUG_BUILD=debug pip install "${INSTALL_FLAGS[@]}" -e python/
 elif [[ "$BUILD_TYPE" == "asan" ]]; then
-  pip install -v -e python/
+  pip install "${INSTALL_FLAGS[@]}" -e python/
   bazel run $(./ci/run/bazel_export_options) --no//:jemalloc_flag //:gen_ray_pkg
 elif [[ "$BUILD_TYPE" == "multi-lang" ]]; then
-  RAY_DISABLE_EXTRA_CPP=0 RAY_INSTALL_JAVA=1 pip install -v -e python/
+  RAY_DISABLE_EXTRA_CPP=0 RAY_INSTALL_JAVA=1 pip install "${INSTALL_FLAGS[@]}" -e python/
 elif [[ "$BUILD_TYPE" == "java" ]]; then
   bash java/build-jar-multiplatform.sh linux
-  RAY_INSTALL_JAVA=1 pip install -v -e python/
+  RAY_INSTALL_JAVA=1 pip install "${INSTALL_FLAGS[@]}" -e python/
 else
-  pip install -v -e python/
+  pip install "${INSTALL_FLAGS[@]}" -e python/
 fi
 
 EOF


### PR DESCRIPTION
this saves some time and efforts of querying the Internet for ray core dependencies
