### PR TITLE
[Data] Make hash shuffle `Aggregator` execute out-of-order by default

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -529,7 +529,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
                 input_logical_ops,
             )
 
-        default_ray_remote_args = self._get_default_aggregator_ray_remote_args(
+        ray_remote_args = self._get_default_aggregator_ray_remote_args(
             num_partitions=target_num_partitions,
             num_aggregators=num_aggregators,
             total_available_cluster_resources=total_available_cluster_resources,
@@ -538,18 +538,13 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
 
         if aggregator_ray_remote_args_override is not None:
             # Set default values missing for configs missing in the override
-            for k, v in default_ray_remote_args.items():
-                aggregator_ray_remote_args_override.setdefault(k, v)
-
-            final_ray_remote_args = aggregator_ray_remote_args_override
-        else:
-            final_ray_remote_args = default_ray_remote_args
+            ray_remote_args.update(aggregator_ray_remote_args_override)
 
         self._aggregator_pool: AggregatorPool = AggregatorPool(
             num_partitions=target_num_partitions,
             num_aggregators=num_aggregators,
             aggregation_factory=partition_aggregation_factory,
-            aggregator_ray_remote_args=final_ray_remote_args,
+            aggregator_ray_remote_args=ray_remote_args,
             data_context=data_context,
         )
 

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1088,6 +1088,9 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
             #       nodes to prevent any single node being overloaded with a "thundering
             #       herd"
             "scheduling_strategy": "SPREAD",
+            # Allow actor tasks to execute out of order by default to prevent head-of-line
+            # blocking scenario.
+            "allow_out_of_order_execution": True,
         }
 
         return remote_args

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -529,19 +529,27 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
                 input_logical_ops,
             )
 
+        default_ray_remote_args = self._get_default_aggregator_ray_remote_args(
+            num_partitions=target_num_partitions,
+            num_aggregators=num_aggregators,
+            total_available_cluster_resources=total_available_cluster_resources,
+            estimated_dataset_bytes=estimated_dataset_bytes,
+        )
+
+        if aggregator_ray_remote_args_override is not None:
+            # Set default values missing for configs missing in the override
+            for k, v in default_ray_remote_args.items():
+                aggregator_ray_remote_args_override.setdefault(k, v)
+
+            final_ray_remote_args = aggregator_ray_remote_args_override
+        else:
+            final_ray_remote_args = default_ray_remote_args
+
         self._aggregator_pool: AggregatorPool = AggregatorPool(
             num_partitions=target_num_partitions,
             num_aggregators=num_aggregators,
             aggregation_factory=partition_aggregation_factory,
-            aggregator_ray_remote_args=(
-                aggregator_ray_remote_args_override
-                or self._get_default_aggregator_ray_remote_args(
-                    num_partitions=target_num_partitions,
-                    num_aggregators=num_aggregators,
-                    total_available_cluster_resources=total_available_cluster_resources,
-                    estimated_dataset_bytes=estimated_dataset_bytes,
-                )
-            ),
+            aggregator_ray_remote_args=final_ray_remote_args,
             data_context=data_context,
         )
 


### PR DESCRIPTION
<!-- Thank you for contributing to Ray! 🚀 -->
<!-- Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
<!-- 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete -->

## Description

This change would allow `Aggregator` actor to execute tasks out of order to avoid head-of-line blocking scenario.

Also, made sure that overridden Ray remote args are applied as an overlay on top of default ones.

## Related issues

<!-- Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234" -->

## Types of change

- [ ] Bug fix 🐛
- [ ] New feature ✨
- [ ] Enhancement 🚀
- [ ] Code refactoring 🔧
- [ ] Documentation update 📖
- [ ] Chore 🧹
- [ ] Style 🎨

## Checklist

**Does this PR introduce breaking changes?**
- [ ] Yes ⚠️
- [ ] No
<!-- If yes, describe what breaks and how users should migrate -->

**Testing:**
- [ ] Added/updated tests for my changes
- [ ] Tested the changes manually
- [ ] This PR is not tested ❌ _(please explain why)_

**Code Quality:**
- [ ] Signed off every commit (`git commit -s`)
- [ ] Ran pre-commit hooks ([setup guide](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))

**Documentation:**
- [ ] Updated documentation (if applicable) ([contribution guide](https://docs.ray.io/en/latest/ray-contribute/docs.html))
- [ ] Added new APIs to `doc/source/` (if applicable)

## Additional context

<!-- Optional: Add screenshots, examples, performance impact, breaking change details -->
