### PR TITLE
[Data] Support serializing zero-length numpy arrays

### DIFF
--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -732,13 +732,18 @@ class ArrowTensorArray(pa.ExtensionArray):
         else:
             pa_type_ = ArrowTensorType(element_shape, scalar_dtype)
 
+        offset_dtype = pa_type_.OFFSET_DTYPE.to_pandas_dtype()
+
         # Create offsets buffer
-        offsets = np.arange(
-            0,
-            (outer_len + 1) * num_items_per_element,
-            num_items_per_element,
-            dtype=pa_type_.OFFSET_DTYPE.to_pandas_dtype(),
-        )
+        if num_items_per_element == 0:
+            offsets = np.zeros(outer_len + 1, dtype=offset_dtype)
+        else:
+            offsets = np.arange(
+                0,
+                (outer_len + 1) * num_items_per_element,
+                num_items_per_element,
+                dtype=offset_dtype,
+            )
         offset_buffer = pa.py_buffer(offsets)
 
         storage = pa.Array.from_buffers(

--- a/python/ray/data/tests/test_tensor_extension.py
+++ b/python/ray/data/tests/test_tensor_extension.py
@@ -508,6 +508,17 @@ def test_tensor_array_reductions(restore_data_context, tensor_format):
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
+def test_zero_length_arrow_tensor_array_roundtrip(restore_data_context, tensor_format):
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
+
+    arr = np.empty((2, 0), dtype=np.int8)
+    t_arr = ArrowTensorArray.from_numpy(arr)
+    assert len(t_arr) == len(arr)
+    out = t_arr.to_numpy()
+    np.testing.assert_array_equal(out, arr)
+
+
+@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("chunked", [False, True])
 def test_arrow_tensor_array_getitem(chunked, restore_data_context, tensor_format):
     DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"

--- a/python/ray/data/tests/test_tensor_extension.py
+++ b/python/ray/data/tests/test_tensor_extension.py
@@ -507,11 +507,13 @@ def test_tensor_array_reductions(restore_data_context, tensor_format):
         np.testing.assert_equal(df["two"].agg(name), reducer(arr, axis=0, **np_kwargs))
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_zero_length_arrow_tensor_array_roundtrip(restore_data_context, tensor_format):
+@pytest.mark.parametrize("shape", [(2, 0), (2, 5, 0), (0, 5), (0, 0)])
+def test_zero_length_arrow_tensor_array_roundtrip(
+    restore_data_context, tensor_format, shape
+):
     DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
-    arr = np.empty((2, 0), dtype=np.int8)
+    arr = np.empty(shape, dtype=np.int8)
     t_arr = ArrowTensorArray.from_numpy(arr)
     assert len(t_arr) == len(arr)
     out = t_arr.to_numpy()

--- a/python/ray/data/tests/test_tensor_extension.py
+++ b/python/ray/data/tests/test_tensor_extension.py
@@ -507,6 +507,7 @@ def test_tensor_array_reductions(restore_data_context, tensor_format):
         np.testing.assert_equal(df["two"].agg(name), reducer(arr, axis=0, **np_kwargs))
 
 
+@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("shape", [(2, 0), (2, 5, 0), (0, 5), (0, 0)])
 def test_zero_length_arrow_tensor_array_roundtrip(
     restore_data_context, tensor_format, shape


### PR DESCRIPTION
## Description

Ray data can't serialize zero (byte) length numpy arrays:

```python3
import numpy as np
import ray.data

array = np.empty((2, 0), dtype=np.int8)

ds = ray.data.from_items([{"array": array}])

for batch in ds.iter_batches(batch_size=1):
     print(batch)
```

What I expect to see:

```
{'array': array([], shape=(1, 2, 0), dtype=int8)}
```

What I see:

```
/Users/chris.ohara/Downloads/.venv/lib/python3.12/site-packages/ray/air/util/tensor_extensions/arrow.py:736: RuntimeWarning: invalid value encountered in scalar divide
  offsets = np.arange(
2025-10-17 17:18:09,499 WARNING arrow.py:189 -- Failed to convert column 'array' into pyarrow array due to: Error converting data to Arrow: column: 'array', shape: (1, 2, 0), dtype: int8, data: []; falling back to serialize as pickled python objects
Traceback (most recent call last):
  File "/Users/chris.ohara/Downloads/.venv/lib/python3.12/site-packages/ray/air/util/tensor_extensions/arrow.py", line 672, in from_numpy
    return cls._from_numpy(arr)
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris.ohara/Downloads/.venv/lib/python3.12/site-packages/ray/air/util/tensor_extensions/arrow.py", line 736, in _from_numpy
    offsets = np.arange(
              ^^^^^^^^^^
ValueError: arange: cannot compute length

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/chris.ohara/Downloads/.venv/lib/python3.12/site-packages/ray/air/util/tensor_extensions/arrow.py", line 141, in convert_to_pyarrow_array
    return ArrowTensorArray.from_numpy(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris.ohara/Downloads/.venv/lib/python3.12/site-packages/ray/air/util/tensor_extensions/arrow.py", line 678, in from_numpy
    raise ArrowConversionError(data_str) from e
ray.air.util.tensor_extensions.arrow.ArrowConversionError: Error converting data to Arrow: column: 'array', shape: (1, 2, 0), dtype: int8, data: []
2025-10-17 17:18:09,789 INFO logging.py:293 -- Registered dataset logger for dataset dataset_0_0
2025-10-17 17:18:09,815 WARNING resource_manager.py:134 -- ⚠️  Ray's object store is configured to use only 33.5% of available memory (2.0GiB out of 6.0GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.
{'array': array([array([], shape=(2, 0), dtype=int8)], dtype=object)}
```

This PR fixes the issue so that zero-length arrays are serialized correctly, and the shape and dtype is preserved.

## Additional information

This is `ray==2.50.0`.
