### PR TITLE
[release][ci] updating hello world release tests to py310

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -109,7 +109,7 @@
       cluster:
         ray_version: 2.50.0
 
-- name: py310_hello_world_custom_byod
+- name: hello_world_custom_byod
   python: "3.10"
   team: reef
   group: hello_world
@@ -136,7 +136,7 @@
       cluster:
         ray_version: 2.50.0
 
-- name: py310_hello_world_custom_byod_depset_only
+- name: hello_world_custom_byod_depset_only
   python: "3.10"
   team: reef
   group: hello_world
@@ -160,7 +160,7 @@
 #######################
 # Cluster scaling tests
 #######################
-- name: py310_cluster_tune_scale_up_down
+- name: cluster_tune_scale_up_down
   python: "3.10"
   group: Cluster tests
   working_dir: cluster_tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -79,7 +79,8 @@
 #######################
 # Baseline test
 #######################
-- name: hello_world
+- name: ctest_hello_world
+  python: "3.10"
   team: reef
   group: hello_world
   frequency: nightly
@@ -108,7 +109,8 @@
       cluster:
         ray_version: 2.50.0
 
-- name: hello_world_custom_byod
+- name: py310_hello_world_custom_byod
+  python: "3.10"
   team: reef
   group: hello_world
   frequency: nightly
@@ -134,7 +136,8 @@
       cluster:
         ray_version: 2.50.0
 
-- name: hello_world_custom_byod_depset_only
+- name: py310_hello_world_custom_byod_depset_only
+  python: "3.10"
   team: reef
   group: hello_world
   frequency: nightly
@@ -157,7 +160,8 @@
 #######################
 # Cluster scaling tests
 #######################
-- name: cluster_tune_scale_up_down
+- name: py310_cluster_tune_scale_up_down
+  python: "3.10"
   group: Cluster tests
   working_dir: cluster_tests
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -79,7 +79,7 @@
 #######################
 # Baseline test
 #######################
-- name: ctest_hello_world
+- name: hello_world
   python: "3.10"
   team: reef
   group: hello_world


### PR DESCRIPTION
Updating hello world release & cluster release tests to run on py3.10

Passing release tests: https://buildkite.com/ray-project/release/builds/65844
