### PR TITLE
[Core] Remove success field from the release test json result

### DIFF
--- a/release/autoscaling_tests/run.py
+++ b/release/autoscaling_tests/run.py
@@ -70,7 +70,6 @@ def run(local):
 
     results = {
         "time": time.time() - start_time,
-        "success": "1",
     }
     if "TEST_OUTPUT_JSON" in os.environ:
         with open(os.environ["TEST_OUTPUT_JSON"], "w") as out_file:

--- a/release/benchmarks/distributed/many_nodes_tests/actor_test.py
+++ b/release/benchmarks/distributed/many_nodes_tests/actor_test.py
@@ -86,7 +86,6 @@ def run_one(total_actors, cpus_per_actor, no_wait):
         "actor_ready_time": actor_ready_time,
         "total_time": actor_launch_time + actor_ready_time,
         "num_actors": total_actors,
-        "success": "1",
         "throughput": throughput,
     }
 

--- a/release/benchmarks/distributed/many_nodes_tests/multi_master_test.py
+++ b/release/benchmarks/distributed/many_nodes_tests/multi_master_test.py
@@ -82,7 +82,6 @@ def main():
                 "actor_ready_time": actor_ready_time,
                 "total_time": actor_launch_time + actor_ready_time,
                 "num_actors": args.total_actors,
-                "success": "1",
             }
             json.dump(results, out_file)
 

--- a/release/benchmarks/distributed/test_many_actors.py
+++ b/release/benchmarks/distributed/test_many_actors.py
@@ -74,7 +74,6 @@ results = {
     "actors_per_second": rate,
     "num_actors": MAX_ACTORS_IN_CLUSTER,
     "time": end_time - start_time,
-    "success": "1",
     "_peak_memory": round(used_gb, 2),
     "_peak_process_memory": usage,
 }

--- a/release/benchmarks/distributed/test_many_pgs.py
+++ b/release/benchmarks/distributed/test_many_pgs.py
@@ -104,7 +104,6 @@ results = {
     "pgs_per_second": rate,
     "num_pgs": MAX_PLACEMENT_GROUPS,
     "time": end_time - start_time,
-    "success": "1",
     "_peak_memory": round(used_gb, 2),
     "_peak_process_memory": usage,
 }

--- a/release/benchmarks/distributed/test_many_tasks.py
+++ b/release/benchmarks/distributed/test_many_tasks.py
@@ -113,7 +113,6 @@ def test(num_tasks):
         "num_tasks": num_tasks,
         "time": end_time - start_time,
         "used_cpus": used_cpus,
