### PR TITLE
[Data] Allow `ArrowVariableShapedTensorTypes` w/ diverging `ndim`s to be combined 

### DIFF
--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -976,7 +976,7 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
     first_tensors = [
         # (1, 2, 1)
         np.array([[[1], [2]], [[3], [4]]]),
-        # (2, 2, 1)
+        # (2, 3, 1)
         np.array([[[5], [6], [7]], [[8], [9], [10]]]),
     ]
     second_tensors = [

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -922,7 +922,6 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
     when concatenating Arrow arrays with variable shaped tensors."""
     from ray.data.extensions.tensor_extension import (
         ArrowVariableShapedTensorArray,
-        ArrowVariableShapedTensorType,
     )
 
     #
@@ -934,13 +933,13 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
         # (2, 2)
         np.array([[1, 2], [3, 4]]),
         # (2, 3)
-        np.array([[5, 6, 7], [8, 9, 10]])
+        np.array([[5, 6, 7], [8, 9, 10]]),
     ]
     second_tensors = [
         # (1, 4)
         np.array([[11, 12, 13, 14]]),
         # (3, 1)
-        np.array([[15], [16], [17]])
+        np.array([[15], [16], [17]]),
     ]
 
     first_arr = ArrowVariableShapedTensorArray.from_numpy(first_tensors)
@@ -960,11 +959,12 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
 
     result_ndarray = concatenated.to_numpy()
 
-    for i, expected_ndarray in enumerate(itertools.chain.from_iterable([first_tensors, second_tensors])):
+    for i, expected_ndarray in enumerate(
+        itertools.chain.from_iterable([first_tensors, second_tensors])
+    ):
         assert result_ndarray[i].shape == expected_ndarray.shape
 
         np.testing.assert_array_equal(result_ndarray[i], expected_ndarray)
-
 
     #
     # Case 2: Tensors are variable-shaped, with diverging ``ndim``s
@@ -975,13 +975,13 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
         # (1, 2, 1)
         np.array([[[1], [2]], [[3], [4]]]),
         # (2, 2, 1)
-        np.array([[[5], [6], [7]], [[8], [9], [10]]])
+        np.array([[[5], [6], [7]], [[8], [9], [10]]]),
     ]
     second_tensors = [
         # (1, 4)
         np.array([[11, 12, 13, 14]]),
         # (3, 1)
-        np.array([[15], [16], [17]])
+        np.array([[15], [16], [17]]),
     ]
 
     first_arr = ArrowVariableShapedTensorArray.from_numpy(first_tensors)
@@ -1004,7 +1004,9 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
 
     print(f">>> Result: {[arr.shape for arr in result_ndarray]=}")
 
-    for i, expected_ndarray in enumerate(itertools.chain.from_iterable([first_tensors, second_tensors])):
+    for i, expected_ndarray in enumerate(
+        itertools.chain.from_iterable([first_tensors, second_tensors])
+    ):
         assert result_ndarray[i].shape == expected_ndarray.shape
 
         np.testing.assert_array_equal(result_ndarray[i], expected_ndarray)

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -948,6 +948,8 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
     # Assert commutation
     assert first_arr.type == second_arr.type
     assert second_arr.type == first_arr.type
+    # Assert hashing is correct
+    assert hash(first_arr.type) == hash(second_arr.type)
 
     assert first_arr.type.ndim == 2
     assert second_arr.type.ndim == 2
@@ -990,6 +992,8 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
     # Assert commutation
     assert first_arr.type == second_arr.type
     assert second_arr.type == first_arr.type
+    # Assert hashing is correct
+    assert hash(first_arr.type) == hash(second_arr.type)
 
     assert first_arr.type.ndim == 3
     assert second_arr.type.ndim == 2

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -850,7 +850,7 @@ def test_tensor_type_equality_checks():
     vs_tensor_type = ArrowVariableShapedTensorType(pa.int64(), 2)
 
     # Test that different types are not equal
-    assert vs_tensor_type != ArrowVariableShapedTensorType(pa.int64(), 3)
+    assert vs_tensor_type == ArrowVariableShapedTensorType(pa.int64(), 3)
     assert vs_tensor_type != ArrowVariableShapedTensorType(pa.float64(), 2)
     assert vs_tensor_type != fs_tensor_type_v1
     assert vs_tensor_type != fs_tensor_type_v2

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -925,30 +925,89 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
         ArrowVariableShapedTensorType,
     )
 
-    # Create ArrowVariableShapedTensorType
-    var_tensor_type = ArrowVariableShapedTensorType(pa.int64(), 2)
+    #
+    # Case 1: Tensors are variable-shaped but same ``ndim``
+    #
 
-    # Create arrays with variable-shaped tensors
-    tensors1 = [np.array([[1, 2], [3, 4]]), np.array([[5, 6, 7], [8, 9, 10]])]
-    tensors2 = [np.array([[11, 12, 13, 14]]), np.array([[15], [16], [17]])]
+    # Create arrays with variable-shaped tensors (but same ndim)
+    first_tensors = [
+        # (2, 2)
+        np.array([[1, 2], [3, 4]]),
+        # (2, 3)
+        np.array([[5, 6, 7], [8, 9, 10]])
+    ]
+    second_tensors = [
+        # (1, 4)
+        np.array([[11, 12, 13, 14]]),
+        # (3, 1)
+        np.array([[15], [16], [17]])
+    ]
 
-    arr1 = ArrowVariableShapedTensorArray.from_numpy(tensors1)
-    arr2 = ArrowVariableShapedTensorArray.from_numpy(tensors2)
+    first_arr = ArrowVariableShapedTensorArray.from_numpy(first_tensors)
+    second_arr = ArrowVariableShapedTensorArray.from_numpy(second_tensors)
 
-    assert arr1.type == arr2.type
     # Assert commutation
-    assert var_tensor_type == arr1.type
-    assert arr1.type == var_tensor_type
+    assert first_arr.type == second_arr.type
+    assert second_arr.type == first_arr.type
+
+    assert first_arr.type.ndim == 2
+    assert second_arr.type.ndim == 2
 
     # Test concatenation works appropriately
-    concatenated = pa.concat_arrays([arr1, arr2])
+    concatenated = pa.concat_arrays([first_arr, second_arr])
     assert len(concatenated) == 4
-    assert concatenated.type == var_tensor_type
+    assert concatenated.type == first_arr.type
 
-    result = concatenated.to_numpy()
-    expected_shapes = [(2, 2), (2, 3), (1, 4), (3, 1)]
-    for i, expected_shape in enumerate(expected_shapes):
-        assert result[i].shape == expected_shape
+    result_ndarray = concatenated.to_numpy()
+
+    for i, expected_ndarray in enumerate(itertools.chain.from_iterable([first_tensors, second_tensors])):
+        assert result_ndarray[i].shape == expected_ndarray.shape
+
+        np.testing.assert_array_equal(result_ndarray[i], expected_ndarray)
+
+
+    #
+    # Case 2: Tensors are variable-shaped, with diverging ``ndim``s
+    #
+
+    # Create arrays with variable-shaped tensors (but same ndim)
+    first_tensors = [
+        # (1, 2, 1)
+        np.array([[[1], [2]], [[3], [4]]]),
+        # (2, 2, 1)
+        np.array([[[5], [6], [7]], [[8], [9], [10]]])
+    ]
+    second_tensors = [
+        # (1, 4)
+        np.array([[11, 12, 13, 14]]),
+        # (3, 1)
+        np.array([[15], [16], [17]])
+    ]
+
+    first_arr = ArrowVariableShapedTensorArray.from_numpy(first_tensors)
+    second_arr = ArrowVariableShapedTensorArray.from_numpy(second_tensors)
+
+    # Assert commutation
+    assert first_arr.type == second_arr.type
+    assert second_arr.type == first_arr.type
+
+    assert first_arr.type.ndim == 3
+    assert second_arr.type.ndim == 2
+
+    # Test concatenation works appropriately
+    concatenated = pa.concat_arrays([first_arr, second_arr])
+
+    assert len(concatenated) == 4
+    assert concatenated.type == first_arr.type
+
+    result_ndarray = concatenated.to_numpy()
+
+    print(f">>> Result: {[arr.shape for arr in result_ndarray]=}")
+
+    for i, expected_ndarray in enumerate(itertools.chain.from_iterable([first_tensors, second_tensors])):
+        assert result_ndarray[i].shape == expected_ndarray.shape
+
+        np.testing.assert_array_equal(result_ndarray[i], expected_ndarray)
 
 
 def test_reverse_order():

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -970,7 +970,7 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
     # Case 2: Tensors are variable-shaped, with diverging ``ndim``s
     #
 
-    # Create arrays with variable-shaped tensors (but same ndim)
+    # Create arrays with variable-shaped tensors (but different ndim)
     first_tensors = [
         # (1, 2, 1)
         np.array([[[1], [2]], [[3], [4]]]),
@@ -1001,8 +1001,6 @@ def test_arrow_variable_shaped_tensor_type_eq_with_concat():
     assert concatenated.type == first_arr.type
 
     result_ndarray = concatenated.to_numpy()
-
-    print(f">>> Result: {[arr.shape for arr in result_ndarray]=}")
 
     for i, expected_ndarray in enumerate(
         itertools.chain.from_iterable([first_tensors, second_tensors])

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -984,11 +984,12 @@ class ArrowVariableShapedTensorType(pa.ExtensionType):
         return str(self)
 
     def __eq__(self, other):
+        # NOTE: This check is deliberately not comparing the ``ndim`` since
+        #       we allow tensor types w/ varying ``ndim``s to be combined
         return (
             isinstance(other, ArrowVariableShapedTensorType)
             and other.extension_name == self.extension_name
             and other.scalar_type == self.scalar_type
-            and other.ndim == self.ndim
         )
 
     def __ne__(self, other):

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -997,7 +997,7 @@ class ArrowVariableShapedTensorType(pa.ExtensionType):
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        return hash((self.extension_name, self.scalar_type, self._ndim))
+        return hash((self.extension_name, self.scalar_type))
 
     def _extension_scalar_to_ndarray(self, scalar: "pa.ExtensionScalar") -> np.ndarray:
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Original [PR](https://github.com/ray-project/ray/pull/56918) had while fixing all of the infra missed to delete the line in the end relaxing this constraint:

1. Removed constraint allowing AVSTT w/ diverging `ndim`s to be merged
2. Added tests

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
