### PR TITLE
[core] Make Unsubscribe Idempotent

### DIFF
--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -1177,8 +1177,8 @@ void ReferenceCounter::WaitForRefRemoved(const ReferenceTable::iterator &ref_it,
 
     CleanupBorrowersOnRefRemoved(new_borrower_refs, object_id, addr);
     // Unsubscribe the object once the message is published.
-    RAY_CHECK(object_info_subscriber_->Unsubscribe(
-        rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL, addr, object_id.Binary()));
+    object_info_subscriber_->Unsubscribe(
+        rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL, addr, object_id.Binary());
   };
 
   // If the borrower is failed, this callback will be called.

--- a/src/ray/core_worker/tests/reference_counter_test.cc
+++ b/src/ray/core_worker/tests/reference_counter_test.cc
@@ -190,11 +190,9 @@ class MockDistributedSubscriber : public pubsub::SubscriberInterface {
     failure_callback_it->second.emplace(oid, subscription_failure_callback);
   }
 
-  bool Unsubscribe(rpc::ChannelType channel_type,
+  void Unsubscribe(rpc::ChannelType channel_type,
                    const rpc::Address &publisher_address,
-                   const std::optional<std::string> &key_id_binary) override {
-    return true;
-  }
+                   const std::optional<std::string> &key_id_binary) override {}
 
   bool IsSubscribed(rpc::ChannelType channel_type,
                     const rpc::Address &publisher_address,

--- a/src/ray/pubsub/fake_subscriber.h
+++ b/src/ray/pubsub/fake_subscriber.h
@@ -45,11 +45,9 @@ class FakeSubscriber : public SubscriberInterface {
       pubsub::SubscriptionItemCallback subscription_callback,
       pubsub::SubscriptionFailureCallback subscription_failure_callback) override {}
 
-  bool Unsubscribe(rpc::ChannelType channel_type,
+  void Unsubscribe(rpc::ChannelType channel_type,
                    const rpc::Address &publisher_address,
-                   const std::optional<std::string> &key_id) override {
-    return true;
-  }
+                   const std::optional<std::string> &key_id) override {}
 
   bool IsSubscribed(rpc::ChannelType channel_type,
                     const rpc::Address &publisher_address,

--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -53,7 +53,7 @@ void SubscriberChannel::Subscribe(
   }
 }
 
-bool SubscriberChannel::Unsubscribe(const rpc::Address &publisher_address,
+void SubscriberChannel::Unsubscribe(const rpc::Address &publisher_address,
                                     const std::optional<std::string> &key_id) {
   cum_unsubscribe_requests_++;
   const auto publisher_id = UniqueID::FromBinary(publisher_address.worker_id());
@@ -61,17 +61,16 @@ bool SubscriberChannel::Unsubscribe(const rpc::Address &publisher_address,
   // Find subscription info.
   auto subscription_it = subscription_map_.find(publisher_id);
   if (subscription_it == subscription_map_.end()) {
-    return false;
+    return;
   }
   auto &subscription_index = subscription_it->second;
 
   // Unsubscribing from the channel.
   if (!key_id) {
     RAY_CHECK(subscription_index.per_entity_subscription.empty());
-    const bool unsubscribed = subscription_index.all_entities_subscription != nullptr;
     subscription_index.all_entities_subscription.reset();
     subscription_map_.erase(subscription_it);
-    return unsubscribed;
+    return;
   }
 
   // Unsubscribing from a single key.
@@ -80,13 +79,12 @@ bool SubscriberChannel::Unsubscribe(const rpc::Address &publisher_address,
 
   auto subscription_callback_it = per_entity_subscription.find(*key_id);
   if (subscription_callback_it == per_entity_subscription.end()) {
-    return false;
+    return;
   }
   per_entity_subscription.erase(subscription_callback_it);
   if (per_entity_subscription.empty()) {
     subscription_map_.erase(subscription_it);
   }
-  return true;
 }
 
 bool SubscriberChannel::IsSubscribed(const rpc::Address &publisher_address,
@@ -171,10 +169,8 @@ void SubscriberChannel::HandlePublisherFailure(const rpc::Address &publisher_add
 
   for (const auto &key_id : key_ids_to_unsubscribe) {
     // If the publisher is failed, we automatically unsubscribe objects from this
-    // publishers. If the failure callback called UnsubscribeObject, this will raise
-    // check failures.
-    RAY_CHECK(Unsubscribe(publisher_address, key_id))
-        << "Calling UnsubscribeObject inside a failure callback is not allowed.";
+    // publishers.
+    Unsubscribe(publisher_address, key_id);
   }
 }
 
@@ -189,8 +185,7 @@ void SubscriberChannel::HandlePublisherFailure(const rpc::Address &publisher_add
   auto unsubscribe_needed =
       HandlePublisherFailureInternal(publisher_address, key_id, Status::OK());
   if (unsubscribe_needed) {
-    RAY_CHECK(Unsubscribe(publisher_address, key_id))
-        << "Calling UnsubscribeObject inside a failure callback is not allowed.";
+    Unsubscribe(publisher_address, key_id);
   }
 }
 
@@ -229,7 +224,7 @@ std::string SubscriberChannel::DebugString() const {
 /// Subscriber
 ///////////////////////////////////////////////////////////////////////////////
 
-bool Subscriber::Unsubscribe(rpc::ChannelType channel_type,
+void Subscriber::Unsubscribe(rpc::ChannelType channel_type,
                              const rpc::Address &publisher_address,
                              const std::optional<std::string> &key_id) {
   // Batch the unsubscribe command.
@@ -245,7 +240,7 @@ bool Subscriber::Unsubscribe(rpc::ChannelType channel_type,
   commands_[publisher_id].emplace(std::move(command));
   SendCommandBatchIfPossible(publisher_address);
 
-  return Channel(channel_type)->Unsubscribe(publisher_address, key_id);
+  Channel(channel_type)->Unsubscribe(publisher_address, key_id);
 }
 
 bool Subscriber::IsSubscribed(rpc::ChannelType channel_type,

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -85,7 +85,7 @@ class SubscriberChannel {
   /// \param publisher_address The publisher address that it will unsubscribe to.
   /// \param key_id The entity id to unsubscribe.
   /// \return True if the publisher is unsubscribed.
-  bool Unsubscribe(const rpc::Address &publisher_address,
+  void Unsubscribe(const rpc::Address &publisher_address,
                    const std::optional<std::string> &key_id);
 
   /// Test only.
@@ -238,7 +238,7 @@ class Subscriber : public SubscriberInterface {
                  SubscriptionItemCallback subscription_callback,
                  SubscriptionFailureCallback subscription_failure_callback) override;
 
-  bool Unsubscribe(rpc::ChannelType channel_type,
+  void Unsubscribe(rpc::ChannelType channel_type,
                    const rpc::Address &publisher_address,
                    const std::optional<std::string> &key_id) override;
 

--- a/src/ray/pubsub/subscriber_interface.h
+++ b/src/ray/pubsub/subscriber_interface.h
@@ -72,8 +72,7 @@ class SubscriberInterface {
   /// \param publisher_address The publisher address that it will unsubscribe from.
   /// \param key_id The entity id to unsubscribe. Unsubscribes from all entities if
   /// nullopt.
-  /// \return Returns whether the entity key_id has been subscribed before.
-  virtual bool Unsubscribe(rpc::ChannelType channel_type,
+  virtual void Unsubscribe(rpc::ChannelType channel_type,
                            const rpc::Address &publisher_address,
                            const std::optional<std::string> &key_id) = 0;
 

--- a/src/ray/pubsub/tests/subscriber_test.cc
+++ b/src/ray/pubsub/tests/subscriber_test.cc
@@ -228,7 +228,8 @@ TEST_F(SubscriberTest, TestBasicSubscription) {
 
   const auto owner_addr = GenerateOwnerAddress();
   const auto object_id = ObjectID::FromRandom();
-  ASSERT_FALSE(subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary()));
+  subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary());
+  ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
   ASSERT_TRUE(owner_client->ReplyCommandBatch());
   subscriber_->Subscribe(GenerateSubMessage(object_id),
                          channel,
@@ -254,7 +255,8 @@ TEST_F(SubscriberTest, TestBasicSubscription) {
     ASSERT_EQ(object_subscribed_[oid], 2);
   }
 
-  ASSERT_TRUE(subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary()));
+  subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary());
+  ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
   ASSERT_TRUE(owner_client->ReplyCommandBatch());
   ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
 
@@ -504,7 +506,8 @@ TEST_F(SubscriberTest, TestSubscribeAllEntities) {
   }
 
   // Unsubscribe from the channel.
-  ASSERT_TRUE(subscriber_->Unsubscribe(channel, owner_addr, /*key_id=*/std::nullopt));
+  subscriber_->Unsubscribe(channel, owner_addr, /*key_id=*/std::nullopt);
+  ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, /*key_id=*/""));
 }
 
 TEST_F(SubscriberTest, TestIgnoreBatchAfterUnsubscription) {
@@ -527,7 +530,8 @@ TEST_F(SubscriberTest, TestIgnoreBatchAfterUnsubscription) {
                          subscription_callback,
                          failure_callback);
   ASSERT_TRUE(owner_client->ReplyCommandBatch());
-  ASSERT_TRUE(subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary()));
+  subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary());
+  ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
   ASSERT_TRUE(owner_client->ReplyCommandBatch());
   std::vector<ObjectID> objects_batched;
   objects_batched.push_back(object_id);
@@ -560,7 +564,8 @@ TEST_F(SubscriberTest, TestIgnoreBatchAfterUnsubscribeFromAll) {
                          subscription_callback,
                          failure_callback);
   ASSERT_TRUE(owner_client->ReplyCommandBatch());
-  ASSERT_TRUE(subscriber_->Unsubscribe(channel, owner_addr, /*key_id=*/std::nullopt));
+  subscriber_->Unsubscribe(channel, owner_addr, /*key_id=*/std::nullopt);
+  ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, /*key_id=*/""));
   ASSERT_TRUE(owner_client->ReplyCommandBatch());
 
   const auto object_id = ObjectID::FromRandom();
@@ -614,6 +619,7 @@ TEST_F(SubscriberTest, TestUnsubscribeInSubscriptionCallback) {
   auto subscription_callback = [this, owner_addr](const rpc::PubMessage &msg) {
     const auto object_id = ObjectID::FromBinary(msg.key_id());
     subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary());
+    ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
     ASSERT_TRUE(owner_client->ReplyCommandBatch());
     object_subscribed_[object_id]++;
   };
@@ -705,6 +711,7 @@ TEST_F(SubscriberTest, TestSubUnsubCommandBatchMultiEntries) {
 
   // Test multiple entries in the batch before new reply is coming.
   subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary());
+  ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
   subscriber_->Subscribe(GenerateSubMessage(object_id),
                          channel,
                          owner_addr,
@@ -967,7 +974,7 @@ TEST_F(SubscriberTest, TestIsSubscribed) {
   const auto owner_addr = GenerateOwnerAddress();
   const auto object_id = ObjectID::FromRandom();
 
-  ASSERT_FALSE(subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary()));
+  subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary());
   ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
 
   subscriber_->Subscribe(GenerateSubMessage(object_id),
@@ -979,7 +986,7 @@ TEST_F(SubscriberTest, TestIsSubscribed) {
                          failure_callback);
   ASSERT_TRUE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
 
-  ASSERT_TRUE(subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary()));
+  subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary());
   ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
 }
 

--- a/src/ray/raylet/tests/local_object_manager_test.cc
+++ b/src/ray/raylet/tests/local_object_manager_test.cc
@@ -87,7 +87,7 @@ class MockSubscriber : public pubsub::SubscriberInterface {
   }
 
   MOCK_METHOD3(Unsubscribe,
-               bool(rpc::ChannelType channel_type,
+               void(rpc::ChannelType channel_type,
                     const rpc::Address &publisher_address,
                     const std::optional<std::string> &key_id_binary));
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With #56436 it is possible that we can get multiple unsubscribes with the following set of operations: 
1.) Ref goes out of scope
2.) CommandBatch request sent (message immediately published to mailbox since ref is out of scope)
3.) CommandBatch reply lost
4.) Retry CommandBatch request (another message published to mailbox!)
5.) LongPollingResponse retrieves 2 WORKER_REF_REMOVED messages which will trigger unsubscribe twice and trigger the RAY_CHECK

Since this function just cleans up local subscriber state, I don't think there's any issues with making it a void return type instead of returning a bool. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
