### PR TITLE
[core] Attempt to deflake `test_actor_failures.py::test_async_generator_crash_restart`

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -6,7 +6,7 @@ import signal
 import sys
 import tempfile
 import time
-from typing import Callable, Generator
+from typing import Callable, Generator, List
 
 import numpy as np
 import pytest
@@ -103,95 +103,77 @@ def test_actor_spilled(ray_start_regular):
 def test_async_generator_crash_restart(ray_start_cluster):
     """
     Timeline:
-    1. In worker node, creates a generator that generates 2 objects
-    2. Kills worker node, objs exist in ref, but data lost
-    3. In worker node, creates a consumer that consumes 2 objects
-    4. Start a worker node to enable the task and lineage reconstruction
-    5. Lineage reconstruction should be working here.
-        The gen is dead after it only generated 1.
-    6. Verify that the consumer task can still run (it's not)
+
+    1. On a worker node, run a generator task that generates 2 objects in total and
+       another task that consumes the objects.
+    2. After the generator generates 1 object, kill the node they're both running on.
+       The first ObjectRef will have been generated, but its data lost, and the second
+       ObjectRef won't have been generated yet.
+    3. Add a new worker node for the tasks to be re-run on.
+    4. Verify that the generator task is retried and the consumer task successfully
+       retrieves its outputs.
     """
     cluster = ray_start_cluster
-    cluster.add_node(num_cpus=1, resources={"head": 1})
+    head_node_id = cluster.add_node(
+        _system_config={
+            "health_check_timeout_ms": 1000,
+            "health_check_failure_threshold": 1,
+        }
+    ).node_id
     cluster.wait_for_nodes()
-
     ray.init(address=cluster.address)
 
-    @ray.remote(num_cpus=0, resources={"head": 0.1})
-    class Killer:
-        def __init__(self):
-            self.pid = None
-            self.at_num = None
-            self.kill_num = 0
-
-        def set_pid(self, pid):
-            self.pid = pid
-
-        def set_at_num(self, at_num):
-            self.at_num = at_num
-
-        def kill_if_needed(self, num):
-            if self.kill_num > 3:
-                return
-            self.kill_num = self.kill_num + 1
-            if self.pid is not None and self.at_num is not None and num == self.at_num:
-                import os
-                import signal
-
-                print(f"Killing the pid = {self.pid}")
-                os.kill(self.pid, signal.SIGKILL)
+    # Used to pause the generator task and kill it after it generates the first object.
+    signal = SignalActor.remote()
 
     @ray.remote(
-        num_cpus=1, max_restarts=-1, max_task_retries=-1, resources={"worker": 1}
+        label_selector={"ray.io/node-id": f"!{head_node_id}"}, max_restarts=-1, max_task_retries=-1,
     )
     class Generator:
-        async def gen(self, nums, killer):
-            """
-            Generates "value_holder" objects. For each object, it first notifies the
-            killer, and yields the object.
-            """
-            print(f"my pid is {os.getpid()}, telling to killer")
-            await killer.set_pid.remote(os.getpid())
-            print(f"generates total {nums}")
-            for i in range(nums):
-                await killer.kill_if_needed.remote(i)
+        async def generate(self):
+            print("Generate first object.")
+            yield np.ones(1024 ** 2, dtype=np.uint8)
+            print("Wait for SignalActor.")
+            ray.get(signal.wait.remote())
+            print("Generate second object.")
+            yield np.ones(1024 ** 2, dtype=np.uint8)
 
-                print(f"generating {i}")
-                yield np.ones((1000, 1000), dtype=np.uint8) * i
-                print(f"generated {i}")
-            print(f"generated total {nums}")
+    @ray.remote(label_selector={"ray.io/node-id": f"!{head_node_id}"})
+    def consumer(object_refs: List[ray.ObjectRef]):
+        assert len(object_refs) == 2
+        print("Calling `ray.get`.")
+        ray.get(object_refs)
+        print("`ray.get` succeeded.")
 
-    @ray.remote(num_cpus=1, resources={"worker": 1})
-    def consumes(objs, expected_num):
-        nums = ray.get(objs)
-        assert len(nums) == expected_num
-        print(f"consumes {len(nums)}")
-        print(nums)
-        return expected_num
-
-    worker_node = cluster.add_node(num_cpus=10, resources={"worker": 10})
+    worker_node = cluster.add_node(num_cpus=2, resources={"worker": 2})
     cluster.wait_for_nodes()
 
     generator = Generator.remote()
