### PR TITLE
[train][doc] Document checkpoint_upload_fn

### DIFF
--- a/doc/source/train/doc_code/checkpoints.py
+++ b/doc/source/train/doc_code/checkpoints.py
@@ -497,3 +497,40 @@ def train_fn(config):
 
 
 # __checkpoint_upload_mode_no_upload_end__
+
+
+# __checkpoint_upload_function_start__
+
+from torch.distributed.checkpoint.state_dict_saver import async_save
+
+
+def train_fn(config):
+    ...
+    for epoch in config["num_epochs"]:
+        # Start async checkpoint upload to s3 with Torch
+        model, optimizer = ...
+        storage_context = ray.train.get_context().get_storage()
+        checkpoint_path = (
+            f"s3://{storage_context.build_checkpoint_path_from_name(str(epoch))}"
+        )
+        storage_writer = S3StorageWriter(region="us-west-2", path=checkpoint_path)
+        model_dict, opt_dict = get_state_dict(model=model, optimizers=optimizer)
+        ckpt_ref = async_save(
+            {"model": model_dict, "opt": opt_dict},
+            storage_writer=storage_writer,
+        )
+
+        def wait_async_save(checkpoint, checkpoint_dir):
+            ckpt_ref.result()
+            return checkpoint
+
+        # Ray Train kicks off a thread that waits for the async checkpoint upload to complete
+        # before reporting the checkpoint
+        metrics = {...}
+        checkpoint = Checkpoint(checkpoint_path)
+        ray.train.report(
+            metrics=metrics,
+            checkpoint=checkpoint,
+            checkpoint_upload_mode=train.CheckpointUploadMode.ASYNC,
+            checkpoint_upload_function=wait_async_save,
+        )

--- a/doc/source/train/doc_code/checkpoints.py
+++ b/doc/source/train/doc_code/checkpoints.py
@@ -534,3 +534,6 @@ def train_fn(config):
             checkpoint_upload_mode=train.CheckpointUploadMode.ASYNC,
             checkpoint_upload_function=wait_async_save,
         )
+
+
+# __checkpoint_upload_function_end__

--- a/doc/source/train/doc_code/checkpoints.py
+++ b/doc/source/train/doc_code/checkpoints.py
@@ -502,6 +502,11 @@ def train_fn(config):
 # __checkpoint_upload_function_start__
 
 from torch.distributed.checkpoint.state_dict_saver import async_save
+from s3torchconnector.dcp import S3StorageWriter
+from torch.distributed.checkpoint.state_dict import get_state_dict
+
+from ray import train
+from ray.train import Checkpoint
 
 
 def train_fn(config):
@@ -509,7 +514,7 @@ def train_fn(config):
     for epoch in config["num_epochs"]:
         # Start async checkpoint upload to s3 with Torch
         model, optimizer = ...
-        storage_context = ray.train.get_context().get_storage()
+        storage_context = train.get_context().get_storage()
         checkpoint_path = (
             f"s3://{storage_context.build_checkpoint_path_from_name(str(epoch))}"
         )
@@ -520,7 +525,8 @@ def train_fn(config):
             storage_writer=storage_writer,
         )
 
-        def wait_async_save(checkpoint, checkpoint_dir):
+        def wait_async_save(checkpoint, checkpoint_dir_name):
+            # This function waits for checkpoint to be finalized before returning it as is
             ckpt_ref.result()
             return checkpoint
 
@@ -528,7 +534,7 @@ def train_fn(config):
         # before reporting the checkpoint
         metrics = {...}
         checkpoint = Checkpoint(checkpoint_path)
