### PR TITLE
[data.dashboard] Fix broken Ray Data per node metrics because of unsupported operator filter

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -330,7 +330,7 @@ OUTPUT_BYTES_BY_NODE_PANEL = Panel(
     unit="Bps",
     targets=[
         Target(
-            expr='sum(rate(ray_data_bytes_outputs_of_finished_tasks_per_node{{{global_filters}, operator=~"$Operator"}}[1m])) by (dataset, node_ip)',
+            expr="sum(rate(ray_data_bytes_outputs_of_finished_tasks_per_node{{{global_filters}}}[1m])) by (dataset, node_ip)",
             legend="Bytes output / Second: {{dataset}}, {{node_ip}}",
         )
     ],
@@ -347,7 +347,7 @@ BLOCKS_BY_NODE_PANEL = Panel(
     unit="blocks/s",
     targets=[
         Target(
-            expr='sum(rate(ray_data_blocks_outputs_of_finished_tasks_per_node{{{global_filters}, operator=~"$Operator"}}[1m])) by (dataset, node_ip)',
+            expr="sum(rate(ray_data_blocks_outputs_of_finished_tasks_per_node{{{global_filters}}}[1m])) by (dataset, node_ip)",
             legend="Blocks output / Second: {{dataset}}, {{node_ip}}",
         )
     ],
@@ -438,7 +438,7 @@ TASK_THROUGHPUT_BY_NODE_PANEL = Panel(
     unit="tasks/s",
     targets=[
         Target(
-            expr='sum(rate(ray_data_num_tasks_finished_per_node{{{global_filters}, operator=~"$Operator"}}[1m])) by (dataset, node_ip)',
+            expr="sum(rate(ray_data_num_tasks_finished_per_node{{{global_filters}}}[1m])) by (dataset, node_ip)",
             legend="Finished Tasks: {{dataset}}, {{node_ip}}",
         )
     ],


### PR DESCRIPTION
## Description
The per node metrics at OSS Ray Data dashboard are not displayed as expected.
Because of this code change #55495, the following three metrics were added a filter for `operator`, which is [not supported](https://github.com/ray-project/ray/blob/e51f8039bc6992d37834bcff109a3d340e78fcde/python/ray/data/_internal/stats.py#L448) by per node metrics, and causes empty result.
ray_data_num_tasks_finished_per_node
ray_data_bytes_outputs_of_finished_tasks_per_node
ray_data_blocks_outputs_of_finished_tasks_per_node
