### PR TITLE
[core][rdt] Reuse previous metadata if transferring the same tensor list with nixl

### DIFF
--- a/doc/source/ray-core/direct-transport.rst
+++ b/doc/source/ray-core/direct-transport.rst
@@ -298,7 +298,7 @@ For collective-based tensor transports (Gloo and NCCL):
    * Any unexpected system bugs
 
 
-Due to a known issue, we currently do not support repeated transfers of tensors that share the same memory space but simultaneously belong to different objects. To support this pattern, ensure that the first object is freed before storing the same tensor again in a second object.
+Due to a known issue, for NIXL, we currently do not support transferring different GPU objects that contain tensors sharing the same memory space when those tensors are only partially identical. To support this pattern, ensure that the first object is freed before storing the same tensor again in a second object.
 
 .. literalinclude:: doc_code/direct_transport_nixl.py
    :language: python

--- a/doc/source/ray-core/direct-transport.rst
+++ b/doc/source/ray-core/direct-transport.rst
@@ -298,7 +298,7 @@ For collective-based tensor transports (Gloo and NCCL):
    * Any unexpected system bugs
 
 
-Due to a known issue, for NIXL, we currently do not support transferring different GPU objects that contain tensors sharing the same memory space when those tensors are only partially identical. To support this pattern, ensure that the first object is freed before storing the same tensor again in a second object.
+Due to a known issue, for NIXL, we currently do not support transferring different GPU objects that contain tensors sharing the same memory space when those objects are only partially identical. To support this pattern, ensure that the first object is freed before storing the same tensor again in a second object.
 
 .. literalinclude:: doc_code/direct_transport_nixl.py
    :language: python

--- a/doc/source/ray-core/direct-transport.rst
+++ b/doc/source/ray-core/direct-transport.rst
@@ -298,7 +298,7 @@ For collective-based tensor transports (Gloo and NCCL):
    * Any unexpected system bugs
 
 
-Due to a known issue, for NIXL, we currently do not support transferring different GPU objects that contain tensors sharing the same memory space when those objects are only partially identical. To support this pattern, ensure that the first object is freed before storing the same tensor again in a second object.
+Due to a known issue, for NIXL, we currently do not support storing different GPU objects at the same actor, where the objects contain an overlapping but not equal set of tensors. To support this pattern, ensure that the first `ObjectRef` has gone out of scope before storing the same tensor(s) again in a second object.
 
 .. literalinclude:: doc_code/direct_transport_nixl.py
    :language: python

--- a/doc/source/ray-core/doc_code/direct_transport_nixl.py
+++ b/doc/source/ray-core/doc_code/direct_transport_nixl.py
@@ -59,6 +59,8 @@ print(ray.get(ref1))
 
 
 # __nixl_limitations_start__
+from ray.exceptions import ActorDiedError
+
 @ray.remote(num_gpus=1)
 class Actor:
     def __init__(self):
@@ -86,6 +88,6 @@ ref2 = sender.send_dict2.remote()
 result2 = receiver.sum_dict.remote(ref2)
 try:
     print(ray.get(result2))
-except ValueError as e:
+except ActorDiedError as e:
     print("Error caught:", e)
 # __nixl_limitations_end__

--- a/python/ray/experimental/collective/collective_tensor_transport.py
+++ b/python/ray/experimental/collective/collective_tensor_transport.py
@@ -72,7 +72,7 @@ class CollectiveTensorTransport(TensorTransportManager):
             # timeout.
             gpu_object = gpu_object_store.wait_and_get_object(obj_id)
             return CollectiveTensorTransport.extract_tensor_transport_metadata(
-                gpu_object
+                obj_id, gpu_object
             )
 
         # Submit a Ray actor task to the source actor to get the tensor metadata.

--- a/python/ray/experimental/collective/collective_tensor_transport.py
+++ b/python/ray/experimental/collective/collective_tensor_transport.py
@@ -178,5 +178,7 @@ class CollectiveTensorTransport(TensorTransportManager):
             )
 
     @staticmethod
-    def garbage_collect(tensor_transport_meta: CollectiveTransportMetadata):
+    def garbage_collect(
+        obj_id: str, tensor_transport_meta: CollectiveTransportMetadata
+    ):
         pass

--- a/python/ray/experimental/collective/collective_tensor_transport.py
+++ b/python/ray/experimental/collective/collective_tensor_transport.py
@@ -36,6 +36,7 @@ class CollectiveTensorTransport(TensorTransportManager):
 
     @staticmethod
     def extract_tensor_transport_metadata(
+        obj_id: str,
         gpu_object: List["torch.Tensor"],
     ) -> CollectiveTransportMetadata:
         tensor_meta = []

