### PR TITLE
Fix the flaky test: test_gpu_objects_gloo.py::test_recv_actor_dies

### DIFF
--- a/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
+++ b/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
@@ -950,11 +950,6 @@ def test_recv_actor_dies(ray_start_regular, caplog, propagate_logs):
     result_ref = actors[1].recv.remote(gpu_obj_ref)
     ray.kill(actors[1])
 
-    with pytest.raises(ray.exceptions.ActorDiedError):
-        ray.get(result_ref)
-    with pytest.raises(ray.exceptions.ActorDiedError):
-        ray.get(actors[0].recv.remote(1))
-
     def check_logs():
         records = caplog.records
         return any(
@@ -968,6 +963,11 @@ def test_recv_actor_dies(ray_start_regular, caplog, propagate_logs):
         )
 
     wait_for_condition(check_logs)
+
+    with pytest.raises(ray.exceptions.ActorDiedError):
+        ray.get(result_ref)
+    with pytest.raises(ray.exceptions.ActorDiedError):
+        ray.get(actors[0].recv.remote(1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Before this PR, since the thread that kills the actor is different from the thread that executes ray_send/ray_recv, sometimes         `ray.get(actors[0].recv.remote(1))` can be executed before the actor is killed. In this PR, move this after `check_logs` to ensure the actor has been killed before executing this line.

This test has been tested 100 times locally without flaky issues (could reproduce the issue before this pr).

