### PR TITLE
[Data] Fixed `max_task_in_flight_per_actor` to be defined by `max_concurrency` set by default

### DIFF
--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -136,20 +136,19 @@ class DefaultActorAutoscaler(ActorAutoscaler):
             max_actor_concurrency: The maximum concurrency per actor.
             max_tasks_in_flight_per_actor: The maximum tasks in flight per actor.
         """
+        max_tasks_in_flight_per_actor = actor_pool.max_tasks_in_flight_per_actor()
+        max_concurrency = actor_pool.max_actor_concurrency()
 
-    max_tasks_in_flight_per_actor = actor_pool.max_tasks_in_flight_per_actor()
-    max_concurrency = actor_pool.max_actor_concurrency()
-
-    if (
-        max_tasks_in_flight_per_actor / max_concurrency < self._actor_pool_scaling_up_threshold
-    ):
-        logger.warning(
-            f"{WARN_PREFIX} Actor Pool configuration of the {op} will not allow it to scale up: "
-            f"configured utilization threshold ({self._actor_pool_scaling_up_threshold * 100}%) "
-            f"couldn't be reached with configured max_concurrency={max_concurrency} "
-            f"and max_tasks_in_flight_per_actor={max_tasks_in_flight_per_actor} "
-            f"(max utilization will be max_tasks_in_flight_per_actor / max_actor_concurrency = {(max_tasks_in_flight_per_actor / max_actor_concurrency) * 100:0f}%)"
-        )
+        if (
+            max_tasks_in_flight_per_actor / max_concurrency < self._actor_pool_scaling_up_threshold
+        ):
+            logger.warning(
+                f"{WARN_PREFIX} Actor Pool configuration of the {op} will not allow it to scale up: "
+                f"configured utilization threshold ({self._actor_pool_scaling_up_threshold * 100}%) "
+                f"couldn't be reached with configured max_concurrency={max_concurrency} "
+                f"and max_tasks_in_flight_per_actor={max_tasks_in_flight_per_actor} "
+                f"(max utilization will be max_tasks_in_flight_per_actor / max_concurrency = {(max_tasks_in_flight_per_actor / max_concurrency) * 100:0f}%)"
+            )
 
 
 def _get_max_scale_up(

--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -132,9 +132,8 @@ class DefaultActorAutoscaler(ActorAutoscaler):
         """Validate autoscaling configuration.
 
         Args:
