### PR TITLE
[Data] Fix renamed columns to be appropriately dropped from the ouput

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -27,7 +27,8 @@ from ray.air.util.tensor_extensions.arrow import (
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.arrow_ops.transform_pyarrow import shuffle
 from ray.data._internal.row import TableRow
-from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
+from ray.data._internal.table_block import TableBlockAccessor, \
+    TableBlockBuilder
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -360,6 +361,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
         extension arrays.
         """
         return transform_pyarrow.take_table(self._table, indices)
+
+    def drop(self, columns: List[str]) -> Block:
+        return self._table.drop(columns)
 
     def select(self, columns: List[str]) -> "pyarrow.Table":
         if not all(isinstance(col, str) for col in columns):

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -27,8 +27,7 @@ from ray.air.util.tensor_extensions.arrow import (
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.arrow_ops.transform_pyarrow import shuffle
 from ray.data._internal.row import TableRow
-from ray.data._internal.table_block import TableBlockAccessor, \
-    TableBlockBuilder
+from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
 from ray.data.block import (
     Block,
     BlockAccessor,

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -5,7 +5,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.logical.interfaces import LogicalOperator
-from ray.data._internal.logical.operators.one_to_one_operator import AbstractOneToOne
+from ray.data._internal.logical.operators.one_to_one_operator import \
+    AbstractOneToOne
 from ray.data.block import UserDefinedFunction
 from ray.data.expressions import Expr, StarExpr
 from ray.data.preprocessor import Preprocessor
@@ -296,8 +297,15 @@ class Project(AbstractMap):
                 )
 
     def has_star_expr(self) -> bool:
+        return self.get_star_expr() is not None
+
+    def get_star_expr(self) -> Optional[StarExpr]:
         """Check if this projection contains a star() expression."""
-        return any(isinstance(expr, StarExpr) for expr in self._exprs)
+        for expr in self._exprs:
+            if isinstance(expr, StarExpr):
+                return expr
+
+        return None
 
     @property
     def exprs(self) -> List["Expr"]:

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -5,8 +5,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.logical.interfaces import LogicalOperator
-from ray.data._internal.logical.operators.one_to_one_operator import \
-    AbstractOneToOne
+from ray.data._internal.logical.operators.one_to_one_operator import AbstractOneToOne
 from ray.data.block import UserDefinedFunction
 from ray.data.expressions import Expr, StarExpr
 from ray.data.preprocessor import Preprocessor

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -246,19 +246,10 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
 
         # When fusing 2 projections
         for e in upstream_project.exprs:
-            if isinstance(e, StarExpr):
-                target_expr = e
-            else:
-                # When downstream is renaming its input column, we project
-                # upstream's output column expression to just be aliased with
-                # that new name
-                if e.name in downstream_input_column_rename_map:
-                    new_name = downstream_input_column_rename_map[e.name]
-                    target_expr = e.alias(new_name)
-                else:
-                    target_expr = e
-
-            projected_upstream_output_col_exprs.append(target_expr)
+            # NOTE: We have to filter out upstream output columns that are
+            #       being *renamed* by downstream expression
+            if e.name not in downstream_input_column_rename_map:
+                projected_upstream_output_col_exprs.append(e)
 
         new_exprs = projected_upstream_output_col_exprs + rebound_downstream_exprs
 

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -325,18 +325,18 @@ class ProjectionPushdown(Rule):
             and input_op.supports_projection_pushdown()
         ):
             if current_project.has_star_expr():
-                # If project has a star, than no projection is feasible
+                # If project has a star, then projection is not feasible
                 required_columns = None
             else:
-                # Otherwise, collect required column for projection
+                # Otherwise, collect required columns to push projection down
+                # into the reader
                 required_columns = _collect_referenced_columns(current_project.exprs)
 
             # Check if it's a simple projection that could be pushed into
             # read as a whole
             is_projection = all(
                 _is_col_expr(expr)
-                for expr in current_project.exprs
-                if not isinstance(expr, StarExpr)
+                for expr in _filter_out_star(current_project.exprs)
             )
 
             if is_projection:

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -10,6 +10,7 @@ from ray.data._internal.logical.operators.map_operator import Project
 from ray.data._internal.planner.plan_expression.expression_visitors import (
     _ColumnReferenceCollector,
     _ColumnRefRebindingVisitor,
+    _is_col_expr,
 )
 from ray.data.expressions import (
     AliasExpr,
@@ -360,12 +361,6 @@ class ProjectionPushdown(Rule):
                 )
 
         return current_project
-
-
-def _is_col_expr(expr: Expr) -> bool:
-    return isinstance(expr, ColumnExpr) or (
-        isinstance(expr, AliasExpr) and isinstance(expr.expr, ColumnExpr)
-    )
 
 
 def _extract_input_columns_renaming_mapping(

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -22,8 +22,7 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.utils import _should_convert_to_tensor
 from ray.data._internal.numpy_support import convert_to_numpy
 from ray.data._internal.row import TableRow
-from ray.data._internal.table_block import TableBlockAccessor, \
-    TableBlockBuilder
+from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
 from ray.data._internal.util import is_null
 from ray.data.block import (
     Block,

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -22,7 +22,8 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.utils import _should_convert_to_tensor
 from ray.data._internal.numpy_support import convert_to_numpy
 from ray.data._internal.row import TableRow
-from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
+from ray.data._internal.table_block import TableBlockAccessor, \
+    TableBlockBuilder
 from ray.data._internal.util import is_null
 from ray.data.block import (
     Block,
@@ -362,6 +363,9 @@ class PandasBlockAccessor(TableBlockAccessor):
         table = self._table.take(indices)
         table.reset_index(drop=True, inplace=True)
         return table
+
+    def drop(self, columns: List[str]) -> Block:
+        return self._table.drop(columns, axis="columns")
 
     def select(self, columns: List[str]) -> "pandas.DataFrame":
         if not all(isinstance(col, str) for col in columns):

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -751,4 +751,4 @@ def eval_projection(projection_exprs: List[Expr], block: Block) -> Block:
     for name, output_col in zip(names, output_cols):
         new_block = BlockAccessor.for_block(new_block).fill_column(name, output_col)
 
-    return BlockAccessor.for_block(new_block).drop("__stub__")
+    return BlockAccessor.for_block(new_block).drop(["__stub__"])

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -11,8 +11,9 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.dataset as ds
 
-from ray.data._internal.logical.rules.projection_pushdown import \
-    _extract_input_columns_renaming_mapping
+from ray.data._internal.logical.rules.projection_pushdown import (
+    _extract_input_columns_renaming_mapping,
+)
 from ray.data.block import Block, BlockAccessor, BlockColumn, BlockType
 from ray.data.expressions import (
     AliasExpr,
@@ -25,7 +26,8 @@ from ray.data.expressions import (
     StarExpr,
     UDFExpr,
     UnaryExpr,
-    _ExprVisitor, col,
+    _ExprVisitor,
+    col,
 )
 
 logger = logging.getLogger(__name__)
@@ -731,8 +733,7 @@ def eval_projection(projection_exprs: List[Expr], block: Block) -> Block:
         # Cherry-pick input block's columns that aren't explicitly removed via
         # renaming
         input_column_ref_exprs = [
-            col(c) for c in input_column_names
-            if c not in input_column_rename_map
+            col(c) for c in input_column_names if c not in input_column_rename_map
         ]
 
         projection_exprs = input_column_ref_exprs + projection_exprs[1:]

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -725,6 +725,8 @@ def eval_projection(exprs: List[Expr], block: Block) -> Block:
     if len(exprs) == 1 and isinstance(exprs[0], StarExpr):
         return block
 
+    # TODO drop renames
+
     # Helper function to check if expression is a simple rename of existing column.
     def is_simple_rename(expr: Expr) -> bool:
         return isinstance(expr, AliasExpr) and expr.expr.name in existing_cols

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -93,13 +93,6 @@ class _ColumnReferenceCollector(_ExprVisitorBase):
         """
         self.visit(expr.expr)
 
-    def visit_star(self, expr: StarExpr) -> None:
-        """Since ``StarExpr`` holds deferred renaming mapping, we add
-        source column refs into the list of target refs"""
-
-        for col_ref in expr.get_column_rename_map().keys():
-            self._col_refs[col_ref] = None
-
 
 class _ColumnRefRebindingVisitor(_ExprVisitor[Expr]):
     """Visitor rebinding column references in ``Expression``s.

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -183,7 +183,9 @@ class _ColumnRefRebindingVisitor(_ExprVisitor[Expr]):
         Returns:
             A new alias expression with rewritten inner expression and preserved name.
         """
-        return self.visit(expr.expr).alias(expr.name)
+        visited = self.visit(expr.expr)
+
+        return AliasExpr(visited.data_type, visited, expr.name, _is_rename=expr._is_rename)
 
     def visit_download(self, expr: "Expr") -> Expr:
         """Visit a download expression (no rewriting needed).

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -93,6 +93,13 @@ class _ColumnReferenceCollector(_ExprVisitorBase):
         """
         self.visit(expr.expr)
 
+    def visit_star(self, expr: StarExpr) -> None:
+        """Since ``StarExpr`` holds deferred renaming mapping, we add
+        source column refs into the list of target refs"""
+
+        for col_ref in expr.get_column_rename_map().keys():
+            self._col_refs[col_ref] = None
+
 
 class _ColumnRefRebindingVisitor(_ExprVisitor[Expr]):
     """Visitor rebinding column references in ``Expression``s.

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -195,7 +195,7 @@ class _ColumnRefRebindingVisitor(_ExprVisitor[Expr]):
             # so long as it's referencing another column (and not otherwise)
             #
             # TODO replace w/ standalone rename expr
-            _is_rename=expr._is_rename and _is_col_expr(visited)
+            _is_rename=expr._is_rename and _is_col_expr(visited),
         )
 
     def visit_download(self, expr: "Expr") -> Expr:

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -94,7 +94,7 @@ class _ColumnReferenceCollector(_ExprVisitorBase):
         self.visit(expr.expr)
 
 
-class _RefRebindingVisitor(_ExprVisitor[Expr]):
+class _ColumnRefRebindingVisitor(_ExprVisitor[Expr]):
     """Visitor rebinding column references in ``Expression``s.
 
     This visitor traverses given ``Expression`` trees and substitutes column references

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, TypeVar
+from typing import Dict, List, TypeVar
 
 from ray.data.expressions import (
     AliasExpr,
@@ -94,34 +94,20 @@ class _ColumnReferenceCollector(_ExprVisitorBase):
         self.visit(expr.expr)
 
 
-class _ColumnRewriter(_ExprVisitor[Expr]):
-    """Visitor that rewrites column references in expression trees.
+class _RefRebindingVisitor(_ExprVisitor[Expr]):
+    """Visitor rebinding column references in ``Expression``s.
 
-    This visitor traverses expression trees and substitutes column references
-    according to a provided substitution map, preserving the structure of the tree.
+    This visitor traverses given ``Expression`` trees and substitutes column references
+    according to a provided substitution map.
     """
 
-    def __init__(self, column_substitutions: dict[str, Expr]):
+    def __init__(self, column_ref_substitutions: Dict[str, Expr]):
         """Initialize with a column substitution map.
 
         Args:
-            column_substitutions: Mapping from column names to replacement expressions.
+            column_ref_substitutions: Mapping from column names to replacement expressions.
         """
-        self.column_substitutions = column_substitutions
-        self._currently_substituting: Set[
-            str
-        ] = set()  # Track columns being substituted to prevent cycles
-
-    def visit(self, expr: Expr) -> Expr:
-        """Visit an expression node and return the rewritten expression.
-
-        Args:
-            expr: The expression to visit.
-
-        Returns:
-            The rewritten expression.
-        """
-        return super().visit(expr)
+        self._col_ref_substitutions = column_ref_substitutions
 
     def visit_column(self, expr: ColumnExpr) -> Expr:
         """Visit a column expression and substitute it.
@@ -132,36 +118,9 @@ class _ColumnRewriter(_ExprVisitor[Expr]):
         Returns:
             The substituted expression or the original if no substitution exists.
         """
-        # Check for cycles: if we're already substituting this column, stop
-        if expr.name in self._currently_substituting:
-            return expr
+        substitution = self._col_ref_substitutions.get(expr.name)
 
-        substitution = self.column_substitutions.get(expr.name)
-        if substitution is None:
-            return expr
-
-        # Mark this column as being substituted
-        self._currently_substituting.add(expr.name)
-
-        try:
-            if not isinstance(substitution, AliasExpr):
-                # Non-aliased expression: recursively rewrite
-                return self.visit(substitution)
-
-            inner = substitution.expr
-            if isinstance(inner, ColumnExpr):
-                inner_def = self.column_substitutions.get(inner.name)
-                if isinstance(inner_def, AliasExpr) and isinstance(
-                    inner_def.expr, ColumnExpr
-                ):
-                    # Preserve simple rename chain (swap semantics -> Example: [col("a").alias("b"), col("b").alias("a")])
-                    return substitution
-
-            # Aliased expression: rewrite inner and preserve alias (unless preserved above)
-            return self.visit(inner).alias(substitution.name)
-        finally:
-            # Remove from tracking when done
-            self._currently_substituting.discard(expr.name)
+        return substitution if substitution is not None else expr
 
     def visit_literal(self, expr: LiteralExpr) -> Expr:
         """Visit a literal expression (no rewriting needed).

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -342,6 +342,10 @@ class BlockAccessor:
         """
         raise NotImplementedError
 
+    def drop(self, columns: List[str]) -> Block:
+        """Return a new block with the list of provided columns dropped"""
+        raise NotImplementedError
+
     def select(self, columns: List[Optional[str]]) -> Block:
         """Return a new block containing the provided columns."""
         raise NotImplementedError

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -511,7 +511,7 @@ class BlockAccessor:
         import pandas
         import pyarrow
 
-        if isinstance(block, pyarrow.Table):
+        if isinstance(block, (pyarrow.Table, pyarrow.RecordBatch)):
             from ray.data._internal.arrow_block import ArrowBlockAccessor
 
             return ArrowBlockAccessor(block)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1175,7 +1175,7 @@ class Dataset:
                     "rename_columns requires both keys and values in the 'names' "
                     "to be strings."
                 )
-            exprs = [col(old).alias(new) for old, new in names.items()]
+            exprs = [col(old).rename(new) for old, new in names.items()]
 
         elif isinstance(names, list):
             if not names:
@@ -1201,7 +1201,7 @@ class Dataset:
                 )
 
             exprs = [
-                col(old).alias(new)
+                col(old).rename(new)
                 for old, new in dict(zip(current_names, names)).items()
             ]
         else:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1181,7 +1181,10 @@ class Dataset:
                     "to be strings."
                 )
 
-            col_rename_map = dict(names)
+            exprs = [
+                col(prev)._rename(new)
+                for prev, new in names.items()
+            ]
 
         elif isinstance(names, list):
             if not names:
@@ -1206,7 +1209,10 @@ class Dataset:
                     f"schema names: {current_names}."
                 )
 
-            col_rename_map = dict(zip(current_names, names))
+            exprs = [
+                col(prev)._rename(new)
+                for prev, new in zip(current_names, names)
+            ]
         else:
             raise TypeError(
                 f"rename_columns expected names to be either List[str] or "
@@ -1227,7 +1233,7 @@ class Dataset:
         plan = self._plan.copy()
         select_op = Project(
             self._logical_plan.dag,
-            exprs=[StarExpr(col_rename_map)],
+            exprs=[StarExpr(), exprs],
             compute=compute,
             ray_remote_args=ray_remote_args,
         )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -49,8 +49,7 @@ from ray.data._internal.datasource.numpy_datasink import NumpyDatasink
 from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
 from ray.data._internal.datasource.sql_datasink import SQLDatasink
 from ray.data._internal.datasource.tfrecords_datasink import TFRecordDatasink
-from ray.data._internal.datasource.webdataset_datasink import \
-    WebDatasetDatasink
+from ray.data._internal.datasource.webdataset_datasink import WebDatasetDatasink
 from ray.data._internal.equalize import _equalize
 from ray.data._internal.execution.interfaces import RefBundle
 from ray.data._internal.execution.interfaces.ref_bundle import (
@@ -58,8 +57,7 @@ from ray.data._internal.execution.interfaces.ref_bundle import (
 )
 from ray.data._internal.execution.util import memory_string
 from ray.data._internal.iterator.iterator_impl import DataIteratorImpl
-from ray.data._internal.iterator.stream_split_iterator import \
-    StreamSplitDataIterator
+from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIterator
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators.all_to_all_operator import (
     RandomizeBlocks,
@@ -83,17 +81,14 @@ from ray.data._internal.logical.operators.n_ary_operator import (
     Zip,
 )
 from ray.data._internal.logical.operators.one_to_one_operator import Limit
-from ray.data._internal.logical.operators.streaming_split_operator import \
-    StreamingSplit
+from ray.data._internal.logical.operators.streaming_split_operator import StreamingSplit
 from ray.data._internal.logical.operators.write_operator import Write
-from ray.data._internal.pandas_block import PandasBlockBuilder, \
-    PandasBlockSchema
+from ray.data._internal.pandas_block import PandasBlockBuilder, PandasBlockSchema
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.split import _get_num_rows, _split_at_indices
-from ray.data._internal.stats import DatasetStats, DatasetStatsSummary, \
-    StatsManager
+from ray.data._internal.stats import DatasetStats, DatasetStatsSummary, StatsManager
 from ray.data._internal.util import (
     AllToAllAPI,
     ConsumptionAPI,
@@ -114,10 +109,8 @@ from ray.data.block import (
     _apply_batch_format,
 )
 from ray.data.context import DataContext
-from ray.data.datasource import Connection, Datasink, FilenameProvider, \
-    SaveMode
-from ray.data.datasource.datasink import WriteResult, \
-    _gen_datasink_write_result
+from ray.data.datasource import Connection, Datasink, FilenameProvider, SaveMode
+from ray.data.datasource.datasink import WriteResult, _gen_datasink_write_result
 from ray.data.datasource.file_datasink import _FileDatasink
 from ray.data.iterator import DataIterator
 from ray.data.random_access_dataset import RandomAccessDataset
@@ -143,7 +136,7 @@ if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces import Executor, NodeIdStr
     from ray.data.grouped_data import GroupedData
 
-from ray.data.expressions import StarExpr, Expr, col
+from ray.data.expressions import Expr, StarExpr, col
 
 logger = logging.getLogger(__name__)
 
@@ -1162,8 +1155,6 @@ class Dataset:
                 :func:`ray.remote` for details.
         """  # noqa: E501
 
-        col_rename_map = []
-
         if isinstance(names, dict):
             if not names:
                 raise ValueError("rename_columns received 'names' with no entries.")
@@ -1181,10 +1172,7 @@ class Dataset:
                     "to be strings."
                 )
 
-            exprs = [
-                col(prev)._rename(new)
-                for prev, new in names.items()
-            ]
+            exprs = [col(prev)._rename(new) for prev, new in names.items()]
 
         elif isinstance(names, list):
             if not names:
@@ -1209,10 +1197,7 @@ class Dataset:
                     f"schema names: {current_names}."
                 )
 
