### PR TITLE
[train] Create top-level ray.train aliases for public APIs

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -61,7 +61,7 @@ TEAM_API_CONFIGS = {
             # NOTE: These APIs are documented in a separate file (deprecated.rst).
             # These are deprecated APIs, so just white-listing them here for CI.
             "ray.train.error.SessionMisuseError",
-            "ray.train.base_trainer.TrainingFailedError",
+            "ray.train.TrainingFailedError",
             "ray.train.context.TrainContext",
         },
     },

--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -136,7 +136,7 @@ Ray Train Utilities
 
     ~train.Checkpoint
     ~train.CheckpointUploadMode
-    ~train.v2.api.context.TrainContext
+    ~train.TrainContext
 
 **Functions**
 

--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -178,8 +178,9 @@ Ray Train Errors
     :template: autosummary/class_without_autosummary.rst
     :toctree: doc/
 
-    ~train.v2.api.exceptions.ControllerError
-    ~train.v2.api.exceptions.WorkerGroupError
+    ~train.ControllerError
+    ~train.WorkerGroupError
+    ~train.TrainingFailedError
 
 Ray Tune Integration Utilities
 ------------------------------

--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -180,7 +180,7 @@ Ray Train Errors
 
     ~train.ControllerError
     ~train.WorkerGroupError
-    ~train.TrainingFailedError
+    ~train.v2.api.exceptions.TrainingFailedError
 
 Ray Tune Integration Utilities
 ------------------------------

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -23,7 +23,7 @@ from ray.train._internal.session import get_checkpoint, get_dataset_shard, repor
 from ray.train._internal.syncer import SyncConfig
 from ray.train.backend import BackendConfig
 from ray.train.constants import TRAIN_DATASET_KEY
-from ray.train.context import get_context
+from ray.train.context import TrainContext, get_context
 from ray.train.trainer import TrainingIterator
 from ray.train.v2._internal.constants import is_v2_enabled
 
@@ -41,6 +41,7 @@ if is_v2_enabled():
         RunConfig,
         ScalingConfig,
     )
+    from ray.train.v2.api.context import TrainContext  # noqa: F811
     from ray.train.v2.api.report_config import CheckpointUploadMode  # noqa: F811
     from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint  # noqa: F811
     from ray.train.v2.api.result import Result  # noqa: F811
@@ -84,6 +85,7 @@ Result.__module__ = "ray.train"
 RunConfig.__module__ = "ray.train"
 ScalingConfig.__module__ = "ray.train"
 SyncConfig.__module__ = "ray.train"
+TrainContext.__module__ = "ray.train"
 TrainingIterator.__module__ = "ray.train"
 
 # TODO: consider implementing these in v1 and raising ImportError instead.

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -22,6 +22,7 @@ from ray.train._internal.data_config import DataConfig
 from ray.train._internal.session import get_checkpoint, get_dataset_shard, report
 from ray.train._internal.syncer import SyncConfig
 from ray.train.backend import BackendConfig
+from ray.train.base_trainer import TrainingFailedError
 from ray.train.constants import TRAIN_DATASET_KEY
 from ray.train.context import TrainContext, get_context
 from ray.train.trainer import TrainingIterator
@@ -42,6 +43,11 @@ if is_v2_enabled():
         ScalingConfig,
     )
     from ray.train.v2.api.context import TrainContext  # noqa: F811
+    from ray.train.v2.api.exceptions import (  # noqa: F811
+        ControllerError,
+        TrainingFailedError,
+        WorkerGroupError,
+    )
     from ray.train.v2.api.report_config import CheckpointUploadMode  # noqa: F811
     from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint  # noqa: F811
     from ray.train.v2.api.result import Result  # noqa: F811
@@ -68,6 +74,8 @@ __all__ = [
     "RunConfig",
     "ScalingConfig",
     "SyncConfig",
+    "TrainContext",
+    "TrainingFailedError",
     "TrainingIterator",
     "TRAIN_DATASET_KEY",
 ]
@@ -86,18 +94,30 @@ RunConfig.__module__ = "ray.train"
 ScalingConfig.__module__ = "ray.train"
 SyncConfig.__module__ = "ray.train"
 TrainContext.__module__ = "ray.train"
