### PR TITLE
[train] Set JAX_PLATFORMS env var based on ScalingConfig

### DIFF
--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -41,16 +41,14 @@ def _setup_jax_distributed_environment(
         use_tpu: Whether to configure for TPU. If True and JAX_PLATFORMS is not
             already set, it will be set to "tpu".
     """
-    # If user/test already set JAX_PLATFORMS, respect their choice
-    if os.environ.get("JAX_PLATFORMS"):
-        jax_platforms = os.environ.get("JAX_PLATFORMS", "").lower()
-    else:
-        # Set JAX_PLATFORMS based on configuration
-        if use_tpu:
-            os.environ["JAX_PLATFORMS"] = "tpu"
-            jax_platforms = "tpu"
-        else:
-            jax_platforms = ""
+    # Get JAX_PLATFORMS from environment if already set
+    jax_platforms = os.environ.get("JAX_PLATFORMS", "").lower()
+
+    if not jax_platforms and use_tpu:
+        os.environ["JAX_PLATFORMS"] = "tpu"
+        jax_platforms = "tpu"
+
+    # TODO(lehui): Add env vars for JAX on GPU.
 
     import jax
 

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -26,31 +26,33 @@ class JaxConfig(BackendConfig):
         return _JaxBackend
 
 
-def _set_jax_env_vars(use_tpu: bool):
-    """Set JAX environment variables based on configuration.
-
-    If JAX_PLATFORMS is already set (by user or test), we trust that configuration
-    and do nothing. Otherwise, if use_tpu=True, we set it to "tpu".
-    """
-    # If user/test already set JAX_PLATFORMS, respect their choice
-    if os.environ.get("JAX_PLATFORMS"):
-        return
-
-    # Only set JAX_PLATFORMS if not already specified
-    if use_tpu:
-        os.environ["JAX_PLATFORMS"] = "tpu"
-
-
 def _setup_jax_distributed_environment(
-    master_addr_with_port: str, num_workers: int, index: int
+    master_addr_with_port: str, num_workers: int, index: int, use_tpu: bool
 ):
     """Set up distributed Jax training information.
 
-    This function should be called on each worker.
-    """
-    import jax
+    This function should be called on each worker. It sets JAX environment
+    variables and initializes JAX distributed training.
 
-    jax_platforms = os.environ.get("JAX_PLATFORMS", "").lower()
+    Args:
+        master_addr_with_port: The master address with port for coordination.
+        num_workers: Total number of workers.
+        index: Index of this worker.
+        use_tpu: Whether to configure for TPU. If True and JAX_PLATFORMS is not
+            already set, it will be set to "tpu".
+    """
+    # If user/test already set JAX_PLATFORMS, respect their choice
+    if os.environ.get("JAX_PLATFORMS"):
+        jax_platforms = os.environ.get("JAX_PLATFORMS", "").lower()
+    else:
+        # Set JAX_PLATFORMS based on configuration
+        if use_tpu:
+            os.environ["JAX_PLATFORMS"] = "tpu"
+            jax_platforms = "tpu"
+        else:
+            jax_platforms = ""
+
+    import jax
 
     if "tpu" in jax_platforms.split(","):
         jax.distributed.initialize(master_addr_with_port, num_workers, index)
@@ -75,13 +77,11 @@ class _JaxBackend(Backend):
         if not backend_config.use_tpu:
             return
 
-        # Set JAX environment variables on all workers
-        worker_group.execute(_set_jax_env_vars, use_tpu=backend_config.use_tpu)
-
         master_addr, master_port = worker_group.execute_single(0, get_address_and_port)
         master_addr_with_port = f"{master_addr}:{master_port}"
 
-        # Get setup tasks in order to throw errors on failure.
+        # Set up JAX distributed environment on all workers
+        # This sets JAX_PLATFORMS env var and initializes JAX distributed
         setup_futures = []
         for i in range(len(worker_group)):
             setup_futures.append(
@@ -91,6 +91,7 @@ class _JaxBackend(Backend):
                     master_addr_with_port=master_addr_with_port,
                     num_workers=len(worker_group),
                     index=i,
+                    use_tpu=backend_config.use_tpu,
                 )
             )
         ray.get(setup_futures)

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -35,10 +35,8 @@ def _set_jax_env_vars(use_tpu: bool):
         if "tpu" in existing_jax_platforms:
             return
         elif existing_jax_platforms:
