### PR TITLE
Add perf metrics for 2.50.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 116.87936,
+    "_dashboard_memory_usage_mb": 108.838912,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.56,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3537\t2.03GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5556\t0.87GiB\tpython distributed/test_many_actors.py\n2945\t0.39GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3735\t0.23GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n582\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n1143\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3652\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4226\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3108\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4228\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
-    "actors_per_second": 566.4200586217125,
+    "_peak_memory": 4.57,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3786\t2.08GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n6618\t0.81GiB\tpython distributed/test_many_actors.py\n3245\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4000\t0.25GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n1389\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4496\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3216\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4498\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3919\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n6383\t0.07GiB\tray::JobSupervisor",
+    "actors_per_second": 508.9808896382363,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 566.4200586217125
+            "perf_metric_value": 508.9808896382363
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.833
+            "perf_metric_value": 11.744
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2612.102
+            "perf_metric_value": 2876.107
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3446.344
+            "perf_metric_value": 4160.517
         }
     ],
     "success": "1",
-    "time": 17.654742002487183
+    "time": 19.64710307121277
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 96.198656,
+    "_dashboard_memory_usage_mb": 98.254848,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.28,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3348\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2901\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4907\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3546\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n1091\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4032\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2825\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5133\t0.09GiB\tray::StateAPIGeneratorActor.start\n3464\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n3549\t0.08GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s",
+    "_peak_memory": 2.33,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3580\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3098\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5630\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3796\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n1458\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4276\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3020\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3713\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4278\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n5857\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 179.67755143550417
+            "perf_metric_value": 190.09519026949954
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.935
+            "perf_metric_value": 7.136
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13.338
+            "perf_metric_value": 13.982
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 35.162
+            "perf_metric_value": 49.716
         }
     ],
     "success": "1",
-    "tasks_per_second": 179.67755143550417,
-    "time": 305.5655255317688,
+    "tasks_per_second": 190.09519026949954,
+    "time": 305.26052236557007,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 98.287616,
+    "_dashboard_memory_usage_mb": 90.76736,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.78,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1146\t7.94GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3546\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3049\t0.47GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5004\t0.37GiB\tpython distributed/test_many_pgs.py\n581\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3758\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n2816\t0.11GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4241\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3665\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2941\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/",
+    "_peak_memory": 2.81,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1393\t7.16GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3778\t0.97GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3247\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5319\t0.36GiB\tpython distributed/test_many_pgs.py\n600\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4001\t0.11GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n3044\t0.11GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4486\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3232\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4488\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.028153672527967
+            "perf_metric_value": 12.47149444972938
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.26
+            "perf_metric_value": 4.935
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.799
+            "perf_metric_value": 11.336
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 188.103
+            "perf_metric_value": 232.641
         }
     ],
-    "pgs_per_second": 13.028153672527967,
+    "pgs_per_second": 12.47149444972938,
     "success": "1",
-    "time": 76.75684714317322
+    "time": 80.18285250663757
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 104.443904,
+    "_dashboard_memory_usage_mb": 95.678464,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.96,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3538\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5120\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3748\t0.46GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n3008\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3751\t0.19GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s\n1134\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4231\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3653\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n3029\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4233\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "_peak_memory": 4.01,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3780\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5801\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3998\t0.48GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n3294\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4001\t0.18GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s\n4493\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n1403\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3184\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3916\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4495\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 388.36439061844453
+            "perf_metric_value": 368.5098005212305
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.544
+            "perf_metric_value": 6.4
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 652.763
+            "perf_metric_value": 487.355
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 779.606
+            "perf_metric_value": 749.022
         }
     ],
     "success": "1",
