### PR TITLE
[train] Add SHUTTING_DOWN TrainControllerState and improve logging

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -11,10 +11,12 @@ from ray.train.v2._internal.execution.controller.state import (
     AbortedState,
     ErroredState,
     FinishedState,
+    ReschedulingState,
     ResizingState,
     RestartingState,
     RunningState,
     SchedulingState,
+    ShuttingDownState,
     TrainControllerState,
 )
 from ray.train.v2._internal.execution.scaling_policy.scaling_policy import (
@@ -111,11 +113,13 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
                 run_id=self._run_id,
             )
 
-        elif not current_state._state_type.is_hidden:
-            logger.warning(
-                "Unexpected state transition to non-hidden state "
-                f"{current_state._state_type.state_name}."
-            )
+        elif isinstance(current_state, ReschedulingState):
+            # substate of SchedulingState
+            pass
+
+        elif isinstance(current_state, ShuttingDownState):
+            # substate of RunningState
+            pass
 
     def before_worker_group_start(self, worker_group_context: WorkerGroupContext):
         self._state_manager.create_train_run_attempt(

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -111,9 +111,9 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
                 run_id=self._run_id,
             )
 
-        elif not current_state._state_type.is_transient:
+        elif not current_state._state_type.is_hidden:
             logger.warning(
-                "Unexpected state transition to non-transient state "
+                "Unexpected state transition to non-hidden state "
                 f"{current_state._state_type.state_name}."
             )
 

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -111,6 +111,9 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
                 run_id=self._run_id,
             )
 
+        # Intentionally do not update state manager for transient states like
+        # SHUTTING_DOWN.
+
     def before_worker_group_start(self, worker_group_context: WorkerGroupContext):
         self._state_manager.create_train_run_attempt(
             run_id=self._run_id,

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -111,8 +111,11 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
                 run_id=self._run_id,
             )
 
