### PR TITLE
[release test] move `upload_working_dir_to_gcs` to `glue.py`

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -6,6 +6,8 @@ import random
 import string
 from typing import Optional, List, Tuple
 
+from google.cloud import storage as gcs_storage
+
 from ray_release.alerts.handle import handle_result, require_result
 from ray_release.anyscale_util import (
     create_cluster_env_from_image,
@@ -14,6 +16,7 @@ from ray_release.anyscale_util import (
     LAST_LOGS_LENGTH,
 )
 from ray_release.buildkite.output import buildkite_group, buildkite_open_last
+from ray_release.cloud_util import archive_directory
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager
 from ray_release.cluster_manager.minimal import MinimalClusterManager
@@ -49,9 +52,6 @@ from ray_release.signal_handling import (
     setup_signal_handling,
     reset_signal_handling,
     register_handler,
-)
-from ray_release.util import (
-    upload_working_dir_to_gcs,
 )
 from ray_release.kuberay_util import convert_cluster_compute_to_kuberay_compute_config
 
@@ -296,6 +296,28 @@ def _prepare_remote_environment(
             raise PrepareCommandTimeout(e)
 
 
+def _upload_working_dir_to_gcs(working_dir: str) -> str:
+    """Upload working directory to GCS bucket.
+
+    Args:
+        working_dir: Path to directory to upload.
+    Returns:
+        GCS path where directory was uploaded.
+    """
+    # Create archive of working dir
+    logger.info(f"Archiving working directory: {working_dir}")
+    archived_file_path = archive_directory(working_dir)
+    archived_filename = os.path.basename(archived_file_path)
+
+    # Upload to GCS
+    gcs_client = gcs_storage.Client()
+    bucket = gcs_client.bucket("ray-release-working-dir")
+    blob = bucket.blob(archived_filename)
+    blob.upload_from_filename(archived_filename)
+
+    return f"gs://ray-release-working-dir/{blob.name}"
+
+
 def _running_test_script(
     test: Test,
     smoke_test: bool,
@@ -438,7 +460,7 @@ def run_release_test_kuberay(
             kuberay_autoscaler_config = {"version": kuberay_autoscaler_version}
         else:
             kuberay_autoscaler_config = None
-        working_dir_upload_path = upload_working_dir_to_gcs(get_working_dir(test))
+        working_dir_upload_path = _upload_working_dir_to_gcs(get_working_dir(test))
 
         command_timeout = int(test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT))
         test_name_hash = hashlib.sha256(test["name"].encode()).hexdigest()[:10]

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -6,11 +6,9 @@ import subprocess
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from google.cloud import storage
 import requests
 
 from ray_release.logger import logger
-from ray_release.cloud_util import archive_directory
 from ray_release.configs.global_config import get_global_config
 
 if TYPE_CHECKING:
@@ -189,25 +187,3 @@ def get_pip_packages() -> List[str]:
 def python_version_str(python_version: Tuple[int, int]) -> str:
     """From (X, Y) to XY"""
     return "".join([str(x) for x in python_version])
-
-
-def upload_working_dir_to_gcs(working_dir: str) -> str:
-    """Upload working directory to GCS bucket.
-
-    Args:
-        working_dir: Path to directory to upload.
-    Returns:
-        GCS path where directory was uploaded.
-    """
-    # Create archive of working dir
-    logger.info(f"Archiving working directory: {working_dir}")
-    archived_file_path = archive_directory(working_dir)
-    archived_filename = os.path.basename(archived_file_path)
-
-    # Upload to GCS
-    gcs_client = storage.Client()
-    bucket = gcs_client.bucket("ray-release-working-dir")
-    blob = bucket.blob(archived_filename)
-    blob.upload_from_filename(archived_filename)
-
-    return f"gs://ray-release-working-dir/{blob.name}"


### PR DESCRIPTION
it is only used in glue.py
