### PR TITLE
[core] Guarantee min amount of failures for request/response using rpc chaos…

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -853,8 +853,6 @@ RAY_CONFIG(std::string, testing_asio_delay_us, "")
 /// that the first X request RPCs will fail, followed by Y response RPCs that will fail.
 /// Afterwards, it will revert to the probabilistic failures. You can combine this with
 /// the wildcard so that each RPC method will have the same lower bounds applied.
-/// NOTE: It's recommended to set the total amount as -1 when using the wildcard as the
-/// lower bound will be applied to each individual RPC method.
 /// Ex. unlimited failures for all rpc's with 25% request failures and 50% response
 /// failures with at least 2 request failures and 3 response failures.
 ///     export RAY_testing_rpc_failure="*=-1:25:50:2:3"

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -845,6 +845,19 @@ RAY_CONFIG(std::string, testing_asio_delay_us, "")
 /// failures.
 ///     export RAY_testing_rpc_failure="*=-1:25:50"
 /// NOTE: Setting the wildcard will override any configuration for other methods.
+///
+/// You can also provide an optional fourth and/or fifth parameter to specify that there
+/// should be at least a certain amount of failures on the request and response. The
+/// fourth parameter is for the request and the fifth parameter is for the response. By
+/// default these are set to 0, but by setting them to positive values it guarantees
+/// that the first X request RPCs will fail, followed by Y response RPCs that will fail.
+/// Afterwards, it will revert to the probabilistic failures. You can combine this with
+/// the wildcard so that each RPC method will have the same lower bounds applied.
+/// NOTE: It's recommended to set the total amount as -1 when using the wildcard as the
+/// lower bound will be applied to each individual RPC method.
+/// Ex. unlimited failures for all rpc's with 25% request failures and 50% response
+/// failures with at least 2 request failures and 3 response failures.
+///     export RAY_testing_rpc_failure="*=-1:25:50:2:3"
 RAY_CONFIG(std::string, testing_rpc_failure, "")
 /// If this is set, when injecting RPC failures, we'll check if the server and client have
 /// the same address. If they do, we won't inject the failure.