-            # Prepend tpu to existing platforms
             os.environ["JAX_PLATFORMS"] = "tpu," + existing_jax_platforms
         else:
-            # No existing platforms, just set to "tpu"
             os.environ["JAX_PLATFORMS"] = "tpu"
 
 

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -87,6 +87,11 @@ def mock_jax_distributed(monkeypatch):
 
 
 def train_func():
+    import os
+
+    # Set JAX_PLATFORMS to cpu for testing (avoid TPU initialization without hardware)
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
     import jax
 
     from ray import train

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -71,6 +71,16 @@ def train_func():
     train.report({"result": [str(d) for d in devices]})
 
 
+def train_func_check_env():
+    """Training function to verify JAX_PLATFORMS env var is set."""
+    import os
+
+    from ray import train
+
+    jax_platforms = os.environ.get("JAX_PLATFORMS", "")
+    train.report({"jax_platforms": jax_platforms})
+
+
 def test_minimal_singlehost(ray_tpu_single_host, tmp_path):
     trainer = JaxTrainer(
         train_loop_per_worker=train_func,
@@ -122,6 +132,107 @@ def test_minimal_multihost(ray_tpu_multi_host, tmp_path):
         if node["Alive"] and node["Labels"].get("ray.io/tpu-slice-name") == slice_label
     ]
     assert len(labeled_nodes) == 2
+
+
+def test_jax_platforms_env_var_no_existing(ray_tpu_single_host, tmp_path, monkeypatch):
+    """Test that JAX_PLATFORMS is set to 'tpu' when use_tpu=True and no existing value."""
+    # Ensure JAX_PLATFORMS is not set
+    monkeypatch.delenv("JAX_PLATFORMS", raising=False)
+
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_func_check_env,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            resources_per_worker={"TPU": 8},
+            use_tpu=True,
+            accelerator_type="TPU-V6E",
+        ),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+        ),
+    )
+    result = trainer.fit()
+    assert result.error is None
+
+    # Check that JAX_PLATFORMS was set to "tpu"
+    jax_platforms = result.metrics["jax_platforms"]
+    assert jax_platforms == "tpu"
+
+
+def test_jax_platforms_env_var_with_existing_tpu(
+    ray_tpu_single_host, tmp_path, monkeypatch
+):
+    """Test that JAX_PLATFORMS is not modified when 'tpu' is already present."""
+    monkeypatch.setenv("JAX_PLATFORMS", "tpu,cpu")
+
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_func_check_env,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            resources_per_worker={"TPU": 8},
+            use_tpu=True,
+            accelerator_type="TPU-V6E",
+        ),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+        ),
+    )
+    result = trainer.fit()
+    assert result.error is None
+
+    # Check that JAX_PLATFORMS was not modified
+    jax_platforms = result.metrics["jax_platforms"]
+    assert jax_platforms == "tpu,cpu"
+
+
+def test_jax_platforms_env_var_with_existing_other(
+    ray_tpu_single_host, tmp_path, monkeypatch
+):
+    """Test that 'tpu' is prepended when JAX_PLATFORMS contains other platforms."""
+    monkeypatch.setenv("JAX_PLATFORMS", "cpu")
+
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_func_check_env,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            resources_per_worker={"TPU": 8},
+            use_tpu=True,
+            accelerator_type="TPU-V6E",
+        ),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+        ),
+    )
+    result = trainer.fit()
+    assert result.error is None
+
+    # Check that 'tpu' was prepended to existing platforms
+    jax_platforms = result.metrics["jax_platforms"]
+    assert jax_platforms == "tpu,cpu"
+
+
+def test_jax_platforms_env_var_no_tpu_flag(ray_tpu_single_host, tmp_path, monkeypatch):
+    """Test that JAX_PLATFORMS is not set when use_tpu=False."""
+    monkeypatch.delenv("JAX_PLATFORMS", raising=False)
+
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_func_check_env,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            resources_per_worker={"TPU": 8},
+            use_tpu=False,  # Not using TPU
+            accelerator_type="TPU-V6E",
+        ),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+        ),
+    )
+    result = trainer.fit()
+    assert result.error is None
+
+    # Check that JAX_PLATFORMS was not set
+    jax_platforms = result.metrics["jax_platforms"]
+    assert jax_platforms == ""
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -71,16 +71,6 @@ def train_func():
     train.report({"result": [str(d) for d in devices]})
 
 