-            exprs = [
-                col(prev)._rename(new)
-                for prev, new in zip(current_names, names)
-            ]
+            exprs = [col(prev)._rename(new) for prev, new in zip(current_names, names)]
         else:
             raise TypeError(
                 f"rename_columns expected names to be either List[str] or "

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -143,7 +143,7 @@ if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces import Executor, NodeIdStr
     from ray.data.grouped_data import GroupedData
 
-from ray.data.expressions import StarExpr, Expr
+from ray.data.expressions import StarExpr, Expr, col
 
 logger = logging.getLogger(__name__)
 
@@ -1233,7 +1233,7 @@ class Dataset:
         plan = self._plan.copy()
         select_op = Project(
             self._logical_plan.dag,
-            exprs=[StarExpr(), exprs],
+            exprs=[StarExpr(), *exprs],
             compute=compute,
             ray_remote_args=ray_remote_args,
         )

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -378,7 +378,9 @@ class Expr(ABC):
             >>> expr = (col("price") * col("quantity")).alias("total")
             >>> # Can be used with Dataset operations that support named expressions
         """
-        return AliasExpr(data_type=self.data_type, expr=self, _name=name, _is_rename=False)
+        return AliasExpr(
+            data_type=self.data_type, expr=self, _name=name, _is_rename=False
+        )
 
 
 @DeveloperAPI(stability="alpha")
@@ -697,7 +699,9 @@ class AliasExpr(Expr):
 
     def alias(self, name: str) -> "Expr":
         # Always unalias before creating new one
-        return AliasExpr(self.expr.data_type, self.expr, _name=name, _is_rename=self._is_rename)
+        return AliasExpr(
+            self.expr.data_type, self.expr, _name=name, _is_rename=self._is_rename
+        )
 
     def structurally_equals(self, other: Any) -> bool:
         return (

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -697,7 +697,7 @@ class AliasExpr(Expr):
 
     def alias(self, name: str) -> "Expr":
         # Always unalias before creating new one
-        return AliasExpr(self.expr.data_type, self.expr, _name=name)
+        return AliasExpr(self.expr.data_type, self.expr, _name=name, _is_rename=self._is_rename)
 
     def structurally_equals(self, other: Any) -> bool:
         return (

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -382,6 +382,9 @@ class Expr(ABC):
             data_type=self.data_type, expr=self, _name=name, _is_rename=False
         )
 
+    def _unalias(self) -> "Expr":
+        return self
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False)
@@ -703,11 +706,15 @@ class AliasExpr(Expr):
             self.expr.data_type, self.expr, _name=name, _is_rename=self._is_rename
         )
 
+    def _unalias(self) -> "Expr":
+        return self.expr
+
     def structurally_equals(self, other: Any) -> bool:
         return (
             isinstance(other, AliasExpr)
             and self.expr.structurally_equals(other.expr)
             and self.name == other.name
+            and self._is_rename == self._is_rename
         )
 
 

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -407,6 +407,9 @@ class ColumnExpr(Expr):
         """Get the column name."""
         return self._name
 
+    def rename(self, new_name: str) -> Expr:
+        return AliasExpr(data_type=self.data_type, expr=self, _name=new_name, _is_rename=True)
+
     def structurally_equals(self, other: Any) -> bool:
         return isinstance(other, ColumnExpr) and self.name == other.name
 
@@ -685,6 +688,8 @@ class AliasExpr(Expr):
 
     expr: Expr
     _name: str
+
+    _is_rename: bool = False
 
     @property
     def name(self) -> str:

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -696,6 +696,10 @@ class AliasExpr(Expr):
         """Get the alias name."""
         return self._name
 
+    def alias(self, name: str) -> "Expr":
+        # Always unalias before creating new one
+        return AliasExpr(self.expr.data_type, self.expr, _name=name)
+
     def structurally_equals(self, other: Any) -> bool:
         return (
             isinstance(other, AliasExpr)

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -267,7 +267,7 @@ class TestProjectionFusion:
                 f"Expected {expected_content} to be subset of {actual_levels[i]}"
             )
 
-    def test_pairwise_fusion_behavior(self):
+    def test_pairwise_fusion_behavior(self, ray_start_regular_shared):
         """Test to understand how pairwise fusion works in practice."""
         input_data = [{"id": i} for i in range(10)]
 
@@ -312,7 +312,7 @@ class TestProjectionFusion:
         assert result3 == {"id": 0, "col1": 1, "col2": 0, "col3": -1}
         assert result4 == {"id": 0, "col1": 1, "col2": 0, "col3": -1, "col4": 5}
 
-    def test_optimal_fusion_with_single_chain(self):
+    def test_optimal_fusion_with_single_chain(self, ray_start_regular_shared):
         """Test fusion when all operations are added in a single chain (ideal case)."""
         input_data = [{"id": i} for i in range(10)]
 
@@ -363,7 +363,7 @@ class TestProjectionFusion:
             check_dtype=False,
         )
 
-    def test_basic_fusion_works(self):
+    def test_basic_fusion_works(self, ray_start_regular_shared):
         """Test that basic fusion of two independent operations works."""
         input_data = [{"id": i} for i in range(5)]
 
@@ -439,7 +439,7 @@ class TestProjectionFusion:
                         actual[key] == expected_val
                     ), f"Mismatch for key {key}: expected {expected_val}, got {actual[key]}"
 
-    def test_dependency_prevents_fusion(self):
+    def test_dependency_prevents_fusion(self, ray_start_regular_shared):
         """Test that dependencies are handled in single operator with OrderedDict."""
         input_data = [{"id": i} for i in range(5)]
 
@@ -487,7 +487,7 @@ class TestProjectionFusion:
             check_dtype=False,
         )
 
-    def test_mixed_udf_regular_end_to_end(self):
+    def test_mixed_udf_regular_end_to_end(self, ray_start_regular_shared):
         """Test the exact failing scenario from the original issue."""
         input_data = [{"id": i} for i in range(5)]
 
@@ -543,7 +543,7 @@ class TestProjectionFusion:
             optimized_count == 1
         ), f"Expected 1 operator with all expressions fused, got {optimized_count}"
 
-    def test_optimal_fusion_comparison(self):
+    def test_optimal_fusion_comparison(self, ray_start_regular_shared):
         """Compare optimized with_column approach against manual map_batches."""
         input_data = [{"id": i} for i in range(10)]
 
@@ -590,7 +590,7 @@ class TestProjectionFusion:
             check_dtype=False,
         )
 
-    def test_chained_udf_dependencies(self):
+    def test_chained_udf_dependencies(self, ray_start_regular_shared):
         """Test multiple non-vectorized UDFs in a dependency chain."""
         input_data = [{"id": i} for i in range(5)]
 
@@ -632,7 +632,7 @@ class TestProjectionFusion:
             check_dtype=False,
         )
 
-    def test_performance_impact_of_udf_chains(self):
+    def test_performance_impact_of_udf_chains(self, ray_start_regular_shared):
         """Test performance characteristics of UDF dependency chains vs independent UDFs."""
         input_data = [{"id": i} for i in range(100)]
 
@@ -758,7 +758,7 @@ class TestProjectionFusion:
             ),
         ],
     )
-    def test_projection_operations_comprehensive(self, operations, expected):
+    def test_projection_operations_comprehensive(self, ray_start_regular_shared, operations, expected):
         """Comprehensive test for projection operations combinations."""
         from ray.data.expressions import col, lit
 
@@ -862,7 +862,7 @@ class TestProjectionFusion:
             ),
         ],
     )
-    def test_projection_fusion_with_count_and_filter(self, operations, expected):
+    def test_projection_fusion_with_count_and_filter(self, ray_start_regular_shared, operations, expected):
         """Test projection fusion with count operations including filters."""
         from ray.data.expressions import lit
 
@@ -994,7 +994,7 @@ class TestProjectionFusion:
         ],
     )
     def test_projection_operations_invalid_order(
-        self, invalid_operations, error_type, error_message_contains
+        self, ray_start_regular_shared, invalid_operations, error_type, error_message_contains
     ):
         """Test that operations fail gracefully when referencing non-existent columns."""
         import ray
@@ -1306,7 +1306,7 @@ class TestProjectionFusion:
         ],
     )
     def test_projection_pushdown_into_parquet_read(
-        self, tmp_path, operations, expected_output
+        self, ray_start_regular_shared, tmp_path, operations, expected_output
     ):
         """Test that projection operations fuse and push down into parquet reads.
 

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -732,8 +732,8 @@ class TestProjectionFusion:
                 {"x": 1, "b": 2, "d": 4},
             ),
             # Column swap (no actual changes)
