### PR TITLE
[train] Raise errors when mixing V1 and V2 API usage

### DIFF
--- a/python/ray/air/tests/test_air_usage.py
+++ b/python/ray/air/tests/test_air_usage.py
@@ -204,31 +204,6 @@ def test_tag_air_entrypoint(ray_start_4_cpus, mock_record, entrypoint, tuner, tr
     assert mock_record[TagKey.AIR_ENTRYPOINT] == entrypoint.value
 
 
-@pytest.mark.skipif(
-    sys.version_info.major == 3 and sys.version_info.minor >= 12,
-    reason="Python 3.12+ does not have Tensorflow installed on CI due to dependency conflicts.",
-)
-def test_tag_train_entrypoint(mock_record):
-    """Test that Train v2 entrypoints are recorded correctly."""
-    from ray.train.v2.lightgbm.lightgbm_trainer import LightGBMTrainer
-    from ray.train.v2.tensorflow.tensorflow_trainer import TensorflowTrainer
-    from ray.train.v2.torch.torch_trainer import TorchTrainer
-    from ray.train.v2.xgboost.xgboost_trainer import XGBoostTrainer
-
-    trainer_classes = [
-        TorchTrainer,
-        TensorflowTrainer,
-        XGBoostTrainer,
-        LightGBMTrainer,
-    ]
-    for trainer_cls in trainer_classes:
-        trainer = trainer_cls(
-            train_loop_per_worker=train_fn,
-            scaling_config=train.ScalingConfig(num_workers=2),
-        )
-        assert mock_record[TagKey.TRAIN_TRAINER] == trainer.__class__.__name__
-
-
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -542,12 +542,13 @@ class BaseTrainer(abc.ABC):
 
         if is_v2_enabled():
             raise DeprecationWarning(
-                f"Ray Train V2 does not support the V1 Trainer class from this module: `{self.__class__.__module__}`. "
-                "You may be using a deprecated import path for the Trainer class. "
-                "For example, you should replace `from ray.train.torch.torch_trainer import TorchTrainer` "
-                "with `from ray.train.torch import TorchTrainer`. "
-                "Please either update your import path, or explicitly disable Ray Train V2 by "
-                f"setting the environment variable: {V2_ENABLED_ENV_VAR}=0"
+                f"Detected use of a deprecated Trainer import from `{self.__class__.__module__}`. "
+                "This Trainer class is not compatible with Ray Train V2.\n"
+                "To fix this:\n"
+                "  - Update to use the new import path. For example, "
+                "`from ray.train.torch.torch_trainer import TorchTrainer` -> "
+                "`from ray.train.torch import TorchTrainer`\n"
+                f"  - Or, explicitly disable V2 by setting: {V2_ENABLED_ENV_VAR}=0"
             )
 
         if not _v2_migration_warnings_enabled():

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -538,6 +538,17 @@ class BaseTrainer(abc.ABC):
         constructors to avoid logging incorrect deprecation warnings when
         `ray.train.RunConfig` is passed to Ray Tune.
         """
+        from ray.train.v2._internal.constants import V2_ENABLED_ENV_VAR, is_v2_enabled
+
+        if is_v2_enabled():
+            raise DeprecationWarning(
+                f"Ray Train V2 does not support the V1 Trainer class from this module: `{self.__class__.__module__}`. "
+                "You may be using a deprecated import path for the Trainer class. "
+                "For example, you should replace `from ray.train.torch.torch_trainer import TorchTrainer` "
+                "with `from ray.train.torch import TorchTrainer`. "
+                "Please either update your import path, or explicitly disable Ray Train V2 by "
+                f"setting the environment variable: {V2_ENABLED_ENV_VAR}=0"
+            )
 
         if not _v2_migration_warnings_enabled():
             return

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -548,7 +548,9 @@ class BaseTrainer(abc.ABC):
                 "  - Update to use the new import path. For example, "
                 "`from ray.train.torch.torch_trainer import TorchTrainer` -> "
                 "`from ray.train.torch import TorchTrainer`\n"
-                f"  - Or, explicitly disable V2 by setting: {V2_ENABLED_ENV_VAR}=0"
+                f"  - Or, explicitly disable V2 by setting: {V2_ENABLED_ENV_VAR}=0\n"
+                "See this issue for more context: "
+                "https://github.com/ray-project/ray/issues/49454"
             )
 
         if not _v2_migration_warnings_enabled():

--- a/python/ray/train/tests/test_api_migrations.py
+++ b/python/ray/train/tests/test_api_migrations.py
@@ -141,5 +141,18 @@ def test_train_context_deprecations(ray_start_4_cpus, tmp_path):
     trainer.fit()
 
 
+def test_v2_enabled_error(monkeypatch):
+    """Running a V1 Trainer with V2 enabled should raise an error."""
+    from ray.train.v2._internal.constants import V2_ENABLED_ENV_VAR
+
+    monkeypatch.setenv(V2_ENABLED_ENV_VAR, "1")
+
+    with pytest.raises(DeprecationWarning, match="Detected use of a deprecated"):
+        DataParallelTrainer(
+            lambda _: None,
+            scaling_config=ray.train.ScalingConfig(num_workers=1),
+        )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -248,13 +248,13 @@ class RunConfig:
 
         if not isinstance(self.checkpoint_config, CheckpointConfig):
             raise ValueError(
-                f"Invalid `CheckpointConfig` type: `{self.checkpoint_config.__class__}`. "
+                f"Invalid `CheckpointConfig` type: {self.checkpoint_config.__class__}. "
                 "Use `ray.train.CheckpointConfig` instead."
             )
 
         if not isinstance(self.failure_config, FailureConfig):
             raise ValueError(
-                f"Invalid `FailureConfig` type: `{self.failure_config.__class__}`. "
+                f"Invalid `FailureConfig` type: {self.failure_config.__class__}. "
                 "Use `ray.train.FailureConfig` instead."
             )
 

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -246,6 +246,7 @@ class RunConfig:
                 "https://github.com/ray-project/ray/issues/49454"
             )
 
+        # TODO: Create a separate V2 CheckpointConfig class.
         if not isinstance(self.checkpoint_config, CheckpointConfig):
             raise ValueError(
                 f"Invalid `CheckpointConfig` type: {self.checkpoint_config.__class__}. "

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -246,6 +246,18 @@ class RunConfig:
                 "https://github.com/ray-project/ray/issues/49454"
             )
 
+        if not isinstance(self.failure_config, CheckpointConfig):
+            raise ValueError(
+                f"Invalid `CheckpointConfig` type: `{self.checkpoint_config.__class__}`. "
+                "Use `ray.train.CheckpointConfig` instead."
+            )
+
+        if not isinstance(self.failure_config, FailureConfig):
+            raise ValueError(
+                f"Invalid `FailureConfig` type: `{self.failure_config.__class__}`. "
+                "Use `ray.train.FailureConfig` instead."
+            )
+
     @cached_property
     def storage_context(self) -> StorageContext:
         return StorageContext(

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -246,7 +246,7 @@ class RunConfig:
                 "https://github.com/ray-project/ray/issues/49454"
             )
 
-        if not isinstance(self.failure_config, CheckpointConfig):
+        if not isinstance(self.checkpoint_config, CheckpointConfig):
             raise ValueError(
                 f"Invalid `CheckpointConfig` type: `{self.checkpoint_config.__class__}`. "
                 "Use `ray.train.CheckpointConfig` instead."

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -249,13 +249,17 @@ class RunConfig:
         if not isinstance(self.checkpoint_config, CheckpointConfig):
             raise ValueError(
                 f"Invalid `CheckpointConfig` type: {self.checkpoint_config.__class__}. "
-                "Use `ray.train.CheckpointConfig` instead."
+                "Use `ray.train.CheckpointConfig` instead. "
+                "See this issue for more context: "
+                "https://github.com/ray-project/ray/issues/49454"
             )
 
         if not isinstance(self.failure_config, FailureConfig):
             raise ValueError(
                 f"Invalid `FailureConfig` type: {self.failure_config.__class__}. "
-                "Use `ray.train.FailureConfig` instead."
+                "Use `ray.train.FailureConfig` instead. "
+                "See this issue for more context: "
+                "https://github.com/ray-project/ray/issues/49454"
             )
 
     @cached_property

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -120,6 +120,23 @@ class DataParallelTrainer:
                 "when using this V2 Trainer API."
             )
 
+        from ray.train.v2.api.config import (
+            RunConfig as RunConfigV2,
+            ScalingConfig as ScalingConfigV2,
+        )
+
+        if not isinstance(self.run_config, RunConfigV2):
+            raise ValueError(
+                f"Invalid `RunConfig` type: `{self.run_config.__class__}`. "
+                "Use `ray.train.RunConfig` instead."
+            )
+
+        if not isinstance(self.scaling_config, ScalingConfigV2):
+            raise ValueError(
+                f"Invalid `ScalingConfig` type: `{self.scaling_config.__class__}`. "
+                "Use `ray.train.ScalingConfig` instead."
+            )
+
     def _get_train_func(self) -> Callable[[], None]:
         return construct_train_func(
             self.train_loop_per_worker,

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import signal
 import sys
 import threading
@@ -42,7 +41,9 @@ from ray.train.v2._internal.callbacks.user_callback import UserCallbackHandler
 from ray.train.v2._internal.constants import (
     DEFAULT_RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_VALUE,
     METRICS_ENABLED_ENV_VAR,
+    V2_ENABLED_ENV_VAR,
     get_env_vars_to_propagate,
+    is_v2_enabled,
 )
 from ray.train.v2._internal.data_integration.interfaces import GenDataset
 from ray.train.v2._internal.execution.callback import RayTrainCallback
@@ -107,15 +108,17 @@ class DataParallelTrainer:
         if metadata is not None:
             raise DeprecationWarning(_GET_METADATA_DEPRECATION_MESSAGE)
 
-        self._set_default_env_vars()
+        self._validate_configs()
+
         usage_lib.record_library_usage("train")
         tag_train_v2_trainer(self)
 
-    def _set_default_env_vars(self):
-        if RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR not in os.environ:
-            os.environ[
-                RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR
-            ] = DEFAULT_RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_VALUE
+    def _validate_configs(self):
+        if not is_v2_enabled():
+            raise ValueError(
+                f"Ray Train V2 must be enabled with `{V2_ENABLED_ENV_VAR}=1` "
+                "when using this V2 Trainer API."
+            )
 
     def _get_train_func(self) -> Callable[[], None]:
         return construct_train_func(
@@ -132,8 +135,11 @@ class DataParallelTrainer:
             A Result object containing the training result.
 
         Raises:
-            ray.train.v2.api.exceptions.ControllerError: If a non-retryable error occurs in the Ray Train controller itself, or if the number of retries configured in `FailureConfig` is exhausted.
-            ray.train.v2.api.exceptions.WorkerGroupError: If one or more workers fail during training and the number of retries configured in `FailureConfig` is exhausted.
+            ray.train.v2.api.exceptions.ControllerError: If a non-retryable error occurs in
+                the Ray Train controller itself, or if the number of retries configured in
+                `FailureConfig` is exhausted.
+            ray.train.v2.api.exceptions.WorkerGroupError: If one or more workers fail during
+                training and the number of retries configured in `FailureConfig` is exhausted.
         """
         train_fn = self._get_train_func()
         if self.running_in_local_mode:
@@ -223,6 +229,12 @@ class DataParallelTrainer:
         return self._get_local_controller().run(train_func)
 
     def _initialize_and_run_controller(self, **controller_init_kwargs) -> Result:
+        env_vars = get_env_vars_to_propagate()
+        env_vars.setdefault(
+            RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR,
+            DEFAULT_RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_VALUE,
+        )
+
         # Attach the controller to the node running the driver script.
         controller_actor_cls = ray.remote(
             num_cpus=0,
@@ -231,7 +243,7 @@ class DataParallelTrainer:
             ),
             # TODO: Extract env variables that affect controller behavior
             # and pass them as explicit args
-            runtime_env={"env_vars": get_env_vars_to_propagate()},
+            runtime_env={"env_vars": env_vars},
         )(TrainController)
 
         controller = controller_actor_cls.remote(**controller_init_kwargs)

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -127,13 +127,13 @@ class DataParallelTrainer:
 
         if not isinstance(self.run_config, RunConfigV2):
             raise ValueError(
-                f"Invalid `RunConfig` type: `{self.run_config.__class__}`. "
+                f"Invalid `RunConfig` type: {self.run_config.__class__}. "
                 "Use `ray.train.RunConfig` instead."
             )
 
         if not isinstance(self.scaling_config, ScalingConfigV2):
             raise ValueError(
-                f"Invalid `ScalingConfig` type: `{self.scaling_config.__class__}`. "
+                f"Invalid `ScalingConfig` type: {self.scaling_config.__class__}. "
                 "Use `ray.train.ScalingConfig` instead."
             )
 

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -128,13 +128,17 @@ class DataParallelTrainer:
         if not isinstance(self.run_config, RunConfigV2):
             raise ValueError(
                 f"Invalid `RunConfig` type: {self.run_config.__class__}. "
-                "Use `ray.train.RunConfig` instead."
+                "Use `ray.train.RunConfig` instead. "
+                "See this issue for more context: "
+                "https://github.com/ray-project/ray/issues/49454"
             )
 
         if not isinstance(self.scaling_config, ScalingConfigV2):
             raise ValueError(
                 f"Invalid `ScalingConfig` type: {self.scaling_config.__class__}. "
-                "Use `ray.train.ScalingConfig` instead."
+                "Use `ray.train.ScalingConfig` instead. "
+                "See this issue for more context: "
+                "https://github.com/ray-project/ray/issues/49454"
             )
 
     def _get_train_func(self) -> Callable[[], None]:

