### PR TITLE
[core][stats-die/03bis] improve scheduler_placement_time_s metric

### DIFF
--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -787,17 +787,17 @@ def test_workload_placement_metrics(ray_start_regular):
     placement_metric_condition = get_metric_check_condition(
         [
             MetricSamplePattern(
-                name="ray_scheduler_placement_time_s_bucket",
+                name="ray_scheduler_placement_time_ms_bucket",
                 value=1.0,
                 partial_label_match={"WorkloadType": "Actor"},
             ),
             MetricSamplePattern(
-                name="ray_scheduler_placement_time_s_bucket",
+                name="ray_scheduler_placement_time_ms_bucket",
                 value=1.0,
                 partial_label_match={"WorkloadType": "Task"},
             ),
             MetricSamplePattern(
-                name="ray_scheduler_placement_time_s_bucket",
+                name="ray_scheduler_placement_time_ms_bucket",
                 value=1.0,
                 partial_label_match={"WorkloadType": "PlacementGroup"},
             ),

--- a/src/ray/common/metrics.h
+++ b/src/ray/common/metrics.h
@@ -73,15 +73,15 @@ inline ray::stats::Gauge GetObjectStoreMemoryGaugeMetric() {
   };
 }
 
-inline ray::stats::Histogram GetSchedulerPlacementTimeSHistogramMetric() {
+inline ray::stats::Histogram GetSchedulerPlacementTimeMsHistogramMetric() {
   return ray::stats::Histogram{
-      /*name=*/"scheduler_placement_time_s",
+      /*name=*/"scheduler_placement_time_ms",
       /*description=*/
-      "The time it takes for a worklod (task, actor, placement group) to "
+      "The time it takes for a workload (task, actor, placement group) to "
       "be placed. This is the time from when the tasks dependencies are "
       "resolved to when it actually reserves resources on a node to run.",
-      /*unit=*/"s",
-      /*boundaries=*/{0.1, 1, 10, 100, 1000, 10000},
+      /*unit=*/"ms",
+      /*boundaries=*/{1, 10, 100, 1000, 10000},
       /*tag_keys=*/{"WorkloadType"},
   };
 }

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -602,15 +602,15 @@ bool TaskSpecification::IsRetriable() const {
 }
 
 void TaskSpecification::EmitTaskMetrics(
-    ray::observability::MetricInterface &scheduler_placement_time_s_histogram) const {
-  double duration_s = (GetMessage().lease_grant_timestamp_ms() -
-                       GetMessage().dependency_resolution_timestamp_ms()) /
-                      1000;
+    ray::observability::MetricInterface &scheduler_placement_time_ms_histogram) const {
+  double duration_ms = GetMessage().lease_grant_timestamp_ms() -
+                       GetMessage().dependency_resolution_timestamp_ms();
 
   if (IsActorCreationTask()) {
-    scheduler_placement_time_s_histogram.Record(duration_s, {{"WorkloadType", "Actor"}});
+    scheduler_placement_time_ms_histogram.Record(duration_ms,
+                                                 {{"WorkloadType", "Actor"}});
   } else {
-    scheduler_placement_time_s_histogram.Record(duration_s, {{"WorkloadType", "Task"}});
+    scheduler_placement_time_ms_histogram.Record(duration_ms, {{"WorkloadType", "Task"}});
   }
 }
 

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -359,7 +359,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   bool IsRetriable() const;
 
   void EmitTaskMetrics(
-      ray::observability::MetricInterface &scheduler_placement_time_s_histogram) const;
+      ray::observability::MetricInterface &scheduler_placement_time_ms_histogram) const;
 
   /// \return true if task events from this task should be reported.
   bool EnableTaskEvents() const;

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -554,7 +554,7 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
         return rpc::TensorTransport::OBJECT_STORE;
       },
       boost::asio::steady_timer(io_service_),
-      *scheduler_placement_time_s_histogram_);
+      *scheduler_placement_time_ms_histogram_);
 
   auto report_locality_data_callback = [this](
                                            const ObjectID &object_id,
@@ -798,8 +798,8 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
       new ray::stats::Gauge(GetActorByStateGaugeMetric()));
   total_lineage_bytes_gauge_ = std::unique_ptr<ray::stats::Gauge>(
       new ray::stats::Gauge(GetTotalLineageBytesGaugeMetric()));
