### PR TITLE
Added backend API and CLI for custom autoscaling

### DIFF
--- a/python/ray/dashboard/modules/serve/sdk.py
+++ b/python/ray/dashboard/modules/serve/sdk.py
@@ -14,6 +14,7 @@ except ImportError:
 DEPLOY_PATH = "/api/serve/applications/"
 DELETE_PATH = "/api/serve/applications/"
 STATUS_PATH = "/api/serve/applications/"
+OBSERVABILITY_PATH = "/api/serve/autoscaling/observability"
 
 
 class ServeSubmissionClient(SubmissionClient):
@@ -83,3 +84,9 @@ class ServeSubmissionClient(SubmissionClient):
         response = self._do_request("DELETE", DELETE_PATH)
         if response.status_code != 200:
             self._raise_error(response)
+
+    def get_autoscaling_observability(self) -> Dict:
+        response = self._do_request("GET", OBSERVABILITY_PATH)
+        if response.status_code != 200:
+            self._raise_error(response)
+        return response.json()

--- a/python/ray/dashboard/modules/serve/serve_head.py
+++ b/python/ray/dashboard/modules/serve/serve_head.py
@@ -1,9 +1,11 @@
 import asyncio
 import dataclasses
+import glob
 import json
 import logging
+import os
 from functools import wraps
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import aiohttp
 from aiohttp.web import Request, Response
@@ -15,7 +17,12 @@ from ray.dashboard.modules.version import CURRENT_VERSION, VersionResponse
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 from ray.exceptions import RayTaskError
+from ray.serve._private.logging_utils import get_serve_logs_dir
+from ray.serve.schema import (
+    DeploymentAutoscalingDetail,
+)
 
+DEFAULT_SNAPSHOT_TAIL_LINES = 50
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -323,3 +330,76 @@ class ServeHead(SubprocessModule):
                 )
 
             return self._controller