-            autoscaling_config: The autoscaling configuration to validate.
-            max_actor_concurrency: The maximum concurrency per actor.
-            max_tasks_in_flight_per_actor: The maximum tasks in flight per actor.
+            actor_pool: Actor pool to validate configuration thereof.
+            op: ``PhysicalOperator`` using target actor pool.
         """
         max_tasks_in_flight_per_actor = actor_pool.max_tasks_in_flight_per_actor()
         max_concurrency = actor_pool.max_actor_concurrency()

--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -140,7 +140,8 @@ class DefaultActorAutoscaler(ActorAutoscaler):
         max_concurrency = actor_pool.max_actor_concurrency()
 
         if (
-            max_tasks_in_flight_per_actor / max_concurrency < self._actor_pool_scaling_up_threshold
+            max_tasks_in_flight_per_actor / max_concurrency
+            < self._actor_pool_scaling_up_threshold
         ):
             logger.warning(
                 f"{WARN_PREFIX} Actor Pool configuration of the {op} will not allow it to scale up: "

--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -147,7 +147,7 @@ class DefaultActorAutoscaler(ActorAutoscaler):
                 f"configured utilization threshold ({self._actor_pool_scaling_up_threshold * 100}%) "
                 f"couldn't be reached with configured max_concurrency={max_concurrency} "
                 f"and max_tasks_in_flight_per_actor={max_tasks_in_flight_per_actor} "
-                f"(max utilization will be max_tasks_in_flight_per_actor / max_concurrency = {(max_tasks_in_flight_per_actor / max_concurrency) * 100:0f}%)"
+                f"(max utilization will be max_tasks_in_flight_per_actor / max_concurrency = {(max_tasks_in_flight_per_actor / max_concurrency) * 100:g}%)"
             )
 
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -37,7 +37,12 @@ from ray.data._internal.execution.operators.map_transformer import MapTransforme
 from ray.data._internal.execution.util import locality_string
 from ray.data._internal.remote_fn import _add_system_error_to_retry_exceptions
 from ray.data.block import Block, BlockMetadata
-from ray.data.context import DataContext
+from ray.data.context import (
+    AutoscalingConfig,
+    DataContext,
+    DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR,
+    WARN_PREFIX,
+)
 from ray.types import ObjectRef
 from ray.util.common import INT32_MAX
 
@@ -141,12 +146,13 @@ class ActorPoolMapOperator(MapOperator):
             initial_size=compute_strategy.initial_size,
             max_actor_concurrency=max_actor_concurrency,
             max_tasks_in_flight_per_actor=(
-                # NOTE: Unless explicitly configured by the user, max tasks-in-flight config
-                #       will fall back to be 2 x of `max_concurrency`, entailing that for every
-                #       running task we'd allow 1 more task to be enqueued
+                # Unless explicitly overridden by the user, max tasks-in-flight config
+                # will fall back to be:
+                #
+                #   DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR * max_concurrency,
                 compute_strategy.max_tasks_in_flight_per_actor
                 or data_context.max_tasks_in_flight_per_actor
-                or max_actor_concurrency * 2
+                or max_actor_concurrency * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR
             ),
             _enable_actor_pool_on_exit_hook=self.data_context._enable_actor_pool_on_exit_hook,
         )

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -38,10 +38,8 @@ from ray.data._internal.execution.util import locality_string
 from ray.data._internal.remote_fn import _add_system_error_to_retry_exceptions
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import (
-    AutoscalingConfig,
-    DataContext,
     DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR,
-    WARN_PREFIX,
+    DataContext,
 )
 from ray.types import ObjectRef
 from ray.util.common import INT32_MAX
@@ -152,7 +150,8 @@ class ActorPoolMapOperator(MapOperator):
                 #   DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR * max_concurrency,
                 compute_strategy.max_tasks_in_flight_per_actor
                 or data_context.max_tasks_in_flight_per_actor
-                or max_actor_concurrency * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR
+                or max_actor_concurrency
+                * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR
             ),
             _enable_actor_pool_on_exit_hook=self.data_context._enable_actor_pool_on_exit_hook,
         )

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -212,7 +212,9 @@ DEFAULT_WAIT_FOR_MIN_ACTORS_S = env_integer(
     "RAY_DATA_DEFAULT_WAIT_FOR_MIN_ACTORS_S", -1
 )
 
-DEFAULT_MAX_TASKS_IN_FLIGHT_PER_ACTOR = 4
+DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR = env_integer(
+    "RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR", 4
+)
 
 # Enable per node metrics reporting for Ray Data, disabled by default.
 DEFAULT_ENABLE_PER_NODE_METRICS = bool(
@@ -576,7 +578,8 @@ class DataContext:
     # Setting non-positive value here (ie <= 0) disables this functionality
     # (defaults to -1).
     wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
-    max_tasks_in_flight_per_actor: Optional[int] = DEFAULT_MAX_TASKS_IN_FLIGHT_PER_ACTOR
+    # This setting serves as a global override
+    max_tasks_in_flight_per_actor: Optional[int] = None
     retried_io_errors: List[str] = field(
         default_factory=lambda: list(DEFAULT_RETRIED_IO_ERRORS)
     )

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -347,7 +347,9 @@ def test_autoscaling_config_validation_warnings(
     # Test #1: Invalid config (should warn)
     #   - max_tasks_in_flight / max_concurrency == 1
     #   - Default upscaling threshold (200%)
-    with patch("ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning") as mock_warning:
+    with patch(
+        "ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning"
+    ) as mock_warning:
         ds = ray.data.range(2, override_num_blocks=2).map_batches(
             SimpleMapper,
             compute=ray.data.ActorPoolStrategy(
@@ -373,7 +375,9 @@ def test_autoscaling_config_validation_warnings(
     # Test #2: Provided config is valid (no warnings)
     #   - max_tasks_in_flight / max_concurrency == 2 (default)
     #   - Default upscaling threshold (200%)
-    with patch("ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning") as mock_warning:
+    with patch(
+        "ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning"
+    ) as mock_warning:
         ds = ray.data.range(2, override_num_blocks=2).map_batches(
             SimpleMapper,
             compute=ray.data.ActorPoolStrategy(
@@ -392,14 +396,14 @@ def test_autoscaling_config_validation_warnings(
 
     assert expected_message not in wanr_log_args_str
 
-
     # Test #3: Default config is valid (no warnings)
     #   - max_tasks_in_flight / max_concurrency == 4 (default)
     #   - Default upscaling threshold (200%)
-    with patch("ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning") as mock_warning:
+    with patch(
+        "ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning"
+    ) as mock_warning:
         ds = ray.data.range(2, override_num_blocks=2).map_batches(
-            SimpleMapper,
-            compute=ray.data.ActorPoolStrategy()
+            SimpleMapper, compute=ray.data.ActorPoolStrategy()
         )
         ds.take_all()
 
@@ -411,7 +415,6 @@ def test_autoscaling_config_validation_warnings(
     )
 
     assert expected_message not in wanr_log_args_str
-
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -398,7 +398,8 @@ def test_autoscaling_config_validation_warnings(
     #   - Default upscaling threshold (200%)
     with patch("ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning") as mock_warning:
         ds = ray.data.range(2, override_num_blocks=2).map_batches(
-            SimpleMapper
+            SimpleMapper,
+            compute=ray.data.ActorPoolStrategy()
         )
         ds.take_all()
 

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -331,6 +331,81 @@ def test_actor_pool_respects_max_size(ray_start_10_cpus_shared, restore_data_con
         ).take_all()
 
 
+def test_autoscaling_config_validation_warnings(
+    ray_start_10_cpus_shared, restore_data_context
+):
+    """Test that validation warnings are emitted when actor pool config won't allow scaling up."""
+    from unittest.mock import patch
+
+    class SimpleMapper:
+        """Simple callable class for testing autoscaling validation."""
+
+        def __call__(self, row):
+            # Map operates on rows which are dicts
+            return {"value": row["id"] * 2}
+
+    # Test case 1: max_tasks_in_flight / max_concurrency < threshold should emit warning
+    # max_tasks_in_flight=1, max_concurrency=2 => ratio=0.5 < threshold=0.6
+    ctx = ray.data.DataContext.get_current()
+    ctx.target_max_block_size = 1 * 1024**2
+    ctx.autoscaling_config = AutoscalingConfig(
+        actor_pool_util_upscaling_threshold=0.6,
+        actor_pool_util_downscaling_threshold=0.3,
+    )
+
+    with patch("ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning") as mock_warning:
+        ds = ray.data.range(2, override_num_blocks=2).map(
+            SimpleMapper,
+            compute=ray.data.ActorPoolStrategy(
+                min_size=1,
+                max_size=1,
+                max_tasks_in_flight_per_actor=1,
+            ),
+            max_concurrency=2,
+        )
+        # Take just one item to minimize execution time
+        list(ds.iter_rows())
+
+    # Check that warning was called with expected message
+    assert mock_warning.called, "Expected warning to be logged"
+    warning_message = str(mock_warning.call_args_list[0][0][0])
+    expected_message = (
+        "⚠️  Actor Pool configuration of the "
+        "ActorPoolMapOperator(Map(SimpleMapper)) will not allow it to scale up: "
+        "configured utilization threshold (60.0%) couldn't be reached with "
+        "configured max_concurrency=2 and max_tasks_in_flight_per_actor=1 "
+        "(max utilization will be max_tasks_in_flight_per_actor / max_concurrency = 50%)"
+    )
+    assert warning_message == expected_message, f"Warning message mismatch.\nExpected: {expected_message}\nGot: {warning_message}"
+
+    # Test case 2: Valid config - no warning should be emitted
+    # max_tasks_in_flight=2, max_concurrency=1 (default) => ratio=2.0 >= threshold=0.8
+    ctx.autoscaling_config = AutoscalingConfig(
+        actor_pool_util_upscaling_threshold=0.8,
+        actor_pool_util_downscaling_threshold=0.3,
+    )
+
+    with patch("ray.data._internal.actor_autoscaler.default_actor_autoscaler.logger.warning") as mock_warning:
+        ds = ray.data.range(2, override_num_blocks=2).map(
+            SimpleMapper,
+            compute=ray.data.ActorPoolStrategy(
+                min_size=1,
+                max_size=1,
+                max_tasks_in_flight_per_actor=2,
+            ),
+            # max_concurrency defaults to 1
+        )
+        # Take just one item to minimize execution time
+        list(ds.iter_rows())
+
+    # Check that NO warning was called about scaling
+    scale_up_warnings = [
+        call for call in mock_warning.call_args_list
+        if "will not allow it to scale up" in str(call[0][0])
+    ]
+    assert len(scale_up_warnings) == 0, f"Unexpected warning found: {scale_up_warnings}"
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -51,7 +51,10 @@ from ray.data._internal.logical.optimizers import get_execution_plan
 from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data._internal.stats import Timer
 from ray.data.block import Block, BlockAccessor
