### PR TITLE
[train] Fix py312 GPU test filter

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -107,7 +107,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... //python/ray/tune/... //python/ray/air/... ml
         --workers 4 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
         --python-version {{matrix.python}}
-        --except-tags gpu,minimal,doctest,needs_credentials,soft_imports,rllib
+        --except-tags gpu,train_v2_gpu,minimal,doctest,needs_credentials,soft_imports,rllib
     depends_on:
       - mlbuild-multipy
       - forge
@@ -141,7 +141,7 @@ steps:
         --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 2
         --python-version {{matrix.python}}
         --build-name mlgpubuild-py{{matrix.python}}
-        --only-tags gpu
+        --only-tags gpu,train_v2_gpu
         --except-tags doctest
     depends_on: [ "mlgpubuild-multipy", "forge" ]
     matrix:


### PR DESCRIPTION
## Summary

https://github.com/ray-project/ray/pull/56868 replaced `gpu` tags with `train_v2_gpu` in order to separate out the tests into 2 CI pipelines. However, there's a py312 test that only runs in postmerge that filters out the `gpu` tag. This resulted in GPU tests running on the py312 CPU test runner. This PR fixes the issue by filtering out the new `train_v2_gpu` tag as well.