### PR TITLE
[Core] Introduce new macros for user facing exceptions

### DIFF
--- a/src/ray/pubsub/python_gcs_subscriber.h
+++ b/src/ray/pubsub/python_gcs_subscriber.h
@@ -80,6 +80,10 @@ class RAY_EXPORT PythonGcsSubscriber {
   std::deque<rpc::PubMessage> queue_ ABSL_GUARDED_BY(mu_);
   bool closed_ ABSL_GUARDED_BY(mu_) = false;
   std::shared_ptr<grpc::ClientContext> current_polling_context_ ABSL_GUARDED_BY(mu_);
+
+  // Set authentication token on a gRPC client context if token-based authentication is
+  // enabled
+  void SetAuthenticationToken(grpc::ClientContext &context);
 };
 
 /// Get the .lines() attribute of a LogBatch as a std::vector

--- a/src/ray/pubsub/tests/BUILD.bazel
+++ b/src/ray/pubsub/tests/BUILD.bazel
@@ -40,3 +40,20 @@ ray_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+ray_cc_test(
+    name = "python_gcs_subscriber_auth_test",
+    size = "small",
+    srcs = ["python_gcs_subscriber_auth_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:ray_config",
+        "//src/ray/common:status",
+        "//src/ray/protobuf:gcs_service_cc_grpc",
+        "//src/ray/pubsub:python_gcs_subscriber",
+        "//src/ray/rpc:grpc_server",
+        "//src/ray/rpc/authentication:authentication_token",
+        "//src/ray/rpc/authentication:authentication_token_loader",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/pubsub/tests/python_gcs_subscriber_auth_test.cc
+++ b/src/ray/pubsub/tests/python_gcs_subscriber_auth_test.cc
@@ -1,0 +1,352 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "ray/common/ray_config.h"
+#include "ray/common/status.h"
+#include "ray/pubsub/python_gcs_subscriber.h"
+#include "ray/rpc/authentication/authentication_token.h"
+#include "ray/rpc/authentication/authentication_token_loader.h"
+#include "ray/rpc/grpc_server.h"
+#include "src/ray/protobuf/gcs_service.grpc.pb.h"
+
+namespace ray {
+namespace pubsub {
+
+// Mock implementation of InternalPubSubGcsService for testing authentication
+class MockInternalPubSubGcsService final : public rpc::InternalPubSubGcsService::Service {
+ public:
+  explicit MockInternalPubSubGcsService(bool should_accept_requests)
+      : should_accept_requests_(should_accept_requests) {}
+
+  grpc::Status GcsSubscriberCommandBatch(
+      grpc::ServerContext *context,
+      const rpc::GcsSubscriberCommandBatchRequest *request,
+      rpc::GcsSubscriberCommandBatchReply *reply) override {
+    if (should_accept_requests_) {
+      for (const auto &command : request->commands()) {
+        if (command.has_subscribe_message()) {
+          subscribe_count_++;
+        } else if (command.has_unsubscribe_message()) {
+          unsubscribe_count_++;
+        }
+      }
+      return grpc::Status::OK;
+    } else {
+      return grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Authentication failed");
+    }
+  }
+
+  grpc::Status GcsSubscriberPoll(grpc::ServerContext *context,
+                                 const rpc::GcsSubscriberPollRequest *request,
+                                 rpc::GcsSubscriberPollReply *reply) override {
+    if (should_accept_requests_) {
+      poll_count_++;
+      // Simulate long polling: block until deadline expires since we have no messages
+      // Real server would hold the connection open until messages arrive or timeout
+      auto deadline = context->deadline();
+      std::this_thread::sleep_until(deadline);
+
+      // Return deadline exceeded (timeout) with empty messages
+      // This simulates the real server behavior when no messages are published
+      return grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED, "Long poll timeout");
+    } else {
+      return grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Authentication failed");
+    }
+  }
+
+  int subscribe_count() const { return subscribe_count_; }
+  int poll_count() const { return poll_count_; }
+  int unsubscribe_count() const { return unsubscribe_count_; }
+
+ private:
+  bool should_accept_requests_;
+  std::atomic<int> subscribe_count_{0};
+  std::atomic<int> poll_count_{0};
+  std::atomic<int> unsubscribe_count_{0};
+};
+
+class PythonGcsSubscriberAuthTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Enable token authentication by default
+    RayConfig::instance().initialize(R"({"auth_mode": "token"})");
+    rpc::AuthenticationTokenLoader::instance().ResetCache();
+  }
+
+  void TearDown() override {
+    if (server_) {
+      server_->Shutdown();
+      server_.reset();
+    }
+    unsetenv("RAY_AUTH_TOKEN");
+    // Reset to default auth mode
+    RayConfig::instance().initialize(R"({"auth_mode": "disabled"})");
+    rpc::AuthenticationTokenLoader::instance().ResetCache();
+  }
+
+  // Start a GCS server with optional authentication token
+  void StartServer(const std::string &server_token, bool should_accept_requests = true) {
+    auto mock_service =
+        std::make_unique<MockInternalPubSubGcsService>(should_accept_requests);
+    mock_service_ptr_ = mock_service.get();
+
+    std::optional<rpc::AuthenticationToken> auth_token;
+    if (!server_token.empty()) {
+      auth_token = rpc::AuthenticationToken(server_token);
+    } else {
+      // Empty token means no auth required
+      auth_token = rpc::AuthenticationToken("");
+    }
+
+    server_ = std::make_unique<rpc::GrpcServer>("test-gcs-server",
+                                                0,  // Random port
+                                                true,
+                                                1,
+                                                7200000,
+                                                auth_token);
+
+    server_->RegisterService(std::move(mock_service));
+    server_->Run();
+
+    // Wait for server to start
+    while (server_->GetPort() == 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    server_port_ = server_->GetPort();
+  }
+
+  // Set client authentication token via environment variable
+  void SetClientToken(const std::string &client_token) {
+    if (!client_token.empty()) {
+      setenv("RAY_AUTH_TOKEN", client_token.c_str(), 1);
+      RayConfig::instance().initialize(R"({"auth_mode": "token"})");
+    } else {
+      unsetenv("RAY_AUTH_TOKEN");
+      RayConfig::instance().initialize(R"({"auth_mode": "disabled"})");
+    }
+    rpc::AuthenticationTokenLoader::instance().ResetCache();
+  }
+
+  std::unique_ptr<PythonGcsSubscriber> CreateSubscriber() {
+    return std::make_unique<PythonGcsSubscriber>("127.0.0.1",
+                                                 server_port_,
+                                                 rpc::ChannelType::RAY_LOG_CHANNEL,
+                                                 "test-subscriber-id",
+                                                 "test-worker-id");
+  }
+
+  std::unique_ptr<rpc::GrpcServer> server_;
+  MockInternalPubSubGcsService *mock_service_ptr_ = nullptr;
+  int server_port_ = 0;
+};
+
+TEST_F(PythonGcsSubscriberAuthTest, MatchingTokens) {
+  // Test that subscription succeeds when client and server use the same token
+  const std::string test_token = "matching-test-token-12345";
+
+  StartServer(test_token);
+  SetClientToken(test_token);
+
+  auto subscriber = CreateSubscriber();
+  Status status = subscriber->Subscribe();
+
+  ASSERT_TRUE(status.ok()) << "Subscribe should succeed with matching tokens: "
+                           << status.ToString();
+  EXPECT_EQ(mock_service_ptr_->subscribe_count(), 1);
+
+  ASSERT_TRUE(subscriber->Close().ok());
+}
+
+TEST_F(PythonGcsSubscriberAuthTest, MismatchedTokens) {
+  // Test that subscription fails when client and server use different tokens
+  const std::string server_token = "server-token-12345";
+  const std::string client_token = "wrong-client-token-67890";
+
+  StartServer(server_token, false);  // Server will reject requests
+  SetClientToken(client_token);
+
+  auto subscriber = CreateSubscriber();
+  Status status = subscriber->Subscribe();
+
+  ASSERT_FALSE(status.ok()) << "Subscribe should fail with mismatched tokens";
+  EXPECT_TRUE(status.IsRpcError()) << "Status should be RpcError";
+
+  ASSERT_TRUE(subscriber->Close().ok());
+}
+
+TEST_F(PythonGcsSubscriberAuthTest, ClientTokenServerNoAuth) {
+  // Test that subscription succeeds when client provides token but server doesn't require
+  // it
+  const std::string client_token = "client-token-12345";
+
+  StartServer("");  // Server doesn't require auth
+  SetClientToken(client_token);
+
+  auto subscriber = CreateSubscriber();
+  Status status = subscriber->Subscribe();
+
+  ASSERT_TRUE(status.ok())
+      << "Subscribe should succeed when server doesn't require auth: "
+      << status.ToString();
+  EXPECT_EQ(mock_service_ptr_->subscribe_count(), 1);
+
+  ASSERT_TRUE(subscriber->Close().ok());
+}
+
+TEST_F(PythonGcsSubscriberAuthTest, ServerTokenClientNoAuth) {
+  // Test that subscription fails when server requires token but client doesn't provide it
+  const std::string server_token = "server-token-12345";
+
+  StartServer(server_token, false);  // Server will reject requests without valid token
+  SetClientToken("");                // Client doesn't provide token
+
+  auto subscriber = CreateSubscriber();
+  Status status = subscriber->Subscribe();
+
+  ASSERT_FALSE(status.ok())
+      << "Subscribe should fail when server requires token but client doesn't provide it";
+  EXPECT_TRUE(status.IsRpcError()) << "Status should be RpcError";
+
+  ASSERT_TRUE(subscriber->Close().ok());
+}
+
+TEST_F(PythonGcsSubscriberAuthTest, MatchingTokensPoll) {
+  // Test that polling succeeds when client and server use the same token
+  const std::string test_token = "matching-test-token-12345";
+
+  StartServer(test_token);
+  SetClientToken(test_token);
+
+  auto subscriber = CreateSubscriber();
+  Status status = subscriber->Subscribe();
+  ASSERT_TRUE(status.ok()) << "Subscribe should succeed: " << status.ToString();
+
+  // Test polling with matching tokens - use very short timeout to avoid blocking
+  std::string key_id;
+  rpc::LogBatch log_batch;
+  status = subscriber->PollLogs(&key_id, 10, &log_batch);
+
+  // Poll should succeed (returns OK even on timeout or when no messages available)
+  ASSERT_TRUE(status.ok()) << "Poll should succeed with matching tokens: "
+                           << status.ToString();
+  // At least one poll should have been made
+  EXPECT_GE(mock_service_ptr_->poll_count(), 1);
+
+  ASSERT_TRUE(subscriber->Close().ok());
+}
+
+TEST_F(PythonGcsSubscriberAuthTest, MismatchedTokensPoll) {
+  // Test that polling fails when tokens don't match
+  const std::string server_token = "server-token-12345";
+  const std::string client_token = "wrong-client-token-67890";
+
+  StartServer(server_token, false);  // Server will reject requests
+  SetClientToken(client_token);
+
+  auto subscriber = CreateSubscriber();
+
+  // Subscribe will fail, but let's try anyway
+  ASSERT_FALSE(subscriber->Subscribe().ok());
+
+  // Test polling with mismatched tokens - use very short timeout
+  std::string key_id;
+  rpc::LogBatch log_batch;
+  Status status = subscriber->PollLogs(&key_id, 10, &log_batch);
+
+  // Poll should fail with auth error or return OK if it was cancelled
+  // (OK is acceptable because the subscriber may have been closed)
+  if (!status.ok()) {
+    EXPECT_TRUE(status.IsInvalid() || status.IsRpcError())
+        << "Status should be Invalid or RpcError: " << status.ToString();
+  }
+
+  ASSERT_TRUE(subscriber->Close().ok());
+}
+
+TEST_F(PythonGcsSubscriberAuthTest, MatchingTokensClose) {
+  // Test that closing/unsubscribing succeeds with matching tokens
+  const std::string test_token = "matching-test-token-12345";
+
+  StartServer(test_token);
+  SetClientToken(test_token);
+
+  auto subscriber = CreateSubscriber();
+  Status status = subscriber->Subscribe();
+  ASSERT_TRUE(status.ok()) << "Subscribe should succeed: " << status.ToString();
+  EXPECT_EQ(mock_service_ptr_->subscribe_count(), 1);
+
+  // Close should succeed with matching tokens
+  ASSERT_TRUE(subscriber->Close().ok())
+      << "Close should succeed with matching tokens: " << status.ToString();
+  // This assertion will fail until auth is added to `Close()` and the mock is updated.
+  EXPECT_EQ(mock_service_ptr_->unsubscribe_count(), 1);
+}
+
+TEST_F(PythonGcsSubscriberAuthTest, NoAuthRequired) {
+  // Test that everything works when neither client nor server use auth
+  StartServer("");     // Server doesn't require auth
+  SetClientToken("");  // Client doesn't provide token
+
+  auto subscriber = CreateSubscriber();
+  Status status = subscriber->Subscribe();
+
+  ASSERT_TRUE(status.ok()) << "Subscribe should succeed without auth: "
+                           << status.ToString();
+  EXPECT_EQ(mock_service_ptr_->subscribe_count(), 1);
+
+  // Test polling without auth - use very short timeout
+  std::string key_id;
+  rpc::LogBatch log_batch;
+  status = subscriber->PollLogs(&key_id, 10, &log_batch);
+  ASSERT_TRUE(status.ok()) << "Poll should succeed without auth: " << status.ToString();
+
+  // Test close without auth
+  status = subscriber->Close();
+  ASSERT_TRUE(status.ok()) << "Close should succeed without auth: " << status.ToString();
+}
+
+TEST_F(PythonGcsSubscriberAuthTest, MultipleSubscribersMatchingTokens) {
+  // Test multiple subscribers with the same token
+  const std::string test_token = "shared-token-12345";
+
+  StartServer(test_token);
+  SetClientToken(test_token);
+
+  auto subscriber1 = CreateSubscriber();
+  auto subscriber2 = CreateSubscriber();
+
+  Status status1 = subscriber1->Subscribe();
+  Status status2 = subscriber2->Subscribe();
+
+  ASSERT_TRUE(status1.ok()) << "First subscriber should succeed: " << status1.ToString();
+  ASSERT_TRUE(status2.ok()) << "Second subscriber should succeed: " << status2.ToString();
+  EXPECT_EQ(mock_service_ptr_->subscribe_count(), 2);
+
+  ASSERT_TRUE(subscriber1->Close().ok());
+  ASSERT_TRUE(subscriber2->Close().ok());
+}
+
+}  // namespace pubsub
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -57,8 +57,9 @@ std::optional<AuthenticationToken> AuthenticationTokenLoader::GetToken() {
   AuthenticationToken token = LoadTokenFromSources();
 
   // If no token found and auth is enabled, fail with RAY_CHECK
-  RAY_CHECK(!token.empty())
-      << "Token authentication is enabled but Ray couldn't find an authentication token. "
+  RAY_USER_CHECK(!token.empty())
+      << "Ray Setup Error: Token authentication is enabled but Ray couldn't find an "
+         "authentication token. "
       << "Set the RAY_AUTH_TOKEN environment variable, or set RAY_AUTH_TOKEN_PATH to "
          "point to a file with the token, "
       << "or create a token file at ~/.ray/auth_token.";
@@ -100,9 +101,9 @@ AuthenticationToken AuthenticationTokenLoader::LoadTokenFromSources() {
     std::string path_str(env_token_path);
     if (!path_str.empty()) {
       std::string token_str = TrimWhitespace(ReadTokenFromFile(path_str));
-      RAY_CHECK(!token_str.empty())
-          << "RAY_AUTH_TOKEN_PATH is set but file cannot be opened or is empty: "
-          << path_str;
+      RAY_USER_CHECK(!token_str.empty()) << "Ray Setup Error: RAY_AUTH_TOKEN_PATH is set "
+                                            "but file cannot be opened or is empty: "
+                                         << path_str;
       RAY_LOG(DEBUG) << "Loaded authentication token from file: " << path_str;
       return AuthenticationToken(token_str);
     }

--- a/src/ray/rpc/tests/authentication_token_loader_test.cc
+++ b/src/ray/rpc/tests/authentication_token_loader_test.cc
@@ -299,7 +299,8 @@ TEST_F(AuthenticationTokenLoaderTest, TestErrorWhenAuthEnabledButNoToken) {
         auto &loader = AuthenticationTokenLoader::instance();
         loader.GetToken();
       },
-      "Token authentication is enabled but Ray couldn't find an authentication token.");
+      "Ray Setup Error: Token authentication is enabled but Ray couldn't find an "
+      "authentication token.");
 }
 
 TEST_F(AuthenticationTokenLoaderTest, TestCaching) {

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -297,6 +297,8 @@ void RayLog::InitSeverityThreshold(RayLogLevel severity_threshold) {
       severity_threshold = RayLogLevel::WARNING;
     } else if (data == "error") {
       severity_threshold = RayLogLevel::ERROR;
+    } else if (data == "user_fatal") {
+      severity_threshold = RayLogLevel::USER_FATAL;
     } else if (data == "fatal") {
       severity_threshold = RayLogLevel::FATAL;
     } else {
@@ -601,7 +603,7 @@ RayLog::~RayLog() {
   }
   logger->flush();
 
-  if (severity_ == RayLogLevel::FATAL || severity_ == RayLogLevel::USER_FATAL) {
+  if (IsFatal()) {
     std::_Exit(EXIT_FAILURE);
   }
 }

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -569,8 +569,11 @@ bool RayLog::IsFatal() const { return is_fatal_; }
 
 RayLog::~RayLog() {
   if (IsFatal()) {
-    msg_osstream_ << "\n*** StackTrace Information ***\n" << ray::StackTrace();
-    expose_fatal_osstream_ << "\n*** StackTrace Information ***\n" << ray::StackTrace();
+    // Only add stack trace for internal fatal errors, not user-facing errors
+    if (severity_ == RayLogLevel::FATAL) {
+      msg_osstream_ << "\n*** StackTrace Information ***\n" << ray::StackTrace();
+      expose_fatal_osstream_ << "\n*** StackTrace Information ***\n" << ray::StackTrace();
+    }
     const char *callback_label = (severity_ == RayLogLevel::USER_FATAL)
                                      ? "RAY_USER_ERROR"
                                      : "RAY_FATAL_CHECK_FAILED";

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -122,7 +122,8 @@ enum class RayLogLevel {
   INFO = 0,
   WARNING = 1,
   ERROR = 2,
-  FATAL = 3
+  USER_FATAL = 3,  // User-facing fatal errors (config/usage errors)
+  FATAL = 4        // Internal fatal errors (bugs in Ray)
 };
 
 #define RAY_LOG_INTERNAL(level) ::ray::RayLog(__FILE__, __LINE__, level)
@@ -150,6 +151,12 @@ enum class RayLogLevel {
                            "with you to fix it. Check failed: " display " ")
 
 #define RAY_CHECK(condition) RAY_CHECK_WITH_DISPLAY(condition, #condition)
+
+// User-facing fatal check without "bug in Ray" message
+#define RAY_USER_CHECK(condition) \
+  RAY_PREDICT_TRUE((condition))   \
+  ? RAY_IGNORE_EXPR(0)            \
+  : ::ray::Voidify() & ::ray::RayLog(__FILE__, __LINE__, ray::RayLogLevel::USER_FATAL)
 
 #ifdef NDEBUG
 

--- a/src/ray/util/tests/logging_test.cc
+++ b/src/ray/util/tests/logging_test.cc
@@ -379,6 +379,31 @@ TEST(PrintLogTest, TestFailureSignalHandler) {
   ASSERT_DEATH(abort(), ".*SIGABRT received.*");
 }
 
+TEST(UserErrorTest, TestUserCheck) {
+  // RAY_USER_CHECK should not exit the application when condition is true
+  RAY_USER_CHECK(true) << "This should not trigger";
+  // RAY_USER_CHECK should exit the application when condition is false
+  // and should NOT contain "bug in Ray" message
+  ASSERT_DEATH(
+    { RAY_USER_CHECK(false) << "Custom user error message"; },
+    testing::AllOf(
+      testing::HasSubstr("Custom user error message"),
+      testing::Not(testing::HasSubstr("bug in Ray"))
+    )
+  );
+}
+
+TEST(UserErrorTest, TestUserError) {
+  // RAY_USER_ERROR should always fail with user message
+  ASSERT_DEATH(
+    { RAY_USER_ERROR() << "Token authentication is enabled but token is missing"; },
+    testing::AllOf(
+      testing::HasSubstr("Token authentication is enabled but token is missing"),
+      testing::Not(testing::HasSubstr("bug in Ray"))
+    )
+  );
+}
+
 }  // namespace ray
 
 int main(int argc, char **argv) {

--- a/src/ray/util/tests/logging_test.cc
+++ b/src/ray/util/tests/logging_test.cc
@@ -384,24 +384,18 @@ TEST(UserErrorTest, TestUserCheck) {
   RAY_USER_CHECK(true) << "This should not trigger";
   // RAY_USER_CHECK should exit the application when condition is false
   // and should NOT contain "bug in Ray" message
-  ASSERT_DEATH(
-    { RAY_USER_CHECK(false) << "Custom user error message"; },
-    testing::AllOf(
-      testing::HasSubstr("Custom user error message"),
-      testing::Not(testing::HasSubstr("bug in Ray"))
-    )
-  );
+  ASSERT_DEATH({ RAY_USER_CHECK(false) << "Custom user error message"; },
+               testing::AllOf(testing::HasSubstr("Custom user error message"),
+                              testing::Not(testing::HasSubstr("bug in Ray"))));
 }
 
 TEST(UserErrorTest, TestUserError) {
   // RAY_USER_ERROR should always fail with user message
   ASSERT_DEATH(
-    { RAY_USER_ERROR() << "Token authentication is enabled but token is missing"; },
-    testing::AllOf(
-      testing::HasSubstr("Token authentication is enabled but token is missing"),
-      testing::Not(testing::HasSubstr("bug in Ray"))
-    )
-  );
+      { RAY_USER_ERROR() << "Token authentication is enabled but token is missing"; },
+      testing::AllOf(
+          testing::HasSubstr("Token authentication is enabled but token is missing"),
+          testing::Not(testing::HasSubstr("bug in Ray"))));
 }
 
 }  // namespace ray

--- a/src/ray/util/tests/logging_test.cc
+++ b/src/ray/util/tests/logging_test.cc
@@ -379,23 +379,15 @@ TEST(PrintLogTest, TestFailureSignalHandler) {
   ASSERT_DEATH(abort(), ".*SIGABRT received.*");
 }
 
-TEST(UserErrorTest, TestUserCheck) {
+TEST(PrintLogTest, TestUserCheck) {
   // RAY_USER_CHECK should not exit the application when condition is true
   RAY_USER_CHECK(true) << "This should not trigger";
   // RAY_USER_CHECK should exit the application when condition is false
-  // and should NOT contain "bug in Ray" message
-  ASSERT_DEATH({ RAY_USER_CHECK(false) << "Custom user error message"; },
-               testing::AllOf(testing::HasSubstr("Custom user error message"),
-                              testing::Not(testing::HasSubstr("bug in Ray"))));
-}
-
-TEST(UserErrorTest, TestUserError) {
-  // RAY_USER_ERROR should always fail with user message
   ASSERT_DEATH(
-      { RAY_USER_ERROR() << "Token authentication is enabled but token is missing"; },
-      testing::AllOf(
-          testing::HasSubstr("Token authentication is enabled but token is missing"),
-          testing::Not(testing::HasSubstr("bug in Ray"))));
+      { RAY_USER_CHECK(false) << "Custom user error message"; },
+      testing::AllOf(testing::HasSubstr("Custom user error message"),
+                     testing::Not(testing::HasSubstr("bug in Ray")),
+                     testing::Not(testing::HasSubstr("StackTrace Information"))));
 }
 
 }  // namespace ray


### PR DESCRIPTION
## Description
The existing RAY_CHECK macro prints the message “You have likely discovered a bug in Ray” along with the error message, which can be confusing to users in cases of user exceptions (e.g., when a valid token is not provided while token-based authentication is enabled).
This PR introduces a new log level, USER_FATAL, for user-facing exceptions, and a corresponding macro, RAY_USER_CHECK, for conditionally checking and failing on user errors.

We are adding a new log level instead of reusing the existing FATAL level to enable differentiation between error types, improving observability and metric tracking. This also provides a clear semantic distinction between user-facing and system errors.