-            ([("rename", {"a": "b", "b": "a"}), ("select", ["a"])], {"a": 1}),
-            ([("rename", {"a": "b", "b": "a"}), ("select", ["b"])], {"b": 2}),
+            ([("rename", {"a": "b", "b": "a"}), ("select", ["a"])], {"a": 2}),
+            ([("rename", {"a": "b", "b": "a"}), ("select", ["b"])], {"b": 1}),
             # Multiple same operations
             (
                 [("rename", {"a": "x"}), ("rename", {"x": "y"})],

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -731,9 +731,9 @@ class TestProjectionFusion:
                 ],
                 {"x": 1, "b": 2, "d": 4},
             ),
-            # Column swap
-            ([("rename", {"a": "b", "b": "a"}), ("select", ["a"])], {"a": 2}),
-            ([("rename", {"a": "b", "b": "a"}), ("select", ["b"])], {"b": 1}),
+            # Column swap (no actual changes)
+            ([("rename", {"a": "b", "b": "a"}), ("select", ["a"])], {"a": 1}),
+            ([("rename", {"a": "b", "b": "a"}), ("select", ["b"])], {"b": 2}),
             # Multiple same operations
             (
                 [("rename", {"a": "x"}), ("rename", {"x": "y"})],

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -759,7 +759,9 @@ class TestProjectionFusion:
             ),
         ],
     )
