### PR TITLE
[core] Change config defaults to enable io_service metrics

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -30,7 +30,7 @@ RAY_CONFIG(bool, event_stats, true)
 /// Whether to enable Ray event stats metrics for main services
 /// such as gcs and raylet (which today are the sole consumers of
 /// this config)
-RAY_CONFIG(bool, emit_main_service_metrics, false)
+RAY_CONFIG(bool, emit_main_service_metrics, true)
 
 /// Whether to enable cluster authentication.
 RAY_CONFIG(bool, enable_cluster_auth, true)
@@ -552,7 +552,7 @@ RAY_CONFIG(std::string, enable_grpc_metrics_collection_for, "")
 /// `ray_io_context_event_loop_lag_ms`.
 ///
 /// A probe task is only posted after a previous probe task has completed.
-RAY_CONFIG(int64_t, io_context_event_loop_lag_collection_interval_ms, 250)
+RAY_CONFIG(int64_t, io_context_event_loop_lag_collection_interval_ms, 6000)
 
 // Max number bytes of inlined objects in a task rpc request/response.
 RAY_CONFIG(int64_t, task_rpc_inlined_bytes_limit, 10 * 1024 * 1024)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -552,7 +552,7 @@ RAY_CONFIG(std::string, enable_grpc_metrics_collection_for, "")
 /// `ray_io_context_event_loop_lag_ms`.
 ///
 /// A probe task is only posted after a previous probe task has completed.
-RAY_CONFIG(int64_t, io_context_event_loop_lag_collection_interval_ms, 60000)
+RAY_CONFIG(int64_t, io_context_event_loop_lag_collection_interval_ms, 10000)
 
 // Max number bytes of inlined objects in a task rpc request/response.
 RAY_CONFIG(int64_t, task_rpc_inlined_bytes_limit, 10 * 1024 * 1024)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -552,7 +552,7 @@ RAY_CONFIG(std::string, enable_grpc_metrics_collection_for, "")
 /// `ray_io_context_event_loop_lag_ms`.
 ///
 /// A probe task is only posted after a previous probe task has completed.
-RAY_CONFIG(int64_t, io_context_event_loop_lag_collection_interval_ms, 6000)
+RAY_CONFIG(int64_t, io_context_event_loop_lag_collection_interval_ms, 60000)
 
 // Max number bytes of inlined objects in a task rpc request/response.
 RAY_CONFIG(int64_t, task_rpc_inlined_bytes_limit, 10 * 1024 * 1024)


### PR DESCRIPTION
After some experimentation, the main culprit for the performance degredation is actually from the lag probe being too aggressive.  The default lag probe previously being 250ms caused as much as a 20% degredation in performance when used in combination with with enabling io_context metrics.  Setting the default to abouve 60s seems to mitigate the issue.  To come to this conclusion we tested with the below:

Trail 1: ~400 actors/s <-- way too slow
 -RAY_emit_main_serivce_metrics = 1

Trial 2: ~500+ actor/s <-- where we want to be
 -RAY_emit_main_serivce_metrics = -1

Trial 3: ~500+ actor/s
 -RAY_emit_main_serivce_metrics = 1
 -RAY_io_context_event_loop_lag_collection_interval_ms = -1 <-- disabled

Trial 4: ~500+ actor/s <-- bingo!
 -RAY_emit_main_serivce_metrics = 1
 -RAY_io_context_event_loop_lag_collection_interval_ms = 6000

The default value of 250ms combined with the increased usage of lag probes when the metrics are enabled causes enough degredation as to be noticable.  Increasing the interval sufficiently seems to be the way to go to avoid this and have our metrics.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
