### PR TITLE
[core] use `invoke_result_t` in cpp worker example

### DIFF
--- a/cpp/src/ray/test/examples/simple_kv_store.cc
+++ b/cpp/src/ray/test/examples/simple_kv_store.cc
@@ -217,8 +217,8 @@ class Client {
   }
 
   template <typename F>
-  std::result_of_t<F()> AlwaysRetry(const F &f) {
-    using R = std::result_of_t<F()>;
+  std::invoke_result_t<F> AlwaysRetry(const F &f) {
+    using R = std::invoke_result_t<F>;
     R r{};
     while (true) {
       try {


### PR DESCRIPTION
`result_of_t` is deprecated
