### PR TITLE
[train] Turn on Train v2 by default

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -61,6 +61,7 @@ TEAM_API_CONFIGS = {
             # NOTE: These APIs are documented in a separate file (deprecated.rst).
             # These are deprecated APIs, so just white-listing them here for CI.
             "ray.train.error.SessionMisuseError",
+            "ray.train.base_trainer.TrainingFailedError",
             "ray.train.TrainingFailedError",
             "ray.train.context.TrainContext",
             "ray.train.context.get_context",

--- a/python/ray/train/v2/_internal/constants.py
+++ b/python/ray/train/v2/_internal/constants.py
@@ -118,7 +118,7 @@ METRICS_ENABLED_ENV_VAR = "RAY_TRAIN_METRICS_ENABLED"
 
 
 def is_v2_enabled() -> bool:
-    return env_bool(V2_ENABLED_ENV_VAR, False)
+    return env_bool(V2_ENABLED_ENV_VAR, True)
 
 
 def get_env_vars_to_propagate() -> Dict[str, str]:


### PR DESCRIPTION
## Description

Release tests, unit tests, doctests, and examples are all migrated to V2, so this PR turns V2 on by default. To run with Train V1 (deprecated), set `RAY_TRAIN_V2_ENABLED=0`.

## Related issues

#49454 

## Additional information

User guides and API references have already been updated to V2.