### PR TITLE
[Autoscaler] [Azure] Cleaning up extra resources (MSI, VNET, NSG) during cluster teardown

### DIFF
--- a/python/ray/autoscaler/_private/_azure/azure-config-template.json
+++ b/python/ray/autoscaler/_private/_azure/azure-config-template.json
@@ -29,6 +29,12 @@
         "createMsi": {
             "type": "bool",
             "defaultValue": "true"
+        },
+        "roleAssignmentGuid": {
+            "type": "string",
+            "metadata": {
+                "description": "Deterministic resource name for the MSI role assignment."
+            }
         }
     },
     "variables": {
@@ -51,12 +57,13 @@
         {
             "type": "Microsoft.Authorization/roleAssignments",
             "apiVersion": "2022-04-01",
-            "name": "[guid(variables('roleAssignmentName'))]",
+            "name": "[parameters('roleAssignmentGuid')]",
             "properties": {
                 "principalId": "[reference(resourceId(parameters('msiResourceGroup'), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('msiName')), '2024-11-30').principalId]",
                 "roleDefinitionId": "[variables('contributor')]",
                 "scope": "[resourceGroup().id]",
-                "principalType": "ServicePrincipal"
+                "principalType": "ServicePrincipal",
+                "description": "[concat('Ray autoscaler cluster ', parameters('clusterId'))]"
             },
             "dependsOn": [
                 "[parameters('msiName')]"

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
@@ -17,6 +18,8 @@ from azure.mgmt.resource.resources.models import DeploymentMode
 
 from ray._common.usage.usage_lib import get_cloud_from_metadata_requests
 from ray.autoscaler._private._azure.config import (
+    _delete_role_assignments_for_principal,
+    _generate_arm_guid,
     bootstrap_azure,
     get_azure_sdk_function,
 )
@@ -665,6 +668,267 @@ class AzureNodeProvider(NodeProvider):
             and (time.monotonic() - st) < AUTOSCALER_NODE_TERMINATE_WAIT_S
         ):
             time.sleep(0.1)
+
+    def cleanup_cluster_resources(self):
+        """Delete shared cluster infrastructure (MSI, NSG, Subnet, VNet)."""
+
+        resource_group = self.provider_config["resource_group"]
+
+        msi_principal_id = self._cleanup_managed_identity(
+            resource_group, self.provider_config.get("msi")
+        )
+
+        subnet_id = self.provider_config.get("subnet")
+        vnet_name = self._cleanup_subnet(resource_group, subnet_id)
+
+        nsg_id = self.provider_config.get("nsg")
+        self._cleanup_nsg(resource_group, nsg_id)
+
+        self._cleanup_vnet(resource_group, subnet_id, vnet_name)
+
+        self._cleanup_role_assignments(resource_group, msi_principal_id)
+
+        self._prune_provider_config_entries()
+        self._cleanup_config_cache()
+
+    @staticmethod
+    def _get_resource_name_from_id(resource_id: Optional[str]) -> Optional[str]:
+        if resource_id:
+            return resource_id.split("/")[-1]
+        return None
+
+    @staticmethod
+    def _retry_delete(delete_fn, max_retries: int = 5, initial_delay: int = 2):
+        """Retry a delete operation with exponential backoff."""
+
+        delay = initial_delay
+        for attempt in range(max_retries):
+            try:
+                return delete_fn()
+            except Exception as exc:  # noqa: BLE001
+                error_msg = str(exc)
+                if "InUse" in error_msg and attempt < max_retries - 1:
+                    logger.info(
+                        "Resource still in use, retrying in %ss (attempt %s/%s)...",
+                        delay,
+                        attempt + 1,
+                        max_retries,
+                    )
+                    time.sleep(delay)
+                    delay *= 2
+                else:
+                    raise
+
+    def _cleanup_managed_identity(
+        self, resource_group: str, msi_id: Optional[str]
+    ) -> Optional[str]:
+        if not msi_id:
+            return None
+
+        msi_name = self._get_resource_name_from_id(msi_id)
+        if not msi_name:
+            return None
+
+        msi_principal_id: Optional[str] = None
+        try:
+            get_identity = get_azure_sdk_function(
+                client=self.resource_client.resources,
+                function_name="get_by_id",
+            )
+            existing_msi = get_identity(msi_id, "2023-01-31")
+            msi_principal_id = getattr(existing_msi, "properties", {}).get(
+                "principalId"
+            )
+        except ResourceNotFoundError:
+            msi_principal_id = None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to query MSI %s for principal ID prior to deletion: %s",
+                msi_name,
+                exc,
+            )
+
+        try:
+            logger.info("Deleting Managed Service Identity: %s", msi_name)
+            delete = get_azure_sdk_function(
+                client=self.resource_client.resources,
+                function_name="delete_by_id",
+            )
+            delete(resource_id=msi_id, api_version="2023-01-31").wait()
+            logger.info("Successfully deleted MSI: %s", msi_name)
+        except ResourceNotFoundError:
+            logger.info("MSI %s not found, may have been already deleted", msi_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to delete MSI %s: %s", msi_name, exc)
+
+        return msi_principal_id
+
+    def _cleanup_subnet(
+        self, resource_group: str, subnet_id: Optional[str]
+    ) -> Optional[str]:
+        if not subnet_id:
+            return None
+
+        subnet_name = self._get_resource_name_from_id(subnet_id)
+        vnet_name: Optional[str] = None
+
+        if subnet_id and "/virtualNetworks/" in subnet_id:
+            parts = subnet_id.split("/")
+            vnet_idx = parts.index("virtualNetworks")
+            if vnet_idx + 1 < len(parts):
+                vnet_name = parts[vnet_idx + 1]
+
+        if not subnet_name or not vnet_name:
+            return None
+
+        try:
+            logger.info("Deleting Subnet: %s in VNet: %s", subnet_name, vnet_name)
+
+            def delete_subnet():
+                delete = get_azure_sdk_function(
+                    client=self.network_client.subnets, function_name="delete"
+                )
+                delete(
+                    resource_group_name=resource_group,
+                    virtual_network_name=vnet_name,
+                    subnet_name=subnet_name,
+                ).wait()
+
+            self._retry_delete(delete_subnet)
+            logger.info("Successfully deleted Subnet: %s", subnet_name)
+        except ResourceNotFoundError:
+            logger.info(
+                "Subnet %s not found, may have been already deleted", subnet_name
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to delete Subnet %s: %s", subnet_name, exc)
+
+        return vnet_name
+
+    def _cleanup_nsg(self, resource_group: str, nsg_id: Optional[str]) -> None:
+        if not nsg_id:
+            return
+
+        nsg_name = self._get_resource_name_from_id(nsg_id)
+        if not nsg_name:
+            return
+
+        try:
+            logger.info("Deleting Network Security Group: %s", nsg_name)
+
+            def delete_nsg():
+                delete = get_azure_sdk_function(
+                    client=self.network_client.network_security_groups,
+                    function_name="delete",
+                )
+                delete(
+                    resource_group_name=resource_group,
+                    network_security_group_name=nsg_name,
+                ).wait()
+
+            self._retry_delete(delete_nsg)
+            logger.info("Successfully deleted NSG: %s", nsg_name)
+        except ResourceNotFoundError:
+            logger.info("NSG %s not found, may have been already deleted", nsg_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to delete NSG %s: %s", nsg_name, exc)
+
+    def _cleanup_vnet(
+        self,
+        resource_group: str,
+        subnet_id: Optional[str],
+        vnet_name: Optional[str],
+    ) -> None:
+        if not subnet_id or not vnet_name:
+            return
+
+        try:
+            logger.info("Deleting Virtual Network: %s", vnet_name)
+
+            def delete_vnet():
+                delete = get_azure_sdk_function(
+                    client=self.network_client.virtual_networks,
+                    function_name="delete",
+                )
+                delete(
+                    resource_group_name=resource_group,
+                    virtual_network_name=vnet_name,
+                ).wait()
+
+            self._retry_delete(delete_vnet)
+            logger.info("Successfully deleted VNet: %s", vnet_name)
+        except ResourceNotFoundError:
+            logger.info("VNet %s not found, may have been already deleted", vnet_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to delete VNet %s: %s", vnet_name, exc)
+
+    def _cleanup_role_assignments(
+        self, resource_group: str, msi_principal_id: Optional[str]
+    ) -> None:
+        subscription_id = self.provider_config.get("subscription_id")
+        unique_id = self.provider_config.get("unique_id")
+        if not subscription_id or not unique_id:
+            return
+
+        cluster_id = f"{self.cluster_name}-{unique_id}"
+        role_assignment_name = f"ray-{cluster_id}-ra"
+        role_assignment_guid = _generate_arm_guid(role_assignment_name)
+        role_assignment_id = (
+            f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers"
+            f"/Microsoft.Authorization/roleAssignments/{role_assignment_guid}"
+        )
+
+        if msi_principal_id:
+            _delete_role_assignments_for_principal(
+                self.resource_client, resource_group, msi_principal_id
+            )
+
+        delete_role_assignment = get_azure_sdk_function(
+            client=self.resource_client.resources, function_name="delete_by_id"
+        )
+        try:
+            delete_lro = delete_role_assignment(
+                resource_id=role_assignment_id,
+                api_version="2022-04-01",
+            )
+            if hasattr(delete_lro, "wait"):
+                delete_lro.wait()
+            logger.info(
+                "Deleted role assignment %s for cluster %s",
+                role_assignment_guid,
+                self.cluster_name,
+            )
+        except ResourceNotFoundError:
+            logger.debug(
+                "Role assignment %s not found during cleanup", role_assignment_guid
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to delete role assignment %s: %s",
+                role_assignment_guid,
+                exc,
+            )
+
+    def _prune_provider_config_entries(self) -> None:
+        for key in ("msi", "nsg", "subnet"):
+            self.provider_config.pop(key, None)
+
+    def _cleanup_config_cache(self) -> None:
+        cache_path = self.provider_config.get("_config_cache_path")
+        if not cache_path:
+            return
+
+        try:
+            if os.path.exists(cache_path):
+                os.remove(cache_path)
+                logger.info(
+                    "Deleted cached Ray config at %s after resource cleanup",
+                    cache_path,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to delete cached Ray config %s: %s", cache_path, exc)
+        finally:
+            self.provider_config.pop("_config_cache_path", None)
 
     def _get_node(self, node_id):
         self._get_filtered_nodes({})  # Side effect: updates cache


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After running `ray down` several resources (a managed service identiy, network security group, etc) at left in the subscription and re-running `ray up` (without specifying --no-config-cache) will sometimes run into errors because of this.

## Related issue number

Fixes: https://github.com/ray-project/ray/issues/55392

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