-    "tasks_per_second": 388.36439061844453,
-    "time": 325.74901366233826,
+    "tasks_per_second": 368.5098005212305,
+    "time": 327.1363203525543,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.49.1"}
+{"release_version": "2.50.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        7925.658042658907,
-        333.79803776770194
+        7445.809146193413,
+        142.8712431149235
     ],
     "1_1_actor_calls_concurrent": [
-        4710.115509639389,
-        60.79075536787328
+        5222.99132120111,
+        146.8937349655467
     ],
     "1_1_actor_calls_sync": [
-        1826.440590474467,
-        30.44826694257455
+        1704.5035425495187,
+        22.868223875898593
     ],
     "1_1_async_actor_calls_async": [
-        3645.3291604906276,
-        145.09649825222274
+        4826.171895058453,
+        262.2733105494892
     ],
     "1_1_async_actor_calls_sync": [
-        1374.047824125402,
-        35.86321385785778
+        1251.6025859481733,
+        14.6951101117741
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2426.398157992012,
-        38.78002524735766
+        2766.907182403518,
+        136.80643069653217
     ],
     "1_n_actor_calls_async": [
-        7563.474741840271,
-        160.3419047539893
+        7474.798821945149,
+        138.58967943337706
     ],
     "1_n_async_actor_calls_async": [
-        6964.257909926722,
-        53.3826400982145
+        6491.439808045807,
+        39.06279449672571
     ],
     "client__1_1_actor_calls_async": [
-        846.4118553774217,
-        21.74145942353796
+        1014.64288638885,
+        58.95270781050083
     ],
     "client__1_1_actor_calls_concurrent": [
-        862.8335019710298,
-        5.40969189845287
+        1037.1186014627438,
+        25.96539922119042
     ],
     "client__1_1_actor_calls_sync": [
-        488.0060975075199,
-        18.43611203884743
+        524.6134993747014,
+        11.009504690857641
     ],
     "client__get_calls": [
-        983.5607099398597,
-        44.68614802894011
+        1129.1409512898194,
+        8.925683262293038
     ],
     "client__put_calls": [
-        769.3648317551028,
-        25.86986897843832
+        805.4069136266919,
+        47.45864374825948
     ],
     "client__put_gigabytes": [
-        0.10294244610916167,
-        0.00021781279103519403
+        0.10100883378233687,
+        0.0007236742887246127
     ],
     "client__tasks_and_get_batch": [
-        0.8049748278618892,
-        0.0384792096927115
+        0.9643252583791863,
+        0.03947979440575364
     ],
     "client__tasks_and_put_batch": [
-        10098.586104880465,
-        158.55761529403424
+        12873.97871447783,
+        194.12384860618832
     ],
     "multi_client_put_calls_Plasma_Store": [
-        10922.349171697762,
-        411.8369713180647
+        13779.913284159866,
+        211.90531537289394
     ],
     "multi_client_put_gigabytes": [
-        27.572292929404366,
-        0.301414736739597
+        36.697734067834084,
+        1.9311472421112734
     ],
     "multi_client_tasks_async": [
-        19294.747670848352,
-        1531.838851224768
+        19972.309576843323,
+        862.8524220158357
     ],
     "n_n_actor_calls_async": [
-        24808.730524179864,
-        580.5120779930962
+        23168.372784365154,
+        988.046573423015
     ],
     "n_n_actor_calls_with_arg_async": [
-        2564.489147392739,
-        58.242925806948335
+        4105.951978131054,
+        85.14262018346888
     ],
     "n_n_async_actor_calls_async": [
-        21602.16598513169,
-        648.5971305332962
+        20479.183697143773,
+        784.0156381083401
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9176.686326011131
+            "perf_metric_value": 8378.589542828342
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4795.051007052156
+            "perf_metric_value": 4498.3519827438895
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10922.349171697762
+            "perf_metric_value": 13779.913284159866
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.350152593657818
+            "perf_metric_value": 19.30103208209274
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.261194854317881
+            "perf_metric_value": 4.415850247347108
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27.572292929404366
+            "perf_metric_value": 36.697734067834084
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.142098493341212
+            "perf_metric_value": 12.272053704608084
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.8129125825624035
+            "perf_metric_value": 4.700920788730696
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 900.96738867954
+            "perf_metric_value": 800.5633840543425
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7418.67591750316
+            "perf_metric_value": 7034.736389002367
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19294.747670848352
+            "perf_metric_value": 19972.309576843323
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1826.440590474467
+            "perf_metric_value": 1704.5035425495187
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7925.658042658907
+            "perf_metric_value": 7445.809146193413
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4710.115509639389
+            "perf_metric_value": 5222.99132120111
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7563.474741840271
+            "perf_metric_value": 7474.798821945149
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 24808.730524179864
+            "perf_metric_value": 23168.372784365154
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2564.489147392739
+            "perf_metric_value": 4105.951978131054
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1374.047824125402
+            "perf_metric_value": 1251.6025859481733
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3645.3291604906276
+            "perf_metric_value": 4826.171895058453
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2426.398157992012
+            "perf_metric_value": 2766.907182403518
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6964.257909926722
+            "perf_metric_value": 6491.439808045807
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21602.16598513169
+            "perf_metric_value": 20479.183697143773
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 751.064903521573
+            "perf_metric_value": 666.2773993932936
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 983.5607099398597
+            "perf_metric_value": 1129.1409512898194
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 769.3648317551028
+            "perf_metric_value": 805.4069136266919
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.10294244610916167
+            "perf_metric_value": 0.10100883378233687
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10098.586104880465
+            "perf_metric_value": 12873.97871447783
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 488.0060975075199
+            "perf_metric_value": 524.6134993747014
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 846.4118553774217
+            "perf_metric_value": 1014.64288638885
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 862.8335019710298
+            "perf_metric_value": 1037.1186014627438
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8049748278618892
+            "perf_metric_value": 0.9643252583791863
         }
     ],
     "placement_group_create/removal": [
-        751.064903521573,
-        5.332518268184338
+        666.2773993932936,
+        8.374316408003613
     ],
     "single_client_get_calls_Plasma_Store": [
-        9176.686326011131,
-        202.59360315795405
+        8378.589542828342,
+        580.7193571692346
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.142098493341212,
-        0.280827763090365
+        12.272053704608084,
+        0.7982063002656874
     ],
     "single_client_put_calls_Plasma_Store": [
-        4795.051007052156,
-        55.29886971022227
+        4498.3519827438895,
+        81.55679060284112
     ],
     "single_client_put_gigabytes": [
-        20.350152593657818,
-        6.284060239581299
+        19.30103208209274,
+        10.059794667066702
     ],
     "single_client_tasks_and_get_batch": [
-        5.261194854317881,
-        2.8864991514393927
+        4.415850247347108,
+        2.1601305262136594
     ],
     "single_client_tasks_async": [
-        7418.67591750316,
-        224.65732622349898
+        7034.736389002367,
+        397.0712504592145
     ],
     "single_client_tasks_sync": [
-        900.96738867954,
-        14.441231923805944
+        800.5633840543425,
+        6.368316318983872
     ],
     "single_client_wait_1k_refs": [
-        4.8129125825624035,
-        0.007111082814526685
+        4.700920788730696,
+        0.02600364734531685
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 13.41017694899999,
+    "broadcast_time": 13.777409734000003,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13.41017694899999
+            "perf_metric_value": 13.777409734000003
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 19.077259766999987,
-    "get_time": 24.000713915999995,
+    "args_time": 20.028864411,
+    "get_time": 25.136106761999997,
     "large_object_size": 107374182400,
-    "large_object_time": 31.36117459099995,
+    "large_object_time": 30.109750160999965,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.077259766999987
+            "perf_metric_value": 20.028864411
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.790547841000006
+            "perf_metric_value": 6.1422604579999955
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.000713915999995
+            "perf_metric_value": 25.136106761999997
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 179.146127773
+            "perf_metric_value": 199.115312395
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.36117459099995
+            "perf_metric_value": 30.109750160999965
         }
     ],
