### PR TITLE
update docs for custom request router and policy

### DIFF
--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -721,5 +721,5 @@ When you provide a custom policy, Ray Serve can fully support it as long as it's
 When your custom autoscaling policy has complex dependencies or you want better control over versioning and deployment, you have several alternatives:
 
 - **Contribute to Ray Serve**: If your policy is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in policy by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues).
-- **Ensure dependencies in your environment**: Make sure that the external dependencies are present in your Docker image or environment.
+- **Ensure dependencies in your environment**: Make sure that the external dependencies are installed in your Docker image or environment.
 :::

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -714,14 +714,12 @@ When you specify both a deployment-level policy and an application-level policy,
 :::{warning}
 ### Gotchas and limitations
 
-When you provide a custom policy, Ray Serve can fully support it as long as it's simple, self-contained Python code that relies only on the standard library. Once the policy becomes more complex (such as depending on other custom modules or packages), you'll need to ensure those modules are bundled into the Docker image or environment. This is because Ray Serve uses `cloudpickle` to serialize custom policies, which doesn't vendor transitive dependencies—if your policy inherits from a superclass in another module or imports custom packages, those must exist in the target environment. Additionally, environment parity matters: differences in Python version, `cloudpickle` version, or library versions can affect deserialization.
+When you provide a custom policy, Ray Serve can fully support it as long as it's simple, self-contained Python code that relies only on the standard library. Once the policy becomes more complex, such as depending on other custom modules or packages, you need to bundle those modules into the Docker image or environment. This is because Ray Serve uses `cloudpickle` to serialize custom policies and it doesn't vendor transitive dependencies—if your policy inherits from a superclass in another module or imports custom packages, those must exist in the target environment. Additionally, environment parity matters: differences in Python version, `cloudpickle` version, or library versions can affect deserialization.
 
 #### Alternatives for complex policies
 
 When your custom autoscaling policy has complex dependencies or you want better control over versioning and deployment, you have several alternatives:
 
 - **Contribute to Ray Serve**: If your policy is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in policy by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues).
-- **Publish a Python package**: Package your policy as a standalone Python package and publish to PyPI (or a private package index), then install the package in your Docker image or environment—this gives you version control and clear dependency management.
 - **Ensure dependencies in your environment**: Make sure that the external dependencies are present in your Docker image or environment.