-    def test_projection_operations_comprehensive(self, ray_start_regular_shared, operations, expected):
+    def test_projection_operations_comprehensive(
+        self, ray_start_regular_shared, operations, expected
+    ):
         """Comprehensive test for projection operations combinations."""
         from ray.data.expressions import col, lit
 
@@ -863,7 +865,9 @@ class TestProjectionFusion:
             ),
         ],
     )
-    def test_projection_fusion_with_count_and_filter(self, ray_start_regular_shared, operations, expected):
+    def test_projection_fusion_with_count_and_filter(
+        self, ray_start_regular_shared, operations, expected
+    ):
         """Test projection fusion with count operations including filters."""
         from ray.data.expressions import lit
 
@@ -995,7 +999,11 @@ class TestProjectionFusion:
         ],
     )
     def test_projection_operations_invalid_order(
-        self, ray_start_regular_shared, invalid_operations, error_type, error_message_contains
+        self,
+        ray_start_regular_shared,
+        invalid_operations,
+        error_type,
+        error_message_contains,
     ):
         """Test that operations fail gracefully when referencing non-existent columns."""
         import ray

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -114,7 +114,6 @@ class TestGC:
         class A:
             def test_import(self):
                 import pip_install_test  # noqa: F401
-
                 import test_module
 
                 test_module.one()
@@ -241,7 +240,6 @@ class TestGC:
         class A:
             def test_import(self):
                 import pip_install_test  # noqa: F401
-
                 import test_module
 
                 test_module.one()

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -114,6 +114,7 @@ class TestGC:
         class A:
             def test_import(self):
                 import pip_install_test  # noqa: F401
+
                 import test_module
 
                 test_module.one()
@@ -240,6 +241,7 @@ class TestGC:
         class A:
             def test_import(self):
                 import pip_install_test  # noqa: F401
+
                 import test_module
 
                 test_module.one()


### PR DESCRIPTION
## Description

This change addresses the issues that currently upon column renaming we're not removing original columns.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
