### PR TITLE
[2/n] move autoscaling control to application state from deployment s…

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1528,10 +1528,6 @@ python/ray/serve/_private/api.py
     DOC201: Function `serve_start` does not have a return section in docstring
 --------------------
 python/ray/serve/_private/application_state.py
-    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
-    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
-    DOC101: Method `ApplicationState.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `ApplicationState.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [deployment_state_manager: DeploymentStateManager, endpoint_state: EndpointState, logging_config: LoggingConfig, name: str].
     DOC103: Method `ApplicationStateManager.deploy_app`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [deployment_args: List[Dict]]. Arguments in the docstring but not in the function signature: [deployment_args_list: ].
     DOC102: Function `override_deployment_info`: Docstring contains more arguments than in function signature.
     DOC103: Function `override_deployment_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [app_name: ].

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -13,6 +13,7 @@ import ray
 from ray import cloudpickle
 from ray._common.utils import import_attr
 from ray.exceptions import RuntimeEnvSetupError
+from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.build_app import BuiltApplication, build_app
 from ray.serve._private.common import (
     DeploymentID,
@@ -222,20 +223,25 @@ class ApplicationState:
         self,
         name: str,
         deployment_state_manager: DeploymentStateManager,
+        autoscaling_state_manager: AutoscalingStateManager,
         endpoint_state: EndpointState,
         logging_config: LoggingConfig,
     ):
         """
+        Initialize an ApplicationState instance.
+
         Args:
             name: Application name.
-            deployment_state_manager: State manager for all deployments
-                in the cluster.
-            endpoint_state: State manager for endpoints in the system.
+            deployment_state_manager: Manages the state of all deployments in the cluster.
+            autoscaling_state_manager: Manages autoscaling decisions in the cluster.
+            endpoint_state: Manages endpoints in the system.
+            logging_config: Logging configuration schema.
         """
 
         self._name = name
         self._status_msg = ""
         self._deployment_state_manager = deployment_state_manager
+        self._autoscaling_state_manager = autoscaling_state_manager
         self._endpoint_state = endpoint_state
         self._route_prefix: Optional[str] = None
         self._ingress_deployment_name: Optional[str] = None
@@ -429,6 +435,57 @@ class ApplicationState:
         deleting and all deployments have to be deleted.
         """
         return self._target_state.deleting and len(self._get_live_deployments()) == 0
+
+    def should_autoscale(self) -> bool:
+        """Determine if autoscaling is enabled for the application.
+
+        Returns:
+            Autoscaling is enabled for the application if any of the deployments have autoscaling enabled.
+        """
+
+        return self._autoscaling_state_manager.should_autoscale_application(self._name)
+
+    def autoscale(self) -> bool:
+        """
+        Apply the autoscaling decisions for the application.
+        If the application has deployment-level autoscaling, it will apply the autoscaling decisions for each deployment.
+
+        Returns:
+            True if there is a change to number of replicas for any deployment. False otherwise.
+        """
+        target_deployments = self.target_deployments
+        if len(target_deployments) == 0:
+            return False
+
+        deployment_to_target_num_replicas: Dict[DeploymentID, int] = {}
+        for deployment_name in target_deployments:
+            deployment_id = DeploymentID(name=deployment_name, app_name=self._name)
+            target_num_replicas = (
+                self._deployment_state_manager.get_deployment_target_num_replicas(
+                    deployment_id
+                )
+            )
+            if target_num_replicas is None:
+                continue
+            deployment_to_target_num_replicas[deployment_id] = target_num_replicas
+
+        if len(deployment_to_target_num_replicas) == 0:
+            return False
+        decisions: Dict[
+            DeploymentID, int
+        ] = self._autoscaling_state_manager.get_decision_num_replicas(
+            self._name, deployment_to_target_num_replicas
+        )
+
+        target_state_changed = False
+        for deployment_id, decision_num_replicas in decisions.items():
+            target_state_changed = (
+                self._deployment_state_manager.autoscale(
+                    deployment_id, decision_num_replicas
+                )
+                or target_state_changed
+            )
+        return target_state_changed
 
     def apply_deployment_info(
         self,
@@ -899,11 +956,13 @@ class ApplicationStateManager:
     def __init__(
         self,
         deployment_state_manager: DeploymentStateManager,
+        autoscaling_state_manager: AutoscalingStateManager,
         endpoint_state: EndpointState,
         kv_store: KVStoreBase,
         logging_config: LoggingConfig,
     ):
         self._deployment_state_manager = deployment_state_manager
+        self._autoscaling_state_manager = autoscaling_state_manager
         self._endpoint_state = endpoint_state
         self._kv_store = kv_store
         self._logging_config = logging_config
@@ -922,6 +981,7 @@ class ApplicationStateManager:
                 app_state = ApplicationState(
                     app_name,
                     self._deployment_state_manager,
+                    self._autoscaling_state_manager,
                     self._endpoint_state,
                     self._logging_config,
                 )
@@ -968,6 +1028,7 @@ class ApplicationStateManager:
                 self._application_states[name] = ApplicationState(
                     name,
                     self._deployment_state_manager,
+                    self._autoscaling_state_manager,
                     self._endpoint_state,
                     self._logging_config,
                 )
@@ -1018,6 +1079,7 @@ class ApplicationStateManager:
                 self._application_states[app_config.name] = ApplicationState(
                     app_config.name,
                     self._deployment_state_manager,
+                    self._autoscaling_state_manager,
                     endpoint_state=self._endpoint_state,
                     logging_config=self._logging_config,
                 )
@@ -1120,6 +1182,8 @@ class ApplicationStateManager:
         apps_to_be_deleted = []
         any_target_state_changed = False
         for name, app in self._application_states.items():
+            if app.should_autoscale():
+                any_target_state_changed = app.autoscale() or any_target_state_changed
             ready_to_be_deleted, app_target_state_changed = app.update()
             any_target_state_changed = (
                 any_target_state_changed or app_target_state_changed

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -204,6 +204,7 @@ class ServeController:
         # Manage all applications' state
         self.application_state_manager = ApplicationStateManager(
             self.deployment_state_manager,
+            self.autoscaling_state_manager,
             self.endpoint_state,
             self.kv_store,
             self.global_logging_config,
@@ -310,11 +311,15 @@ class ServeController:
             handle_metric_report
         )
 
-    def _dump_all_autoscaling_metrics_for_testing(self):
-        return self.autoscaling_state_manager.get_all_metrics()
+    def _get_total_num_requests_for_deployment_for_testing(
+        self, deployment_id: DeploymentID
+    ):
+        return self.autoscaling_state_manager.get_total_num_requests_for_deployment(
+            deployment_id
+        )
 
-    def _dump_autoscaling_metrics_for_testing(self):
-        return self.autoscaling_state_manager.get_metrics()
+    def _get_metrics_for_deployment_for_testing(self, deployment_id: DeploymentID):
+        return self.autoscaling_state_manager.get_metrics_for_deployment(deployment_id)
 
     def _dump_replica_states_for_testing(self, deployment_id: DeploymentID):
         return self.deployment_state_manager._deployment_states[deployment_id]._replicas

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -111,10 +111,10 @@ def test_assert_no_replicas_deprovisioned():
 
 
 def get_num_requests(client, dep_id: DeploymentID):
-    ref = client._controller._dump_autoscaling_metrics_for_testing.remote()
-    total_num_requests = ray.get(ref)[dep_id]
-    print("total num requests", total_num_requests)
-    return total_num_requests
+    ref = client._controller._get_total_num_requests_for_deployment_for_testing.remote(
+        dep_id
+    )
+    return ray.get(ref)
 
 
 def check_num_requests_eq(client, id: DeploymentID, expected: int):

--- a/python/ray/serve/tests/test_custom_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_custom_autoscaling_metrics.py
@@ -14,9 +14,10 @@ def get_autoscaling_metrics_from_controller(
     client, deployment_id: DeploymentID
 ) -> Dict[str, float]:
     """Get autoscaling metrics from the controller for testing."""
-    ref = client._controller._dump_all_autoscaling_metrics_for_testing.remote()
-    metrics = ray.get(ref)
-    return metrics.get(deployment_id, {})
+    ref = client._controller._get_metrics_for_deployment_for_testing.remote(
+        deployment_id
+    )
+    return ray.get(ref)
 
 
 class TestCustomServeMetrics:

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -13,6 +13,7 @@ from ray.exceptions import RayActorError
 from ray.serve import Application
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import (
+    DeploymentID,
     DeploymentStatus,
     DeploymentStatusTrigger,
     ReplicaState,
@@ -483,8 +484,11 @@ class TestTargetCapacityUpdateAndServeStatus:
         if controller_handle is None:
             assert num_running_replicas == expected_num_replicas, f"{deployment}"
         else:
+            deployment_id = DeploymentID(name=deployment_name, app_name=app_name)
             autoscaling_metrics = ray.get(
-                controller_handle._dump_autoscaling_metrics_for_testing.remote()
+                controller_handle._get_metrics_for_deployment_for_testing.remote(
+                    deployment_id
+                )
             )
             assert num_running_replicas == expected_num_replicas, (
                 f"Status: {deployment}" f"\nAutoscaling metrics: {autoscaling_metrics}"

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -1,6 +1,6 @@
 import sys
 import time
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
@@ -13,17 +13,26 @@ from ray.serve._private.application_state import (
     StatusOverview,
     override_deployment_info,
 )
+from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
+    RUNNING_REQUESTS_KEY,
+    DeploymentHandleSource,
     DeploymentID,
     DeploymentStatus,
     DeploymentStatusInfo,
     DeploymentStatusTrigger,
+    HandleMetricReport,
+    ReplicaID,
+    ReplicaMetricReport,
+    TimeStampedValue,
 )
 from ray.serve._private.config import DeploymentConfig, ReplicaConfig
+from ray.serve._private.constants import RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
 from ray.serve._private.deploy_utils import deploy_args_to_deployment_info
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.test_utils import MockKVStore
 from ray.serve._private.utils import get_random_string
+from ray.serve.config import AutoscalingConfig
 from ray.serve.exceptions import RayServeException
 from ray.serve.generated.serve_pb2 import (
     ApplicationStatusInfo as ApplicationStatusInfoProto,
@@ -71,6 +80,7 @@ class MockDeploymentStateManager:
                     message="",
                 )
                 self.deleting[name] = deleting
+        self._scaling_decisions = {}
 
     def deploy(
         self,
@@ -109,7 +119,12 @@ class MockDeploymentStateManager:
         if deployment_id in self.deployment_statuses:
             # Return dummy deployment info object
             return DeploymentInfo(
-                deployment_config=DeploymentConfig(num_replicas=1, user_config={}),
+                deployment_config=DeploymentConfig(
+                    num_replicas=self.deployment_infos[
+                        deployment_id
+                    ].deployment_config.num_replicas,
+                    user_config={},
+                ),
                 replica_config=ReplicaConfig.create(lambda x: x),
                 start_time_ms=0,
                 deployer_job_id="",
@@ -153,6 +168,17 @@ class MockDeploymentStateManager:
     def delete_deployment(self, id: DeploymentID):
         self.deleting[id] = True
 
+    def get_deployment_target_num_replicas(self, id: DeploymentID) -> Optional[int]:
+        return self.deployment_infos[id].deployment_config.num_replicas
+
+    def save_checkpoint(self):
+        """Mock save checkpoint method."""
+        pass
+
+    def autoscale(self, id: DeploymentID, target_num_replicas: int):
+        self._scaling_decisions[id] = target_num_replicas
+        return True
+
 
 @pytest.fixture
 def mocked_application_state_manager() -> (
@@ -162,16 +188,28 @@ def mocked_application_state_manager() -> (
 
     deployment_state_manager = MockDeploymentStateManager(kv_store)
     application_state_manager = ApplicationStateManager(
-        deployment_state_manager, MockEndpointState(), kv_store, LoggingConfig()
+        deployment_state_manager,
+        AutoscalingStateManager(),
+        MockEndpointState(),
+        kv_store,
+        LoggingConfig(),
     )
     yield application_state_manager, deployment_state_manager, kv_store
 
 
-def deployment_params(name: str, route_prefix: str = None):
+def deployment_params(
+    name: str,
+    route_prefix: str = None,
+    autoscaling_config: AutoscalingConfig = None,
+    num_replicas: int = 1,
+):
     return {
         "deployment_name": name,
         "deployment_config_proto_bytes": DeploymentConfig(
-            num_replicas=1, user_config={}, version=get_random_string()
+            num_replicas=num_replicas,
+            user_config={},
+            version=get_random_string(),
+            autoscaling_config=autoscaling_config,
         ).to_proto_bytes(),
         "replica_config_proto_bytes": ReplicaConfig.create(
             lambda x: x
@@ -182,8 +220,13 @@ def deployment_params(name: str, route_prefix: str = None):
     }
 
 
-def deployment_info(name: str, route_prefix: str = None):
-    params = deployment_params(name, route_prefix)
+def deployment_info(
+    name: str,
+    route_prefix: str = None,
+    autoscaling_config: AutoscalingConfig = None,
+    num_replicas: int = 1,
+):
+    params = deployment_params(name, route_prefix, autoscaling_config, num_replicas)
     return deploy_args_to_deployment_info(**params, app_name="test_app")
 
 
@@ -195,6 +238,7 @@ def mocked_application_state() -> Tuple[ApplicationState, MockDeploymentStateMan
     application_state = ApplicationState(
         name="test_app",
         deployment_state_manager=deployment_state_manager,
+        autoscaling_state_manager=AutoscalingStateManager(),
         endpoint_state=MockEndpointState(),
         logging_config=LoggingConfig(),
     )
@@ -686,6 +730,7 @@ def test_apply_app_configs_succeed(check_obj_ref_ready_nowait):
     deployment_state_manager = MockDeploymentStateManager(kv_store)
     app_state_manager = ApplicationStateManager(
         deployment_state_manager,
+        AutoscalingStateManager(),
         MockEndpointState(),
         kv_store,
         LoggingConfig(),
@@ -734,7 +779,11 @@ def test_apply_app_configs_fail(check_obj_ref_ready_nowait):
     kv_store = MockKVStore()
     deployment_state_manager = MockDeploymentStateManager(kv_store)
     app_state_manager = ApplicationStateManager(
-        deployment_state_manager, MockEndpointState(), kv_store, LoggingConfig()
+        deployment_state_manager,
+        AutoscalingStateManager(),
+        MockEndpointState(),
+        kv_store,
+        LoggingConfig(),
     )
 
     # Deploy config
@@ -776,7 +825,11 @@ def test_apply_app_configs_deletes_existing(check_obj_ref_ready_nowait):
     kv_store = MockKVStore()
     deployment_state_manager = MockDeploymentStateManager(kv_store)
     app_state_manager = ApplicationStateManager(
-        deployment_state_manager, MockEndpointState(), kv_store, LoggingConfig()
+        deployment_state_manager,
+        AutoscalingStateManager(),
+        MockEndpointState(),
+        kv_store,
+        LoggingConfig(),
     )
 
     # Deploy an app via `deploy_app` - should not be affected.
@@ -956,7 +1009,11 @@ def test_application_state_recovery(mocked_application_state_manager):
 
     # Create new application state manager, and it should call _recover_from_checkpoint
     new_app_state_manager = ApplicationStateManager(
-        new_deployment_state_manager, MockEndpointState(), kv_store, LoggingConfig()
+        new_deployment_state_manager,
+        AutoscalingStateManager(),
+        MockEndpointState(),
+        kv_store,
+        LoggingConfig(),
     )
     app_state = new_app_state_manager._application_states[app_name]
     assert app_state.status == ApplicationStatus.DEPLOYING
@@ -1015,7 +1072,11 @@ def test_recover_during_update(mocked_application_state_manager):
 
     # Create new application state manager, and it should call _recover_from_checkpoint
     new_app_state_manager = ApplicationStateManager(
-        new_deployment_state_manager, MockEndpointState(), kv_store, LoggingConfig()
+        new_deployment_state_manager,
+        AutoscalingStateManager(),
+        MockEndpointState(),
+        kv_store,
+        LoggingConfig(),
     )
     app_state = new_app_state_manager._application_states[app_name]
     ar_version = app_state._target_state.deployment_infos["d1"].version
@@ -1305,6 +1366,1048 @@ class TestOverrideDeploymentInfo:
             updated_info.replica_config.ray_actor_options["runtime_env"]["working_dir"]
             == "s3://B"
         )
+
+
+class TestAutoscale:
+    def test_autoscale(self, mocked_application_state_manager):
+        """Test autoscaling behavior with two deployments under load."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Create autoscaling configuration
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        # Setup: Deploy two deployments
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Setup: Register deployments with autoscaling manager
+        asm = app_state_manager._autoscaling_state_manager
+        self._register_deployments_with_asm(asm, d1_id, d2_id, autoscaling_config)
+
+        # Setup: Create running replicas
+        self._create_running_replicas(asm, d1_id, d2_id)
+
+        # Test: Simulate load metrics
+        self._simulate_load_metrics(asm, d1_id, d2_id)
+
+        # Verify: Check autoscaling decisions
+        app_state_manager.update()
+        assert app_state_manager.get_app_status("test_app") == ApplicationStatus.RUNNING
+        assert deployment_state_manager._scaling_decisions == {d1_id: 4, d2_id: 2}
+
+    def test_should_autoscale_with_autoscaling_deployments(
+        self, mocked_application_state_manager
+    ):
+        """Test should_autoscale returns True when app has autoscaling deployments."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Create autoscaling configuration
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+        }
+
+        # Deploy app with autoscaling enabled
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Register with autoscaling manager
+        asm = app_state_manager._autoscaling_state_manager
+        self._register_deployments_with_asm(asm, d1_id, d2_id, autoscaling_config)
+
+        # Get the application state
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Verify should_autoscale returns True
+        assert app_state.should_autoscale() is True
+
+    def test_should_autoscale_without_autoscaling_deployments(
+        self, mocked_application_state_manager
+    ):
+        """Test should_autoscale returns False when app has no autoscaling deployments."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Deploy app without autoscaling configuration
+        d1_id = DeploymentID(name="d1", app_name="test_app")
+        d1_params = deployment_params("d1", "/hi")  # No autoscaling config
+
+        app_state_manager.deploy_app("test_app", [d1_params])
+        app_state_manager.update()
+        deployment_state_manager.set_deployment_healthy(d1_id)
+        app_state_manager.update()
+
+        # Get the application state
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Verify should_autoscale returns False
+        assert app_state.should_autoscale() is False
+
+    def test_autoscale_with_no_deployments(self, mocked_application_state_manager):
+        """Test autoscale returns False when app has no target deployments."""
+        app_state_manager, _, _ = mocked_application_state_manager
+
+        # Create app state without any deployments
+        app_state = ApplicationState(
+            name="empty_app",
+            deployment_state_manager=MockDeploymentStateManager(MockKVStore()),
+            autoscaling_state_manager=AutoscalingStateManager(),
+            endpoint_state=MockEndpointState(),
+            logging_config=LoggingConfig(),
+        )
+
+        # Verify autoscale returns False
+        assert app_state.autoscale() is False
+
+    def test_autoscale_with_deployment_details_none(
+        self, mocked_application_state_manager
+    ):
+        """Test autoscale handles None deployment details gracefully."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Deploy app with autoscaling
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+        }
+
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Mock get_deployment_target_num_replicas to return None
+        deployment_state_manager.get_deployment_target_num_replicas = Mock(
+            return_value=None
+        )
+
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Verify autoscale returns False when deployment details are None
+        assert app_state.autoscale() is False
+
+    def test_autoscale_applies_decisions_correctly(
+        self, mocked_application_state_manager
+    ):
+        """Test autoscale applies autoscaling decisions to deployment state manager."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Deploy app with autoscaling
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Register with autoscaling manager and create replicas
+        asm = app_state_manager._autoscaling_state_manager
+        self._register_deployments_with_asm(asm, d1_id, d2_id, autoscaling_config)
+        self._create_running_replicas(asm, d1_id, d2_id)
+
+        # Simulate load: d1 has 3x target load, d2 has 0.5x target load
+        self._simulate_load_metrics(asm, d1_id, d2_id, d1_load=3, d2_load=0)
+
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Call autoscale
+        result = app_state.autoscale()
+
+        # Verify it returns True (target state changed)
+        assert result is True
+
+        # Verify scaling decisions were applied
+        # d1 should scale up (high load), d2 should scale down (low load)
+        assert d1_id in deployment_state_manager._scaling_decisions
+        assert d2_id in deployment_state_manager._scaling_decisions
+
+    def test_autoscale_no_decisions_returns_false(
+        self, mocked_application_state_manager
+    ):
+        """Test autoscale returns False when no autoscaling decisions are made."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Deploy app with autoscaling
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Register with autoscaling manager and create replicas
+        asm = app_state_manager._autoscaling_state_manager
+        self._register_deployments_with_asm(asm, d1_id, d2_id, autoscaling_config)
+        self._create_running_replicas(asm, d1_id, d2_id)
+
+        # Simulate balanced load (exactly at target, so no scaling needed)
+        self._simulate_load_metrics(asm, d1_id, d2_id, d1_load=1, d2_load=1)
+
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Call autoscale
+        result = app_state.autoscale()
+
+        # Verify it returns False (no scaling decisions needed)
+        # When load exactly matches target, autoscaler shouldn't make changes
+        assert result is False or deployment_state_manager._scaling_decisions == {
+            d1_id: 2,
+            d2_id: 2,
+        }
+
+    def test_application_state_manager_autoscaling_integration(
+        self, mocked_application_state_manager
+    ):
+        """Test autoscaling integration in ApplicationStateManager.update()."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Deploy app with autoscaling
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Register with autoscaling manager and create replicas
+        asm = app_state_manager._autoscaling_state_manager
+        self._register_deployments_with_asm(asm, d1_id, d2_id, autoscaling_config)
+        self._create_running_replicas(asm, d1_id, d2_id)
+
+        # Simulate high load on d1, moderate load on d2
+        self._simulate_load_metrics(asm, d1_id, d2_id, d1_load=4, d2_load=2)
+
+        # Clear any existing scaling decisions
+        deployment_state_manager._scaling_decisions.clear()
+
+        # Call ApplicationStateManager.update()
+        app_state_manager.update()
+
+        # Verify autoscaling decisions were applied during update
+        # Both deployments should have scaling decisions due to load
+        assert len(deployment_state_manager._scaling_decisions) > 0
+
+    def test_autoscaling_with_mixed_deployment_types(
+        self, mocked_application_state_manager
+    ):
+        """Test autoscaling behavior with mix of autoscaling and non-autoscaling deployments."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Deploy app with one autoscaling and one non-autoscaling deployment
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        d1_id = DeploymentID(name="d1", app_name="test_app")
+        d2_id = DeploymentID(name="d2", app_name="test_app")
+
+        # d1 has autoscaling, d2 doesn't
+        d1_params = deployment_params(
+            "d1", "/hi", autoscaling_config=autoscaling_config
+        )
+        d2_params = deployment_params("d2")  # No autoscaling config
+
+        app_state_manager.deploy_app("test_app", [d1_params, d2_params])
+        app_state_manager.update()
+
+        deployment_state_manager.set_deployment_healthy(d1_id)
+        deployment_state_manager.set_deployment_healthy(d2_id)
+        app_state_manager.update()
+
+        # Register only d1 with autoscaling manager and create replicas
+        asm = app_state_manager._autoscaling_state_manager
+        d1_info = deployment_info("d1", "/hi", autoscaling_config=autoscaling_config)
+        asm.register_deployment(d1_id, d1_info, 1)
+
+        # Create replicas for d1 only
+        d1_replicas = [
+            ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id) for i in [1, 2]
+        ]
+        asm.update_running_replica_ids(d1_id, d1_replicas)
+
+        # Simulate high load on d1
+        current_time = time.time()
+        timestamp_offset = current_time - 0.1
+
+        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
+            d1_handle_report = HandleMetricReport(
+                deployment_id=d1_id,
+                handle_id="random",
+                actor_id="actor_id",
+                handle_source=DeploymentHandleSource.UNKNOWN,
+                queued_requests=[TimeStampedValue(timestamp_offset, 0)],
+                aggregated_queued_requests=0,
+                aggregated_metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        ReplicaID(unique_id="replica_1", deployment_id=d1_id): 3,
+                        ReplicaID(unique_id="replica_2", deployment_id=d1_id): 3,
+                    }
+                },
+                metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        ReplicaID(unique_id="replica_1", deployment_id=d1_id): [
+                            TimeStampedValue(timestamp_offset, 3)
+                        ],
+                        ReplicaID(unique_id="replica_2", deployment_id=d1_id): [
+                            TimeStampedValue(timestamp_offset, 3)
+                        ],
+                    }
+                },
+                timestamp=time.time(),
+            )
+            asm.record_request_metrics_for_handle(d1_handle_report)
+        else:
+            for i in [1, 2]:
+                replica_report = ReplicaMetricReport(
+                    replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id),
+                    aggregated_metrics={RUNNING_REQUESTS_KEY: 3},
+                    metrics={
+                        RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 3)]
+                    },
+                    timestamp=time.time(),
+                )
+                asm.record_request_metrics_for_replica(replica_report)
+
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Call autoscale
+        result = app_state.autoscale()
+
+        # Verify only d1's decision was applied (d2 has no autoscaling)
+        assert result is True
+        assert d1_id in deployment_state_manager._scaling_decisions
+        assert d2_id not in deployment_state_manager._scaling_decisions
+
+    def test_autoscale_multiple_apps_independent(
+        self, mocked_application_state_manager
+    ):
+        """Test that autoscaling decisions for one app don't affect another app."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Create autoscaling configuration
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        # Deploy app1 with two deployments
+        app1_d1_id = DeploymentID(name="d1", app_name="app1")
+        app1_d2_id = DeploymentID(name="d2", app_name="app1")
+        app1_d1_params = deployment_params(
+            "d1", "/app1", autoscaling_config=autoscaling_config
+        )
+        app1_d2_params = deployment_params("d2", autoscaling_config=autoscaling_config)
+
+        app_state_manager.deploy_app("app1", [app1_d1_params, app1_d2_params])
+        app_state_manager.update()
+        deployment_state_manager.set_deployment_healthy(app1_d1_id)
+        deployment_state_manager.set_deployment_healthy(app1_d2_id)
+        app_state_manager.update()
+
+        # Deploy app2 with two deployments
+        app2_d1_id = DeploymentID(name="d1", app_name="app2")
+        app2_d2_id = DeploymentID(name="d2", app_name="app2")
+        app2_d1_params = deployment_params(
+            "d1", "/app2", autoscaling_config=autoscaling_config
+        )
+        app2_d2_params = deployment_params("d2", autoscaling_config=autoscaling_config)
+
+        app_state_manager.deploy_app("app2", [app2_d1_params, app2_d2_params])
+        app_state_manager.update()
+        deployment_state_manager.set_deployment_healthy(app2_d1_id)
+        deployment_state_manager.set_deployment_healthy(app2_d2_id)
+        app_state_manager.update()
+
+        # Register app1 deployments with autoscaling manager
+        asm = app_state_manager._autoscaling_state_manager
+        app1_d1_info = deployment_info(
+            "d1", "/app1", autoscaling_config=autoscaling_config
+        )
+        app1_d2_info = deployment_info("d2", autoscaling_config=autoscaling_config)
+        app1_d1_info.app_name = "app1"
+        app1_d2_info.app_name = "app1"
+        asm.register_deployment(app1_d1_id, app1_d1_info, 1)
+        asm.register_deployment(app1_d2_id, app1_d2_info, 1)
+
+        # Register app2 deployments with autoscaling manager
+        app2_d1_info = deployment_info(
+            "d1", "/app2", autoscaling_config=autoscaling_config
+        )
+        app2_d2_info = deployment_info("d2", autoscaling_config=autoscaling_config)
+        app2_d1_info.app_name = "app2"
+        app2_d2_info.app_name = "app2"
+        asm.register_deployment(app2_d1_id, app2_d1_info, 1)
+        asm.register_deployment(app2_d2_id, app2_d2_info, 1)
+
+        # Create replicas for both apps
+        app1_d1_replicas = [
+            ReplicaID(unique_id=f"app1_d1_replica_{i}", deployment_id=app1_d1_id)
+            for i in [1, 2]
+        ]
+        app1_d2_replicas = [
+            ReplicaID(unique_id=f"app1_d2_replica_{i}", deployment_id=app1_d2_id)
+            for i in [3, 4]
+        ]
+        asm.update_running_replica_ids(app1_d1_id, app1_d1_replicas)
+        asm.update_running_replica_ids(app1_d2_id, app1_d2_replicas)
+
+        app2_d1_replicas = [
+            ReplicaID(unique_id=f"app2_d1_replica_{i}", deployment_id=app2_d1_id)
+            for i in [5, 6]
+        ]
+        app2_d2_replicas = [
+            ReplicaID(unique_id=f"app2_d2_replica_{i}", deployment_id=app2_d2_id)
+            for i in [7, 8]
+        ]
+        asm.update_running_replica_ids(app2_d1_id, app2_d1_replicas)
+        asm.update_running_replica_ids(app2_d2_id, app2_d2_replicas)
+
+        # Simulate high load on app1, low load on app2
+        current_time = time.time()
+        timestamp_offset = current_time - 0.1
+
+        # App1: High load
+        for replica_id in app1_d1_replicas + app1_d2_replicas:
+            replica_report = ReplicaMetricReport(
+                replica_id=replica_id,
+                aggregated_metrics={RUNNING_REQUESTS_KEY: 3},
+                metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 3)]},
+                timestamp=time.time(),
+            )
+            asm.record_request_metrics_for_replica(replica_report)
+
+        # App2: Low load
+        for replica_id in app2_d1_replicas + app2_d2_replicas:
+            replica_report = ReplicaMetricReport(
+                replica_id=replica_id,
+                aggregated_metrics={RUNNING_REQUESTS_KEY: 0},
+                metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 0)]},
+                timestamp=time.time(),
+            )
+            asm.record_request_metrics_for_replica(replica_report)
+
+        # Clear scaling decisions
+        deployment_state_manager._scaling_decisions.clear()
+
+        # Call update which triggers autoscaling for both apps
+        app_state_manager.update()
+
+        # Verify app1 deployments scaled up (high load)
+        assert app1_d1_id in deployment_state_manager._scaling_decisions
+        assert app1_d2_id in deployment_state_manager._scaling_decisions
+        assert deployment_state_manager._scaling_decisions[app1_d1_id] > 2
+
+        # Verify app2 deployments scaled down (low load)
+        assert app2_d1_id in deployment_state_manager._scaling_decisions
+        assert app2_d2_id in deployment_state_manager._scaling_decisions
+        assert deployment_state_manager._scaling_decisions[app2_d1_id] == 1
+
+    def test_autoscale_with_partial_deployment_details(
+        self, mocked_application_state_manager
+    ):
+        """Test autoscale when some deployments have details and others return None."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Deploy app with autoscaling
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Register only d1 with autoscaling manager (d2 won't be registered)
+        asm = app_state_manager._autoscaling_state_manager
+        d1_info = deployment_info("d1", "/hi", autoscaling_config=autoscaling_config)
+        asm.register_deployment(d1_id, d1_info, 1)
+
+        # Create replicas for d1 only
+        d1_replicas = [
+            ReplicaID(unique_id=f"d1_replica_{i}", deployment_id=d1_id) for i in [1, 2]
+        ]
+        asm.update_running_replica_ids(d1_id, d1_replicas)
+
+        # Simulate load for d1
+        current_time = time.time()
+        timestamp_offset = current_time - 0.1
+        for i in [1, 2]:
+            replica_report = ReplicaMetricReport(
+                replica_id=ReplicaID(unique_id=f"d1_replica_{i}", deployment_id=d1_id),
+                aggregated_metrics={RUNNING_REQUESTS_KEY: 3},
+                metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 3)]},
+                timestamp=time.time(),
+            )
+            asm.record_request_metrics_for_replica(replica_report)
+
+        # Mock get_deployment_target_num_replicas to return None for d2 only
+        original_get_details = (
+            deployment_state_manager.get_deployment_target_num_replicas
+        )
+
+        def selective_get_details(dep_id) -> Optional[int]:
+            if dep_id == d2_id:
+                return None
+            return original_get_details(dep_id)
+
+        deployment_state_manager.get_deployment_target_num_replicas = (
+            selective_get_details
+        )
+
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Call autoscale
+        result = app_state.autoscale()
+
+        # Verify it returns True (d1 has scaling decision)
+        assert result is True
+
+        # Verify only d1 has scaling decision (d2 was skipped due to None details)
+        assert d1_id in deployment_state_manager._scaling_decisions
+        assert d2_id not in deployment_state_manager._scaling_decisions
+
+    def test_autoscale_single_deployment_in_app(self, mocked_application_state_manager):
+        """Test autoscaling with only one deployment in the app."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Create autoscaling configuration
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        # Deploy single deployment
+        d1_id = DeploymentID(name="d1", app_name="test_app")
+        d1_params = deployment_params(
+            "d1", "/hi", autoscaling_config=autoscaling_config
+        )
+
+        app_state_manager.deploy_app("test_app", [d1_params])
+        app_state_manager.update()
+        deployment_state_manager.set_deployment_healthy(d1_id)
+        app_state_manager.update()
+
+        # Register with autoscaling manager
+        asm = app_state_manager._autoscaling_state_manager
+        d1_info = deployment_info("d1", "/hi", autoscaling_config=autoscaling_config)
+        asm.register_deployment(d1_id, d1_info, 1)
+
+        # Create replicas
+        d1_replicas = [
+            ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id) for i in [1, 2]
+        ]
+        asm.update_running_replica_ids(d1_id, d1_replicas)
+
+        # Simulate high load
+        current_time = time.time()
+        timestamp_offset = current_time - 0.1
+        for i in [1, 2]:
+            replica_report = ReplicaMetricReport(
+                replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id),
+                aggregated_metrics={RUNNING_REQUESTS_KEY: 4},
+                metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 4)]},
+                timestamp=time.time(),
+            )
+            asm.record_request_metrics_for_replica(replica_report)
+
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Call autoscale
+        result = app_state.autoscale()
+
+        # Verify it returns True
+        assert result is True
+
+        # Verify scaling decision was made
+        assert d1_id in deployment_state_manager._scaling_decisions
+        assert deployment_state_manager._scaling_decisions[d1_id] > 2
+
+    def test_autoscale_during_app_deletion(self, mocked_application_state_manager):
+        """Test autoscaling behavior when app is being deleted."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Deploy app with autoscaling
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Register with autoscaling manager and create replicas
+        asm = app_state_manager._autoscaling_state_manager
+        self._register_deployments_with_asm(asm, d1_id, d2_id, autoscaling_config)
+        self._create_running_replicas(asm, d1_id, d2_id)
+
+        # Simulate load
+        self._simulate_load_metrics(asm, d1_id, d2_id, d1_load=5, d2_load=5)
+
+        # Delete the app
+        app_state_manager.delete_app("test_app")
+
+        # Get app state
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Verify app status is DELETING
+        assert app_state.status == ApplicationStatus.DELETING
+
+        # Clear scaling decisions
+        deployment_state_manager._scaling_decisions.clear()
+
+        # Call update (should not autoscale deleting apps)
+        app_state_manager.update()
+
+        # Verify no autoscaling decisions were made (app is deleting)
+        assert len(deployment_state_manager._scaling_decisions) == 0
+
+    def test_autoscale_many_deployments_in_app(self, mocked_application_state_manager):
+        """Test autoscaling with many (15+) deployments in single app."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Create autoscaling configuration
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 3,
+            "initial_replicas": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        # Deploy 15 deployments
+        num_deployments = 15
+        deployment_ids = []
+        deployment_params_list = []
+
+        for i in range(num_deployments):
+            deployment_ids.append(DeploymentID(name=f"d{i}", app_name="test_app"))
+            deployment_params_list.append(
+                deployment_params(f"d{i}", autoscaling_config=autoscaling_config)
+            )
+
+        app_state_manager.deploy_app("test_app", deployment_params_list)
+        app_state_manager.update()
+
+        # Mark all as healthy
+        for dep_id in deployment_ids:
+            deployment_state_manager.set_deployment_healthy(dep_id)
+        app_state_manager.update()
+
+        # Register all with autoscaling manager
+        asm = app_state_manager._autoscaling_state_manager
+        for i, dep_id in enumerate(deployment_ids):
+            info = deployment_info(f"d{i}", autoscaling_config=autoscaling_config)
+            asm.register_deployment(dep_id, info, 1)
+
+            # Create replicas
+            replicas = [
+                ReplicaID(unique_id=f"d{i}_replica_{j}", deployment_id=dep_id)
+                for j in [1, 2]
+            ]
+            asm.update_running_replica_ids(dep_id, replicas)
+
+            # Simulate load (alternating high/low)
+            load = 3 if i % 2 == 0 else 0
+            current_time = time.time()
+            timestamp_offset = current_time - 0.1
+            for replica in replicas:
+                replica_report = ReplicaMetricReport(
+                    replica_id=replica,
+                    aggregated_metrics={RUNNING_REQUESTS_KEY: load},
+                    metrics={
+                        RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, load)]
+                    },
+                    timestamp=time.time(),
+                )
+                asm.record_request_metrics_for_replica(replica_report)
+
+        # Clear scaling decisions
+        deployment_state_manager._scaling_decisions.clear()
+
+        # Call update
+        app_state_manager.update()
+
+        # Verify all deployments have scaling decisions
+        assert len(deployment_state_manager._scaling_decisions) == num_deployments
+
+        # Verify high-load deployments scaled up
+        for i in range(0, num_deployments, 2):  # Even indices have high load
+            assert deployment_state_manager._scaling_decisions[deployment_ids[i]] == 3
+
+        # Verify low-load deployments scaled down
+        for i in range(1, num_deployments, 2):  # Odd indices have low load
+            assert deployment_state_manager._scaling_decisions[deployment_ids[i]] == 1
+
+    def test_autoscale_with_min_equals_max_replicas(
+        self, mocked_application_state_manager
+    ):
+        """Test autoscaling when min_replicas equals max_replicas (no room to scale)."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Create autoscaling configuration with no scaling room
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 3,
+            "max_replicas": 3,  # Same as min
+            "initial_replicas": 3,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        d1_id = DeploymentID(name="d1", app_name="test_app")
+        d1_params = deployment_params(
+            "d1", "/hi", autoscaling_config=autoscaling_config
+        )
+
+        app_state_manager.deploy_app("test_app", [d1_params])
+        app_state_manager.update()
+        deployment_state_manager.set_deployment_healthy(d1_id)
+        app_state_manager.update()
+
+        # Register with autoscaling manager
+        asm = app_state_manager._autoscaling_state_manager
+        d1_info = deployment_info("d1", "/hi", autoscaling_config=autoscaling_config)
+        asm.register_deployment(d1_id, d1_info, 3)
+
+        # Create replicas
+        d1_replicas = [
+            ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id) for i in range(3)
+        ]
+        asm.update_running_replica_ids(d1_id, d1_replicas)
+
+        # Simulate extreme load (should want to scale up but can't)
+        current_time = time.time()
+        timestamp_offset = current_time - 0.1
+        for i in range(3):
+            replica_report = ReplicaMetricReport(
+                replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id),
+                aggregated_metrics={RUNNING_REQUESTS_KEY: 10},
+                metrics={
+                    RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 10)]
+                },
+                timestamp=time.time(),
+            )
+            asm.record_request_metrics_for_replica(replica_report)
+
+        app_state = app_state_manager._application_states["test_app"]
+
+        # Call autoscale
+        _ = app_state.autoscale()
+
+        # Decision should be made but capped at max_replicas (3)
+        assert d1_id in deployment_state_manager._scaling_decisions
+        assert deployment_state_manager._scaling_decisions[d1_id] == 3
+
+    def test_autoscale_multiple_updates_stable_load(
+        self, mocked_application_state_manager
+    ):
+        """Test multiple update() calls with stable load don't cause thrashing."""
+        (
+            app_state_manager,
+            deployment_state_manager,
+            _,
+        ) = mocked_application_state_manager
+
+        # Setup: Deploy app with autoscaling
+        autoscaling_config = {
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "initial_replicas": 2,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+        }
+
+        d1_id, d2_id = self._deploy_test_deployments(
+            app_state_manager, deployment_state_manager, autoscaling_config
+        )
+
+        # Register with autoscaling manager and create replicas
+        asm = app_state_manager._autoscaling_state_manager
+        self._register_deployments_with_asm(asm, d1_id, d2_id, autoscaling_config)
+        self._create_running_replicas(asm, d1_id, d2_id)
+
+        # Simulate stable load at target
+        self._simulate_load_metrics(asm, d1_id, d2_id, d1_load=1, d2_load=1)
+
+        # Clear scaling decisions
+        deployment_state_manager._scaling_decisions.clear()
+
+        # Call update multiple times
+        for _ in range(5):
+            app_state_manager.update()
+
+        # Verify decisions are stable (should be 2 replicas - no change)
+        # If decisions keep changing, that's thrashing
+        if deployment_state_manager._scaling_decisions:
+            assert deployment_state_manager._scaling_decisions.get(d1_id, 2) == 2
+            assert deployment_state_manager._scaling_decisions.get(d2_id, 2) == 2
+
+    def _deploy_test_deployments(
+        self, app_state_manager, deployment_state_manager, autoscaling_config
+    ):
+        """Deploy two test deployments and mark them as healthy."""
+        d1_id = DeploymentID(name="d1", app_name="test_app")
+        d2_id = DeploymentID(name="d2", app_name="test_app")
+
+        d1_params = deployment_params(
+            "d1", "/hi", autoscaling_config=autoscaling_config
+        )
+        d2_params = deployment_params("d2", autoscaling_config=autoscaling_config)
+
+        app_state_manager.deploy_app("test_app", [d1_params, d2_params])
+        app_state_manager.update()
+
+        deployment_state_manager.set_deployment_healthy(d1_id)
+        deployment_state_manager.set_deployment_healthy(d2_id)
+        app_state_manager.update()
+
+        assert app_state_manager.get_app_status("test_app") == ApplicationStatus.RUNNING
+        return d1_id, d2_id
+
+    def _register_deployments_with_asm(self, asm, d1_id, d2_id, autoscaling_config):
+        """Register deployments with the autoscaling state manager."""
+        d1_info = deployment_info("d1", "/hi", autoscaling_config=autoscaling_config)
+        d2_info = deployment_info("d2", autoscaling_config=autoscaling_config)
+
+        asm.register_deployment(d1_id, d1_info, 1)
+        asm.register_deployment(d2_id, d2_info, 1)
+
+    def _create_running_replicas(self, asm, d1_id, d2_id):
+        """Create running replicas for both deployments."""
+        # d1 gets 2 replicas
+        d1_replicas = [
+            ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id) for i in [1, 2]
+        ]
+        asm.update_running_replica_ids(d1_id, d1_replicas)
+
+        # d2 gets 2 replicas
+        d2_replicas = [
+            ReplicaID(unique_id=f"replica_{i}", deployment_id=d2_id) for i in [3, 4]
+        ]
+        asm.update_running_replica_ids(d2_id, d2_replicas)
+
+    def _simulate_load_metrics(self, asm, d1_id, d2_id, d1_load=2, d2_load=1):
+        current_time = time.time()
+        timestamp_offset = current_time - 0.1
+
+        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
+            self._record_handle_metrics(
+                asm, d1_id, d2_id, timestamp_offset, d1_load, d2_load
+            )
+        else:
+            self._record_replica_metrics(
+                asm, d1_id, d2_id, timestamp_offset, d1_load, d2_load
+            )
+
+    def _record_handle_metrics(
+        self, asm, d1_id, d2_id, timestamp_offset, d1_load=2, d2_load=1
+    ):
+        """Record metrics using handle-based reporting."""
+        # d1: Load based on d1_load parameter
+        d1_handle_report = HandleMetricReport(
+            deployment_id=d1_id,
+            handle_id="random",
+            actor_id="actor_id",
+            handle_source=DeploymentHandleSource.UNKNOWN,
+            queued_requests=[TimeStampedValue(timestamp_offset, 0)],
+            aggregated_queued_requests=0,
+            aggregated_metrics={
+                RUNNING_REQUESTS_KEY: {
+                    ReplicaID(unique_id="replica_1", deployment_id=d1_id): d1_load,
+                    ReplicaID(unique_id="replica_2", deployment_id=d1_id): d1_load,
+                }
+            },
+            metrics={
+                RUNNING_REQUESTS_KEY: {
+                    ReplicaID(unique_id="replica_1", deployment_id=d1_id): [
+                        TimeStampedValue(timestamp_offset, d1_load)
+                    ],
+                    ReplicaID(unique_id="replica_2", deployment_id=d1_id): [
+                        TimeStampedValue(timestamp_offset, d1_load)
+                    ],
+                }
+            },
+            timestamp=time.time(),
+        )
+        asm.record_request_metrics_for_handle(d1_handle_report)
+
+        # d2: Load based on d2_load parameter
+        d2_handle_report = HandleMetricReport(
+            deployment_id=d2_id,
+            handle_id="random",
+            actor_id="actor_id",
+            handle_source=DeploymentHandleSource.UNKNOWN,
+            queued_requests=[TimeStampedValue(timestamp_offset, 0)],
+            aggregated_queued_requests=0,
+            aggregated_metrics={
+                RUNNING_REQUESTS_KEY: {
+                    ReplicaID(unique_id="replica_3", deployment_id=d2_id): d2_load,
+                    ReplicaID(unique_id="replica_4", deployment_id=d2_id): d2_load,
+                }
+            },
+            metrics={
+                RUNNING_REQUESTS_KEY: {
+                    ReplicaID(unique_id="replica_3", deployment_id=d2_id): [
+                        TimeStampedValue(timestamp_offset, d2_load)
+                    ],
+                    ReplicaID(unique_id="replica_4", deployment_id=d2_id): [
+                        TimeStampedValue(timestamp_offset, d2_load)
+                    ],
+                }
+            },
+            timestamp=time.time(),
+        )
+        asm.record_request_metrics_for_handle(d2_handle_report)
+
+    def _record_replica_metrics(
+        self, asm, d1_id, d2_id, timestamp_offset, d1_load=2, d2_load=1
+    ):
+        """Record metrics using replica-based reporting."""
+        # d1: Load based on d1_load parameter
+        for i in [1, 2]:
+            replica_report = ReplicaMetricReport(
+                replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id),
+                aggregated_metrics={RUNNING_REQUESTS_KEY: d1_load},
+                metrics={
+                    RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, d1_load)]
+                },
+                timestamp=time.time(),
+            )
+            asm.record_request_metrics_for_replica(replica_report)
+
+        # d2: Load based on d2_load parameter
+        for i in [3, 4]:
+            replica_report = ReplicaMetricReport(
+                replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d2_id),
+                aggregated_metrics={RUNNING_REQUESTS_KEY: d2_load},
+                metrics={
+                    RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, d2_load)]
+                },
+                timestamp=time.time(),
+            )
+            asm.record_request_metrics_for_replica(replica_report)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -2778,6 +2778,28 @@ def test_get_active_node_ids_none(mock_deployment_state_manager):
 
 
 class TestAutoscaling:
+    def scale(
+        self,
+        dsm: DeploymentStateManager,
+        asm: AutoscalingStateManager,
+        deployment_ids: List[DeploymentID],
+    ):
+        if not deployment_ids:
+            return
+
+        app_name = deployment_ids[0].app_name
+        assert all(dep_id.app_name == app_name for dep_id in deployment_ids)
+
+        deployment_to_target_num_replicas = {
+            dep_id: dsm.get_deployment_details(dep_id).target_num_replicas
+            for dep_id in deployment_ids
+        }
+        decisions = asm.get_decision_num_replicas(
+            app_name, deployment_to_target_num_replicas
+        )
+        for deployment_id, decision_num_replicas in decisions.items():
+            dsm.autoscale(deployment_id, decision_num_replicas)
+
     @pytest.mark.parametrize("target_capacity_direction", ["up", "down"])
     def test_basic_autoscaling(
         self, mock_deployment_state_manager, target_capacity_direction
@@ -2878,6 +2900,8 @@ class TestAutoscaling:
                 )
                 asm.record_request_metrics_for_replica(replica_metric_report)
 
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
+
         # status=UPSCALING/DOWNSCALING, status_trigger=AUTOSCALE
         dsm.update()
         if target_capacity_direction == "up":
@@ -2929,6 +2953,7 @@ class TestAutoscaling:
                 ],
             )
             # Trigger the second stage of downscaling
+            self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
             dsm.update()
             check_counts(ds, total=3, by_state=[(ReplicaState.STOPPING, 3, None)])
 
@@ -2941,7 +2966,9 @@ class TestAutoscaling:
                 replica._actor.set_done_stopping()
 
             dsm.update()
-            astate = asm._autoscaling_states[TEST_DEPLOYMENT_ID]
+            astate = asm._app_autoscaling_states[
+                TEST_DEPLOYMENT_ID.app_name
+            ]._deployment_autoscaling_states[TEST_DEPLOYMENT_ID]
             assert len(astate._replica_metrics) == 0
 
         # status=HEALTHY, status_trigger=UPSCALE/DOWNSCALE
@@ -2960,7 +2987,7 @@ class TestAutoscaling:
             replica._actor.set_done_stopping()
         dsm.update()
         assert TEST_DEPLOYMENT_ID not in dsm._deployment_states
-        assert TEST_DEPLOYMENT_ID not in asm._autoscaling_states
+        assert TEST_DEPLOYMENT_ID.app_name not in asm._app_autoscaling_states
 
     @pytest.mark.parametrize(
         "target_startup_status",
@@ -3065,6 +3092,7 @@ class TestAutoscaling:
                 asm.record_request_metrics_for_replica(replica_metric_report)
 
         # status=UPSCALING, status_trigger=AUTOSCALE
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(
             ds,
@@ -3162,6 +3190,7 @@ class TestAutoscaling:
                 asm.record_request_metrics_for_replica(replica_metric_report)
 
         # status=DOWNSCALING, status_trigger=AUTOSCALE
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(
             ds,
@@ -3292,6 +3321,7 @@ class TestAutoscaling:
         dsm.deploy(TEST_DEPLOYMENT_ID, info2)
 
         # 3 new replicas should be starting, status should be UPDATING (not upscaling)
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(
             ds,
@@ -3366,6 +3396,7 @@ class TestAutoscaling:
             timestamp=timer.time(),
         )
         asm.record_request_metrics_for_handle(handle_metric_report)
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
 
         # The controller should try to start a new replica. If that replica repeatedly
         # fails to start, the deployment should transition to UNHEALTHY and NOT retry
@@ -3464,6 +3495,7 @@ class TestAutoscaling:
         )
 
         # There are no requests, so the deployment should be downscaled to zero.
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
         ds._replicas.get()[0]._actor.set_done_stopping()
@@ -3483,7 +3515,7 @@ class TestAutoscaling:
             timestamp=timer.time(),
         )
         asm.record_request_metrics_for_handle(handle_metric_report)
-
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         # The controller should try to start a new replica. If that replica repeatedly
         # fails to start, the deployment should transition to UNHEALTHY. Meanwhile
         # the controller should continue retrying after 3 times.
@@ -3569,6 +3601,7 @@ class TestAutoscaling:
         )
         asm.record_request_metrics_for_handle(handle_metric_report)
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(
             ds,
@@ -3578,20 +3611,22 @@ class TestAutoscaling:
                 (ReplicaState.STARTING, 1, None),
             ],
         )
-        assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 2
+        assert asm.get_total_num_requests_for_deployment(TEST_DEPLOYMENT_ID) == 2
         ds._replicas.get([ReplicaState.STARTING])[0]._actor.set_ready()
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
-        assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 2
+        assert asm.get_total_num_requests_for_deployment(TEST_DEPLOYMENT_ID) == 2
 
         # Simulate handle was on an actor that died. 10 seconds later
         # the handle fails to push metrics
         timer.advance(10)
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
-        assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 2
+        assert asm.get_total_num_requests_for_deployment(TEST_DEPLOYMENT_ID) == 2
 
         # Another 10 seconds later handle still fails to push metrics. At
         # this point the data from the handle should be invalidated. As a
@@ -3599,6 +3634,7 @@ class TestAutoscaling:
         timer.advance(10)
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
         # The first update will trigger the first stage of downscaling to 1
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(
             ds,
@@ -3609,9 +3645,10 @@ class TestAutoscaling:
             ],
         )
         # The second update will trigger the second stage of downscaling from 1 to 0
+        self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.STOPPING, 2, None)])
-        assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 0
+        assert asm.get_total_num_requests_for_deployment(TEST_DEPLOYMENT_ID) == 0
 
     @pytest.mark.skipif(
         not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
@@ -3677,6 +3714,7 @@ class TestAutoscaling:
         )
         asm.record_request_metrics_for_handle(handle_metric_report)
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
+        self.scale(dsm, asm, [d_id1, d_id2])
         dsm.update()
         check_counts(
             ds1,
@@ -3686,16 +3724,18 @@ class TestAutoscaling:
                 (ReplicaState.STARTING, 1, None),
             ],
         )
-        assert asm.get_total_num_requests(d_id1) == 2
+        assert asm.get_total_num_requests_for_deployment(d_id1) == 2
         ds1._replicas.get([ReplicaState.STARTING])[0]._actor.set_ready()
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
+        self.scale(dsm, asm, [d_id1, d_id2])
         dsm.update()
         check_counts(ds1, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
-        assert asm.get_total_num_requests(d_id1) == 2
+        assert asm.get_total_num_requests_for_deployment(d_id1) == 2
 
         # d2 replica died
         ds2._replicas.get()[0]._actor.set_unhealthy()
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
+        self.scale(dsm, asm, [d_id1, d_id2])
         dsm.update()
         check_counts(
             ds2,
@@ -3707,12 +3747,14 @@ class TestAutoscaling:
         )
         ds2._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
+        self.scale(dsm, asm, [d_id1, d_id2])
         dsm.update()
         check_counts(ds2, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
 
         # Now that the d2 replica is dead, its metrics should be dropped.
         # Consequently d1 should scale down to 0 replicas
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
+        self.scale(dsm, asm, [d_id1, d_id2])
         dsm.update()
         # Due to two-stage downscaling one of the replicas will still be running
         check_counts(
@@ -3724,6 +3766,7 @@ class TestAutoscaling:
             ],
         )
         # Trigger the second stage of downscaling
+        self.scale(dsm, asm, [d_id1, d_id2])
         dsm.update()
         check_counts(ds1, total=2, by_state=[(ReplicaState.STOPPING, 2, None)])
 


### PR DESCRIPTION
part 2 of https://github.com/ray-project/ray/pull/56149, a significant portion of the code is taken from the original PR.

This PR does not introduce any change in functionality. Autoscaling is still performed at the deployment level. This will help us make the transition towards application level autoscaling.

The only change in this PR
1. is moving the autoscaling control loop from the deployment state to the application state. 
2. adding application autoscaling state class, in the new design autoscaling state manager will manage a list of application autoscaling states and each application autoscaling state will manage a list of deployment autoscaling states