### PR TITLE
[ci] exclude `build_in_docker_windows` from `ray_ci_lib`

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -9,6 +9,7 @@ py_library(
             "test_*.py",
             "test_in_docker.py",
             "build_in_docker.py",
+            "build_in_docker_windows.py",
         ],
     ),
     data = glob(["*.yaml"]),


### PR DESCRIPTION
it is part of the `py_binary`
