### PR TITLE
[release] Don't check for Azure env vars

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -154,13 +154,6 @@ def get_step(
     default_project_id = env_dict.get("RELEASE_DEFAULT_PROJECT")
     env_dict["ANYSCALE_PROJECT"] = get_test_project_id(test, default_project_id)
 
-    if test.is_azure():
-        for env_var in ["AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_TENANT_ID"]:
-            value = os.environ.get(env_var)
-            if not value:
-                raise ValueError(f"{env_var} must be set")
-            env_dict[env_var] = value
-
     step["env"].update(env_dict)
     step["plugins"][0][DOCKER_PLUGIN_KEY]["image"] = "python:3.9"
 


### PR DESCRIPTION
Since we are now logging into Azure using certificate, these environment variables are not used anymore. 