### PR TITLE
[train] update failure policy log message

### DIFF
--- a/python/ray/train/v2/_internal/execution/failure_handling/default.py
+++ b/python/ray/train/v2/_internal/execution/failure_handling/default.py
@@ -42,10 +42,10 @@ class DefaultFailurePolicy(FailurePolicy):
             raise ValueError(f"Unknown error type: {type(training_failed_error)}")
 
         logger.info(
-            f"[FailurePolicy] Decision: {decision}, "
-            f"Error source: {error_source}, "
-            f"Error count / maximum errors allowed: {error_count}/{retry_limit}, "
-            f"Error: {training_failed_error}"
+            f"[FailurePolicy] {decision.value}\n"
+            f"  Source: {error_source}\n"
+            f"  Error count: {error_count} (max allowed: {retry_limit})\n\n"
+            f"{training_failed_error}"
         )
 
     def _is_retryable_error(self, training_failed_error: TrainingFailedError) -> bool:


### PR DESCRIPTION
## Description
Update formatting of FailurePolicy log message to be more readable.

## Additional information

**Before:**

```
[FailurePolicy] Decision: FailureDecision.RAISE, Error source: controller, Error count / maximum errors allowed: 1/0, Error: Training failed due to controller error:
Worker group is not active. Call WorkerGroup.create() to create a new worker group.
```

**After:**

```
[FailurePolicy] RAISE
  Source: controller
  Error count: 1 (max allowed: 0)

Training failed due to controller error:
Worker group is not active. Call WorkerGroup.create() to create a new worker group.
```