### PR TITLE
[runtime env] properly support apple silicon wheel urls

### DIFF
--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import logging
 import os
-import platform
 import runpy
 import shutil
 import subprocess
@@ -111,10 +110,6 @@ def _current_py_version():
     return ".".join(map(str, sys.version_info[:3]))  # like 3.6.10
 
 
-def _is_m1_mac():
-    return sys.platform == "darwin" and platform.machine() == "arm64"
-
-
 def current_ray_pip_specifier(
     logger: Optional[logging.Logger] = default_logger,
 ) -> Optional[str]:
@@ -148,17 +143,9 @@ def current_ray_pip_specifier(
         return None
     elif "dev" in ray.__version__:
         # Running on a nightly wheel.
-        if _is_m1_mac():
-            raise ValueError("Nightly wheels are not available for M1 Macs.")
         return get_master_wheel_url()
     else:
-        if _is_m1_mac():
-            # M1 Mac release wheels are currently not uploaded to AWS S3; they
-            # are only available on PyPI.  So unfortunately, this codepath is
-            # not end-to-end testable prior to the release going live on PyPI.
-            return f"ray=={ray.__version__}"
-        else:
-            return get_release_wheel_url()
+        return get_release_wheel_url()
 
 
 def inject_dependencies(

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -947,28 +947,25 @@ def get_wheel_filename(
 
     architecture = architecture or platform.processor()
 
-    if py_version_str in ["311", "310", "39", "38"] and architecture == "arm64":
-        darwin_os_string = "macosx_12_0_arm64"
-    else:
-        darwin_os_string = "macosx_12_0_x86_64"
+    assert sys_platform in ["darwin", "linux", "win32"], sys_platform
 
-    if architecture == "aarch64":
-        linux_os_string = "manylinux2014_aarch64"
-    else:
-        linux_os_string = "manylinux2014_x86_64"
-
-    os_strings = {
-        "darwin": darwin_os_string,
-        "linux": linux_os_string,
-        "win32": "win_amd64",
-    }
-
-    assert sys_platform in os_strings, sys_platform
+    if sys_platform == "darwin":
+        if architecture == "x86_64":
+            os_string = "macosx_12_0_x86_64"
+        else:
+            os_string = "macosx_12_0_arm64"
+    elif sys_platform == "linux":
+        if architecture == "aarch64" or architecture == "arm64":
+            os_string = "manylinux2014_aarch64"
+        else:
+            os_string = "manylinux2014_x86_64"
+    elif sys_platform == "win32":
+        os_string = "win_amd64"
 
     wheel_filename = (
         f"ray-{ray_version}-cp{py_version_str}-"
         f"cp{py_version_str}{'m' if py_version_str in ['37'] else ''}"
-        f"-{os_strings[sys_platform]}.whl"
+        f"-{os_string}.whl"
     )
 
     return wheel_filename

--- a/python/ray/tests/test_runtime_env_get_wheel_names.py
+++ b/python/ray/tests/test_runtime_env_get_wheel_names.py
@@ -17,6 +17,13 @@ def test_get_wheel_filename():
     ray_version = "3.0.0.dev0"
     for arch in ["x86_64", "aarch64", "arm64"]:
         for sys_platform in ["darwin", "linux", "win32"]:
+            # Windows only has x86_64 wheels
+            if sys_platform == "win32" and arch != "x86_64":
+                continue
+            # MacOS only has arm64 wheels
+            if sys_platform == "darwin" and arch == "x86_64":
+                continue
+
             for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
                 filename = get_wheel_filename(
                     sys_platform, ray_version, py_version, arch
@@ -35,8 +42,8 @@ def test_get_master_wheel_url():
     # `s3://ray-wheels/master/<test_commit>/`.
     #
     # Link to commit:
-    # https://github.com/ray-project/ray/commit/263c7e1e66746c03f16e8ee20753d05a9936f6f0
-    test_commit = "263c7e1e66746c03f16e8ee20753d05a9936f6f0"
+    # https://github.com/ray-project/ray/commit/faf06e09e55558fb36c72e91a5cf8a7e3da8b8c6
+    test_commit = "faf06e09e55558fb36c72e91a5cf8a7e3da8b8c6"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             url = get_master_wheel_url(
@@ -50,7 +57,7 @@ def test_get_release_wheel_url():
     # This should be a commit for which wheels have already been built for
     # all platforms and python versions at
     # `s3://ray-wheels/releases/2.2.0/<commit>/`.
-    test_commits = {"2.47.1": "61d3f2f1aa33563faa398105f4abda88cb39440b"}
+    test_commits = {"2.49.2": "479fa716904109d9df4b56b98ca3c3350e1ec13c"}
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             for version, commit in test_commits.items():


### PR DESCRIPTION
and update commits used in tests

also stops testing x86_64 osx wheels on "latest", those are deprecated.