### PR TITLE
[release][ci] updating jobs tests to run on 3.10

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1268,7 +1268,7 @@
 # Jobs tests
 ########################
 
-- name: jobs_basic_local_working_dir-py3.10
+- name: jobs_basic_local_working_dir
   python: "3.10"
   group: Jobs tests
   working_dir: jobs_tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1268,7 +1268,7 @@
 # Jobs tests
 ########################
 
-- name: py310_jobs_basic_local_working_dir
+- name: jobs_basic_local_working_dir-py3.10
   python: "3.10"
   group: Jobs tests
   working_dir: jobs_tests
@@ -1298,7 +1298,7 @@
       cluster:
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
-- name: py310_jobs_basic_remote_working_dir
+- name: jobs_basic_remote_working_dir
   python: "3.10"
   group: Jobs tests
   working_dir: jobs_tests
@@ -1328,7 +1328,7 @@
       cluster:
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
-- name: py310_jobs_remote_multi_node
+- name: jobs_remote_multi_node
   python: "3.10"
   group: Jobs tests
   team: serve
@@ -1353,7 +1353,7 @@
       cluster:
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
-- name: py310_jobs_check_cuda_available
+- name: jobs_check_cuda_available
   python: "3.10"
   group: Jobs tests
   team: serve
@@ -1378,7 +1378,7 @@
       cluster:
         cluster_compute: compute_tpl_gce_gpu_node.yaml
 
-- name: py310_jobs_specify_num_gpus
+- name: jobs_specify_num_gpus
   python: "3.10"
   group: Jobs tests
   team: serve

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1268,7 +1268,8 @@
 # Jobs tests
 ########################
 
-- name: jobs_basic_local_working_dir
+- name: py310_jobs_basic_local_working_dir
+  python: "3.10"
   group: Jobs tests
   working_dir: jobs_tests
 
@@ -1297,7 +1298,8 @@
       cluster:
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
-- name: jobs_basic_remote_working_dir
+- name: py310_jobs_basic_remote_working_dir
+  python: "3.10"
   group: Jobs tests
   working_dir: jobs_tests
 
@@ -1326,7 +1328,8 @@
       cluster:
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
-- name: jobs_remote_multi_node
+- name: py310_jobs_remote_multi_node
+  python: "3.10"
   group: Jobs tests
   team: serve
   frequency: nightly
@@ -1350,7 +1353,8 @@
       cluster:
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
-- name: jobs_check_cuda_available
+- name: py310_jobs_check_cuda_available
+  python: "3.10"
   group: Jobs tests
   team: serve
 
@@ -1374,7 +1378,8 @@
       cluster:
         cluster_compute: compute_tpl_gce_gpu_node.yaml
 
-- name: jobs_specify_num_gpus
+- name: py310_jobs_specify_num_gpus
+  python: "3.10"
   group: Jobs tests
   team: serve
 


### PR DESCRIPTION
upgrading jobs tests to run on python 3.10

Successful release tests: https://buildkite.com/ray-project/release/builds/65845