### PR TITLE
[core][event] feature flag for enabling ray export event

### DIFF
--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -166,6 +166,7 @@ ray_cc_library(
         ":ray_event",
         ":ray_event_recorder_interface",
         "//src/ray/common:asio",
+        "//src/ray/common:ray_config",
         "//src/ray/protobuf:events_event_aggregator_service_cc_proto",
         "//src/ray/rpc:event_aggregator_client",
         "//src/ray/util:logging",

--- a/src/ray/observability/ray_event_recorder.cc
+++ b/src/ray/observability/ray_event_recorder.cc
@@ -36,6 +36,10 @@ RayEventRecorder::RayEventRecorder(
 
 void RayEventRecorder::StartExportingEvents() {
   absl::MutexLock lock(&mutex_);
+  if (!RayConfig::instance().enable_ray_event()) {
+    RAY_LOG(INFO) << "Ray event recording is disabled. Skipping start exporting events.";
+    return;
+  }
   RAY_CHECK(!exporting_started_)
       << "RayEventRecorder::StartExportingEvents() should be called only once.";
   exporting_started_ = true;
@@ -74,6 +78,9 @@ void RayEventRecorder::ExportEvents() {
 void RayEventRecorder::AddEvents(
     std::vector<std::unique_ptr<RayEventInterface>> &&data_list) {
   absl::MutexLock lock(&mutex_);
+  if (!RayConfig::instance().enable_ray_event()) {
+    return;
+  }
   if (data_list.size() + buffer_.size() > max_buffer_size_) {
     size_t events_to_remove = data_list.size() + buffer_.size() - max_buffer_size_;
     // Record dropped events from the buffer

--- a/src/ray/observability/ray_event_recorder.h
+++ b/src/ray/observability/ray_event_recorder.h
@@ -18,6 +18,7 @@
 
 #include "absl/synchronization/mutex.h"
 #include "ray/common/asio/periodical_runner.h"
+#include "ray/common/ray_config.h"
 #include "ray/observability/metric_interface.h"
 #include "ray/observability/ray_event_interface.h"
 #include "ray/observability/ray_event_recorder_interface.h"


### PR DESCRIPTION
We have a feature flag to control the rolling out of ray export event, but the feature flag is missing the controlling of `StartExportingEvents`. This PR fixes the issue.

Test:
- CI