### PR TITLE
[release][ci] updating observ tests to py310

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3468,6 +3468,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_compute: agent_stress_compute_gce.yaml
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3445,7 +3445,8 @@
 #####################
 # Observability tests
 #####################
-- name: agent_stress_test
+- name: py310_agent_stress_test
+  python: "3.10"
   group: core-observability-test
   working_dir: dashboard
 
@@ -3471,7 +3472,8 @@
       cluster:
         cluster_compute: agent_stress_compute_gce.yaml
 
-- name: k8s_serve_ha_test
+- name: py310_k8s_serve_ha_test
+  python: "3.10"
   group: k8s-test
   working_dir: k8s_tests
 
@@ -3490,7 +3492,8 @@
     prepare: bash prepare.sh
     script: python run_gcs_ft_on_k8s.py
 
-- name: azure_cluster_launcher
+- name: py310_azure_cluster_launcher
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
   frequency: nightly
@@ -3511,7 +3514,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python -I launch_and_verify_cluster.py azure/tests/azure-cluster.yaml --num-expected-nodes 3 --retries 10
 
-- name: aws_cluster_launcher
+- name: py310_aws_cluster_launcher
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3534,7 +3538,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10
 
-- name: aws_cluster_launcher_nightly_image
+- name: py310_aws_cluster_launcher_nightly_image
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3556,7 +3561,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override nightly
 
-- name: aws_cluster_launcher_latest_image
+- name: py310_aws_cluster_launcher_latest_image
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3578,7 +3584,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override latest
 
-- name: aws_cluster_launcher_release_image
+- name: py310_aws_cluster_launcher_release_image
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3601,7 +3608,8 @@
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override commit
 
 
-- name: aws_cluster_launcher_minimal
+- name: py310_aws_cluster_launcher_minimal
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3623,7 +3631,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/example-minimal.yaml
 
-- name: aws_cluster_launcher_full
+- name: py310_aws_cluster_launcher_full
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3645,7 +3654,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/example-full.yaml --num-expected-nodes 2 --retries 20 --docker-override latest
 
-- name: gcp_cluster_launcher_minimal
+- name: py310_gcp_cluster_launcher_minimal
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3670,7 +3680,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
 
-- name: gcp_cluster_launcher_full
+- name: py310_gcp_cluster_launcher_full
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3695,7 +3706,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 30 --docker-override latest
 
-- name: gcp_cluster_launcher_latest_image
+- name: py310_gcp_cluster_launcher_latest_image
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3720,7 +3732,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
 
-- name: gcp_cluster_launcher_nightly_image
+- name: py310_gcp_cluster_launcher_nightly_image
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3745,7 +3758,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
 
-- name: gcp_cluster_launcher_release_image
+- name: py310_gcp_cluster_launcher_release_image
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3770,7 +3784,8 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override commit
 
-- name: gcp_cluster_launcher_gpu_docker
+- name: py310_gcp_cluster_launcher_gpu_docker
+  python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3445,7 +3445,7 @@
 #####################
 # Observability tests
 #####################
-- name: py310_agent_stress_test
+- name: agent_stress_test
   python: "3.10"
   group: core-observability-test
   working_dir: dashboard
@@ -3468,12 +3468,10 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
-      frequency: manual
       cluster:
         cluster_compute: agent_stress_compute_gce.yaml
 
-- name: py310_k8s_serve_ha_test
-  python: "3.10"
+- name: k8s_serve_ha_test
   group: k8s-test
   working_dir: k8s_tests
 
@@ -3492,7 +3490,7 @@
     prepare: bash prepare.sh
     script: python run_gcs_ft_on_k8s.py
 
-- name: py310_azure_cluster_launcher
+- name: azure_cluster_launcher
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3514,7 +3512,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python -I launch_and_verify_cluster.py azure/tests/azure-cluster.yaml --num-expected-nodes 3 --retries 10
 
-- name: py310_aws_cluster_launcher
+- name: aws_cluster_launcher
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3538,7 +3536,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10
 
-- name: py310_aws_cluster_launcher_nightly_image
+- name: aws_cluster_launcher_nightly_image
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3561,7 +3559,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override nightly
 
-- name: py310_aws_cluster_launcher_latest_image
+- name: aws_cluster_launcher_latest_image
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3584,7 +3582,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override latest
 
-- name: py310_aws_cluster_launcher_release_image
+- name: aws_cluster_launcher_release_image
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3608,7 +3606,7 @@
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10 --docker-override commit
 
 
-- name: py310_aws_cluster_launcher_minimal
+- name: aws_cluster_launcher_minimal
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3631,7 +3629,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/example-minimal.yaml
 
-- name: py310_aws_cluster_launcher_full
+- name: aws_cluster_launcher_full
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3654,7 +3652,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py aws/example-full.yaml --num-expected-nodes 2 --retries 20 --docker-override latest
 
-- name: py310_gcp_cluster_launcher_minimal
+- name: gcp_cluster_launcher_minimal
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3680,7 +3678,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
 
-- name: py310_gcp_cluster_launcher_full
+- name: gcp_cluster_launcher_full
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3706,8 +3704,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 30 --docker-override latest
 
-- name: py310_gcp_cluster_launcher_latest_image
-  python: "3.10"
+- name: gcp_cluster_launcher_latest_image
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
@@ -3732,7 +3729,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
 
-- name: py310_gcp_cluster_launcher_nightly_image
+- name: gcp_cluster_launcher_nightly_image
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3758,7 +3755,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
 
-- name: py310_gcp_cluster_launcher_release_image
+- name: gcp_cluster_launcher_release_image
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
@@ -3784,7 +3781,7 @@
       run:
         script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override commit
 
-- name: py310_gcp_cluster_launcher_gpu_docker
+- name: gcp_cluster_launcher_gpu_docker
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/


### PR DESCRIPTION
observability release tests on py3.10

Successful release test run: https://buildkite.com/ray-project/release/builds/65851
failing tests are set to manual (disabled):
aws_cluster_launcher_release_image
k8s_serve_ha_test

enabling agent_stress_test.gce which is now passing