### PR TITLE
[CI] Skip linux_wheels tests for Data-only changes

### DIFF
--- a/ci/pipeline/test_conditional_testing.py
+++ b/ci/pipeline/test_conditional_testing.py
@@ -16,7 +16,7 @@ _runfiles = runfiles.Create()
 
 _TESTS_YAML = """
 ci/pipeline/test_conditional_testing.py: lint tools
-python/ray/data/__init__.py: lint data linux_wheels ml train
+python/ray/data/__init__.py: lint data ml train
 doc/index.md: lint
 
 python/ray/air/__init__.py: lint ml train tune data linux_wheels

--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -39,7 +39,7 @@ ci/docker/data.build.wanda.yaml
 ci/docker/datan.build.wanda.yaml
 ci/docker/data9.build.wanda.yaml
 ci/docker/datal.build.wanda.yaml
-@ data ml train linux_wheels
+@ data ml train
 ;
 
 python/ray/workflow/


### PR DESCRIPTION
## Why are these changes needed?

This PR removes the `linux_wheels` tag from the `python/ray/data/` rule in `test_rules.txt`. This prevents Core and Serve wheel tests from running unnecessarily on Data-only changes, improving CI efficiency.

## What changes were made?

- Removed `linux_wheels` from the tags for `python/ray/data/` in `ci/pipeline/test_rules.txt`
- Data-only changes will now only trigger: `data`, `ml`, and `train` tests
- The `linux_wheels` tests will still run for changes to other components (Core, Serve, Tune, Train, Dashboard, etc.)

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. For example, if I added a
      method in Tune, I've added it in `doc/source/tune/api/` under the
      corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] This change only affects CI configuration, no code changes
   - [x] Will verify that Data-only changes no longer trigger linux_wheels tests