### PR TITLE
[Data] Fix `max_calls` to not be passed into `.options()`

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -349,7 +349,7 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
     ) -> Dict[str, Any]:
         ray_remote_args = copy.deepcopy(self._ray_remote_args)
 
-        # Pop `max_calls` as it's a `@ray.remote` argument, not a `.options()` argument.
+        # max_calls isn't supported in `.options()`, so we remove it when generating dynamic ray_remote_args
         ray_remote_args.pop("max_calls", None)
 
         # Override parameters from user provided remote args function.

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -349,7 +349,7 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
     ) -> Dict[str, Any]:
         ray_remote_args = copy.deepcopy(self._ray_remote_args)
 
-        # Remove max_calls from the dynamic options.
+        # Pop `max_calls` as it's a `@ray.remote` argument, not a `.options()` argument.
         ray_remote_args.pop("max_calls", None)
 
         # Override parameters from user provided remote args function.

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -349,6 +349,9 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
     ) -> Dict[str, Any]:
         ray_remote_args = copy.deepcopy(self._ray_remote_args)
 
+        # Remove max_calls from the dynamic options.
+        ray_remote_args.pop("max_calls", None)
+
         # Override parameters from user provided remote args function.
         if self._ray_remote_args_fn:
             new_remote_args = self._ray_remote_args_fn()

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -344,7 +344,7 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
             # queue
             self._add_bundled_input(bundled_input)
 
-    def _get_runtime_ray_remote_args(
+    def _get_dynamic_ray_remote_args(
         self, input_bundle: Optional[RefBundle] = None
     ) -> Dict[str, Any]:
         ray_remote_args = copy.deepcopy(self._ray_remote_args)

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -87,7 +87,7 @@ class TaskPoolMapOperator(MapOperator):
             target_max_block_size_override=self.target_max_block_size_override,
         )
 
-        dynamic_ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)
+        dynamic_ray_remote_args = self._get_dynamic_ray_remote_args(input_bundle=bundle)
         dynamic_ray_remote_args["name"] = self.name
 
         if (

--- a/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
@@ -48,7 +48,7 @@ class HighMemoryIssueDetector(IssueDetector):
         for op in self._executor._topology.keys():
             if isinstance(op, MapOperator):
                 self._initial_memory_requests[op] = (
-                    op._get_runtime_ray_remote_args().get("memory") or 0
+                    op._get_dynamic_ray_remote_args().get("memory") or 0
                 )
 
     def detect(self) -> List[Issue]:
@@ -60,7 +60,7 @@ class HighMemoryIssueDetector(IssueDetector):
             if op.metrics.average_max_uss_per_task is None:
                 continue
 
-            remote_args = op._get_runtime_ray_remote_args()
+            remote_args = op._get_dynamic_ray_remote_args()
             num_cpus_per_task = remote_args.get("num_cpus", 1)
             max_memory_per_task = self._MEMORY_PER_CORE_ESTIMATE * num_cpus_per_task
 

--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -488,7 +488,7 @@ def test_configure_map_task_memory_rule(
 
     new_plan = rule.apply(plan)
 
-    remote_args = new_plan.dag._get_runtime_ray_remote_args()
+    remote_args = new_plan.dag._get_dynamic_ray_remote_args()
     assert remote_args.get("memory") == expected_memory
 
 

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -3220,6 +3220,26 @@ def test_with_column_alias_expressions(
     pd.testing.assert_frame_equal(result_df, non_aliased_df)
 
 
+def test_map_with_max_calls():
+
+    ds = ray.data.range(10)
+
+    # OK to set 'max_calls' as static option
+    ds = ds.map(lambda x: x, max_calls=1)
+
+    assert ds.count() == 10
+
+    ds = ray.data.range(10)
+
+    # Not OK to set 'max_calls' as dynamic option
+    with pytest.raises(ValueError):
+        ds = ds.map(
+            lambda x: x,
+            ray_remote_args_fn=lambda: {"max_calls": 1},
+        )
+        ds.take_all()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -544,10 +544,10 @@ def test_configure_output_locality(mock_scale_up):
 
     # Current node locality.
     build_streaming_topology(o3, ExecutionOptions(locality_with_output=True))
-    s1 = o2._get_runtime_ray_remote_args()["scheduling_strategy"]
+    s1 = o2._get_dynamic_ray_remote_args()["scheduling_strategy"]
     assert isinstance(s1, NodeAffinitySchedulingStrategy)
     assert s1.node_id == ray.get_runtime_context().get_node_id()
-    s2 = o3._get_runtime_ray_remote_args()["scheduling_strategy"]
+    s2 = o3._get_dynamic_ray_remote_args()["scheduling_strategy"]
     assert isinstance(s2, NodeAffinitySchedulingStrategy)
     assert s2.node_id == ray.get_runtime_context().get_node_id()
 
@@ -557,15 +557,15 @@ def test_configure_output_locality(mock_scale_up):
     build_streaming_topology(
         o3, ExecutionOptions(locality_with_output=[node_id_1, node_id_2])
     )
-    s1a = o2._get_runtime_ray_remote_args()["scheduling_strategy"]
-    s1b = o2._get_runtime_ray_remote_args()["scheduling_strategy"]
-    s1c = o2._get_runtime_ray_remote_args()["scheduling_strategy"]
+    s1a = o2._get_dynamic_ray_remote_args()["scheduling_strategy"]
+    s1b = o2._get_dynamic_ray_remote_args()["scheduling_strategy"]
+    s1c = o2._get_dynamic_ray_remote_args()["scheduling_strategy"]
     assert s1a.node_id == node_id_1
     assert s1b.node_id == node_id_2
     assert s1c.node_id == node_id_1
-    s2a = o3._get_runtime_ray_remote_args()["scheduling_strategy"]
-    s2b = o3._get_runtime_ray_remote_args()["scheduling_strategy"]
-    s2c = o3._get_runtime_ray_remote_args()["scheduling_strategy"]
+    s2a = o3._get_dynamic_ray_remote_args()["scheduling_strategy"]
+    s2b = o3._get_dynamic_ray_remote_args()["scheduling_strategy"]
+    s2c = o3._get_dynamic_ray_remote_args()["scheduling_strategy"]
     assert s2a.node_id == node_id_1
     assert s2b.node_id == node_id_2
     assert s2c.node_id == node_id_1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allow passing `max_calls` as `ray_remote_args` in map as static option. Still does not allow `max_calls` dynamic option via `ray_remote_args_fn`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
