### PR TITLE
Update documentation and hooks to use pre-commit instead of format.sh

### DIFF
--- a/ci/lint/pre-push
+++ b/ci/lint/pre-push
@@ -2,14 +2,14 @@
 
 echo "Linting changes as part of pre-push hook"
 echo ""
-echo "ci/lint/format.sh:"
-ci/lint/format.sh
+echo "pre-commit:"
+pre-commit run --from-ref master --to-ref HEAD
 
 lint_exit_status=$?
 if [ $lint_exit_status -ne 0 ]; then
 	echo ""
 	echo "Linting changes failed."
-	echo "Please make sure 'ci/lint/format.sh'"\
+	echo "Please make sure 'pre-commit'"\
 		"runs with no errors before pushing."
 	echo "If you want to ignore this and push anyways,"\
 		"re-run with '--no-verify'."

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -319,11 +319,12 @@ You can tweak the build with the following environment variables (when running `
 Installing additional dependencies for development
 --------------------------------------------------
 
-Dependencies for the linter (``scripts/format.sh``) can be installed with:
+Dependencies for the linter (``pre-commit``) can be installed with:
 
 .. code-block:: shell
 
- pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
+  pip install -c python/requirements_compiled.txt pre-commit
+  pre-commit install
 
 Dependencies for running Ray unit tests under ``python/ray/tests`` can be installed with:
 
@@ -336,12 +337,9 @@ Requirement files for running Ray Data / ML library tests are under ``python/req
 Pre-commit Hooks
 ----------------
 
-Ray is planning to replace the pre-push hooks that are invoked from ``scripts/format.sh`` with
-pre-commit hooks using `the pre-commit python package <https://pre-commit.com/>`_ in the future. At
-the moment, we have configured a ``.pre-commit-config.yaml`` which runs all the same checks done by
-``scripts/format.sh`` along with a few additional ones too. Currently this developer tooling is
-opt-in, with any formatting changes made by ``scripts/format.sh`` expected to be caught by
-``pre-commit`` as well. To start using ``pre-commit``:
+Ray uses pre-commit hooks via `the pre-commit python package <https://pre-commit.com/>`_.
+The ``.pre-commit-config.yaml`` file configures all the linting and formatting checks.
+To start using ``pre-commit``:
 
 .. code-block:: shell
 
@@ -356,8 +354,7 @@ you commit new code changes with git. To temporarily skip pre-commit checks, use
 
    git commit -n
 
-If you find that ``scripts/format.sh`` makes a change that is different from what ``pre-commit``
-does, please `report an issue here`_.
+If you encounter any issues with ``pre-commit``, please `report an issue here`_.
 
 .. _report an issue here: https://github.com/ray-project/ray/issues/new?template=bug-report.yml
 

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -337,7 +337,7 @@ Requirement files for running Ray Data / ML library tests are under ``python/req
 Pre-commit Hooks
 ----------------
 
-Ray uses pre-commit hooks via `the pre-commit python package <https://pre-commit.com/>`_.
+Ray uses pre-commit hooks with `the pre-commit python package <https://pre-commit.com/>`_.
 The ``.pre-commit-config.yaml`` file configures all the linting and formatting checks.
 To start using ``pre-commit``:
 

--- a/doc/source/ray-contribute/docs.md
+++ b/doc/source/ray-contribute/docs.md
@@ -100,7 +100,7 @@ It's considered good practice to check the output of your build to make sure eve
 
 Before committing any changes, make sure you run the
 [linter](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting)
-with `../scripts/format.sh` from the `doc` folder,
+with `pre-commit run` from the `doc` folder,
 to make sure your changes are formatted correctly.
 
 ### Code completion and other developer tooling

--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -260,7 +260,7 @@ An output like the following indicates failure:
    * branch                master     -> FETCH_HEAD
   python/ray/util/sgd/tf/tf_runner.py:4:1: F401 'numpy as np' imported but unused  # Below is the failure
 
-In addition, there are other formatting and semantic checkers for components like the following (not included in ``scripts/format.sh``):
+In addition, there are other formatting and semantic checkers for components like the following (not included in ``pre-commit``):
 
 * Python README format:
 


### PR DESCRIPTION
Update Ray documentation and pre-push hooks to standardize on pre-commit for linting and formatting.

## Summary

- Updated `ci/lint/pre-push` hook to use `pre-commit run` instead of `ci/lint/format.sh`
- Updated development documentation to reference `pre-commit` instead of `format.sh` for linting
- Removed language suggesting pre-commit is "opt-in" or "planned for the future" since it's now the standard approach
- Updated installation instructions to use `pre-commit install`

## Test plan

- Verified documentation changes are accurate
- Confirmed pre-commit configuration works correctly