### PR TITLE
[Data] Make `image_embedding_from_jsonl_fixed_size_chaos` run on manual frequency

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -565,7 +565,7 @@
 
 
 - name: image_embedding_from_jsonl_{{case}}
-  frequency: weekly
+  frequency: "{{frequency}}"
   group: data-batch-inference
 
   matrix:
@@ -578,14 +578,18 @@
           case: fixed_size
           cluster_type: fixed_size
           args: --inference-concurrency 40 40
+          frequency: weekly
       - with:
           case: autoscaling
           cluster_type: autoscaling
           args: --inference-concurrency 1 40
+          frequency: weekly
       - with:
           case: fixed_size_chaos
           cluster_type: fixed_size
           args: --inference-concurrency 40 40 --chaos
+          # This release test is run on a 'manual' frequency because it fails.
+          frequency: manual
 
   cluster:
     cluster_compute: image_embedding_from_jsonl/{{cluster_type}}_cluster_compute.yaml

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -573,6 +573,7 @@
       case: []
       cluster_type: []
       args: []
+      frequency: []
     adjustments:
       - with:
           case: fixed_size
@@ -588,7 +589,8 @@
           case: fixed_size_chaos
           cluster_type: fixed_size
           args: --inference-concurrency 40 40 --chaos
-          # This release test is run on a 'manual' frequency because it fails.
+          # This release test is run on a 'manual' frequency because it's expected to
+          # fail.
           frequency: manual
 
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `image_embedding_from_jsonl_fixed_size_chaos` release test runs a large image embedding workload with a preemption every minute. Since this test features long-running tasks and frequent preemptions, it's expected to time out (it's not a regression). So, this PR changes the frequency to manual.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
