### PR TITLE
[serve] Remove unused _dump_all_autoscaling_metrics_for_testing

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -642,12 +642,16 @@ class ApplicationAutoscalingState:
         if dep_id in self._deployment_autoscaling_states:
             self._deployment_autoscaling_states[dep_id].on_replica_stopped(replica_id)
 
-    def get_total_num_requests_by_deployment_id(self, deployment_id: DeploymentID) -> float:
+    def get_total_num_requests_by_deployment_id(
+        self, deployment_id: DeploymentID
+    ) -> float:
         return self._deployment_autoscaling_states[
             deployment_id
         ].get_total_num_requests()
 
-    def get_replica_metrics_by_deployment_id(self, deployment_id: DeploymentID, agg_func="mean"):
+    def get_replica_metrics_by_deployment_id(
+        self, deployment_id: DeploymentID, agg_func="mean"
+    ):
         return self._deployment_autoscaling_states[deployment_id].get_replica_metrics(
             agg_func
         )
@@ -784,8 +788,8 @@ class AutoscalingStateManager:
     ) -> Dict[ReplicaID, List[Any]]:
         if deployment_id.app_name in self._app_autoscaling_states:
             return self._app_autoscaling_states[
-                    deployment_id.app_name
-                ].get_replica_metrics_by_deployment_id(deployment_id, agg_func)
+                deployment_id.app_name
+            ].get_replica_metrics_by_deployment_id(deployment_id, agg_func)
         else:
             logger.warning(
                 f"Cannot get metrics for deployment "
@@ -793,11 +797,13 @@ class AutoscalingStateManager:
             )
             return {}
 
-    def get_total_num_requests_by_deployment_id(self, deployment_id: DeploymentID) -> float:
+    def get_total_num_requests_by_deployment_id(
+        self, deployment_id: DeploymentID
+    ) -> float:
         if deployment_id.app_name in self._app_autoscaling_states:
             return self._app_autoscaling_states[
                 deployment_id.app_name
-            ].get_total_num_requests(deployment_id)
+            ].get_total_num_requests_by_deployment_id(deployment_id)
         else:
             logger.warning(
                 f"Cannot get total number of requests for deployment "

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -311,8 +311,11 @@ class ServeController:
             handle_metric_report
         )
 
-    def _dump_autoscaling_metrics_for_testing(self):
-        return self.autoscaling_state_manager.get_metrics()
+    def _get_total_num_requests_by_deployment_id_for_testing(self, deployment_id: DeploymentID):
+        return self.autoscaling_state_manager.get_total_num_requests_by_deployment_id(deployment_id)
+
+    def _get_metrics_by_deployment_id_for_testing(self, deployment_id: DeploymentID):
+        return self.autoscaling_state_manager.get_metrics_by_deployment_id(deployment_id)
 
     def _dump_replica_states_for_testing(self, deployment_id: DeploymentID):
         return self.deployment_state_manager._deployment_states[deployment_id]._replicas

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -311,9 +311,6 @@ class ServeController:
             handle_metric_report
         )
 
-    def _dump_all_autoscaling_metrics_for_testing(self):
-        return self.autoscaling_state_manager.get_all_metrics()
-
     def _dump_autoscaling_metrics_for_testing(self):
         return self.autoscaling_state_manager.get_metrics()
 

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -311,11 +311,17 @@ class ServeController:
             handle_metric_report
         )
 
-    def _get_total_num_requests_by_deployment_id_for_testing(self, deployment_id: DeploymentID):
-        return self.autoscaling_state_manager.get_total_num_requests_by_deployment_id(deployment_id)
+    def _get_total_num_requests_by_deployment_id_for_testing(
+        self, deployment_id: DeploymentID
+    ):
+        return self.autoscaling_state_manager.get_total_num_requests_by_deployment_id(
+            deployment_id
+        )
 
     def _get_metrics_by_deployment_id_for_testing(self, deployment_id: DeploymentID):
