### PR TITLE
[core] add no_windows tag on cgroup related tests

### DIFF
--- a/python/ray/tests/resource_isolation/BUILD.bazel
+++ b/python/ray/tests/resource_isolation/BUILD.bazel
@@ -16,6 +16,7 @@ py_test(
     tags = [
         "cgroup",
         "exclusive",
+        "no_windows",
         "team:core",
     ],
     target_compatible_with = [
@@ -34,6 +35,7 @@ py_test(
     tags = [
         "cgroup",
         "exclusive",
+        "no_windows",
         "team:core",
     ],
     deps = [


### PR DESCRIPTION
otherwise they are failing windows core python tests
