### PR TITLE
[core] Fix deadlock when cancelling stale requests on in-order actors

### DIFF
--- a/python/ray/tests/test_core_worker_fault_tolerance.py
+++ b/python/ray/tests/test_core_worker_fault_tolerance.py
@@ -14,7 +14,7 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
     [True, False],
 )
 @pytest.mark.parametrize("deterministic_failure", ["request", "response"])
-def test_transient_error_retry(
+def test_push_actor_task_failure(
     monkeypatch,
     ray_start_cluster,
     allow_out_of_order_execution: bool,

--- a/python/ray/tests/test_core_worker_fault_tolerance.py
+++ b/python/ray/tests/test_core_worker_fault_tolerance.py
@@ -1,8 +1,87 @@
+import sys
+
+import numpy as np
 import pytest
 
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray.core.generated import common_pb2, gcs_pb2
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+
+@pytest.mark.parametrize(
+    "allow_out_of_order_execution",
+    [True, False],
+)
+@pytest.mark.parametrize("deterministic_failure", ["request", "response"])
+def test_transient_error_retry(
+    monkeypatch,
+    ray_start_cluster,
+    allow_out_of_order_execution: bool,
+    deterministic_failure: str,
+):
+    with monkeypatch.context() as m:
+        m.setenv(
+            "RAY_testing_rpc_failure",
+            "CoreWorkerService.grpc_client.PushTask=2:"
+            + ("100:0" if deterministic_failure == "request" else "0:100"),
+        )
+        m.setenv("RAY_actor_scheduling_queue_max_reorder_wait_seconds", "0")
+        cluster = ray_start_cluster
+        cluster.add_node(num_cpus=1)
+        ray.init(address=cluster.address)
+
+        @ray.remote(
+            max_task_retries=-1,
+            allow_out_of_order_execution=allow_out_of_order_execution,
+        )
+        class RetryActor:
+            def echo(self, value):
+                return value
+
+        refs = []
+        actor = RetryActor.remote()
+        for i in range(10):
+            refs.append(actor.echo.remote(i))
+        assert ray.get(refs) == list(range(10))
+
+
+@pytest.mark.parametrize("deterministic_failure", ["request", "response"])
+def test_update_object_location_batch_failure(
+    monkeypatch, ray_start_cluster, deterministic_failure
+):
+    with monkeypatch.context() as m:
+        m.setenv(
+            "RAY_testing_rpc_failure",
+            "CoreWorkerService.grpc_client.UpdateObjectLocationBatch=1:"
+            + ("100:0" if deterministic_failure == "request" else "0:100"),
+        )
+        cluster = ray_start_cluster
+        head_node_id = cluster.add_node(
+            num_cpus=0,
+        ).node_id
+        ray.init(address=cluster.address)
+        worker_node_id = cluster.add_node(num_cpus=1).node_id
+
+        @ray.remote(num_cpus=1)
+        def create_large_object():
+            return np.zeros(100 * 1024 * 1024, dtype=np.uint8)
+
+        @ray.remote(num_cpus=0)
+        def consume_large_object(obj):
+            return sys.getsizeof(obj)
+
+        obj_ref = create_large_object.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                node_id=worker_node_id, soft=False
+            )
+        ).remote()
+        consume_ref = consume_large_object.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                node_id=head_node_id, soft=False
+            )
+        ).remote(obj_ref)
+        assert ray.get(consume_ref, timeout=10) > 0
 
 
 @pytest.mark.parametrize("deterministic_failure", ["request", "response"])

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -17,7 +17,6 @@ from ray._private.test_utils import (
     init_error_pubsub,
 )
 from ray.exceptions import ActorDiedError, GetTimeoutError, RayActorError, RayTaskError
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 
 def test_unhandled_errors(ray_start_regular):
@@ -686,81 +685,6 @@ def test_final_user_exception(ray_start_regular, propagate_logs, caplog):
     assert str(exc_info.value.cause) == "MyFinalException from task"
 
     caplog.clear()
