### PR TITLE
[core] Don't log actor restart warning if arg is detached actor

### DIFF
--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -37,7 +37,8 @@ rpc::ActorHandle CreateInnerActorHandle(
     bool allow_out_of_order_execution,
     bool enable_tensor_transport,
     std::optional<bool> enable_task_events,
-    const std::unordered_map<std::string, std::string> &labels) {
+    const std::unordered_map<std::string, std::string> &labels,
+    bool is_detached) {
   rpc::ActorHandle inner;
   inner.set_actor_id(actor_id.Data(), actor_id.Size());
   inner.set_owner_id(owner_id.Binary());
@@ -56,6 +57,7 @@ rpc::ActorHandle CreateInnerActorHandle(
   inner.set_enable_tensor_transport(enable_tensor_transport);
   inner.set_enable_task_events(enable_task_events.value_or(kDefaultTaskEventEnabled));
   inner.mutable_labels()->insert(labels.begin(), labels.end());
+  inner.set_is_detached(is_detached);
   return inner;
 }
 
@@ -89,6 +91,7 @@ rpc::ActorHandle CreateInnerActorHandleFromActorData(
       task_spec.actor_creation_task_spec().allow_out_of_order_execution());
   inner.set_max_pending_calls(task_spec.actor_creation_task_spec().max_pending_calls());
   inner.mutable_labels()->insert(task_spec.labels().begin(), task_spec.labels().end());
+  inner.set_is_detached(task_spec.actor_creation_task_spec().is_detached());
   return inner;
 }
 }  // namespace
@@ -109,7 +112,8 @@ ActorHandle::ActorHandle(
     bool allow_out_of_order_execution,
     bool enable_tensor_transport,
     std::optional<bool> enable_task_events,
-    const std::unordered_map<std::string, std::string> &labels)
+    const std::unordered_map<std::string, std::string> &labels,
+    bool is_detached)
     : ActorHandle(CreateInnerActorHandle(actor_id,
                                          owner_id,
                                          owner_address,
@@ -125,7 +129,8 @@ ActorHandle::ActorHandle(
                                          allow_out_of_order_execution,
                                          enable_tensor_transport,
                                          enable_task_events,
-                                         labels)) {}
+                                         labels,
+                                         is_detached)) {}
 
 ActorHandle::ActorHandle(const std::string &serialized)
     : ActorHandle(CreateInnerActorHandleFromString(serialized)) {}

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -66,6 +66,8 @@ class ActorHandle {
 
   rpc::Address GetOwnerAddress() const { return inner_.owner_address(); }
 
+  bool IsDetached() const { return inner_.has_owner_address(); }
+
   /// ID of the job that created the actor (it is possible that the handle
   /// exists on a job with a different job ID).
   JobID CreationJobID() const { return JobID::FromBinary(inner_.creation_job_id()); };

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -51,7 +51,8 @@ class ActorHandle {
               bool allow_out_of_order_execution = false,
               bool enable_tensor_transport = false,
               std::optional<bool> enable_task_events = absl::nullopt,
-              const std::unordered_map<std::string, std::string> &labels = {});
+              const std::unordered_map<std::string, std::string> &labels = {},
+              bool is_detached = false);
 
   /// Constructs an ActorHandle from a serialized string.
   explicit ActorHandle(const std::string &serialized);
