### PR TITLE
[ci] shorten Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- Thank you for contributing to Ray! 🚀 -->
-<!-- Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
+<!-- Please review https://docs.ray.io/en/master/ray-contribute/getting-involved.html before opening a pull request. -->
 <!-- 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete -->
 
 ## Description
@@ -10,36 +10,6 @@
 
 <!-- Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234" -->
 
-## Types of change
+## Additional information
 
-- [ ] Bug fix 🐛
-- [ ] New feature ✨
-- [ ] Enhancement 🚀
-- [ ] Code refactoring 🔧
-- [ ] Documentation update 📖
-- [ ] Chore 🧹
-- [ ] Style 🎨
-
-## Checklist
-
-**Does this PR introduce breaking changes?**
-- [ ] Yes ⚠️
-- [ ] No
-<!-- If yes, describe what breaks and how users should migrate -->
-
-**Testing:**
-- [ ] Added/updated tests for my changes
-- [ ] Tested the changes manually
-- [ ] This PR is not tested ❌ _(please explain why)_
-
-**Code Quality:**
-- [ ] Signed off every commit (`git commit -s`)
-- [ ] Ran pre-commit hooks ([setup guide](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))
-
-**Documentation:**
-- [ ] Updated documentation (if applicable) ([contribution guide](https://docs.ray.io/en/latest/ray-contribute/docs.html))
-- [ ] Added new APIs to `doc/source/` (if applicable)
-
-## Additional context
-
-<!-- Optional: Add screenshots, examples, performance impact, breaking change details -->
+<!-- Optional: Add implementation details, API changes, usage examples, screenshots, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,13 +3,10 @@
 <!-- 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete -->
 
 ## Description
-
 <!-- Briefly describe what this PR accomplishes and why it's needed -->
 
 ## Related issues
-
 <!-- Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234" -->
 
 ## Additional information
-
 <!-- Optional: Add implementation details, API changes, usage examples, screenshots, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
-<!-- Thank you for contributing to Ray! 🚀 -->
-<!-- Please review https://docs.ray.io/en/master/ray-contribute/getting-involved.html before opening a pull request. -->
-<!-- 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete -->
+> Thank you for contributing to Ray! 🚀
+> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.
+
+> ⚠️ Remove these instructions before submitting your PR.
+
+> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.
 
 ## Description
-<!-- Briefly describe what this PR accomplishes and why it's needed -->
+> Briefly describe what this PR accomplishes and why it's needed.
 
 ## Related issues
-<!-- Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234" -->
+> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".
 
 ## Additional information
-<!-- Optional: Add implementation details, API changes, usage examples, screenshots, etc. -->
+> Optional: Add implementation details, API changes, usage examples, screenshots, etc.


### PR DESCRIPTION
## Description
Shortening the template per @edoakes' feedback.

## Related issues
Follow-up to https://github.com/ray-project/ray/pull/57193.

## Additional information
Made the following changes:
1. Removed `Types of change` and `Checklist`.
2. Updated contribution guide to point to Ray Docs.
3. Renamed `Additional context` to `Additional information` to be more encompassing.