### PR TITLE
[docs] Exclude /doc/source/serve/llm/ from ray-serve team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,6 @@
 /python/ray/data/llm.py @ray-project/ray-llm
 /python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py @ray-project/ray-llm
 /python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json @ray-project/ray-llm
-/doc/source/serve/llm/ @ray-project/ray-llm
 
 # Ray Serve
 /python/ray/serve/ @ray-project/ray-serve
@@ -79,6 +78,7 @@
 /src/ray/protobuf/serve.proto @ray-project/ray-serve
 /python/ray/dashboard/modules/serve/ @ray-project/ray-serve
 /doc/source/serve/ @ray-project/ray-serve @ray-project/ray-docs
+/doc/source/serve/llm/ @ray-project/ray-llm @ray-project/ray-docs
 
 # ML Docker Dependencies
 /python/requirements/ml/dl-cpu-requirements.txt @richardliaw @matthewdeng


### PR DESCRIPTION
Move /doc/source/serve/llm/ rule to after /doc/source/serve/ so that LLM documentation changes only notify @ray-project/ray-llm and @ray-project/ray-docs, excluding @ray-project/ray-serve.
