### PR TITLE
[deps] raydepsets: expanding depsets recursively

### DIFF
--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -352,7 +352,9 @@ class DependencySetManager:
         # handle both depsets and requirements
         depset_req_list = []
         for depset_name in depsets:
-            depset_req_list.extend(self.get_nested_depsets(depset_name, []))
+            depset_req_list.extend(
+                self.get_expanded_depset_requirements(depset_name, [])
+            )
         if requirements:
             depset_req_list.extend(requirements)
         self.compile(
@@ -380,14 +382,23 @@ class DependencySetManager:
                     f"Requirement {req} is not a subset of {source_depset.name}"
                 )
 
-    def get_nested_depsets(
+    def get_expanded_depset_requirements(
         self, depset_name: str, requirements_list: List[str]
     ) -> List[str]:
+        """Get all requirements for expanded depsets
+
+        Args:
+            depset_name: The name of the expanded depset to get the requirements for.
+            requirements_list: The list of requirements to extend.
+
+        Returns:
+            A list of requirements for the expanded depset.
+        """
         depset = _get_depset(self.config.depsets, depset_name)
         requirements_list.extend(depset.requirements)
         if depset.operation == "expand":
             for dep in depset.depsets:
-                self.get_nested_depsets(dep, requirements_list)
+                self.get_expanded_depset_requirements(dep, requirements_list)
         return list(set(requirements_list))
 
     def cleanup(self):

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -736,13 +736,15 @@ class TestCli(unittest.TestCase):
             assert "Pre-hook test\n" in stdout
             assert "Executed pre_hook pre-hook-test.sh test successfully" in stdout
 
-    def test_get_nested_depsets(self):
+    def test_get_expanded_depset_requirements(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             copy_data_to_tmpdir(tmpdir)
             manager = _create_test_manager(tmpdir)
-            requirements = manager.get_nested_depsets("general_depset__py311_cpu", [])
+            requirements = manager.get_expanded_depset_requirements(
+                "general_depset__py311_cpu", []
+            )
             assert requirements == ["requirements_test.txt"]
-            requirements = manager.get_nested_depsets(
+            requirements = manager.get_expanded_depset_requirements(
                 "expand_general_depset__py311_cpu", []
             )
             assert sorted(requirements) == sorted(
@@ -751,7 +753,7 @@ class TestCli(unittest.TestCase):
                     "requirements_expanded.txt",
                 ]
             )
-            requirements = manager.get_nested_depsets(
+            requirements = manager.get_expanded_depset_requirements(
                 "nested_expand_depset__py311_cpu", []
             )
             assert sorted(requirements) == sorted(

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -377,8 +377,8 @@ class TestCli(unittest.TestCase):
             copy_data_to_tmpdir(tmpdir)
             manager = _create_test_manager(tmpdir)
             assert manager.build_graph is not None
-            assert len(manager.build_graph.nodes()) == 6
-            assert len(manager.build_graph.edges()) == 3
+            assert len(manager.build_graph.nodes()) == 7
+            assert len(manager.build_graph.edges()) == 4
             # assert that the compile depsets are first
             assert (
                 manager.build_graph.nodes["general_depset__py311_cpu"]["operation"]
@@ -735,6 +735,32 @@ class TestCli(unittest.TestCase):
             stdout = mock_stdout.getvalue()
             assert "Pre-hook test\n" in stdout
             assert "Executed pre_hook pre-hook-test.sh test successfully" in stdout
+
+    def test_get_nested_depsets(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            manager = _create_test_manager(tmpdir)
+            requirements = manager.get_nested_depsets("general_depset__py311_cpu", [])
+            assert requirements == ["requirements_test.txt"]
+            requirements = manager.get_nested_depsets(
+                "expand_general_depset__py311_cpu", []
+            )
+            assert sorted(requirements) == sorted(
+                [
+                    "requirements_test.txt",
+                    "requirements_expanded.txt",
+                ]
+            )
+            requirements = manager.get_nested_depsets(
+                "nested_expand_depset__py311_cpu", []
+            )
+            assert sorted(requirements) == sorted(
+                [
+                    "requirements_compiled_test_expand.txt",
+                    "requirements_expanded.txt",
+                    "requirements_test.txt",
+                ]
+            )
 
 
 if __name__ == "__main__":

--- a/ci/raydepsets/tests/test_data/test.depsets.yaml
+++ b/ci/raydepsets/tests/test_data/test.depsets.yaml
@@ -51,3 +51,12 @@ depsets:
     output: requirements_compiled_expand_general.txt
     build_arg_sets:
       - py311_cpu
+  - name: nested_expand_depset__py311_cpu
+    operation: expand
+    requirements:
+      - requirements_compiled_test_expand.txt
+    depsets:
+      - expand_general_depset__py311_cpu
+    constraints:
+      - requirement_constraints_expand.txt
+    output: requirements_compiled_nested_expand.txt

--- a/ci/raydepsets/tests/test_workspace.py
+++ b/ci/raydepsets/tests/test_workspace.py
@@ -82,7 +82,7 @@ def test_load_first_config():
         workspace = Workspace(dir=tmpdir)
         config = workspace.load_config(config_path=Path(tmpdir) / "test.depsets.yaml")
         assert config.depsets is not None
-        assert len(config.depsets) == 6
+        assert len(config.depsets) == 7
 
 
 def test_load_second_config():
@@ -101,14 +101,14 @@ def test_load_all_configs_first_config():
         workspace = Workspace(dir=tmpdir)
         config = workspace.load_configs(config_path=Path(tmpdir) / "test.depsets.yaml")
         assert config.depsets is not None
-        assert len(config.depsets) == 9
+        assert len(config.depsets) == 10
     # load all configs should always load all depsets
     with tempfile.TemporaryDirectory() as tmpdir:
         copy_data_to_tmpdir(tmpdir)
         workspace = Workspace(dir=tmpdir)
         config = workspace.load_configs(config_path=Path(tmpdir) / "test2.depsets.yaml")
         assert config.depsets is not None
-        assert len(config.depsets) == 9
+        assert len(config.depsets) == 10
 
 
 def test_merge_configs():
@@ -119,7 +119,7 @@ def test_merge_configs():
         config2 = workspace.load_config(config_path=Path(tmpdir) / "test2.depsets.yaml")
         merged_config = workspace.merge_configs([config, config2])
         assert merged_config.depsets is not None
-        assert len(merged_config.depsets) == 9
+        assert len(merged_config.depsets) == 10
 
 
 def test_get_configs_dir():


### PR DESCRIPTION
Expanding nested depsets recursively when expanding.
Expand currently only allows for single level depset-> depset expansion
if there are more than a single level (ex depset1 -> depset2 -> depset3. Depset3 will not contain the requirements of depset 1)