+TrainingFailedError.__module__ = "ray.train"
 TrainingIterator.__module__ = "ray.train"
 
 # TODO: consider implementing these in v1 and raising ImportError instead.
 if is_v2_enabled():
-    __all__.append("UserCallback")
-    UserCallback.__module__ = "ray.train"
-    __all__.append("CheckpointUploadMode")
+    __all__.extend(
+        [
+            "CheckpointUploadMode",
+            "ControllerError",
+            "ReportedCheckpoint",
+            "TrainingFailedError",
+            "UserCallback",
+            "WorkerGroupError",
+            "get_all_reported_checkpoints",
+        ]
+    )
+
     CheckpointUploadMode.__module__ = "ray.train"
-    __all__.append("get_all_reported_checkpoints")
-    get_all_reported_checkpoints.__module__ = "ray.train"
-    __all__.append("ReportedCheckpoint")
+    ControllerError.__module__ = "ray.train"
     ReportedCheckpoint.__module__ = "ray.train"
+    TrainingFailedError.__module__ = "ray.train"
+    UserCallback.__module__ = "ray.train"
+    WorkerGroupError.__module__ = "ray.train"
+    get_all_reported_checkpoints.__module__ = "ray.train"
 
 
 # DO NOT ADD ANYTHING AFTER THIS LINE.

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -25,7 +25,6 @@ from ray.train.backend import BackendConfig
 from ray.train.base_trainer import TrainingFailedError
 from ray.train.constants import TRAIN_DATASET_KEY
 from ray.train.context import TrainContext, get_context
-from ray.train.trainer import TrainingIterator
 from ray.train.v2._internal.constants import is_v2_enabled
 
 if is_v2_enabled():
@@ -76,7 +75,6 @@ __all__ = [
     "SyncConfig",
     "TrainContext",
     "TrainingFailedError",
-    "TrainingIterator",
     "TRAIN_DATASET_KEY",
 ]
 
@@ -95,7 +93,6 @@ ScalingConfig.__module__ = "ray.train"
 SyncConfig.__module__ = "ray.train"
 TrainContext.__module__ = "ray.train"
 TrainingFailedError.__module__ = "ray.train"
-TrainingIterator.__module__ = "ray.train"
 
 # TODO: consider implementing these in v1 and raising ImportError instead.
 if is_v2_enabled():
@@ -104,7 +101,6 @@ if is_v2_enabled():
             "CheckpointUploadMode",
             "ControllerError",
             "ReportedCheckpoint",
-            "TrainingFailedError",
             "UserCallback",
             "WorkerGroupError",
             "get_all_reported_checkpoints",
@@ -114,7 +110,6 @@ if is_v2_enabled():
     CheckpointUploadMode.__module__ = "ray.train"
     ControllerError.__module__ = "ray.train"
     ReportedCheckpoint.__module__ = "ray.train"
-    TrainingFailedError.__module__ = "ray.train"
     UserCallback.__module__ = "ray.train"
     WorkerGroupError.__module__ = "ray.train"
     get_all_reported_checkpoints.__module__ = "ray.train"

--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -6,7 +6,7 @@ import ray
 from ray._private.ray_constants import env_integer
 from ray._private.thirdparty.tabulate.tabulate import tabulate
 from ray.air.config import RunConfig, ScalingConfig
-from ray.train import BackendConfig, Checkpoint, TrainingIterator
+from ray.train import BackendConfig, Checkpoint
 from ray.train._internal import session
 from ray.train._internal.backend_executor import BackendExecutor, TrialInfo
 from ray.train._internal.data_config import DataConfig
@@ -14,7 +14,7 @@ from ray.train._internal.session import _TrainingResult, get_session
 from ray.train._internal.utils import construct_train_func, count_required_parameters
 from ray.train.base_trainer import _TRAINER_RESTORE_DEPRECATION_WARNING
 from ray.train.constants import RAY_TRAIN_ENABLE_STATE_TRACKING
-from ray.train.trainer import BaseTrainer, GenDataset
+from ray.train.trainer import BaseTrainer, GenDataset, TrainingIterator
 from ray.util.annotations import Deprecated, DeveloperAPI
 from ray.widgets import Template
 from ray.widgets.util import repr_with_fallback

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -156,11 +156,11 @@ class DataParallelTrainer:
             A Result object containing the training result.
 
         Raises:
