### PR TITLE
[release test] extract bazel.py into its own py_library

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -14,10 +14,11 @@ py_library(
     data = glob(["*.yaml"]),
     visibility = ["//ci/ray_ci:__subpackages__"],
     deps = [
+        "//release:bazel",
+        "//release:ray_release",
         ci_require("boto3"),
         ci_require("pyyaml"),
         ci_require("click"),
-        "//release:ray_release",
     ],
 )
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -309,10 +309,23 @@ py_binary(
 )
 
 py_library(
+    name = "bazel",
+    srcs = ["ray_release/bazel.py"],
+    imports = ["."],
+    visibility = ["//ci/ray_ci:__pkg__"],
+    deps = [
+        bk_require("bazel-runfiles"),
+    ],
+)
+
+py_library(
     name = "ray_release",
     srcs = glob(
         ["ray_release/**/*.py"],
-        exclude = ["ray_release/tests/*.py"],
+        exclude = [
+            "ray_release/tests/*.py",
+            "ray_release/bazel.py",
+        ],
     ),
     data = glob([
         "ray_release/environments/*.env",
@@ -329,6 +342,7 @@ py_library(
     imports = ["."],
     visibility = ["//visibility:public"],
     deps = [
+        ":bazel",
         bk_require("anyscale"),
         bk_require("aws-requests-auth"),
         bk_require("azure-storage-blob"),
@@ -692,6 +706,7 @@ py_test(
         "team:ci",
     ],
     deps = [
+        ":bazel",
         ":ray_release",
         bk_require("pytest"),
     ],


### PR DESCRIPTION
starting to breaking down `ray_release` into smaller bazel build rules.

required to fix windows CI builds, where `test_in_docker` now imports third-party libraries that do not yet work on windows machines.