-    "queued_time": 179.146127773,
-    "returns_time": 5.790547841000006,
+    "queued_time": 199.115312395,
+    "returns_time": 6.1422604579999955,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.2971700072288512,
-    "max_iteration_time": 5.189502000808716,
-    "min_iteration_time": 0.06091117858886719,
+    "avg_iteration_time": 1.4568077945709228,
+    "max_iteration_time": 12.06541132926941,
+    "min_iteration_time": 0.06909847259521484,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2971700072288512
+            "perf_metric_value": 1.4568077945709228
         }
     ],
     "success": 1,
-    "total_time": 129.71714234352112
+    "total_time": 145.68089246749878
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.735846281051636
+            "perf_metric_value": 7.882433891296387
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.93162693977356
+            "perf_metric_value": 13.99826169013977
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 33.983641386032104
+            "perf_metric_value": 36.08304100036621
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.8725192546844482
+            "perf_metric_value": 2.7449533939361572
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1821.4706330299377
+            "perf_metric_value": 1901.6145586967468
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.5580154959703073
+            "perf_metric_value": 0.565494858742622
         }
     ],
-    "stage_0_time": 7.735846281051636,
-    "stage_1_avg_iteration_time": 12.93162693977356,
-    "stage_1_max_iteration_time": 13.44619870185852,
-    "stage_1_min_iteration_time": 11.569173812866211,
-    "stage_1_time": 129.31632256507874,
-    "stage_2_avg_iteration_time": 33.983641386032104,
-    "stage_2_max_iteration_time": 34.43809151649475,
-    "stage_2_min_iteration_time": 33.45232319831848,
-    "stage_2_time": 169.91874861717224,
-    "stage_3_creation_time": 1.8725192546844482,
-    "stage_3_time": 1821.4706330299377,
-    "stage_4_spread": 0.5580154959703073,
+    "stage_0_time": 7.882433891296387,
+    "stage_1_avg_iteration_time": 13.99826169013977,
+    "stage_1_max_iteration_time": 14.502009868621826,
+    "stage_1_min_iteration_time": 12.637654781341553,
+    "stage_1_time": 139.98268675804138,
+    "stage_2_avg_iteration_time": 36.08304100036621,
+    "stage_2_max_iteration_time": 36.41135549545288,
+    "stage_2_min_iteration_time": 35.36338019371033,
+    "stage_2_time": 180.41578841209412,
+    "stage_3_creation_time": 2.7449533939361572,
+    "stage_3_time": 1901.6145586967468,
+    "stage_4_spread": 0.565494858742622,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.5636188018035782,
-    "avg_pg_remove_time_ms": 1.396923734234321,
+    "avg_pg_create_time_ms": 1.5650917102100173,
+    "avg_pg_remove_time_ms": 1.419495533032749,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5636188018035782
+            "perf_metric_value": 1.5650917102100173
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.396923734234321
+            "perf_metric_value": 1.419495533032749
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 16.07%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 5.261194854317881 to 4.415850247347108 in microbenchmark.json
REGRESSION 11.29%: placement_group_create/removal (THROUGHPUT) regresses from 751.064903521573 to 666.2773993932936 in microbenchmark.json
REGRESSION 11.14%: single_client_tasks_sync (THROUGHPUT) regresses from 900.96738867954 to 800.5633840543425 in microbenchmark.json
REGRESSION 10.14%: actors_per_second (THROUGHPUT) regresses from 566.4200586217125 to 508.9808896382363 in benchmarks/many_actors.json
REGRESSION 8.91%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1374.047824125402 to 1251.6025859481733 in microbenchmark.json
REGRESSION 8.70%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 9176.686326011131 to 8378.589542828342 in microbenchmark.json
REGRESSION 6.79%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 6964.257909926722 to 6491.439808045807 in microbenchmark.json
REGRESSION 6.68%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1826.440590474467 to 1704.5035425495187 in microbenchmark.json
REGRESSION 6.62%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.142098493341212 to 12.272053704608084 in microbenchmark.json
REGRESSION 6.61%: n_n_actor_calls_async (THROUGHPUT) regresses from 24808.730524179864 to 23168.372784365154 in microbenchmark.json
REGRESSION 6.19%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 4795.051007052156 to 4498.3519827438895 in microbenchmark.json
REGRESSION 6.05%: 1_1_actor_calls_async (THROUGHPUT) regresses from 7925.658042658907 to 7445.809146193413 in microbenchmark.json
REGRESSION 5.20%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 21602.16598513169 to 20479.183697143773 in microbenchmark.json
REGRESSION 5.18%: single_client_tasks_async (THROUGHPUT) regresses from 7418.67591750316 to 7034.736389002367 in microbenchmark.json
REGRESSION 5.16%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.350152593657818 to 19.30103208209274 in microbenchmark.json
REGRESSION 5.11%: tasks_per_second (THROUGHPUT) regresses from 388.36439061844453 to 368.5098005212305 in benchmarks/many_tasks.json
REGRESSION 4.27%: pgs_per_second (THROUGHPUT) regresses from 13.028153672527967 to 12.47149444972938 in benchmarks/many_pgs.json
REGRESSION 2.33%: single_client_wait_1k_refs (THROUGHPUT) regresses from 4.8129125825624035 to 4.700920788730696 in microbenchmark.json
REGRESSION 1.88%: client__put_gigabytes (THROUGHPUT) regresses from 0.10294244610916167 to 0.10100883378233687 in microbenchmark.json
REGRESSION 1.17%: 1_n_actor_calls_async (THROUGHPUT) regresses from 7563.474741840271 to 7474.798821945149 in microbenchmark.json
REGRESSION 46.59%: stage_3_creation_time (LATENCY) regresses from 1.8725192546844482 to 2.7449533939361572 in stress_tests/stress_test_many_tasks.json
REGRESSION 41.39%: dashboard_p99_latency_ms (LATENCY) regresses from 35.162 to 49.716 in benchmarks/many_nodes.json
REGRESSION 23.68%: dashboard_p99_latency_ms (LATENCY) regresses from 188.103 to 232.641 in benchmarks/many_pgs.json
REGRESSION 20.72%: dashboard_p99_latency_ms (LATENCY) regresses from 3446.344 to 4160.517 in benchmarks/many_actors.json
REGRESSION 15.85%: dashboard_p50_latency_ms (LATENCY) regresses from 4.26 to 4.935 in benchmarks/many_pgs.json
REGRESSION 15.44%: dashboard_p50_latency_ms (LATENCY) regresses from 5.544 to 6.4 in benchmarks/many_tasks.json
REGRESSION 12.31%: avg_iteration_time (LATENCY) regresses from 1.2971700072288512 to 1.4568077945709228 in stress_tests/stress_test_dead_actors.json
REGRESSION 11.15%: 1000000_queued_time (LATENCY) regresses from 179.146127773 to 199.115312395 in scalability/single_node.json
REGRESSION 10.11%: dashboard_p95_latency_ms (LATENCY) regresses from 2612.102 to 2876.107 in benchmarks/many_actors.json
REGRESSION 8.41%: dashboard_p50_latency_ms (LATENCY) regresses from 10.833 to 11.744 in benchmarks/many_actors.json
REGRESSION 8.25%: stage_1_avg_iteration_time (LATENCY) regresses from 12.93162693977356 to 13.99826169013977 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.18%: stage_2_avg_iteration_time (LATENCY) regresses from 33.983641386032104 to 36.08304100036621 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.07%: 3000_returns_time (LATENCY) regresses from 5.790547841000006 to 6.1422604579999955 in scalability/single_node.json
REGRESSION 4.99%: 10000_args_time (LATENCY) regresses from 19.077259766999987 to 20.028864411 in scalability/single_node.json
REGRESSION 4.97%: dashboard_p95_latency_ms (LATENCY) regresses from 10.799 to 11.336 in benchmarks/many_pgs.json
REGRESSION 4.83%: dashboard_p95_latency_ms (LATENCY) regresses from 13.338 to 13.982 in benchmarks/many_nodes.json
REGRESSION 4.73%: 10000_get_time (LATENCY) regresses from 24.000713915999995 to 25.136106761999997 in scalability/single_node.json
REGRESSION 4.40%: stage_3_time (LATENCY) regresses from 1821.4706330299377 to 1901.6145586967468 in stress_tests/stress_test_many_tasks.json
REGRESSION 2.90%: dashboard_p50_latency_ms (LATENCY) regresses from 6.935 to 7.136 in benchmarks/many_nodes.json
REGRESSION 2.74%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 13.41017694899999 to 13.777409734000003 in scalability/object_store.json
REGRESSION 1.89%: stage_0_time (LATENCY) regresses from 7.735846281051636 to 7.882433891296387 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.62%: avg_pg_remove_time_ms (LATENCY) regresses from 1.396923734234321 to 1.419495533032749 in stress_tests/stress_test_placement_group.json
REGRESSION 1.34%: stage_4_spread (LATENCY) regresses from 0.5580154959703073 to 0.565494858742622 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.09%: avg_pg_create_time_ms (LATENCY) regresses from 1.5636188018035782 to 1.5650917102100173 in stress_tests/stress_test_placement_group.json
```