-- **Use PYTHONPATH**: Place your policy module in a location accessible through `PYTHONPATH`, which is simpler but requires careful environment management.
 :::

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -710,3 +710,18 @@ Programmatic configuration of application-level autoscaling policies through `se
 :::{note}
 When you specify both a deployment-level policy and an application-level policy, the application-level policy takes precedence. Ray Serve logs a warning if you configure both.
 :::
+
+:::{warning}
+### Gotchas and limitations
+
+When you provide a custom policy, Ray Serve can fully support it as long as it's simple, self-contained Python code that relies only on the standard library. Once the policy becomes more complex (such as depending on other custom modules or packages), you'll need to ensure those modules are bundled into the Docker image or environment. This is because Ray Serve uses `cloudpickle` to serialize custom policies, which doesn't vendor transitive dependencies—if your policy inherits from a superclass in another module or imports custom packages, those must exist in the target environment. Additionally, environment parity matters: differences in Python version, `cloudpickle` version, or library versions can affect deserialization.
+
+#### Alternatives for complex policies
+
+When your custom autoscaling policy has complex dependencies or you want better control over versioning and deployment, you have several alternatives:
+
+- **Contribute to Ray Serve**: If your policy is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in policy by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues).
+- **Publish a Python package**: Package your policy as a standalone Python package and publish to PyPI (or a private package index), then install the package in your Docker image or environment—this gives you version control and clear dependency management.
+- **Ensure dependencies in your environment**: Make sure that the external dependencies are present in your Docker image or environment.
+- **Use PYTHONPATH**: Place your policy module in a location accessible through `PYTHONPATH`, which is simpler but requires careful environment management.
+:::

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -720,6 +720,6 @@ When you provide a custom policy, Ray Serve can fully support it as long as it's
 
 When your custom autoscaling policy has complex dependencies or you want better control over versioning and deployment, you have several alternatives:
 
-- **Contribute to Ray Serve**: If your policy is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in policy by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues).
+- **Contribute to Ray Serve**: If your policy is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in policy by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues). The recommended location for the implementation is `python/ray/serve/autoscaling_policy.py`.
 - **Ensure dependencies in your environment**: Make sure that the external dependencies are installed in your Docker image or environment.
 :::

--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -169,5 +169,5 @@ When your custom request router has complex dependencies or you want better cont
 
 - **Use built-in routers**: Consider using the routers shipped with Ray Serve—these are well-tested, production-ready, and guaranteed to work across different environments.
 - **Contribute to Ray Serve**: If your router is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in router by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues).
-- **Ensure dependencies in your environment**: Make sure that the external dependencies are present in your Docker image or environment.
+- **Ensure dependencies in your environment**: Make sure that the external dependencies are installed in your Docker image or environment.
 :::

--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -161,7 +161,7 @@ replicas and use it in the routing policy.
 :::{warning}
 ## Gotchas and limitations
 
-When you provide a custom router, Ray Serve can fully support it as long as it's simple, self-contained Python code that relies only on the standard library. Once the router becomes more complex (such as depending on other custom modules or packages), you'll need to ensure those modules are bundled into the Docker image or environment. This is because Ray Serve uses `cloudpickle` to serialize custom routers, which doesn't vendor transitive dependencies—if your router inherits from a superclass in another module or imports custom packages, those must exist in the target environment. Additionally, environment parity matters: differences in Python version, `cloudpickle` version, or library versions can affect deserialization.
+When you provide a custom router, Ray Serve can fully support it as long as it's simple, self-contained Python code that relies only on the standard library. Once the router becomes more complex, such as depending on other custom modules or packages, you need to ensure those modules are bundled into the Docker image or environment. This is because Ray Serve uses `cloudpickle` to serialize custom routers and it doesn't vendor transitive dependencies—if your router inherits from a superclass in another module or imports custom packages, those must exist in the target environment. Additionally, environment parity matters: differences in Python version, `cloudpickle` version, or library versions can affect deserialization.
 
 ### Alternatives for complex routers
 
@@ -169,7 +169,5 @@ When your custom request router has complex dependencies or you want better cont
 
 - **Use built-in routers**: Consider using the routers shipped with Ray Serve—these are well-tested, production-ready, and guaranteed to work across different environments.
 - **Contribute to Ray Serve**: If your router is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in router by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues).
-- **Publish a Python package**: Package your router as a standalone Python package and publish to PyPI (or a private package index), then install the package in your Docker image or environment—this gives you version control and clear dependency management.
 - **Ensure dependencies in your environment**: Make sure that the external dependencies are present in your Docker image or environment.
-- **Use PYTHONPATH**: Place your router module in a location accessible through `PYTHONPATH`, which is simpler but requires careful environment management.
 :::

--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -156,3 +156,20 @@ You can customize the emission of these statistics by overriding `record_routing
 in the definition of the deployment class. The custom request router can then get the
 updated routing stats by looking up the `routing_stats` attribute of the running
 replicas and use it in the routing policy.
