### PR TITLE
[core] fix idle node termination on object pulling

### DIFF
--- a/src/ray/raylet/local_lease_manager.cc
+++ b/src/ray/raylet/local_lease_manager.cc
@@ -113,6 +113,8 @@ void LocalLeaseManager::WaitForLeaseArgsRequests(std::shared_ptr<internal::Work>
       RAY_LOG(DEBUG) << "Waiting for args for lease: " << lease_id;
       auto it = waiting_lease_queue_.insert(waiting_lease_queue_.end(), std::move(work));
       RAY_CHECK(waiting_leases_index_.emplace(lease_id, it).second);
+      cluster_resource_scheduler_.GetLocalResourceManager().MarkFootprintAsBusy(
+          WorkFootprint::PULLING_TASK_ARGUMENTS);
     }
   } else {
     RAY_LOG(DEBUG) << "No args, lease can be granted " << lease_id;
@@ -322,6 +324,8 @@ void LocalLeaseManager::GrantScheduledLeasesToWorkers() {
           auto it = waiting_lease_queue_.insert(waiting_lease_queue_.begin(),
                                                 std::move(*work_it));
           RAY_CHECK(waiting_leases_index_.emplace(lease_id, it).second);
+          cluster_resource_scheduler_.GetLocalResourceManager().MarkFootprintAsBusy(
+              WorkFootprint::PULLING_TASK_ARGUMENTS);
           work_it = leases_to_grant_queue.erase(work_it);
         } else {
           // The lease's args cannot be pinned due to lack of memory. We should
@@ -497,6 +501,10 @@ void LocalLeaseManager::SpillWaitingLeases() {
       num_waiting_lease_spilled_++;
       waiting_leases_index_.erase(lease_id);
       it = waiting_lease_queue_.erase(it);
+      if (waiting_lease_queue_.empty()) {
+        cluster_resource_scheduler_.GetLocalResourceManager().MarkFootprintAsIdle(
+            WorkFootprint::PULLING_TASK_ARGUMENTS);
+      }
     } else {
       if (scheduling_node_id.IsNil()) {
         RAY_LOG(DEBUG) << "RayLease " << lease_id
@@ -724,6 +732,10 @@ void LocalLeaseManager::LeasesUnblocked(const std::vector<LeaseID> &ready_ids) {
       leases_to_grant_[scheduling_key].push_back(work);
       waiting_lease_queue_.erase(it->second);
       waiting_leases_index_.erase(it);
+      if (waiting_lease_queue_.empty()) {
+        cluster_resource_scheduler_.GetLocalResourceManager().MarkFootprintAsIdle(
+            WorkFootprint::PULLING_TASK_ARGUMENTS);
+      }
     }
   }
   ScheduleAndGrantLeases();
@@ -885,6 +897,10 @@ std::vector<std::shared_ptr<internal::Work>> LocalLeaseManager::CancelLeasesWith
         cancelled_works.push_back(work);
         return true;
       });
+  if (waiting_lease_queue_.empty()) {
+    cluster_resource_scheduler_.GetLocalResourceManager().MarkFootprintAsIdle(
+        WorkFootprint::PULLING_TASK_ARGUMENTS);
+  }
 
   return cancelled_works;
 }
@@ -990,7 +1006,7 @@ void LocalLeaseManager::Grant(
 
   RAY_CHECK(!leased_workers.contains(lease_spec.LeaseId()));
   leased_workers[lease_spec.LeaseId()] = worker;
-  cluster_resource_scheduler_.GetLocalResourceManager().SetBusyFootprint(
+  cluster_resource_scheduler_.GetLocalResourceManager().MarkFootprintAsBusy(
       WorkFootprint::NODE_WORKERS);
 
   // Update our internal view of the cluster state.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -330,7 +330,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
 
   void SetIdleIfLeaseEmpty() {
     if (leased_workers_.empty()) {
-      cluster_resource_scheduler_.GetLocalResourceManager().SetIdleFootprint(
+      cluster_resource_scheduler_.GetLocalResourceManager().MarkFootprintAsIdle(
           WorkFootprint::NODE_WORKERS);
     }
   }

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -122,7 +122,7 @@ void LocalResourceManager::FreeTaskResourceInstances(
     }
   }
 }
-void LocalResourceManager::SetBusyFootprint(WorkFootprint item) {
+void LocalResourceManager::MarkFootprintAsBusy(WorkFootprint item) {
   auto prev = last_idle_times_.find(item);
   if (prev != last_idle_times_.end() && !prev->second.has_value()) {
     return;
@@ -131,7 +131,7 @@ void LocalResourceManager::SetBusyFootprint(WorkFootprint item) {
   OnResourceOrStateChanged();
 }
 
-void LocalResourceManager::SetIdleFootprint(WorkFootprint item) {
+void LocalResourceManager::MarkFootprintAsIdle(WorkFootprint item) {
   auto prev = last_idle_times_.find(item);
   bool state_change = prev == last_idle_times_.end() || !prev->second.has_value();
 
@@ -349,6 +349,9 @@ void LocalResourceManager::PopulateResourceViewSyncMessage(
         switch (std::get<WorkFootprint>(iter.first)) {
         case WorkFootprint::NODE_WORKERS:
           resource_view_sync_message.add_node_activity("Busy workers on node.");
+          break;
+        case WorkFootprint::PULLING_TASK_ARGUMENTS:
+          resource_view_sync_message.add_node_activity("Pulling task arguments.");
           break;
         default:
           UNREACHABLE;

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -32,6 +32,7 @@ namespace ray {
 /// Encapsulates non-resource artifacts that evidence work when present.
 enum WorkFootprint {
   NODE_WORKERS = 1,
+  PULLING_TASK_ARGUMENTS = 2,
 };
 
 // Represents artifacts of a node that can be busy or idle.
@@ -117,9 +118,9 @@ class LocalResourceManager : public syncer::ReporterInterface {
   void ReleaseWorkerResources(std::shared_ptr<TaskResourceInstances> task_allocation);
 
   // Removes idle time for a WorkFootprint, thereby marking it busy.
-  void SetBusyFootprint(WorkFootprint item);
+  void MarkFootprintAsBusy(WorkFootprint item);
   // Sets the idle time for a WorkFootprint to now.
-  void SetIdleFootprint(WorkFootprint item);
+  void MarkFootprintAsIdle(WorkFootprint item);
 
   double GetLocalAvailableCpus() const;
 

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -1314,7 +1314,7 @@ TEST_P(DrainRayletIdempotencyTest, TestHandleDrainRayletIdempotency) {
 
   auto [drain_reason, is_node_idle] = GetParam();
   if (!is_node_idle) {
-    cluster_resource_scheduler_->GetLocalResourceManager().SetBusyFootprint(
+    cluster_resource_scheduler_->GetLocalResourceManager().MarkFootprintAsBusy(
         WorkFootprint::NODE_WORKERS);
   }
 


### PR DESCRIPTION
Currently, a node is considered idle while pulling objects from the remote object store. This can lead to situations where a node is terminated as idle, causing the cluster to enter an infinite loop when pulling large objects that exceed the node idle termination timeout.

This PR fixes the issue by treating object pulling as a busy activity. Note that nodes can still accept additional tasks while pulling objects (since pulling consumes no resources), but the auto-scaler will no longer terminate the node prematurely.

Closes #54372

Test:
- CI