### PR TITLE
[docs] updating scipy inventory link

### DIFF
--- a/ci/docker/doctest.build.wanda.yaml
+++ b/ci/docker/doctest.build.wanda.yaml
@@ -7,7 +7,7 @@ srcs:
   - python/requirements.txt
   - python/requirements_compiled.txt
   - python/requirements/test-requirements.txt
-  - python/requirements/ml/core-requiremextnts.txt
+  - python/requirements/ml/core-requirements.txt
   - python/requirements/ml/dl-cpu-requirements.txt
   - python/requirements/ml/train-requirements.txt
   - python/requirements/ml/train-test-requirements.txt

--- a/ci/docker/doctest.build.wanda.yaml
+++ b/ci/docker/doctest.build.wanda.yaml
@@ -7,7 +7,7 @@ srcs:
   - python/requirements.txt
   - python/requirements_compiled.txt
   - python/requirements/test-requirements.txt
-  - python/requirements/ml/core-requirements.txt
+  - python/requirements/ml/core-requiremextnts.txt
   - python/requirements/ml/dl-cpu-requirements.txt
   - python/requirements/ml/train-requirements.txt
   - python/requirements/ml/train-test-requirements.txt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -720,7 +720,10 @@ intersphinx_mapping = {
     "pyspark": ("https://spark.apache.org/docs/latest/api/python/", None),
     "python": ("https://docs.python.org/3", None),
     "pytorch_lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", "https://github.com/ray-project/scipy/releases/download/object-mirror-0.1.0/objects.inv"),
+    "scipy": (
+        "https://docs.scipy.org/doc/scipy/",
+        "https://github.com/ray-project/scipy/releases/download/object-mirror-0.1.0/objects.inv",
+    ),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "tensorflow": (
         "https://www.tensorflow.org/api_docs/python",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -720,7 +720,7 @@ intersphinx_mapping = {
     "pyspark": ("https://spark.apache.org/docs/latest/api/python/", None),
     "python": ("https://docs.python.org/3", None),
     "pytorch_lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", "https://github.com/ray-project/scipy/releases/download/scipy-0.1.0/objects.inv"),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", "https://github.com/ray-project/scipy/releases/download/object-mirror-0.1.0/objects.inv"),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "tensorflow": (
         "https://www.tensorflow.org/api_docs/python",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -720,7 +720,7 @@ intersphinx_mapping = {
     "pyspark": ("https://spark.apache.org/docs/latest/api/python/", None),
     "python": ("https://docs.python.org/3", None),
     "pytorch_lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", "https://github.com/ray-project/scipy/releases/download/scipy-0.1.0/objects.inv"),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "tensorflow": (
         "https://www.tensorflow.org/api_docs/python",


### PR DESCRIPTION
updating scipy inventory link to referenced forked scipy repo that contains the artifact in a release