--- a/python/ray/experimental/collective/nixl_tensor_transport.py
+++ b/python/ray/experimental/collective/nixl_tensor_transport.py
@@ -96,14 +96,11 @@ class NixlTensorTransport(TensorTransportManager):
             duplicate_obj_id = gpu_object_store.get_duplicate_objects(
                 obj_id, gpu_object
             )
-            print(f"Duplicate object {duplicate_obj_id}")
             if duplicate_obj_id is not None:
                 meta = gpu_object_store._managed_meta_nixl[duplicate_obj_id]
                 gpu_object_store._managed_meta_counts_nixl[meta] += 1
                 gpu_object_store._managed_meta_nixl[obj_id] = meta
-                print(
-                    f"Duplicate object {duplicate_obj_id} found, incrementing reference count to {gpu_object_store._managed_meta_counts_nixl[meta]}"
-                )
+
                 return meta
             meta = NixlTensorTransport.extract_tensor_transport_metadata(gpu_object)
             gpu_object_store._managed_meta_nixl[obj_id] = meta
@@ -175,15 +172,11 @@ class NixlTensorTransport(TensorTransportManager):
         from ray.util.collective.collective import get_group_handle
         from ray.util.collective.collective_group.nixl_backend import NixlBackend
 
-        print("hihihi")
         gpu_object_store = global_worker.gpu_object_manager.gpu_object_store
         meta = gpu_object_store._managed_meta_nixl[obj_id]
         gpu_object_store._managed_meta_counts_nixl[meta] -= 1
-        print(
-            f"decrementing reference count of tensor_transport_meta to {gpu_object_store._managed_meta_counts_nixl[meta]}"
-        )
+
         if gpu_object_store._managed_meta_counts_nixl[meta] == 0:
-            print("reference count of tensor_transport_meta is 0, deregistering memory")
             descs = tensor_transport_meta.nixl_reg_descs
             if descs is not None:
                 nixl_backend: NixlBackend = get_group_handle(NIXL_GROUP_NAME)

--- a/python/ray/experimental/collective/tensor_transport_manager.py
+++ b/python/ray/experimental/collective/tensor_transport_manager.py
@@ -129,10 +129,11 @@ class TensorTransportManager(ABC):
 
     @staticmethod
     @abstractmethod
-    def garbage_collect(tensor_transport_meta: TensorTransportMetadata):
+    def garbage_collect(obj_id: str, tensor_transport_meta: TensorTransportMetadata):
         """
         Garbage collect for the tensor transport after the GPU object is freed.
 
         Args:
+            obj_id: The ID of the GPU object to garbage collect.
             tensor_transport_meta: The tensor transport metadata.
         """

