### PR TITLE
[Data] - Add human friendly repr for Expression Tree

### DIFF
--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -5,6 +5,7 @@ from ray.data.expressions import (
     AliasExpr,
     BinaryExpr,
     ColumnExpr,
+    DownloadExpr,
     Expr,
     LiteralExpr,
     StarExpr,
@@ -225,3 +226,126 @@ def _is_col_expr(expr: Expr) -> bool:
     return isinstance(expr, ColumnExpr) or (
         isinstance(expr, AliasExpr) and isinstance(expr.expr, ColumnExpr)
     )
+
+
+class _TreeReprVisitor(_ExprVisitor[str]):
+    """Visitor that generates a readable tree representation of expressions. Returns in pre-order traversal."""
+
+    def __init__(self, prefix: str = "", is_last: bool = True):
+        """
+        Initialize the tree representation visitor.
+
+        Args:
+            prefix: The prefix string for indentation (accumulated from parent nodes)
+            is_last: Whether this node is the last child of its parent
+        """
+        self.prefix = prefix
+        self.is_last = is_last
+
+    def _make_tree_lines(
+        self,
+        node_label: str,
+        children: List[tuple[str, "Expr"]] = None,
+        expr: "Expr" = None,
+    ) -> str:
+        """
+        Format a node and its children with tree box-drawing characters.
+
+        Args:
+            node_label: The label for this node (e.g., "ADD")
+            children: List of (label, child_expr) tuples to render as children
+            expr: The expression node (used to extract datatype)
+
+        Returns:
+            Multi-line string representation of the tree
+        """
+        # Add datatype annotation if expr is provided
+        if expr is not None:
+            node_label = f"{node_label}"
+        lines = [node_label]
+
+        if children:
+            for i, (label, child_expr) in enumerate(children):
+                is_last_child = i == len(children) - 1
+
+                # Build prefix for the child based on whether current node is last
+                child_prefix = self.prefix + ("    " if self.is_last else "│   ")
+
+                # Choose connector: └── for last child, ├── for others
+                connector = "└── " if is_last_child else "├── "
+
+                # Recursively visit the child with updated prefix
+                child_visitor = _TreeReprVisitor(child_prefix, is_last_child)
+                child_lines = child_visitor.visit(child_expr).split("\n")
+
+                # Add the first line with label and connector
+                if label:
+                    lines.append(f"{child_prefix}{connector}{label}: {child_lines[0]}")
+                else:
+                    lines.append(f"{child_prefix}{connector}{child_lines[0]}")
+
+                # Add remaining lines from child with proper indentation
+                for line in child_lines[1:]:
+                    lines.append(line)
+
+        return "\n".join(lines)
+
+    def visit_column(self, expr: "ColumnExpr") -> str:
+        return self._make_tree_lines(f"COL({expr.name!r})", expr=expr)
+
+    def visit_literal(self, expr: "LiteralExpr") -> str:
+        # Truncate long values for readability
+        value_repr = repr(expr.value)
+        if len(value_repr) > 50:
+            value_repr = value_repr[:47] + "..."
+        return self._make_tree_lines(f"LIT({value_repr})", expr=expr)
+
+    def visit_binary(self, expr: "BinaryExpr") -> str:
+        return self._make_tree_lines(
+            f"{expr.op.name}",
+            children=[
+                ("", expr.left),
+                ("", expr.right),
+            ],
+            expr=expr,
+        )
+
+    def visit_unary(self, expr: "UnaryExpr") -> str:
+        return self._make_tree_lines(
+            f"{expr.op.name}",
+            children=[("", expr.operand)],
+            expr=expr,
+        )
+
+    def visit_alias(self, expr: "AliasExpr") -> str:
+        rename_marker = " [rename]" if expr._is_rename else ""
+        return self._make_tree_lines(
+            f"ALIAS({expr.name!r}){rename_marker}",
+            children=[("", expr.expr)],
+            expr=expr,
+        )
+
+    def visit_udf(self, expr: "UDFExpr") -> str:
+        # Get function name for better readability
+        fn_name = getattr(expr.fn, "__name__", str(expr.fn))
+
+        children = []
+        # Add positional arguments
+        for i, arg in enumerate(expr.args):
+            children.append((f"arg[{i}]", arg))
+
+        # Add keyword arguments
+        for key, value in expr.kwargs.items():
+            children.append((f"kwarg[{key!r}]", value))
+
+        return self._make_tree_lines(
+            f"UDF({fn_name})",
+            children=children if children else None,
+            expr=expr,
+        )
+
+    def visit_download(self, expr: "DownloadExpr") -> str:
+        return self._make_tree_lines(f"DOWNLOAD({expr.uri_column_name!r})", expr=expr)
+
+    def visit_star(self, expr: "StarExpr") -> str:
+        return self._make_tree_lines("COL(*)", expr=expr)

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -241,6 +241,7 @@ class _TreeReprVisitor(_ExprVisitor[str]):
         """
         self.prefix = prefix
         self.is_last = is_last
+        self._max_length = 50  # Maximum length of the node label
 
     def _make_tree_lines(
         self,
@@ -259,9 +260,6 @@ class _TreeReprVisitor(_ExprVisitor[str]):
         Returns:
             Multi-line string representation of the tree
         """
-        # Add datatype annotation if expr is provided
-        if expr is not None:
-            node_label = f"{node_label}"
         lines = [node_label]
 
         if children:
@@ -296,16 +294,16 @@ class _TreeReprVisitor(_ExprVisitor[str]):
     def visit_literal(self, expr: "LiteralExpr") -> str:
         # Truncate long values for readability
         value_repr = repr(expr.value)
-        if len(value_repr) > 50:
-            value_repr = value_repr[:47] + "..."
+        if len(value_repr) > self._max_length:
+            value_repr = value_repr[: self._max_length - 3] + "..."
         return self._make_tree_lines(f"LIT({value_repr})", expr=expr)
 
     def visit_binary(self, expr: "BinaryExpr") -> str:
         return self._make_tree_lines(
             f"{expr.op.name}",
             children=[
-                ("", expr.left),
-                ("", expr.right),
+                ("left", expr.left),
+                ("right", expr.right),
             ],
             expr=expr,
         )
@@ -313,7 +311,7 @@ class _TreeReprVisitor(_ExprVisitor[str]):
     def visit_unary(self, expr: "UnaryExpr") -> str:
         return self._make_tree_lines(
             f"{expr.op.name}",
-            children=[("", expr.operand)],
+            children=[("operand", expr.operand)],
             expr=expr,
         )
 

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -242,6 +242,29 @@ class Expr(ABC):
         """
         return _PyArrowExpressionVisitor().visit(self)
 
+    def __repr__(self) -> str:
+        """Return a tree-structured string representation of the expression.
+
+        Returns:
+            A multi-line string showing the expression tree structure using
+            box-drawing characters for visual clarity.
+
+        Example:
+            >>> from ray.data.expressions import col, lit
+            >>> expr = (col("x") + lit(5)) * col("y")
+            >>> print(expr)
+            MUL
+            ├── left: ADD
+            │   ├── left: COL('x')
+            │   └── right: LIT(5)
+            └── right: COL('y')
+        """
+        from ray.data._internal.planner.plan_expression.expression_visitors import (
+            _TreeReprVisitor,
+        )
+
+        return _TreeReprVisitor().visit(self)
+
     def _bin(self, other: Any, op: Operation) -> "Expr":
         """Create a binary expression with the given operation.
 
@@ -387,7 +410,7 @@ class Expr(ABC):
 
 
 @DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, repr=False)
 class ColumnExpr(Expr):
     """Expression that references a column by name.
 
@@ -420,7 +443,7 @@ class ColumnExpr(Expr):
 
 
 @DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, repr=False)
 class LiteralExpr(Expr):
     """Expression that represents a constant scalar value.
 