-  scheduler_placement_time_s_histogram_ = std::unique_ptr<ray::stats::Histogram>(
-      new ray::stats::Histogram(GetSchedulerPlacementTimeSHistogramMetric()));
+  scheduler_placement_time_ms_histogram_ = std::unique_ptr<ray::stats::Histogram>(
+      new ray::stats::Histogram(GetSchedulerPlacementTimeMsHistogramMetric()));
 
   // Initialize event framework before starting up worker.
   if (RayConfig::instance().event_log_reporter_enabled() && !options_.log_dir.empty()) {

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -188,7 +188,7 @@ class CoreWorkerProcessImpl {
   std::unique_ptr<ray::stats::Gauge> task_by_state_gauge_;
   std::unique_ptr<ray::stats::Gauge> actor_by_state_gauge_;
   std::unique_ptr<ray::stats::Gauge> total_lineage_bytes_gauge_;
-  std::unique_ptr<ray::stats::Histogram> scheduler_placement_time_s_histogram_;
+  std::unique_ptr<ray::stats::Histogram> scheduler_placement_time_ms_histogram_;
 };
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/task_submission/normal_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.cc
@@ -177,7 +177,7 @@ void NormalTaskSubmitter::OnWorkerIdle(
       scheduling_key_entry.num_busy_workers++;
 
       task_spec.GetMutableMessage().set_lease_grant_timestamp_ms(current_sys_time_ms());
-      task_spec.EmitTaskMetrics(scheduler_placement_time_s_histogram_);
+      task_spec.EmitTaskMetrics(scheduler_placement_time_ms_histogram_);
 
       executing_tasks_.emplace(task_spec.TaskId(), addr);
       PushNormalTask(

--- a/src/ray/core_worker/task_submission/normal_task_submitter.h
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.h
@@ -96,7 +96,7 @@ class NormalTaskSubmitter {
       std::shared_ptr<LeaseRequestRateLimiter> lease_request_rate_limiter,
       const TensorTransportGetter &tensor_transport_getter,
       boost::asio::steady_timer cancel_timer,
-      ray::observability::MetricInterface &scheduler_placement_time_s_histogram)
+      ray::observability::MetricInterface &scheduler_placement_time_ms_histogram)
       : rpc_address_(std::move(rpc_address)),
         local_raylet_client_(std::move(local_raylet_client)),
         raylet_client_pool_(std::move(raylet_client_pool)),
@@ -111,7 +111,7 @@ class NormalTaskSubmitter {
         job_id_(job_id),
         lease_request_rate_limiter_(std::move(lease_request_rate_limiter)),
         cancel_retry_timer_(std::move(cancel_timer)),
-        scheduler_placement_time_s_histogram_(scheduler_placement_time_s_histogram) {}
+        scheduler_placement_time_ms_histogram_(scheduler_placement_time_ms_histogram) {}
 
   /// Schedule a task for direct submission to a worker.
   void SubmitTask(TaskSpecification task_spec);
@@ -365,7 +365,7 @@ class NormalTaskSubmitter {
   // Retries cancelation requests if they were not successful.
   boost::asio::steady_timer cancel_retry_timer_ ABSL_GUARDED_BY(mu_);
 
-  ray::observability::MetricInterface &scheduler_placement_time_s_histogram_;
+  ray::observability::MetricInterface &scheduler_placement_time_ms_histogram_;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
@@ -496,7 +496,7 @@ class NormalTaskSubmitterTest : public testing::Test {
         rate_limiter,
         [](const ObjectID &object_id) { return rpc::TensorTransport::OBJECT_STORE; },
         boost::asio::steady_timer(io_context),
-        fake_scheduler_placement_time_s_histogram_);
+        fake_scheduler_placement_time_ms_histogram_);
   }
 
   NodeID local_node_id;
@@ -513,7 +513,7 @@ class NormalTaskSubmitterTest : public testing::Test {
   std::unique_ptr<MockLeasePolicy> lease_policy;
   MockLeasePolicy *lease_policy_ptr = nullptr;
   instrumented_io_context io_context;
-  ray::observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
+  ray::observability::FakeHistogram fake_scheduler_placement_time_ms_histogram_;
 };
 
 TEST_F(NormalTaskSubmitterTest, TestLocalityAwareSubmitOneTask) {
@@ -1433,7 +1433,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
                        const TaskSpecification &same2,
                        const TaskSpecification &different) {
   rpc::Address address;
-  ray::observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
+  ray::observability::FakeHistogram fake_scheduler_placement_time_ms_histogram_;
   auto local_node_id = NodeID::FromRandom();
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto raylet_client_pool = std::make_shared<rpc::RayletClientPool>(
@@ -1462,7 +1462,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
       std::make_shared<StaticLeaseRequestRateLimiter>(1),
       [](const ObjectID &object_id) { return rpc::TensorTransport::OBJECT_STORE; },
       boost::asio::steady_timer(io_context),
-      fake_scheduler_placement_time_s_histogram_);
+      fake_scheduler_placement_time_ms_histogram_);
 
   submitter.SubmitTask(same1);
   submitter.SubmitTask(same2);

--- a/src/ray/core_worker/tests/core_worker_test.cc
+++ b/src/ray/core_worker/tests/core_worker_test.cc
@@ -224,7 +224,7 @@ class CoreWorkerTest : public ::testing::Test {
         lease_request_rate_limiter,
         [](const ObjectID &object_id) { return rpc::TensorTransport::OBJECT_STORE; },
         boost::asio::steady_timer(io_service_),
-        fake_scheduler_placement_time_s_histogram_);
+        fake_scheduler_placement_time_ms_histogram_);
 
     auto actor_task_submitter = std::make_unique<ActorTaskSubmitter>(
         *core_worker_client_pool,
@@ -300,7 +300,7 @@ class CoreWorkerTest : public ::testing::Test {
   ray::observability::FakeGauge fake_task_by_state_gauge_;
   ray::observability::FakeGauge fake_actor_by_state_gauge_;
   ray::observability::FakeGauge fake_total_lineage_bytes_gauge_;
-  ray::observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
+  ray::observability::FakeHistogram fake_scheduler_placement_time_ms_histogram_;
   std::unique_ptr<FakePeriodicalRunner> fake_periodical_runner_;
 
   // Controllable time for testing publisher timeouts

--- a/src/ray/gcs/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_actor_scheduler.cc
@@ -35,7 +35,7 @@ GcsActorScheduler::GcsActorScheduler(
     GcsActorSchedulerSuccessCallback schedule_success_handler,
     rpc::RayletClientPool &raylet_client_pool,
     rpc::CoreWorkerClientPool &worker_client_pool,
-    ray::observability::MetricInterface &scheduler_placement_time_s_histogram,
+    ray::observability::MetricInterface &scheduler_placement_time_ms_histogram,
     std::function<void(const NodeID &, const rpc::ResourcesData &)>
         normal_task_resources_changed_callback)
     : io_context_(io_context),
@@ -46,7 +46,7 @@ GcsActorScheduler::GcsActorScheduler(
       schedule_success_handler_(std::move(schedule_success_handler)),
       raylet_client_pool_(raylet_client_pool),
       worker_client_pool_(worker_client_pool),
-      scheduler_placement_time_s_histogram_(scheduler_placement_time_s_histogram),
+      scheduler_placement_time_ms_histogram_(scheduler_placement_time_ms_histogram),
       normal_task_resources_changed_callback_(
           std::move(normal_task_resources_changed_callback)) {
   RAY_CHECK(schedule_failure_handler_ != nullptr && schedule_success_handler_ != nullptr);
@@ -396,7 +396,7 @@ void GcsActorScheduler::HandleWorkerLeaseGrantedReply(
     actor->GetMutableActorTableData()->set_pid(reply.worker_pid());
     actor->GetMutableTaskSpec()->set_lease_grant_timestamp_ms(current_sys_time_ms());
     actor->GetCreationTaskSpecification().EmitTaskMetrics(
-        scheduler_placement_time_s_histogram_);
+        scheduler_placement_time_ms_histogram_);
     // Make sure to connect to the client before persisting actor info to GCS.
     // Without this, there could be a possible race condition. Related issues:
     // https://github.com/ray-project/ray/pull/9215/files#r449469320

--- a/src/ray/gcs/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_actor_scheduler.h
@@ -130,7 +130,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
       GcsActorSchedulerSuccessCallback schedule_success_handler,
       rpc::RayletClientPool &raylet_client_pool,
       rpc::CoreWorkerClientPool &worker_client_pool,
-      ray::observability::MetricInterface &scheduler_placement_time_s_histogram,
+      ray::observability::MetricInterface &scheduler_placement_time_ms_histogram,
       std::function<void(const NodeID &, const rpc::ResourcesData &)>
           normal_task_resources_changed_callback = nullptr);
 
@@ -390,7 +390,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// The resource changed listeners.
   std::vector<std::function<void()>> resource_changed_listeners_;
 
-  ray::observability::MetricInterface &scheduler_placement_time_s_histogram_;
+  ray::observability::MetricInterface &scheduler_placement_time_ms_histogram_;
 
   /// Normal task resources changed callback.
   std::function<void(const NodeID &, const rpc::ResourcesData &)>

--- a/src/ray/gcs/gcs_placement_group.cc
+++ b/src/ray/gcs/gcs_placement_group.cc
@@ -29,13 +29,12 @@ void GcsPlacementGroup::UpdateState(
     placement_group_table_data_.set_placement_group_final_bundle_placement_timestamp_ms(
         current_sys_time_ms());
 
-    double duration_s =
-        (placement_group_table_data_
-             .placement_group_final_bundle_placement_timestamp_ms() -
-         placement_group_table_data_.placement_group_creation_timestamp_ms()) /
-        1000;
-    scheduler_placement_time_s_histogram_.Record(duration_s,
-                                                 {{"WorkloadType", "PlacementGroup"}});
+    double duration_ms =
+        placement_group_table_data_
+            .placement_group_final_bundle_placement_timestamp_ms() -
+        placement_group_table_data_.placement_group_creation_timestamp_ms();
+    scheduler_placement_time_ms_histogram_.Record(duration_ms,
+                                                  {{"WorkloadType", "PlacementGroup"}});
   }
   placement_group_table_data_.set_state(state);
   RefreshMetrics();

--- a/src/ray/gcs/gcs_placement_group.h
+++ b/src/ray/gcs/gcs_placement_group.h
@@ -208,8 +208,8 @@ class GcsPlacementGroup {
   /// The last recorded metric state.
   std::optional<rpc::PlacementGroupTableData::PlacementGroupState> last_metric_state_;
 
-  ray::stats::Histogram scheduler_placement_time_s_histogram_{
-      ray::GetSchedulerPlacementTimeSHistogramMetric()};
+  ray::stats::Histogram scheduler_placement_time_ms_histogram_{
+      ray::GetSchedulerPlacementTimeMsHistogramMetric()};
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -523,7 +523,7 @@ void GcsServer::InitGcsActorManager(
       schedule_success_handler,
       raylet_client_pool_,
       worker_client_pool_,
-      metrics_.scheduler_placement_time_s_histogram,
+      metrics_.scheduler_placement_time_ms_histogram,
       /*normal_task_resources_changed_callback=*/
       [this](const NodeID &node_id, const rpc::ResourcesData &resources) {
         gcs_resource_manager_->UpdateNodeNormalTaskResources(node_id, resources);

--- a/src/ray/gcs/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server_main.cc
@@ -188,8 +188,8 @@ int main(int argc, char *argv[]) {
       ray::gcs::GetGcsStorageOperationLatencyInMsHistogramMetric();
   auto storage_operation_count_counter =
       ray::gcs::GetGcsStorageOperationCountCounterMetric();
-  auto scheduler_placement_time_s_histogram =
-      ray::GetSchedulerPlacementTimeSHistogramMetric();
+  auto scheduler_placement_time_ms_histogram =
+      ray::GetSchedulerPlacementTimeMsHistogramMetric();
 
   // Create the metrics struct
   ray::gcs::GcsServerMetrics gcs_server_metrics{
@@ -211,7 +211,7 @@ int main(int argc, char *argv[]) {
       /*storage_operation_latency_in_ms_histogram=*/
       storage_operation_latency_in_ms_histogram,
       /*storage_operation_count_counter=*/storage_operation_count_counter,
-      scheduler_placement_time_s_histogram,
+      scheduler_placement_time_ms_histogram,
   };
 
   ray::gcs::GcsServer gcs_server(gcs_server_config, gcs_server_metrics, main_service);

--- a/src/ray/gcs/metrics.h
+++ b/src/ray/gcs/metrics.h
@@ -36,7 +36,7 @@ struct GcsServerMetrics {
   ray::observability::MetricInterface &event_recorder_dropped_events_counter;
   ray::observability::MetricInterface &storage_operation_latency_in_ms_histogram;
   ray::observability::MetricInterface &storage_operation_count_counter;
-  ray::observability::MetricInterface &scheduler_placement_time_s_histogram;
+  ray::observability::MetricInterface &scheduler_placement_time_ms_histogram;
 };
 
 inline ray::stats::Gauge GetRunningJobGaugeMetric() {

--- a/src/ray/gcs/tests/gcs_actor_scheduler_mock_test.cc
+++ b/src/ray/gcs/tests/gcs_actor_scheduler_mock_test.cc
@@ -86,7 +86,7 @@ class GcsActorSchedulerMockTest : public Test {
         [this](auto a, const rpc::PushTaskReply) { schedule_success_handler(a); },
         *client_pool,
         *worker_client_pool_,
-        fake_scheduler_placement_time_s_histogram_);
+        fake_scheduler_placement_time_ms_histogram_);
     auto node_info = std::make_shared<rpc::GcsNodeInfo>();
     node_info->set_state(rpc::GcsNodeInfo::ALIVE);
     node_id = NodeID::FromRandom();
@@ -107,7 +107,7 @@ class GcsActorSchedulerMockTest : public Test {
   std::unique_ptr<rpc::CoreWorkerClientPool> worker_client_pool_;
   std::unique_ptr<rpc::RayletClientPool> client_pool;
   observability::FakeRayEventRecorder fake_ray_event_recorder_;
-  observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
+  observability::FakeHistogram fake_scheduler_placement_time_ms_histogram_;
   std::shared_ptr<CounterMap<std::pair<rpc::ActorTableData::ActorState, std::string>>>
       counter;
   MockCallback schedule_failure_handler;

--- a/src/ray/gcs/tests/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_actor_scheduler_test.cc
@@ -149,7 +149,7 @@ class GcsActorSchedulerTest : public ::testing::Test {
         },
         *raylet_client_pool_,
         *worker_client_pool_,
-        fake_scheduler_placement_time_s_histogram_,
+        fake_scheduler_placement_time_ms_histogram_,
         /*normal_task_resources_changed_callback=*/
         [gcs_resource_manager](const NodeID &node_id,
                                const rpc::ResourcesData &resources) {
@@ -223,7 +223,7 @@ class GcsActorSchedulerTest : public ::testing::Test {
   std::shared_ptr<pubsub::GcsPublisher> gcs_publisher_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<rpc::RayletClientPool> raylet_client_pool_;
-  ray::observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
+  ray::observability::FakeHistogram fake_scheduler_placement_time_ms_histogram_;
   NodeID local_node_id_;
 };
 

--- a/src/ray/gcs/tests/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/tests/gcs_server_rpc_test.cc
@@ -49,7 +49,7 @@ class GcsServerTest : public ::testing::Test {
             /*storage_operation_latency_in_ms_histogram=*/
             storage_operation_latency_in_ms_histogram_,
             /*storage_operation_count_counter=*/storage_operation_count_counter_,
-            fake_scheduler_placement_time_s_histogram_,
+            fake_scheduler_placement_time_ms_histogram_,
         } {
     TestSetupUtil::StartUpRedisServers(std::vector<int>());
   }
@@ -269,7 +269,7 @@ class GcsServerTest : public ::testing::Test {
   observability::FakeHistogram storage_operation_latency_in_ms_histogram_;
   observability::FakeCounter storage_operation_count_counter_;
   observability::FakeCounter fake_dropped_events_counter_;
-  observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
+  observability::FakeHistogram fake_scheduler_placement_time_ms_histogram_;
 
   // Fake metrics struct
   gcs::GcsServerMetrics fake_metrics_;

--- a/src/ray/gcs_rpc_client/tests/gcs_client_reconnection_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_reconnection_test.cc
@@ -66,7 +66,7 @@ class GcsClientReconnectionTest : public ::testing::Test {
         /*storage_operation_latency_in_ms_histogram=*/
         storage_operation_latency_in_ms_histogram_,
         /*storage_operation_count_counter=*/storage_operation_count_counter_,
-        scheduler_placement_time_s_histogram_,
+        scheduler_placement_time_ms_histogram_,
     };
 
     gcs_server_ = std::make_unique<gcs::GcsServer>(
@@ -200,7 +200,7 @@ class GcsClientReconnectionTest : public ::testing::Test {
   observability::FakeHistogram storage_operation_latency_in_ms_histogram_;
   observability::FakeCounter storage_operation_count_counter_;
   observability::FakeCounter fake_dropped_events_counter_;
-  observability::FakeHistogram scheduler_placement_time_s_histogram_;
+  observability::FakeHistogram scheduler_placement_time_ms_histogram_;
 
   // GCS client.
   std::unique_ptr<std::thread> client_io_service_thread_;

--- a/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
@@ -105,7 +105,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
         /*storage_operation_latency_in_ms_histogram=*/
         storage_operation_latency_in_ms_histogram_,
         /*storage_operation_count_counter=*/storage_operation_count_counter_,
-        scheduler_placement_time_s_histogram_,
+        scheduler_placement_time_ms_histogram_,
     };
 
     gcs_server_ = std::make_unique<gcs::GcsServer>(
@@ -193,7 +193,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
         /*storage_operation_latency_in_ms_histogram=*/
         storage_operation_latency_in_ms_histogram_,
         /*storage_operation_count_counter=*/storage_operation_count_counter_,
-        scheduler_placement_time_s_histogram_,
+        scheduler_placement_time_ms_histogram_,
     };
 
     gcs_server_.reset(
@@ -485,7 +485,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
   observability::FakeHistogram storage_operation_latency_in_ms_histogram_;
   observability::FakeCounter storage_operation_count_counter_;
   observability::FakeCounter fake_dropped_events_counter_;
-  observability::FakeHistogram scheduler_placement_time_s_histogram_;
+  observability::FakeHistogram scheduler_placement_time_ms_histogram_;
 };
 
 INSTANTIATE_TEST_SUITE_P(RedisMigration, GcsClientTest, testing::Bool());

--- a/src/ray/gcs_rpc_client/tests/global_state_accessor_test.cc
+++ b/src/ray/gcs_rpc_client/tests/global_state_accessor_test.cc
@@ -86,7 +86,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
         /*storage_operation_latency_in_ms_histogram=*/
         fake_storage_operation_latency_in_ms_histogram_,
         /*storage_operation_count_counter=*/fake_storage_operation_count_counter_,
-        fake_scheduler_placement_time_s_histogram_,
+        fake_scheduler_placement_time_ms_histogram_,
     };
 
     gcs_server_.reset(new gcs::GcsServer(config, gcs_server_metrics, *io_service_));
@@ -159,7 +159,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
   observability::FakeGauge fake_task_events_stored_gauge_;
   observability::FakeHistogram fake_storage_operation_latency_in_ms_histogram_;
   observability::FakeCounter fake_storage_operation_count_counter_;
-  observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
+  observability::FakeHistogram fake_scheduler_placement_time_ms_histogram_;
 
   std::unique_ptr<gcs::GlobalStateAccessor> global_state_;
 

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -117,13 +117,6 @@ DEFINE_stats(scheduler_failed_worker_startup_total,
              ("Reason"),
              (),
              ray::stats::GAUGE);
-DEFINE_stats(scheduler_placement_time_s,
-             "The time it takes for a worklod (task, actor, placement group) to "
-             "be placed. This is the time from when the tasks dependencies are "
-             "resolved to when it actually reserves resources on a node to run.",
-             ("WorkloadType"),
-             ({0.1, 1, 10, 100, 1000, 10000}, ),
-             ray::stats::HISTOGRAM);
 
 /// Local Object Manager
 DEFINE_stats(

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -55,7 +55,6 @@ DECLARE_stats(operation_active_count);
 DECLARE_stats(scheduler_failed_worker_startup_total);
 DECLARE_stats(scheduler_tasks);
 DECLARE_stats(scheduler_unscheduleable_tasks);
-DECLARE_stats(scheduler_placement_time_s);
 
 /// Raylet Resource Manager
 DECLARE_stats(resources);


### PR DESCRIPTION
Change the unit of `scheduler_placement_time` from seconds to mili-seconds. The current bucket is in the range of 0.1s to 2.5 hours which doesn't make sense. According to a sample of data, the range we are interested in would be from us to s. Thanks @ZacAttack for pointing this out.

```
Note: This is an internal (non–public-facing) metric, so we only need to update its usage within Ray (e.g., the dashboard). A simple code change should suffice.
```

<img width="1609" height="421" alt="505491038-c5d81017-b86c-406f-acf4-614560752062" src="https://github.com/user-attachments/assets/cc647b97-42ec-42eb-bf01-4d1867940207" />

Test:
- CI
