### PR TITLE
[core] Add a test for nested sub-processes cleanup

### DIFF
--- a/python/ray/tests/test_kill_subprocesses.py
+++ b/python/ray/tests/test_kill_subprocesses.py
@@ -249,7 +249,7 @@ def test_detached_setsido_escape_with_pg_cleanup(enable_pg_cleanup, shutdown_onl
 
 @pytest.mark.skipif(
     sys.platform != "linux" and sys.platform != "darwin",
-    reason="Orphan process killing only works on Linux and macOS.",
+    reason="Process‑group cleanup is POSIX‑only (Linux/macOS).",
 )
 def test_nested_subprocess_cleanup_with_pg_cleanup(enable_pg_cleanup, shutdown_only):
     """
@@ -267,8 +267,7 @@ def test_nested_subprocess_cleanup_with_pg_cleanup(enable_pg_cleanup, shutdown_o
                     sys.executable,
                     "-c",
                     "import subprocess; "
-                    "p = subprocess.Popen(['sleep', '150']); "
-                    "print(p.pid); "
+                    "subprocess.Popen(['sleep', '150']); "
                     "import time; time.sleep(100)",
                 ],
                 stdout=subprocess.PIPE,

--- a/python/ray/tests/test_kill_subprocesses.py
+++ b/python/ray/tests/test_kill_subprocesses.py
@@ -270,7 +270,6 @@ def test_nested_subprocess_cleanup_with_pg_cleanup(enable_pg_cleanup, shutdown_o
                     "subprocess.Popen(['sleep', '150']); "
                     "import time; time.sleep(100)",
                 ],
-                stdout=subprocess.PIPE,
                 text=True,
             )
             child_pid = proc.pid


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I've encountered an issue where Ray sends SIGKILL to child processes (grandchild will not receive the signal) launched by a Ray actor. As a result, the subprocess cannot catch the signal to gracefully clean up its child processes. Therefore, the grandchild processes of the actor will leak.

I'm glad to see https://github.com/ray-project/ray/pull/56476 by @codope, and I also built a similar solution myself. This PR adds the case where I met.

@codope why not enable this feature by default?

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
