### PR TITLE
[Data] - Handle batches of `ndarrays`  in a single column

### DIFF
--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -60,15 +60,22 @@ def _get_leaf_element(value: Any, max_depth: int = 10) -> Any:
 
 
 def _contains_nested_ndarrays(column_values: Sequence[Any]) -> bool:
-    """Check if column_values contains nested sequences with ndarrays at leaf level."""
+    """Return True if any sampled element contains nested sequences with ndarray(-like) leaves."""
     if not isinstance(column_values, (list, tuple)) or len(column_values) == 0:
         return False
 
-    # Get the leaf element by traversing nested sequences
-    leaf = _get_leaf_element(column_values[0])
+    # Just bounding this to a small sample size.
+    max_samples: int = 10
+    samples_checked = 0
+    for value in column_values:
+        if samples_checked >= max_samples:
+            break
+        samples_checked += 1
+        leaf = _get_leaf_element(value)
+        if isinstance(leaf, np.ndarray) or _is_ndarray_like_not_pyarrow_array(leaf):
+            return True
 
-    # Check if the leaf is an ndarray or ndarray-like (but not pyarrow)
-    return isinstance(leaf, np.ndarray) or _is_ndarray_like_not_pyarrow_array(leaf)
+    return False
 
 
 def _should_convert_to_tensor(

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -39,7 +39,7 @@ def _is_arrow_array(value: ArrayLike) -> bool:
     return isinstance(value, (pa.Array, pa.ChunkedArray))
 
 
-def _get_leaf_element(value, max_depth=10):
+def _get_leaf_element(value: Any, max_depth: int = 10) -> Any:
     """Recursively traverse nested sequences to find a leaf element.
 
     Args:
@@ -59,7 +59,7 @@ def _get_leaf_element(value, max_depth=10):
     return value
 
 
-def _contains_nested_ndarrays(column_values) -> bool:
+def _contains_nested_ndarrays(column_values: Sequence[Any]) -> bool:
     """Check if column_values contains nested sequences with ndarrays at leaf level."""
     if not isinstance(column_values, (list, tuple)) or len(column_values) == 0:
         return False

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -153,6 +153,16 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
                 # Use `np.asarray` instead of `np.array` to avoid copying if possible.
                 column_values = [np.asarray(e) for e in column_values]
 
+            # Handle nested lists of ndarrays by recursively flattening them
+            # For example: [[img1, img2], [img3, img4]] becomes [list_of_imgs1, list_of_imgs2]
+            # Also handle mixed cases like [img1, [img2]]
+            if any(isinstance(e, list) for e in column_values):
+                # Recursively convert any nested lists
+                column_values = [
+                    convert_to_numpy(e) if isinstance(e, list) else e
+                    for e in column_values
+                ]
+
             shapes = set()
             has_object = False
             for e in column_values:


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

## Description
Enables Ray Data to handle nested lists of numpy arrays (e.g., [[img1, img2], [img3, img4]]) by recursively detecting and converting them to Arrow tensor arrays.

- Uniform nesting like [[img1, img2], [img3, img4]] → ArrowTensorArray
- Varying batch sizes like [[img1, img2, img3], [img4, img5]] → ArrowVariableShapedTensorArray (when images have same dimensions)
- Inconsistent dimensions (e.g., mixing 3D and 4D tensors) → gracefully falls back to ArrowPythonObjectArray (pickling)

## Related issues
Related to https://github.com/ray-project/ray/issues/57840

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