-        "success": "1",
         "_peak_memory": round(used_gb, 2),
         "_peak_process_memory": usage,
         "perf_metrics": [

--- a/release/benchmarks/object_store/test_large_objects.py
+++ b/release/benchmarks/object_store/test_large_objects.py
@@ -85,7 +85,6 @@ if "TEST_OUTPUT_JSON" in os.environ:
             "one_to_many_time": one_to_many_duration,
             "object_size": OBJECT_SIZE,
             "num_nodes": NUM_NODES,
-            "success": "1",
         }
         results["perf_metrics"] = [
             {

--- a/release/benchmarks/object_store/test_object_store.py
+++ b/release/benchmarks/object_store/test_object_store.py
@@ -63,7 +63,6 @@ if "TEST_OUTPUT_JSON" in os.environ:
             "broadcast_time": duration,
             "object_size": OBJECT_SIZE,
             "num_nodes": NUM_NODES,
-            "success": "1",
         }
         perf_metric_name = f"time_to_broadcast_{OBJECT_SIZE}_bytes_to_{NUM_NODES}_nodes"
         results["perf_metrics"] = [

--- a/release/benchmarks/object_store/test_small_objects.py
+++ b/release/benchmarks/object_store/test_small_objects.py
@@ -63,7 +63,6 @@ if "TEST_OUTPUT_JSON" in os.environ:
         results = {
             "num_messages_many_to_one": many_to_one_throughput,
             "num_messages_one_to_many": one_to_many_throughput,
-            "success": "1",
         }
         results["perf_metrics"] = [
             {

--- a/release/dashboard/mem_check.py
+++ b/release/dashboard/mem_check.py
@@ -79,7 +79,6 @@ if __name__ == "__main__":
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
         results = {
             "memory_growth_gb": mem_growth,
-            "success": 1,
         }
         results["perf_metrics"] = [
             {

--- a/release/nightly_tests/chaos_test/test_chaos_basic.py
+++ b/release/nightly_tests/chaos_test/test_chaos_basic.py
@@ -223,7 +223,6 @@ def main():
         f.write(
             json.dumps(
                 {
-                    "success": 1,
                     "_peak_memory": round(used_gb, 2),
                     "_peak_process_memory": usage,
                 }

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_sort.py
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_sort.py
@@ -241,7 +241,7 @@ if __name__ == "__main__":
     duration = np.mean(output)
 
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
-        f.write(json.dumps({"duration": duration, "success": 1}))
+        f.write(json.dumps({"duration": duration}))
 
     write_header = (
         not os.path.exists("output.csv") or os.path.getsize("output.csv") == 0

--- a/release/nightly_tests/dask_on_ray/large_scale_test.py
+++ b/release/nightly_tests/dask_on_ray/large_scale_test.py
@@ -470,7 +470,6 @@ def main():
         f.write(
             json.dumps(
                 {
-                    "success": 1,
                     "_peak_memory": round(used_gb, 2),
                     "_peak_process_memory": usage,
                 }

--- a/release/nightly_tests/decision_tree/cart_with_tree.py
+++ b/release/nightly_tests/decision_tree/cart_with_tree.py
@@ -367,4 +367,4 @@ if __name__ == "__main__":
         print(f"Test Accuracy: {accuracy}")
 
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
-        f.write(json.dumps({"build_time": treetime, "success": 1}))
+        f.write(json.dumps({"build_time": treetime}))

--- a/release/nightly_tests/placement_group_tests/placement_group_performance_test.py
+++ b/release/nightly_tests/placement_group_tests/placement_group_performance_test.py
@@ -167,5 +167,5 @@ if __name__ == "__main__":
 
     if "TEST_OUTPUT_JSON" in os.environ:
         with open(os.environ["TEST_OUTPUT_JSON"], "w") as out_file:
-            results = {"success": 1}
+            results = {}
             json.dump(results, out_file)

--- a/release/nightly_tests/shuffle/shuffle_test.py
+++ b/release/nightly_tests/shuffle/shuffle_test.py
@@ -39,7 +39,6 @@ if __name__ == "__main__":
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
         results = {
             "shuffle_time": delta,
-            "success": 1,
         }
         results["perf_metrics"] = [
             {

--- a/release/nightly_tests/stress_tests/test_dead_actors.py
+++ b/release/nightly_tests/stress_tests/test_dead_actors.py
@@ -60,7 +60,7 @@ def parse_script_args():
 
 if __name__ == "__main__":
     args, unknown = parse_script_args()
-    result = {"success": 0}
+    result = {}
     # These numbers need to correspond with the autoscaler config file.
     # The number of remote nodes in the autoscaler should upper bound
     # these because sometimes nodes fail to update.
@@ -106,7 +106,6 @@ if __name__ == "__main__":
     result["avg_iteration_time"] = sum(loop_times) / len(loop_times)
     result["max_iteration_time"] = max(loop_times)
     result["min_iteration_time"] = min(loop_times)
-    result["success"] = 1
     if os.environ.get("IS_SMOKE_TEST") != "1":
         result["perf_metrics"] = [
             {

--- a/release/nightly_tests/stress_tests/test_many_tasks.py
+++ b/release/nightly_tests/stress_tests/test_many_tasks.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
     total_num_remote_cpus = num_remote_nodes * num_remote_cpus
     is_smoke_test = args.smoke_test
 
-    result = {"success": 0}
+    result = {}
     num_nodes = len(ray.nodes())
     assert (
         num_nodes == num_remote_nodes + 1
@@ -224,7 +224,6 @@ if __name__ == "__main__":
     # avg_spread ~ 115 with Ray 1.0 scheduler. ~695 with (buggy) 0.8.7
     # scheduler.
     result["stage_4_spread"] = stage_4_spread
-    result["success"] = 1
 
     if not is_smoke_test:
         result["perf_metrics"] = [

--- a/release/nightly_tests/stress_tests/test_placement_group.py
+++ b/release/nightly_tests/stress_tests/test_placement_group.py
@@ -99,7 +99,7 @@ def pg_launcher(pre_created_pgs, num_pgs_to_create):
 
 
 if __name__ == "__main__":
-    result = {"success": 0}
+    result = {}
 
     # Wait until the expected number of nodes have joined the cluster.
     ray.init(address="auto")
@@ -167,7 +167,6 @@ if __name__ == "__main__":
 
     result["avg_pg_create_time_ms"] = total_creating_time / total_trial * 1000
     result["avg_pg_remove_time_ms"] = total_removing_time / total_trial * 1000
-    result["success"] = 1
     result["perf_metrics"] = [
         {
             "perf_metric_name": "avg_pg_create_time_ms",

--- a/release/nightly_tests/stress_tests/test_state_api_scale.py
+++ b/release/nightly_tests/stress_tests/test_state_api_scale.py
@@ -417,7 +417,6 @@ def test(
     state_perf_result = aggregate_perf_results()
     results = {
         "time": end_time - start_time,
-        "success": "1",
         "_peak_memory": round(used_gb, 2),
         "_peak_process_memory": usage,
     }

--- a/release/nightly_tests/stress_tests/test_threaded_actors.py
+++ b/release/nightly_tests/stress_tests/test_threaded_actors.py
@@ -154,7 +154,7 @@ def main():
     # Report the result.
     ray.get(monitor_actor.stop_run.remote())
 
-    result = {"success": 1}
+    result = {}
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
         f.write(json.dumps(result))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`success` field in the json output is useless and is misleading. The release test infra replies on the script exit code instead of this field to decide whether a release test succeeds or not.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
