### PR TITLE
[Core]Bug fix: The inner objects contained in the object yielded by the streaming generator can encounter reference-count lost.

### DIFF
--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -250,6 +250,7 @@ Status TaskExecutor::ExecuteTask(
     size_t total = cross_lang ? (XLANG_HEADER_LEN + data_size) : data_size;
     RAY_CHECK_OK(CoreWorkerProcess::GetCoreWorker().AllocateReturnObject(
         result_id,
+        /*generator_id=*/ray::ObjectID::Nil(),
         total,
         meta_buffer,
         std::vector<ray::ObjectID>(),

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -4261,8 +4261,8 @@ cdef class CoreWorker:
             # the object doesn't already exist in plasma.
             check_status(
                 CCoreWorkerProcess.GetCoreWorker().AllocateReturnObject(
-                    return_id, data_size, metadata, contained_id, caller_address,
-                    task_output_inlined_bytes, return_ptr))
+                    return_id, generator_id, data_size, metadata, contained_id,
+                    caller_address, task_output_inlined_bytes, return_ptr))
 
         if return_ptr.get() != NULL:
             if return_ptr.get().HasData():

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -168,6 +168,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const c_string &event_type)
         CRayStatus AllocateReturnObject(
             const CObjectID &object_id,
+            const CObjectID &generator_id,
             const size_t &data_size,
             const shared_ptr[CBuffer] &metadata,
             const c_vector[CObjectID] &contained_object_id,

--- a/python/ray/tests/test_streaming_generator_4.py
+++ b/python/ray/tests/test_streaming_generator_4.py
@@ -398,5 +398,33 @@ def test_cancel(shutdown_only, use_asyncio):
         pass
 
 
+def test_reference_count_of_inner_object(shutdown_only):
+    """This case used to test the yield contains an object ref owned
+    by the producer actor.
+    """
+    ray.init()
+
+    @ray.remote
+    class Producer:
+        def run(self):
+            # Since this bug is caused by a specific timing issue,
+            # a certain number of objects must be yielded to ensure
+            # it can be reproduced.
+            for i in range(100):
+                yield [ray.put(data) for data in range(5)]
+
+    @ray.remote
+    class Consumer:
+        def run(self, refs):
+            return ray.get(refs)
+
+    p = Producer.remote()
+    c = Consumer.remote()
+
+    ref_generator = p.run.remote()
+    for refs in ref_generator:
+        ray.get(c.run.remote(refs))
+
+        
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1034,6 +1034,9 @@ class CoreWorker {
   /// To avoid deadlock, the caller should allocate and seal a single object at a time.
   ///
   /// \param[in] object_id Object ID of the return value.
+  /// \param[in] generator_id For dynamically created objects, this is the ID
+  /// of the object that wraps the dynamically created ObjectRefs in a
+  /// generator.
   /// \param[in] data_size Size of the return value.
   /// \param[in] metadata Metadata buffer of the return value.
   /// \param[in] caller_address The address of the caller of the method.
@@ -1044,6 +1047,7 @@ class CoreWorker {
   /// \param[out] return_object RayObject containing buffers to write results into.
   /// \return Status.
   Status AllocateReturnObject(const ObjectID &object_id,
+                              const ObjectID &generator_id,
                               const size_t &data_size,
                               const std::shared_ptr<Buffer> &metadata,
                               const std::vector<ObjectID> &contained_object_id,

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -233,6 +233,7 @@ Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(JNIEnv *env,
 
             RAY_CHECK_OK(CoreWorkerProcess::GetCoreWorker().AllocateReturnObject(
                 result_id,
+                /*generator_id=*/ObjectID::Nil(),
                 data_size,
                 metadata,
                 contained_object_ids,

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -1152,7 +1152,8 @@ void ReferenceCounter::CleanupBorrowersOnRefRemoved(
 
 void ReferenceCounter::WaitForRefRemoved(const ReferenceTable::iterator &ref_it,
                                          const rpc::Address &addr,
-                                         const ObjectID &contained_in_id) {
+                                         const ObjectID &contained_in_id,
+                                         const ObjectID &generator_id) {
   const ObjectID &object_id = ref_it->first;
   RAY_LOG(DEBUG).WithField(object_id).WithField(WorkerID::FromBinary(addr.worker_id()))
       << "WaitForRefRemoved object, dest worker";
@@ -1166,6 +1167,7 @@ void ReferenceCounter::WaitForRefRemoved(const ReferenceTable::iterator &ref_it,
   request->set_contained_in_id(contained_in_id.Binary());
   request->set_intended_worker_id(addr.worker_id());
   request->set_subscriber_worker_id(rpc_address_.worker_id());
+  if (!generator_id.IsNil()) request->set_generator_id(generator_id.Binary());
 
   // If the message is published, this callback will be invoked.
   const auto message_published_callback = [this, addr, object_id](
@@ -1206,14 +1208,16 @@ void ReferenceCounter::WaitForRefRemoved(const ReferenceTable::iterator &ref_it,
 
 void ReferenceCounter::AddNestedObjectIds(const ObjectID &object_id,
                                           const std::vector<ObjectID> &inner_ids,
-                                          const rpc::Address &owner_address) {
+                                          const rpc::Address &owner_address,
+                                          const ObjectID &generator_id) {
   absl::MutexLock lock(&mutex_);
-  AddNestedObjectIdsInternal(object_id, inner_ids, owner_address);
+  AddNestedObjectIdsInternal(object_id, inner_ids, owner_address, generator_id);
 }
 
 void ReferenceCounter::AddNestedObjectIdsInternal(const ObjectID &object_id,
                                                   const std::vector<ObjectID> &inner_ids,
-                                                  const rpc::Address &owner_address) {
+                                                  const rpc::Address &owner_address,
+                                                  const ObjectID &generator_id) {
   RAY_CHECK(!WorkerID::FromBinary(owner_address.worker_id()).IsNil());
   auto it = object_id_refs_.find(object_id);
   if (owner_address.worker_id() == rpc_address_.worker_id()) {
@@ -1258,7 +1262,7 @@ void ReferenceCounter::AddNestedObjectIdsInternal(const ObjectID &object_id,
             inner_it->second.mutable_borrow()->borrowers.insert(owner_address).second;
         if (inserted) {
           // Wait for it to remove its reference.
-          WaitForRefRemoved(inner_it, owner_address, object_id);
+          WaitForRefRemoved(inner_it, owner_address, object_id, generator_id);
         }
       } else {
         auto inserted = inner_it->second.mutable_borrow()

--- a/src/ray/core_worker/reference_counter.h
+++ b/src/ray/core_worker/reference_counter.h
@@ -181,7 +181,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   void AddNestedObjectIds(const ObjectID &object_id,
                           const std::vector<ObjectID> &inner_ids,
-                          const rpc::Address &owner_address) override
+                          const rpc::Address &owner_address,
+                          const ObjectID &generator_id = ObjectID::Nil()) override
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   void UpdateObjectPinnedAtRaylet(const ObjectID &object_id,
@@ -564,9 +565,12 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// outer object ID is not owned by us, then this is used to contact the
   /// outer object's owner, since it is considered a borrower for the inner
   /// IDs.
+  /// \param generator_id When it's set, this means that `object_id` is a
+  /// dynamically ObjectID, so we need to notify the owner of the outer ObjectID
   void AddNestedObjectIdsInternal(const ObjectID &object_id,
                                   const std::vector<ObjectID> &inner_ids,
-                                  const rpc::Address &owner_address)
+                                  const rpc::Address &owner_address,
+                                  const ObjectID &generator_id = ObjectID::Nil())
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Populates the table with the ObjectID that we were or are still
@@ -621,9 +625,12 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// ID. This is used in cases where we return an object ID that we own inside
   /// an object that we do not own. Then, we must notify the owner of the outer
   /// object that they are borrowing the inner.
+  /// \param generator_id When it's set, this means that `contained_in_id` is a
+  /// dynamically ObjectID, so we need to notify the owner of the outer ObjectID
   void WaitForRefRemoved(const ReferenceTable::iterator &reference_it,
                          const rpc::Address &addr,
-                         const ObjectID &contained_in_id = ObjectID::Nil())
+                         const ObjectID &contained_in_id = ObjectID::Nil(),
+                         const ObjectID &generator_id = ObjectID::Nil())
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Helper method to add an object that we are borrowing. This is used when

--- a/src/ray/core_worker/reference_counter_interface.h
+++ b/src/ray/core_worker/reference_counter_interface.h
@@ -380,9 +380,12 @@ class ReferenceCounterInterface {
   /// outer object ID is not owned by us, then this is used to contact the
   /// outer object's owner, since it is considered a borrower for the inner
   /// IDs.
+  /// \param generator_id When it's set, this means that `object_id` is a
+  /// dynamically ObjectID, so we need to notify the owner of the outer ObjectID
   virtual void AddNestedObjectIds(const ObjectID &object_id,
                                   const std::vector<ObjectID> &inner_ids,
-                                  const rpc::Address &owner_address) = 0;
+                                  const rpc::Address &owner_address,
+                                  const ObjectID &generator_id = ObjectID::Nil()) = 0;
 
   /// Update the pinned location of an object stored in plasma.
   ///

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -186,6 +186,8 @@ message WorkerRefRemovedSubMessage {
   bytes contained_in_id = 3;
   // The ID of the worker that waits for the ref removed message.
   bytes subscriber_worker_id = 4;
+  // The GeneratorID of `contained_in_id`
+  optional bytes generator_id = 5;
 }
 
 message WorkerObjectLocationsSubMessage {


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
details: #58080

Consider the following scenario:
I have an actor called the producer and another called the consumer. The driver fetches objects from the producer (each of these objects internally wraps several objects that the producer has put). It then passes these objects on to the consumer. When the consumer tries to use the inner objects, it finds that their reference counts have already dropped to zero.

code:
```python
def test_reference_count_of_inner_object(shutdown_only):
    """This case used to test the yield contains an object ref owned
    by the producer actor.
    """
    ray.init()

    @ray.remote
    class Producer:
        def run(self):
            # Since this bug is caused by a specific timing issue,
            # a certain number of objects must be yielded to ensure
            # it can be reproduced.
            for i in range(100):
                yield [ray.put(data) for data in range(5)]

    @ray.remote
    class Consumer:
        def run(self, refs):
            return ray.get(refs)

    p = Producer.remote()
    c = Consumer.remote()

    ref_generator = p.run.remote()
    for refs in ref_generator:
        ray.get(c.run.remote(refs))

```

The root cause is that the owner of the inner object (Producer) sends a `WaitForRefRemove` message to the driver at the moment it yields. If this message arrives before the corresponding `ReportGeneratorItemReturns`, the driver—the owner of the streaming generator—has not yet been notified of the outer object that wraps the inner one. Consequently, the owner immediately concludes that no reference to the inner object remains on the driver side, causing the reference count to be lost.

the debug log of driver:
``` txt
[2025-10-24 15:17:59,800 D 1330193 1331139] reference_counter.cc:1282: PublishRefRemoved  object_id=00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505
[2025-10-24 15:17:59,800 D 1330193 1331139] reference_counter.cc:1285: REF 00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505: Reference{borrowers: 0 local_ref_count: 0 submitted_count: 0 contained_on_owned: 0 contained_in_borrowed: 0 contains: 0 stored_in: 0 lineage_ref_count: 0}
[2025-10-24 15:17:59,800 D 1330193 1331139] reference_counter.cc:1008: Pop object for_ref_removed 1 object_id=00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505
[2025-10-24 15:17:59,800 D 1330193 1331139] reference_counter.cc:1293: Object has 0 borrowers, stored in 0 object_id=00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505
[2025-10-24 15:17:59,800 D 1330193 1331139] reference_counter.cc:1306: Publishing WaitForRefRemoved message for object, message has 1 borrowed references. object_id=00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505
[2025-10-24 15:17:59,800 D 1330193 1331139] publisher.cc:301: enqueue: 23
[2025-10-24 15:17:59,800 D 1330193 1331139] reference_counter.cc:704: Attempting to delete object 00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505
[2025-10-24 15:17:59,800 D 1330193 1331139] reference_counter.cc:711: REF 00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505: Reference{borrowers: 0 local_ref_count: 0 submitted_count: 0 contained_on_owned: 0 contained_in_borrowed: 0 contains: 0 stored_in: 0 lineage_ref_count: 0}
[2025-10-24 15:17:59,801 D 1330193 1331139] reference_counter.cc:799: Calling on_object_out_of_scope_or_freed_callbacks for object 00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505 num callbacks: 0
[2025-10-24 15:17:59,801 D 1330193 1331139] reference_counter.cc:747: Deleting Reference to object 00668a65bda616c18c92015059cdb324bd3c6d1a0100000020e1f505
```
It can be seen that, immediately after receiving `WaitForRefRemove`, the reference count of the inner object is deleted right away.

The fix is to call TemporarilyOwnGeneratorReturnRefIfNeeded upon receiving WaitForRefRemove, which temporarily creates the outer object.

## Related issues
Closes #58080 

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
