### PR TITLE
[doc][data][llm] Update documentation for cross-node parallelism

### DIFF
--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -235,7 +235,7 @@ How to configure LLM stage to parallelize across multiple nodes?
 
 Ray Data LLM now supports cross-node parallelism for both tensor parallelism (TP) 
 and pipeline parallelism (PP). By default, Ray Data uses the 
-`PACK strategy <https://docs.ray.io/en/latest/ray-core/scheduling/placement-group.html#pgroup-strategy>`_, 
+:ref:`PACK strategy <pgroup-strategy>`, 
 which attempts to place all resources on a single node when possible, but 
 allows cross-node placement if a single node doesn't have enough resources.
 

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -268,9 +268,7 @@ For explicit control over cross-node placement, you can specify a custom
 - The default ``PACK`` strategy provides good performance for most use cases
 - Use ``SPREAD`` or ``STRICT_SPREAD`` only when you specifically need cross-node distribution
 
-You can also horizontally scale the LLM stage to multiple nodes by increasing 
-the ``concurrency`` argument in :class:`vLLMEngineProcessorConfig <ray.data.llm.vLLMEngineProcessorConfig>`.
-Each replica will run independently with its own TP/PP configuration.
+In addition to parallelizing a single model instance with TP/PP, you can also run multiple independent model replicas to increase data parallelism. This is controlled by the ``concurrency`` argument in :class:`vLLMEngineProcessorConfig <ray.data.llm.vLLMEngineProcessorConfig>`. Each replica will run independently with its own TP/PP configuration.
 
 .. _gpu_memory_management:
 


### PR DESCRIPTION
## Description

This PR updates the Ray Data LLM documentation to reflect that cross-node tensor parallelism (TP) and pipeline parallelism (PP) are now supported. The previous documentation stated that cross-node parallelism was not supported.

The changes include:
- Removing outdated statements about the lack of cross-node parallelism.
- Clarifying that cross-node TP/PP is supported (as enabled by #56779).
- Explaining the default `PACK` placement strategy and its behavior for cross-node placement.
- Providing a code example demonstrating how to explicitly configure cross-node placement using the `SPREAD` strategy with `placement_group_config`.
- Adding important notes regarding `distributed_executor_backend` and bundle configuration for cross-node setups.

## Related issues

Related to #56779 (which enabled cross-node parallelism).

## Types of change

- [ ] Bug fix 🐛
- [ ] New feature ✨
- [ ] Enhancement 🚀
- [ ] Code refactoring 🔧
- [x] Documentation update 📖
- [ ] Chore 🧹
- [ ] Style 🎨

## Checklist

**Does this PR introduce breaking changes?**
- [ ] Yes ⚠️
- [x] No

**Testing:**
- [ ] Added/updated tests for my changes
- [x] Tested the changes manually
- [ ] This PR is not tested ❌ _(please explain why)_

**Code Quality:**
- [x] Signed off every commit (`git commit -s`)
- [x] Ran pre-commit hooks ([setup guide](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))

**Documentation:**
- [x] Updated documentation (if applicable) ([contribution guide](https://docs.ray.io/en/latest/ray-contribute/docs.html))
- [ ] Added new APIs to `doc/source/` (if applicable)

## Additional context

The documentation now accurately reflects the current capabilities of Ray Data LLM for large model inference across multiple nodes.


