### PR TITLE
[release] running all air release tests on py3.10

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -159,6 +159,7 @@
 
 # Ray Train distributed Torch benchmarks
 - name: air_benchmark_torch_mnist_gpu_4x4
+  python: "3.10"
   group: AIR tests
   working_dir: air_tests/air_benchmarks
 
@@ -205,6 +206,7 @@
   alert: default
 
 - name: air_benchmark_tune_torch_mnist
+  python: "3.10"
   group: AIR tests
   working_dir: air_tests/air_benchmarks
 
@@ -235,6 +237,7 @@
 
 # Ray Train distributed Tensorflow benchmarks
 - name: air_benchmark_tensorflow_mnist_gpu_4x4
+  python: "3.10"
   group: AIR tests
   working_dir: air_tests/air_benchmarks
 
@@ -287,6 +290,7 @@
 
 # Test additional CPU nodes for preprocessing.
 - name: air_example_dreambooth_finetuning
+  python: "3.10"
   group: AIR examples
   working_dir: air_examples/dreambooth
 
@@ -308,6 +312,7 @@
   # variations: A10G not available on GCE, yet.
 
 - name: air_example_dreambooth_finetuning_lora
+  python: "3.10"
   group: AIR examples
   working_dir: air_examples/dreambooth
 
@@ -327,6 +332,7 @@
     artifact_path: /tmp/artifacts/example_out.jpg
 
 - name: air_example_gptj_deepspeed_fine_tuning
+  python: "3.10"
   group: AIR examples
   working_dir: air_examples/gptj_deepspeed_finetuning
   frequency: weekly
@@ -342,6 +348,7 @@
     script: python test_myst_doc.py --path gptj_deepspeed_fine_tuning.ipynb
 
 - name: air_example_dolly_v2_lightning_fsdp_finetuning
+  python: "3.10"
   group: AIR examples
   working_dir: air_examples/dolly_v2_lightning_fsdp_finetuning
   frequency: weekly
@@ -359,6 +366,7 @@
   # variations: TODO(jungong): add GCP variation.
 
 - name: air_example_vicuna_13b_lightning_deepspeed_finetuning
+  python: "3.10"
   group: AIR examples
   working_dir: air_examples/vicuna_13b_lightning_deepspeed_finetuning
   frequency: weekly


### PR DESCRIPTION
Running air release tests on python ver 3.10

Successful release tests: https://buildkite.com/ray-project/release/builds/62145