### PR TITLE
removed adding the TaskPoolStrategy as it's not needed here

### DIFF
--- a/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/01-Batch-Inference.ipynb
+++ b/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/01-Batch-Inference.ipynb
@@ -320,10 +320,7 @@
    "outputs": [],
    "source": [
     "# Add class.\n",
-    "ds = ds.map(add_class,\n",
-    "    num_cpus=1,\n",
-    "    num_gpus=0,\n",
-    "    compute=ray.data.TaskPoolStrategy(size=4))\n"
+    "ds = ds.map(add_class)\n"
    ]
   },
   {


### PR DESCRIPTION
## Description
I have removed the line indicating the TaskPoolStrategy in the notebook. It's not needed here and it's an internal compute concept we shouldn't introduce for these introductory examples. Also, it is not used in the other ray data map calls in this example.
