### PR TITLE
docs: improve CONTRIBUTING.rst with PR guidelines and Slack link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,5 +51,4 @@ For contributors who are not in the ray-project organization:
 .. _`Getting Involved`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html
 .. _`Setting up your development environment`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#setting-up-your-development-environment
 .. _`Code Style`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#code-style
-.. _`Pre-commit hooks`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting
 .. _`Testing guide`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#testing

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,8 @@ You can post questions or issues or feedback through the following channels:
 
 1. `Discourse forum`_: For discussions about development and questions about usage.
 2. `GitHub Issues`_: For bug reports and feature requests.
-3. `StackOverflow`_
+3. `Join Slack`_: For real-time community discussions and support.
+4. `StackOverflow`_
 
 To contribute a patch:
 ----------------------
@@ -20,6 +21,7 @@ the `Setting up your development environment`_ section.
 .. _`Discourse forum`: https://discuss.ray.io/
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
+.. _`Join Slack`: https://www.ray.io/join-slack
 .. _`Getting Involved`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html
 .. _`Setting up your development environment`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#setting-up-your-development-environment
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,16 +14,16 @@ You can post questions or issues or feedback through the following channels:
 To contribute a patch:
 ----------------------
 
-We welcome contributions! See `Getting Involved`_. To set up your development environment, see
-the `Setting up your development environment`_ section.
+Before submitting a pull request:
 
+1. Review the `Getting Involved`_ guide for detailed contribution guidelines
+2. Set up your `Setting up your development environment`_
+3. Follow the `Code Style`_ guidelines (lint and formatting) and the `Testing guide`_ for tests.
+4. Sign off all commits with ``git commit -s``
+5. Write tests and update docs for your changes
 
-.. _`Discourse forum`: https://discuss.ray.io/
-.. _`GitHub Issues`: https://github.com/ray-project/ray/issues
-.. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
-.. _`Join Slack`: https://www.ray.io/join-slack
-.. _`Getting Involved`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html
-.. _`Setting up your development environment`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#setting-up-your-development-environment
+Our PR template will guide you through the rest when you open the PR. 
+See the PR Review Process section below for what happens after you submit your PR.
 
 PR Review Process
 -----------------
@@ -43,3 +43,13 @@ For contributors who are not in the ray-project organization:
 
 - Your PRs will have assignees shortly. Assignees or PRs will be actively engaging with contributors to merge the PR.
 - Please actively ping assignees after you address your comments!
+
+.. _`Discourse forum`: https://discuss.ray.io/
+.. _`GitHub Issues`: https://github.com/ray-project/ray/issues
+.. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
+.. _`Join Slack`: https://www.ray.io/join-slack
+.. _`Getting Involved`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html
+.. _`Setting up your development environment`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#setting-up-your-development-environment
+.. _`Code Style`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#code-style
+.. _`Pre-commit hooks`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting
+.. _`Testing guide`: https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#testing


### PR DESCRIPTION
## Why are these changes needed?

Since we are updating our [PR template](https://github.com/ray-project/ray/pull/57193) and I also added things into the [Ray Contribute Github page](https://github.com/ray-project/ray/contribute), I figured now is a good time to update the `CONTRIBUTING.rst` text, since that is also linked to the GitHub Contribute page.

**Changes**:
- Add structured "To contribute a patch" checklist
- Add Slack community link
- Consolidate all reference links at bottom for consistency
- Align with new PR template structure.
 
## Related PR number

Updates along with #57193

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