-        # Intentionally do not update state manager for transient states like
-        # SHUTTING_DOWN.
+        elif not current_state._state_type.is_transient:
+            logger.warning(
+                "Unexpected state transition to non-transient state "
+                f"{current_state._state_type.state_name}."
+            )
 
     def before_worker_group_start(self, worker_group_context: WorkerGroupContext):
         self._state_manager.create_train_run_attempt(

--- a/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
+++ b/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
@@ -88,10 +88,9 @@ class ValidationManager(ControllerCallback, ReportCallback):
             self._finished_validations[task] = self._pending_validations[task]
             self._pending_validations.pop(task)
         if done_checkpoints:
-            # TODO: consider better logging
             logger.info(
-                f"Finished async validation task for checkpoint(s) {done_checkpoints}. "
-                f"Remaining pending validations for checkpoint(s): {self._pending_validations.values()}"
+                f"Finished async validation task(s) for checkpoint(s) {done_checkpoints}. "
+                f"Remaining pending validations for checkpoint(s): {list(self._pending_validations.values())}"
             )
 
         # Process next finished validation

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -498,9 +498,9 @@ class TrainController:
         self._shutdown()
 
         # Call after_controller_finish with the final result
-        result = self._build_result()
         if isinstance(self.get_state(), ShuttingDownState):
             self._set_state(self.get_state().next_state)
+        result = self._build_result()
         for callback in self._controller_callbacks:
             callback.after_controller_finish(result)
 

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -33,8 +33,7 @@ class TrainControllerStateType(Enum):
         needs_new_run_attempt: Whether this state requires starting a new run attempt, where
             a run attempt is a logical unit that encompasses both scheduling workers and
             executing training on those workers.
-        is_hidden: Whether this is a hidden state that should not show up on the Train
-            Dashboard UI.
+        is_hidden: Whether this is a hidden state that should not show up as a RunStatus.
     """
 
     INITIALIZING = ("INITIALIZING", False, True, False)

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -29,27 +29,37 @@ class TrainControllerStateType(Enum):
 
     Args:
         state_name: The name of the state.
-        is_terminal: Whether this is a terminal state that should not be further processed.
+        is_terminal: Whether this is a terminal state, meaning that we are done processing
+            worker group(s).
         needs_new_run_attempt: Whether this state requires starting a new run attempt, where
             a run attempt is a logical unit that encompasses both scheduling workers and
             executing training on those workers.
+        is_transient: Whether this is a transient state that should not show up on the Train
+            Dashboard UI.
     """
 
-    INITIALIZING = ("INITIALIZING", False, True)
-    SCHEDULING = ("SCHEDULING", False, False)
-    RESCHEDULING = ("RESCHEDULING", False, False)
-    RUNNING = ("RUNNING", False, False)
-    RESTARTING = ("RESTARTING", False, True)
-    RESIZING = ("RESIZING", False, True)
-    SHUTTING_DOWN = ("SHUTTING_DOWN", True, False)
-    ERRORED = ("ERRORED", True, False)
-    FINISHED = ("FINISHED", True, False)
-    ABORTED = ("ABORTED", True, False)
+    INITIALIZING = ("INITIALIZING", False, True, False)
+    SCHEDULING = ("SCHEDULING", False, False, False)
+    RESCHEDULING = ("RESCHEDULING", False, False, True)
+    RUNNING = ("RUNNING", False, False, False)
+    RESTARTING = ("RESTARTING", False, True, False)
+    RESIZING = ("RESIZING", False, True, False)
+    SHUTTING_DOWN = ("SHUTTING_DOWN", True, False, True)
+    ERRORED = ("ERRORED", True, False, False)
+    FINISHED = ("FINISHED", True, False, False)
+    ABORTED = ("ABORTED", True, False, False)
 
-    def __init__(self, state_name: str, is_terminal: bool, needs_new_run_attempt: bool):
+    def __init__(
+        self,
+        state_name: str,
+        is_terminal: bool,
+        needs_new_run_attempt: bool,
+        is_transient: bool,
+    ):
         self.state_name = state_name
         self.is_terminal = is_terminal
         self.needs_new_run_attempt = needs_new_run_attempt
+        self.is_transient = is_transient
 
 
 class TrainControllerState:

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -33,31 +33,28 @@ class TrainControllerStateType(Enum):
         needs_new_run_attempt: Whether this state requires starting a new run attempt, where
             a run attempt is a logical unit that encompasses both scheduling workers and
             executing training on those workers.
-        is_hidden: Whether this is a hidden state that should not show up as a RunStatus.
     """
 
-    INITIALIZING = ("INITIALIZING", False, True, False)
-    SCHEDULING = ("SCHEDULING", False, False, False)
-    RESCHEDULING = ("RESCHEDULING", False, False, True)
-    RUNNING = ("RUNNING", False, False, False)
-    RESTARTING = ("RESTARTING", False, True, False)
-    RESIZING = ("RESIZING", False, True, False)
-    SHUTTING_DOWN = ("SHUTTING_DOWN", False, False, True)
-    ERRORED = ("ERRORED", True, False, False)
-    FINISHED = ("FINISHED", True, False, False)
-    ABORTED = ("ABORTED", True, False, False)
+    INITIALIZING = ("INITIALIZING", False, True)
+    SCHEDULING = ("SCHEDULING", False, False)
+    RESCHEDULING = ("RESCHEDULING", False, False)
+    RUNNING = ("RUNNING", False, False)
+    RESTARTING = ("RESTARTING", False, True)
+    RESIZING = ("RESIZING", False, True)
+    SHUTTING_DOWN = ("SHUTTING_DOWN", False, False)
+    ERRORED = ("ERRORED", True, False)
+    FINISHED = ("FINISHED", True, False)
+    ABORTED = ("ABORTED", True, False)
 
     def __init__(
         self,
         state_name: str,
         is_terminal: bool,
         needs_new_run_attempt: bool,
-        is_hidden: bool,
     ):
         self.state_name = state_name
         self.is_terminal = is_terminal
         self.needs_new_run_attempt = needs_new_run_attempt
-        self.is_hidden = is_hidden
 
 
 class TrainControllerState:

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -29,8 +29,7 @@ class TrainControllerStateType(Enum):
 
     Args:
         state_name: The name of the state.
-        is_terminal: Whether this is a terminal state, meaning that we are done processing
-            worker group(s).
+        is_terminal: Whether this is a terminal state that should not be further processed.
         needs_new_run_attempt: Whether this state requires starting a new run attempt, where
             a run attempt is a logical unit that encompasses both scheduling workers and
             executing training on those workers.
@@ -44,7 +43,7 @@ class TrainControllerStateType(Enum):
     RUNNING = ("RUNNING", False, False, False)
     RESTARTING = ("RESTARTING", False, True, False)
     RESIZING = ("RESIZING", False, True, False)
-    SHUTTING_DOWN = ("SHUTTING_DOWN", True, False, True)
+    SHUTTING_DOWN = ("SHUTTING_DOWN", False, False, True)
     ERRORED = ("ERRORED", True, False, False)
     FINISHED = ("FINISHED", True, False, False)
     ABORTED = ("ABORTED", True, False, False)

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -127,7 +127,7 @@ class ResizingState(TrainControllerState):
 
 
 class ShuttingDownState(TrainControllerState):
-    def __init__(self, next_state: TrainControllerStateType):
+    def __init__(self, next_state: "TrainControllerState"):
         super().__init__(state_type=TrainControllerStateType.SHUTTING_DOWN)
         self.next_state = next_state
 

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -34,7 +34,7 @@ class TrainControllerStateType(Enum):
         needs_new_run_attempt: Whether this state requires starting a new run attempt, where
             a run attempt is a logical unit that encompasses both scheduling workers and
             executing training on those workers.
-        is_transient: Whether this is a transient state that should not show up on the Train
+        is_hidden: Whether this is a hidden state that should not show up on the Train
             Dashboard UI.
     """
 
@@ -54,12 +54,12 @@ class TrainControllerStateType(Enum):
         state_name: str,
         is_terminal: bool,
         needs_new_run_attempt: bool,
-        is_transient: bool,
+        is_hidden: bool,
     ):
         self.state_name = state_name
         self.is_terminal = is_terminal
         self.needs_new_run_attempt = needs_new_run_attempt
