### PR TITLE
[core] add an option to disable otel sdk error logs

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -533,6 +533,11 @@ RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
 /// using OpenCensus.
 RAY_CONFIG(bool, enable_open_telemetry, false)
 
+/// Whether to disable the OpenTelemetry SDK logs. They are disabled by default
+/// to prevent noisy gRPC errors during shutdown.
+/// See https://github.com/ray-project/ray/issues/58256 for details.
+RAY_CONFIG(bool, disable_open_telemetry_sdk_log, true)
+
 /// Whether to enable Ray Event as the event collection backend. The default is
 /// using the Export API.
 RAY_CONFIG(bool, enable_ray_event, false)

--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -9,6 +9,7 @@ ray_cc_library(
         "open_telemetry_metric_recorder.h",
     ],
     deps = [
+        "//src/ray/common:ray_config",
         "//src/ray/util:logging",
         "@com_google_absl//absl/container:flat_hash_map",
         "@io_opentelemetry_cpp//api",

--- a/src/ray/observability/open_telemetry_metric_recorder.cc
+++ b/src/ray/observability/open_telemetry_metric_recorder.cc
@@ -17,6 +17,7 @@
 #include <opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h>
 #include <opentelemetry/metrics/provider.h>
 #include <opentelemetry/nostd/variant.h>
+#include <opentelemetry/sdk/common/global_log_handler.h>
 #include <opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h>
 #include <opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h>
 #include <opentelemetry/sdk/metrics/instruments.h>
@@ -88,7 +89,10 @@ void OpenTelemetryMetricRecorder::RegisterGrpcExporter(
 }
 
 OpenTelemetryMetricRecorder::OpenTelemetryMetricRecorder() {
-  // Default constructor
+  if (RayConfig::instance().disable_open_telemetry_sdk_log()) {
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(
+        opentelemetry::sdk::common::internal_log::LogLevel::None);
+  }
   meter_provider_ = std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
   opentelemetry::metrics::Provider::SetMeterProvider(
       opentelemetry::nostd::shared_ptr<opentelemetry::metrics::MeterProvider>(

--- a/src/ray/observability/open_telemetry_metric_recorder.h
+++ b/src/ray/observability/open_telemetry_metric_recorder.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "ray/common/ray_config.h"
 
 namespace ray {
 namespace observability {


### PR DESCRIPTION
Currently, Ray metrics and events are exported through a centralized process called the Dashboard Agent. This process functions as a gRPC server, receiving data from all other components (GCS, Raylet, workers, etc.). However, during a node shutdown, the Dashboard Agent may terminate before the other components, resulting in gRPC errors and potential loss of metrics and events.

As this issue occurs, the otel sdk logs become very noisy. Add a default options to disable otel sdk logs to avoid confusion.

Test:
- CI