-        return self.autoscaling_state_manager.get_metrics_by_deployment_id(deployment_id)
+        return self.autoscaling_state_manager.get_metrics_by_deployment_id(
+            deployment_id
+        )
 
     def _dump_replica_states_for_testing(self, deployment_id: DeploymentID):
         return self.deployment_state_manager._deployment_states[deployment_id]._replicas

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2197,7 +2197,7 @@ class DeploymentState:
 
         curr_stats_str = (
             f"Current ongoing requests: "
-            f"{self._autoscaling_state_manager.get_total_num_requests(self._id):.2f}, "
+            f"{self._autoscaling_state_manager.get_total_num_requests_by_deployment_id(self._id):.2f}, "
             f"current running replicas: "
             f"{self._replicas.count(states=[ReplicaState.RUNNING])}."
         )

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -111,9 +111,8 @@ def test_assert_no_replicas_deprovisioned():
 
 
 def get_num_requests(client, dep_id: DeploymentID):
-    total_num_requests = client._controller.autoscaling_state_manager.get_total_num_requests_by_deployment_id(dep_id).remote()
-    print("total num requests", total_num_requests)
-    return total_num_requests
+    ref = client._controller.get_total_num_requests_by_deployment_id_for_testing.remote(dep_id)
+    return ray.get(ref)
 
 
 def check_num_requests_eq(client, id: DeploymentID, expected: int):

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -111,7 +111,11 @@ def test_assert_no_replicas_deprovisioned():
 
 
 def get_num_requests(client, dep_id: DeploymentID):
-    ref = client._controller.get_total_num_requests_by_deployment_id_for_testing.remote(dep_id)
+    ref = (
+        client._controller._get_total_num_requests_by_deployment_id_for_testing.remote(
+            dep_id
+        )
+    )
     return ray.get(ref)
 
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -111,8 +111,7 @@ def test_assert_no_replicas_deprovisioned():
 
 
 def get_num_requests(client, dep_id: DeploymentID):
-    ref = client._controller._dump_autoscaling_metrics_for_testing.remote()
-    total_num_requests = ray.get(ref)[dep_id]
+    total_num_requests = client._controller.autoscaling_state_manager.get_total_num_requests_by_deployment_id(dep_id).remote()
     print("total num requests", total_num_requests)
     return total_num_requests
 

--- a/python/ray/serve/tests/test_custom_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_custom_autoscaling_metrics.py
@@ -14,9 +14,8 @@ def get_autoscaling_metrics_from_controller(
     client, deployment_id: DeploymentID
 ) -> Dict[str, float]:
     """Get autoscaling metrics from the controller for testing."""
-    ref = client._controller._dump_all_autoscaling_metrics_for_testing.remote()
-    metrics = ray.get(ref)
-    return metrics.get(deployment_id, {})
+    metrics = client._controller.autoscaling_state_manager.get_metrics_by_deployment_id(deployment_id).remote()
+    return metrics
 
 
 class TestCustomServeMetrics:

--- a/python/ray/serve/tests/test_custom_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_custom_autoscaling_metrics.py
@@ -14,8 +14,8 @@ def get_autoscaling_metrics_from_controller(
     client, deployment_id: DeploymentID
 ) -> Dict[str, float]:
     """Get autoscaling metrics from the controller for testing."""
-    metrics = client._controller.autoscaling_state_manager.get_metrics_by_deployment_id(deployment_id).remote()
-    return metrics
+    ref = client._controller._get_metrics_by_deployment_id_for_testing.remote(deployment_id)
+    return ray.get(ref)
 
 
 class TestCustomServeMetrics:

--- a/python/ray/serve/tests/test_custom_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_custom_autoscaling_metrics.py
@@ -14,7 +14,9 @@ def get_autoscaling_metrics_from_controller(
     client, deployment_id: DeploymentID
 ) -> Dict[str, float]:
     """Get autoscaling metrics from the controller for testing."""
-    ref = client._controller._get_metrics_by_deployment_id_for_testing.remote(deployment_id)
+    ref = client._controller._get_metrics_by_deployment_id_for_testing.remote(
+        deployment_id
+    )
     return ray.get(ref)
 
 

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -484,7 +484,7 @@ class TestTargetCapacityUpdateAndServeStatus:
         if controller_handle is None:
             assert num_running_replicas == expected_num_replicas, f"{deployment}"
         else:
