### PR TITLE
[Core][Channel] Fix the exception type for accelerator ID visibility check in accelerator_context.py

### DIFF
--- a/python/ray/experimental/channel/accelerator_context.py
+++ b/python/ray/experimental/channel/accelerator_context.py
@@ -135,7 +135,7 @@ class AcceleratorContext:
             for accelerator_id in accelerator_ids:
                 try:
                     device_ids.append(accelerator_visible_list.index(accelerator_id))
-                except IndexError:
+                except ValueError:
                     raise RuntimeError(
                         f"{accelerator_manager.get_visible_accelerator_ids_env_var()} set incorrectly. "
                         f"expected to include {accelerator_id}. "


### PR DESCRIPTION
## Description

- Change the caught exception type from IndexError to TypeError
- This modification ensures that the correct exception is raised when the expected accelerator ID is not included in the accelerator_visible_list

`list.index` will raise a [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError) if there is no such item.

https://docs.python.org/3/tutorial/datastructures.html

<img width="797" height="79" alt="image" src="https://github.com/user-attachments/assets/830cf4aa-d9cb-44d3-9363-8e5cd576bae9" />

Now, the error logs will be correctly captured and printed.
<img width="1454" height="143" alt="image" src="https://github.com/user-attachments/assets/2b0ed0aa-60c7-49c3-84b0-7f0d4f1ebe48" />


