### PR TITLE
[data] allow custom batching in iter_batches

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1238,8 +1238,6 @@ python/ray/data/dataset.py
     DOC103: Method `Dataset.write_webdataset`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [encoder: Optional[Union[bool, str, callable, list]]].
     DOC101: Method `Dataset.write_lance`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `Dataset.write_lance`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [concurrency: Optional[int], ray_remote_args: Dict[str, Any]].
-    DOC101: Method `Dataset.iter_batches`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `Dataset.iter_batches`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_collate_fn: Optional[Callable[[DataBatch], CollatedData]]].
     DOC201: Method `Dataset.to_random_access_dataset` does not have a return section in docstring
     DOC201: Method `Dataset.stats` does not have a return section in docstring
     DOC201: Method `Dataset.has_serializable_lineage` does not have a return section in docstring

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -6,10 +6,9 @@ from typing import Any, Callable, Iterator, List, Optional, Tuple
 
 import ray
 from ray.actor import ActorHandle
-from ray.data._internal.batcher import Batcher, ShufflingBatcher
+from ray.data._internal.batcher import BatchingIteratorInterface
 from ray.data._internal.block_batching.interfaces import (
     Batch,
-    BatchMetadata,
     BlockPrefetcher,
     CollatedBatch,
 )
@@ -74,73 +73,20 @@ def resolve_block_refs(
 
 def blocks_to_batches(
     block_iter: Iterator[Block],
-    stats: Optional[DatasetStats] = None,
-    batch_size: Optional[int] = None,
-    drop_last: bool = False,
-    shuffle_buffer_min_size: Optional[int] = None,
-    shuffle_seed: Optional[int] = None,
-    ensure_copy: bool = False,
+    batching_iterator: BatchingIteratorInterface,
 ) -> Iterator[Batch]:
     """Given an iterator over blocks, returns an iterator over blocks
-    of the appropriate bacth size.
-
-    If the shuffling configurations are specified, then the
-    output blocks contain shuffled data.
+    of the appropriate bacth size specified by the block iterator.
 
     Args:
         block_iter: An iterator over blocks.
-        stats: Dataset stats object used to store block batching time.
-        batch_size: Record batch size, or None to let the system pick.
-        drop_last: Whether to drop the last batch if it's incomplete.
-        shuffle_buffer_min_size: If non-None, the data will be randomly shuffled
-            using a local in-memory shuffle buffer, and this value will serve as the
-            minimum number of rows that must be in the local in-memory shuffle buffer in
-            order to yield a batch.
-        shuffle_seed: The seed to use for the local random shuffle.
-        ensure_copy: Whether batches are always copied from the underlying base
-            blocks (not zero-copy views).
+        batching_iterator: A batching iterator, which is a subclass of `BatchingIteratorInterface`.
 
     Returns:
-        An iterator over blocks of the given size that are potentially shuffled.
+        An iterator over batches.
     """
-    if shuffle_buffer_min_size is not None:
-        batcher = ShufflingBatcher(
-            batch_size=batch_size,
-            shuffle_buffer_min_size=shuffle_buffer_min_size,
-            shuffle_seed=shuffle_seed,
-        )
-    else:
-        batcher = Batcher(batch_size=batch_size, ensure_copy=ensure_copy)
 
-    def get_iter_next_batch_s_timer():
-        return stats.iter_next_batch_s.timer() if stats else nullcontext()
-
-    global_counter = 0
-
-    for block in block_iter:
-        batcher.add(block)
-        while batcher.has_batch():
-            with get_iter_next_batch_s_timer():
-                batch = batcher.next_batch()
-            yield Batch(metadata=BatchMetadata(batch_idx=global_counter), data=batch)
-            global_counter += 1
-
-    # Signal to the batcher that there are no more blocks to add.
-    batcher.done_adding()
-
-    # Get any leftover batches in ShufflingBatcher.
-    while batcher.has_batch():
-        with get_iter_next_batch_s_timer():
-            batch = batcher.next_batch()
-        yield Batch(metadata=BatchMetadata(batch_idx=global_counter), data=batch)
-        global_counter += 1
-
-    # Get any remaining data.
-    if not drop_last and batcher.has_any():
-        with get_iter_next_batch_s_timer():
-            batch = batcher.next_batch()
-        yield Batch(metadata=BatchMetadata(batch_idx=global_counter), data=batch)
-        global_counter += 1
+    yield from batching_iterator.iter_batches(block_iter)
 
 
 def format_batches(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -28,6 +28,7 @@ import ray
 import ray.cloudpickle as pickle
 from ray._common.usage import usage_lib
 from ray._private.thirdparty.tabulate.tabulate import tabulate
+from ray.data._internal.batcher import BatchingFactoryProtocol
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.dataset_repr import _build_dataset_ascii_repr
 from ray.data._internal.datasource.bigquery_datasink import BigQueryDatasink
@@ -5450,6 +5451,7 @@ class Dataset:
         local_shuffle_buffer_size: Optional[int] = None,
         local_shuffle_seed: Optional[int] = None,
         _collate_fn: Optional[Callable[[DataBatch], CollatedData]] = None,
+        _batching_factory: Optional[BatchingFactoryProtocol] = None,
     ) -> Iterable[DataBatch]:
         """Return an iterable over batches of data.
 
@@ -5494,6 +5496,11 @@ class Dataset:
                 buffer in order to yield a batch. When there are no more rows to add to
                 the buffer, the remaining rows in the buffer are drained.
             local_shuffle_seed: The seed to use for the local random shuffle.
+            _collate_fn: [Alpha] A function to apply to each data batch before returning it.
+            _batching_factory: [Alpha] A factory function that creates a ``BatchingIteratorInterface`` instance,
+                which is used to iterate over blocks and yield batches. Default is None which uses
+                default batching logic. An ``BatchingIteratorInterface`` subclass can be used to customize
+                how input blocks are iterated over and batches are yielded.
 
         Returns:
             An iterable over batches of data.
@@ -5507,6 +5514,7 @@ class Dataset:
             local_shuffle_buffer_size=local_shuffle_buffer_size,
             local_shuffle_seed=local_shuffle_seed,
             _collate_fn=_collate_fn,
+            _batching_factory=_batching_factory,
         )
 
     @ConsumptionAPI

--- a/python/ray/data/tests/block_batching/test_block_batching.py
+++ b/python/ray/data/tests/block_batching/test_block_batching.py
@@ -13,7 +13,7 @@ def block_generator(num_rows: int, num_blocks: int):
 
 def test_batch_blocks():
     with mock.patch(
-        "ray.data._internal.block_batching.block_batching.blocks_to_batches"
+        "ray.data._internal.block_batching.util.blocks_to_batches"
     ) as mock_batch, mock.patch(
         "ray.data._internal.block_batching.block_batching.format_batches"
     ) as mock_format:
@@ -21,7 +21,8 @@ def test_batch_blocks():
         batch_iter = batch_blocks(block_iter)
         for _ in batch_iter:
             pass
-        assert mock_batch.call_count == 1
+        # We no longer need to call blocks_to_batches
+        assert mock_batch.call_count == 0
         assert mock_format.call_count == 1
 
 


### PR DESCRIPTION
## Why are these changes needed?

I would like to customize the batching of blocks in `iter_torch_batches()` APIs in data ingestion for model training. I considered the following two ways, but both have some shortcomings:
* wrap around `iter_batches()` with another iterator; OR
* expose the underlying non-public `BatcherInterface` class

For example, users want to split each block by group and wrote something like:
```python
def splitter(iterable: Iterable[Any]) -> Iterable[Any]:
    for batch in iterable:
        for _, grouped in batch.groupby("id"):
            yield grouped
```
Option 1 means `dataloader = splitter(ds.iter_batches(.., batch_size=None))`. It kind of works but technically we have two places that handle block-to-batch conversion (inside/outside iter_batches)

Option 2 requires users to write a OOP-style iterator (has_batch, next_batch), which may be overkill for simple iterator. Users have to verify both implementations work the same.

### Changes
A new `BatchingIteratorInterface` is defined, which consolidates the block to batch iterations. Existing OOP-style batcher (`BatcherInterface`) implementations stay the same and they are wrapped by the `BatcherBasedBlockIterator` class. Users provide a factory function to customize the batching logic:
```python
dataloader = ds.iter_torch_batches(..., batching_factory=create_splitter_fn)
```
where `create_splitter_fn` creates an `BatchingIteratorInterface` instance.

The underlying `blocks_to_batches()` (which does the actual block iteration) becomes
```python
yield from iterator.iter_batches(blocks)
```
where `iter_batches` consolidates the `has_batch`/`next_batch` calls into for-loops:
```python
def iter_batches(self, block_iter: Iterator[Block]) -> Iterator[Batch]:
    ...
    # Process each block and yield complete batches
    for block in block_iter:
        for batch in self.iter_from_block(block):
            yield ...
    else:
        # After all blocks, get final batches
        for batch in self.iter_leftovers():
            yield ...
```

The new `BatchingIteratorInterface` only requires overriding one `iter_from_block` method. Back to the original example, users can implement
```python
class MyBlockIterator(BatchingIteratorInterface):
    def __init__(self, col):
        self.col = col

    def iter_from_block(self, block: Block) -> Iterator[Block]:
       for _, df in block.groupby(self.col):
            yield df
```
This will ensure each batch contains only a single group.

Finally, users can use either OOP-style iterator or pythonic iterator in their factory method:
* OOP-style: subclass `BatcherInterface` and implement required methods. Wrap the batcher instance with `BatcherBasedBatchingIterator`
* pythonic iterator: subclass `BatchingIteratorInterface` directly and implement `iter_from_block` and optionally `iter_leftovers`

### TODO
* I would like BatchingIteratorInterface to be DeveloperAPI
* not sure what is the best way to expose this in the public APIs, e.g., `iter_torch_batches`. Currently I just call it `batching_factory=None`.
* tests (no ray task involved)
* 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes  #54197

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