-            deployment_id = DeploymentID(name=deployment, app_name=app_name)
+            deployment_id = DeploymentID(name=deployment_name, app_name=app_name)
             autoscaling_metrics = ray.get(
                 controller_handle._get_metrics_by_deployment_id_for_testing.remote(
                     deployment_id

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -484,11 +484,11 @@ class TestTargetCapacityUpdateAndServeStatus:
         if controller_handle is None:
             assert num_running_replicas == expected_num_replicas, f"{deployment}"
         else:
-            deployment_id = DeploymentID(
-                name=deployment, app_name=app_name
-            )
+            deployment_id = DeploymentID(name=deployment, app_name=app_name)
             autoscaling_metrics = ray.get(
-                controller_handle._get_metrics_by_deployment_id_for_testing.remote(deployment_id)
+                controller_handle._get_metrics_by_deployment_id_for_testing.remote(
+                    deployment_id
+                )
             )
             assert num_running_replicas == expected_num_replicas, (
                 f"Status: {deployment}" f"\nAutoscaling metrics: {autoscaling_metrics}"

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -13,6 +13,7 @@ from ray.exceptions import RayActorError
 from ray.serve import Application
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import (
+    DeploymentID,
     DeploymentStatus,
     DeploymentStatusTrigger,
     ReplicaState,
@@ -483,8 +484,11 @@ class TestTargetCapacityUpdateAndServeStatus:
         if controller_handle is None:
             assert num_running_replicas == expected_num_replicas, f"{deployment}"
         else:
+            deployment_id = DeploymentID(
+                name=deployment, app_name=app_name
+            )
             autoscaling_metrics = ray.get(
-                controller_handle._dump_autoscaling_metrics_for_testing.remote()
+                controller_handle._get_metrics_by_deployment_id_for_testing.remote(deployment_id)
             )
             assert num_running_replicas == expected_num_replicas, (
                 f"Status: {deployment}" f"\nAutoscaling metrics: {autoscaling_metrics}"

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -3611,13 +3611,13 @@ class TestAutoscaling:
                 (ReplicaState.STARTING, 1, None),
             ],
         )
-        assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 2
+        assert asm.get_total_num_requests_by_deployment_id(TEST_DEPLOYMENT_ID) == 2
         ds._replicas.get([ReplicaState.STARTING])[0]._actor.set_ready()
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
         self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
-        assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 2
+        assert asm.get_total_num_requests_by_deployment_id(TEST_DEPLOYMENT_ID) == 2
 
         # Simulate handle was on an actor that died. 10 seconds later
         # the handle fails to push metrics
@@ -3626,7 +3626,7 @@ class TestAutoscaling:
         self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
-        assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 2
+        assert asm.get_total_num_requests_by_deployment_id(TEST_DEPLOYMENT_ID) == 2
 
         # Another 10 seconds later handle still fails to push metrics. At
         # this point the data from the handle should be invalidated. As a
@@ -3648,7 +3648,7 @@ class TestAutoscaling:
         self.scale(dsm, asm, [TEST_DEPLOYMENT_ID])
         dsm.update()
         check_counts(ds, total=2, by_state=[(ReplicaState.STOPPING, 2, None)])
-        assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 0
+        assert asm.get_total_num_requests_by_deployment_id(TEST_DEPLOYMENT_ID) == 0
 
     @pytest.mark.skipif(
         not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
@@ -3724,13 +3724,13 @@ class TestAutoscaling:
                 (ReplicaState.STARTING, 1, None),
             ],
         )
-        assert asm.get_total_num_requests(d_id1) == 2
+        assert asm.get_total_num_requests_by_deployment_id(d_id1) == 2
         ds1._replicas.get([ReplicaState.STARTING])[0]._actor.set_ready()
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
         self.scale(dsm, asm, [d_id1, d_id2])
         dsm.update()
         check_counts(ds1, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
-        assert asm.get_total_num_requests(d_id1) == 2
+        assert asm.get_total_num_requests_by_deployment_id(d_id1) == 2
 
         # d2 replica died
         ds2._replicas.get()[0]._actor.set_unhealthy()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