--- a/python/ray/experimental/collective/tensor_transport_manager.py
+++ b/python/ray/experimental/collective/tensor_transport_manager.py
@@ -64,12 +64,14 @@ class TensorTransportManager(ABC):
     @staticmethod
     @abstractmethod
     def extract_tensor_transport_metadata(
+        obj_id: str,
         gpu_object: List["torch.Tensor"],
     ) -> TensorTransportMetadata:
         """
         Extract the tensor transport metadata from the GPU object.
 
         Args:
+            obj_id: The ID of the GPU object to extract the tensor transport metadata from.
             gpu_object: The GPU object to extract the tensor transport metadata from.
 
         Returns:

--- a/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
@@ -284,6 +284,8 @@ class GPUObjectManager:
             sent_dest_actors=set(),
             sent_to_src_actor_and_others_warned=False,
         )
+        print(f"Added GPU object metadata for object {obj_id}")
+        print(f"added Managed GPU object metadata: {self.managed_gpu_object_metadata}")
 
     def _get_gpu_object_metadata(self, obj_ref: ObjectRef) -> GPUObjectMeta:
         obj_id = obj_ref.hex()
@@ -546,10 +548,6 @@ class GPUObjectManager:
             src_actor.__ray_call__.options(concurrency_group="_ray_system").remote(
                 __ray_free__, object_id, tensor_transport_backend, tensor_transport_meta
             )
-            # NOTE: This may have to change if we support lineage reconstruction for RDT
-            # TODO(#57962): Metadata is currently not removed on borrowers that borrow through
-            # the NIXL ray.put / ray.get
-            self.managed_gpu_object_metadata.pop(object_id, None)
         except Exception as e:
             logger.error(
                 "Something went wrong while freeing the RDT object!", exc_info=e

--- a/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
@@ -546,6 +546,10 @@ class GPUObjectManager:
             src_actor.__ray_call__.options(concurrency_group="_ray_system").remote(
                 __ray_free__, object_id, tensor_transport_backend, tensor_transport_meta
             )
+            # NOTE: This may have to change if we support lineage reconstruction for RDT
+            # TODO(#57962): Metadata is currently not removed on borrowers that borrow through
+            # the NIXL ray.put / ray.get
+            self.managed_gpu_object_metadata.pop(object_id, None)
         except Exception as e:
             logger.error(
                 "Something went wrong while freeing the RDT object!", exc_info=e

--- a/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
@@ -604,7 +604,7 @@ class GPUObjectManager:
         )
         transport_manager = get_tensor_transport_manager(tensor_transport_backend)
         tensor_transport_meta = transport_manager.extract_tensor_transport_metadata(
-            tensors
+            obj_ref.hex(), tensors
         )
 
         src_actor = ray.get_runtime_context().current_actor

--- a/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
@@ -284,8 +284,6 @@ class GPUObjectManager:
             sent_dest_actors=set(),
             sent_to_src_actor_and_others_warned=False,
         )
-        print(f"Added GPU object metadata for object {obj_id}")
-        print(f"added Managed GPU object metadata: {self.managed_gpu_object_metadata}")
 
     def _get_gpu_object_metadata(self, obj_ref: ObjectRef) -> GPUObjectMeta:
         obj_id = obj_ref.hex()

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -176,6 +176,7 @@ class GPUObjectStore:
         self._object_freed_cv = threading.Condition(self._lock)
 
         # These are only used for NIXL. Will be removed in the future.
+        self._nixl_meta_lock = threading.Lock()
         # Mapping from object ID to the NIXL managed meta.
         self._managed_meta_nixl: Dict[str, Any] = {}
         # Mapping from NIXL managed meta to the number of objects that contain it.
@@ -354,5 +355,5 @@ class GPUObjectStore:
         """
         Return the number of NIXL managed meta in the GPU object store.
         """
-        with self._lock:
+        with self._nixl_meta_lock:
             return len(self._managed_meta_nixl)

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -126,7 +126,6 @@ def __ray_free__(
         # TODO(#57962): Metadata is currently not removed on borrowers that borrow through
         # the NIXL ray.put / ray.get
         gpu_object_manager.managed_gpu_object_metadata.pop(obj_id, None)
-        print(f"Popped GPU object metadata for object {obj_id}")
     except AssertionError:
         # This could fail if this is a retry and it's already been freed.
         pass
@@ -260,7 +259,6 @@ class GPUObjectStore:
         """Get another object ID of the GPU object that duplicates the given GPU object."""
         with self._lock:
             if len(src_gpu_object) == 0:
-                print("Source GPU object is empty")
                 return None
             obj_id_set = set()
             for tensor in src_gpu_object:

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -122,10 +122,6 @@ def __ray_free__(
         gpu_object_manager = global_worker.gpu_object_manager
         gpu_object_store = gpu_object_manager.gpu_object_store
         gpu_object_store.pop_object(obj_id)
-        # NOTE: This may have to change if we support lineage reconstruction for RDT
-        # TODO(#57962): Metadata is currently not removed on borrowers that borrow through
-        # the NIXL ray.put / ray.get
-        gpu_object_manager.managed_gpu_object_metadata.pop(obj_id, None)
     except AssertionError:
         # This could fail if this is a retry and it's already been freed.
         pass

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -180,7 +180,10 @@ class GPUObjectStore:
         # Signal when an object is freed from the object store.
         self._object_freed_cv = threading.Condition(self._lock)
 
+        # These are only used for NIXL. Will be removed in the future.
+        # Mapping from object ID to the NIXL managed meta.
         self._managed_meta_nixl: Dict[str, Any] = {}
+        # Mapping from NIXL managed meta to the number of objects that contain it.
         self._managed_meta_counts_nixl: Dict[Any, int] = {}
 
     def has_object(self, obj_id: str) -> bool:
@@ -355,7 +358,7 @@ class GPUObjectStore:
 
     def get_num_managed_meta_nixl(self) -> int:
         """
