### PR TITLE
add deployment status check in test

### DIFF
--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -1713,6 +1713,12 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
+        wait_for_condition(
+            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+        )
+        wait_for_condition(
+            check_deployment_status, name="B", expected_status=DeploymentStatus.HEALTHY
+        )
         wait_for_condition(check_running, timeout=15)
         print(time.ctime(), "Application is RUNNING.")
         self.verify_scaling_decisions(signal_A, signal_B)
@@ -1744,6 +1750,9 @@ class TestAppLevelAutoscalingPolicy:
 
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
+        )
+        wait_for_condition(
+            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
         )
         wait_for_condition(check_running, timeout=15)
 
@@ -1794,6 +1803,12 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
+        wait_for_condition(
+            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+        )
+        wait_for_condition(
+            check_deployment_status, name="B", expected_status=DeploymentStatus.HEALTHY
+        )
         wait_for_condition(check_running, timeout=15)
 
         hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)
@@ -1838,6 +1853,9 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
+        wait_for_condition(
+            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+        )
         wait_for_condition(check_running, timeout=15)
 
         hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)
@@ -1862,6 +1880,9 @@ class TestAppLevelAutoscalingPolicy:
         }
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
+        )
+        wait_for_condition(
+            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
         )
         wait_for_condition(check_running, timeout=15)
 
@@ -1896,6 +1917,9 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
+        wait_for_condition(
+            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+        )
         wait_for_condition(check_running, timeout=15)
 
         hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)
@@ -1919,6 +1943,10 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
+        wait_for_condition(
+            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+        )
+        wait_for_condition(check_running, timeout=15)
 
         wait_for_condition(check_num_replicas_eq, name="A", target=1)
         hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -1713,12 +1713,6 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
-        wait_for_condition(
-            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-        )
-        wait_for_condition(
-            check_deployment_status, name="B", expected_status=DeploymentStatus.HEALTHY
-        )
         wait_for_condition(check_running, timeout=15)
         print(time.ctime(), "Application is RUNNING.")
         self.verify_scaling_decisions(signal_A, signal_B)
@@ -1750,9 +1744,6 @@ class TestAppLevelAutoscalingPolicy:
 
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
-        )
-        wait_for_condition(
-            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
         )
         wait_for_condition(check_running, timeout=15)
 
@@ -1803,12 +1794,6 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
-        wait_for_condition(
-            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-        )
-        wait_for_condition(
-            check_deployment_status, name="B", expected_status=DeploymentStatus.HEALTHY
-        )
         wait_for_condition(check_running, timeout=15)
 
         hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)
@@ -1853,9 +1838,6 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
-        wait_for_condition(
-            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-        )
         wait_for_condition(check_running, timeout=15)
 
         hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)
@@ -1880,9 +1862,6 @@ class TestAppLevelAutoscalingPolicy:
         }
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
-        )
-        wait_for_condition(
-            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
         )
         wait_for_condition(check_running, timeout=15)
 
@@ -1917,9 +1896,6 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
-        wait_for_condition(
-            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-        )
         wait_for_condition(check_running, timeout=15)
 
         hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)
@@ -1943,11 +1919,7 @@ class TestAppLevelAutoscalingPolicy:
         client.deploy_apps(
             ServeDeploySchema.parse_obj({"applications": [config_template]})
         )
-        wait_for_condition(
-            check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
-        )
         wait_for_condition(check_running, timeout=15)
-
         wait_for_condition(check_num_replicas_eq, name="A", target=1)
         hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)
         results = [hA.remote() for _ in range(120)]


### PR DESCRIPTION
I suspect that when we deploy the app config, we dont wait long enough before sending traffic, so requests could go to the wrong version 