### PR TITLE
[train] disable train_colocate_trainer

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1896,7 +1896,9 @@
   group: Train tests
   working_dir: train_tests/colocate_trainer
 
-  frequency: nightly
+  # Ray Train V2 doesn't support colocation.
+  # TODO: Decide whether to remove this test or re-enable it if we add support again.
+  frequency: manual
   team: ml
 
   cluster:


### PR DESCRIPTION
## Description
Change `train_colocate_trainer` release test frequency to be manual.

## Related issues
Related to #49454.

## Additional information

`ScalingConfig.trainer_resources` has been deprecated in Ray Train V2. As a result, we should disable the test for now. In the future, we can either:
1. Delete this test entirely.
2. Add back functionality for colocation & reenable this test.

