### PR TITLE
Check if temp_dir is subdir of virtualenv, to prevent problem of runtime virtualenv

### DIFF
--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -440,9 +440,11 @@ class RayParams:
         if self.temp_dir is not None and os.getenv("VIRTUAL_ENV"):
             is_relative = True
             try:
-                (pathlib.Path(self.temp_dir)
-                .resolve()
-                .relative_to(pathlib.Path(os.getenv("VIRTUAL_ENV")).resolve()))
+                (
+                    pathlib.Path(self.temp_dir)
+                    .resolve()
+                    .relative_to(pathlib.Path(os.getenv("VIRTUAL_ENV")).resolve())
+                )
             except ValueError:
                 is_relative = False
 

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 from typing import Dict, List, Optional
 
 import ray._private.ray_constants as ray_constants
@@ -435,6 +436,11 @@ class RayParams:
 
         if self.temp_dir is not None and not os.path.isabs(self.temp_dir):
             raise ValueError("temp_dir must be absolute path or None.")
+
+        if self.temp_dir is not None and os.getenv('VIRTUAL_ENV'):
+            if pathlib.Path(self.temp_dir).resolve().is_relative_to(
+                    pathlib.Path(os.getenv('VIRTUAL_ENV')).resolve()):
+                raise ValueError("temp_dir must not be child directory of virtualenv root")
 
     def _format_ports(self, pre_selected_ports):
         """Format the pre-selected ports information to be more human-readable."""

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -440,9 +440,9 @@ class RayParams:
         if self.temp_dir is not None and os.getenv("VIRTUAL_ENV"):
             is_relative = True
             try:
-                pathlib.Path(self.temp_dir)
+                (pathlib.Path(self.temp_dir)
                 .resolve()
-                .relative_to(pathlib.Path(os.getenv("VIRTUAL_ENV")).resolve())
+                .relative_to(pathlib.Path(os.getenv("VIRTUAL_ENV")).resolve()))
             except ValueError:
                 is_relative = False
 

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -438,11 +438,15 @@ class RayParams:
             raise ValueError("temp_dir must be absolute path or None.")
 
         if self.temp_dir is not None and os.getenv("VIRTUAL_ENV"):
-            if (
+            is_relative = True
+            try:
                 pathlib.Path(self.temp_dir)
                 .resolve()
-                .is_relative_to(pathlib.Path(os.getenv("VIRTUAL_ENV")).resolve())
-            ):
+                .relative_to(pathlib.Path(os.getenv("VIRTUAL_ENV")).resolve())
+            except ValueError:
+                is_relative = False
+
+            if is_relative:
                 raise ValueError(
                     "temp_dir must not be child directory of virtualenv root"
                 )

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -437,10 +437,15 @@ class RayParams:
         if self.temp_dir is not None and not os.path.isabs(self.temp_dir):
             raise ValueError("temp_dir must be absolute path or None.")
 
-        if self.temp_dir is not None and os.getenv('VIRTUAL_ENV'):
-            if pathlib.Path(self.temp_dir).resolve().is_relative_to(
-                    pathlib.Path(os.getenv('VIRTUAL_ENV')).resolve()):
-                raise ValueError("temp_dir must not be child directory of virtualenv root")
+        if self.temp_dir is not None and os.getenv("VIRTUAL_ENV"):
+            if (
+                pathlib.Path(self.temp_dir)
+                .resolve()
+                .is_relative_to(pathlib.Path(os.getenv("VIRTUAL_ENV")).resolve())
+            ):
+                raise ValueError(
+                    "temp_dir must not be child directory of virtualenv root"
+                )
 
     def _format_ports(self, pre_selected_ports):
         """Format the pre-selected ports information to be more human-readable."""


### PR DESCRIPTION
If temp_dir is a subdirectory of current virtualenv root, it will cause copying files recursively and not finishing when ray try to create runtime virtualenv.

## Description
If temp_dir is a subdirectory of current virtualenv root, when we submit a task, and specify pip dependencies, ray will create a runtime virtualenv, cause copying directories recursively, and runtime virtualenv directory explosion.
