### PR TITLE
[serve] Change test_controller_recovery logging config condition

### DIFF
--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -472,11 +472,12 @@ def test_controller_crashes_with_logging_config(serve_instance):
     proxy_handles = ray.get(client._controller.get_proxies.remote())
     proxy_handle = list(proxy_handles.values())[0]
     file_path = ray.get(proxy_handle._get_logging_config.remote())
-    # Send request, we should see json logging and debug log message in proxy log.
-    resp = httpx.get("http://localhost:8000")
-    assert resp.status_code == 200
+    # We should see the health check debug log in the proxy logs.
     wait_for_condition(
-        check_log_file, log_file=file_path, expected_regex=['"levelname": "DEBUG"']
+        check_log_file,
+        log_file=file_path,
+        expected_regex=['"message": "Received health check."'],
+        timeout=15,  # The health check period is 10 seconds.
     )
 
 

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -476,7 +476,7 @@ def test_controller_crashes_with_logging_config(serve_instance):
     resp = httpx.get("http://localhost:8000")
     assert resp.status_code == 200
     wait_for_condition(
-        check_log_file, log_file=file_path, expected_regex=['.*"message":.*GET / 200.*']
+        check_log_file, log_file=file_path, expected_regex=['"levelname": "DEBUG"']
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes the test condition to actually check for debug and json logs after controller recovers. The specific access log format is checked in test_logging.py
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
