### PR TITLE
[llm][data] Change example pip install to ray[llm]

### DIFF
--- a/doc/source/llm/examples/batch/vllm-with-lora.ipynb
+++ b/doc/source/llm/examples/batch/vllm-with-lora.ipynb
@@ -11,7 +11,7 @@
     "To run this example, we need to install the following dependencies:\n",
     "\n",
     "```bash\n",
-    "pip install -qU \"ray[data]\" \"vllm==0.7.2\"\n",
+    "pip install -qU \"ray[data]==2.50.1\" \"vllm==0.10.2\"\n",
     "```"
    ]
   },

--- a/doc/source/llm/examples/batch/vllm-with-lora.ipynb
+++ b/doc/source/llm/examples/batch/vllm-with-lora.ipynb
@@ -11,7 +11,7 @@
     "To run this example, we need to install the following dependencies:\n",
     "\n",
     "```bash\n",
-    "pip install -qU \"ray[data]==2.50.1\" \"vllm==0.10.2\"\n",
+    "pip install -qU \"ray[llm]\"\n",
     "```"
    ]
   },

--- a/doc/source/llm/examples/batch/vllm-with-structural-output.ipynb
+++ b/doc/source/llm/examples/batch/vllm-with-structural-output.ipynb
@@ -11,7 +11,7 @@
     "In this example, we show how to perform batch inference using Ray Data LLM with structural outputs in JSON format. To run this example, we need to install the following dependencies:\n",
     "\n",
     "```bash\n",
-    "pip install -qU \"ray[data]==2.50.1\" \"vllm==0.10.2\"\n",
+    "pip install -qU \"ray[llm]\"\n",
     "```"
    ]
   },

--- a/doc/source/llm/examples/batch/vllm-with-structural-output.ipynb
+++ b/doc/source/llm/examples/batch/vllm-with-structural-output.ipynb
@@ -11,7 +11,7 @@
     "In this example, we show how to perform batch inference using Ray Data LLM with structural outputs in JSON format. To run this example, we need to install the following dependencies:\n",
     "\n",
     "```bash\n",
-    "pip install -qU \"ray[data]\" \"vllm==0.7.2\" \"xgrammar==0.1.11\"\n",
+    "pip install -qU \"ray[data]==2.50.1\" \"vllm==0.10.2\"\n",
     "```"
    ]
   },


### PR DESCRIPTION
## Description
- Markdown instructions out of date with notebook contents
- Notebooks are already tested in CI, but with ray-llm image
- ray[llm] already bundles data, and is used for ray-llm image, so it more accurately reflects the tested configuration

## Additional information
Manual tests complete successfully with `rayproject/ray-llm:2.50.1-py311-cu128`:
<img width="1840" height="1191" alt="Screenshot 2025-10-24 at 2 59 22 PM" src="https://github.com/user-attachments/assets/85af3f52-9b12-4652-a124-c2629d4197e7" />
<img width="1840" height="1191" alt="Screenshot 2025-10-24 at 2 54 16 PM" src="https://github.com/user-attachments/assets/f9247a2e-60bf-43d5-a56e-00c80fea07b1" />