-
-
-@pytest.mark.parametrize(
-    "allow_out_of_order_execution",
-    [True, False],
-)
-@pytest.mark.parametrize("deterministic_failure", ["request", "response"])
-def test_transient_error_retry(
-    monkeypatch,
-    ray_start_cluster,
-    allow_out_of_order_execution: bool,
-    deterministic_failure: str,
-):
-    with monkeypatch.context() as m:
-        m.setenv(
-            "RAY_testing_rpc_failure",
-            "CoreWorkerService.grpc_client.PushTask=2:"
-            + ("100:0" if deterministic_failure == "request" else "0:100"),
-        )
-        m.setenv("RAY_actor_scheduling_queue_max_reorder_wait_seconds", "0")
-        cluster = ray_start_cluster
-        cluster.add_node(num_cpus=1)
-        ray.init(address=cluster.address)
-
-        @ray.remote(
-            max_task_retries=-1,
-            allow_out_of_order_execution=allow_out_of_order_execution,
-        )
-        class RetryActor:
-            def echo(self, value):
-                return value
-
-        refs = []
-        actor = RetryActor.remote()
-        for i in range(10):
-            refs.append(actor.echo.remote(i))
-        assert ray.get(refs) == list(range(10))
-
-
-@pytest.mark.parametrize("deterministic_failure", ["request", "response"])
-def test_update_object_location_batch_failure(
-    monkeypatch, ray_start_cluster, deterministic_failure
-):
-    with monkeypatch.context() as m:
-        m.setenv(
-            "RAY_testing_rpc_failure",
-            "CoreWorkerService.grpc_client.UpdateObjectLocationBatch=1:"
-            + ("100:0" if deterministic_failure == "request" else "0:100"),
-        )
-        cluster = ray_start_cluster
-        head_node_id = cluster.add_node(
-            num_cpus=0,
-        ).node_id
-        ray.init(address=cluster.address)
-        worker_node_id = cluster.add_node(num_cpus=1).node_id
-
-        @ray.remote(num_cpus=1)
-        def create_large_object():
-            return np.zeros(100 * 1024 * 1024, dtype=np.uint8)
-
-        @ray.remote(num_cpus=0)
-        def consume_large_object(obj):
-            return sys.getsizeof(obj)
-
-        obj_ref = create_large_object.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(
-                node_id=worker_node_id, soft=False
-            )
-        ).remote()
-        consume_ref = consume_large_object.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(
-                node_id=head_node_id, soft=False
-            )
-        ).remote(obj_ref)
-        assert ray.get(consume_ref, timeout=10) > 0
 
 
 def test_raytaskerror_serialization(ray_start_regular):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -689,9 +689,8 @@ def test_final_user_exception(ray_start_regular, propagate_logs, caplog):
 
 
 @pytest.mark.parametrize(
-    # TODO(dayshah): add `False` variant once in-order is fixed.
     "allow_out_of_order_execution",
-    [True],
+    [True, False],
 )
 @pytest.mark.parametrize("deterministic_failure", ["request", "response"])
 def test_transient_error_retry(
@@ -701,7 +700,6 @@ def test_transient_error_retry(
     deterministic_failure: str,
 ):
     with monkeypatch.context() as m:
-        # This test submits 200 tasks with infinite retries and verifies that all tasks eventually succeed in the unstable network environment.
         m.setenv(
             "RAY_testing_rpc_failure",
             "CoreWorkerService.grpc_client.PushTask=2:"

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -104,10 +104,8 @@ class TaskReceiver {
   void SetActorReprName(const std::string &repr_name);
 
  private:
-  /// Guard for shutdown state.
-  absl::Mutex stop_mu_;
   // True once shutdown begins. Requests to execute new tasks will be rejected.
-  bool stopping_ ABSL_GUARDED_BY(stop_mu_) = false;
+  std::atomic<bool> stopping_ = false;
   /// Set up the configs for an actor.
   /// This should be called once for the actor creation task.
   void SetupActor(bool is_asyncio,


### PR DESCRIPTION
### Problem
Today we hold `stop_mu` while calling into `ActorSchedulingQueue::Add`. This calls into `ActorSchedulingQueue::ScheduleRequests` which can potentially cancel and therefore call the cancel callback which also tries to acquire `stop_mu` in the same call stack.

Cancel inside `ActorSchedulingQueue::ScheduleRequests`
https://github.com/ray-project/ray/blob/c6b8c9f41bd6e7f816be22d7a2c7ae07a2468c45/src/ray/core_worker/task_execution/actor_scheduling_queue.cc#L174

cancel_callback grabbing `stop_mu`
https://github.com/ray-project/ray/blob/c6b8c9f41bd6e7f816be22d7a2c7ae07a2468c45/src/ray/core_worker/task_execution/task_receiver.cc#L176

Grabbing `stop_mu` in `TaskReceiver::HandleTask` which eventually leads into `ActorSchedulingQueue::ScheduleRequests`
https://github.com/ray-project/ray/blob/c6b8c9f41bd6e7f816be22d7a2c7ae07a2468c45/src/ray/core_worker/task_execution/task_receiver.cc#L195


### Solution
The solution here is just to turn `stopping_` into an atomic bool. The mutex only exists to protect this.

#### Extra
- Renaming `test_transient_error_retry` to `test_push_actor_task_failure` and moving it and `test_update_object_location_batch_failure` to test_core_worker_fault_tolerance
- out_of_order=False case for the push task failure test
