### PR TITLE
[core][otel] print a warning if metric name contains the ":" character

### DIFF
--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -73,6 +73,14 @@ class Metric:
             if not isinstance(key, str):
                 raise TypeError(f"Tag keys must be str, got {type(key)}.")
 
+        if ":" in self._name:
+            warnings.warn(
+                f"Metric name {self._name} contains a : character, which is no longer allowed. "
+                f"Please migrate to the new metric name format. "
+                f"This will be an error in the future.",
+                FutureWarning,
+            )
+
     def set_default_tags(self, default_tags: Dict[str, str]):
         """Set default tags of metrics.
 


### PR DESCRIPTION
We’re upgrading Ray’s underlying metrics infrastructure from OpenCensus to OpenTelemetry. As part of this migration, the : character is no longer allowed in metric names (a restriction imposed by OpenTelemetry). One of the major Ray applications affected by this change is vLLM, which previously used : in its metric names. The good news is that vLLM has already migrated from using : to _.

Starting with the next Ray release, a warning will be printed to help other Ray applications prepare for this change. In the following release, Ray will switch fully to the OpenTelemetry backend, and the : character will be officially disallowed in metric names.

Test:
- CI

Tested locally with

- A ray program with all of its default metrics:

```
import ray

@ray.remote
def f():
        print("hi")

ray.get(f.remote())
```

```
> python ray_program.py
(f pid=59068) hi
```

- A ray program with a custom metric with the character ":"

```
import ray
from ray.util.metrics import Counter

counter = Counter("my:test", description="w00t")

@ray.remote
def f():
        counter.inc()
        print("hi")

ray.get([f.remote() for _ in range(5)])
```

```
> python ray_program.py
/Users/can/Projects/ray/python/ray/util/metrics.py:77: FutureWarning: Metric name my:test contains a : character, which is no longer allowed. Please migrate to the new metric name format. This will be an error in the future.
(f pid=74565) hi
(pid=74567) /Users/can/Projects/ray/python/ray/util/metrics.py:77: FutureWarning: Metric name my:test contains a : character, which is no longer allowed. Please migrate to the new metric name format. This will be an error in the future.
(f pid=74564) hi [repeated 4x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)
(pid=74563) /Users/can/Projects/ray/python/ray/util/metrics.py:77: FutureWarning: Metric name my:test contains a : character, which is no longer allowed. Please migrate to the new metric name format. This will be an error in the future. [repeated 4x across cluster]
```