### PR TITLE
[core] stop populating deprecated runtime_env field

### DIFF
--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -244,10 +244,6 @@ ray_cc_library(
     name = "task_event_buffer",
     srcs = ["task_event_buffer.cc"],
     hdrs = ["task_event_buffer.h"],
-    copts = select({
-        "//conditions:default": ["-Wno-error=deprecated-declarations"],
-        "@platforms//os:windows": [],
-    }),
     visibility = [":__subpackages__"],
     deps = [
         "//src/ray/common:asio",

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -192,9 +192,6 @@ void TaskStatusEvent::PopulateRpcRayTaskDefinitionEvent(T &definition_event_data
       std::make_move_iterator(required_resources.end()));
   definition_event_data.set_serialized_runtime_env(
       task_spec_->RuntimeEnvInfo().serialized_runtime_env());
-  // TODO(CORE-2277): Remove this once runtime_env_info is fully deprecated.
-  definition_event_data.mutable_runtime_env_info()->CopyFrom(
-      task_spec_->RuntimeEnvInfo());
   definition_event_data.set_job_id(job_id_.Binary());
   definition_event_data.set_parent_task_id(task_spec_->ParentTaskId().Binary());
   definition_event_data.set_placement_group_id(

--- a/src/ray/protobuf/public/events_actor_task_definition_event.proto
+++ b/src/ray/protobuf/public/events_actor_task_definition_event.proto
@@ -22,6 +22,8 @@ package ray.rpc.events;
 // Message containing the definition information of an actor task.
 // The message is expected to be emitted once per task attempt.
 message ActorTaskDefinitionEvent {
+  reserved 7;
+  reserved "runtime_env_info";
   // task_id and task_attempt forms the unique identifier for a task.
   bytes task_id = 1;
   int32 task_attempt = 2;
@@ -31,7 +33,6 @@ message ActorTaskDefinitionEvent {
   FunctionDescriptor actor_func = 4;
   string actor_task_name = 5;
   map<string, double> required_resources = 6;
-  RuntimeEnvInfo runtime_env_info = 7 [deprecated = true];
 
   // The correlation ids of the task that can be used to correlate the task with
   // other events.

--- a/src/ray/protobuf/public/events_task_definition_event.proto
+++ b/src/ray/protobuf/public/events_task_definition_event.proto
@@ -22,6 +22,8 @@ package ray.rpc.events;
 // Message containing the definition information of a task.
 // The message is expected to be emitted once per task attempt.
 message TaskDefinitionEvent {
+  reserved 8;
+  reserved "runtime_env_info";
   // task_id and task_attempt form the unique identifier of a task.
   bytes task_id = 1;
   int32 task_attempt = 2;
@@ -33,7 +35,6 @@ message TaskDefinitionEvent {
   FunctionDescriptor task_func = 5;
   string task_name = 6;
   map<string, double> required_resources = 7;
-  RuntimeEnvInfo runtime_env_info = 8 [deprecated = true];
 
   // The correlation ids of the task that can be used to correlate the task with
   // other events.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously we deprecated `runtime_env_info` field in Task and Actor definition events, for backwards compatibility we continued populating these fields in the proto objects. This pr stops populating the filed so that it is fully deprecated
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run pre-commit jobs to lint the changes in this PR. ([pre-commit setup](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
