### PR TITLE
doc: Update to remove MeetUp links and add Luma links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ Getting Involved
      - For asking questions about how to use Ray.
      - 3-5 days
      - Community
-   * - `Luma Calendar`_
+   * - `Luma Calendar (Ray Meetups)`_
      - For attending Ray meetups and events.
      - Monthly
      - Ray DevRel

--- a/README.rst
+++ b/README.rst
@@ -123,8 +123,8 @@ Getting Involved
      - For asking questions about how to use Ray.
      - 3-5 days
      - Community
-   * - `Meetup Group`_
-     - For learning about Ray projects and best practices.
+   * - `Luma Calendar`_
+     - For attending Ray meetups and events.
      - Monthly
      - Ray DevRel
    * - `Twitter`_
@@ -135,6 +135,6 @@ Getting Involved
 .. _`Discourse Forum`: https://discuss.ray.io/
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
-.. _`Meetup Group`: https://www.meetup.com/Bay-Area-Ray-Meetup/
+.. _`Luma Calendar (Ray Meetups)`: https://luma.com/calendar/cal-v0NBtAknV4Ogv8L
 .. _`Twitter`: https://x.com/raydistributed
 .. _`Slack`: https://www.ray.io/join-slack?utm_source=github&utm_medium=ray_readme&utm_campaign=getting_involved

--- a/doc/source/_templates/index.html
+++ b/doc/source/_templates/index.html
@@ -436,7 +436,7 @@
       <b>Contribute to Ray</b>
       <a
         class="community-box"
-        href="https://www.meetup.com/Bay-Area-Ray-Meetup/"
+        href="https://luma.com/calendar/cal-v0NBtAknV4Ogv8L"
         target="_blank"
       >
         <i class="ri-team-line"></i>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -273,7 +273,6 @@ if os.environ.get("LINKCHECK_ALL"):
         "https://www.oracle.com/java/technologies/javase-jdk15-downloads.html",  # forbidden for client
         "https://speakerdeck.com/*",  # forbidden for bots
         r"https://huggingface.co/*",  # seems to be flaky
-        r"https://www.meetup.com/*",  # seems to be flaky
         r"https://www.pettingzoo.ml/*",  # seems to be flaky
         r"http://localhost[:/].*",  # Ignore localhost links
         r"^http:/$",  # Ignore incomplete links

--- a/doc/source/ray-contribute/involvement.rst
+++ b/doc/source/ray-contribute/involvement.rst
@@ -5,7 +5,7 @@ researchers, and folks that love machine learning. Here's a list of tips for get
 - Star and follow us on `on GitHub`_.
 - To post questions or feature requests, check out the `Discussion Board`_.
 - Follow us and spread the word on `Twitter`_.
-- Subscribe our `Luma Calendar`_ to stay up to date with Ray meetups and events.
+- Subscribe to our `Luma Calendar`_ to stay up to date with Ray meetups and events.
 - Use the `[ray]` tag on `StackOverflow`_ to ask and answer questions about Ray usage.
 
 

--- a/doc/source/ray-contribute/involvement.rst
+++ b/doc/source/ray-contribute/involvement.rst
@@ -5,7 +5,7 @@ researchers, and folks that love machine learning. Here's a list of tips for get
 - Star and follow us on `on GitHub`_.
 - To post questions or feature requests, check out the `Discussion Board`_.
 - Follow us and spread the word on `Twitter`_.
-- Join our `Meetup Group`_ to connect with others in the community.
+- Subscribe our `Luma Calendar`_ to stay up to date with Ray meetups and events.
 - Use the `[ray]` tag on `StackOverflow`_ to ask and answer questions about Ray usage.
 
 
@@ -14,5 +14,5 @@ researchers, and folks that love machine learning. Here's a list of tips for get
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
 .. _`Pull Requests`: https://github.com/ray-project/ray/pulls
 .. _`Twitter`: https://x.com/raydistributed
-.. _`Meetup Group`: https://www.meetup.com/Bay-Area-Ray-Meetup/
+.. _`Luma Calendar`: https://luma.com/calendar/cal-v0NBtAknV4Ogv8L
 .. _`on GitHub`: https://github.com/ray-project/ray


### PR DESCRIPTION
## Description
Since we are not using our Ray meetup group anymore, I've updated all the links to point to our Luma calendar, which is what we will be using to organize meetups moving forward. Let me know if you have any questions.