### PR TITLE
[serve] [dashboard] fix mulitplexed model cache hit rate axes

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/serve_deployment_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_deployment_dashboard_panels.py
@@ -230,7 +230,7 @@ SERVE_DEPLOYMENT_GRAFANA_PANELS = [
         unit="%",
         targets=[
             Target(
-                expr="(1 - sum(rate(ray_serve_multiplexed_models_load_counter_total{{{global_filters}}}[5m]))/sum(rate(ray_serve_multiplexed_get_model_requests_counter_total{{{global_filters}}}[5m])))",
+                expr="(1 - sum by (application, deployment, replica)(rate(ray_serve_multiplexed_models_load_counter_total{{{global_filters}}}[5m]))/sum by (application, deployment, replica)(rate(ray_serve_multiplexed_get_model_requests_counter_total{{{global_filters}}}[5m]))) * 100",
                 legend="{{application}}#{{deployment}}#{{replica}}",
             ),
         ],


### PR DESCRIPTION
## Description
> Briefly describe what this PR accomplishes and why it's needed.


Before fix:

<img width="592" height="312" alt="Screenshot 2025-10-17 at 6 58 04 PM" src="https://github.com/user-attachments/assets/e21f677e-7857-4541-985d-1911cbdbea9b" />

After fix:
<img width="864" height="310" alt="Screenshot 2025-10-17 at 6 58 48 PM" src="https://github.com/user-attachments/assets/b6dd2e43-f238-4c84-a952-73f94ba3bb35" />


## Changes

1. Added * 100 at the end to properly convert the decimal value (0-1) to a percentage (0-100)
2. Added sum by (application, deployment, replica) to both rate aggregations to preserve the labels needed for the legend
