### PR TITLE
[release test] remove the use of typing extension for TypedDict

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -357,7 +357,6 @@ py_library(
     visibility = ["//ci/ray_ci:__pkg__"],
     deps = [
         bk_require("pyyaml"),
-        bk_require("typing-extensions"),
     ],
 )
 

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -1,8 +1,7 @@
 import os
+from typing import List, TypedDict
 
 import yaml
-from typing import List
-from typing_extensions import TypedDict
 
 
 class GlobalConfig(TypedDict):


### PR DESCRIPTION
should all be using hermetic python with python 3.8 or above now