+
+
+:::{warning}
+## Gotchas and limitations
+
+When you provide a custom router, Ray Serve can fully support it as long as it's simple, self-contained Python code that relies only on the standard library. Once the router becomes more complex (such as depending on other custom modules or packages), you'll need to ensure those modules are bundled into the Docker image or environment. This is because Ray Serve uses `cloudpickle` to serialize custom routers, which doesn't vendor transitive dependencies—if your router inherits from a superclass in another module or imports custom packages, those must exist in the target environment. Additionally, environment parity matters: differences in Python version, `cloudpickle` version, or library versions can affect deserialization.
+
+### Alternatives for complex routers
+
+When your custom request router has complex dependencies or you want better control over versioning and deployment, you have several alternatives:
+
+- **Use built-in routers**: Consider using the routers shipped with Ray Serve—these are well-tested, production-ready, and guaranteed to work across different environments.
+- **Contribute to Ray Serve**: If your router is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in router by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues).
+- **Publish a Python package**: Package your router as a standalone Python package and publish to PyPI (or a private package index), then install the package in your Docker image or environment—this gives you version control and clear dependency management.
+- **Ensure dependencies in your environment**: Make sure that the external dependencies are present in your Docker image or environment.
+- **Use PYTHONPATH**: Place your router module in a location accessible through `PYTHONPATH`, which is simpler but requires careful environment management.
+:::

--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -168,6 +168,6 @@ When you provide a custom router, Ray Serve can fully support it as long as it's
 When your custom request router has complex dependencies or you want better control over versioning and deployment, you have several alternatives:
 
 - **Use built-in routers**: Consider using the routers shipped with Ray Serve—these are well-tested, production-ready, and guaranteed to work across different environments.
