### PR TITLE
[Data] Make all map ops zero-copy by default 

### DIFF
--- a/doc/source/data/api/from_other_data_libs.rst
+++ b/doc/source/data/api/from_other_data_libs.rst
@@ -80,7 +80,7 @@ For PyArrow Users
    * - ``pa.Table.drop()``
      - :meth:`ds.drop_columns() <ray.data.Dataset.drop_columns>`
    * - ``pa.Table.add_column()``
-     - :meth:`ds.add_column() <ray.data.Dataset.add_column>`
+     - :meth:`ds.with_column() <ray.data.Dataset.with_column>`
    * - ``pa.Table.groupby()``
      - :meth:`ds.groupby() <ray.data.Dataset.groupby>`
    * - ``pa.Table.sort_by()``

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -327,7 +327,7 @@ class BatchMapTransformFn(MapTransformFn):
         is_udf: bool = False,
         batch_size: Optional[int] = None,
         batch_format: Optional[BatchFormat] = None,
-        zero_copy_batch: bool = False,
+        zero_copy_batch: bool = True,
         output_block_size_option: Optional[OutputBlockSizeOption] = None,
     ):
         super().__init__(

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -162,7 +162,7 @@ class MapBatches(AbstractUDFMap):
         fn: UserDefinedFunction,
         batch_size: Optional[int] = None,
         batch_format: str = "default",
-        zero_copy_batch: bool = False,
+        zero_copy_batch: bool = True,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
         fn_constructor_args: Optional[Iterable[Any]] = None,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -485,15 +485,15 @@ class Dataset:
             ``fn`` should generally avoid modifying data buffers behind its input
             since these could be zero-copy views into the underlying object residing
             inside Ray's Object Store.
-            
-            To perform any modifications it's recommended to copy the data you 
-            want to modify. 
-            
+
+            To perform any modifications it's recommended to copy the data you
+            want to modify.
+
             In rare cases when you can't copy inside your UDF, you can instead
-            specify ``zero_copy_batch=False`` and then Ray Data will copy the 
-            *whole* batch for you, providing ``fn`` with a copy rather than 
+            specify ``zero_copy_batch=False`` and then Ray Data will copy the
+            *whole* batch for you, providing ``fn`` with a copy rather than
             a zero-copy view.
-            
+
         .. warning::
             Specifying both ``num_cpus`` and ``num_gpus`` for map tasks is experimental,
             and may result in scheduling or stability issues. Please
@@ -616,9 +616,9 @@ class Dataset:
                 batches. If this is ``True`` and no copy is required for the
                 ``batch_format`` conversion, the batch is a zero-copy, read-only
                 view on data in Ray's object store, which can decrease memory
-                utilization and improve performance. Setting this to ``False``, 
-                will make a copy of the *whole* batch, therefore allowing UDF to 
-                modify underlying data buffers (like tensors, binary arrays, etc) 
+                utilization and improve performance. Setting this to ``False``,
+                will make a copy of the *whole* batch, therefore allowing UDF to
+                modify underlying data buffers (like tensors, binary arrays, etc)
                 in place. It's recommended to copy only the data you need to
                 modify instead of resorting to copying the whole batch.
             fn_args: Positional arguments to pass to ``fn`` after the first argument.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -481,10 +481,19 @@ class Dataset:
             To understand the format of the input to ``fn``, call :meth:`~Dataset.take_batch`
             on the dataset to get a batch in the same format as will be passed to ``fn``.
 
-        .. tip::
-            If ``fn`` doesn't mutate its input, set ``zero_copy_batch=True`` to improve
-            performance and decrease memory utilization.
-
+        .. note::
+            ``fn`` should generally avoid modifying data buffers behind its input
+            since these could be zero-copy views into the underlying object residing
+            inside Ray's Object Store.
+            
+            To perform any modifications it's recommended to copy the data you 
+            want to modify. 
+            
+            In rare cases when you can't copy inside your UDF, you can instead
+            specify ``zero_copy_batch=False`` and then Ray Data will copy the 
+            *whole* batch for you, providing ``fn`` with a copy rather than 
+            a zero-copy view.
+            
         .. warning::
             Specifying both ``num_cpus`` and ``num_gpus`` for map tasks is experimental,
             and may result in scheduling or stability issues. Please
@@ -607,11 +616,11 @@ class Dataset:
                 batches. If this is ``True`` and no copy is required for the
                 ``batch_format`` conversion, the batch is a zero-copy, read-only
                 view on data in Ray's object store, which can decrease memory
-                utilization and improve performance. If this is ``False``, the batch
-                is writable, which requires an extra copy to guarantee.
-                If ``fn`` mutates its input, this needs to be ``False`` in order to
-                avoid "assignment destination is read-only" or "buffer source array is
-                read-only" errors. Default is ``False``.
+                utilization and improve performance. Setting this to ``False``, 
+                will make a copy of the *whole* batch, therefore allowing UDF to 
+                modify underlying data buffers (like tensors, binary arrays, etc) 
+                in place. It's recommended to copy only the data you need to
+                modify instead of resorting to copying the whole batch.
             fn_args: Positional arguments to pass to ``fn`` after the first argument.
                 These arguments are top-level arguments to the underlying Ray task.
             fn_kwargs: Keyword arguments to pass to ``fn``. These arguments are

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -454,7 +454,7 @@ class Dataset:
         batch_size: Union[int, None, Literal["default"]] = None,
         compute: Optional[ComputeStrategy] = None,
         batch_format: Optional[str] = "default",
-        zero_copy_batch: bool = False,
+        zero_copy_batch: bool = True,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
         fn_constructor_args: Optional[Iterable[Any]] = None,
@@ -849,6 +849,7 @@ class Dataset:
             logical_plan = LogicalPlan(project_op, self.context)
         return Dataset(plan, logical_plan)
 
+    @Deprecated(message="Use `with_column` API instead")
     @PublicAPI(api_group=BT_API_GROUP)
     def add_column(
         self,
@@ -961,7 +962,7 @@ class Dataset:
             batch_format=batch_format,
             compute=compute,
             concurrency=concurrency,
-            zero_copy_batch=False,
+            zero_copy_batch=True,
             **ray_remote_args,
         )
 

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -98,7 +98,7 @@ class GroupedData:
         self,
         fn: UserDefinedFunction[DataBatch, DataBatch],
         *,
-        zero_copy_batch: bool = False,
+        zero_copy_batch: bool = True,
         compute: Union[str, ComputeStrategy] = None,
         batch_format: Optional[str] = "default",
         fn_args: Optional[Iterable[Any]] = None,

--- a/python/ray/data/tests/test_map_batches.py
+++ b/python/ray/data/tests/test_map_batches.py
@@ -480,7 +480,7 @@ def test_map_batches_batch_mutation(
     ds = ds.map_batches(lambda df: df, batch_format="pandas", batch_size=None)
 
     # Apply UDF that mutates the batches.
-    ds = ds.map_batches(mutate, batch_size=batch_size)
+    ds = ds.map_batches(mutate, batch_size=batch_size, zero_copy_batch=False)
     assert [row["id"] for row in ds.iter_rows()] == list(range(1, num_rows + 1))
 
 


### PR DESCRIPTION
## Description

Historically, the intention was to avoid failures upon attempts to modify provided batch in-place when, for ex, using Torch tensors.

However, that is unjustifiably penalizing 99.9% of use-cases for 0.1% of scenarios. As such, we're flipping this setting to be `zero_copy_batch=True` by default.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
