### PR TITLE
[ci] fix windows test launch and building

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -17,7 +17,8 @@ py_library(
     deps = [
         "//release:bazel",
         "//release:global_config",
-        "//release:ray_release",
+        "//release:test",
+        "//release:test_automation",
         ci_require("boto3"),
         ci_require("pyyaml"),
         ci_require("click"),

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -388,6 +388,79 @@ py_library(
 )
 
 py_library(
+    name = "util",
+    srcs = ["ray_release/util.py"],
+    imports = ["."],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":global_config",
+        ":logger",
+        bk_require("anyscale"),
+    ],
+)
+
+py_library(
+    name = "anyscale_util",
+    srcs = ["ray_release/anyscale_util.py"],
+    imports = ["."],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":exception",
+        ":logger",
+        ":util",
+        bk_require("anyscale"),
+    ],
+)
+
+py_library(
+    name = "aws",
+    srcs = ["ray_release/aws.py"],
+    imports = ["."],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":logger",
+        ":util",
+        bk_require("boto3"),
+        bk_require("botocore"),
+        bk_require("aws-requests-auth"),
+    ],
+)
+
+py_library(
+    name = "test",
+    srcs = ["ray_release/test.py"],
+    imports = ["."],
+    visibility = ["//ci/ray_ci:__pkg__"],
+    deps = [
+        ":aws",
+        ":global_config",
+        ":logger",
+        ":result",
+        ":util",
+        bk_require("aioboto3"),
+        bk_require("boto3"),
+        bk_require("botocore"),
+        bk_require("pygithub"),
+    ],
+)
+
+py_library(
+    name = "test_automation",
+    srcs = [
+        "ray_release/test_automation/ci_state_machine.py",
+        "ray_release/test_automation/release_state_machine.py",
+        "ray_release/test_automation/state_machine.py",
+    ],
+    imports = ["."],
+    visibility = ["//ci/ray_ci:__pkg__"],
+    deps = [
+        ":test",
+        bk_require("pygithub"),
+        bk_require("pybuildkite"),
+    ],
+)
+
+py_library(
     name = "ray_release",
     srcs = glob(
         ["ray_release/**/*.py"],
@@ -395,14 +468,19 @@ py_library(
             "ray_release/tests/*.py",
             "ray_release/configs/*.py",
             "ray_release/scripts/*.py",
+            "ray_release/test_automation/*.py",
             "ray_release/bazel.py",
             "ray_release/logger.py",
             "ray_release/result.py",
             "ray_release/exception.py",
             "ray_release/kuberay_util.py",
             "ray_release/wheels.py",
+            "ray_release/util.py",
             "ray_release/retry.py",
             "ray_release/cloud_util.py",
+            "ray_release/anyscale_util.py",
+            "ray_release/aws.py",
+            "ray_release/test.py",
         ],
     ),
     data = glob([
@@ -419,6 +497,8 @@ py_library(
     imports = ["."],
     visibility = ["//visibility:public"],
     deps = [
+        ":anyscale_util",
+        ":aws",
         ":bazel",
         ":cloud_util",
         ":exception",
@@ -427,6 +507,9 @@ py_library(
         ":logger",
         ":result",
         ":retry",
+        ":test",
+        ":test_automation",
+        ":util",
         ":wheels",
         bk_require("anyscale"),
         bk_require("aws-requests-auth"),
@@ -804,7 +887,7 @@ py_test(
     ],
     deps = [
         ":bazel",
-        ":ray_release",
+        ":test",
         bk_require("pytest"),
     ],
 )


### PR DESCRIPTION
make that `test_in_docker` does not depend on the entire `ray_release` library, but only depends on python files that are required for the test db to work. this removes the dependency of `cryptography` library from `ray_ci`, so that windows wheels can be built and windows tests can run again.
