### PR TITLE
[core][dashboard] clearer error msg for exceeding list actors limit

### DIFF
--- a/python/ray/dashboard/state_api_utils.py
+++ b/python/ray/dashboard/state_api_utils.py
@@ -72,8 +72,9 @@ def options_from_req(req: aiohttp.web.Request) -> ListApiOptions:
     if limit > RAY_MAX_LIMIT_FROM_API_SERVER:
         raise ValueError(
             f"Given limit {limit} exceeds the supported "
-            f"limit {RAY_MAX_LIMIT_FROM_API_SERVER}. Use a lower limit, "
-            f"or set the RAY_MAX_LIMIT_FROM_API_SERVER=limit"
+            f"Given limit {limit} exceeds the supported "
+            f"limit {RAY_MAX_LIMIT_FROM_API_SERVER}. Use a lower limit, or set the "
+            f"`RAY_MAX_LIMIT_FROM_API_SERVER` environment variable to a larger value."
         )
 
     timeout = int(req.query.get("timeout", 30))

--- a/python/ray/dashboard/state_api_utils.py
+++ b/python/ray/dashboard/state_api_utils.py
@@ -44,6 +44,8 @@ async def handle_list_api(
             error_message="",
             result=asdict(result),
         )
+    except ValueError as e:
+        return do_reply(success=False, error_message=str(e), result=None)
     except DataSourceUnavailable as e:
         return do_reply(success=False, error_message=str(e), result=None)
 
@@ -70,7 +72,8 @@ def options_from_req(req: aiohttp.web.Request) -> ListApiOptions:
     if limit > RAY_MAX_LIMIT_FROM_API_SERVER:
         raise ValueError(
             f"Given limit {limit} exceeds the supported "
-            f"limit {RAY_MAX_LIMIT_FROM_API_SERVER}. Use a lower limit."
+            f"limit {RAY_MAX_LIMIT_FROM_API_SERVER}. Use a lower limit, "
+            f"or set the RAY_MAX_LIMIT_FROM_API_SERVER=limit"
         )
 
     timeout = int(req.query.get("timeout", 30))


### PR DESCRIPTION
## Description
Currently, the `ray.util.state.list_actors(limit=N)` API will return a details for at most N actors. However, when N exceeds the default value for `RAY_MAX_LIMIT_FROM_API_SERVER=10_000`, the error will fail with a misleading message (the error msg being that the dashboard or API server is unavailable, even if it is available). The reason why this fails is because we don't handle `ValueErrors`, and default throw a 500 error. My solution is to handle that, and open to suggestions/alternatives

NOTE: I noticed it still fails with internal_server error, I think this should be a 4XX error, but it looks like that will require more code changes since it uses a very ubiquitous function: `do_reply`. Gemini suggests returning `rest_response` directly, happy to follow those orders too

### Before
```python
>>> import ray
>>> import ray.util.state
>>> ray.init()
>>> ray.util.state.list_actors(limit=100000)
ray.util.state.exception.RayStateApiException: Failed to make request to http://127.0.0.1:8265/api/v0/actors. Failed to connect to API server. Please check the API server log for details. Make sure dependencies are installed with `pip install ray[default]`. Please also check dashboard is available, and included when starting ray cluster, i.e. `ray start --include-dashboard=True --head`. Response(url=http://127.0.0.1:8265/api/v0/actors?limit=100000&timeout=24&detail=False&exclude_driver=True&server_timeout_multiplier=0.8,status=500)
```

### After
```python
>>> import ray
>>> import ray.util.state
>>> ray.init()
>>> ray.util.state.list_actors(limit=100000)
ray.util.state.exception.RayStateApiException: API server internal error. See dashboard.log file for more details. Error: Given limit 100000 exceeds the supported limit 10000. Use a lower limit, or set the RAY_MAX_LIMIT_FROM_API_SERVER=limit
```

## Related issues
None
## Additional information
None