### PR TITLE
[train] bump test_util timeout

### DIFF
--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -551,7 +551,7 @@ py_test(
 
 py_test(
     name = "test_util",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_util.py"],
     env = {"RAY_TRAIN_V2_ENABLED": "1"},
     tags = [


### PR DESCRIPTION
## Description
Bumping from small to medium because it's timing out for Python 3.12.