-def train_func_check_env():
-    """Training function to verify JAX_PLATFORMS env var is set."""
-    import os
-
-    from ray import train
-
-    jax_platforms = os.environ.get("JAX_PLATFORMS", "")
-    train.report({"jax_platforms": jax_platforms})
-
-
 def test_minimal_singlehost(ray_tpu_single_host, tmp_path):
     trainer = JaxTrainer(
         train_loop_per_worker=train_func,
@@ -139,6 +129,13 @@ def test_jax_platforms_env_var_no_existing(ray_tpu_single_host, tmp_path, monkey
     # Ensure JAX_PLATFORMS is not set
     monkeypatch.delenv("JAX_PLATFORMS", raising=False)
 
+    def train_func_check_env():
+        """Training function to verify JAX_PLATFORMS env var is set."""
+        import os
+
+        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
+        assert jax_platforms == "tpu"
+
     trainer = JaxTrainer(
         train_loop_per_worker=train_func_check_env,
         scaling_config=ScalingConfig(
@@ -151,19 +148,18 @@ def test_jax_platforms_env_var_no_existing(ray_tpu_single_host, tmp_path, monkey
             storage_path=str(tmp_path),
         ),
     )
-    result = trainer.fit()
-    assert result.error is None
-
-    # Check that JAX_PLATFORMS was set to "tpu"
-    jax_platforms = result.metrics["jax_platforms"]
-    assert jax_platforms == "tpu"
+    trainer.fit()
 
 
-def test_jax_platforms_env_var_with_existing_tpu(
-    ray_tpu_single_host, tmp_path, monkeypatch
-):
+def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
     """Test that JAX_PLATFORMS is not modified when 'tpu' is already present."""
-    monkeypatch.setenv("JAX_PLATFORMS", "tpu,cpu")
+
+    def train_func_check_env():
+        """Training function to verify JAX_PLATFORMS env var is set."""
+        import os
+
+        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
+        assert jax_platforms == "tpu,cpu"
 
     trainer = JaxTrainer(
         train_loop_per_worker=train_func_check_env,
@@ -175,21 +171,27 @@ def test_jax_platforms_env_var_with_existing_tpu(
         ),
         run_config=RunConfig(
             storage_path=str(tmp_path),
+            worker_runtime_env={
+                "env_vars": {
+                    "JAX_PLATFORMS": "tpu,cpu",
+                },
+            },
         ),
     )
-    result = trainer.fit()
-    assert result.error is None
-
-    # Check that JAX_PLATFORMS was not modified
-    jax_platforms = result.metrics["jax_platforms"]
-    assert jax_platforms == "tpu,cpu"
+    trainer.fit()
 
 
 def test_jax_platforms_env_var_with_existing_other(
     ray_tpu_single_host, tmp_path, monkeypatch
 ):
     """Test that 'tpu' is prepended when JAX_PLATFORMS contains other platforms."""
-    monkeypatch.setenv("JAX_PLATFORMS", "cpu")
+
+    def train_func_check_env():
+        """Training function to verify JAX_PLATFORMS env var is set."""
+        import os
+
+        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
+        assert jax_platforms == "tpu,cpu"
 
     trainer = JaxTrainer(
         train_loop_per_worker=train_func_check_env,
@@ -201,38 +203,14 @@ def test_jax_platforms_env_var_with_existing_other(
         ),
         run_config=RunConfig(
             storage_path=str(tmp_path),
+            worker_runtime_env={
+                "env_vars": {
+                    "JAX_PLATFORMS": "cpu",
+                },
+            },
         ),
     )
-    result = trainer.fit()
-    assert result.error is None
-
-    # Check that 'tpu' was prepended to existing platforms
-    jax_platforms = result.metrics["jax_platforms"]
-    assert jax_platforms == "tpu,cpu"
-
-
-def test_jax_platforms_env_var_no_tpu_flag(ray_tpu_single_host, tmp_path, monkeypatch):
-    """Test that JAX_PLATFORMS is not set when use_tpu=False."""
-    monkeypatch.delenv("JAX_PLATFORMS", raising=False)
-
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=False,  # Not using TPU
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-        ),
-    )
-    result = trainer.fit()
-    assert result.error is None
-
-    # Check that JAX_PLATFORMS was not set
-    jax_platforms = result.metrics["jax_platforms"]
-    assert jax_platforms == ""
+    trainer.fit()
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -161,7 +161,6 @@ def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
-
     trainer = JaxTrainer(
         train_loop_per_worker=train_func_check_env,
         scaling_config=ScalingConfig(

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -63,6 +63,29 @@ def reduce_health_check_interval(monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def mock_jax_distributed(monkeypatch):
+    """Mock JAX distributed setup/shutdown to avoid TPU initialization in tests.
+
+    This prevents the RuntimeError: Unable to initialize backend 'tpu' error
+    in test environments without actual TPU hardware.
+    """
+    # Mock the setup and shutdown functions to prevent JAX TPU initialization
+    mock_setup = mock.MagicMock()
+    mock_shutdown = mock.MagicMock()
+
+    monkeypatch.setattr(
+        "ray.train.v2.jax.config._setup_jax_distributed_environment",
+        mock_setup,
+    )
+    monkeypatch.setattr(
+        "ray.train.v2.jax.config._shutdown_jax_distributed",
+        mock_shutdown,
+    )
+
+    yield
+
+
 def train_func():
     import jax
 
@@ -163,28 +186,24 @@ def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
-    # Mock JAX distributed setup to avoid TPU initialization
-    with mock.patch(
-        "ray.train.v2.jax.config._setup_jax_distributed_environment"
-    ), mock.patch("ray.train.v2.jax.config._shutdown_jax_distributed"):
-        trainer = JaxTrainer(
-            train_loop_per_worker=train_func_check_env,
-            scaling_config=ScalingConfig(
-                num_workers=1,
-                resources_per_worker={"TPU": 8},
-                use_tpu=True,
-                accelerator_type="TPU-V6E",
-            ),
-            run_config=RunConfig(
-                storage_path=str(tmp_path),
-                worker_runtime_env={
-                    "env_vars": {
-                        "JAX_PLATFORMS": "tpu,cpu",
-                    },
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_func_check_env,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            resources_per_worker={"TPU": 8},
+            use_tpu=True,
+            accelerator_type="TPU-V6E",
+        ),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+            worker_runtime_env={
+                "env_vars": {
+                    "JAX_PLATFORMS": "tpu,cpu",
                 },
-            ),
-        )
-        trainer.fit()
+            },
+        ),
+    )
+    trainer.fit()
 
 
 def test_jax_platforms_env_var_with_existing_other(
@@ -199,28 +218,24 @@ def test_jax_platforms_env_var_with_existing_other(
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
-    # Mock JAX distributed setup to avoid TPU initialization
-    with mock.patch(
-        "ray.train.v2.jax.config._setup_jax_distributed_environment"
-    ), mock.patch("ray.train.v2.jax.config._shutdown_jax_distributed"):
-        trainer = JaxTrainer(
-            train_loop_per_worker=train_func_check_env,
-            scaling_config=ScalingConfig(
-                num_workers=1,
-                resources_per_worker={"TPU": 8},
-                use_tpu=True,
-                accelerator_type="TPU-V6E",
-            ),
-            run_config=RunConfig(
-                storage_path=str(tmp_path),
-                worker_runtime_env={
-                    "env_vars": {
-                        "JAX_PLATFORMS": "cpu",
-                    },
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_func_check_env,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            resources_per_worker={"TPU": 8},
+            use_tpu=True,
+            accelerator_type="TPU-V6E",
+        ),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+            worker_runtime_env={
+                "env_vars": {
+                    "JAX_PLATFORMS": "cpu",
                 },
-            ),
-        )
-        trainer.fit()
+            },
+        ),
+    )
+    trainer.fit()
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 import ray
@@ -161,24 +163,28 @@ def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=True,
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-            worker_runtime_env={
-                "env_vars": {
-                    "JAX_PLATFORMS": "tpu,cpu",
+    # Mock JAX distributed setup to avoid TPU initialization
+    with mock.patch(
+        "ray.train.v2.jax.config._setup_jax_distributed_environment"
+    ), mock.patch("ray.train.v2.jax.config._shutdown_jax_distributed"):
+        trainer = JaxTrainer(
+            train_loop_per_worker=train_func_check_env,
+            scaling_config=ScalingConfig(
+                num_workers=1,
+                resources_per_worker={"TPU": 8},
+                use_tpu=True,
+                accelerator_type="TPU-V6E",
+            ),
+            run_config=RunConfig(
+                storage_path=str(tmp_path),
+                worker_runtime_env={
+                    "env_vars": {
+                        "JAX_PLATFORMS": "tpu,cpu",
+                    },
                 },
-            },
-        ),
-    )
-    trainer.fit()
+            ),
+        )
+        trainer.fit()
 
 
 def test_jax_platforms_env_var_with_existing_other(
@@ -193,24 +199,28 @@ def test_jax_platforms_env_var_with_existing_other(
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=True,
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-            worker_runtime_env={
-                "env_vars": {
-                    "JAX_PLATFORMS": "cpu",
+    # Mock JAX distributed setup to avoid TPU initialization
+    with mock.patch(
+        "ray.train.v2.jax.config._setup_jax_distributed_environment"
+    ), mock.patch("ray.train.v2.jax.config._shutdown_jax_distributed"):
+        trainer = JaxTrainer(
+            train_loop_per_worker=train_func_check_env,
+            scaling_config=ScalingConfig(
+                num_workers=1,
+                resources_per_worker={"TPU": 8},
+                use_tpu=True,
+                accelerator_type="TPU-V6E",
+            ),
+            run_config=RunConfig(
+                storage_path=str(tmp_path),
+                worker_runtime_env={
+                    "env_vars": {
+                        "JAX_PLATFORMS": "cpu",
+                    },
                 },
-            },
-        ),
-    )
-    trainer.fit()
+            ),
+        )
+        trainer.fit()
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -161,6 +161,7 @@ def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
+
     trainer = JaxTrainer(
         train_loop_per_worker=train_func_check_env,
         scaling_config=ScalingConfig(

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 import ray
@@ -63,35 +61,7 @@ def reduce_health_check_interval(monkeypatch):
     yield
 
 
-@pytest.fixture(autouse=True)
-def mock_jax_distributed(monkeypatch):
-    """Mock JAX distributed setup/shutdown to avoid TPU initialization in tests.
-
-    This prevents the RuntimeError: Unable to initialize backend 'tpu' error
-    in test environments without actual TPU hardware.
-    """
-    # Mock the setup and shutdown functions to prevent JAX TPU initialization
-    mock_setup = mock.MagicMock()
-    mock_shutdown = mock.MagicMock()
-
-    monkeypatch.setattr(
-        "ray.train.v2.jax.config._setup_jax_distributed_environment",
-        mock_setup,
-    )
-    monkeypatch.setattr(
-        "ray.train.v2.jax.config._shutdown_jax_distributed",
-        mock_shutdown,
-    )
-
-    yield
-
-
 def train_func():
-    import os
-
-    # Set JAX_PLATFORMS to cpu for testing (avoid TPU initialization without hardware)
-    os.environ["JAX_PLATFORMS"] = "cpu"
-
     import jax
 
     from ray import train
@@ -113,6 +83,11 @@ def test_minimal_singlehost(ray_tpu_single_host, tmp_path):
         ),
         run_config=RunConfig(
             storage_path=str(tmp_path),
+            worker_runtime_env={
+                "env_vars": {
+                    "JAX_PLATFORMS": "cpu",
+                },
+            },
         ),
     )
     result = trainer.fit()
@@ -138,6 +113,11 @@ def test_minimal_multihost(ray_tpu_multi_host, tmp_path):
         ),
         run_config=RunConfig(
             storage_path=str(tmp_path),
+            worker_runtime_env={
+                "env_vars": {
+                    "JAX_PLATFORMS": "cpu",
+                },
+            },
         ),
     )
     result = trainer.fit()