-        Return the number of managed meta NIXL in the GPU object store.
+        Return the number of NIXL managed meta in the GPU object store.
         """
         with self._lock:
             return len(self._managed_meta_nixl)

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -114,7 +114,6 @@ def __ray_free__(
         from ray._private.worker import global_worker
         from ray.experimental.collective import get_tensor_transport_manager
 
-        print("ray_free")
         tensor_transport_manager = get_tensor_transport_manager(
             tensor_transport_backend
         )

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -272,7 +272,7 @@ class GPUObjectStore:
                     )
                     if not is_same_tensors:
                         raise ValueError(
-                            f"Some of the tensors in this object are still in scope as part of another RDT object."
+                            f"Some of the tensors in this object are still in scope as part of another RDT object. "
                             f"Ensure that ObjectRef({src_object_id}) is out of scope before creating this object."
                         )
                     return dst_obj_id

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -265,10 +265,16 @@ class GPUObjectStore:
             for dst_obj_id in obj_id_set:
                 if dst_obj_id != src_obj_id:
                     dst_gpu_object = self._gpu_object_store[dst_obj_id][0].data
-                    assert len(src_gpu_object) == len(dst_gpu_object) and all(
+                    is_same_tensors = len(src_gpu_object) == len(
+                        dst_gpu_object
+                    ) and all(
                         t1.data_ptr() == t2.data_ptr()
                         for t1, t2 in zip(src_gpu_object, dst_gpu_object)
-                    ), "The duplicate object does not have the same tensors as the source object."
+                    )
+                    if not is_same_tensors:
+                        raise ValueError(
+                            f"The duplicate object {dst_obj_id} does not have the same tensors as the source object {src_obj_id}."
+                        )
                     return dst_obj_id
             return None
 

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -272,7 +272,8 @@ class GPUObjectStore:
                     )
                     if not is_same_tensors:
                         raise ValueError(
-                            f"The duplicate object {dst_obj_id} does not have the same tensors as the source object {src_obj_id}."
+                            f"Some of the tensors in this object are still in scope as part of another RDT object."
+                            f"Ensure that ObjectRef({src_object_id}) is out of scope before creating this object."
                         )
                     return dst_obj_id
             return None

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -273,7 +273,7 @@ class GPUObjectStore:
                     if not is_same_tensors:
                         raise ValueError(
                             f"Some of the tensors in this object are still in scope as part of another RDT object. "
-                            f"Ensure that ObjectRef({src_object_id}) is out of scope before creating this object."
+                            f"Ensure that ObjectRef({src_obj_id}) is out of scope before creating this object."
                         )
                     return dst_obj_id
             return None

--- a/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
+++ b/python/ray/tests/gpu_objects/test_gpu_objects_gloo.py
@@ -809,9 +809,6 @@ def test_wait_tensor_freed(ray_start_regular):
     assert not gpu_object_store.has_object(obj_id)
 
 
-@pytest.mark.skip(
-    reason="RDT currently doesn't support multiple objects containing the same tensor"
-)
 def test_wait_tensor_freed_double_tensor(ray_start_regular):
     """Unit test for ray.experimental.wait_tensor_freed when multiple objects
     contain the same tensor."""
@@ -851,9 +848,6 @@ def test_wait_tensor_freed_double_tensor(ray_start_regular):
     assert not gpu_object_store.has_object(obj_id2)
 
 
-@pytest.mark.skip(
-    reason="RDT currently doesn't support multiple objects containing the same tensor"
-)
 def test_send_back_and_dst_warning(ray_start_regular):
     # Test warning when object is sent back to the src actor and to dst actors
     world_size = 2

--- a/python/ray/tests/gpu_objects/test_gpu_objects_nixl.py
+++ b/python/ray/tests/gpu_objects/test_gpu_objects_nixl.py
@@ -193,18 +193,5 @@ def test_send_duplicate_tensor(ray_start_regular):
     )
 
 
-@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
-def test_send_overlapping_tensor(ray_start_regular):
-    actors = [GPUTestActor.remote() for _ in range(2)]
-    src_actor, dst_actor = actors[0], actors[1]
-    ref1 = src_actor.send_dict1.remote()
-    result1 = dst_actor.sum_dict.remote(ref1)
-    assert ray.get(result1) == 21
-    ref2 = src_actor.send_dict2.remote()
-    result2 = dst_actor.sum_dict.remote(ref2)
-    with pytest.raises(ray.exceptions.ActorDiedError):
-        ray.get(result2)
-
-
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/gpu_objects/test_gpu_objects_nixl.py
+++ b/python/ray/tests/gpu_objects/test_gpu_objects_nixl.py
@@ -4,10 +4,16 @@ import pytest
 import torch
 
 import ray
+from ray._common.test_utils import wait_for_condition
 
 
 @ray.remote(num_gpus=1, num_cpus=0, enable_tensor_transport=True)
 class GPUTestActor:
+    def __init__(self):
+        self.reserved_tensor1 = torch.tensor([1, 2, 3]).to("cuda")
+        self.reserved_tensor2 = torch.tensor([4, 5, 6]).to("cuda")
+        self.reserved_tensor3 = torch.tensor([7, 8, 9]).to("cuda")
+
     @ray.method(tensor_transport="nixl")
     def echo(self, data, device):
         return data.to(device)
@@ -50,6 +56,25 @@ class GPUTestActor:
         assert not gpu_manager.gpu_object_store.has_tensor(tensor)
         assert obj_id not in gpu_manager.managed_gpu_object_metadata
         return "Success"
+
+    @ray.method(tensor_transport="nixl")
+    def send_dict1(self):
+        return {"round1-1": self.reserved_tensor1, "round1-2": self.reserved_tensor2}
+
+    @ray.method(tensor_transport="nixl")
+    def send_dict2(self):
+        return {"round2-1": self.reserved_tensor1, "round2-3": self.reserved_tensor3}
+
+    def sum_dict(self, dict):
+        return sum(v.sum().item() for v in dict.values())
+
+    def get_num_gpu_objects(self):
+        gpu_object_manager = ray._private.worker.global_worker.gpu_object_manager
+        return gpu_object_manager.gpu_object_store.get_num_objects()
+
+    def get_num_managed_meta_nixl(self):
+        gpu_object_manager = ray._private.worker.global_worker.gpu_object_manager
+        return gpu_object_manager.gpu_object_store.get_num_managed_meta_nixl()
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
@@ -141,6 +166,44 @@ def test_put_gc(ray_start_regular):
     actor = GPUTestActor.remote()
     ref = actor.gc.remote()
     assert ray.get(ref) == "Success"
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_send_duplicate_tensor(ray_start_regular):
+    actors = [GPUTestActor.remote() for _ in range(2)]
+    src_actor, dst_actor = actors[0], actors[1]
+    ref1 = src_actor.send_dict1.remote()
+    result1 = dst_actor.sum_dict.remote(ref1)
+    assert ray.get(result1) == 21
+    ref2 = src_actor.send_dict1.remote()
+    result2 = dst_actor.sum_dict.remote(ref2)
+    assert ray.get(result2) == 21
+
+    del ref1
+    del ref2
+    wait_for_condition(
+        lambda: ray.get(src_actor.get_num_gpu_objects.remote()) == 0,
+        timeout=10,
+        retry_interval_ms=100,
+    )
+    wait_for_condition(
+        lambda: ray.get(src_actor.get_num_managed_meta_nixl.remote()) == 0,
+        timeout=10,
+        retry_interval_ms=100,
+    )
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_send_overlapping_tensor(ray_start_regular):
+    actors = [GPUTestActor.remote() for _ in range(2)]
+    src_actor, dst_actor = actors[0], actors[1]
+    ref1 = src_actor.send_dict1.remote()
+    result1 = dst_actor.sum_dict.remote(ref1)
+    assert ray.get(result1) == 21
+    ref2 = src_actor.send_dict2.remote()
+    result2 = dst_actor.sum_dict.remote(ref2)
+    with pytest.raises(ray.exceptions.ActorDiedError):
+        ray.get(result2)
 
 
 if __name__ == "__main__":

--- a/python/ray/util/collective/collective_group/nixl_backend.py
+++ b/python/ray/util/collective/collective_group/nixl_backend.py
@@ -87,6 +87,7 @@ class NixlBackend:
                 break
 
         nixl_agent.release_xfer_handle(xfer_handle)
+        nixl_agent.deregister_memory(local_descs)
         nixl_agent.remove_remote_agent(remote_name)
 
     def get_nixl_metadata(

--- a/python/ray/util/collective/types.py
+++ b/python/ray/util/collective/types.py
@@ -84,6 +84,9 @@ class NixlTransportMetadata(TensorTransportMetadata):
     nixl_serialized_descs: Optional[bytes] = None
     nixl_agent_meta: Optional[bytes] = None
 
+    __eq__ = object.__eq__
+    __hash__ = object.__hash__
+
 
 @dataclass
 class CollectiveTransportMetadata(TensorTransportMetadata):


### PR DESCRIPTION
## Description
For nixl, reuse previous metadata if transferring the same tensor list. This is to avoid repeated `register_memory` before `deregister_memory`