-        self.is_transient = is_transient
+        self.is_hidden = is_hidden
 
 
 class TrainControllerState:

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -12,7 +12,7 @@ class TrainControllerStateType(Enum):
     States:
        INITIALIZING: The train controller is starting up. This is always the initial
            state of the controller.
-       SCHEDULING: The training controller is in the process of scheduling a new worker
+       SCHEDULING: The train controller is in the process of scheduling a new worker
            group.
        RESCHEDULING: The train controller is in the process of rescheduling the worker
            group.
@@ -20,6 +20,8 @@ class TrainControllerStateType(Enum):
        RESTARTING: The train controller is in the process of recovering from an error.
        RESIZING: The train controller is in the process of resizing a running worker
            group.
+       SHUTTING_DOWN: The train controller has already shut down the worker group and
+           and is in the process of shutting itself down.
        ERRORED: A terminal state indicating that training has encountered an error and
            cannot continue.
        FINISHED: A terminal state indicating that training has completed.
@@ -39,6 +41,7 @@ class TrainControllerStateType(Enum):
     RUNNING = ("RUNNING", False, False)
     RESTARTING = ("RESTARTING", False, True)
     RESIZING = ("RESIZING", False, True)
+    SHUTTING_DOWN = ("SHUTTING_DOWN", True, False)
     ERRORED = ("ERRORED", True, False)
     FINISHED = ("FINISHED", True, False)
     ABORTED = ("ABORTED", True, False)
@@ -121,6 +124,12 @@ class ResizingState(TrainControllerState):
     ):
         super().__init__(state_type=TrainControllerStateType.RESIZING)
         self.scaling_decision = scaling_decision
