### PR TITLE
[WIP][data.dashboard] Add data operator id to ActorPoolMapOperator tasks

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -325,6 +325,7 @@ class ActorPoolMapOperator(MapOperator):
             )
             gen = actor.submit.options(
                 num_returns="streaming",
+                _labels={self._OPERATOR_ID_LABEL_KEY: self.id},
                 **self._ray_actor_task_remote_args,
             ).remote(
                 self.data_context,


### PR DESCRIPTION
## Description
Data operator id needs to be added as a [label](https://github.com/ray-project/ray/blob/0b5b80df5774ba49520001d80fcfd34136d25e05/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py#L261) so that it can be associated with task definition [events](https://github.com/ray-project/ray/blob/02559bb098120729e0d4b9d0d175278908a9c79d/src/ray/core_worker/task_event_buffer.cc#L200). In this PR, we add it to other places for ActorPoolMapOperator tasks to enable the operator-task binding.