-- **Contribute to Ray Serve**: If your router is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in router by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues).
+- **Contribute to Ray Serve**: If your router is general-purpose and might benefit others, consider contributing it to Ray Serve as a built-in router by opening a feature request or pull request on the [Ray GitHub repository](https://github.com/ray-project/ray/issues). The recommended location for the implementation is `python/ray/serve/_private/request_router/`.
 - **Ensure dependencies in your environment**: Make sure that the external dependencies are installed in your Docker image or environment.
 :::

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -243,7 +243,19 @@ class RequestRouterConfig(BaseModel):
 
     def get_request_router_class(self) -> Callable:
         """Deserialize the request router from cloudpickled bytes."""
-        return cloudpickle.loads(self._serialized_request_router_cls)
+        try:
+            return cloudpickle.loads(self._serialized_request_router_cls)
+        except (ModuleNotFoundError, ImportError) as e:
+            raise ImportError(
+                f"Failed to deserialize custom request router: {e}\n\n"
+                "This typically happens when the router depends on external modules "
+                "that aren't available in the current environment. To fix this:\n"
+                "  - Ensure all dependencies are installed in your Docker image or environment\n"
+                "  - Package your router as a Python package and install it\n"
+                "  - Place the router module in PYTHONPATH\n\n"
+                "For more details, see: https://docs.ray.io/en/latest/serve/advanced-guides/"
+                "custom-request-router.html#gotchas-and-limitations"
+            ) from e
 
 
 DEFAULT_METRICS_INTERVAL_S = 10.0
@@ -313,7 +325,19 @@ class AutoscalingPolicy(BaseModel):
 
     def get_policy(self) -> Callable:
         """Deserialize policy from cloudpickled bytes."""
-        return cloudpickle.loads(self._serialized_policy_def)
+        try:
+            return cloudpickle.loads(self._serialized_policy_def)
+        except (ModuleNotFoundError, ImportError) as e:
+            raise ImportError(
+                f"Failed to deserialize custom autoscaling policy: {e}\n\n"
+                "This typically happens when the policy depends on external modules "
+                "that aren't available in the current environment. To fix this:\n"
+                "  - Ensure all dependencies are installed in your Docker image or environment\n"
+                "  - Package your policy as a Python package and install it\n"
+                "  - Place the policy module in PYTHONPATH\n\n"
+                "For more details, see: https://docs.ray.io/en/latest/serve/advanced-guides/"
+                "advanced-autoscaling.html#gotchas-and-limitations"
+            ) from e
 
 
 @PublicAPI(stability="stable")


### PR DESCRIPTION
## Description
1. Update docs
2. catch exception and redirect users to docs

## Related issues
https://github.com/ray-project/ray/pull/56855

## Additional information
Hard to write tests for this situation.

Manually verified that this is the right exception to catch
```
try:
    cloudpickle.loads(b'\x80\x05\x95\xbc\x03\x00\x00\x00\x00\x00\x00\x8c\x1bray.cloudpickle.cloudpickle\x94\x8c\x0e_make_function\x94\x93\x94(h\x00\x8c\r_builtin_type\x94\x93\x94\x8c\x08CodeType\x94\x85\x94R\x94(K\x01K\x00K\x00K\x03K\x03KCCnt\x00\xa0\x01\xa1\x00}\x01|\x01j\x02}\x02t\x03t\x04\x83\x01\x01\x00d\x01|\x02\x04\x00\x03\x00k\x01r*d\x02k\x00r:n\x04\x01\x00n\x0cd\x03d\x04d\x05i\x01f\x02S\x00d\x06|\x02\x04\x00\x03\x00k\x01rNd\x07k\x00r^n\x04\x01\x00n\x0cd\x08d\x04d\ti\x01f\x02S\x00d\nd\x04d\x0bi\x01f\x02S\x00d\x00S\x00\x94(NK\tK\x11K\x02\x8c\x06reason\x94\x8c\x0eBusiness hours\x94K\x12K\x14K\x04\x8c\x18Evening batch processing\x94K\x01\x8c\x0eOff-peak hours\x94t\x94(\x8c\x08datetime\x94\x8c\x03now\x94\x8c\x04hour\x94\x8c\x05print\x94\x8c\x04avro\x94t\x94\x8c\x03ctx\x94\x8c\x0ccurrent_time\x94\x8c\x0ccurrent_hour\x94\x87\x94\x8c\x1b/home/ubuntu/apps/policy.py\x94\x8c!scheduled_batch_processing_policy\x94K\x0eC\x10\x00\x03\x08\x01\x06\x01\x08\x02\x18\x01\x0c\x02\x18\x01\x0c\x03\x94))t\x94R\x94}\x94(\x8c\x0b__package__\x94N\x8c\x08__name__\x94\x8c\x08__main__\x94\x8c\x08__file__\x94h\x18uNNNt\x94R\x94h\x00\x8c\x12_function_setstate\x94\x93\x94h#}\x94}\x94(h\x1fh\x19\x8c\x0c__qualname__\x94h\x19\x8c\x0f__annotations__\x94}\x94(h\x14\x8c\x10ray.serve.config\x94\x8c\x12AutoscalingContext\x94\x93\x94\x8c\x06return\x94h\x04\x8c\x0cGenericAlias\x94\x85\x94R\x94\x8c\x08builtins\x94\x8c\x05tuple\x94\x93\x94h2\x8c\x03int\x94\x93\x94\x8c\t_operator\x94\x8c\x07getitem\x94\x93\x94\x8c\x06typing\x94\x8c\x04Dict\x94\x93\x94h2\x8c\x03str\x94\x93\x94h:\x8c\x03Any\x94\x93\x94\x86\x94\x86\x94R\x94\x86\x94\x86\x94R\x94u\x8c\x0e__kwdefaults__\x94N\x8c\x0c__defaults__\x94N\x8c\n__module__\x94h \x8c\x07__doc__\x94N\x8c\x0b__closure__\x94N\x8c\x17_cloudpickle_submodules\x94]\x94\x8c\x0b__globals__\x94}\x94(h\x0eh\x0e\x8c\x08datetime\x94\x93\x94h\x12h\x00\x8c\tsubimport\x94\x93\x94h\x12\x85\x94R\x94uu\x86\x94\x86R0.')
except (ModuleNotFoundError, ImportError) as e:
    print(f"caused by {e} {type(e)}")
```

```
❯ python policy.py
caused by No module named 'avro' <class 'ModuleNotFoundError'>
```
