### PR TITLE
[core] Tune timeout to reduce run time of `test_transient_error_retry`

### DIFF
--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -695,9 +695,7 @@ def test_transient_error_retry(monkeypatch, ray_start_cluster):
             "RAY_testing_rpc_failure",
             "CoreWorkerService.grpc_client.PushTask=100:25:25",
         )
-        m.setenv(
-            "RAY_actor_scheduling_queue_max_reorder_wait_seconds", "5"
-        )
+        m.setenv("RAY_actor_scheduling_queue_max_reorder_wait_seconds", "5")
         cluster = ray_start_cluster
         cluster.add_node(num_cpus=1)
         ray.init(address=cluster.address)

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -695,14 +695,14 @@ def test_transient_error_retry(monkeypatch, ray_start_cluster):
             "RAY_testing_rpc_failure",
             "CoreWorkerService.grpc_client.PushTask=100:25:25",
         )
-        cluster = ray_start_cluster
-        cluster.add_node(
-            num_cpus=1,
-            resources={"head": 1},
+        m.setenv(
+            "RAY_actor_scheduling_queue_max_reorder_wait_seconds", "5"
         )
+        cluster = ray_start_cluster
+        cluster.add_node(num_cpus=1)
         ray.init(address=cluster.address)
 
-        @ray.remote(max_task_retries=-1, resources={"head": 1})
+        @ray.remote(max_task_retries=-1)
         class RetryActor:
             def echo(self, value):
                 return value

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -688,9 +688,15 @@ def test_final_user_exception(ray_start_regular, propagate_logs, caplog):
     caplog.clear()
 
 
-@pytest.mark.parametrize("deterministic_failure", ["request", "response"])
+@pytest.mark.parametrize(
+    # TODO(dayshah): add `False` variant once in-order is fixed.
+    "allow_out_of_order_execution", [True],
+)
+@pytest.mark.parametrize(
+    "deterministic_failure", ["request", "response"]
+)
 def test_transient_error_retry(
-    monkeypatch, ray_start_cluster, deterministic_failure: str
+    monkeypatch, ray_start_cluster, allow_out_of_order_execution: bool, deterministic_failure: str
 ):
     with monkeypatch.context() as m:
         # This test submits 200 tasks with infinite retries and verifies that all tasks eventually succeed in the unstable network environment.
@@ -704,7 +710,7 @@ def test_transient_error_retry(
         cluster.add_node(num_cpus=1)
         ray.init(address=cluster.address)
 
-        @ray.remote(max_task_retries=-1)
+        @ray.remote(max_task_retries=-1, allow_out_of_order_execution=allow_out_of_order_execution)
         class RetryActor:
             def echo(self, value):
                 return value

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -688,9 +688,10 @@ def test_final_user_exception(ray_start_regular, propagate_logs, caplog):
     caplog.clear()
 
 
-
 @pytest.mark.parametrize("deterministic_failure", ["request", "response"])
-def test_transient_error_retry(monkeypatch, ray_start_cluster, deterministic_failure: str):
+def test_transient_error_retry(
+    monkeypatch, ray_start_cluster, deterministic_failure: str
+):
     with monkeypatch.context() as m:
         # This test submits 200 tasks with infinite retries and verifies that all tasks eventually succeed in the unstable network environment.
         m.setenv(

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -690,13 +690,15 @@ def test_final_user_exception(ray_start_regular, propagate_logs, caplog):
 
 @pytest.mark.parametrize(
     # TODO(dayshah): add `False` variant once in-order is fixed.
-    "allow_out_of_order_execution", [True],
+    "allow_out_of_order_execution",
+    [True],
 )
-@pytest.mark.parametrize(
-    "deterministic_failure", ["request", "response"]
-)
+@pytest.mark.parametrize("deterministic_failure", ["request", "response"])
 def test_transient_error_retry(
-    monkeypatch, ray_start_cluster, allow_out_of_order_execution: bool, deterministic_failure: str
+    monkeypatch,
+    ray_start_cluster,
+    allow_out_of_order_execution: bool,
+    deterministic_failure: str,
 ):
     with monkeypatch.context() as m:
         # This test submits 200 tasks with infinite retries and verifies that all tasks eventually succeed in the unstable network environment.
@@ -710,7 +712,10 @@ def test_transient_error_retry(
         cluster.add_node(num_cpus=1)
         ray.init(address=cluster.address)
 
-        @ray.remote(max_task_retries=-1, allow_out_of_order_execution=allow_out_of_order_execution)
+        @ray.remote(
+            max_task_retries=-1,
+            allow_out_of_order_execution=allow_out_of_order_execution,
+        )
         class RetryActor:
             def echo(self, value):
                 return value


### PR DESCRIPTION
The test times out frequently in CI.

Before this change, the test took `~40s` to run on my laptop. After the change, the test took `~15s` to run on my laptop.

There also seems to be hanging related to in-order execution semantics, so for now flipping to `allow_out_of_order_exection=True`. @dayshah will add the `False` variant when he fixes the underlying issue.