### PR TITLE
[core] Bump `doctest[core]` test to `large`

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -552,6 +552,7 @@ doctest(
 
 doctest(
     name = "doctest[core]",
+    size = "large",
     files = glob(
         include = [
             "source/ray-core/**/*.md",


### PR DESCRIPTION
Timed out in a recent run: https://buildkite.com/ray-project/postmerge/builds/13756#0199eb6a-32b9-4892-9a04-d47be5b24a10/652-1951

Looks like it's just bumping up against the timeout: https://buildkite.com/ray-project/postmerge/builds/13749#0199eaff-d7b7-4299-9455-6ffa16433b41/835-999