### PR TITLE
[core] Deflake `test_failure_4.py::test_task_failure_when_driver_local_raylet_dies`

### DIFF
--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -9,7 +9,6 @@ from grpc._channel import _InactiveRpcError
 
 import ray
 import ray._private.ray_constants as ray_constants
-import ray.experimental.internal_kv as internal_kv
 from ray import NodeID
 from ray._common.network_utils import build_address
 from ray._common.test_utils import SignalActor, wait_for_condition

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -545,7 +545,7 @@ def test_task_failure_when_driver_local_raylet_dies(ray_start_cluster):
     cluster = ray_start_cluster
     system_configs = {
         "health_check_initial_delay_ms": 0,
-        "health_check_timeout_ms": 10,
+        "health_check_timeout_ms": 1000,
         "health_check_failure_threshold": 1,
     }
     head = cluster.add_node(
@@ -556,15 +556,16 @@ def test_task_failure_when_driver_local_raylet_dies(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address, include_dashboard=True)
 
+    signal = SignalActor.remote()
+
     @ray.remote(resources={"foo": 1})
     def func():
-        internal_kv._internal_kv_put("test_func", "func")
+        ray.get(signal.send.remote())
         while True:
             time.sleep(1)
 
     func.remote()
-    while not internal_kv._internal_kv_exists("test_func"):
-        time.sleep(0.1)
+    ray.get(signal.wait.remote())
 
     # The lease request should wait inside raylet
     # since there is no available resources.


### PR DESCRIPTION
Example failure: https://buildkite.com/ray-project/postmerge/builds/13835#0199f4a3-5657-46cf-a498-bde0b2ba774e/615-2139

This happens because we tune the Raylet health check threshold to be very tight, so it's marked as dead extraneously during startup. Setting the timeout to 1s, which should increase test runtime slightly but deflake.

Also removed the usage of `internal_kv`.