### PR TITLE
[tracing] Update OpenTelemetry dependencies and fixing doc to make tracing work

### DIFF
--- a/doc/source/ray-observability/user-guides/ray-tracing.rst
+++ b/doc/source/ray-observability/user-guides/ray-tracing.rst
@@ -15,9 +15,9 @@ First, install OpenTelemetry:
 
 .. code-block:: shell
 
-    pip install opentelemetry-api==1.1.0
-    pip install opentelemetry-sdk==1.1.0
-    pip install opentelemetry-exporter-otlp==1.1.0
+    pip install opentelemetry-api==1.34.1
+    pip install opentelemetry-sdk==1.34.1
+    pip install opentelemetry-exporter-otlp==1.34.1
 
 Tracing startup hook
 --------------------

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -79,7 +79,7 @@ class _OpenTelemetryProxy:
             if _is_tracing_enabled():
                 raise ImportError(
                     "Install OpenTelemetry with "
-                    "'pip install opentelemetry-api==1.34.1 opentelemetry-sdk==1.34.1' "
+                    "'pip install opentelemetry-api==1.34.1 opentelemetry-sdk==1.34.1 opentelemetry-exporter-otlp==1.34.1' "
                     "to enable tracing. See the Ray documentation for details: "
                     "https://docs.ray.io/en/latest/ray-observability/user-guides/ray-tracing.html#installation"
                 )

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -76,12 +76,12 @@ class _OpenTelemetryProxy:
         try:
             return importlib.import_module(module)
         except ImportError:
-            if os.getenv("RAY_TRACING_ENABLED", "False").lower() in ["true", "1"]:
+            if _is_tracing_enabled():
                 raise ImportError(
-                    "Install opentelemetry with "
-                    "'pip install opentelemetry-api==1.0.0rc1' "
-                    "and 'pip install opentelemetry-sdk==1.0.0rc1' to enable "
-                    "tracing. See more at docs.ray.io/tracing.html"
+                    "Install OpenTelemetry with "
+                    "'pip install opentelemetry-api==1.34.1 opentelemetry-sdk==1.34.1' "
+                    "to enable tracing. See the Ray documentation for details: "
+                    "https://docs.ray.io/en/latest/ray-observability/user-guides/ray-tracing.html#installation"
                 )
 
 


### PR DESCRIPTION
Tracing code hasn’t been maintained, and it can’t be run by relying on the docs alone.

1. [https://docs.ray.io/en/latest/ray-observability/user-guides/ray-tracing.html#installation](https://docs.ray.io/en/latest/ray-observability/user-guides/ray-tracing.html#installation)

`opentelemetry-api==1.1.0`
Version 1.1.0 is too old—
https://github.com/ray-project/ray/blob/b988ce4e9b0fb618b40865600c0d98f1714c3bcf/ci/docker/serve.build.Dockerfile#L47
we’re already using 1.3.0+, which is incompatible with 1.1.0.

2.
A legacy issue? This prevents the help information from being displayed.