-            ray.train.v2.api.exceptions.ControllerError: If a non-retryable error occurs in
-                the Ray Train controller itself, or if the number of retries configured in
-                `FailureConfig` is exhausted.
-            ray.train.v2.api.exceptions.WorkerGroupError: If one or more workers fail during
-                training and the number of retries configured in `FailureConfig` is exhausted.
+            ray.train.TrainingFailedError: This is a union of the ControllerError and WorkerGroupError.
+                This returns a :class:`ray.train.ControllerError` if internal Ray Train controller logic
+                encounters a non-retryable error or reaches the controller failure limit configured in `FailureConfig`.
+                This returns a :class:`ray.train.WorkerGroupError` if one or more workers fail during
+                training and reaches the worker group failure limit configured in `FailureConfig(max_failures)`.
         """
         train_fn = self._get_train_func()
         if self.running_in_local_mode:

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -17,6 +17,7 @@ from ray.train import (
     Result,
     RunConfig,
     ScalingConfig,
+    TrainingFailedError,  # noqa: F401
 )
 from ray.train.base_trainer import (
     _RESUME_FROM_CHECKPOINT_DEPRECATION_WARNING,

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -17,7 +17,6 @@ from ray.train import (
     Result,
     RunConfig,
     ScalingConfig,
-    TrainingFailedError,  # noqa: F401
 )
 from ray.train.base_trainer import (
     _RESUME_FROM_CHECKPOINT_DEPRECATION_WARNING,
@@ -55,6 +54,7 @@ from ray.train.v2._internal.execution.local_mode.utils import LocalController
 from ray.train.v2._internal.execution.scaling_policy import create_scaling_policy
 from ray.train.v2._internal.util import ObjectRefWrapper, construct_train_func
 from ray.train.v2.api.callback import UserCallback
+from ray.train.v2.api.exceptions import TrainingFailedError  # noqa: F401
 from ray.util.annotations import Deprecated, DeveloperAPI
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -157,7 +157,7 @@ class DataParallelTrainer:
             A Result object containing the training result.
 
         Raises:
-            TrainingFailedError: This is a union of the ControllerError and WorkerGroupError.
+            ray.train.v2.api.exceptions.TrainingFailedError: This is a union of the ControllerError and WorkerGroupError.
                 This returns a :class:`ray.train.ControllerError` if internal Ray Train controller logic
                 encounters a non-retryable error or reaches the controller failure limit configured in `FailureConfig`.
                 This returns a :class:`ray.train.WorkerGroupError` if one or more workers fail during

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -157,7 +157,7 @@ class DataParallelTrainer:
             A Result object containing the training result.
 
         Raises:
-            ray.train.TrainingFailedError: This is a union of the ControllerError and WorkerGroupError.
+            TrainingFailedError: This is a union of the ControllerError and WorkerGroupError.
                 This returns a :class:`ray.train.ControllerError` if internal Ray Train controller logic
                 encounters a non-retryable error or reaches the controller failure limit configured in `FailureConfig`.
                 This returns a :class:`ray.train.WorkerGroupError` if one or more workers fail during

--- a/python/ray/train/v2/api/exceptions.py
+++ b/python/ray/train/v2/api/exceptions.py
@@ -1,11 +1,16 @@
-from typing import Dict, Union
+from typing import Dict
 
 from ray.train.v2._internal.exceptions import RayTrainError
 from ray.util.annotations import PublicAPI
 
 
 @PublicAPI(stability="alpha")
-class WorkerGroupError(RayTrainError):
+class TrainingFailedError(RayTrainError):
+    """Exception raised when training fails from a `trainer.fit()` call."""
+
+
+@PublicAPI(stability="alpha")
+class WorkerGroupError(TrainingFailedError):
     """Exception raised from the worker group during training.
 
     Args:
@@ -24,7 +29,7 @@ class WorkerGroupError(RayTrainError):
 
 
 @PublicAPI(stability="alpha")
