### PR TITLE
[ci][deps] pinning pip before 25.3 breaking change

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -133,7 +133,7 @@ install_upgrade_pip() {
   fi
 
   if "${python}" -m pip --version || "${python}" -m ensurepip; then  # Configure pip if present
-    "${python}" -m pip install --upgrade pip
+    "${python}" -m pip install pip==25.2.0
 
     # If we're in a CI environment, do some configuration
     if [[ "${CI-}" == "true" ]]; then

--- a/doc/source/templates/testing/docker/04_finetuning_llms_with_deepspeed/Dockerfile
+++ b/doc/source/templates/testing/docker/04_finetuning_llms_with_deepspeed/Dockerfile
@@ -6,7 +6,7 @@ COPY requirements.txt ./
 RUN sudo apt-get update
 RUN sudo apt-get install -y libaio1
 
-RUN pip install --upgrade pip
+RUN pip install pip==25.2.0
 # We need pydantic at this version to install deepspeed 0.10.2 (as part of the requirements.txt)
 RUN pip install pydantic==1.10.7
 RUN pip install -U -r requirements.txt

--- a/python/ray/autoscaler/aws/example-java.yaml
+++ b/python/ray/autoscaler/aws/example-java.yaml
@@ -56,7 +56,7 @@ initialization_commands:
 # List of shell commands to run to set up nodes.
 setup_commands:
     - sudo apt-get install -y python3 python3-pip
-    - python3 -m pip install --upgrade pip
+    - python3 -m pip install pip==25.2.0
     - python3 -m pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.9.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands:

--- a/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -11,7 +11,7 @@ else
     echo "conda exists"
 fi
 
-pip install --upgrade pip
+pip install pip==25.2.0
 
 # This is required to use conda activate
 source "$(conda info --base)/etc/profile.d/conda.sh"

--- a/release/util/pip_download_test.sh
+++ b/release/util/pip_download_test.sh
@@ -26,7 +26,7 @@ fi
 
 echo "Start downloading Ray version ${RAY_VERSION} of commit ${RAY_HASH}"
 
-pip install --upgrade pip
+pip install pip==25.2.0
 
 # This is required to use conda activate
 source "$(conda info --base)/etc/profile.d/conda.sh"

--- a/release/util/sanity_check_windows.sh
+++ b/release/util/sanity_check_windows.sh
@@ -27,7 +27,7 @@ fi
 
 echo "Start downloading Ray version ${RAY_VERSION} of commit ${RAY_HASH}"
 
-python -m pip install --upgrade pip
+python -m pip install pip==25.2.0
 
 # This is required to use conda activate
 source "$(conda info --base)/etc/profile.d/conda.sh"


### PR DESCRIPTION
pinning pip==25.2.0

version 25.3 introduces some breaking changes:

- no longer using setup.py
- removal of pep517