### PR TITLE
[core] Fix python 3.12 asyncio RecursionError leading to objects_valid check

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -72,6 +72,7 @@ cdef extern from "Python.h":
     ctypedef struct CPyThreadState "PyThreadState":
         int recursion_limit
         int recursion_remaining
+        int c_recursion_remaining
 
     # From Include/ceveal.h#67
     int Py_GetRecursionLimit()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -688,15 +688,15 @@ cdef increase_recursion_limit():
         On 3.12, when recursion depth increases, c_recursion_remaining will decrease
         and this is what's acutally compared to raise a RecursionError. So increasing
         it by 1000 when it drops below 1000 will keep us from raising the RecursionError.
-        DoOrGetRecursionMadness will return false (so we don't set with Py_SetRecursionLimit).
+        DoOrGetRecursionMadness will return (false, 0), so we don't set with Py_SetRecursionLimit.
     0x30B00A4 is Python 3.11
         On 3.11, the recursion depth can be calculated with recursion_limit - recursion_remaining.
         We can get the current limit with Py_GetRecursionLimit and set it with Py_SetRecursionLimit.
-        DoOrGetRecursionMadness will return true + the current recursion depth.
+        DoOrGetRecursionMadness will return (true, current_depth)
     On older versions
         There's simply a recursion_depth variable and we can increase the max the same
         way we do for 3.11.
-        DoOrGetRecursionMadness will return true + the current recursion depth.
+        DoOrGetRecursionMadness will return (true, current_depth)
     """
     cdef:
         CPyThreadState * s = <CPyThreadState *> PyThreadState_Get()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -686,8 +686,9 @@ cdef increase_recursion_limit():
 
     0x30C0000 is Python 3.12
         On 3.12, when recursion depth increases, c_recursion_remaining will decrease,
-        and that's what's acutally compared to raise a RecursionError. So increasing
+        and that's what's actually compared to raise a RecursionError. So increasing
         it by 1000 when it drops below 1000 will keep us from raising the RecursionError.
+        https://github.com/python/cpython/blob/bfb9e2f4a4e690099ec2ec53c08b90f4d64fde36/Python/pystate.c#L1353
     0x30B00A4 is Python 3.11
         On 3.11, the recursion depth can be calculated with recursion_limit - recursion_remaining.
         We can get the current limit with Py_GetRecursionLimit and set it with Py_SetRecursionLimit.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -688,8 +688,7 @@ cdef increase_recursion_limit():
         On 3.12, when recursion depth increases, c_recursion_remaining will decrease
         and this is what's acutally compared to raise a RecursionError. So increasing
         it by 1000 when it drops below 1000 will keep us from raising the RecursionError.
-        DoOrGetRecursionMadness will return false (so we don't set with Py_SetRecursionLimit)
-        + the current recursion remaining.
+        DoOrGetRecursionMadness will return false (so we don't set with Py_SetRecursionLimit).
     0x30B00A4 is Python 3.11
         On 3.11, the recursion depth can be calculated with recursion_limit - recursion_remaining.
         We can get the current limit with Py_GetRecursionLimit and set it with Py_SetRecursionLimit.
@@ -710,7 +709,7 @@ cdef increase_recursion_limit():
         if (x->c_recursion_remaining < 1000) {
             x->c_recursion_remaining += 1000;
         }
-        return std::make_pair(false, x->c_recursion_remaining);
+        return std::make_pair(false, 0);
     }
 #elif PY_VERSION_HEX >= 0x30B00A4
     std::pair<bool, int> DoOrGetRecursionMadness(PyThreadState *x) {

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1873,8 +1873,6 @@ cdef void execute_task(
     name_of_concurrency_group_to_execute = \
         c_name_of_concurrency_group_to_execute.decode("ascii")
 
-    # increase_recursion_limit()
-
     if <int>task_type == <int>TASK_TYPE_NORMAL_TASK:
         next_title = "ray::IDLE"
         function_executor = execution_info.function

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -679,25 +679,56 @@ def compute_task_id(ObjectRef object_ref):
 
 
 cdef increase_recursion_limit():
-    """Double the recusion limit if current depth is close to the limit"""
+    """
+    Ray does some weird things with asio fibers and asyncio to run asyncio actors.
+    This results in the Python interpreter thinking there's a lot of recursion depth,
+    so we need to increase the limit when we start getting close.
+
+    0x30C0000 is Python 3.12
+        On 3.12, when recursion depth increases, c_recursion_remaining will decrease
+        and this is what's acutally compared to raise a RecursionError. So increasing
+        it by 1000 when it drops below 1000 will keep us from raising the RecursionError.
+        DoOrGetRecursionMadness will return false (so we don't set with Py_SetRecursionLimit)
+        + the current recursion remaining.
+    0x30B00A4 is Python 3.11
+        On 3.11, the recursion depth can be calculated with recursion_limit - recursion_remaining.
+        We can get the current limit with Py_GetRecursionLimit and set it with Py_SetRecursionLimit.
+        DoOrGetRecursionMadness will return true + the current recursion depth.
+    On older versions
+        There's simply a recursion_depth variable and we can increase the max the same
+        way we do for 3.11.
+        DoOrGetRecursionMadness will return true + the current recursion depth.
+    """
     cdef:
         CPyThreadState * s = <CPyThreadState *> PyThreadState_Get()
         int current_limit = Py_GetRecursionLimit()
-        int new_limit = current_limit * 2
+        int new_limit = current_limit * 2 # Only for versions less than 3.12
         cdef extern from *:
             """
 #if PY_VERSION_HEX >= 0x30C0000
-    #define CURRENT_DEPTH(x) ((x)->py_recursion_limit - (x)->py_recursion_remaining)
+    std::pair<bool, int> DoOrGetRecursionMadness(PyThreadState *x) {
+        if (x->c_recursion_remaining < 1000) {
+            x->c_recursion_remaining += 1000;
+        }
+        return std::make_pair(false, x->c_recursion_remaining);
+    }
 #elif PY_VERSION_HEX >= 0x30B00A4
-    #define CURRENT_DEPTH(x)  ((x)->recursion_limit - (x)->recursion_remaining)
+    std::pair<bool, int> DoOrGetRecursionMadness(PyThreadState *x) {
+        return std::make_pair(true, x->recursion_limit - x->recursion_remaining);
+    }
 #else
-    #define CURRENT_DEPTH(x)  ((x)->recursion_depth)
+    std::pair<bool, int> DoOrGetRecursionMadness(PyThreadState *x) {
+        return std::make_pair(true, x->recursion_depth);
+    }
 #endif
             """
-            int CURRENT_DEPTH(CPyThreadState *x)
+            c_pair[c_bool, int] DoOrGetRecursionMadness(CPyThreadState *x)
 
-        int current_depth = CURRENT_DEPTH(s)
-    if current_limit - current_depth < 500:
+        c_pair[c_bool, int] result = DoOrGetRecursionMadness(s)
+        c_bool need_to_increase = result.first
+        int current_depth = result.second
+
+    if need_to_increase and current_limit - current_depth < 500:
         Py_SetRecursionLimit(new_limit)
         logger.debug("Increasing Python recursion limit to {} "
                      "current recursion depth is {}.".format(
@@ -1841,6 +1872,8 @@ cdef void execute_task(
 
     name_of_concurrency_group_to_execute = \
         c_name_of_concurrency_group_to_execute.decode("ascii")
+
+    # increase_recursion_limit()
 
     if <int>task_type == <int>TASK_TYPE_NORMAL_TASK:
         next_title = "ray::IDLE"


### PR DESCRIPTION
## Why are these changes needed?
Currently if the `task_execution_handler` in _raylet.pyx throws an exception before we can get into the actual task handling code that catches all exceptions, cython will end up just continuing execution to return Status::OK. This means that we could finish `ExecuteTask` with Status::OK and a return objects vector that has empty objects leading to the dreaded `objects_valid` check failure.

One of the primary reasons this can happen is due to a RecursionError that can be thrown pretty easily (and in an unexpected way to users) due to the way we do asyncio through boost fibers which makes the Python interpreter think our recursion depth is very high. We try to handle this with this code
https://github.com/ray-project/ray/blob/534b0e46d070b0ceff5d2d6ac6aea37fe78d5f32/python/ray/_raylet.pyx#L681-L701

but it doesn't actually work in the Python 3.12 (PY_VERSION_HEX >= 0x30C0000) case. This is because CPython changed to having separate variables for c recursion and py recursion in 3.12 here https://github.com/python/cpython/pull/96510.

CPython just sets the `c_recursion_remaining` of the thread state to `C_RECURSION_LIMIT` at thread state initialization and then only uses `c_recursion_remaining`, so we can just to increase `c_recursion_remaining` by 1k once it drops below 1k to keep it over 1k.
https://github.com/python/cpython/blob/bfb9e2f4a4e690099ec2ec53c08b90f4d64fde36/Python/pystate.c#L1353

## Repro
Note that there is a test that does something very similar to this and triggers the same condition:  `test_asyncio.py::test_asyncio_actor_high_concurrency`, but it seems like it might not running on Python 3.12 on CI now, trying to get to the bottom of that.
```
import ray
import asyncio

@ray.remote
class AsyncConcurrencyBatcher:
    def __init__(self, batch_size):
        self.batch = []
        self.event = asyncio.Event()
        self.batch_size = batch_size

    async def add(self, x):
        self.batch.append(x)
        if len(self.batch) >= self.batch_size:
            self.event.set()
        else:
            await self.event.wait()
        return sorted(self.batch)


batch_size = 746
actor = AsyncConcurrencyBatcher.remote(
    batch_size
)
ray.get([actor.add.remote(i) for i in range(batch_size)])
```

## Related issue number
https://github.com/ray-project/ray/issues/57173

