### PR TITLE
[Data] "Actor ... has constructor arguments in the object store" warning with minimal Ray Data use

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -29,7 +29,6 @@ from ray.data._internal.execution.interfaces import (
 )
 from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
 from ray.data._internal.execution.node_trackers.actor_location import (
-    ActorLocationTracker,
     get_or_create_actor_location_tracker,
 )
 from ray.data._internal.execution.operators.map_operator import MapOperator, _map_task
@@ -272,7 +271,6 @@ class ActorPoolMapOperator(MapOperator):
             logical_actor_id=logical_actor_id,
             src_fn_name=self.name,
             map_transformer=self._map_transformer,
-            actor_location_tracker=get_or_create_actor_location_tracker(),
         )
         res_ref = actor.get_location.remote()
 
@@ -543,7 +541,6 @@ class _MapWorker:
         src_fn_name: str,
         map_transformer: MapTransformer,
         logical_actor_id: str,
-        actor_location_tracker: ActorLocationTracker,
     ):
         self.src_fn_name: str = src_fn_name
         self._map_transformer = map_transformer
@@ -553,6 +550,7 @@ class _MapWorker:
         # Initialize state for this actor.
         self._map_transformer.init()
         self._logical_actor_id = logical_actor_id
+        actor_location_tracker = get_or_create_actor_location_tracker()
         actor_location_tracker.update_actor_location.remote(
             self._logical_actor_id, ray.get_runtime_context().get_node_id()
         )


### PR DESCRIPTION
## Description

`get_or_create_actor_location_tracker()` is another remote function, instead of passing it into actor as a arguments, we'll just create it in the `_MapWorker` Actor.

As the log show the warning message isn't triggered now.
```py
>>> class Actor:
...     def __call__(self, batch):
...             return batch
... 
>>> ray.data.range(1).map_batches(Actor).materialize()
```
```bash
Usage stats collection is enabled. To disable this, run the following command: `ray disable-usage-stats` before starting Ray. See https://docs.ray.io/en/master/cluster/usage-stats.html for more details.
2025-10-17 14:40:17,990 INFO worker.py:2004 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8266 
/home/ubuntu/miniconda3/envs/myenv/lib/python3.9/site-packages/ray/_private/worker.py:2052: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
2025-10-17 14:40:19,701 INFO streaming_executor.py:85 -- A new progress UI is available. To enable, set `ray.data.DataContext.get_current().enable_rich_progress_bars = True`.
2025-10-17 14:40:19,701 INFO logging.py:397 -- Registered dataset logger for dataset dataset_2_0
2025-10-17 14:40:19,720 INFO streaming_executor.py:170 -- Starting execution of Dataset dataset_2_0. Full logs are in /tmp/ray/session_2025-10-17_14-40-15_580512_2165930/logs/ray-data
2025-10-17 14:40:19,720 INFO streaming_executor.py:171 -- Execution plan of Dataset dataset_2_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadRange] -> ActorPoolMapOperator[MapBatches(Actor)]
Running 0: 0.00 row [00:00, ? row/s]            2025-10-17 14:40:19,743 WARNING resource_manager.py:134 -- ⚠️  Ray's object store is configured to use only 42.9% of available memory (16.1GiB out of 37.6GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.
2025-10-17 14:40:20,460 INFO streaming_executor.py:298 -- ✔️  Dataset dataset_2_0 execution finished in 0.74 seconds
✔️  Dataset dataset_2_0 execution finished in 0.74 seconds: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.00/1.00 [00:00<00:00, 1.39 row/s] 
- ReadRange->SplitBlocks(64): Tasks: 0; Actors: 0; Queued blocks: 0; Resources: 0.0 CPU, 0.0B object store: 100%|███████████████████████████████████████████████████████████████████| 1.00/1.00 [00:00<00:00, 1.39 row/s]
- MapBatches(Actor): Tasks: 0; Actors: 0; Queued blocks: 0; Resources: 1.0 CPU, 8.0B object store; [0/1 objects local]: : 1.00 row [00:00, 1.38 row/s] 
```
## Related issues

Closes #57733 

## Additional information
