### PR TITLE
[core][rdt] Fix deregisterMem with none when using nixl

### DIFF
--- a/python/ray/experimental/collective/nixl_tensor_transport.py
+++ b/python/ray/experimental/collective/nixl_tensor_transport.py
@@ -160,5 +160,6 @@ class NixlTensorTransport(TensorTransportManager):
         from ray.util.collective.collective_group.nixl_backend import NixlBackend
 
         descs = tensor_transport_meta.nixl_reg_descs
-        nixl_backend: NixlBackend = get_group_handle(NIXL_GROUP_NAME)
-        nixl_backend.deregister_memory(descs)
+        if descs is not None:
+            nixl_backend: NixlBackend = get_group_handle(NIXL_GROUP_NAME)
+            nixl_backend.deregister_memory(descs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If user tries to pass pure cpu data with `tensor_transport="nixl"`, the nixl_reg_descs in metadata may be none.
Before this pr, it will throw errors.
```
File "/home/ray/anaconda3/lib/python3.11/site-packages/nixl/_api.py", line 284, in deregister_memory
    self.agent.deregisterMem(dereg_list, handle_list)
TypeError: deregisterMem(): incompatible function arguments. The following argument types are supported:
    1. (self: nixl._bindings.nixlAgent, descs: nixl._bindings.nixlRegDList, backends: collections.abc.Sequence[typing.SupportsInt] = []) -> nixl._bindings.nixl_status_t
Invoked with: <nixl._bindings.nixlAgent object at 0x713d994011f0>, None, []
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
