### PR TITLE
[Data] - Fix expression mapping for Pandas

### DIFF
--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -49,11 +49,11 @@ _PANDAS_EXPR_OPS_MAP: Dict[Operation, Callable[..., Any]] = {
     Operation.NE: operator.ne,
     Operation.AND: operator.and_,
     Operation.OR: operator.or_,
-    Operation.NOT: operator.not_,
+    Operation.NOT: operator.invert,
     Operation.IS_NULL: pd.isna,
     Operation.IS_NOT_NULL: pd.notna,
-    Operation.IN: lambda left, right: left.is_in(right),
-    Operation.NOT_IN: lambda left, right: ~left.is_in(right),
+    Operation.IN: lambda left, right: left.isin(right),
+    Operation.NOT_IN: lambda left, right: ~left.isin(right),
 }
 
 


### PR DESCRIPTION
## Description
`IN`, `NOT_IN` and `NOT` were incorrectly mapped to the wrong pandas function which broke expression evaluation for pandas dfs.

## Related issues
Fixes https://github.com/ray-project/ray/issues/57849

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
