### PR TITLE
[core] fix metric collection for a few release tests

### DIFF
--- a/release/benchmarks/distributed/many_nodes_tests/dashboard_test.py
+++ b/release/benchmarks/distributed/many_nodes_tests/dashboard_test.py
@@ -7,15 +7,18 @@ from pprint import pprint
 import requests
 import ray
 import logging
+import os
 
 from collections import defaultdict
 from ray.util.state import list_nodes
-from ray._private.test_utils import fetch_prometheus_metrics
-from ray._common.network_utils import build_address
+from ray._private.test_utils import get_system_metric_for_component
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from pydantic import BaseModel
-from ray.dashboard.consts import DASHBOARD_METRIC_PORT
 from ray.dashboard.utils import get_address_for_submission_client
+from ray.dashboard.modules.metrics.metrics_head import (
+    DEFAULT_PROMETHEUS_HOST,
+    PROMETHEUS_HOST_ENV_VAR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -125,16 +128,11 @@ class DashboardTestAtScale:
             return Result(success=False)
 
         # Get the memory usage.
-        dashboard_export_addr = build_address(
-            self.addr["node_ip_address"], DASHBOARD_METRIC_PORT
+        memories = get_system_metric_for_component(
+            "ray_component_uss_mb",
+            "dashboard",
+            os.environ.get(PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST),
         )
-        metrics = fetch_prometheus_metrics([dashboard_export_addr])
-        memories = []
-        for name, samples in metrics.items():
-            if name == "ray_component_uss_mb":
-                for sample in samples:
-                    if sample.labels["Component"] == "dashboard":
-                        memories.append(sample.value)
 
         return Result(
             success=True, result=result, memory_mb=max(memories) if memories else None

--- a/release/dashboard/mem_check.py
+++ b/release/dashboard/mem_check.py
@@ -6,8 +6,12 @@ import json
 import ray
 
 from ray._private.memory_monitor import MemoryMonitor, get_top_n_memory_usage
-from ray._private.test_utils import raw_metrics
+from ray._private.test_utils import get_system_metric_for_component
 from ray.job_submission import JobSubmissionClient, JobStatus
+from ray.dashboard.modules.metrics.metrics_head import (
+    DEFAULT_PROMETHEUS_HOST,
+    PROMETHEUS_HOST_ENV_VAR,
+)
 
 # Initialize ray to avoid autosuspend.
 addr = ray.init()
@@ -63,18 +67,17 @@ if __name__ == "__main__":
         print(client.get_job_logs(job_id))
         assert False, "Job has failed."
 
-    me = raw_metrics(addr)
-    found = False
-    for metric, samples in me.items():
-        if metric == "ray_component_uss_mb":
-            for sample in samples:
-                if sample.labels["Component"] == "agent":
-                    print(f"Metrics found memory usage : {sample.value} MB")
-                    found = True
-                    # Make sure it doesn't use more than 500MB of data.
-                    assert sample.value < 500
-
-    assert found, "Agent memory metrics are not found."
+    uss_mb_for_agent_component = get_system_metric_for_component(
+        "ray_component_uss_mb",
+        "agent",
+        os.environ.get(PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST),
+    )
+    assert (
+        len(uss_mb_for_agent_component) > 0
+    ), "Agent component memory metrics are not found."
+    for mb in uss_mb_for_agent_component:
+        print(f"Agent component memory usage: {mb} MB")
+        assert mb < 500, "Agent component memory usage is too high."
 
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
         results = {


### PR DESCRIPTION
A few release tests currently use the `raw_metric` API to retrieve Prometheus metrics. This approach is unreliable because it directly polls the metric export endpoint, which can race with the Prometheus server that also polls the same endpoint.

To address this, add a method to query metrics directly from the Prometheus server instead. This ensures that in end-to-end and production environments, Prometheus remains the sole poller of exported metrics and the single source of truth for metric values.

Test:
- CI
- The memory metric is collected and the number makes sense: https://buildkite.com/ray-project/release/builds/66031/steps/canvas?sid=019a3215-e3be-4e9b-86a3-1f0a8253fea7#019a3215-e3f2-4d0e-877f-5f43d97d6e8e/557-654