### PR TITLE
[train] Enable deprecation warning for legacy xgboost/lightgbm trainer APIs

### DIFF
--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -17,7 +17,7 @@ from ray.util.annotations import PublicAPI
 logger = logging.getLogger(__name__)
 
 
-LEGACY_LIGHTGBMGBM_TRAINER_DEPRECATION_MESSAGE = (
+LEGACY_LIGHTGBM_TRAINER_DEPRECATION_MESSAGE = (
     "Passing in `lightgbm.train` kwargs such as `params`, `num_boost_round`, "
     "`label_column`, etc. to `LightGBMTrainer` is deprecated "
     "in favor of the new API which accepts a `train_loop_per_worker` argument, "
@@ -233,9 +233,9 @@ class LightGBMTrainer(SimpleLightGBMTrainer):
             _log_deprecation_warning(
                 "Passing `lightgbm.train` kwargs to `LightGBMTrainer` is deprecated. "
                 f"Got kwargs: {train_kwargs.keys()}\n"
-                "Please pass in a `train_loop_per_worker` function instead, "
-                "which has full flexibility on the call to `lightgbm.train(**kwargs)`. "
-                f"{LEGACY_LIGHTGBMGBM_TRAINER_DEPRECATION_MESSAGE}"
+                "In your training function, you can call `lightgbm.train(**kwargs)` "
+                "with arbitrary arguments. "
+                f"{LEGACY_LIGHTGBM_TRAINER_DEPRECATION_MESSAGE}"
             )
 
         super(LightGBMTrainer, self).__init__(
@@ -278,7 +278,7 @@ class LightGBMTrainer(SimpleLightGBMTrainer):
 
         num_boost_round = num_boost_round or 10
 
-        _log_deprecation_warning(LEGACY_LIGHTGBMGBM_TRAINER_DEPRECATION_MESSAGE)
+        _log_deprecation_warning(LEGACY_LIGHTGBM_TRAINER_DEPRECATION_MESSAGE)
 
         # Initialize a default Ray Train metrics/checkpoint reporting callback if needed
         callbacks = lightgbm_train_kwargs.get("callbacks", [])

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -11,6 +11,7 @@ from ray.train.lightgbm._lightgbm_utils import RayTrainReportCallback
 from ray.train.lightgbm.config import LightGBMConfig
 from ray.train.lightgbm.v2 import LightGBMTrainer as SimpleLightGBMTrainer
 from ray.train.trainer import GenDataset
+from ray.train.utils import _log_deprecation_warning
 from ray.util.annotations import PublicAPI
 
 logger = logging.getLogger(__name__)
@@ -228,15 +229,14 @@ class LightGBMTrainer(SimpleLightGBMTrainer):
                 datasets=datasets,
             )
             train_loop_config = params or {}
-        # TODO(justinvyu): [Deprecated] Legacy XGBoostTrainer API
-        # elif train_kwargs:
-        #     _log_deprecation_warning(
-        #         "Passing `lightgbm.train` kwargs to `LightGBMTrainer` is deprecated. "
-        #         f"Got kwargs: {train_kwargs.keys()}\n"
-        #         "Please pass in a `train_loop_per_worker` function instead, "
-        #         "which has full flexibility on the call to `lightgbm.train(**kwargs)`. "
-        #         f"{LEGACY_LIGHTGBMGBM_TRAINER_DEPRECATION_MESSAGE}"
-        #     )
+        elif train_kwargs:
+            _log_deprecation_warning(
+                "Passing `lightgbm.train` kwargs to `LightGBMTrainer` is deprecated. "
+                f"Got kwargs: {train_kwargs.keys()}\n"
+                "Please pass in a `train_loop_per_worker` function instead, "
+                "which has full flexibility on the call to `lightgbm.train(**kwargs)`. "
+                f"{LEGACY_LIGHTGBMGBM_TRAINER_DEPRECATION_MESSAGE}"
+            )
 
         super(LightGBMTrainer, self).__init__(
             train_loop_per_worker=train_loop_per_worker,
@@ -278,8 +278,7 @@ class LightGBMTrainer(SimpleLightGBMTrainer):
 
         num_boost_round = num_boost_round or 10
 
-        # TODO: [Deprecated] Legacy LightGBMTrainer API
-        # _log_deprecation_warning(LEGACY_LIGHTGBMGBM_TRAINER_DEPRECATION_MESSAGE)
+        _log_deprecation_warning(LEGACY_LIGHTGBMGBM_TRAINER_DEPRECATION_MESSAGE)
 
         # Initialize a default Ray Train metrics/checkpoint reporting callback if needed
         callbacks = lightgbm_train_kwargs.get("callbacks", [])

--- a/python/ray/train/tests/test_xgboost_trainer.py
+++ b/python/ray/train/tests/test_xgboost_trainer.py
@@ -74,6 +74,7 @@ def test_fit_with_advanced_scaling_config(ray_start_4_cpus):
         label_column="target",
         params=params,
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
+        num_boost_round=1,
     )
     trainer.fit()
 

--- a/python/ray/train/tests/test_xgboost_trainer.py
+++ b/python/ray/train/tests/test_xgboost_trainer.py
@@ -74,7 +74,6 @@ def test_fit_with_advanced_scaling_config(ray_start_4_cpus):
         label_column="target",
         params=params,
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
-        num_boost_round=1,
     )
     trainer.fit()
 

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -9,6 +9,7 @@ import ray.train
 from ray.train import Checkpoint
 from ray.train.constants import TRAIN_DATASET_KEY
 from ray.train.trainer import GenDataset
+from ray.train.utils import _log_deprecation_warning
 from ray.train.xgboost import RayTrainReportCallback, XGBoostConfig
 from ray.train.xgboost.v2 import XGBoostTrainer as SimpleXGBoostTrainer
 from ray.util.annotations import PublicAPI
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 LEGACY_XGBOOST_TRAINER_DEPRECATION_MESSAGE = (
     "Passing in `xgboost.train` kwargs such as `params`, `num_boost_round`, "
     "`label_column`, etc. to `XGBoostTrainer` is deprecated "
-    "in favor of the new API which accepts a ``train_loop_per_worker`` argument, "
+    "in favor of the new API which accepts a training function, "
     "similar to the other DataParallelTrainer APIs (ex: TorchTrainer). "
     "See this issue for more context: "
     "https://github.com/ray-project/ray/issues/50042"
@@ -228,14 +229,13 @@ class XGBoostTrainer(SimpleXGBoostTrainer):
                 datasets=datasets,
             )
             train_loop_config = params or {}
-        # TODO(justinvyu): [Deprecated] Legacy XGBoostTrainer API
-        # elif train_kwargs:
-        #     _log_deprecation_warning(
-        #         "Passing `xgboost.train` kwargs to `XGBoostTrainer` is deprecated. "
-        #         "Please pass in a `train_loop_per_worker` function instead, "
-        #         "which has full flexibility on the call to `xgboost.train(**kwargs)`. "
-        #         f"{LEGACY_XGBOOST_TRAINER_DEPRECATION_MESSAGE}"
-        #     )
+        elif train_kwargs:
+            _log_deprecation_warning(
+                "Passing `xgboost.train` kwargs to `XGBoostTrainer` is deprecated. "
+                "Please pass in a training function instead, "
+                "which has full flexibility on the call to `xgboost.train(**kwargs)`. "
+                f"{LEGACY_XGBOOST_TRAINER_DEPRECATION_MESSAGE}"
+            )
 
         super(XGBoostTrainer, self).__init__(
             train_loop_per_worker=train_loop_per_worker,
@@ -277,8 +277,7 @@ class XGBoostTrainer(SimpleXGBoostTrainer):
 
         num_boost_round = num_boost_round or 10
 
-        # TODO(justinvyu): [Deprecated] Legacy XGBoostTrainer API
-        # _log_deprecation_warning(LEGACY_XGBOOST_TRAINER_DEPRECATION_MESSAGE)
+        _log_deprecation_warning(LEGACY_XGBOOST_TRAINER_DEPRECATION_MESSAGE)
 
         # Initialize a default Ray Train metrics/checkpoint reporting callback if needed
         callbacks = xgboost_train_kwargs.get("callbacks", [])

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -232,8 +232,8 @@ class XGBoostTrainer(SimpleXGBoostTrainer):
         elif train_kwargs:
             _log_deprecation_warning(
                 "Passing `xgboost.train` kwargs to `XGBoostTrainer` is deprecated. "
-                "Please pass in a training function instead, "
-                "which has full flexibility on the call to `xgboost.train(**kwargs)`. "
+                "In your training function, you can call `xgboost.train(**kwargs)` "
+                "with arbitrary arguments. "
                 f"{LEGACY_XGBOOST_TRAINER_DEPRECATION_MESSAGE}"
             )
 


### PR DESCRIPTION
## Summary

Emit the deprecation warning for the legacy XGBoostTrainer API, in preparation for Train V2 migration (which only supports the new custom training function API).

Links to this issue with migration support: https://github.com/ray-project/ray/issues/50042

## Example output

```python
/Users/justin/Developer/ray/python/ray/train/xgboost/xgboost_trainer.py:280: RayDeprecationWarning: Passing in `xgboost.train` kwargs such as `params`, `num_boost_round`, `label_column`, etc. to `XGBoostTrainer` is deprecated in favor of the new API which accepts a training function, similar to the other DataParallelTrainer APIs (ex: TorchTrainer). See this issue for more context: https://github.com/ray-project/ray/issues/50042
```