### PR TITLE
another way of abort train controller inside tune

### DIFF
--- a/python/ray/air/_internal/util.py
+++ b/python/ray/air/_internal/util.py
@@ -112,6 +112,7 @@ class RunnerThread(threading.Thread):
                     "signal to terminate the thread without error."
                 )
             )
+            print(f">>> [debugging] RunnerThread, we entered here because of StopIteration")
         except SystemExit as e:
             # Do not propagate up for graceful termination.
             if e.code == 0:
@@ -124,6 +125,7 @@ class RunnerThread(threading.Thread):
                 )
             else:
                 # If non-zero exit code, then raise exception to main thread.
+                print(f">>> [debugging] RunnerThread, we entered here because of SystemExit")
                 self._propagate_exception(e)
         except BaseException as e:
             # Propagate all other exceptions to the main thread.

--- a/python/ray/train/_internal/session.py
+++ b/python/ray/train/_internal/session.py
@@ -250,6 +250,7 @@ class _TrainSession:
         """
         # Set the stop event for the training thread to gracefully exit.
         self.stop_event.set()
+        print(f">>> [debugging] train session, we entered here to finish, stop_event: {self.stop_event.is_set()}")
 
         # Release the lock so that training thread can process this event.
         self.continue_lock.release()

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -345,6 +345,10 @@ class TrainController:
 
     def get_state(self) -> TrainControllerState:
         return self._state
+    
+    def add_parent_actor(self, parent_actor_id: str):
+        # added to track the parent actor id
+        self._parent_actor_id = parent_actor_id
 
     def _set_state(self, state: TrainControllerState):
         previous_state = self._state
@@ -461,6 +465,13 @@ class TrainController:
 
     def _get_run_attempt_id(self):
         return self._run_attempt_id
+    
+    def __ray_shutdown__(self):
+        print(f">>> train v2 controller, we entered here to __ray_shutdown__")
+    
+    def __ray_terminate__(self):
+        print(f">>> train v2 controller, we entered here to __ray_terminate__")
+
 
     async def _run_control_loop_iteration(self):
         """Run a single iteration of the control loop.

--- a/python/ray/tune/trainable/function_trainable.py
+++ b/python/ray/tune/trainable/function_trainable.py
@@ -150,15 +150,20 @@ class FunctionTrainable(Trainable):
 
     def cleanup(self):
         session = get_session()
+        print(f">>> [debugging] function trainable, we entered here to functionaTrainablecleanup, session trial id: {session.trial_info.id}")
         try:
             # session.finish raises any Exceptions from training.
             # Do not wait for thread termination here (timeout=0).
-            session.finish(timeout=0)
+            res = session.finish(timeout=2)
+            print(f">>> [debugging] function trainable, we entered here to functionaTrainablecleanup, res: {res}")
+            print(f">>> [debugging] function trainable, we entered here to functionaTrainablecleanup, thread is alive?: {session.training_thread.is_alive()}")
         finally:
             # Check for any errors that might have been missed.
             session._report_thread_runner_error()
             # Shutdown session even if session.finish() raises an Exception.
             shutdown_session()
+            print(f">>> [debugging] function trainable, we entered here to functionaTrainablecleanup, thread is alive?: {session.training_thread.is_alive()}")
+            print(f">>> [debugging] function trainable, we entered here to functionaTrainablecleanup, setting globalsession to None")
 
     def reset_config(self, new_config):
         session = get_session()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