--- a/python/ray/train/v2/tests/test_data_parallel_trainer.py
+++ b/python/ray/train/v2/tests/test_data_parallel_trainer.py
@@ -8,16 +8,12 @@ import pyarrow.fs
 import pytest
 
 import ray
-from ray._common.constants import RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR
 from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.train import BackendConfig, Checkpoint, RunConfig, ScalingConfig, UserCallback
 from ray.train.backend import Backend
 from ray.train.constants import RAY_CHDIR_TO_TRIAL_DIR, _get_ray_train_session_dir
 from ray.train.tests.util import create_dict_checkpoint
-from ray.train.v2._internal.constants import (
-    DEFAULT_RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_VALUE,
-    is_v2_enabled,
-)
+from ray.train.v2._internal.constants import is_v2_enabled
 from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 from ray.train.v2.api.exceptions import WorkerGroupError
 from ray.train.v2.api.result import Result
@@ -307,20 +303,6 @@ def test_sigint_abort(spam_sigint):
             time.sleep(1)
             os.kill(process.pid, signal.SIGINT)
     process.join()
-
-
-@pytest.mark.parametrize("env_var_set", [True, False])
-def test_set_default_env_vars(env_var_set, monkeypatch):
-    if env_var_set:
-        monkeypatch.setenv(RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR, "1")
-    DataParallelTrainer(lambda: "not used")
-    if env_var_set:
-        assert os.environ[RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR] == "1"
-    else:
-        assert (
-            os.environ[RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR]
-            == DEFAULT_RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_VALUE
-        )
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_telemetry.py
+++ b/python/ray/train/v2/tests/test_telemetry.py
@@ -26,8 +26,8 @@ def test_not_used_on_import(reset_usage_lib, callsite: TelemetryCallsite):
 
 
 @pytest.mark.parametrize("callsite", list(TelemetryCallsite))
