### PR TITLE
[serve] Fix startup crash when tracing is enabled

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -345,9 +345,7 @@ class ServeController:
         if not self.done_recovering_event.is_set():
             await self.done_recovering_event.wait()
 
-        return await self.long_poll_host.listen_for_change(
-            keys_to_snapshot_ids, _ray_trace_ctx
-        )
+        return await self.long_poll_host.listen_for_change(keys_to_snapshot_ids)
 
     async def listen_for_change_java(
         self,
@@ -365,7 +363,7 @@ class ServeController:
             await self.done_recovering_event.wait()
 
         return await self.long_poll_host.listen_for_change_java(
-            keys_to_snapshot_ids_bytes, _ray_trace_ctx
+            keys_to_snapshot_ids_bytes
         )
 
     def get_all_endpoints(self) -> Dict[DeploymentID, Dict[str, Any]]:

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -329,31 +329,43 @@ class ServeController:
             deployment_id
         ]._stop_one_running_replica_for_testing()
 
-    async def listen_for_change(self, keys_to_snapshot_ids: Dict[str, int]):
+    async def listen_for_change(
+        self,
+        keys_to_snapshot_ids: Dict[str, int],
+        _ray_trace_ctx: Optional[Dict[str, Any]] = None,
+    ):
         """Proxy long pull client's listen request.
 
         Args:
             keys_to_snapshot_ids (Dict[str, int]): Snapshot IDs are used to
               determine whether or not the host should immediately return the
               data or wait for the value to be changed.
+            _ray_trace_ctx (Optional[Dict[str, Any]]): Ray tracing context.
         """
         if not self.done_recovering_event.is_set():
             await self.done_recovering_event.wait()
 
-        return await self.long_poll_host.listen_for_change(keys_to_snapshot_ids)
+        return await self.long_poll_host.listen_for_change(
+            keys_to_snapshot_ids, _ray_trace_ctx
+        )
 
-    async def listen_for_change_java(self, keys_to_snapshot_ids_bytes: bytes):
+    async def listen_for_change_java(
+        self,
+        keys_to_snapshot_ids_bytes: bytes,
+        _ray_trace_ctx: Optional[Dict[str, Any]] = None,
+    ):
         """Proxy long pull client's listen request.
 
         Args:
             keys_to_snapshot_ids_bytes (Dict[str, int]): the protobuf bytes of
               keys_to_snapshot_ids (Dict[str, int]).
+            _ray_trace_ctx (Optional[Dict[str, Any]]): Ray tracing context.
         """
         if not self.done_recovering_event.is_set():
             await self.done_recovering_event.wait()
 
         return await self.long_poll_host.listen_for_change_java(
-            keys_to_snapshot_ids_bytes
+            keys_to_snapshot_ids_bytes, _ray_trace_ctx
         )
 
     def get_all_endpoints(self) -> Dict[DeploymentID, Dict[str, Any]]:

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -293,7 +293,6 @@ class LongPollHost:
     async def listen_for_change(
         self,
         keys_to_snapshot_ids: Dict[KeyType, int],
-        _ray_trace_ctx: Optional[Dict[str, Any]] = None,
     ) -> Union[LongPollState, Dict[KeyType, UpdatedObject]]:
         """Listen for changed objects.
 

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -293,6 +293,7 @@ class LongPollHost:
     async def listen_for_change(
         self,
         keys_to_snapshot_ids: Dict[KeyType, int],
+        _ray_trace_ctx: Optional[Dict[str, Any]] = None,
     ) -> Union[LongPollState, Dict[KeyType, UpdatedObject]]:
         """Listen for changed objects.
 


### PR DESCRIPTION
## Description

This fixes an issue where running serve start when tracing is enabled on the cluster causes serve to crash

This fix is a little weak sauce admittedly....

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
