### PR TITLE
[docs] Fix broken Towards Data Science links

### DIFF
--- a/doc/source/ray-overview/getting-started.md
+++ b/doc/source/ray-overview/getting-started.md
@@ -776,7 +776,7 @@ Ray has a rich ecosystem of resources to help you learn more about distributed c
 - [Ray Distributed AI Framework Curriculum](https://rise.cs.berkeley.edu/blog/ray-intel-curriculum/)
 - [RayOnSpark: Running Emerging AI Applications on Big Data Clusters with Ray and Analytics Zoo](https://medium.com/riselab/rayonspark-running-emerging-ai-applications-on-big-data-clusters-with-ray-and-analytics-zoo-923e0136ed6a)
 - [First user tips for Ray](https://rise.cs.berkeley.edu/blog/ray-tips-for-first-time-users/)
-- [Tune: a Python library for fast hyperparameter tuning at any scale](https://towardsdatascience.com/fast-hyperparameter-tuning-at-scale-d428223b081c)
+- [Tune: a Python library for fast hyperparameter tuning at any scale](https://medium.com/data-science/fast-hyperparameter-tuning-at-scale-d428223b081c)
 - [Cutting edge hyperparameter tuning with Ray Tune](https://medium.com/riselab/cutting-edge-hyperparameter-tuning-with-ray-tune-be6c0447afdf)
 - [New Library Targets High Speed Reinforcement Learning](https://www.datanami.com/2018/02/01/rays-new-library-targets-high-speed-reinforcement-learning/)
 - [Scaling Multi Agent Reinforcement Learning](http://bair.berkeley.edu/blog/2018/12/12/rllib/)

--- a/doc/source/tune/index.rst
+++ b/doc/source/tune/index.rst
@@ -274,7 +274,7 @@ Learn More About Ray Tune
 
 Below you can find blog posts and talks about Ray Tune:
 
-- [blog] `Tune: a Python library for fast hyperparameter tuning at any scale <https://towardsdatascience.com/fast-hyperparameter-tuning-at-scale-d428223b081c>`_
+- [blog] `Tune: a Python library for fast hyperparameter tuning at any scale <https://medium.com/data-science/fast-hyperparameter-tuning-at-scale-d428223b081c>`_
 - [blog] `Cutting edge hyperparameter tuning with Ray Tune <https://medium.com/riselab/cutting-edge-hyperparameter-tuning-with-ray-tune-be6c0447afdf>`_
 - [slides] `Talk given at RISECamp 2019 <https://docs.google.com/presentation/d/1v3IldXWrFNMK-vuONlSdEuM82fuGTrNUDuwtfx4axsQ/edit?usp=sharing>`_
 - [video] `Talk given at RISECamp 2018 <https://www.youtube.com/watch?v=38Yd_dXW51Q>`_

--- a/doc/source/tune/index.rst
+++ b/doc/source/tune/index.rst
@@ -274,7 +274,7 @@ Learn More About Ray Tune
 
 Below you can find blog posts and talks about Ray Tune:
 
-- [blog] `Tune: a Python library for fast hyperparameter tuning at any scale <https://www.anyscale.com/blog/ray-tune-a-python-library-for-fast-hyperparameter-tuning-at-any-scale>`_
+- [blog] `Tune: a Python library for fast hyperparameter tuning at any scale <https://medium.com/data-science/fast-hyperparameter-tuning-at-scale-d428223b081c>`_
 - [blog] `Cutting edge hyperparameter tuning with Ray Tune <https://medium.com/riselab/cutting-edge-hyperparameter-tuning-with-ray-tune-be6c0447afdf>`_
 - [slides] `Talk given at RISECamp 2019 <https://docs.google.com/presentation/d/1v3IldXWrFNMK-vuONlSdEuM82fuGTrNUDuwtfx4axsQ/edit?usp=sharing>`_
 - [video] `Talk given at RISECamp 2018 <https://www.youtube.com/watch?v=38Yd_dXW51Q>`_

--- a/doc/source/tune/index.rst
+++ b/doc/source/tune/index.rst
@@ -274,7 +274,7 @@ Learn More About Ray Tune
 
 Below you can find blog posts and talks about Ray Tune:
 
-- [blog] `Tune: a Python library for fast hyperparameter tuning at any scale <https://medium.com/data-science/fast-hyperparameter-tuning-at-scale-d428223b081c>`_
+- [blog] `Tune: a Python library for fast hyperparameter tuning at any scale <https://www.anyscale.com/blog/ray-tune-a-python-library-for-fast-hyperparameter-tuning-at-any-scale>`_
 - [blog] `Cutting edge hyperparameter tuning with Ray Tune <https://medium.com/riselab/cutting-edge-hyperparameter-tuning-with-ray-tune-be6c0447afdf>`_
 - [slides] `Talk given at RISECamp 2019 <https://docs.google.com/presentation/d/1v3IldXWrFNMK-vuONlSdEuM82fuGTrNUDuwtfx4axsQ/edit?usp=sharing>`_
 - [video] `Talk given at RISECamp 2018 <https://www.youtube.com/watch?v=38Yd_dXW51Q>`_


### PR DESCRIPTION
## Summary

This PR fixes broken links to Towards Data Science (TDS) articles that are now inaccessible. The articles have been republished on Medium's TDS Archive publication and links have been updated accordingly.

## Problem

During investigation of #57187, discovered that Ray documentation contains broken TDS links that redirect to homepage or return 404 errors. Root cause: TDS links are excluded from automated linkcheck in `doc/source/conf.py` due to rate limiting, allowing broken links to accumulate undetected.

## Changes

- Updated Ray Tune blog link in `doc/source/tune/index.rst:277`
- Updated Ray Tune blog link in `doc/source/ray-overview/getting-started.md:779`

**Original (broken):** https://towardsdatascience.com/fast-hyperparameter-tuning-at-scale-d428223b081c  
**Replacement (working):** https://medium.com/data-science/fast-hyperparameter-tuning-at-scale-d428223b081c

**Article:** "Ray Tune: a Python library for fast hyperparameter tuning at any scale"  
**Author:** Richard Liaw  
**Status:** Verified accessible (HTTP 200)

## Testing

Manually verified replacement URLs return HTTP 200 and contain correct content.

## Related Issues

Related to #57187 (broken link in external Anyscale blog)

## Notes

Note that the primary issue in #57187 is in an external Anyscale blog post (not under Ray project control). That link should be updated separately by the Anyscale team:
- Broken: https://towardsdatascience.com/how-to-scale-python-on-every-major-cloud-provider-5e5df3e88274
- Working: https://medium.com/distributed-computing-with-ray/how-to-scale-python-on-every-major-cloud-provider-12b3bde01208