-from ray.data.context import DataContext
+from ray.data.context import (
+    DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR,
+    DataContext,
+)
 from ray.data.tests.util import run_one_op_task, run_op_tasks_sync
 from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.tests.conftest import *  # noqa
@@ -780,8 +783,13 @@ def test_actor_pool_map_operator_init(ray_start_regular_shared, data_context_ove
         (3, 5, 4, 3),
         # DataContext.max_tasks_in_flight_per_actor takes precedence
         (None, 5, 4, 5),
-        # Max tasks in-flight is derived as max_concurrency x 2
-        (None, None, 4, 8),
+        # Max tasks in-flight is derived as max_concurrency x 4
+        (
+            None,
+            None,
+            4,
+            4 * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR,
+        ),
     ],
 )
 def test_actor_pool_map_operator_should_add_input(
@@ -797,7 +805,7 @@ def test_actor_pool_map_operator_should_add_input(
     ctx = DataContext.get_current()
     ctx.max_tasks_in_flight_per_actor = max_tasks_in_flight_ctx
 
-    input_op = InputDataBuffer(ctx, make_ref_bundles([[i] for i in range(10)]))
+    input_op = InputDataBuffer(ctx, make_ref_bundles([[i] for i in range(20)]))
 
     compute_strategy = ActorPoolStrategy(
         size=1,


### PR DESCRIPTION
<!-- Thank you for contributing to Ray! 🚀 -->
<!-- Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
<!-- 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete -->

## Description

Revisited the way `max_task_in_flight_per_actor` is determined by default:

1. Previously: it was statically set to 4
2. Now: it's determined as `max_concurrency * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`

Also, cleaned up validation inside the ActorPool verifying whether provided configuration is valid. Added test to assert that warning is logged properly with invalid configuration.

## Related issues

<!-- Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234" -->

## Types of change

- [ ] Bug fix 🐛
- [ ] New feature ✨
- [ ] Enhancement 🚀
- [ ] Code refactoring 🔧
- [ ] Documentation update 📖
- [ ] Chore 🧹
- [ ] Style 🎨

## Checklist

**Does this PR introduce breaking changes?**
- [ ] Yes ⚠️
- [ ] No
<!-- If yes, describe what breaks and how users should migrate -->

**Testing:**
- [ ] Added/updated tests for my changes
- [ ] Tested the changes manually
- [ ] This PR is not tested ❌ _(please explain why)_

**Code Quality:**
- [ ] Signed off every commit (`git commit -s`)
- [ ] Ran pre-commit hooks ([setup guide](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))

**Documentation:**
- [ ] Updated documentation (if applicable) ([contribution guide](https://docs.ray.io/en/latest/ray-contribute/docs.html))
- [ ] Added new APIs to `doc/source/` (if applicable)

## Additional context

<!-- Optional: Add screenshots, examples, performance impact, breaking change details -->
