### PR TITLE
[Data] Ensure Concatenator is deserializable from Ray 2.45

### DIFF
--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -384,13 +384,13 @@ class Preprocessor(abc.ABC):
         """
         return BatchFormat.PANDAS
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
         # Exclude unpicklable attributes
         state.pop("stat_computation_plan", None)
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]):
         from ray.data.preprocessors.utils import StatComputationPlan
 
         self.__dict__.update(state)

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -153,3 +153,10 @@ class Concatenator(Preprocessor):
                 non_default_arguments.append(f"{parameter}={value}")
 
         return f"{self.__class__.__name__}({', '.join(non_default_arguments)})"
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        super().__setstate__(state)
+        # flatten is a recent field, to ensure backwards compatibility
+        # assign a default in case it is missing in the serialized state
+        if not hasattr(self, "flatten"):
+            self.flatten = False

--- a/python/ray/data/tests/preprocessors/test_concatenator.py
+++ b/python/ray/data/tests/preprocessors/test_concatenator.py
@@ -175,6 +175,14 @@ class TestConcatenator:
             with pytest.raises(ValueError):
                 pd_ds = prep._transform_pandas(df)
 
+    def test_concatenator_deserialize_backward_compat(self):
+        p1 = Concatenator(columns=["A"], flatten=True)
+        delattr(p1, "flatten")
+        data = p1.serialize()
+        p2 = Concatenator.deserialize(data)
+        assert isinstance(p2, Concatenator)
+        assert p2.flatten is False
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Description
The Concatenator preprocessor gained new fields between Ray 2.45 and 2.49. Because Ray Data does not currently support forward-compatible preprocessor serialization, attempting to load serialized data from 2.45 fails in newer versions. This PR adds support to safely deserialize legacy Concatenator state by assigning defaults for missing fields like flatten.