+
+
+class ShuttingDownState(TrainControllerState):
+    def __init__(self, next_state: TrainControllerStateType):
+        super().__init__(state_type=TrainControllerStateType.SHUTTING_DOWN)
+        self.next_state = next_state
 
 
 class ErroredState(TrainControllerState):

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -172,7 +172,8 @@ async def test_failure_handling():
     failure_policy.queue_decision(FailureDecision.RAISE)
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), ShuttingDownState)
-    assert isinstance(controller.get_state().next_state, ErroredState)
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ErroredState)
 
 
 @pytest.mark.parametrize(
@@ -327,9 +328,10 @@ async def test_controller_callback():
     assert callback.failure_decision_called
     assert isinstance(callback.latest_state_update[0], RunningState)
     assert isinstance(callback.latest_state_update[1], ShuttingDownState)
-    assert isinstance(callback.latest_state_update[1].next_state, ErroredState)
 
-    controller._shutdown()
+    await controller._run_control_loop_iteration()
+    assert isinstance(callback.latest_state_update[0], ShuttingDownState)
+    assert isinstance(callback.latest_state_update[1], ErroredState)
     assert callback.shutdown_called
 
 

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -18,6 +18,7 @@ from ray.train.v2._internal.execution.controller.state import (
     RestartingState,
     RunningState,
     SchedulingState,
+    ShuttingDownState,
 )
 from ray.train.v2._internal.execution.scaling_policy import ResizeDecision
 from ray.train.v2._internal.execution.worker_group import (
@@ -537,6 +538,7 @@ def test_callback_controller_state_transitions(ray_start_regular, callback):
             scaling_decision=ResizeDecision(num_workers=2, resources_per_worker={})
         ),
         RunningState(),
+        ShuttingDownState(next_state=FinishedState()),
         FinishedState(),
     ]
     expected_statuses = [
@@ -551,6 +553,7 @@ def test_callback_controller_state_transitions(ray_start_regular, callback):
         RunStatus.SCHEDULING,  # Rescheduling
         RunStatus.SCHEDULING,
         RunStatus.RUNNING,
+        RunStatus.RUNNING,  # Shutting down
         RunStatus.FINISHED,
     ]
 

--- a/python/ray/train/v2/tests/test_validation_manager.py
+++ b/python/ray/train/v2/tests/test_validation_manager.py
@@ -49,7 +49,6 @@ def test_before_controller_shutdown(mock_wait, monkeypatch):
     # Call before_controller_shutdown
     vm.before_controller_shutdown()
     assert mock_wait.call_count == 2
-    # modoru: interesting test 2 levels
     assert checkpoint_manager.update_checkpoints_with_metrics.mock_calls == [
         unittest.mock.call({checkpoint1: {"score": 1}}),
         unittest.mock.call({checkpoint2: {"score": 1}, checkpoint3: {"score": 1}}),


### PR DESCRIPTION
# Summary

The crux of the issue is that in the past, train run status was synonymous with final worker group status, but now, when there are pending validations, the worker group is finished but the train run is not. This leads to confusing situations in which the Train Run is `FINISHED`, but because there are pending validations, the `controller` actor is alive and results are inaccessible.

This PR:
* Adds a new `SHUTTING_DOWN` `TrainControllerState` that happens after the worker group finishes but before the controller shuts everything down. 
* Makes `ValidationManager` logging slightly cleaner.
 
Like `RESCHEDULING`, `SHUTTING_DOWN` is a hidden state that shows up in `StateManager` logs and Grafana but not in the state export. We only want to show terminal states in the state export after `fit()` has returned and results are accessible. More concretely:
* Finished/errored: The worker group finishes (Train Run is `RUNNING` but internal state is `SHUTTING_DOWN`), validation finishes (both Train Run and internal state say `FINISHED` or `ERRORED`), then results are accessible.
* Aborted: Ideally, the worker group should be aborted and in-flight validation tasks canceled before the Train Run is `ABORTED`. However, this PR doesn't change the current behavior, in which the Train Run might be `ABORTED` before reference counting cleans up the validation tasks. I will cancel validation tasks before marking the train run `ABORTED` in a future PR. 

I considered polling both the worker group and validations in `_step` itself, but decided to leave `_step` as a function that only cares about the worker group. 

# Testing

Unit tests