+
+    # Route for autoscaling observability
+    @routes.get("/api/serve/autoscaling/observability")
+    @dashboard_optional_utils.init_ray_and_catch_exceptions()
+    async def get_autoscaling_observability(self, req: Request) -> Response:
+        """
+        Returns the latest autoscaling details for all applications and deployments.
+        """
+        # Read the latest snapshot files and store it as {app_name,{dep_name:raw_data}}
+        latest_snapshots = await self.read_snapshot_files()
+        if not latest_snapshots:
+            # Return an empty dictionary if there are no snapshot files
+            return Response(text=json.dumps({}), content_type="application/json")
+
+        details: Dict[str, Dict[str, Any]] = {}
+        # Build the autoscaling details
+        for app_name, deployments in latest_snapshots.items():
+            details[app_name] = {}
+            for deployment_name, deployment_data in deployments.items():
+                details[app_name][
+                    deployment_name
+                ] = DeploymentAutoscalingDetail.from_snapshot(deployment_data).dict()
+
+        return Response(text=json.dumps(details), content_type="application/json")
+
+    async def read_snapshot_files(self):
+        loop = asyncio.get_event_loop()
+        # Run the blocking file operations in a thread pool
+        return await loop.run_in_executor(None, self._read_snapshot_files_sync)
+
+    def _read_snapshot_files_sync(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Finds the latest snapshot entry for each deployment by searching across all rotated log files,
+        sorted from newest to oldest based on their modification time.
+        Stores the latest entry that matches the application and deployment names not seen before.
+        """
+        # {application_name,{deployment_name:raw data}}
+        latest_snapshots = dict()
+        serve_logs_dir = get_serve_logs_dir()
+        snapshot_pattern = os.path.join(serve_logs_dir, "autoscaling_snapshot_*.log*")
+
+        all_snapshot_files = glob.glob(snapshot_pattern)
+        # Return if there are no files
+        if not all_snapshot_files:
+            return None
+
+        # Sort files by their last modification time, newest first.
+        sorted_files = sorted(all_snapshot_files, key=os.path.getmtime, reverse=True)
+        # Iterate through each file from newest to oldest
+        for log_file in sorted_files:
+            try:
+                with open(log_file, "r") as f:
+                    all_lines = f.readlines()
+                for line in reversed(all_lines):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    raw = json.loads(line)
+                    # Return the most recent entry for the deployment
+                    app_name = raw.get("application_name")
+                    deployment_name = raw.get("deployment_name")
+                    if not app_name or not deployment_name:
+                        continue
+                    if app_name not in latest_snapshots:
+                        latest_snapshots[app_name] = {}
+                    # Only append the most recent entry for the deployment
+                    if deployment_name not in latest_snapshots[app_name]:
+                        latest_snapshots[app_name][deployment_name] = raw
+            # Continue reading other files if there were errors while reading the current file
+            except Exception as e:
+                logger.error(f"Error reading snapshot file {log_file}: {e}")
+                continue
+        return latest_snapshots

--- a/python/ray/dashboard/modules/serve/serve_head.py
+++ b/python/ray/dashboard/modules/serve/serve_head.py
@@ -22,7 +22,6 @@ from ray.serve.schema import (
     DeploymentAutoscalingDetail,
 )
 
-DEFAULT_SNAPSHOT_TAIL_LINES = 50
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -374,7 +373,7 @@ class ServeHead(SubprocessModule):
         all_snapshot_files = glob.glob(snapshot_pattern)
         # Return if there are no files
         if not all_snapshot_files:
-            return None
+            return {}
 
         # Sort files by their last modification time, newest first.
         sorted_files = sorted(all_snapshot_files, key=os.path.getmtime, reverse=True)

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -2,6 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 from zlib import crc32
@@ -1019,9 +1020,6 @@ class ScalingDecision(BaseModel):
     curr_num_replicas: int = Field(
         ..., ge=0, description="Replica count after the decision."
     )
-    policy: Optional[str] = Field(
-        None, description="Policy name or identifier (if applicable)."
-    )
 
 
 @PublicAPI(stability="alpha")
@@ -1044,6 +1042,62 @@ class DeploymentAutoscalingDetail(BaseModel):
     errors: List[str] = Field(
         default_factory=list, description="Recent errors/abnormal events."
     )
+    policy_name: Optional[str] = Field(
+        None, description="Policy name or identifier (if applicable)."
+    )
+
+    @classmethod
+    def from_snapshot(cls, raw: dict):
+        """
+        Factory method to create a DeploymentAutoscalingDetail instance
+        from a raw snapshot dictionary.
+        """
+
+        # Parse and map the list of scaling decisions
+        scaling_decisions = []
+        for raw_decision in raw.get("decisions", []):
+
+            # Convert ISO string from log to float timestamp for the model
+            timestamp_str = raw_decision.get("timestamp_str")
+            # This is a required field so assuming this is always present in raw data
+            timestamp_float = datetime.fromisoformat(
+                str(timestamp_str).replace("Z", "+00:00")
+            ).timestamp()
+
+            scaling_decisions.append(
+                ScalingDecision(
+                    timestamp_s=timestamp_float,
+                    reason=raw_decision.get("reason"),
+                    prev_num_replicas=raw_decision.get("current_num_replicas"),
+                    curr_num_replicas=raw_decision.get("target_num_replicas"),
+                )
+            )
+
+        # Aggregate metrics into the 'metrics' dictionary (#56225)
+        metrics_keys = [
+            "current_replicas",
+            "target_replicas",
+            "min_replicas",
+            "max_replicas",
+            "look_back_period_s",
+            "queued_requests",
+            "ongoing_requests",
+        ]
+        metrics_dict = {
+            key: raw.get(key) for key in metrics_keys if raw.get(key) is not None
+        }
+        if not metrics_dict:
+            metrics_dict = None
+
+        # 3. Create and return the validated Pydantic model
+        return cls(
+            scaling_status=raw.get("scaling_status"),
+            decisions=scaling_decisions,
+            metrics=metrics_dict,
+            metrics_health=raw.get("metrics_health"),
+            errors=raw.get("errors", []),
+            policy_name=raw.get("policy_name"),
+        )
 
 
 @PublicAPI(stability="stable")

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1060,6 +1060,8 @@ class DeploymentAutoscalingDetail(BaseModel):
             # Convert ISO string from log to float timestamp for the model
             timestamp_str = raw_decision.get("timestamp_str")
             # This is a required field so assuming this is always present in raw data
+            if not timestamp_str:
+                continue
             timestamp_float = datetime.fromisoformat(
                 str(timestamp_str).replace("Z", "+00:00")
             ).timestamp()

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -695,7 +695,7 @@ def config(address: str, name: Optional[str]):
 )
 @click.option(
     "--verbose",
-    "--v",
+    "-v",
     is_flag=True,
     help="Verbose mode. If set, this will display the autoscaling observability of all the deployments in the application.",
 )

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -751,30 +751,24 @@ def status(
         autoscaling_details = ServeSubmissionClient(
             address
         ).get_autoscaling_observability()
+        if not autoscaling_details:
+            cli_logger.print("No autoscaling details found.")
+            return
+        if name and name not in autoscaling_details:
+            cli_logger.error(f'Application "{name}" does not exist.')
+            return
+        if deployment_name and not name:
+            cli_logger.error("--deployment-name requires --name to be set.")
+            return
+        if deployment_name and deployment_name not in autoscaling_details[name]:
+            cli_logger.error(f'Deployment "{deployment_name}" does not exist.')
+            return
+        deployment_details = autoscaling_details
         if name:
-            if name not in autoscaling_details:
-                cli_logger.error(f'Application "{name}" does not exist.')
-            else:
-                if deployment_name:
-                    if deployment_name not in autoscaling_details[name]:
-                        cli_logger.error(
-                            f'Deployment "{deployment_name}" does not exist.'
-                        )
-                    else:
-                        print(
-                            yaml.safe_dump(
-                                autoscaling_details[name][deployment_name],
-                                sort_keys=False,
-                            ),
-                            end="",
-                        )
-                else:
-                    print(
-                        yaml.safe_dump(autoscaling_details[name], sort_keys=False),
-                        end="",
-                    )
-        else:
-            print(yaml.safe_dump(autoscaling_details, sort_keys=False), end="")
+            deployment_details = autoscaling_details[name]
+            if deployment_name:
+                deployment_details = deployment_details[deployment_name]
+        print(yaml.safe_dump(deployment_details, sort_keys=False), end="")
 
 
 @cli.command(


### PR DESCRIPTION
## Description
This PR introduces a backend API and CLI support for autoscaling observability. It reads and parses the autoscaling snapshot files (generated by #56225) to display detailed deployment level autoscaling status to the user

Changes:
- `serve_head.py` : Added a GET route that reads from the snapshot files, converts into a `DeploymentAutoscalingDetail` compatible schema and returns a JSON.
- `schema.py` : Added a helper constructor `from_snapshot` on `DeploymentAutoscalingDetail` to map raw snapshot data into a schema compliant object.
- `scripts.py` : Extended serve status with -v  (and optional -d) to display deployment level autoscaling details entirely, per application or a specific deployment.
- Added a test that writes multiple entries across rotated snapshot files and assert that the API returns the latest autoscaling entry for each deployment.

## Related issues
 #56225 #55834 

## Checks

- [x] I've signed off every commit (by using the `-s` flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` under the corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/

**Testing Strategy**
- [x] Unit tests
- [ ] Release tests
- [ ] This PR is not tested :(

## Sample outputs
### Steps
- ray start --head
- ran a python code which initializes ray and populates serve output directory
- serve status -v

<img width="417" height="563" alt="image" src="https://github.com/user-attachments/assets/b39dfbe3-8d41-4f46-81e8-112414c383ad" />


