### PR TITLE
fix default dep name for async inf

### DIFF
--- a/python/ray/serve/task_consumer.py
+++ b/python/ray/serve/task_consumer.py
@@ -158,6 +158,9 @@ def task_consumer(*, task_processor_config: TaskProcessorConfig):
                 if hasattr(target_cls, "__del__"):
                     target_cls.__del__(self)
 
+        # Preserve the original class name
+        _TaskConsumerWrapper.__name__ = target_cls.__name__
+
         return _TaskConsumerWrapper
 
     return decorator

--- a/python/ray/serve/tests/unit/test_task_consumer.py
+++ b/python/ray/serve/tests/unit/test_task_consumer.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
+from ray.serve.api import deployment
 from ray.serve.schema import (
     CeleryAdapterConfig,
     TaskProcessorAdapter,
@@ -283,6 +284,20 @@ class TestTaskConsumerDecorator:
             @task_consumer
             class MyConsumer:
                 pass
+
+
+def test_default_deployment_name_stays_same_with_task_consumer(config):
+    """Test that the default deployment name is the class name when using task_consumer with serve.deployment."""
+
+    @deployment
+    @task_consumer(task_processor_config=config)
+    class MyTaskConsumer:
+        @task_handler
+        def my_task(self):
+            pass
+
+    # The deployment name should default to the class name
+    assert MyTaskConsumer.name == "MyTaskConsumer"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- default deployment name was changed to _TaskConsumerWrapper after async inference implementation, fixed it now