### PR TITLE
[Data] Add repartition to audio transcription benchmark for proper block sizing

### DIFF
--- a/release/nightly_tests/multimodal_inference_benchmarks/audio_transcription/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/audio_transcription/ray_data_main.py
@@ -95,6 +95,7 @@ def decoder(batch):
 start_time = time.time()
 
 ds = ray.data.read_parquet(INPUT_PATH)
+ds = ds.repartition(target_num_rows_per_block=BATCH_SIZE)
 ds = ds.map(resample)
 ds = ds.map_batches(whisper_preprocess, batch_size=BATCH_SIZE)
 ds = ds.map_batches(


### PR DESCRIPTION
## Summary

Add a `repartition` call with `target_num_rows_per_block=BATCH_SIZE` to the audio transcription benchmark. This ensures blocks are appropriately sized to:
- Prevent out-of-memory (OOM) errors
- Ensure individual tasks don't take too long to complete

## Changes

- Added `ds = ds.repartition(target_num_rows_per_block=BATCH_SIZE)` after reading the parquet file in `ray_data_main.py:98`