-        ray.train.report(
+        train.report(
             metrics=metrics,
             checkpoint=checkpoint,
             checkpoint_upload_mode=train.CheckpointUploadMode.ASYNC,

--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -302,7 +302,7 @@ and ``checkpoint_dir_name`` passed to ``ray.train.report`` and returns the persi
 
     In your ``checkpoint_upload_fn``, you should not call ``ray.train.report``, which may
     lead to unexpected behavior. You should also avoid collective operations, such as
-    :func:`~ray.train.report` or ``get_state_dict``, which can easily lead to deadlocks.
+    :func:`~ray.train.report` or ``model.state_dict()``, which can cause deadlocks.
 
 .. _train-dl-configure-checkpoints:
 

--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -248,6 +248,8 @@ your ``storage_path``. This is equivalent to calling :func:`~ray.train.report` w
     :start-after: __checkpoint_upload_mode_sync_start__
     :end-before: __checkpoint_upload_mode_sync_end__
 
+.. _train-checkpoint-upload-mode-async:
+
 Asynchronous checkpoint uploading
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -288,7 +290,8 @@ the ``storage_path`` and then report a reference to the uploaded checkpoint with
     :end-before: __checkpoint_upload_mode_no_upload_end__
 
 If you want to upload the checkpoint manually or with a third-party library like above,
-but still want Ray Train to manage checkpoint upload threads for you, you can pass a
+but still want Ray Train to avoid OOM's by blocking until previous checkpoint upload threads
+complete as explained in :ref:`train-checkpoint-upload-mode-async`, you can pass a
 ``checkpoint_upload_fn`` to ``ray.train.report``. This function takes the ``Checkpoint``
 and ``checkpoint_dir_name`` passed to ``ray.train.report`` and returns the persisted
 ``Checkpoint``.
@@ -298,7 +301,7 @@ and ``checkpoint_dir_name`` passed to ``ray.train.report`` and returns the persi
     :start-after: __checkpoint_upload_function_start__
     :end-before: __checkpoint_upload_function_end__
 
-.. note::
+.. warning::
 
     In your ``checkpoint_upload_fn``, you should not call ``ray.train.report``, which may
     lead to unexpected behavior. You should also avoid collective operations, such as

--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -306,6 +306,13 @@ and returns the persisted ``Checkpoint``.
     lead to unexpected behavior. You should also avoid collective operations, such as
     :func:`~ray.train.report` or ``model.state_dict()``, which can cause deadlocks.
 
+.. note::
+
+    Do not pass a ``checkpoint_upload_fn`` with ``checkpoint_upload_mode=ray.train.CheckpointUploadMode.NO_UPLOAD``
+    because Ray Train will simply ignore ``checkpoint_upload_fn``. You can pass a ``checkpoint_upload_fn`` with
+    ``checkpoint_upload_mode=ray.train.CheckpointUploadMode.SYNC``, but this is equivalent to uploading the
+    checkpoint yourself and reporting the checkpoint with ``ray.train.CheckpointUploadMode.NO_UPLOAD``.
+
 .. _train-dl-configure-checkpoints:
 
 Configure checkpointing

--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -287,6 +287,23 @@ the ``storage_path`` and then report a reference to the uploaded checkpoint with
     :start-after: __checkpoint_upload_mode_no_upload_start__
     :end-before: __checkpoint_upload_mode_no_upload_end__
 
+If you want to upload the checkpoint manually or with a third-party library like above,
+but still want Ray Train to manage checkpoint upload threads for you, you can pass a
+``checkpoint_upload_fn`` to ``ray.train.report``. This function takes the ``Checkpoint``
+and ``checkpoint_dir_name`` passed to ``ray.train.report`` and returns the persisted
+``Checkpoint``.
+
+.. literalinclude:: ../doc_code/checkpoints.py
+    :language: python
+    :start-after: __checkpoint_upload_function_start__
+    :end-before: __checkpoint_upload_function_end__
+
+.. note::
+
+    In your ``checkpoint_upload_fn``, you should not call ``ray.train.report``, which may
+    lead to unexpected behavior. You should also avoid collective operations, such as
+    :func:`~ray.train.report` or ``get_state_dict``, which can easily lead to deadlocks.
+
 .. _train-dl-configure-checkpoints:
 
 Configure checkpointing

--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -298,10 +298,10 @@ you have the following options:
 
     .. tab-item:: Asynchronous
 
-         If you want to upload the checkpoint asynchronously, you can set ``checkpoint_upload_mode``
-         to ``ray.train.CheckpointUploadMode.ASYNC`` and pass a ``checkpoint_upload_fn`` to
-         ``ray.train.report``. This function takes the ``Checkpoint`` and ``checkpoint_dir_name``
-         passed to ``ray.train.report`` and returns the persisted ``Checkpoint``.
+        If you want to upload the checkpoint asynchronously, you can set ``checkpoint_upload_mode``
+        to ``ray.train.CheckpointUploadMode.ASYNC`` and pass a ``checkpoint_upload_fn`` to
+        ``ray.train.report``. This function takes the ``Checkpoint`` and ``checkpoint_dir_name``
+        passed to ``ray.train.report`` and returns the persisted ``Checkpoint``.
 
         .. literalinclude:: ../doc_code/checkpoints.py
             :language: python

--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -280,38 +280,46 @@ Custom checkpoint uploading
 :func:`~ray.train.report` defaults to uploading from disk to the remote ``storage_path``
 with the PyArrow filesystem copying utilities before reporting the checkpoint to Ray Train.
 If you would rather upload the checkpoint manually or with a third-party library
-such as `Torch Distributed Checkpointing <https://docs.pytorch.org/docs/stable/distributed.checkpoint.html>`_, you can first upload the checkpoint to
-the ``storage_path`` and then report a reference to the uploaded checkpoint with
-``ray.train.CheckpointUploadMode.NO_UPLOAD``.
+such as `Torch Distributed Checkpointing <https://docs.pytorch.org/docs/stable/distributed.checkpoint.html>`_,
+you have the following options:
 
-.. literalinclude:: ../doc_code/checkpoints.py
-    :language: python
-    :start-after: __checkpoint_upload_mode_no_upload_start__
-    :end-before: __checkpoint_upload_mode_no_upload_end__
+.. tab-set::
 
-If you want to upload the checkpoint manually or with a third-party library like above,
-but still want Ray Train to do so asynchronously, you can set ``checkpoint_upload_mode`` to
-``ray.train.CheckpointUploadMode.ASYNC`` and pass a ``checkpoint_upload_fn`` to ``ray.train.report``.
-This function takes the ``Checkpoint`` and ``checkpoint_dir_name`` passed to ``ray.train.report``
-and returns the persisted ``Checkpoint``.
+    .. tab-item:: Synchronous
 
-.. literalinclude:: ../doc_code/checkpoints.py
-    :language: python
-    :start-after: __checkpoint_upload_function_start__
-    :end-before: __checkpoint_upload_function_end__
+        If you want to upload the checkpoint synchronously, you can first upload the checkpoint
+        to the ``storage_path``and then report a reference to the uploaded checkpoint with
+        ``ray.train.CheckpointUploadMode.NO_UPLOAD``.
 
-.. warning::
+        .. literalinclude:: ../doc_code/checkpoints.py
+            :language: python
+            :start-after: __checkpoint_upload_mode_no_upload_start__
+            :end-before: __checkpoint_upload_mode_no_upload_end__
 
-    In your ``checkpoint_upload_fn``, you should not call ``ray.train.report``, which may
-    lead to unexpected behavior. You should also avoid collective operations, such as
-    :func:`~ray.train.report` or ``model.state_dict()``, which can cause deadlocks.
+    .. tab-item:: Asynchronous
 
-.. note::
+         If you want to upload the checkpoint asynchronously, you can set ``checkpoint_upload_mode``
+         to ``ray.train.CheckpointUploadMode.ASYNC`` and pass a ``checkpoint_upload_fn`` to
+         ``ray.train.report``. This function takes the ``Checkpoint`` and ``checkpoint_dir_name``
+         passed to ``ray.train.report`` and returns the persisted ``Checkpoint``.
 
-    Do not pass a ``checkpoint_upload_fn`` with ``checkpoint_upload_mode=ray.train.CheckpointUploadMode.NO_UPLOAD``
-    because Ray Train will simply ignore ``checkpoint_upload_fn``. You can pass a ``checkpoint_upload_fn`` with
-    ``checkpoint_upload_mode=ray.train.CheckpointUploadMode.SYNC``, but this is equivalent to uploading the
-    checkpoint yourself and reporting the checkpoint with ``ray.train.CheckpointUploadMode.NO_UPLOAD``.
+        .. literalinclude:: ../doc_code/checkpoints.py
+            :language: python
+            :start-after: __checkpoint_upload_function_start__
+            :end-before: __checkpoint_upload_function_end__
+
+        .. warning::
+
+            In your ``checkpoint_upload_fn``, you should not call ``ray.train.report``, which may
+            lead to unexpected behavior. You should also avoid collective operations, such as
+            :func:`~ray.train.report` or ``model.state_dict()``, which can cause deadlocks.
+
+        .. note::
+
+            Do not pass a ``checkpoint_upload_fn`` with ``checkpoint_upload_mode=ray.train.CheckpointUploadMode.NO_UPLOAD``
+            because Ray Train will simply ignore ``checkpoint_upload_fn``. You can pass a ``checkpoint_upload_fn`` with
+            ``checkpoint_upload_mode=ray.train.CheckpointUploadMode.SYNC``, but this is equivalent to uploading the
+            checkpoint yourself and reporting the checkpoint with ``ray.train.CheckpointUploadMode.NO_UPLOAD``.
 
 .. _train-dl-configure-checkpoints:
 

--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -290,11 +290,10 @@ the ``storage_path`` and then report a reference to the uploaded checkpoint with
     :end-before: __checkpoint_upload_mode_no_upload_end__
 
 If you want to upload the checkpoint manually or with a third-party library like above,
-but still want Ray Train to avoid OOM's by blocking until previous checkpoint upload threads
-complete as explained in :ref:`train-checkpoint-upload-mode-async`, you can pass a
-``checkpoint_upload_fn`` to ``ray.train.report``. This function takes the ``Checkpoint``
-and ``checkpoint_dir_name`` passed to ``ray.train.report`` and returns the persisted
-``Checkpoint``.
+but still want Ray Train to do so asynchronously, you can set ``checkpoint_upload_mode`` to
+``ray.train.CheckpointUploadMode.ASYNC`` and pass a ``checkpoint_upload_fn`` to ``ray.train.report``.
+This function takes the ``Checkpoint`` and ``checkpoint_dir_name`` passed to ``ray.train.report``
+and returns the persisted ``Checkpoint``.
 
 .. literalinclude:: ../doc_code/checkpoints.py
     :language: python


### PR DESCRIPTION
# Summary

This PR adds documentation to the OSS Ray Train Checkpointing User Guide that describes how to upload a checkpoint with third party utilities synchronously or asynchronously with code examples.

# Testing

docbuild