### PR TITLE
[Serve][Add] Include custom autoscaling policy name in logs

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -81,6 +81,13 @@ class DeploymentAutoscalingState:
         self._target_capacity_direction = info.target_capacity_direction
         self._policy_state = {}
 
+        # Log when custom autoscaling policy is used for deployment
+        if not self._config.policy.is_default_policy_function():
+            logger.info(
+                f"Using custom autoscaling policy '{self._config.policy.policy_function}' "
+                f"for deployment '{self._deployment_id}'."
+            )
+
         return self.apply_bounds(target_num_replicas)
 
     def on_replica_stopped(self, replica_id: ReplicaID):
@@ -671,6 +678,13 @@ class ApplicationAutoscalingState:
         """
         self._policy = autoscaling_policy.get_policy()
         self._policy_state = {}
+
+        # Log when custom autoscaling policy is used for application
+        if not autoscaling_policy.is_default_policy_function():
+            logger.info(
+                f"Using custom autoscaling policy '{autoscaling_policy.policy_function}' "
+                f"for application '{self._app_name}'."
+            )
 
     def has_policy(self) -> bool:
         return self._policy is not None


### PR DESCRIPTION
## Description
Now, we hava custom autoscaling policy name in logs.

1. Deployment level
Test code from https://docs.ray.io/en/master/serve/advanced-guides/advanced-autoscaling.html#custom-policy-for-deployment
<img width="1333" height="294" alt="image" src="https://github.com/user-attachments/assets/bd26e576-fd3c-489b-94c2-4c11b25bb400" />


2. Application level 
Test code from https://docs.ray.io/en/master/serve/advanced-guides/advanced-autoscaling.html#application-level-autoscaling
<img width="1321" height="431" alt="image" src="https://github.com/user-attachments/assets/d51f4952-faf5-47eb-80d0-6be357437505" />


## Related issues
Closes #57846

## Additional information