@@ -152,95 +132,6 @@ def test_minimal_multihost(ray_tpu_multi_host, tmp_path):
         if node["Alive"] and node["Labels"].get("ray.io/tpu-slice-name") == slice_label
     ]
     assert len(labeled_nodes) == 2
-
-
-def test_jax_platforms_env_var_no_existing(ray_tpu_single_host, tmp_path, monkeypatch):
-    """Test that JAX_PLATFORMS is set to 'tpu' when use_tpu=True and no existing value."""
-    # Ensure JAX_PLATFORMS is not set
-    monkeypatch.delenv("JAX_PLATFORMS", raising=False)
-
-    def train_func_check_env():
-        """Training function to verify JAX_PLATFORMS env var is set."""
-        import os
-
-        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
-        assert jax_platforms == "tpu"
-
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=True,
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-        ),
-    )
-    trainer.fit()
-
-
-def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
-    """Test that JAX_PLATFORMS is not modified when 'tpu' is already present."""
-
-    def train_func_check_env():
-        """Training function to verify JAX_PLATFORMS env var is set."""
-        import os
-
-        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
-        assert jax_platforms == "tpu,cpu"
-
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=True,
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-            worker_runtime_env={
-                "env_vars": {
-                    "JAX_PLATFORMS": "tpu,cpu",
-                },
-            },
-        ),
-    )
-    trainer.fit()
-
-
-def test_jax_platforms_env_var_with_existing_other(
-    ray_tpu_single_host, tmp_path, monkeypatch
-):
-    """Test that 'tpu' is prepended when JAX_PLATFORMS contains other platforms."""
-
-    def train_func_check_env():
-        """Training function to verify JAX_PLATFORMS env var is set."""
-        import os
-
-        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
-        assert jax_platforms == "tpu,cpu"
-
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=True,
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-            worker_runtime_env={
-                "env_vars": {
-                    "JAX_PLATFORMS": "cpu",
-                },
-            },
-        ),
-    )
-    trainer.fit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
1. JaxTrainer relying on the runtime env var "JAX_PLATFORMS" to be set to initialize jax.distributed: https://github.com/ray-project/ray/blob/master/python/ray/train/v2/jax/config.py#L38
2. Before this change, user will have to configure both `use_tpu=True` in `ray.train.ScalingConfig` and passing `JAX_PLATFORMS=tpu` to be able to start jax.distributed. `JAX_PLATFORMS` can be comma separated  string.
3. If user uses other jax.distributed libraries like Orbax, sometimes, it will leads to misleading error about distributed initialization.
4. After this change, if user sets `use_tpu=True`, we automatically add this to env var.
5. tpu unit test is not available this time, will explore for how to cover it later.
## Related issues

<!-- Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234" -->

## Types of change

- [ ] Bug fix 🐛
- [ ] New feature ✨
- [x] Enhancement 🚀
- [ ] Code refactoring 🔧
- [ ] Documentation update 📖
- [ ] Chore 🧹
- [ ] Style 🎨

## Checklist

**Does this PR introduce breaking changes?**
- [ ] Yes ⚠️
- [x] No
<!-- If yes, describe what breaks and how users should migrate -->

**Testing:**
- [ ] Added/updated tests for my changes
- [ ] Tested the changes manually
- [ ] This PR is not tested ❌ _(please explain why)_

**Code Quality:**
- [x] Signed off every commit (`git commit -s`)
- [x] Ran pre-commit hooks ([setup guide](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))

**Documentation:**
- [ ] Updated documentation (if applicable) ([contribution guide](https://docs.ray.io/en/latest/ray-contribute/docs.html))
- [ ] Added new APIs to `doc/source/` (if applicable)

## Additional context

<!-- Optional: Add screenshots, examples, performance impact, breaking change details -->
