### PR TITLE
[serve][llm] Use aws s3 sync for CloudDownloader

### DIFF
--- a/python/ray/llm/_internal/common/callbacks/cloud_downloader.py
+++ b/python/ray/llm/_internal/common/callbacks/cloud_downloader.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Any, List, Tuple
 
 from pydantic import BaseModel, field_validator
@@ -76,16 +77,11 @@ class CloudDownloader(CallbackBase):
         from ray.llm._internal.common.utils.cloud_utils import CloudFileSystem
 
         paths = self.kwargs["paths"]
-        logger.info(
-            f"CloudDownloader: Starting download of {len(paths)} files from cloud storage"
-        )
-
+        start_time = time.monotonic()
         for cloud_uri, local_path in paths:
             try:
-                logger.info(f"CloudDownloader: Downloading {cloud_uri} to {local_path}")
-                CloudFileSystem.download_files(path=local_path, bucket_uri=cloud_uri)
-                logger.info(
-                    f"CloudDownloader: Successfully downloaded {cloud_uri} to {local_path}"
+                CloudFileSystem.download_files_parallel(
+                    path=local_path, bucket_uri=cloud_uri
                 )
             except Exception as e:
                 logger.error(
@@ -93,3 +89,5 @@ class CloudDownloader(CallbackBase):
                 )
                 if self.raise_error_on_callback:
                     raise
+        end_time = time.monotonic()
+        logger.info(f"CloudDownloader: Time taken: {end_time - start_time} seconds")

--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -417,9 +417,6 @@ class CloudFileSystem:
     ) -> None:
         """Optimized download using PyArrow's built-in copy_files function.
 
-        This leverages PyArrow's native parallel copy implementation which is
-        much simpler and more efficient than manual threading.
-
         Args:
             path: Local directory where files will be downloaded
             bucket_uri: URI of cloud directory
@@ -510,6 +507,7 @@ class CloudFileSystem:
                         future.result()
                     except Exception as e:
                         logger.error(f"Failed to copy file: {e}")
+                        raise
 
         except Exception as e:
             logger.exception(f"Error downloading files from {bucket_uri}: {e}")

--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -574,7 +574,7 @@ class CloudFileSystem:
 
             safetensors_to_exclude = [".safetensors"] if exclude_safetensors else None
 
-            CloudFileSystem.download_files_optimized(
+            CloudFileSystem.download_files_parallel(
                 path=destination_dir,
                 bucket_uri=bucket_uri,
                 substrings_to_include=tokenizer_file_substrings,

--- a/python/ray/llm/_internal/common/utils/download_utils.py
+++ b/python/ray/llm/_internal/common/utils/download_utils.py
@@ -267,7 +267,7 @@ def download_model_files(
     # cannot be created by torch if the parent directory doesn't exist.
     torch_cache_home = torch.hub._get_torch_home()
     os.makedirs(os.path.join(torch_cache_home, "kernels"), exist_ok=True)
-    model_path_or_id = None
+    model_path_or_id = model_id
 
     if callback is not None:
         callback.run_callback_sync("on_before_download_model_files_distributed")

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -26,7 +26,10 @@ from ray.llm._internal.common.utils.cloud_utils import (
     CloudMirrorConfig,
     is_remote_path,
 )
-from ray.llm._internal.common.utils.download_utils import NodeModelDownloadable
+from ray.llm._internal.common.utils.download_utils import (
+    STREAMING_LOAD_FORMATS,
+    NodeModelDownloadable,
+)
 from ray.llm._internal.common.utils.import_utils import load_class, try_import
 from ray.llm._internal.serve.configs.constants import (
     DEFAULT_MULTIPLEX_DOWNLOAD_TIMEOUT_S,
@@ -297,6 +300,10 @@ class LLMConfig(BaseModelExtended):
         assert engine_config is not None
         pg = engine_config.get_or_create_pg()
         runtime_env = engine_config.get_runtime_env_with_local_env_vars()
+        if self.engine_kwargs.get("load_format", None) in STREAMING_LOAD_FORMATS:
+            worker_node_download_model = NodeModelDownloadable.NONE
+        else:
+            worker_node_download_model = NodeModelDownloadable.MODEL_AND_TOKENIZER
 
         # Create new instance
         if isinstance(self.callback_config.callback_class, str):
@@ -308,7 +315,7 @@ class LLMConfig(BaseModelExtended):
             raise_error_on_callback=self.callback_config.raise_error_on_callback,
             llm_config=self,
             ctx_kwargs={
-                "worker_node_download_model": NodeModelDownloadable.MODEL_AND_TOKENIZER,
+                "worker_node_download_model": worker_node_download_model,
                 "placement_group": pg,
                 "runtime_env": runtime_env,
             },

--- a/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
+++ b/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from typing import Optional
 
 import ray
@@ -7,7 +6,7 @@ from ray.llm._internal.common.utils.download_utils import (
     download_model_files,
 )
 from ray.llm._internal.common.utils.import_utils import try_import
-from ray.llm._internal.serve.configs.server_models import LLMConfig, LLMEngine
+from ray.llm._internal.serve.configs.server_models import LLMConfig
 from ray.llm._internal.serve.observability.logging import get_logger
 
 torch = try_import("torch")
@@ -32,24 +31,6 @@ def initialize_remote_node(llm_config: LLMConfig) -> Optional[str]:
     # Validate that the binary exists
     if local_path and local_path != engine_config.actual_hf_model_id:
         engine_config.hf_model_id = local_path
-
-    # Download the tokenizer if it isn't a local file path
-    if not isinstance(local_path, str) or not os.path.exists(local_path):
-        logger.info(f"Downloading the tokenizer for {engine_config.actual_hf_model_id}")
-
-    if llm_config.llm_engine == LLMEngine.vLLM:
-        from vllm.transformers_utils.tokenizer import get_tokenizer
-
-        _ = get_tokenizer(
-            engine_config.actual_hf_model_id,
-            tokenizer_mode=engine_config.engine_kwargs.get("tokenizer_mode", None),
-            trust_remote_code=engine_config.trust_remote_code,
-        )
-    else:
-        _ = transformers.AutoTokenizer.from_pretrained(
-            engine_config.actual_hf_model_id,
-            trust_remote_code=engine_config.trust_remote_code,
-        )
 
     return local_path
 


### PR DESCRIPTION
## Description
Changes CloudDownloader to use aws s3 sync instead of pyarrow filesystem because it is faster, still needs to be investigated but this is a temporary fix.
