### PR TITLE
[core] Some plasma client cleaning

### DIFF
--- a/src/mock/ray/object_manager/plasma/client.h
+++ b/src/mock/ray/object_manager/plasma/client.h
@@ -35,7 +35,7 @@ class MockPlasmaClient : public PlasmaClientInterface {
               (const ObjectID &object_id, bool *has_object),
               (override));
 
-  MOCK_METHOD(Status, Disconnect, (), (override));
+  MOCK_METHOD(void, Disconnect, (), (override));
 
   MOCK_METHOD(Status,
               Get,

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <memory>
 
 #include "ray/thirdparty/aligned_alloc.h"

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -16,10 +16,8 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <functional>
 #include <memory>
 
-#include "ray/common/status.h"
 #include "ray/thirdparty/aligned_alloc.h"
 #include "ray/util/logging.h"
 
@@ -30,6 +28,8 @@ namespace ray {
 /// The interface that represents a buffer of bytes.
 class Buffer {
  public:
+  Buffer() = default;
+
   /// Pointer to the data.
   virtual uint8_t *Data() const = 0;
 
@@ -41,7 +41,10 @@ class Buffer {
 
   virtual bool IsPlasmaBuffer() const = 0;
 
-  virtual ~Buffer(){};
+  virtual ~Buffer() = default;
+
+  Buffer(const Buffer &) = delete;
+  Buffer &operator=(const Buffer &) = delete;
 
   bool operator==(const Buffer &rhs) const {
     if (this->Size() != rhs.Size()) {
@@ -82,10 +85,11 @@ class LocalMemoryBuffer : public Buffer {
   }
 
   /// Construct a LocalMemoryBuffer of all zeros of the given size.
-  LocalMemoryBuffer(size_t size) : has_data_copy_(true) {
-    buffer_ = reinterpret_cast<uint8_t *>(aligned_malloc(size, BUFFER_ALIGNMENT));
+  explicit LocalMemoryBuffer(size_t size)
+      : size_(size),
+        has_data_copy_(true),
+        buffer_(reinterpret_cast<uint8_t *>(aligned_malloc(size_, BUFFER_ALIGNMENT))) {
     data_ = buffer_;
-    size_ = size;
   }
 
   uint8_t *Data() const override { return data_; }
@@ -96,19 +100,17 @@ class LocalMemoryBuffer : public Buffer {
 
   bool IsPlasmaBuffer() const override { return false; }
 
-  ~LocalMemoryBuffer() {
+  ~LocalMemoryBuffer() override {
     size_ = 0;
-    if (buffer_ != NULL) {
+    if (buffer_ != nullptr) {
       aligned_free(buffer_);
     }
   }
 
- private:
-  /// Disable copy constructor and assignment, as default copy will
-  /// cause invalid data_.
   LocalMemoryBuffer &operator=(const LocalMemoryBuffer &) = delete;
   LocalMemoryBuffer(const LocalMemoryBuffer &) = delete;
 
+ private:
   /// Pointer to the data.
   uint8_t *data_;
   /// Size of the buffer.
@@ -116,7 +118,7 @@ class LocalMemoryBuffer : public Buffer {
   /// Whether this buffer holds a copy of data.
   bool has_data_copy_ = false;
   /// This is only valid when `should_copy` is true.
-  uint8_t *buffer_ = NULL;
+  uint8_t *buffer_ = nullptr;
 };
 
 /// Represents a byte buffer in shared memory.
@@ -131,15 +133,11 @@ class SharedMemoryBuffer : public Buffer {
   ///
   /// \param data The data pointer to the passed-in buffer.
   /// \param size The size of the passed in buffer.
-  SharedMemoryBuffer(uint8_t *data, size_t size) {
-    data_ = data;
-    size_ = size;
-  }
+  SharedMemoryBuffer(uint8_t *data, size_t size) : data_(data), size_(size) {}
 
   /// Make a slice.
   SharedMemoryBuffer(const std::shared_ptr<Buffer> &buffer, int64_t offset, int64_t size)
-      : size_(size), parent_(buffer) {
-    data_ = buffer->Data() + offset;
+      : data_(buffer->Data() + offset), size_(size), parent_(buffer) {
     RAY_CHECK(size_ <= parent_->Size());
   }
 
@@ -157,14 +155,12 @@ class SharedMemoryBuffer : public Buffer {
 
   bool IsPlasmaBuffer() const override { return true; }
 
-  ~SharedMemoryBuffer() = default;
+  ~SharedMemoryBuffer() override = default;
 
- private:
-  /// Disable copy constructor and assignment, as default copy will
-  /// cause invalid data_.
   SharedMemoryBuffer &operator=(const LocalMemoryBuffer &) = delete;
   SharedMemoryBuffer(const LocalMemoryBuffer &) = delete;
 
+ private:
   /// Pointer to the data.
   uint8_t *data_;
   /// Size of the buffer.

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -22,10 +22,11 @@ namespace ray {
 namespace core {
 namespace experimental {
 
-MutableObjectProvider::MutableObjectProvider(plasma::PlasmaClientInterface &plasma,
-                                             RayletFactory raylet_client_factory,
-                                             std::function<Status(void)> check_signals)
-    : plasma_(plasma),
+MutableObjectProvider::MutableObjectProvider(
+    std::shared_ptr<plasma::PlasmaClientInterface> plasma,
+    RayletFactory raylet_client_factory,
+    std::function<Status(void)> check_signals)
+    : plasma_(std::move(plasma)),
       object_manager_(std::make_shared<ray::experimental::MutableObjectManager>(
           std::move(check_signals))),
       raylet_client_factory_(std::move(raylet_client_factory)) {}
@@ -47,7 +48,7 @@ void MutableObjectProvider::RegisterWriterChannel(
     const ObjectID &writer_object_id, const std::vector<NodeID> &remote_reader_node_ids) {
   {
     std::unique_ptr<plasma::MutableObject> writer_object;
-    RAY_CHECK_OK(plasma_.GetExperimentalMutableObject(writer_object_id, &writer_object));
+    RAY_CHECK_OK(plasma_->GetExperimentalMutableObject(writer_object_id, &writer_object));
     RAY_CHECK_OK(object_manager_->RegisterChannel(
         writer_object_id, std::move(writer_object), /*reader=*/false));
     // `object` is now a nullptr.
@@ -97,7 +98,7 @@ void MutableObjectProvider::RegisterWriterChannel(
 
 void MutableObjectProvider::RegisterReaderChannel(const ObjectID &object_id) {
   std::unique_ptr<plasma::MutableObject> object;
-  RAY_CHECK_OK(plasma_.GetExperimentalMutableObject(object_id, &object));
+  RAY_CHECK_OK(plasma_->GetExperimentalMutableObject(object_id, &object));
   RAY_CHECK_OK(
       object_manager_->RegisterChannel(object_id, std::move(object), /*reader=*/true));
   // `object` is now a nullptr.

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -145,7 +145,7 @@ class MutableObjectProvider : public MutableObjectProviderInterface {
   using RayletFactory =
       std::function<std::shared_ptr<RayletClientInterface>(const NodeID &)>;
 
-  MutableObjectProvider(plasma::PlasmaClientInterface &plasma,
+  MutableObjectProvider(std::shared_ptr<plasma::PlasmaClientInterface> plasma,
                         RayletFactory raylet_client_factory,
                         std::function<Status(void)> check_signals);
 
@@ -205,7 +205,7 @@ class MutableObjectProvider : public MutableObjectProviderInterface {
   void RunIOContext(instrumented_io_context &io_context);
 
   // The plasma store.
-  plasma::PlasmaClientInterface &plasma_;
+  std::shared_ptr<plasma::PlasmaClientInterface> plasma_;
 
   // Object manager for the mutable objects.
   std::shared_ptr<ray::experimental::MutableObjectManager> object_manager_;

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -92,7 +92,7 @@ CoreWorkerPlasmaStoreProvider::CoreWorkerPlasmaStoreProvider(
 }
 
 CoreWorkerPlasmaStoreProvider::~CoreWorkerPlasmaStoreProvider() {
-  RAY_IGNORE_EXPR(store_client_->Disconnect());
+  store_client_->Disconnect();
 }
 
 Status CoreWorkerPlasmaStoreProvider::Put(const RayObject &object,
@@ -241,9 +241,9 @@ Status CoreWorkerPlasmaStoreProvider::GetIfLocal(
       if (plasma_results[i].metadata && plasma_results[i].metadata->Size()) {
         metadata = plasma_results[i].metadata;
       }
-      const auto result_object = std::make_shared<RayObject>(
+      auto result_object = std::make_shared<RayObject>(
           data, metadata, std::vector<rpc::ObjectReference>());
-      (*results)[object_id] = result_object;
+      (*results)[object_id] = std::move(result_object);
     }
   }
   return Status::OK();

--- a/src/ray/core_worker/tests/mutable_object_provider_test.cc
+++ b/src/ray/core_worker/tests/mutable_object_provider_test.cc
@@ -109,11 +109,11 @@ std::shared_ptr<RayletClientInterface> GetMockRayletClient(
 TEST(MutableObjectProvider, RegisterWriterChannel) {
   ObjectID object_id = ObjectID::FromRandom();
   NodeID node_id = NodeID::FromRandom();
-  auto plasma = std::make_unique<TestPlasma>();
+  auto plasma = std::make_shared<TestPlasma>();
   auto interface = std::make_shared<MockRayletClient>();
 
   MutableObjectProvider provider(
-      *plasma,
+      plasma,
       /*factory=*/absl::bind_front(GetMockRayletClient, interface),
       nullptr);
   provider.RegisterWriterChannel(object_id, {node_id});

--- a/src/ray/core_worker/tests/mutable_object_provider_test.cc
+++ b/src/ray/core_worker/tests/mutable_object_provider_test.cc
@@ -139,8 +139,8 @@ TEST(MutableObjectProvider, RegisterWriterChannel) {
 
 TEST(MutableObjectProvider, MutableObjectBufferReadRelease) {
   ObjectID object_id = ObjectID::FromRandom();
-  auto plasma = std::make_unique<TestPlasma>();
-  MutableObjectProvider provider(*plasma,
+  auto plasma = std::make_shared<TestPlasma>();
+  MutableObjectProvider provider(plasma,
                                  /*factory=*/nullptr,
                                  nullptr);
   provider.RegisterWriterChannel(object_id, {});
@@ -176,11 +176,11 @@ TEST(MutableObjectProvider, MutableObjectBufferReadRelease) {
 TEST(MutableObjectProvider, HandlePushMutableObject) {
   ObjectID object_id = ObjectID::FromRandom();
   ObjectID local_object_id = ObjectID::FromRandom();
-  auto plasma = std::make_unique<TestPlasma>();
+  auto plasma = std::make_shared<TestPlasma>();
   auto interface = std::make_shared<MockRayletClient>();
 
   MutableObjectProvider provider(
-      *plasma,
+      plasma,
       /*factory=*/absl::bind_front(GetMockRayletClient, interface),
       nullptr);
   provider.HandleRegisterMutableObject(object_id, /*num_readers=*/1, local_object_id);
@@ -201,8 +201,8 @@ TEST(MutableObjectProvider, HandlePushMutableObject) {
 
 TEST(MutableObjectProvider, MutableObjectBufferSetError) {
   ObjectID object_id = ObjectID::FromRandom();
-  auto plasma = std::make_unique<TestPlasma>();
-  MutableObjectProvider provider(*plasma,
+  auto plasma = std::make_shared<TestPlasma>();
+  MutableObjectProvider provider(plasma,
                                  /*factory=*/nullptr,
                                  nullptr);
   provider.RegisterWriterChannel(object_id, {});
@@ -257,8 +257,8 @@ TEST(MutableObjectProvider, MutableObjectBufferSetError) {
 
 TEST(MutableObjectProvider, MutableObjectBufferSetErrorBeforeWriteRelease) {
   ObjectID object_id = ObjectID::FromRandom();
-  auto plasma = std::make_unique<TestPlasma>();
-  MutableObjectProvider provider(*plasma,
+  auto plasma = std::make_shared<TestPlasma>();
+  MutableObjectProvider provider(plasma,
                                  /*factory=*/nullptr,
                                  nullptr);
   provider.RegisterWriterChannel(object_id, {});
@@ -313,8 +313,8 @@ TEST(MutableObjectProvider, MutableObjectBufferSetErrorBeforeWriteRelease) {
 
 TEST(MutableObjectProvider, MutableObjectBufferSetErrorBeforeReadRelease) {
   ObjectID object_id = ObjectID::FromRandom();
-  auto plasma = std::make_unique<TestPlasma>();
-  MutableObjectProvider provider(*plasma,
+  auto plasma = std::make_shared<TestPlasma>();
+  MutableObjectProvider provider(plasma,
                                  /*factory=*/nullptr,
                                  nullptr);
   provider.RegisterWriterChannel(object_id, {});

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -15,234 +15,65 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// PLASMA CLIENT: Client library for using the plasma store and manager
-
 #include "ray/object_manager/plasma/client.h"
 
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
-#include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/ray_config.h"
 #include "ray/common/status.h"
-#include "ray/common/status_or.h"
 #include "ray/object_manager/plasma/connection.h"
 #include "ray/object_manager/plasma/plasma.h"
 #include "ray/object_manager/plasma/protocol.h"
-#include "ray/object_manager/plasma/shared_memory.h"
-
-namespace fb = plasma::flatbuf;
 
 namespace plasma {
 
-using fb::MessageType;
-using fb::PlasmaError;
-
-// ----------------------------------------------------------------------
-// PlasmaBuffer
+using plasma::flatbuf::MessageType;
+using plasma::flatbuf::PlasmaError;
 
 /// A Buffer class that automatically releases the backing plasma object
 /// when it goes out of scope. This is returned by Get.
 class PlasmaBuffer : public SharedMemoryBuffer {
  public:
-  ~PlasmaBuffer();
-
-  PlasmaBuffer(std::shared_ptr<PlasmaClient::Impl> client,
+  PlasmaBuffer(std::shared_ptr<PlasmaClient> client,
                const ObjectID &object_id,
                const std::shared_ptr<Buffer> &buffer)
       : SharedMemoryBuffer(buffer, 0, buffer->Size()),
-        client_(client),
+        client_(std::move(client)),
         object_id_(object_id) {}
 
+  ~PlasmaBuffer() override { RAY_UNUSED(client_->Release(object_id_)); }
+
+  PlasmaBuffer(const PlasmaBuffer &) = delete;
+  PlasmaBuffer &operator=(const PlasmaBuffer &) = delete;
+
  private:
-  std::shared_ptr<PlasmaClient::Impl> client_;
+  std::shared_ptr<PlasmaClient> client_;
   ObjectID object_id_;
 };
 
 /// A mutable Buffer class that keeps the backing data alive by keeping a
 /// PlasmaClient shared pointer. This is returned by Create. Release will
 /// be called in the associated Seal call.
-class RAY_NO_EXPORT PlasmaMutableBuffer : public SharedMemoryBuffer {
+class PlasmaMutableBuffer : public SharedMemoryBuffer {
  public:
-  PlasmaMutableBuffer(std::shared_ptr<PlasmaClient::Impl> client,
+  PlasmaMutableBuffer(std::shared_ptr<PlasmaClient> client,
                       uint8_t *mutable_data,
                       int64_t data_size)
       : SharedMemoryBuffer(mutable_data, data_size), client_(std::move(client)) {}
 
  private:
-  std::shared_ptr<PlasmaClient::Impl> client_;
+  std::shared_ptr<PlasmaClient> client_;
 };
-
-// ----------------------------------------------------------------------
-// PlasmaClient::Impl
-
-struct ObjectInUseEntry {
-  /// A count of the number of times this client has called PlasmaClient::Create
-  /// or
-  /// PlasmaClient::Get on this object ID minus the number of calls to
-  /// PlasmaClient::Release.
-  /// When this count reaches zero, we remove the entry from the ObjectsInUse
-  /// and decrement a count in the relevant ClientMmapTableEntry.
-  int count;
-  /// Cached information to read the object.
-  PlasmaObject object;
-  /// A flag representing whether the object has been sealed.
-  bool is_sealed;
-};
-
-class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Impl> {
- public:
-  Impl();
-  explicit Impl(bool exit_on_connection_failure);
-  ~Impl();
-
-  // PlasmaClient method implementations
-
-  Status Connect(const std::string &store_socket_name,
-                 const std::string &manager_socket_name,
-                 int num_retries = -1);
-
-  Status SetClientOptions(const std::string &client_name, int64_t output_memory_quota);
-
-  Status CreateAndSpillIfNeeded(const ObjectID &object_id,
-                                const ray::rpc::Address &owner_address,
-                                bool is_experimental_mutable_object,
-                                int64_t data_size,
-                                const uint8_t *metadata,
-                                int64_t metadata_size,
-                                std::shared_ptr<Buffer> *data,
-                                fb::ObjectSource source,
-                                int device_num = 0);
-
-  Status TryCreateImmediately(const ObjectID &object_id,
-                              const ray::rpc::Address &owner_address,
-                              int64_t data_size,
-                              const uint8_t *metadata,
-                              int64_t metadata_size,
-                              std::shared_ptr<Buffer> *data,
-                              fb::ObjectSource source,
-                              int device_num);
-
-  Status Get(const std::vector<ObjectID> &object_ids,
-             int64_t timeout_ms,
-             std::vector<ObjectBuffer> *object_buffers);
-
-  Status Get(const ObjectID *object_ids,
-             int64_t num_objects,
-             int64_t timeout_ms,
-             ObjectBuffer *object_buffers);
-
-  Status GetExperimentalMutableObject(const ObjectID &object_id,
-                                      std::unique_ptr<MutableObject> *mutable_object);
-
-  Status Release(const ObjectID &object_id);
-
-  Status Contains(const ObjectID &object_id, bool *has_object);
-
-  Status Abort(const ObjectID &object_id);
-
-  Status Seal(const ObjectID &object_id);
-
-  Status Delete(const std::vector<ObjectID> &object_ids);
-
-  Status Disconnect();
-
-  StatusOr<std::string> GetMemoryUsage();
-
-  bool IsInUse(const ObjectID &object_id);
-
-  int64_t store_capacity() { return store_capacity_; }
-
- private:
-  /// Helper method to read and process the reply of a create request.
-  Status HandleCreateReply(const ObjectID &object_id,
-                           bool is_experimental_mutable_object,
-                           const uint8_t *metadata,
-                           uint64_t *retry_with_request_id,
-                           std::shared_ptr<Buffer> *data);
-
-  /// Check if store_fd has already been received from the store. If yes,
-  /// return it. Otherwise, receive it from the store (see analogous logic
-  /// in store.cc).
-  ///
-  /// \param store_fd File descriptor to fetch from the store.
-  /// \return The pointer corresponding to store_fd.
-  uint8_t *GetStoreFdAndMmap(MEMFD_TYPE store_fd, int64_t map_size);
-
-  /// This is a helper method for marking an object as unused by this client.
-  ///
-  /// \param object_id The object ID we mark unused.
-  /// \return The return status.
-  Status MarkObjectUnused(const ObjectID &object_id);
-
-  /// Common helper for Get() variants
-  Status GetBuffers(const ObjectID *object_ids,
-                    int64_t num_objects,
-                    int64_t timeout_ms,
-                    ObjectBuffer *object_buffers);
-
-  uint8_t *LookupMmappedFile(MEMFD_TYPE store_fd_val) const;
-
-  ray::PlasmaObjectHeader *GetPlasmaObjectHeader(const PlasmaObject &object) const {
-    auto base_ptr = LookupMmappedFile(object.store_fd);
-    auto header_ptr = base_ptr + object.header_offset;
-    return reinterpret_cast<ray::PlasmaObjectHeader *>(header_ptr);
-  }
-
-  void InsertObjectInUse(const ObjectID &object_id,
-                         std::unique_ptr<PlasmaObject> object,
-                         bool is_sealed);
-
-  void IncrementObjectCount(const ObjectID &object_id);
-
-  /// The boost::asio IO context for the client.
-  instrumented_io_context main_service_;
-  /// The connection to the store service.
-  std::shared_ptr<StoreConn> store_conn_;
-  /// Table of dlmalloc buffer files that have been memory mapped so far. This
-  /// is a hash table mapping a file descriptor to a struct containing the
-  /// address of the corresponding memory-mapped file.
-  absl::flat_hash_map<MEMFD_TYPE, std::unique_ptr<ClientMmapTableEntry>> mmap_table_;
-  /// Used to clean up old fd entries in mmap_table_ that are no longer needed,
-  /// since their fd has been reused. TODO(ekl) we should be more proactive about
-  /// unmapping unused segments.
-  absl::flat_hash_map<MEMFD_TYPE_NON_UNIQUE, MEMFD_TYPE> dedup_fd_table_;
-  /// A hash table of the object IDs that are currently being used by this
-  /// client.
-  absl::flat_hash_map<ObjectID, std::unique_ptr<ObjectInUseEntry>> objects_in_use_;
-  /// The amount of memory available to the Plasma store. The client needs this
-  /// information to make sure that it does not delay in releasing so much
-  /// memory that the store is unable to evict enough objects to free up space.
-  int64_t store_capacity_;
-  /// A hash set to record the ids that users want to delete but still in use.
-  std::unordered_set<ObjectID> deletion_cache_;
-  /// A mutex which protects this class.
-  std::recursive_mutex client_mutex_;
-  /// Whether the current process should exit when read or write to the connection fails.
-  /// It should only be turned on when the plasma client is in a core worker.
-  bool exit_on_connection_failure_;
-};
-
-PlasmaBuffer::~PlasmaBuffer() { RAY_UNUSED(client_->Release(object_id_)); }
-
-PlasmaClient::Impl::Impl() : store_capacity_(0), exit_on_connection_failure_(false) {}
-
-PlasmaClient::Impl::Impl(bool exit_on_connection_failure)
-    : store_capacity_(0), exit_on_connection_failure_(exit_on_connection_failure) {}
-
-PlasmaClient::Impl::~Impl() {}
 
 // If the file descriptor fd has been mmapped in this client process before,
 // return the pointer that was returned by mmap, otherwise mmap it and store the
 // pointer in a hash table.
-uint8_t *PlasmaClient::Impl::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val,
-                                               int64_t map_size) {
+uint8_t *PlasmaClient::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val, int64_t map_size) {
   auto entry = mmap_table_.find(store_fd_val);
   if (entry != mmap_table_.end()) {
     return entry->second->pointer();
@@ -263,22 +94,22 @@ uint8_t *PlasmaClient::Impl::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val,
 
 // Get a pointer to a file that we know has been memory mapped in this client
 // process before.
-uint8_t *PlasmaClient::Impl::LookupMmappedFile(MEMFD_TYPE store_fd_val) const {
+uint8_t *PlasmaClient::LookupMmappedFile(MEMFD_TYPE store_fd_val) const {
   auto entry = mmap_table_.find(store_fd_val);
   RAY_CHECK(entry != mmap_table_.end());
   return entry->second->pointer();
 }
 
-bool PlasmaClient::Impl::IsInUse(const ObjectID &object_id) {
+bool PlasmaClient::IsInUse(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   const auto elem = objects_in_use_.find(object_id);
   return (elem != objects_in_use_.end());
 }
 
-void PlasmaClient::Impl::InsertObjectInUse(const ObjectID &object_id,
-                                           std::unique_ptr<PlasmaObject> object,
-                                           bool is_sealed) {
+void PlasmaClient::InsertObjectInUse(const ObjectID &object_id,
+                                     std::unique_ptr<PlasmaObject> object,
+                                     bool is_sealed) {
   auto inserted =
       objects_in_use_.insert({object_id, std::make_unique<ObjectInUseEntry>()});
   RAY_CHECK(inserted.second) << "Object already in use";
@@ -292,7 +123,7 @@ void PlasmaClient::Impl::InsertObjectInUse(const ObjectID &object_id,
   it->second->is_sealed = is_sealed;
 }
 
-void PlasmaClient::Impl::IncrementObjectCount(const ObjectID &object_id) {
+void PlasmaClient::IncrementObjectCount(const ObjectID &object_id) {
   // Increment the count of the object to track the fact that it is being used.
   // The corresponding decrement should happen in PlasmaClient::Release.
   auto object_entry = objects_in_use_.find(object_id);
@@ -302,11 +133,11 @@ void PlasmaClient::Impl::IncrementObjectCount(const ObjectID &object_id) {
                  << " count is now: " << object_entry->second->count;
 }
 
-Status PlasmaClient::Impl::HandleCreateReply(const ObjectID &object_id,
-                                             bool is_experimental_mutable_object,
-                                             const uint8_t *metadata,
-                                             uint64_t *retry_with_request_id,
-                                             std::shared_ptr<Buffer> *data) {
+Status PlasmaClient::HandleCreateReply(const ObjectID &object_id,
+                                       bool is_experimental_mutable_object,
+                                       const uint8_t *metadata,
+                                       uint64_t *retry_with_request_id,
+                                       std::shared_ptr<Buffer> *data) {
   std::vector<uint8_t> buffer;
   RAY_RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaCreateReply, &buffer));
   ObjectID id;
@@ -381,15 +212,15 @@ Status PlasmaClient::Impl::HandleCreateReply(const ObjectID &object_id,
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::CreateAndSpillIfNeeded(const ObjectID &object_id,
-                                                  const ray::rpc::Address &owner_address,
-                                                  bool is_experimental_mutable_object,
-                                                  int64_t data_size,
-                                                  const uint8_t *metadata,
-                                                  int64_t metadata_size,
-                                                  std::shared_ptr<Buffer> *data,
-                                                  fb::ObjectSource source,
-                                                  int device_num) {
+Status PlasmaClient::CreateAndSpillIfNeeded(const ObjectID &object_id,
+                                            const ray::rpc::Address &owner_address,
+                                            bool is_experimental_mutable_object,
+                                            int64_t data_size,
+                                            const uint8_t *metadata,
+                                            int64_t metadata_size,
+                                            std::shared_ptr<Buffer> *data,
+                                            plasma::flatbuf::ObjectSource source,
+                                            int device_num) {
   uint64_t retry_with_request_id = 0;
   Status status;
   {
@@ -432,14 +263,14 @@ Status PlasmaClient::Impl::CreateAndSpillIfNeeded(const ObjectID &object_id,
   return status;
 }
 
-Status PlasmaClient::Impl::TryCreateImmediately(const ObjectID &object_id,
-                                                const ray::rpc::Address &owner_address,
-                                                int64_t data_size,
-                                                const uint8_t *metadata,
-                                                int64_t metadata_size,
-                                                std::shared_ptr<Buffer> *data,
-                                                fb::ObjectSource source,
-                                                int device_num) {
+Status PlasmaClient::TryCreateImmediately(const ObjectID &object_id,
+                                          const ray::rpc::Address &owner_address,
+                                          int64_t data_size,
+                                          const uint8_t *metadata,
+                                          int64_t metadata_size,
+                                          std::shared_ptr<Buffer> *data,
+                                          plasma::flatbuf::ObjectSource source,
+                                          int device_num) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   RAY_LOG(DEBUG) << "called plasma_create on conn " << store_conn_ << " with size "
@@ -447,7 +278,7 @@ Status PlasmaClient::Impl::TryCreateImmediately(const ObjectID &object_id,
   RAY_RETURN_NOT_OK(SendCreateRequest(store_conn_,
                                       object_id,
                                       owner_address,
-                                      /*is_experimental_mutable_object=*/false,
+                                      /*is_mutable=*/false,
                                       data_size,
                                       metadata_size,
                                       source,
@@ -457,10 +288,10 @@ Status PlasmaClient::Impl::TryCreateImmediately(const ObjectID &object_id,
       object_id, /*is_experimental_mutable_object=*/false, metadata, nullptr, data);
 }
 
-Status PlasmaClient::Impl::GetBuffers(const ObjectID *object_ids,
-                                      int64_t num_objects,
-                                      int64_t timeout_ms,
-                                      ObjectBuffer *object_buffers) {
+Status PlasmaClient::GetBuffers(const ObjectID *object_ids,
+                                int64_t num_objects,
+                                int64_t timeout_ms,
+                                ObjectBuffer *object_buffers) {
   // Fill out the info for the objects that are already in use locally.
   bool all_present = true;
   for (int64_t i = 0; i < num_objects; ++i) {
@@ -593,11 +424,25 @@ Status PlasmaClient::Impl::GetBuffers(const ObjectID *object_ids,
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::GetExperimentalMutableObject(
+Status PlasmaClient::GetExperimentalMutableObject(
     const ObjectID &object_id, std::unique_ptr<MutableObject> *mutable_object) {
 #if defined(_WIN32)
   return Status::NotImplemented("Not supported on Windows.");
 #endif
+
+  // First make sure the object is in scope. The ObjectBuffer will keep the
+  // value pinned in the plasma store.
+  std::vector<ObjectBuffer> object_buffers;
+  RAY_RETURN_NOT_OK(Get({object_id}, /*timeout_ms=*/0, &object_buffers));
+  if (!object_buffers[0].data) {
+    return Status::Invalid(
+        "Experimental mutable object must be in the local object store to register as "
+        "reader or writer");
+  }
+
+  // Now that the value is pinned, get the object as a MutableObject, which is
+  // used to implement channels. The returned MutableObject will pin the
+  // object in the local object store.
 
   std::unique_lock<std::recursive_mutex> guard(client_mutex_);
 
@@ -623,16 +468,16 @@ Status PlasmaClient::Impl::GetExperimentalMutableObject(
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Get(const std::vector<ObjectID> &object_ids,
-                               int64_t timeout_ms,
-                               std::vector<ObjectBuffer> *out) {
+Status PlasmaClient::Get(const std::vector<ObjectID> &object_ids,
+                         int64_t timeout_ms,
+                         std::vector<ObjectBuffer> *out) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
   const size_t num_objects = object_ids.size();
   *out = std::vector<ObjectBuffer>(num_objects);
   return GetBuffers(object_ids.data(), num_objects, timeout_ms, out->data());
 }
 
-Status PlasmaClient::Impl::MarkObjectUnused(const ObjectID &object_id) {
+Status PlasmaClient::MarkObjectUnused(const ObjectID &object_id) {
   auto object_entry = objects_in_use_.find(object_id);
   RAY_CHECK(object_entry != objects_in_use_.end());
   RAY_CHECK_EQ(object_entry->second->count, 0);
@@ -642,7 +487,7 @@ Status PlasmaClient::Impl::MarkObjectUnused(const ObjectID &object_id) {
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Release(const ObjectID &object_id) {
+Status PlasmaClient::Release(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   // If the client is already disconnected, ignore release requests.
@@ -701,12 +546,12 @@ Status PlasmaClient::Impl::Release(const ObjectID &object_id) {
 }
 
 // This method is used to query whether the plasma store contains an object.
-Status PlasmaClient::Impl::Contains(const ObjectID &object_id, bool *has_object) {
+Status PlasmaClient::Contains(const ObjectID &object_id, bool *has_object) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   // Check if we already have a reference to the object.
   if (objects_in_use_.count(object_id) > 0) {
-    *has_object = 1;
+    *has_object = true;
   } else {
     // If we don't already have a reference to the object, check with the store
     // to see if we have the object.
@@ -716,13 +561,12 @@ Status PlasmaClient::Impl::Contains(const ObjectID &object_id, bool *has_object)
         PlasmaReceive(store_conn_, MessageType::PlasmaContainsReply, &buffer));
     ObjectID object_id2;
     RAY_DCHECK(buffer.size() > 0);
-    RAY_RETURN_NOT_OK(
-        ReadContainsReply(buffer.data(), buffer.size(), &object_id2, has_object));
+    ReadContainsReply(buffer.data(), buffer.size(), &object_id2, has_object);
   }
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Seal(const ObjectID &object_id) {
+Status PlasmaClient::Seal(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
   RAY_LOG(DEBUG) << "Seal " << object_id;
 
@@ -756,7 +600,7 @@ Status PlasmaClient::Impl::Seal(const ObjectID &object_id) {
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Abort(const ObjectID &object_id) {
+Status PlasmaClient::Abort(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
   auto object_entry = objects_in_use_.find(object_id);
   RAY_CHECK(object_entry != objects_in_use_.end())
@@ -780,10 +624,11 @@ Status PlasmaClient::Impl::Abort(const ObjectID &object_id) {
   std::vector<uint8_t> buffer;
   ObjectID id;
   RAY_RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaAbortReply, &buffer));
-  return ReadAbortReply(buffer.data(), buffer.size(), &id);
+  ReadAbortReply(buffer.data(), buffer.size(), &id);
+  return Status::OK();
 }
 
-Status PlasmaClient::Impl::Delete(const std::vector<ObjectID> &object_ids) {
+Status PlasmaClient::Delete(const std::vector<ObjectID> &object_ids) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   std::vector<ObjectID> not_in_use_ids;
@@ -803,31 +648,31 @@ Status PlasmaClient::Impl::Delete(const std::vector<ObjectID> &object_ids) {
     RAY_DCHECK(buffer.size() > 0);
     std::vector<PlasmaError> error_codes;
     not_in_use_ids.clear();
-    RAY_RETURN_NOT_OK(
-        ReadDeleteReply(buffer.data(), buffer.size(), &not_in_use_ids, &error_codes));
+    ReadDeleteReply(buffer.data(), buffer.size(), &not_in_use_ids, &error_codes);
   }
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Connect(const std::string &store_socket_name,
-                                   const std::string &manager_socket_name,
-                                   int num_retries) {
+Status PlasmaClient::Connect(const std::string &store_socket_name,
+                             const std::string &manager_socket_name,
+                             int num_retries) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   /// The local stream socket that connects to store.
   ray::local_stream_socket socket(main_service_);
   RAY_RETURN_NOT_OK(ray::ConnectSocketRetry(socket, store_socket_name));
-  store_conn_.reset(new StoreConn(std::move(socket), exit_on_connection_failure_));
+  store_conn_ =
+      std::make_shared<StoreConn>(std::move(socket), exit_on_connection_failure_);
   // Send a ConnectRequest to the store to get its memory capacity.
   RAY_RETURN_NOT_OK(SendConnectRequest(store_conn_));
   std::vector<uint8_t> buffer;
   RAY_RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaConnectReply, &buffer));
-  RAY_RETURN_NOT_OK(ReadConnectReply(buffer.data(), buffer.size(), &store_capacity_));
+  ReadConnectReply(buffer.data(), buffer.size());
 
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Disconnect() {
+void PlasmaClient::Disconnect() {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   // NOTE: We purposefully do not finish sending release calls for objects in
@@ -837,129 +682,27 @@ Status PlasmaClient::Impl::Disconnect() {
   // Close the connections to Plasma. The Plasma store will release the objects
   // that were in use by us when handling the SIGPIPE.
   store_conn_.reset();
-  return Status::OK();
 }
 
-StatusOr<std::string> PlasmaClient::Impl::GetMemoryUsage() {
+StatusOr<std::string> PlasmaClient::GetMemoryUsage() {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
   auto request_status = SendGetDebugStringRequest(store_conn_);
   if (!request_status.ok()) {
-    return StatusOr<std::string>(request_status);
+    return request_status;
   }
   std::vector<uint8_t> buffer;
   auto recv_status =
       PlasmaReceive(store_conn_, MessageType::PlasmaGetDebugStringReply, &buffer);
   if (!recv_status.ok()) {
-    return StatusOr<std::string>(recv_status);
+    return recv_status;
   }
   std::string debug_string;
   auto response_status =
       ReadGetDebugStringReply(buffer.data(), buffer.size(), &debug_string);
   if (!response_status.ok()) {
-    return StatusOr<std::string>(response_status);
+    return response_status;
   }
-  return StatusOr<std::string>(debug_string);
+  return debug_string;
 }
-
-// ----------------------------------------------------------------------
-// PlasmaClient
-
-PlasmaClient::PlasmaClient() : impl_(std::make_shared<PlasmaClient::Impl>()) {}
-
-PlasmaClient::PlasmaClient(bool exit_on_connection_failure)
-    : impl_(std::make_shared<PlasmaClient::Impl>(exit_on_connection_failure)) {}
-
-Status PlasmaClient::Connect(const std::string &store_socket_name,
-                             const std::string &manager_socket_name,
-                             int num_retries) {
-  return impl_->Connect(store_socket_name, manager_socket_name, num_retries);
-}
-
-Status PlasmaClient::CreateAndSpillIfNeeded(const ObjectID &object_id,
-                                            const ray::rpc::Address &owner_address,
-                                            bool is_experimental_mutable_object,
-                                            int64_t data_size,
-                                            const uint8_t *metadata,
-                                            int64_t metadata_size,
-                                            std::shared_ptr<Buffer> *data,
-                                            fb::ObjectSource source,
-                                            int device_num) {
-  return impl_->CreateAndSpillIfNeeded(object_id,
-                                       owner_address,
-                                       is_experimental_mutable_object,
-                                       data_size,
-                                       metadata,
-                                       metadata_size,
-                                       data,
-                                       source,
-                                       device_num);
-}
-
-Status PlasmaClient::TryCreateImmediately(const ObjectID &object_id,
-                                          const ray::rpc::Address &owner_address,
-                                          int64_t data_size,
-                                          const uint8_t *metadata,
-                                          int64_t metadata_size,
-                                          std::shared_ptr<Buffer> *data,
-                                          fb::ObjectSource source,
-                                          int device_num) {
-  return impl_->TryCreateImmediately(object_id,
-                                     owner_address,
-                                     data_size,
-                                     metadata,
-                                     metadata_size,
-                                     data,
-                                     source,
-                                     device_num);
-}
-
-Status PlasmaClient::Get(const std::vector<ObjectID> &object_ids,
-                         int64_t timeout_ms,
-                         std::vector<ObjectBuffer> *object_buffers) {
-  return impl_->Get(object_ids, timeout_ms, object_buffers);
-}
-
-Status PlasmaClient::GetExperimentalMutableObject(
-    const ObjectID &object_id, std::unique_ptr<MutableObject> *mutable_object) {
-  // First make sure the object is in scope. The ObjectBuffer will keep the
-  // value pinned in the plasma store.
-  std::vector<ObjectBuffer> object_buffers;
-  RAY_RETURN_NOT_OK(impl_->Get({object_id}, /*timeout_ms=*/0, &object_buffers));
-  if (!object_buffers[0].data) {
-    return Status::Invalid(
-        "Experimental mutable object must be in the local object store to register as "
-        "reader or writer");
-  }
-  // Now that the value is pinned, get the object as a MutableObject, which is
-  // used to implement channels. The returned MutableObject will pin the
-  // object in the local object store.
-  return impl_->GetExperimentalMutableObject(object_id, mutable_object);
-}
-
-Status PlasmaClient::Release(const ObjectID &object_id) {
-  return impl_->Release(object_id);
-}
-
-Status PlasmaClient::Contains(const ObjectID &object_id, bool *has_object) {
-  return impl_->Contains(object_id, has_object);
-}
-
-Status PlasmaClient::Abort(const ObjectID &object_id) { return impl_->Abort(object_id); }
-
-Status PlasmaClient::Seal(const ObjectID &object_id) { return impl_->Seal(object_id); }
-
-Status PlasmaClient::Delete(const std::vector<ObjectID> &object_ids) {
-  return impl_->Delete(object_ids);
-}
-
-Status PlasmaClient::Disconnect() { return impl_->Disconnect(); }
-
-StatusOr<std::string> PlasmaClient::GetMemoryUsage() { return impl_->GetMemoryUsage(); }
-
-bool PlasmaClient::IsInUse(const ObjectID &object_id) {
-  return impl_->IsInUse(object_id);
-}
-
-int64_t PlasmaClient::store_capacity() { return impl_->store_capacity(); }
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -17,17 +17,20 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
+#include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/buffer.h"
 #include "ray/common/status.h"
 #include "ray/common/status_or.h"
 #include "ray/object_manager/common.h"
 #include "ray/object_manager/plasma/common.h"
-#include "ray/util/visibility.h"
+#include "ray/object_manager/plasma/connection.h"
+#include "ray/object_manager/plasma/shared_memory.h"
 #include "src/ray/protobuf/common.pb.h"
 
 namespace plasma {
@@ -51,7 +54,6 @@ struct MutableObject {
   const int64_t allocated_size;
 };
 
-/// Object buffer data structure.
 struct ObjectBuffer {
   /// The data buffer.
   std::shared_ptr<SharedMemoryBuffer> data;
@@ -76,7 +78,6 @@ class PlasmaClientInterface {
   ///        will return failure if this is not "".
   /// \param release_delay Deprecated (not used).
   /// \param num_retries number of attempts to connect to IPC socket, default 50
-  /// \return The return status.
   virtual Status Connect(const std::string &store_socket_name,
                          const std::string &manager_socket_name = "",
                          int num_retries = -1) = 0;
@@ -86,7 +87,6 @@ class PlasmaClientInterface {
   /// After this call, the buffer returned by Get() is no longer valid.
   ///
   /// \param object_id The ID of the object that is no longer needed.
-  /// \return The return status.
   virtual Status Release(const ObjectID &object_id) = 0;
 
   /// Check if the object store contains a particular object and the object has
@@ -98,14 +98,11 @@ class PlasmaClientInterface {
   /// \param object_id The ID of the object whose presence we are checking.
   /// \param has_object The function will write true at this address if
   ///        the object is present and false if it is not present.
-  /// \return The return status.
   virtual Status Contains(const ObjectID &object_id, bool *has_object) = 0;
 
   /// Disconnect from the local plasma instance, including the local store and
   /// manager.
-  ///
-  /// \return The return status.
-  virtual Status Disconnect() = 0;
+  virtual void Disconnect() = 0;
 
   /// Get some objects from the Plasma Store. This function will block until the
   /// objects have all been created and sealed in the Plasma Store or the
@@ -120,7 +117,6 @@ class PlasmaClientInterface {
   /// \param timeout_ms The amount of time in milliseconds to wait before this
   ///        request times out. If this value is -1, then no timeout is set.
   /// \param[out] object_buffers The object results.
-  /// \return The return status.
   virtual Status Get(const std::vector<ObjectID> &object_ids,
                      int64_t timeout_ms,
                      std::vector<ObjectBuffer> *object_buffers) = 0;
@@ -131,7 +127,6 @@ class PlasmaClientInterface {
   /// \param[in] mutable_object Struct containing pointers for the object
   /// header, which is used to synchronize with other writers and readers, and
   /// the object data and metadata, which is read by the application.
-  /// \return The return status.
   virtual Status GetExperimentalMutableObject(
       const ObjectID &object_id, std::unique_ptr<MutableObject> *mutable_object) = 0;
 
@@ -139,7 +134,6 @@ class PlasmaClientInterface {
   /// this call.
   ///
   /// \param object_id The ID of the object to seal.
-  /// \return The return status.
   virtual Status Seal(const ObjectID &object_id) = 0;
 
   /// Abort an unsealed object in the object store. If the abort succeeds, then
@@ -148,7 +142,6 @@ class PlasmaClientInterface {
   /// calling Seal).
   ///
   /// \param object_id The ID of the object to abort.
-  /// \return The return status.
   virtual Status Abort(const ObjectID &object_id) = 0;
 
   /// Create an object in the Plasma Store. Any metadata for this object must be
@@ -173,7 +166,6 @@ class PlasmaClientInterface {
   ///        device_num = 0 corresponds to the host,
   ///        device_num = 1 corresponds to GPU0,
   ///        device_num = 2 corresponds to GPU1, etc.
-  /// \return The return status.
   ///
   /// The returned object must be released once it is done with.  It must also
   /// be either sealed or aborted.
@@ -209,7 +201,6 @@ class PlasmaClientInterface {
   ///        device_num = 0 corresponds to the host,
   ///        device_num = 1 corresponds to GPU0,
   ///        device_num = 2 corresponds to GPU1, etc.
-  /// \return The return status.
   ///
   /// The returned object must be released once it is done with.  It must also
   /// be either sealed or aborted.
@@ -227,7 +218,7 @@ class PlasmaClientInterface {
   /// it is a no operation.
   ///
   /// \param object_ids The list of IDs of the objects to delete.
-  /// \return The return status. If all the objects are non-existent, return OK.
+  /// \return Returns ok if all the objects are non-existent.
   virtual Status Delete(const std::vector<ObjectID> &object_ids) = 0;
 
   /// Get the current debug string from the plasma store server.
@@ -236,11 +227,13 @@ class PlasmaClientInterface {
   virtual StatusOr<std::string> GetMemoryUsage() = 0;
 };
 
-class PlasmaClient : public PlasmaClientInterface {
+class PlasmaClient : public std::enable_shared_from_this<PlasmaClient>,
+                     public PlasmaClientInterface {
  public:
-  PlasmaClient();
+  PlasmaClient() : exit_on_connection_failure_(false) {}
 
-  explicit PlasmaClient(bool exit_on_connection_failure);
+  explicit PlasmaClient(bool exit_on_connection_failure)
+      : exit_on_connection_failure_(exit_on_connection_failure) {}
 
   Status Connect(const std::string &store_socket_name,
                  const std::string &manager_socket_name = "",
@@ -248,7 +241,7 @@ class PlasmaClient : public PlasmaClientInterface {
 
   Status CreateAndSpillIfNeeded(const ObjectID &object_id,
                                 const ray::rpc::Address &owner_address,
-                                bool is_mutable,
+                                bool is_experimental_mutable_object,
                                 int64_t data_size,
                                 const uint8_t *metadata,
                                 int64_t metadata_size,
@@ -282,25 +275,91 @@ class PlasmaClient : public PlasmaClientInterface {
 
   Status Delete(const std::vector<ObjectID> &object_ids) override;
 
-  Status Disconnect() override;
+  void Disconnect() override;
 
-  /// Get the current debug string from the plasma store server.
-  ///
-  /// \return the debug string if successful, otherwise return an error status.
   StatusOr<std::string> GetMemoryUsage() override;
 
-  /// Get the memory capacity of the store.
-  ///
-  /// \return Memory capacity of the store in bytes.
-  int64_t store_capacity();
-
  private:
-  friend class PlasmaBuffer;
-  friend class PlasmaMutableBuffer;
   bool IsInUse(const ObjectID &object_id);
 
-  class Impl;
-  std::shared_ptr<Impl> impl_;
+  /// Helper method to read and process the reply of a create request.
+  Status HandleCreateReply(const ObjectID &object_id,
+                           bool is_experimental_mutable_object,
+                           const uint8_t *metadata,
+                           uint64_t *retry_with_request_id,
+                           std::shared_ptr<Buffer> *data);
+
+  /// Check if store_fd has already been received from the store. If yes,
+  /// return it. Otherwise, receive it from the store (see analogous logic
+  /// in store.cc).
+  ///
+  /// \param store_fd File descriptor to fetch from the store.
+  /// \return The pointer corresponding to store_fd.
+  uint8_t *GetStoreFdAndMmap(MEMFD_TYPE store_fd, int64_t map_size);
+
+  /// This is a helper method for marking an object as unused by this client.
+  ///
+  /// \param object_id The object ID we mark unused.
+  /// \return The return status.
+  Status MarkObjectUnused(const ObjectID &object_id);
+
+  /// Common helper for Get() variants
+  Status GetBuffers(const ObjectID *object_ids,
+                    int64_t num_objects,
+                    int64_t timeout_ms,
+                    ObjectBuffer *object_buffers);
+
+  uint8_t *LookupMmappedFile(MEMFD_TYPE store_fd_val) const;
+
+  ray::PlasmaObjectHeader *GetPlasmaObjectHeader(const PlasmaObject &object) const {
+    auto base_ptr = LookupMmappedFile(object.store_fd);
+    auto header_ptr = base_ptr + object.header_offset;
+    return reinterpret_cast<ray::PlasmaObjectHeader *>(header_ptr);
+  }
+
+  void InsertObjectInUse(const ObjectID &object_id,
+                         std::unique_ptr<PlasmaObject> object,
+                         bool is_sealed);
+
+  void IncrementObjectCount(const ObjectID &object_id);
+
+  /// The boost::asio IO context for the client.
+  instrumented_io_context main_service_;
+  /// The connection to the store service.
+  std::shared_ptr<StoreConn> store_conn_;
+  /// Table of dlmalloc buffer files that have been memory mapped so far. This
+  /// is a hash table mapping a file descriptor to a struct containing the
+  /// address of the corresponding memory-mapped file.
+  absl::flat_hash_map<MEMFD_TYPE, std::unique_ptr<ClientMmapTableEntry>> mmap_table_;
+  /// Used to clean up old fd entries in mmap_table_ that are no longer needed,
+  /// since their fd has been reused. TODO(ekl) we should be more proactive about
+  /// unmapping unused segments.
+  absl::flat_hash_map<MEMFD_TYPE_NON_UNIQUE, MEMFD_TYPE> dedup_fd_table_;
+
+  struct ObjectInUseEntry {
+    /// A count of the number of times this client has called PlasmaClient::Create
+    /// or
+    /// PlasmaClient::Get on this object ID minus the number of calls to
+    /// PlasmaClient::Release.
+    /// When this count reaches zero, we remove the entry from the ObjectsInUse
+    /// and decrement a count in the relevant ClientMmapTableEntry.
+    int count = 0;
+    /// Cached information to read the object.
+    PlasmaObject object;
+    /// A flag representing whether the object has been sealed.
+    bool is_sealed = false;
+  };
+  /// A hash table of the object IDs that are currently being used by this
+  /// client.
+  absl::flat_hash_map<ObjectID, std::unique_ptr<ObjectInUseEntry>> objects_in_use_;
+
+  /// A hash set to record the ids that users want to delete but still in use.
+  std::unordered_set<ObjectID> deletion_cache_;
+  /// A mutex which protects this class.
+  std::recursive_mutex client_mutex_;
+  /// Whether the current process should exit when read or write to the connection fails.
+  /// It should only be turned on when the plasma client is in a core worker.
+  bool exit_on_connection_failure_;
 };
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/connection.cc
+++ b/src/ray/object_manager/plasma/connection.cc
@@ -85,11 +85,12 @@ std::shared_ptr<Client> Client::Create(
     PlasmaStoreConnectionErrorHandler connection_error_handler,
     ray::local_stream_socket &&socket) {
   ray::MessageHandler ray_message_handler =
-      [message_handler](std::shared_ptr<ray::ClientConnection> client,
+      [message_handler](const std::shared_ptr<ray::ClientConnection> &client,
                         int64_t message_type,
                         const std::vector<uint8_t> &message) {
-        Status s = message_handler(
-            std::static_pointer_cast<Client>(client), (MessageType)message_type, message);
+        Status s = message_handler(std::static_pointer_cast<Client>(client),
+                                   static_cast<MessageType>(message_type),
+                                   message);
         if (!s.ok()) {
           if (!s.IsDisconnected()) {
             RAY_LOG(ERROR) << "Fail to process client message. " << s.ToString();
@@ -101,7 +102,7 @@ std::shared_ptr<Client> Client::Create(
       };
 
   ray::ConnectionErrorHandler ray_connection_error_handler =
-      [connection_error_handler](std::shared_ptr<ray::ClientConnection> client,
+      [connection_error_handler](const std::shared_ptr<ray::ClientConnection> &client,
                                  const boost::system::error_code &error) {
         connection_error_handler(std::static_pointer_cast<Client>(client), error);
       };

--- a/src/ray/object_manager/plasma/connection.h
+++ b/src/ray/object_manager/plasma/connection.h
@@ -41,7 +41,7 @@ using PlasmaStoreConnectionErrorHandler =
 
 class ClientInterface {
  public:
-  virtual ~ClientInterface() {}
+  virtual ~ClientInterface() = default;
 
   virtual ray::Status SendFd(MEMFD_TYPE fd) = 0;
   virtual const std::unordered_set<ray::ObjectID> &GetObjectIDs() = 0;

--- a/src/ray/object_manager/plasma/fake_plasma_client.h
+++ b/src/ray/object_manager/plasma/fake_plasma_client.h
@@ -116,7 +116,7 @@ class FakePlasmaClient : public PlasmaClientInterface {
     return Status::OK();
   }
 
-  Status Disconnect() override { return Status::OK(); };
+  void Disconnect() override{};
 
   std::string DebugString() { return ""; }
 

--- a/src/ray/object_manager/plasma/fake_plasma_client.h
+++ b/src/ray/object_manager/plasma/fake_plasma_client.h
@@ -120,8 +120,6 @@ class FakePlasmaClient : public PlasmaClientInterface {
 
   std::string DebugString() { return ""; }
 
-  int64_t store_capacity() { return 0; }
-
   StatusOr<std::string> GetMemoryUsage() override { return std::string("fake"); }
 
   absl::flat_hash_map<ObjectID, std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
@@ -40,8 +39,6 @@ using ray::Status;
 using flatbuf::MessageType;
 using flatbuf::ObjectSource;
 using flatbuf::PlasmaError;
-
-Status PlasmaErrorStatus(flatbuf::PlasmaError plasma_error);
 
 template <class T>
 bool VerifyFlatbuffer(T *object, const uint8_t *data, size_t size) {
@@ -124,17 +121,17 @@ Status ReadCreateReply(uint8_t *data,
 
 Status SendAbortRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID object_id);
 
-Status ReadAbortRequest(const uint8_t *data, size_t size, ObjectID *object_id);
+void ReadAbortRequest(const uint8_t *data, size_t size, ObjectID *object_id);
 
 Status SendAbortReply(const std::shared_ptr<Client> &client, ObjectID object_id);
 
-Status ReadAbortReply(uint8_t *data, size_t size, ObjectID *object_id);
+void ReadAbortReply(uint8_t *data, size_t size, ObjectID *object_id);
 
 /* Plasma Seal message functions. */
 
 Status SendSealRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID object_id);
 
-Status ReadSealRequest(const uint8_t *data, size_t size, ObjectID *object_id);
+void ReadSealRequest(const uint8_t *data, size_t size, ObjectID *object_id);
 
 Status SendSealReply(const std::shared_ptr<Client> &client,
                      ObjectID object_id,
@@ -149,10 +146,10 @@ Status SendGetRequest(const std::shared_ptr<StoreConn> &store_conn,
                       int64_t num_objects,
                       int64_t timeout_ms);
 
-Status ReadGetRequest(const uint8_t *data,
-                      size_t size,
-                      std::vector<ObjectID> &object_ids,
-                      int64_t *timeout_ms);
+void ReadGetRequest(const uint8_t *data,
+                    size_t size,
+                    std::vector<ObjectID> &object_ids,
+                    int64_t *timeout_ms);
 
 Status SendGetReply(const std::shared_ptr<Client> &client,
                     ObjectID object_ids[],
@@ -175,10 +172,10 @@ Status SendReleaseRequest(const std::shared_ptr<StoreConn> &store_conn,
                           ObjectID object_id,
                           bool may_unmap);
 
-Status ReadReleaseRequest(const uint8_t *data,
-                          size_t size,
-                          ObjectID *object_id,
-                          bool *may_unmap);
+void ReadReleaseRequest(const uint8_t *data,
+                        size_t size,
+                        ObjectID *object_id,
+                        bool *may_unmap);
 
 Status SendReleaseReply(const std::shared_ptr<Client> &client,
                         ObjectID object_id,
@@ -195,43 +192,38 @@ Status ReadReleaseReply(uint8_t *data,
 Status SendDeleteRequest(const std::shared_ptr<StoreConn> &store_conn,
                          const std::vector<ObjectID> &object_ids);
 
-Status ReadDeleteRequest(const uint8_t *data,
-                         size_t size,
-                         std::vector<ObjectID> *object_ids);
+void ReadDeleteRequest(const uint8_t *data,
+                       size_t size,
+                       std::vector<ObjectID> *object_ids);
 
 Status SendDeleteReply(const std::shared_ptr<Client> &client,
                        const std::vector<ObjectID> &object_ids,
                        const std::vector<PlasmaError> &errors);
 
-Status ReadDeleteReply(uint8_t *data,
-                       size_t size,
-                       std::vector<ObjectID> *object_ids,
-                       std::vector<PlasmaError> *errors);
+void ReadDeleteReply(uint8_t *data,
+                     size_t size,
+                     std::vector<ObjectID> *object_ids,
+                     std::vector<PlasmaError> *errors);
 
 /* Plasma Contains message functions. */
 
 Status SendContainsRequest(const std::shared_ptr<StoreConn> &store_conn,
                            ObjectID object_id);
 
-Status ReadContainsRequest(const uint8_t *data, size_t size, ObjectID *object_id);
+void ReadContainsRequest(const uint8_t *data, size_t size, ObjectID *object_id);
 
 Status SendContainsReply(const std::shared_ptr<Client> &client,
                          ObjectID object_id,
                          bool has_object);
 
-Status ReadContainsReply(uint8_t *data,
-                         size_t size,
-                         ObjectID *object_id,
-                         bool *has_object);
+void ReadContainsReply(uint8_t *data, size_t size, ObjectID *object_id, bool *has_object);
 
 /* Plasma Connect message functions. */
 
 Status SendConnectRequest(const std::shared_ptr<StoreConn> &store_conn);
 
-Status ReadConnectRequest(uint8_t *data, size_t size);
-
 Status SendConnectReply(const std::shared_ptr<Client> &client, int64_t memory_capacity);
 
-Status ReadConnectReply(uint8_t *data, size_t size, int64_t *memory_capacity);
+void ReadConnectReply(uint8_t *data, size_t size);
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -207,7 +207,7 @@ class PlasmaStore {
   ///
   /// \param client The client whose connection the error occurred on.
   /// \param error The error details.
-  void HandleClientConnectionError(std::shared_ptr<Client> client,
+  void HandleClientConnectionError(const std::shared_ptr<Client> &client,
                                    const boost::system::error_code &error)
       ABSL_LOCKS_EXCLUDED(mutex_);
 
@@ -216,7 +216,7 @@ class PlasmaStore {
   /// \param client The client that the message is from.
   /// \param type The message type.
   /// \param message The message data.
-  Status ProcessClientMessage(std::shared_ptr<Client> client,
+  Status ProcessClientMessage(const std::shared_ptr<Client> &client,
                               plasma::flatbuf::MessageType type,
                               const std::vector<uint8_t> &message)
       ABSL_LOCKS_EXCLUDED(mutex_);

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -328,7 +328,7 @@ int main(int argc, char *argv[]) {
   std::unique_ptr<ray::raylet::Raylet> raylet;
 
   ray::stats::Gauge task_by_state_counter = ray::core::GetTaskByStateGaugeMetric();
-  std::unique_ptr<plasma::PlasmaClient> plasma_client;
+  std::shared_ptr<plasma::PlasmaClient> plasma_client;
   std::unique_ptr<ray::raylet::NodeManager> node_manager;
   std::unique_ptr<ray::rpc::ClientCallManager> client_call_manager;
   std::unique_ptr<ray::rpc::CoreWorkerClientPool> worker_rpc_pool;
@@ -912,7 +912,7 @@ int main(int argc, char *argv[]) {
       return raylet_client_pool->GetOrConnectByAddress(addr);
     };
 
-    plasma_client = std::make_unique<plasma::PlasmaClient>();
+    plasma_client = std::make_shared<plasma::PlasmaClient>();
     node_manager = std::make_unique<ray::raylet::NodeManager>(
         main_service,
         raylet_node_id,
@@ -932,9 +932,9 @@ int main(int argc, char *argv[]) {
         *lease_dependency_manager,
         *worker_pool,
         leased_workers,
-        *plasma_client,
+        plasma_client,
         std::make_unique<ray::core::experimental::MutableObjectProvider>(
-            *plasma_client,
+            plasma_client,
             std::move(raylet_client_factory),
             /*check_signals=*/nullptr),
         shutdown_raylet_gracefully,

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -150,7 +150,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
       LeaseDependencyManager &lease_dependency_manager,
       WorkerPoolInterface &worker_pool,
       absl::flat_hash_map<LeaseID, std::shared_ptr<WorkerInterface>> &leased_workers,
-      plasma::PlasmaClientInterface &store_client,
+      std::shared_ptr<plasma::PlasmaClientInterface> store_client,
       std::unique_ptr<core::experimental::MutableObjectProviderInterface>
           mutable_object_provider,
       std::function<void(const rpc::NodeDeathInfo &)> shutdown_raylet_gracefully,
@@ -162,7 +162,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   ///
   /// \param client The client whose connection the error occurred on.
   /// \param error The error details.
-  void HandleClientConnectionError(std::shared_ptr<ClientConnection> client,
+  void HandleClientConnectionError(const std::shared_ptr<ClientConnection> &client,
                                    const boost::system::error_code &error);
 
   /// Process a message from a client. This method is responsible for
@@ -752,7 +752,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// A Plasma object store client. This is used for creating new objects in
   /// the object store (e.g., for actor tasks that can't be run because the
   /// actor died) and to pin objects that are in scope in the cluster.
-  plasma::PlasmaClientInterface &store_client_;
+  std::shared_ptr<plasma::PlasmaClientInterface> store_client_;
   /// Mutable object provider for compiled graphs.
   std::unique_ptr<core::experimental::MutableObjectProviderInterface>
       mutable_object_provider_;

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -156,15 +156,16 @@ void Raylet::DoAccept() {
 
 void Raylet::HandleAccept(const boost::system::error_code &error) {
   if (!error) {
-    ConnectionErrorHandler error_handler = [this](
-                                               std::shared_ptr<ClientConnection> client,
-                                               const boost::system::error_code &err) {
-      node_manager_.HandleClientConnectionError(client, err);
-    };
+    ConnectionErrorHandler error_handler =
+        [this](const std::shared_ptr<ClientConnection> &client,
+               const boost::system::error_code &err) {
+          node_manager_.HandleClientConnectionError(client, err);
+        };
 
-    MessageHandler message_handler = [this](std::shared_ptr<ClientConnection> client,
-                                            int64_t message_type,
-                                            const std::vector<uint8_t> &message) {
+    MessageHandler message_handler = [this](
+                                         const std::shared_ptr<ClientConnection> &client,
+                                         int64_t message_type,
+                                         const std::vector<uint8_t> &message) {
       node_manager_.ProcessClientMessage(client, message_type, message.data());
     };
 

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -414,7 +414,7 @@ class NodeManagerTest : public ::testing::Test {
         *lease_dependency_manager_,
         mock_worker_pool_,
         leased_workers_,
-        *mock_store_client_,
+        mock_store_client_,
         std::move(mutable_object_provider),
         /*shutdown_raylet_gracefully=*/
         [](const auto &) {},


### PR DESCRIPTION
## Why are these changes needed?
Cleaning out plasma and the plasma client and its neighbors.

The plasma client had a pimpl implementation, even though we didn't really need anything that would come with pimpl out of plasma. So just killing the separate impl class and just having the plasma client and its interface. One note about this is that it needs `shared_from_this` and the old plasma client would always contain a shared ptr to the impl, so had to refactor the raylet to use a shared ptr to the plasma client so we could keep using the `shared_from_this`.

Other cleanup:
- a lot of the ipc functions always returned status::ok so changed to void
- some extra reserving of vectors and moving
- unnecessary consts in pull manager that would prevent moves
etc.