### PR TITLE
[tune] update release tests to import from tune

### DIFF
--- a/release/cluster_tests/workloads/tune_scale_up_down.py
+++ b/release/cluster_tests/workloads/tune_scale_up_down.py
@@ -27,7 +27,7 @@ import time
 
 import ray
 
-from ray import train, tune
+from ray import tune
 
 
 def train_fn(config):
@@ -35,12 +35,12 @@ def train_fn(config):
     if config["head_node_ip"] == this_node_ip:
         # On the head node, run for 30 minutes
         for i in range(30):
-            train.report({"metric": i})
+            tune.report({"metric": i})
             time.sleep(60)
     else:
         # On worker nodes, run for 3 minutes
         for i in range(3):
-            train.report({"metric": i})
+            tune.report({"metric": i})
             time.sleep(60)
 
 

--- a/release/tune_tests/fault_tolerance_tests/workloads/test_tune_worker_fault_tolerance.py
+++ b/release/tune_tests/fault_tolerance_tests/workloads/test_tune_worker_fault_tolerance.py
@@ -28,7 +28,7 @@ import random
 import gc
 
 import ray
-from ray import train
+from ray import tune
 from ray.tune import Checkpoint, RunConfig, FailureConfig, CheckpointConfig
 from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
@@ -43,12 +43,12 @@ WARMUP_TIME_S = 45
 
 def objective(config):
     start_iteration = 0
-    checkpoint = train.get_checkpoint()
+    checkpoint = tune.get_checkpoint()
     # Ensure that after the node killer warmup time, we always have
     # a checkpoint to restore from.
     if (time.monotonic() - config["start_time"]) >= config["warmup_time_s"]:
         assert checkpoint
-    checkpoint = train.get_checkpoint()
+    checkpoint = tune.get_checkpoint()
     if checkpoint:
         with checkpoint.as_directory() as checkpoint_dir:
             with open(os.path.join(checkpoint_dir, "ckpt.pkl"), "rb") as f:
@@ -61,7 +61,7 @@ def objective(config):
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "ckpt.pkl"), "wb") as f:
                 pickle.dump(dct, f)
-            train.report(dct, checkpoint=Checkpoint.from_directory(tmpdir))
+            tune.report(dct, checkpoint=Checkpoint.from_directory(tmpdir))
 
 
 def main(bucket_uri: str):

--- a/release/tune_tests/fault_tolerance_tests/workloads/test_tune_worker_fault_tolerance.py
+++ b/release/tune_tests/fault_tolerance_tests/workloads/test_tune_worker_fault_tolerance.py
@@ -29,7 +29,7 @@ import gc
 
 import ray
 from ray import train
-from ray.train import Checkpoint, RunConfig, FailureConfig, CheckpointConfig
+from ray.tune import Checkpoint, RunConfig, FailureConfig, CheckpointConfig
 from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
 


### PR DESCRIPTION
## Description

Fix release tests that are still importing from `ray.train` to import from `ray.tune`, as described in https://github.com/ray-project/ray/issues/49454.

## Additional information

Test Runs:

| Test Name | Before | After|
| --- | --- | ---|
| `cluster_tune_scale_up_down.aws` | https://buildkite.com/ray-project/release/builds/64733#019a0546-dbe2-47b1-ba85-983d48098352 | https://buildkite.com/ray-project/release/builds/64809/steps/canvas?sid=019a0804-dc62-4177-a24a-b23806cd0d51 |
| `cluster_tune_scale_up_down.kuberay` | https://buildkite.com/ray-project/release/builds/64733#019a0549-25dd-4dd3-ba84-df9d3ce5a72a | https://buildkite.com/ray-project/release/builds/64809/steps/canvas?sid=019a0804-dc63-49b3-8efc-ff3bd5fb8d28 |
| `tune_worker_fault_tolerance` | https://buildkite.com/ray-project/release/builds/64734#019a058c-2f15-401c-88d9-894002152fff | https://buildkite.com/ray-project/release/builds/64845/steps/canvas?sid=019a08aa-6c85-43d4-83e0-bf56d49ab474 |