### PR TITLE
[Doc][Core] Update accelerator-type Doc Regarding CPU-only Nodes

### DIFF
--- a/doc/source/ray-core/scheduling/labels.md
+++ b/doc/source/ray-core/scheduling/labels.md
@@ -35,7 +35,7 @@ During cluster initialization or as autoscaling events add nodes to your cluster
 | Label | Description |
 | --- | --- |
 | `ray.io/node-id` | A unique ID generated for the node. |
-| `ray.io/accelerator-type` | The accelerator type of the node, for example `L4`. CPU-only machines have an empty string. See {ref}`accelerator types <accelerator-types>` for a mapping of values. |
+| `ray.io/accelerator-type` | The accelerator type of the node, for example `L4`. CPU-only machines don't have the label. See {ref}`accelerator types <accelerator-types>` for a mapping of values. |
 
 ```{note} 
 You can override default values using `ray start` parameters.
@@ -44,7 +44,7 @@ You can override default values using `ray start` parameters.
 The following are examples of default labels:
 
 ```python
-"ray.io/accelerator-type": "" # Default label indicating the machine is CPU-only.
+"ray.io/accelerator-type": "L4" # Default label indicating the machine has Nvidia L4 GPU
 ```
 
 (custom)=
@@ -105,7 +105,7 @@ def f():
     pass
 
 # An example of specifying label_selector in actor's @ray.remote annotation
-@ray.remote(label_selector={"ray.io/accelerator-type": "nvidia-h100"})
+@ray.remote(label_selector={"ray.io/accelerator-type": "H100"})
 class Actor:
     pass
 
@@ -122,7 +122,7 @@ class Actor:
     pass
 
 actor_1 = Actor.options(
-    label_selector={"ray.io/accelerator-type": "nvidia-h100"},
+    label_selector={"ray.io/accelerator-type": "H100"},
 ).remote()
 ```
 
@@ -149,7 +149,7 @@ Autoscaler V2 supports label-based scheduling. To enable autoscaler to scale up 
 
 ```python
     rayStartParams: {
-      labels: "region=me-central1,ray.io/accelerator-type=nvidia-h100"
+      labels: "region=me-central1,ray.io/accelerator-type=H100"
     }
 ```
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Based on a recent discussion, to specify a CPU-only node, we decided to make not set the `accelerator-type` label instead of setting it to empty. At the same time, we will implement the `exists()` and `!exists()` labels for users to specify deploying to CPU-only node in the label selectors. 

The logic of not setting the `accelerator-type` for CPU-only node is already implemented. This PR is to update the document to describe the behavior. It also fixes some examples to use the standard accelerator types. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
N/A

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