@@ -458,7 +481,7 @@ class LiteralExpr(Expr):
 
 
 @DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, repr=False)
 class BinaryExpr(Expr):
     """Expression that represents a binary operation between two expressions.
 
@@ -494,7 +517,7 @@ class BinaryExpr(Expr):
 
 
 @DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, repr=False)
 class UnaryExpr(Expr):
     """Expression that represents a unary operation on a single expression.
 
@@ -530,7 +553,7 @@ class UnaryExpr(Expr):
 
 
 @DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, repr=False)
 class UDFExpr(Expr):
     """Expression that represents a user-defined function call.
 
@@ -672,7 +695,7 @@ def udf(return_dtype: DataType) -> Callable[..., UDFExpr]:
 
 
 @DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, repr=False)
 class DownloadExpr(Expr):
     """Expression that represents a download operation."""
 
@@ -687,7 +710,7 @@ class DownloadExpr(Expr):
 
 
 @DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, repr=False)
 class AliasExpr(Expr):
     """Expression that represents an alias for an expression."""
 
@@ -719,7 +742,7 @@ class AliasExpr(Expr):
 
 
 @DeveloperAPI(stability="alpha")
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, repr=False)
 class StarExpr(Expr):
     """Expression that represents all columns from the input.
 

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -254,10 +254,10 @@ class Expr(ABC):
             >>> expr = (col("x") + lit(5)) * col("y")
             >>> print(expr)
             MUL
