### PR TITLE
[core] Unexpected system exit instead of objects_valid crash on exception

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2462,6 +2462,10 @@ cdef CRayStatus task_execution_handler(
                 if hasattr(e, "unexpected_error_traceback"):
                     msg += (f" {e.unexpected_error_traceback}")
                 return CRayStatus.UnexpectedSystemExit(msg)
+        except Exception as e:
+            msg = "Unexpected exception raised in task execution handler: {}".format(e)
+            logger.error(msg)
+            return CRayStatus.UnexpectedSystemExit(msg)
 
     return CRayStatus.OK()
 


### PR DESCRIPTION
## Why are these changes needed?
Currently if the task_execution_handler in _raylet.pyx throws an exception before we can get into the actual task handling code that catches all exceptions, cython will end up just continuing execution to return Status::OK. This means that we could finish ExecuteTask with Status::OK and a return objects vector that has empty objects leading to the dreaded objects_valid check failure.

Instead of a check failure this will catch the exception, log an error, and return an UnexpectedSystemExit with the exception information so the worker can exit gracefully and the driver can get the exception information for better debuggability. For example: https://github.com/ray-project/ray/pull/57253 was hard to figure out for a long time because we didn't know why we were skipping the object storing phase in Cython. This would've made it much easier.