### PR TITLE
[Train] Add streaming repartition to Training Ingest benchmarks

### DIFF
--- a/release/train_tests/benchmark/image_classification/jpeg/factory.py
+++ b/release/train_tests/benchmark/image_classification/jpeg/factory.py
@@ -103,6 +103,7 @@ class ImageClassificationJpegRayDataLoaderFactory(
             partitioning=train_partitioning,
             filesystem=filesystem,
         ).map(get_preprocess_map_fn(random_transforms=True))
+        train_ds = train_ds.repartition(target_num_rows_per_block=self.get_dataloader_config().train_batch_size)
 
         if self.get_dataloader_config().limit_training_rows > 0:
             train_ds = train_ds.limit(self.get_dataloader_config().limit_training_rows)
@@ -116,6 +117,7 @@ class ImageClassificationJpegRayDataLoaderFactory(
             partitioning=val_partitioning,
             filesystem=filesystem,
         ).map(get_preprocess_map_fn(random_transforms=False))
+        val_ds = val_ds.repartition(target_num_rows_per_block=self.get_dataloader_config().validation_batch_size)
 
         if self.get_dataloader_config().limit_validation_rows > 0:
             val_ds = val_ds.limit(self.get_dataloader_config().limit_validation_rows)

--- a/release/train_tests/benchmark/image_classification/parquet/factory.py
+++ b/release/train_tests/benchmark/image_classification/parquet/factory.py
@@ -53,6 +53,7 @@ class ImageClassificationParquetRayDataLoaderFactory(
             self._data_dirs[DatasetKey.TRAIN],
             columns=["image", "label"],
         ).map(get_preprocess_map_fn(decode_image=True, random_transforms=True))
+        train_ds = train_ds.repartition(target_num_rows_per_block=self.get_dataloader_config().train_batch_size)
 
         if self.get_dataloader_config().limit_training_rows > 0:
             train_ds = train_ds.limit(self.get_dataloader_config().limit_training_rows)
@@ -62,6 +63,7 @@ class ImageClassificationParquetRayDataLoaderFactory(
             self._data_dirs[DatasetKey.TRAIN],
             columns=["image", "label"],
         ).map(get_preprocess_map_fn(decode_image=True, random_transforms=False))
+        val_ds = val_ds.repartition(target_num_rows_per_block=self.get_dataloader_config().validation_batch_size)
 
         if self.get_dataloader_config().limit_validation_rows > 0:
             val_ds = val_ds.limit(self.get_dataloader_config().limit_validation_rows)


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

### [Train] Add streaming repartition to Training Ingest benchmarks

To reduce batching overhead on the iterator, insert streaming repartition with target_num_rows_per_block as batch_size.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
