### PR TITLE
[doc] Fix a MLFlow doc for `mlflow.set_tracking_uri`

### DIFF
--- a/doc/source/train/user-guides/experiment-tracking.rst
+++ b/doc/source/train/user-guides/experiment-tracking.rst
@@ -182,8 +182,10 @@ If applicable, make sure that you properly set up credentials on each training w
 
         .. testcode::
             :skipif: True
-
-            mlflow.start_run(tracking_uri="file:some_shared_storage_path/mlruns")
+            
+            mlflow.set_tracking_uri("file://some_shared_storage_path/mlruns")
+            mlflow.set_experiment("my_experiment")
+            mlflow.start_run()
 
         **Remote, hosted by Databricks**
 

--- a/doc/source/train/user-guides/experiment-tracking.rst
+++ b/doc/source/train/user-guides/experiment-tracking.rst
@@ -183,7 +183,7 @@ If applicable, make sure that you properly set up credentials on each training w
         .. testcode::
             :skipif: True
             
-            mlflow.set_tracking_uri("file://some_shared_storage_path/mlruns")
+            mlflow.set_tracking_uri(uri="file://some_shared_storage_path/mlruns")
             mlflow.set_experiment("my_experiment")
             mlflow.start_run()
 

--- a/doc/source/train/user-guides/experiment-tracking.rst
+++ b/doc/source/train/user-guides/experiment-tracking.rst
@@ -184,7 +184,6 @@ If applicable, make sure that you properly set up credentials on each training w
             :skipif: True
             
             mlflow.set_tracking_uri(uri="file://some_shared_storage_path/mlruns")
-            mlflow.set_experiment("my_experiment")
             mlflow.start_run()
 
         **Remote, hosted by Databricks**


### PR DESCRIPTION
## Description
1. the `mlflow.start_run()` does not have the `tracking_uri` arg: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.html#mlflow.start_run
2. rewrite the mlflow set up as follow
```
mlflow.set_tracking_uri(uri="file://some_shared_storage_path/mlruns")
mlflow.set_experiment("my_experiment")
mlflow.start_run()
```

## Related issues
N/A