-            ├── left: ADD
-            │   ├── left: COL('x')
-            │   └── right: LIT(5)
-            └── right: COL('y')
+                ├── left: ADD
+                │   ├── left: COL('x')
+                │   └── right: LIT(5)
+                └── right: COL('y')
         """
         from ray.data._internal.planner.plan_expression.expression_visitors import (
             _TreeReprVisitor,

--- a/python/ray/data/tests/test_expressions.py
+++ b/python/ray/data/tests/test_expressions.py
@@ -469,16 +469,16 @@ class TestExpressionRepr:
         """Test repr for simple binary expressions."""
         expr = col("x") + lit(5)
         expected = """ADD
-    ├── COL('x')
-    └── LIT(5)"""
+    ├── left: COL('x')
+    └── right: LIT(5)"""
         assert repr(expr) == expected
 
     def test_binary_expr_multiplication_repr(self):
         """Test repr for multiplication."""
         expr = col("price") * lit(2)
         expected = """MUL
-    ├── COL('price')
-    └── LIT(2)"""
+    ├── left: COL('price')
+    └── right: LIT(2)"""
         assert repr(expr) == expected
 
     def test_nested_binary_expr_repr(self):
@@ -486,10 +486,10 @@ class TestExpressionRepr:
         # (col("x") + 5) * col("y")
         expr = (col("x") + lit(5)) * col("y")
         expected = """MUL
-    ├── ADD
-    │   ├── COL('x')
-    │   └── LIT(5)
-    └── COL('y')"""
+    ├── left: ADD
+    │   ├── left: COL('x')
+    │   └── right: LIT(5)
+    └── right: COL('y')"""
         assert repr(expr) == expected
 
     def test_deeply_nested_binary_expr_repr(self):
@@ -497,33 +497,33 @@ class TestExpressionRepr:
         # ((col("a") + 5) * col("b")) > 100
         expr = ((col("a") + lit(5)) * col("b")) > lit(100)
         expected = """GT
-    ├── MUL
-    │   ├── ADD
-    │   │   ├── COL('a')
-    │   │   └── LIT(5)
-    │   └── COL('b')
-    └── LIT(100)"""
+    ├── left: MUL
+    │   ├── left: ADD
+    │   │   ├── left: COL('a')
+    │   │   └── right: LIT(5)
+    │   └── right: COL('b')
+    └── right: LIT(100)"""
         assert repr(expr) == expected
 
     def test_unary_expr_not_repr(self):
         """Test repr for NOT operation."""
         expr = ~col("active")
         expected = """NOT
-    └── COL('active')"""
+    └── operand: COL('active')"""
         assert repr(expr) == expected
 
     def test_unary_expr_is_null_repr(self):
         """Test repr for IS_NULL operation."""
         expr = col("value").is_null()
         expected = """IS_NULL
-    └── COL('value')"""
+    └── operand: COL('value')"""
         assert repr(expr) == expected
 
     def test_unary_expr_is_not_null_repr(self):
         """Test repr for IS_NOT_NULL operation."""
         expr = col("value").is_not_null()
         expected = """IS_NOT_NULL
-    └── COL('value')"""
+    └── operand: COL('value')"""
         assert repr(expr) == expected
 
     def test_alias_simple_repr(self):
@@ -538,8 +538,8 @@ class TestExpressionRepr:
         expr = (col("x") + lit(5)).alias("result")
         expected = """ALIAS('result')
     └── ADD
-        ├── COL('x')
-        └── LIT(5)"""
+        ├── left: COL('x')
+        └── right: LIT(5)"""
         assert repr(expr) == expected
 
     def test_udf_expr_with_args_repr(self):
@@ -620,40 +620,40 @@ class TestExpressionRepr:
         """Test repr for AND operation."""
         expr = (col("age") > lit(18)) & (col("status") == lit("active"))
         expected = """AND
