### PR TITLE
[core] Make `ObjectBufferPool::FreeObjects` lock free

### DIFF
--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -326,7 +326,6 @@ Status ObjectBufferPool::EnsureBufferExists(const ObjectID &object_id,
 }
 
 void ObjectBufferPool::FreeObjects(const std::vector<ObjectID> &object_ids) {
-  absl::MutexLock lock(&pool_mutex_);
   RAY_CHECK_OK(store_client_->Delete(object_ids));
 }
 

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -132,8 +132,7 @@ class ObjectBufferPool {
   /// Free a list of objects from object store.
   ///
   /// \param object_ids the The list of ObjectIDs to be deleted.
-  void FreeObjects(const std::vector<ObjectID> &object_ids)
-      ABSL_LOCKS_EXCLUDED(pool_mutex_);
+  void FreeObjects(const std::vector<ObjectID> &object_ids);
 
   /// Abort the create operation associated with an object. This destroys the buffer
   /// state, including create operations in progress for all chunks of the object.


### PR DESCRIPTION
## Description

Make `ObjectBufferPool::FreeObjects` lock free. The `pool_mutex_` lock in `FreeObjects` provides no actual synchronization benefit because:
1. PlasmaClient is already internally synchronized.
2. No ObjectBufferPool state is accessed.

See https://github.com/ray-project/ray/pull/57550#discussion_r2413089221 for the discussion.