### PR TITLE
[core][ci] Upgrade RDT and cgraph microbenchmark machines

### DIFF
--- a/release/microbenchmark/experimental/compute_gpu_2_aws.yaml
+++ b/release/microbenchmark/experimental/compute_gpu_2_aws.yaml
@@ -5,6 +5,6 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: g4dn.8xlarge
+    instance_type: g4dn.12xlarge
 
 worker_node_types: []

--- a/release/microbenchmark/experimental/compute_gpu_2_aws.yaml
+++ b/release/microbenchmark/experimental/compute_gpu_2_aws.yaml
@@ -5,6 +5,6 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: g3.8xlarge
+    instance_type: g4dn.8xlarge
 
 worker_node_types: []

--- a/release/microbenchmark/experimental/compute_gpu_2x1_aws.yaml
+++ b/release/microbenchmark/experimental/compute_gpu_2x1_aws.yaml
@@ -5,11 +5,11 @@ max_workers: 1
 
 head_node_type:
     name: head_node
-    instance_type: g3.4xlarge
+    instance_type: g4dn.4xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: g3.4xlarge
+      instance_type: g4dn.4xlarge
       max_workers: 1
       min_workers: 1
       use_spot: false


### PR DESCRIPTION
## Why are these changes needed?
Availability of g3 is pretty low on aws, so the release tests will often fail because we can't secure the machines within the timeout.

Upgrading to g4dn like train tests did here https://github.com/ray-project/ray/pull/56175


Closes https://github.com/ray-project/ray/issues/57204