-    ├── GT
-    │   ├── COL('age')
-    │   └── LIT(18)
-    └── EQ
-        ├── COL('status')
-        └── LIT('active')"""
+    ├── left: GT
+    │   ├── left: COL('age')
+    │   └── right: LIT(18)
+    └── right: EQ
+        ├── left: COL('status')
+        └── right: LIT('active')"""
         assert repr(expr) == expected
 
     def test_boolean_or_repr(self):
         """Test repr for OR operation."""
         expr = (col("age") < lit(18)) | (col("age") > lit(65))
         expected = """OR
-    ├── LT
-    │   ├── COL('age')
-    │   └── LIT(18)
-    └── GT
-        ├── COL('age')
-        └── LIT(65)"""
+    ├── left: LT
+    │   ├── left: COL('age')
+    │   └── right: LIT(18)
+    └── right: GT
+        ├── left: COL('age')
+        └── right: LIT(65)"""
         assert repr(expr) == expected
 
     def test_is_in_operation_repr(self):
         """Test repr for is_in operations."""
         expr = col("status").is_in(["active", "pending"])
         expected = """IN
-    ├── COL('status')
-    └── LIT(['active', 'pending'])"""
+    ├── left: COL('status')
+    └── right: LIT(['active', 'pending'])"""
         assert repr(expr) == expected
 
     def test_not_in_operation_repr(self):
         """Test repr for not_in operations."""
         expr = col("status").not_in(["deleted", "archived"])
         expected = """NOT_IN
-    ├── COL('status')
-    └── LIT(['deleted', 'archived'])"""
+    ├── left: COL('status')
+    └── right: LIT(['deleted', 'archived'])"""
         assert repr(expr) == expected
 
     def test_all_binary_operations_repr(self):
@@ -676,8 +676,8 @@ class TestExpressionRepr:
 
         for expr, op_name in test_cases:
             expected = f"""{op_name}
-    ├── COL('a')
-    └── COL('b')"""
+    ├── left: COL('a')
+    └── right: COL('b')"""
             assert repr(expr) == expected, f"Failed for operation {op_name}"
 
     def test_complex_nested_with_unary_repr(self):
@@ -685,11 +685,11 @@ class TestExpressionRepr:
         # ~((col("age") > 18) & col("active"))
         expr = ~((col("age") > lit(18)) & col("active"))
         expected = """NOT
-    └── AND
-        ├── GT
-        │   ├── COL('age')
-        │   └── LIT(18)
-        └── COL('active')"""
+    └── operand: AND
+        ├── left: GT
+        │   ├── left: COL('age')
+        │   └── right: LIT(18)
+        └── right: COL('active')"""
         assert repr(expr) == expected
 
     def test_right_side_nested_repr(self):
@@ -697,10 +697,10 @@ class TestExpressionRepr:
         # col("x") + (col("y") * col("z"))
         expr = col("x") + (col("y") * col("z"))
         expected = """ADD
-    ├── COL('x')
-    └── MUL
-        ├── COL('y')
-        └── COL('z')"""
+    ├── left: COL('x')
+    └── right: MUL
+        ├── left: COL('y')
+        └── right: COL('z')"""
         assert repr(expr) == expected
 
     def test_multiple_levels_both_sides_repr(self):
@@ -708,12 +708,12 @@ class TestExpressionRepr:
         # (col("a") + col("b")) * (col("c") - col("d"))
         expr = (col("a") + col("b")) * (col("c") - col("d"))
         expected = """MUL
-    ├── ADD
-    │   ├── COL('a')
-    │   └── COL('b')
-    └── SUB
-        ├── COL('c')
-        └── COL('d')"""
+    ├── left: ADD
+    │   ├── left: COL('a')
+    │   └── right: COL('b')
+    └── right: SUB
+        ├── left: COL('c')
+        └── right: COL('d')"""
         assert repr(expr) == expected
 
     def test_print_expr(self, capsys):
@@ -722,8 +722,8 @@ class TestExpressionRepr:
         print(expr)
 
         expected = """ADD
-    ├── COL('x')
-    └── LIT(5)
+    ├── left: COL('x')
+    └── right: LIT(5)
 """
         captured = capsys.readouterr()
         assert captured.out == expected


### PR DESCRIPTION
## Description
As title states.

Example:

```
from ray.data.expressions import col, lit
expr = (col("x") + lit(5)) * col("y")
print(expr)
  MUL
  ├── left: ADD
  │   ├── left: COL('x')
  │   └── right: LIT(5)
  └── right: COL('y')
```

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
