### PR TITLE
[Doc] : replace 404 GitHub links with valid ones

### DIFF
--- a/doc/source/ray-overview/examples/e2e-audio/README.md
+++ b/doc/source/ray-overview/examples/e2e-audio/README.md
@@ -2,7 +2,7 @@
 
 <div align="left">
 <a target="_blank" href="https://console.anyscale.com/"><img src="https://img.shields.io/badge/🚀 Run_on-Anyscale-9hf"></a>&nbsp;
-<a href="https://github.com/anyscale/e2e-audio" role="button"><img src="https://img.shields.io/static/v1?label=&amp;message=View%20On%20GitHub&amp;color=586069&amp;logo=github&amp;labelColor=2f363d"></a>&nbsp;
+<a href="https://github.com/ray-project/ray/tree/master/doc/source/ray-overview/examples/e2e-audio" role="button"><img src="https://img.shields.io/static/v1?label=&amp;message=View%20On%20GitHub&amp;color=586069&amp;logo=github&amp;labelColor=2f363d"></a>&nbsp;
 </div>
 
 


### PR DESCRIPTION
> This PR fixes broken "View on GitHub" 404 links in the documentation that were leading to 404 errors. These links have been replaced with valid and correct URLs to improve navigation and user experience.