-def test_used_on_train__fit(reset_usage_lib, callsite: TelemetryCallsite):
-    def _call_train_fit():
+def test_used_on_trainer_fit(reset_usage_lib, callsite: TelemetryCallsite):
+    def _call_trainer_fit():
         def train_fn():
             pass
 
@@ -35,13 +35,41 @@ def test_used_on_train__fit(reset_usage_lib, callsite: TelemetryCallsite):
         trainer.fit()
 
     check_library_usage_telemetry(
-        _call_train_fit,
+        _call_trainer_fit,
         callsite=callsite,
         expected_library_usages=[{"train"}, {"core", "train"}],
         expected_extra_usage_tags={
             "train_trainer": "DataParallelTrainer",
         },
     )
+
+
+@pytest.mark.skipif(
+    sys.version_info.major == 3 and sys.version_info.minor >= 12,
+    reason="Python 3.12+ does not have Tensorflow installed on CI due to dependency conflicts.",
+)
+def test_tag_train_entrypoint(mock_record):
+    """Test that Train v2 entrypoints are recorded correctly."""
+    from ray.train.v2.lightgbm.lightgbm_trainer import LightGBMTrainer
+    from ray.train.v2.tensorflow.tensorflow_trainer import TensorflowTrainer
+    from ray.train.v2.torch.torch_trainer import TorchTrainer
+    from ray.train.v2.xgboost.xgboost_trainer import XGBoostTrainer
+
+    trainer_classes = [
+        TorchTrainer,
+        TensorflowTrainer,
+        XGBoostTrainer,
+        LightGBMTrainer,
+    ]
+    for trainer_cls in trainer_classes:
+        trainer = trainer_cls(
+            lambda: None,
+            scaling_config=ray.train.ScalingConfig(num_workers=2),
+        )
+        assert (
+            mock_record[ray_usage_lib.TagKey.TRAIN_TRAINER]
+            == trainer.__class__.__name__
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_telemetry.py
+++ b/python/ray/train/v2/tests/test_telemetry.py
@@ -9,6 +9,23 @@ from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 
 
 @pytest.fixture
+def mock_record(monkeypatch):
+    import ray.air._internal.usage
+
+    recorded = {}
+
+    def mock_record_extra_usage_tag(key: ray_usage_lib.TagKey, value: str):
+        recorded[key] = value
+
+    monkeypatch.setattr(
+        ray.air._internal.usage,
+        "record_extra_usage_tag",
+        mock_record_extra_usage_tag,
+    )
+    yield recorded
+
+
+@pytest.fixture
 def reset_usage_lib():
     yield
     ray.shutdown()

--- a/python/ray/train/v2/tests/test_v2_api.py
+++ b/python/ray/train/v2/tests/test_v2_api.py
@@ -146,6 +146,23 @@ def test_exceptions_are_picklable(error):
     assert type(unpickled_error) is type(error)
 
 
+def test_v1_config_validation(monkeypatch):
+    """Test that V1 configs raise an error when V2 is enabled."""
+    import ray.air
+
+    with pytest.raises(ValueError, match="ray.train.ScalingConfig"):
+        DataParallelTrainer(lambda: None, scaling_config=ray.air.ScalingConfig())
+
+    with pytest.raises(ValueError, match="ray.train.RunConfig"):
+        DataParallelTrainer(lambda: None, run_config=ray.air.RunConfig())
+
+    with pytest.raises(ValueError, match="ray.train.FailureConfig"):
+        DataParallelTrainer(
+            lambda: None,
+            run_config=ray.train.RunConfig(failure_config=ray.air.FailureConfig()),
+        )
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/v2/tests/test_v2_api.py
+++ b/python/ray/train/v2/tests/test_v2_api.py
@@ -96,7 +96,7 @@ def test_serialized_imports(ray_start_4_cpus):
     ray.get(dummy_task.remote())
 
 
-def test_v1_config_validation(monkeypatch):
+def test_v1_config_validation():
     """Test that V1 configs raise an error when V2 is enabled."""
     import ray.air
 


### PR DESCRIPTION
## Summary

Raise if users try running with a cross of V1/V2 APIs. This includes V1 Trainer with V2 configs and V2 Trainer with V1 configs.

## Examples

V1 Trainer with V2 configs:

```python
import os

os.environ["RAY_TRAIN_V2_ENABLED"] = "1"

import ray.train
from ray.train.data_parallel_trainer import DataParallelTrainer

DataParallelTrainer(
    lambda: ray.train.get_dataset_shard("train"),
    scaling_config=ray.train.ScalingConfig(num_workers=1),
).fit()
```

```python
DeprecationWarning: Detected use of a deprecated Trainer import from `ray.train.data_parallel_trainer`. This Trainer class is not compatible with Ray Train V2.
To fix this:
  - Update to use the new import path. For example, `from ray.train.torch.torch_trainer import TorchTrainer` -> `from ray.train.torch import TorchTrainer`
  - Or, explicitly disable V2 by setting: RAY_TRAIN_V2_ENABLED=0
```

V2 Trainer with V1 configs:

```python
import os

os.environ["RAY_TRAIN_V2_ENABLED"] = "1"

import ray.air
import ray.tune
import ray.train

from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer


DataParallelTrainer(
    lambda: ray.train.get_dataset_shard("train"),
    scaling_config=ray.train.ScalingConfig(num_workers=1),
    run_config=ray.air.RunConfig(failure_config=ray.tune.FailureConfig(max_failures=1)),
).fit()
```

```python
Traceback (most recent call last):
  File "/Users/justin/Developer/random/v1_to_v2.py", line 24, in <module>
    DataParallelTrainer(
  File "/Users/justin/Developer/ray/python/ray/train/v2/api/data_parallel_trainer.py", line 111, in __init__
    self._validate_configs()
  File "/Users/justin/Developer/ray/python/ray/train/v2/api/data_parallel_trainer.py", line 129, in _validate_configs
    raise ValueError(
ValueError: Invalid `RunConfig` type: <class 'ray.air.config.RunConfig'>. Use `ray.train.RunConfig` instead.
```