@@ -65,8 +66,6 @@ class ActorHandle {
   TaskID GetOwnerId() const { return TaskID::FromBinary(inner_.owner_id()); }
 
   rpc::Address GetOwnerAddress() const { return inner_.owner_address(); }
-
-  bool IsDetached() const { return inner_.has_owner_address(); }
 
   /// ID of the job that created the actor (it is possible that the handle
   /// exists on a job with a different job ID).
@@ -114,6 +113,8 @@ class ActorHandle {
   bool AllowOutOfOrderExecution() const { return inner_.allow_out_of_order_execution(); }
 
   bool EnableTensorTransport() const { return inner_.enable_tensor_transport(); }
+
+  bool IsDetached() const { return inner_.is_detached(); }
 
   const ::google::protobuf::Map<std::string, std::string> &GetLabels() const {
     return inner_.labels();

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -119,6 +119,16 @@ bool ActorManager::CheckActorHandleExists(const ActorID &actor_id) {
   return actor_handles_.find(actor_id) != actor_handles_.end();
 }
 
+std::shared_ptr<ActorHandle> ActorManager::GetActorHandleIfExists(
+    const ActorID &actor_id) {
+  absl::MutexLock lock(&mutex_);
+  auto it = actor_handles_.find(actor_id);
+  if (it != actor_handles_.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
 bool ActorManager::AddNewActorHandle(std::unique_ptr<ActorHandle> actor_handle,
                                      const std::string &call_site,
                                      const rpc::Address &caller_address,

--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -143,6 +143,9 @@ class ActorManager {
   /// \param actor_id ID of the actor to be subscribed.
   void SubscribeActorState(const ActorID &actor_id);
 
+  /// Returns the actor handle if it exists, nullptr otherwise.
+  std::shared_ptr<ActorHandle> GetActorHandleIfExists(const ActorID &actor_id);
+
  private:
   /// Give this worker a handle to an actor.
   ///

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2115,7 +2115,8 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       actor_creation_options.allow_out_of_order_execution,
       actor_creation_options.enable_tensor_transport,
       actor_creation_options.enable_task_events,
-      actor_creation_options.labels);
+      actor_creation_options.labels,
+      is_detached);
   std::string serialized_actor_handle;
   actor_handle->Serialize(&serialized_actor_handle);
   ActorID root_detached_actor_id;
@@ -2162,28 +2163,36 @@ Status CoreWorker::CreateActor(const RayFunction &function,
     return Status::OK();
   }
 
+  static auto ref_is_detached_actor = [this](const std::string &object_id) {
+    auto ref_object_id = ObjectID::FromBinary(object_id);
+    if (ObjectID::IsActorID(ref_object_id)) {
+      auto ref_actor_id = ObjectID::ToActorID(ref_object_id);
+      if (auto ref_actor_handle = actor_manager_->GetActorHandleIfExists(ref_actor_id)) {
+        if (ref_actor_handle->IsDetached()) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
   if (task_spec.MaxActorRestarts() != 0) {
     bool actor_restart_warning = false;
     for (size_t i = 0; i < task_spec.NumArgs(); i++) {
-      if (!task_spec.ArgInlinedRefs(i).empty()) {
+      if (task_spec.ArgByRef(i)) {
         actor_restart_warning = true;
         break;
       }
-      if (task_spec.ArgByRef(i)) {
-        auto ref_object_id = ObjectID::FromBinary(task_spec.ArgRef(i).object_id());
-        if (ObjectID::IsActorID(ref_object_id)) {
-          auto ref_actor_id = ObjectID::ToActorID(ref_object_id);
-          if (auto ref_actor_handle =
-                  actor_manager_->GetActorHandleIfExists(ref_actor_id)) {
-            if (ref_actor_handle->IsDetached()) {
-              // Don't show the warning if the actor is detached since it'll never go out
-              // of scope
-              RAY_LOG(ERROR) << "Actor is detached";
-              continue;
-            }
+      if (!task_spec.ArgInlinedRefs(i).empty()) {
+        for (const auto &ref : task_spec.ArgInlinedRefs(i)) {
+          if (!ref_is_detached_actor(ref.object_id())) {
+            // There's an inlined ref that's not a detached actor, so we want to
+            // show the warning.
+            actor_restart_warning = true;
+            break;
           }
         }
-        actor_restart_warning = true;
+      }
+      if (actor_restart_warning) {
         break;
       }
     }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2163,7 +2163,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
     return Status::OK();
   }
 
-  static auto ref_is_detached_actor = [this](const std::string &object_id) {
+  auto ref_is_detached_actor = [this](const std::string &object_id) {
     auto ref_object_id = ObjectID::FromBinary(object_id);
     if (ObjectID::IsActorID(ref_object_id)) {
       auto ref_actor_id = ObjectID::ToActorID(ref_object_id);

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -74,6 +74,8 @@ message ActorHandle {
   map<string, string> labels = 15;
 
   bool enable_tensor_transport = 16;
+
+  bool is_detached = 17;
 }
 
 message PushTaskRequest {


### PR DESCRIPTION
## Description
Ray Data doesn't want this warning log to show on all workloads. Now, they pass a detached ActorLocationTracker into actors with max_restarts > 0. A detached actor won't go out of scope, so as long as it isn't ray.killed it'll still exist when the actor with it as an arg needs to restart. See - https://github.com/ray-project/ray/pull/57838 - minimal ray data usage will result in the log now.

We'll revert this logic back once https://github.com/ray-project/ray/issues/53727 is fixed.


Here I'm just checking if an inlined arg passed by ref is a detached actor. If it is, we'll skip setting the warning flag so we won't log the warning. The actor handle has no way of knowing whether the actor is detached so I had to create that path.

Used this script to test that we don't log the warning.
```
@ray.remote(max_restarts=-1)
class Actor:
    def __init__(self, other_actor_ref):
        self.other_actor_ref = other_actor_ref

    def do_thing(self):
        print("hi")

detached_actor = Actor.options(name="detached_actor").remote(None)
actor = Actor.remote(detached_actor)

ray.get(actor.do_thing.remote())
```


Note: There's one gotcha here - is_detached doesn't get through all the way if you're passing the actor handle around because the serialization doesn't take it into account, I'll fix this in a follow up right after