-    killer = Killer.remote()
 
-    # First run, no kills
-    gen = ray.get(generator.gen.remote(2, killer))  # returns ObjectRefGenerator
-    objs = list(gen)  # [ObjectRef, ...]
-    assert len(objs) == 2
+    # First run, let the generator run to completion.
+    obj_ref_gen_ref = generator.generate.remote()
+    wait_for_condition(lambda: ray.get(signal.cur_num_waiters.remote()) == 1)
+    ray.get(signal.send.remote(clear=True))
+    object_refs = list(ray.get(obj_ref_gen_ref))
+    assert len(object_refs) == 2
 
-    # kill the worker node
+    # Kill the worker node that holds the objects.
     cluster.remove_node(worker_node, allow_graceful=False)
 
-    # In the lineage reconstruction, the generator is dead after it only generated 5...
-    ray.get(killer.set_at_num.remote(1))
+    # Submit a consumer task that requires the objects from the generator.
+    consumer = consumer.remote(object_refs)
 
-    # ... but a consumer takes all 10
-    consumer = consumes.remote(objs, 2)
-    # start a new worker node
-    worker_node = cluster.add_node(num_cpus=10, resources={"worker": 10})
+    # Start a new worker node that the generator can be rerun on and the consumer can
+    # run on.
+    worker_node = cluster.add_node(num_cpus=2, resources={"worker": 2})
     cluster.wait_for_nodes()
 
+    # Kill the generator after it generates a single object.
+    wait_for_condition(lambda: ray.get(signal.cur_num_waiters.remote()) == 1)
+    ray.kill(generator, no_restart=False)
+
+    # Now let the generator complete and check that the consumer succeeds.
+    ray.get(signal.send.remote())
     ray.get(consumer)
 
 

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -127,16 +127,18 @@ def test_async_generator_crash_restart(ray_start_cluster):
     signal = SignalActor.remote()
 
     @ray.remote(
-        label_selector={"ray.io/node-id": f"!{head_node_id}"}, max_restarts=-1, max_task_retries=-1,
+        label_selector={"ray.io/node-id": f"!{head_node_id}"},
+        max_restarts=-1,
+        max_task_retries=-1,
     )
     class Generator:
         async def generate(self):
             print("Generate first object.")
-            yield np.ones(1024 ** 2, dtype=np.uint8)
+            yield np.ones(1024**2, dtype=np.uint8)
             print("Wait for SignalActor.")
             ray.get(signal.wait.remote())
             print("Generate second object.")
-            yield np.ones(1024 ** 2, dtype=np.uint8)
+            yield np.ones(1024**2, dtype=np.uint8)
 
     @ray.remote(label_selector={"ray.io/node-id": f"!{head_node_id}"})
     def consumer(object_refs: List[ray.ObjectRef]):

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -104,14 +104,12 @@ def test_async_generator_crash_restart(ray_start_cluster):
     """
     Timeline:
 
-    1. On a worker node, run a generator task that generates 2 objects in total and
-       another task that consumes the objects.
-    2. After the generator generates 1 object, kill the node they're both running on.
-       The first ObjectRef will have been generated, but its data lost, and the second
-       ObjectRef won't have been generated yet.
-    3. Add a new worker node for the tasks to be re-run on.
-    4. Verify that the generator task is retried and the consumer task successfully
-       retrieves its outputs.
+    1. On a worker node, run a generator task that generates 2 objects in total and run
+       it to completion.
+    2. Kill the worker node so the objects are lost but the object refs exist.
+    3. Submit a consumer task that depends on the generated object refs.
+    4. Add a new worker node that the generator and the consumer can be run on
+    5. Verify that the generator outputs are reconstructed and the consumer succeeds.
     """
     cluster = ray_start_cluster
     head_node_id = cluster.add_node(


### PR DESCRIPTION
The test is periodically failing due to an OOM in CI: https://buildkite.com/ray-project/postmerge/builds/13835#0199f4a3-5657-46cf-a498-bde0b2ba774e/615-2139

There's no clear reason for it aside from just consuming a lot of memory. I've attempted to reduce the memory consumption by reducing the size of the objects generated.

The test was also just a mess and very hard to understand, so I've cleaned it up and hopefully made it more clear. Also reduced the Raylet health check threshold to speed it up (~20s -> ~10s).