### PR TITLE
[air] enable a test that was mistakenly disabled

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -199,9 +199,7 @@
   group: AIR tests
   working_dir: air_tests/air_benchmarks
 
-  # Failing since Aug 2024
-  # https://github.com/ray-project/ray/issues/46687
-  frequency: manual
+  frequency: weekly
   team: ml
 
   cluster:
@@ -217,7 +215,7 @@
       num_nodes: 4
 
   smoke_test:
-    frequency: manual
+    frequency: weekly
 
     cluster:
       cluster_compute: compute_gpu_2x2_aws.yaml


### PR DESCRIPTION
disabled the wrong test with a different name from the issue

mistakenly associated issue: https://github.com/ray-project/ray/issues/46687