### PR TITLE
[release] Use released image for jobs

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -205,10 +205,11 @@ def get_step(
     step["label"] = full_label
 
     image = test.get_anyscale_byod_image()
+    base_image = test.get_anyscale_base_byod_image()
     if test.require_custom_byod_image():
         step["depends_on"] = generate_custom_build_step_key(image)
     else:
-        step["depends_on"] = get_prerequisite_step(image)
+        step["depends_on"] = get_prerequisite_step(image, base_image)
 
     if block_step_key:
         if not step["depends_on"]:

--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -60,7 +60,9 @@ def build_anyscale_custom_byod_image(
         stdout=sys.stderr,
         env=env,
     )
-    _validate_and_push(image)
+    if not base_image.startswith("anyscale/ray"):
+        _validate_image(image)
+    _push_image(image)
     if os.environ.get("BUILDKITE"):
         subprocess.run(
             [
@@ -93,6 +95,40 @@ def build_anyscale_base_byod_images(tests: List[Test]) -> List[str]:
             raise RuntimeError(f"Image {image} not found")
 
     return image_list
+
+
+def _validate_image(byod_image: str) -> None:
+    docker_ray_commit = (
+        subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "-ti",
+                "--entrypoint",
+                "python",
+                byod_image,
+                "-c",
+                "import ray; print(ray.__commit__)",
+            ],
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    if os.environ.get("RAY_IMAGE_TAG"):
+        logger.info(f"Ray commit from image: {docker_ray_commit}")
+    else:
+        expected_ray_commit = _get_ray_commit()
+        assert (
+            docker_ray_commit == expected_ray_commit
+        ), f"Expected ray commit {expected_ray_commit}, found {docker_ray_commit}"
+
+
+def _push_image(byod_image: str) -> None:
+    logger.info(f"Pushing image to registry: {byod_image}")
+    subprocess.check_call(
+        ["docker", "push", byod_image],
+        stdout=sys.stderr,
+    )
 
 
 def _validate_and_push(byod_image: str) -> None:

--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -9,7 +9,7 @@ from ray_release.logger import logger
 from ray_release.test import (
     Test,
 )
-from ray_release.util import AZURE_REGISTRY_NAME
+from ray_release.util import AZURE_REGISTRY_NAME, ANYSCALE_RAY_IMAGE_PREFIX
 
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 
@@ -60,7 +60,7 @@ def build_anyscale_custom_byod_image(
         stdout=sys.stderr,
         env=env,
     )
-    if not base_image.startswith("anyscale/ray"):
+    if not base_image.startswith(ANYSCALE_RAY_IMAGE_PREFIX):
         _validate_image(image)
     _push_image(image)
     if os.environ.get("BUILDKITE"):

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Optional
 import yaml
 import os
 from ray_release.configs.global_config import get_global_config
@@ -87,13 +87,13 @@ def create_custom_build_yaml(destination_file: str, tests: List[Test]) -> None:
         yaml.dump(build_config, f, default_flow_style=False, sort_keys=False)
 
 
-def get_prerequisite_step(image: str, base_image: str) -> str:
+def get_prerequisite_step(image: str, base_image: str) -> Optional[str]:
     """Get the base image build step for a job that depends on it."""
     config = get_global_config()
     image_repository, _ = image.split(":")
     image_name = image_repository.split("/")[-1]
     if base_image.startswith("rayproject/ray:"):
-        return "~"
+        return None
     if image_name == "ray-ml":
         return config["release_image_step_ray_ml"]
     elif image_name == "ray-llm":

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -4,7 +4,7 @@ import os
 from ray_release.configs.global_config import get_global_config
 from ray_release.logger import logger
 from ray_release.test import Test
-from ray_release.util import AZURE_REGISTRY_NAME
+from ray_release.util import AZURE_REGISTRY_NAME, ANYSCALE_RAY_IMAGE_PREFIX
 import hashlib
 
 
@@ -92,7 +92,7 @@ def get_prerequisite_step(image: str, base_image: str) -> Optional[str]:
     config = get_global_config()
     image_repository, _ = image.split(":")
     image_name = image_repository.split("/")[-1]
-    if base_image.startswith("rayproject/ray:"):
+    if base_image.startswith(ANYSCALE_RAY_IMAGE_PREFIX):
         return None
     if image_name == "ray-ml":
         return config["release_image_step_ray_ml"]

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -93,7 +93,7 @@ def get_prerequisite_step(image: str, base_image: str) -> Optional[str]:
     image_repository, _ = image.split(":")
     image_name = image_repository.split("/")[-1]
     if base_image.startswith(ANYSCALE_RAY_IMAGE_PREFIX):
-        return None
+        return "forge"
     if image_name == "ray-ml":
         return config["release_image_step_ray_ml"]
     elif image_name == "ray-llm":

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -93,7 +93,7 @@ def get_prerequisite_step(image: str, base_image: str) -> Optional[str]:
     image_repository, _ = image.split(":")
     image_name = image_repository.split("/")[-1]
     if base_image.startswith("rayproject/ray:"):
-        return None
+        return "[]"
     if image_name == "ray-ml":
         return config["release_image_step_ray_ml"]
     elif image_name == "ray-llm":

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -81,8 +81,6 @@ def create_custom_build_yaml(destination_file: str, tests: List[Test]) -> None:
         step["depends_on"] = get_prerequisite_step(image, base_image)
         build_config["steps"].append(step)
 
-    logger.info(f"Build config: {build_config}")
-    print("writing to file: ", destination_file)
     with open(destination_file, "w") as f:
         yaml.dump(build_config, f, default_flow_style=False, sort_keys=False)
 

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -93,7 +93,7 @@ def get_prerequisite_step(image: str, base_image: str) -> Optional[str]:
     image_repository, _ = image.split(":")
     image_name = image_repository.split("/")[-1]
     if base_image.startswith("rayproject/ray:"):
-        return "[]"
+        return None
     if image_name == "ray-ml":
         return config["release_image_step_ray_ml"]
     elif image_name == "ray-llm":

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -73,6 +73,9 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
+				"ray_version": {
+					"type": "string"
+				},
 				"cluster_compute": {
 					"type": "string"
 				},

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -23,6 +23,7 @@ from ray_release.result import (
 )
 from ray_release.logger import logger
 from ray_release.util import (
+    ANYSCALE_RAY_IMAGE_PREFIX,
     dict_hash,
     get_read_state_machine_aws_bucket,
     get_write_state_machine_aws_bucket,
@@ -636,7 +637,7 @@ class Test(dict):
             tag_suffix = self.get_tag_suffix()
             if tag_suffix == "gpu":
                 tag_suffix = "cu121"
-            return f"anyscale/ray:{ray_version}-{python_version}-{tag_suffix}"
+            return f"{ANYSCALE_RAY_IMAGE_PREFIX}:{ray_version}-{python_version}-{tag_suffix}"
         return (
             f"{self.get_byod_ecr()}/"
             f"{self.get_byod_repo()}:{self.get_byod_base_image_tag(build_id)}"
@@ -663,7 +664,7 @@ class Test(dict):
             tag_suffix = self.get_tag_suffix()
             if tag_suffix == "gpu":
                 tag_suffix = "cu121"
-            return f"anyscale/ray:{ray_version}-{python_version}-{tag_suffix}"
+            return f"{ANYSCALE_RAY_IMAGE_PREFIX}:{ray_version}-{python_version}-{tag_suffix}"
 
         return (
             f"{self.get_byod_ecr()}/"

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -634,6 +634,8 @@ class Test(dict):
         if ray_version:
             python_version = "py" + self.get_python_version().replace(".", "")
             tag_suffix = self.get_tag_suffix()
+            if tag_suffix == "gpu":
+                tag_suffix = "cu121"
             return f"anyscale/ray:{ray_version}-{python_version}-{tag_suffix}"
         return (
             f"{self.get_byod_ecr()}/"
@@ -659,6 +661,8 @@ class Test(dict):
             # Use released Ray image from DockerHub
             python_version = "py" + self.get_python_version().replace(".", "")
             tag_suffix = self.get_tag_suffix()
+            if tag_suffix == "gpu":
+                tag_suffix = "cu121"
             return f"anyscale/ray:{ray_version}-{python_version}-{tag_suffix}"
 
         return (

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -655,7 +655,7 @@ class Test(dict):
     def get_anyscale_byod_image(self, build_id: Optional[str] = None) -> str:
         """
         Returns the anyscale byod image to use for this test.
-        If ray_version is specified in cluster config, returns a DockerHub image.
+        If ray_version is specified in cluster config, returns anyscale/ray image.
         """
         ray_version = self.get_ray_version()
         if ray_version and not self.require_custom_byod_image():
@@ -664,6 +664,8 @@ class Test(dict):
             tag_suffix = self.get_tag_suffix()
             if tag_suffix == "gpu":
                 tag_suffix = "cu121"
+            if self.require_custom_byod_image():
+                tag_suffix = tag_suffix + "-" + self.get_byod_image_tag(build_id)
             return f"{ANYSCALE_RAY_IMAGE_PREFIX}:{ray_version}-{python_version}-{tag_suffix}"
 
         return (

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -473,7 +473,7 @@ class Test(dict):
     def get_ray_version(self) -> Optional[str]:
         """
         Returns the Ray version to use from DockerHub if specified in cluster config.
-        If set, this will use released Ray images like rayproject/ray:2.50.0-py39-cpu
+        If set, this will use released Ray images like anyscale/ray:2.50.0-py39-cpu
         instead of building custom BYOD images.
         """
         return self["cluster"].get("ray_version", None)
@@ -634,7 +634,7 @@ class Test(dict):
         if ray_version:
             python_version = "py" + self.get_python_version().replace(".", "")
             tag_suffix = self.get_tag_suffix()
-            return f"rayproject/ray:{ray_version}-{python_version}-{tag_suffix}"
+            return f"anyscale/ray:{ray_version}-{python_version}-{tag_suffix}"
         return (
             f"{self.get_byod_ecr()}/"
             f"{self.get_byod_repo()}:{self.get_byod_base_image_tag(build_id)}"
@@ -659,7 +659,7 @@ class Test(dict):
             # Use released Ray image from DockerHub
             python_version = "py" + self.get_python_version().replace(".", "")
             tag_suffix = self.get_tag_suffix()
-            return f"rayproject/ray:{ray_version}-{python_version}-{tag_suffix}"
+            return f"anyscale/ray:{ray_version}-{python_version}-{tag_suffix}"
 
         return (
             f"{self.get_byod_ecr()}/"

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -581,7 +581,7 @@ class Test(dict):
         tag = f"{self.get_byod_base_image_tag(build_id)}-{dict_hash(custom_info)}"
         ray_version = self.get_ray_version()
         if ray_version:
-            tag = f"{ray_version}-{tag}"
+            tag = f"{tag}-{ray_version}"
         return tag
 
     def use_byod_ml_image(self) -> bool:

--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -150,7 +150,7 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
                 f"--image-name {custom_byod_images[3][0]}"
                 in content["steps"][2]["commands"][6]
             )
-            assert content["steps"][4]["depends_on"] == "forge"
+            assert content["steps"][3]["depends_on"] == "forge"
 
 
 def test_get_prerequisite_step():

--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -50,6 +50,12 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
             "custom_script.sh",
             "python_depset.lock",
         ),
+        (
+            "custom_ecr/ray-ml:abc123-py37-cpu-custom-abcdef123456789abc987654321",
+            "anyscale/ray:2.50.0-py37-cpu",
+            "custom_script.sh",
+            "python_depset.lock",
+        ),
     ]
     custom_image_test_names_map = {
         "ray-project/ray-ml:abc123-custom-123456789abc123456789": ["test_1"],
@@ -61,6 +67,9 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
         "ray-project/ray-ml:abc123-py37-cpu-custom-abcdef123456789abc987654321": [
             "test_1",
             "test_2",
+        ],
+        "custom_ecr/ray-ml:abc123-py37-cpu-custom-abcdef123456789abc987654321": [
+            "test_3",
         ],
     }
     mock_get_images_from_tests.return_value = (
@@ -86,6 +95,16 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
             team="test_team",
             working_dir="test_working_dir",
         ),
+        Test(
+            name="test_3",
+            frequency="manual",
+            group="test_group",
+            team="test_team",
+            working_dir="test_working_dir",
+            cluster={
+                "ray_version": "2.50.0",
+            },
+        ),
     ]
     with tempfile.TemporaryDirectory() as tmpdir:
         create_custom_build_yaml(
@@ -94,7 +113,7 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
         with open(os.path.join(tmpdir, "custom_byod_build.rayci.yml"), "r") as f:
             content = yaml.safe_load(f)
             assert content["group"] == "Custom images build"
-            assert len(content["steps"]) == 3
+            assert len(content["steps"]) == 4
             assert (
                 content["steps"][0]["label"]
                 == f":tapioca: build custom: ray-ml:custom ({step_keys[0]}) test_1"
@@ -127,21 +146,36 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
                 f"--image-name {custom_byod_images[2][0]}"
                 in content["steps"][1]["commands"][6]
             )
+            assert (
+                f"--image-name {custom_byod_images[3][0]}"
+                in content["steps"][2]["commands"][6]
+            )
+            assert content["steps"][4]["depends_on"] == "forge"
 
 
 def test_get_prerequisite_step():
     config = get_global_config()
     assert (
-        get_prerequisite_step("ray-project/ray-ml:abc123-custom")
+        get_prerequisite_step(
+            "ray-project/ray-ml:abc123-custom", "ray-project/ray-ml:abc123-base"
+        )
         == config["release_image_step_ray_ml"]
     )
     assert (
-        get_prerequisite_step("ray-project/ray-llm:abc123-custom")
+        get_prerequisite_step(
+            "ray-project/ray-llm:abc123-custom", "ray-project/ray-llm:abc123-base"
+        )
         == config["release_image_step_ray_llm"]
     )
     assert (
-        get_prerequisite_step("ray-project/ray:abc123-custom")
+        get_prerequisite_step(
+            "ray-project/ray:abc123-custom", "ray-project/ray:abc123-base"
+        )
         == config["release_image_step_ray"]
+    )
+    assert (
+        get_prerequisite_step("anyscale/ray:abc123-custom", "anyscale/ray:abc123-base")
+        == "forge"
     )
 
 

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -31,7 +31,7 @@ from ray_release.test import (
     WINDOWS_TEST_PREFIX,
     MACOS_BISECT_DAILY_RATE_LIMIT,
 )
-from ray_release.util import dict_hash
+from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX, dict_hash
 
 
 init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
@@ -207,6 +207,42 @@ def test_get_anyscale_byod_image():
         f"{get_global_config()['byod_ecr']}"
         f"/{DATAPLANE_ECR_ML_REPO}:a1b2c3d4-py38-gpu-"
         "5f311914c59730d72cee8e2a015c5d6eedf6523bfbf5abe2494e0cb85a5a7b70"
+    )
+
+
+def test_get_anyscale_byod_image_ray_version():
+    os.environ["RAYCI_BUILD_ID"] = "a1b2c3d4"
+    assert (
+        _stub_test({"python": "3.7", "cluster": {"byod": {}}}).get_anyscale_byod_image()
+        == f"{get_global_config()['byod_ecr']}/{DATAPLANE_ECR_REPO}:a1b2c3d4-py37-cpu"
+    )
+    assert _stub_test(
+        {
+            "python": "3.8",
+            "cluster": {
+                "ray_version": "2.50.0",
+                "byod": {
+                    "type": "gpu",
+                },
+            },
+        }
+    ).get_anyscale_byod_image() == (f"{ANYSCALE_RAY_IMAGE_PREFIX}:2.50.0-py38-cu121")
+    assert _stub_test(
+        {
+            "python": "3.8",
+            "cluster": {
+                "ray_version": "2.50.0",
+                "byod": {
+                    "type": "gpu",
+                    "post_build_script": "foo.sh",
+                },
+            },
+        }
+    ).get_anyscale_byod_image() == (
+        f"{get_global_config()['byod_ecr']}"
+        f"/{DATAPLANE_ECR_ML_REPO}:a1b2c3d4-py38-gpu-"
+        "5f311914c59730d72cee8e2a015c5d6eedf6523bfbf5abe2494e0cb85a5a7b70"
+        "-2.50.0"
     )
 
 
@@ -531,6 +567,29 @@ def test_get_byod_image_tag(mock_get_byod_base_image_tag):
     }
     hash_value = dict_hash(custom_info)
     assert test.get_byod_image_tag() == f"test-image-{hash_value}"
+
+
+@patch("ray_release.test.Test.get_byod_base_image_tag")
+def test_get_byod_image_tag_ray_version(mock_get_byod_base_image_tag):
+    test = _stub_test(
+        {
+            "name": "linux://test",
+            "cluster": {
+                "ray_version": "2.50.0",
+                "byod": {
+                    "post_build_script": "test_post_build_script.sh",
+                    "python_depset": "test_python_depset.lock",
+                },
+            },
+        }
+    )
+    mock_get_byod_base_image_tag.return_value = "test-image"
+    custom_info = {
+        "post_build_script": "test_post_build_script.sh",
+        "python_depset": "test_python_depset.lock",
+    }
+    hash_value = dict_hash(custom_info)
+    assert test.get_byod_image_tag() == f"test-image-{hash_value}-2.50.0"
 
 
 if __name__ == "__main__":

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -32,6 +32,7 @@ AZURE_STORAGE_CONTAINER = "working-dirs"
 AZURE_STORAGE_ACCOUNT = "rayreleasetests"
 GS_BUCKET = "anyscale-oss-dev-bucket"
 AZURE_REGISTRY_NAME = "rayreleasetest"
+ANYSCALE_RAY_IMAGE_PREFIX = "anyscale/ray"
 ERROR_LOG_PATTERNS = [
     "ERROR",
     "Traceback (most recent call last)",

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -86,6 +86,7 @@
   working_dir: hello_world_tests
 
   cluster:
+    ray_version: 2.50.0
     byod: {}
     cluster_compute: hello_world_compute_config.yaml
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -86,7 +86,6 @@
   working_dir: hello_world_tests
 
   cluster:
-    ray_version: 2.50.0
     byod: {}
     cluster_compute: hello_world_compute_config.yaml
 
@@ -96,6 +95,9 @@
 
   variations:
     - __suffix__: aws
+    - __suffix__: released
+      cluster:
+        ray_version: 2.50.0
 
 - name: hello_world_custom_byod
   team: reef
@@ -104,7 +106,6 @@
   working_dir: hello_world_tests
 
   cluster:
-    ray_version: 2.50.0
     byod:
       type: gpu
       post_build_script: byod_hello_world.sh
@@ -117,6 +118,9 @@
 
   variations:
     - __suffix__: aws
+    - __suffix__: released
+      cluster:
+        ray_version: 2.50.0
 
 - name: hello_world_custom_byod_depset_only
   team: reef

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -104,6 +104,7 @@
   working_dir: hello_world_tests
 
   cluster:
+    ray_version: 2.50.0
     byod:
       type: gpu
       post_build_script: byod_hello_world.sh


### PR DESCRIPTION
- Use released image:
  - for test jobs that specify release version and don't need custom img
  - for custom image build jobs that can use released image as base
- Change dependency path so these jobs can skip waiting for image build