### PR TITLE
[core] Deflake `test_gcs_fault_tolerance.py::test_worker_raylet_resubscription`

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -283,7 +283,7 @@ def test_worker_raylet_resubscription(tmp_path, ray_start_regular_with_external_
         blocking_child_pid = int((tmp_path / "blocking_child.pid").read_text())
         return True
 
-    wait_for_condition(condition, timeout=5)
+    wait_for_condition(condition, timeout=10)
 
     # Kill and restart the GCS to trigger resubscription.
     ray._private.worker._global_node.kill_gcs_server()
@@ -303,7 +303,7 @@ def test_worker_raylet_resubscription(tmp_path, ray_start_regular_with_external_
     p.wait()
 
     # The blocking child task should exit.
-    wait_for_pid_to_exit(blocking_child_pid, 5)
+    wait_for_pid_to_exit(blocking_child_pid, 10)
 
 
 def test_core_worker_resubscription(tmp_path, ray_start_regular_with_external_redis):


### PR DESCRIPTION
Failures in CI:

- https://buildkite.com/ray-project/postmerge-macos/builds/8825#0199f6fb-e711-468c-875f-04bc66f9a545/2385-4866
- https://buildkite.com/ray-project/postmerge-macos/builds/8878#019a052b-723a-4a17-a563-f3b49d0d48a0/2384-3840

Looks like the timeout is just tight -- bumping from 5s -> 10s.