--- a/src/ray/rpc/rpc_chaos.cc
+++ b/src/ray/rpc/rpc_chaos.cc
@@ -46,10 +46,9 @@ namespace testing {
 // these are set to 0, but by setting them to positive values it guarantees that the first
 // X request RPCs will fail, followed by Y response RPCs. Afterwards, it will revert to
 // the probabilistic failures. You can combine this with the wildcard so that each RPC
-// method will have the same lower bounds applied. It's recommended to set the total
-// amount as -1 when using the wildcard as the lower bound will be applied to each
-// individual RPC method. Ex. unlimited failures for all rpc's with 25% request failures
-// and 50% response failures with at least 2 request failures and 3 response failures.
+// method will have the same lower bounds applied.
+// Ex. unlimited failures for all rpc's with 25% request failures and 50% response
+// failures with at least 2 request failures and 3 response failures.
 //     export RAY_testing_rpc_failure="*=-1:25:50:2:3"
 
 class RpcFailureManager {

--- a/src/ray/rpc/rpc_chaos.cc
+++ b/src/ray/rpc/rpc_chaos.cc
@@ -41,6 +41,17 @@ namespace testing {
 // This will set the probabilities for all rpc's to 25% for request failures and 50% for
 // reply failures.
 
+// You can also provide a fourth and/or fifth optional parameter to specify that there
+// should be at least a certain amount of request and/or response failures. By default
+// these are set to 0, but by setting them to positive values it guarantees that the first
+// X request RPCs will fail, followed by Y response RPCs. Afterwards, it will revert to
+// the probabilistic failures. You can combine this with the wildcard so that each RPC
+// method will have the same lower bounds applied. It's recommended to set the total
+// amount as -1 when using the wildcard as the lower bound will be applied to each
+// individual RPC method. Ex. unlimited failures for all rpc's with 25% request failures
+// and 50% response failures with at least 2 request failures and 3 response failures.
+//     export RAY_testing_rpc_failure="*=-1:25:50:2:3"
+
 class RpcFailureManager {
  public:
   RpcFailureManager() { Init(); }
@@ -50,6 +61,8 @@ class RpcFailureManager {
 
     // Clear old state
     failable_methods_.clear();
+    num_req_failures_.clear();
+    num_resp_failures_.clear();
     wildcard_set_ = false;
     has_failures_ = false;
 
@@ -59,11 +72,15 @@ class RpcFailureManager {
         std::vector<std::string> equal_split = absl::StrSplit(item, '=');
         RAY_CHECK_EQ(equal_split.size(), 2UL);
         std::vector<std::string> colon_split = absl::StrSplit(equal_split[1], ':');
-        RAY_CHECK_EQ(colon_split.size(), 3UL);
-        auto [iter, _] = failable_methods_.emplace(equal_split[0],
-                                                   Failable{std::stol(colon_split[0]),
-                                                            std::stoul(colon_split[1]),
-                                                            std::stoul(colon_split[2])});
+        RAY_CHECK_GE(colon_split.size(), 3UL);
+        RAY_CHECK_LE(colon_split.size(), 5UL);
+        auto [iter, _] = failable_methods_.emplace(
+            equal_split[0],
+            Failable{std::stol(colon_split[0]),
+                     std::stoul(colon_split[1]),
+                     std::stoul(colon_split[2]),
+                     colon_split.size() >= 4UL ? std::stoul(colon_split[3]) : 0UL,
+                     colon_split.size() == 5UL ? std::stoul(colon_split[4]) : 0UL});
         const auto &failable = iter->second;
         RAY_CHECK_LE(failable.req_failure_prob + failable.resp_failure_prob, 100UL);
         if (equal_split[0] == "*") {
@@ -90,14 +107,14 @@ class RpcFailureManager {
 
     // Wildcard overrides any other method configurations.
     if (wildcard_set_) {
-      return GetFailureTypeFromFailable(failable_methods_["*"]);
+      return GetFailureTypeFromFailable(failable_methods_["*"], name);
     }
 
     auto iter = failable_methods_.find(name);
     if (iter == failable_methods_.end()) {
       return RpcFailure::None;
     }
-    return GetFailureTypeFromFailable(iter->second);
+    return GetFailureTypeFromFailable(iter->second, name);
   }
 
  private:
@@ -109,19 +126,36 @@ class RpcFailureManager {
   // failable_methods_
   bool wildcard_set_ = false;
 
-  // call name -> (num_remaining_failures, req_failure_prob, resp_failure_prob)
+  // call name -> (num_remaining_failures, req_failure_prob, resp_failure_prob,
+  // num_lower_bound_req_failures, num_lower_bound_resp_failures)
   struct Failable {
     int64_t num_remaining_failures;
     size_t req_failure_prob;
     size_t resp_failure_prob;
+    size_t num_lower_bound_req_failures = 0;
+    size_t num_lower_bound_resp_failures = 0;
   };
   absl::flat_hash_map<std::string, Failable> failable_methods_ ABSL_GUARDED_BY(&mu_);
+  absl::flat_hash_map<std::string, size_t> num_req_failures_ ABSL_GUARDED_BY(&mu_);
+  absl::flat_hash_map<std::string, size_t> num_resp_failures_ ABSL_GUARDED_BY(&mu_);
 
-  RpcFailure GetFailureTypeFromFailable(Failable &failable) {
+  RpcFailure GetFailureTypeFromFailable(Failable &failable, const std::string &name) {
     if (failable.num_remaining_failures == 0) {
       // If < 0, unlimited failures.
       return RpcFailure::None;
     }
+
+    if (num_req_failures_[name] < failable.num_lower_bound_req_failures) {
+      failable.num_remaining_failures--;
+      num_req_failures_[name]++;
+      return RpcFailure::Request;
+    }
+    if (num_resp_failures_[name] < failable.num_lower_bound_resp_failures) {
+      failable.num_remaining_failures--;
+      num_resp_failures_[name]++;
+      return RpcFailure::Response;
+    }
+
     std::uniform_int_distribution<size_t> dist(1ul, 100ul);
     const size_t random_number = dist(gen_);
     if (random_number <= failable.req_failure_prob) {

--- a/src/ray/rpc/rpc_chaos.cc
+++ b/src/ray/rpc/rpc_chaos.cc
@@ -139,7 +139,8 @@ class RpcFailureManager {
   absl::flat_hash_map<std::string, size_t> num_req_failures_ ABSL_GUARDED_BY(&mu_);
   absl::flat_hash_map<std::string, size_t> num_resp_failures_ ABSL_GUARDED_BY(&mu_);
 
-  RpcFailure GetFailureTypeFromFailable(Failable &failable, const std::string &name) {
+  RpcFailure GetFailureTypeFromFailable(Failable &failable, const std::string &name)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
     if (failable.num_remaining_failures == 0) {
       // If < 0, unlimited failures.
       return RpcFailure::None;


### PR DESCRIPTION

## Why are these changes needed?

For cases where we use the wildcard and have a wide variety of RPCs, often the amount of times a couple RPCs will be called will be vastly greater than the others. Using the probability based config means its highly unlikely these less used RPCs will be tested. Added an additional 4/5 config to guarantee a lower bound of failures for EACH individual RPC on request and response. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
