### PR TITLE
[data] support generator udf for map_groups

### DIFF
--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -548,7 +548,8 @@ def _apply_udf_to_groups(
     """Apply UDF to groups of rows having the same set of values of the specified
     columns (keys).
 
-    NOTE: This function is defined at module level to avoid capturing closures and make it serializable."""
+    NOTE: This function is defined at module level to avoid capturing closures and make it serializable.
+    """
     block_accessor = BlockAccessor.for_block(block)
 
     boundaries = block_accessor._get_group_boundaries_sorted(keys)
@@ -560,7 +561,17 @@ def _apply_udf_to_groups(
         # Convert corresponding block of each group to batch format here,
         # because the block format here can be different from batch format
         # (e.g. block is Arrow format, and batch is NumPy format).
-        yield udf(group_block_accessor.to_batch_format(batch_format), *args, **kwargs)
+        result = udf(
+            group_block_accessor.to_batch_format(batch_format), *args, **kwargs
+        )
+
+        # Check if the UDF returned an iterator/generator.
+        if isinstance(result, Iterator):
+            # If so, yield each item from the iterator.
+            yield from result
+        else:
+            # Otherwise, yield the single result.
+            yield result
 
 
 # Backwards compatibility alias.

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator as IteratorABC
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
@@ -569,7 +570,7 @@ def _apply_udf_to_groups(
         )
 
         # Check if the UDF returned an iterator/generator.
-        if isinstance(result, Iterator):
+        if isinstance(result, IteratorABC):
             # If so, yield each item from the iterator.
             yield from result
         else:

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -538,7 +538,10 @@ class GroupedData:
 
 
 def _apply_udf_to_groups(
-    udf: Callable[[DataBatch, ...], DataBatch],
+    udf: Union[
+        Callable[[DataBatch, ...], DataBatch],
+        Callable[[DataBatch, ...], Iterator[DataBatch]],
+    ],
     block: Block,
     keys: List[str],
     batch_format: Optional[str],

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -1142,7 +1142,7 @@ def test_groupby_map_groups_with_partial(disable_fallback_to_object_extension):
     assert "MapBatches(func)" in ds.__repr__()
 
 
-def test_map_groups_generator_udf(ray_start_regular_shared):
+def test_map_groups_generator_udf(ray_start_regular_shared_2_cpus):
     """
     Tests that map_groups supports UDFs that return generators (iterators).
     """

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -1,7 +1,7 @@
 import itertools
 import random
 import time
-from typing import Optional
+from typing import Iterator, Optional
 
 import numpy as np
 import pandas as pd
@@ -1140,6 +1140,40 @@ def test_groupby_map_groups_with_partial(disable_fallback_to_object_extension):
         {"x_add_5": 25},
     ]
     assert "MapBatches(func)" in ds.__repr__()
+
+
+def test_map_groups_generator_udf(ray_start_regular_shared):
+    """
+    Tests that map_groups supports UDFs that return generators (iterators).
+    """
+    ds = ray.data.from_items(
+        [
+            {"group": 1, "data": 10},
+            {"group": 1, "data": 20},
+            {"group": 2, "data": 30},
+        ]
+    )
+
+    def generator_udf(df: pd.DataFrame) -> Iterator[pd.DataFrame]:
+        # For each group, yield two DataFrames.
+        # 1. A DataFrame where 'data' is multiplied by 2.
+        yield df.assign(data=df["data"] * 2)
+        # 2. A DataFrame where 'data' is multiplied by 3.
+        yield df.assign(data=df["data"] * 3)
+
+    # Apply the generator UDF to the grouped data.
+    result_ds = ds.groupby("group").map_groups(generator_udf)
+
+    # The final dataset should contain all results from all yields.
+    # Group 1 -> data: [20, 40] and [30, 60]
+    # Group 2 -> data: [60] and [90]
+    expected_data = sorted([20, 40, 30, 60, 60, 90])
+
+    # Collect and sort the actual data to ensure correctness regardless of order.
+    actual_data = sorted([row["data"] for row in result_ds.take_all()])
+
+    assert actual_data == expected_data
+    assert result_ds.count() == 6
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This pr support return a generator object from map_groups UDF. if UDF have a large output , we return iterator to reduce memory cost.

## Related issues

Close #57935

## Additional information

  This change centers on the `_apply_udf_to_groups` helper function within the file ray/data/grouped_data.py.

  `map_groups` internally calls map_batches, providing a wrapper function (wrapped_fn) that in turn calls `_apply_udf_to_groups` to apply the user's UDF to each group.

  The key modification is that instead of directly yielding the UDF's return value, the logic now inspects the result first. If the result is an Iterator, it is consumed with `yield from` to produce each data batch individually. If it is not an iterator, the single data batch is yielded directly, preserving the original behavior.
