### PR TITLE
[Data] Avoid `iter_batches` inference benchmark

### DIFF
--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -114,10 +114,13 @@ def main(args):
         max_concurrency=2,
     )
 
-    # Force execution.
     total_images = 0
-    for batch in ds.iter_batches(batch_size=None, batch_format="pyarrow"):
-        total_images += len(batch)
+
+    # NOTE: We're iterating over ref-bundles to avoid pulling blocks into the
+    #       driver, therefore making it a factor impacting benchmark performance
+    for bundle in ds.iter_internal_ref_bundles():
+        total_images += bundle.num_rows()
+
     end_time = time.time()
 
     total_time = end_time - start_time


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR replaces `iter_batches` with `iter_internal_ref_bundles` in the `gpu_batch_inference` release test. The motivation for this change is to avoid pulling blocks into the driver (something you wouldn't do in an actual batch inference workload).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