-class ControllerError(RayTrainError):
+class ControllerError(TrainingFailedError):
     """Exception raised when training fails due to a controller error.
 
     Args:
@@ -39,6 +44,3 @@ class ControllerError(RayTrainError):
 
     def __reduce__(self):
         return (self.__class__, (self.controller_failure,))
-
-
-TrainingFailedError = Union[WorkerGroupError, ControllerError]

--- a/python/ray/train/v2/api/exceptions.py
+++ b/python/ray/train/v2/api/exceptions.py
@@ -7,7 +7,7 @@ from ray.util.annotations import PublicAPI
 @PublicAPI(stability="alpha")
 class TrainingFailedError(RayTrainError):
     """Exception raised when training fails from a `trainer.fit()` call.
-    This is either `WorkerGroupError` or `ControllerError`.
+    This is either :class:`ray.train.WorkerGroupError` or :class:`ray.train.ControllerError`.
     """
 
 

--- a/python/ray/train/v2/api/exceptions.py
+++ b/python/ray/train/v2/api/exceptions.py
@@ -6,7 +6,9 @@ from ray.util.annotations import PublicAPI
 
 @PublicAPI(stability="alpha")
 class TrainingFailedError(RayTrainError):
-    """Exception raised when training fails from a `trainer.fit()` call."""
+    """Exception raised when training fails from a `trainer.fit()` call.
+    This is either `WorkerGroupError` or `ControllerError`.
+    """
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/train/v2/tests/test_data_parallel_trainer.py
+++ b/python/ray/train/v2/tests/test_data_parallel_trainer.py
@@ -15,7 +15,7 @@ from ray.train.constants import RAY_CHDIR_TO_TRIAL_DIR, _get_ray_train_session_d
 from ray.train.tests.util import create_dict_checkpoint
 from ray.train.v2._internal.constants import is_v2_enabled
 from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
-from ray.train.v2.api.exceptions import WorkerGroupError
+from ray.train.v2.api.exceptions import TrainingFailedError, WorkerGroupError
 from ray.train.v2.api.result import Result
 
 assert is_v2_enabled()
@@ -176,9 +176,10 @@ def test_error(tmp_path):
         scaling_config=ScalingConfig(num_workers=2),
         run_config=RunConfig(name="test", storage_path=str(tmp_path)),
     )
-    with pytest.raises(WorkerGroupError) as exc_info:
+    with pytest.raises(TrainingFailedError) as exc_info:
         trainer.fit()
-        assert isinstance(exc_info.value.worker_failures[0], ValueError)
+        assert isinstance(exc_info.value, WorkerGroupError)
+        assert isinstance(exc_info.value.__cause__.worker_failures[0], ValueError)
 
 
 @pytest.mark.parametrize("env_disabled", [True, False])


### PR DESCRIPTION
<!-- Thank you for contributing to Ray! 🚀 -->
<!-- Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
<!-- 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete -->

## Description

Add top-level aliases for public APIs. Users should never import from internal modules.

This includes:
* `ray.train.TrainingFailedError`
* `ray.train.WorkerGroupError`
* `ray.train.ControllerError`
* `ray.train.TrainContext`

Also removes the top-level `ray.train.TrainingIterator` import since this is a V1 DeveloperAPI that shouldn't be imported anymore.

## Related issues

<!-- Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234" -->

## Types of change

- [ ] Bug fix 🐛
- [ ] New feature ✨
- [ ] Enhancement 🚀
- [x] Code refactoring 🔧
- [ ] Documentation update 📖
- [ ] Chore 🧹
- [ ] Style 🎨

## Checklist

**Does this PR introduce breaking changes?**
- [ ] Yes ⚠️
- [ ] No
<!-- If yes, describe what breaks and how users should migrate -->

**Testing:**
- [ ] Added/updated tests for my changes
- [ ] Tested the changes manually
- [ ] This PR is not tested ❌ _(please explain why)_

**Code Quality:**
- [ ] Signed off every commit (`git commit -s`)
- [ ] Ran pre-commit hooks ([setup guide](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))

**Documentation:**
- [ ] Updated documentation (if applicable) ([contribution guide](https://docs.ray.io/en/latest/ray-contribute/docs.html))
- [ ] Added new APIs to `doc/source/` (if applicable)

## Additional context

<!-- Optional: Add screenshots, examples, performance impact, breaking change details -->
