### PR TITLE
[Data] Add serialization framework for preprocessors

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -135,6 +135,9 @@ nitpick_ignore_regex = [
     ("py:class", ".*"),
     # Workaround for https://github.com/sphinx-doc/sphinx/issues/10974
     ("py:obj", "ray\\.data\\.datasource\\.datasink\\.WriteReturnType"),
+    # UnknownPreprocessorError is an internal exception not exported in public API
+    ("py:exc", "UnknownPreprocessorError"),
+    ("py:exc", "ray\\.data\\.preprocessors\\.version_support\\.UnknownPreprocessorError"),
 ]
 
 # Cache notebook outputs in _build/.jupyter_cache

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -502,6 +502,7 @@ You can use this with Ray Train Trainers by applying them on the dataset before 
 
 .. testcode::
 
+    import base64
     import numpy as np
     from tempfile import TemporaryDirectory
 
@@ -542,16 +543,22 @@ You can use this with Ray Train Trainers by applying them on the dataset before 
                 checkpoint=Checkpoint.from_directory(temp_dir),
             )
 
+    # Serialize the preprocessor. Since serialize() returns bytes,
+    # convert to base64 string for JSON compatibility.
+    serialized_preprocessor = base64.b64encode(scaler.serialize()).decode("ascii")
+
     my_trainer = TorchTrainer(
         train_loop_per_worker,
         scaling_config=ScalingConfig(num_workers=2),
         datasets={"train": dataset},
-        metadata={"preprocessor_pkl": scaler.serialize()},
+        metadata={"preprocessor_pkl": serialized_preprocessor},
     )
 
     # Get the fitted preprocessor back from the result metadata.
     metadata = my_trainer.fit().checkpoint.get_metadata()
-    print(StandardScaler.deserialize(metadata["preprocessor_pkl"]))
+    # Decode from base64 before deserializing
+    serialized_data = base64.b64decode(metadata["preprocessor_pkl"])
+    print(StandardScaler.deserialize(serialized_data))
 
 
 This example persists the fitted preprocessor using the ``Trainer(metadata={...})`` constructor argument. This arg specifies a dict that is available from ``TrainContext.get_metadata()`` and ``checkpoint.get_metadata()`` for checkpoints that the Trainer saves. This design enables the recreation of the fitted preprocessor for inference.

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -425,6 +425,7 @@ class Preprocessor(abc.ABC):
         return pickle.loads(base64.b64decode(serialized))
 
 
+@DeveloperAPI
 class SerializablePreprocessorBase(Preprocessor, abc.ABC):
     """Abstract base class for serializable preprocessors.
 
@@ -466,6 +467,7 @@ class SerializablePreprocessorBase(Preprocessor, abc.ABC):
     - Handle version migration and backwards compatibility in ``_set_serializable_fields()`` if needed
     """
 
+    @DeveloperAPI
     class SerializationFormat(Enum):
         CLOUDPICKLE = "cloudpickle"
         PICKLE = "pickle"  # legacy

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -1,10 +1,11 @@
 import abc
 import base64
 import collections
+import logging
 import pickle
 import warnings
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, final
 
 from ray.air.util.data_batch_conversion import BatchFormat
 from ray.util.annotations import DeveloperAPI, PublicAPI
@@ -15,6 +16,9 @@ if TYPE_CHECKING:
 
     from ray.air.data_batch_type import DataBatchType
     from ray.data.dataset import Dataset
+
+
+logger = logging.getLogger(__name__)
 
 
 @PublicAPI(stability="beta")
@@ -128,6 +132,9 @@ class Preprocessor(abc.ABC):
     def _fit_execute(self, dataset: "Dataset"):
         self.stats_ |= self.stat_computation_plan.compute(dataset)
         return self
+
+    def has_stats(self) -> bool:
+        return hasattr(self, "stats_") and len(self.stats_) > 0
 
     def fit_transform(
         self,
@@ -384,13 +391,19 @@ class Preprocessor(abc.ABC):
         """
         return BatchFormat.PANDAS
 
-    def __getstate__(self):
+    def get_input_columns(self) -> List[str]:
+        return getattr(self, "columns", [])
+
+    def get_output_columns(self) -> List[str]:
+        return getattr(self, "output_columns", [])
+
+    def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
         # Exclude unpicklable attributes
         state.pop("stat_computation_plan", None)
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]):
         from ray.data.preprocessors.utils import StatComputationPlan
 
         self.__dict__.update(state)
@@ -399,7 +412,6 @@ class Preprocessor(abc.ABC):
     @DeveloperAPI
     def serialize(self) -> str:
         """Return this preprocessor serialized as a string.
-
         Note: This is not a stable serialization format as it uses `pickle`.
         """
         # Convert it to a plain string so that it can be included as JSON metadata
@@ -411,3 +423,310 @@ class Preprocessor(abc.ABC):
     def deserialize(serialized: str) -> "Preprocessor":
         """Load the original preprocessor serialized via `self.serialize()`."""
         return pickle.loads(base64.b64decode(serialized))
+
+
+class SerializablePreprocessorBase(Preprocessor, abc.ABC):
+    """Abstract base class for serializable preprocessors.
+
+    This class defines the serialization interface that all preprocessors must implement
+    to support saving and loading their state. The serialization system uses CloudPickle
+    as the primary format.
+
+    **Architecture Overview:**
+
+    The serialization system is built around two types of methods:
+
+    1. **Final Methods (DO NOT OVERRIDE):**
+       - ``serialize()``: Orchestrates the serialization process
+       - ``deserialize()``: Orchestrates the deserialization process
+
+       These methods are marked as ``@final`` and should never be overridden by
+       subclasses. They handle format detection, factory coordination, and error handling.
+
+    2. **Abstract Methods (MUST IMPLEMENT):**
+       - ``_get_serializable_fields()``: Extract instance fields for serialization
+       - ``_set_serializable_fields()``: Restore instance fields from deserialization
+       - ``_get_stats()``: Extract computed statistics for serialization
+       - ``_set_stats()``: Restore computed statistics from deserialization
+
+       These methods must be implemented by each preprocessor subclass to define
+       their specific serialization behavior.
+
+    **Format Support:**
+
+    - **CloudPickle** (default):
+    - **Pickle** (legacy): Backward compatibility for existing serialized data
+
+    **Important Notes:**
+
+    - Never override ``serialize()`` or ``deserialize()`` in subclasses
+    - Always call ``super().__init__()`` in subclass constructors
+    - Use ``_fitted`` attribute to track fitting state
+    - Store computed statistics in ``stats_`` dictionary
+    - Handle version migration and backwards compatibility in ``_set_serializable_fields()`` if needed
+    """
+
+    class SerializationFormat(Enum):
+        CLOUDPICKLE = "cloudpickle"
+        PICKLE = "pickle"  # legacy
+
+    MAGIC_CLOUDPICKLE = b"CPKL:"
+    SERIALIZER_FORMAT_VERSION = 1
+
+    @abc.abstractmethod
+    def _get_serializable_fields(self) -> Dict[str, Any]:
+        """Extract instance fields that should be serialized.
+
+        This method should return a dictionary containing all instance attributes
+        that are necessary to restore the preprocessor's configuration state.
+        This typically includes constructor parameters and internal state flags.
+
+        Returns:
+            Dictionary mapping field names to their values
+        """
+        pass
+
+    @abc.abstractmethod
+    def _set_serializable_fields(self, fields: Dict[str, Any], version: int):
+        """Restore instance fields from deserialized data.
+
+        This method should restore the preprocessor's configuration state from
+        the provided fields' dictionary. It's called during deserialization to
+        recreate the instance state.
+
+        **Version Migration:**
+
+        If the serialized version differs from the current ``VERSION``,
+        implement migration logic to handle schema changes:
+
+        .. testcode::
+
+            def _set_serializable_fields(self, fields: Dict[str, Any], version: int):
+                # Handle version migration
+                if version == 1 and self.VERSION == 2:
+                    # Migrate from version 1 to 2
+                    if "old_field" in fields:
+                        fields["new_field"] = migrate_old_field(fields.pop("old_field"))
+
+                # Set all fields
+                for key, value in fields.items():
+                    setattr(self, key, value)
+
+                # Reinitialize derived state
+                self.stat_computation_plan = StatComputationPlan()
+
+        Args:
+            fields: Dictionary of field names to values
+            version: Version of the serialized data
+        """
+        pass
+
+    def _get_stats(self) -> Dict[str, Any]:
+        """Extract computed statistics that should be serialized.
+
+        This method should return the computed statistics that were generated
+        during the ``fit()`` process. These statistics are typically stored in
+        the ``stats_`` attribute and contain the learned parameters needed for
+        transformation.
+
+        Returns:
+            Dictionary containing computed statistics
+        """
+        return getattr(self, "stats_", {})
+
+    def _set_stats(self, stats: Dict[str, Any]):
+        """Restore computed statistics from deserialized data.
+
+        This method should restore the preprocessor's computed statistics from
+        the provided stats dictionary. These statistics are typically stored in
+        the ``stats_`` attribute and contain learned parameters from fitting.
+
+        Args:
+            stats: Dictionary containing computed statistics
+        """
+        self.stats_ = stats
+
+    @classmethod
+    def get_preprocessor_class_id(cls) -> str:
+        """Get the preprocessor class identifier for this preprocessor class.
+
+        Returns:
+            The preprocessor class identifier string used to identify this preprocessor
+            type in serialized data.
+        """
+        return cls.__PREPROCESSOR_CLASS_ID
+
+    @classmethod
+    def set_preprocessor_class_id(cls, identifier: str) -> None:
+        """Set the preprocessor class identifier for this preprocessor class.
+
+        Args:
+            identifier: The preprocessor class identifier string to use.
+        """
+        cls.__PREPROCESSOR_CLASS_ID = identifier
+
+    @classmethod
+    def get_version(cls) -> int:
+        """Get the version number for this preprocessor class.
+
+        Returns:
+            The version number for this preprocessor's serialization format.
+        """
+        return cls.__VERSION
+
+    @classmethod
+    def set_version(cls, version: int) -> None:
+        """Set the version number for this preprocessor class.
+
+        Args:
+            version: The version number for this preprocessor's serialization format.
+        """
+        cls.__VERSION = version
+
+    @final
+    @DeveloperAPI
+    def serialize(self) -> Union[str, bytes]:
+        """Serialize this preprocessor to a string or bytes.
+
+        **⚠️ DO NOT OVERRIDE THIS METHOD IN SUBCLASSES ⚠️**
+
+        This method is marked as ``@final`` in the concrete implementation and handles
+        the complete serialization orchestration. Subclasses should implement the
+        abstract methods instead: ``_get_serializable_fields()`` and ``_get_stats()``.
+
+        **Serialization Process:**
+
+        1. Extracts fields via ``_get_serializable_fields()``
+        2. Extracts statistics via ``_get_stats()``
+        3. Packages data with metadata (type, version, format)
+        4. Delegates to ``SerializationHandlerFactory`` for format-specific handling
+        5. Returns serialized data with magic bytes for format identification
+
+        **Supported Formats:**
+
+        - **CloudPickle** (default):
+        - **Pickle** (legacy): Backward compatibility for existing serialized data
+
+        Args:
+            output_format: The serialization format to use
+
+        Returns:
+            Serialized preprocessor data (bytes for CloudPickle, str for legacy Pickle)
+
+        Raises:
+            ValueError: If the serialization format is invalid or unsupported
+        """
+        from ray.data.preprocessors.serialization_handlers import (
+            HandlerFormatName,
+            SerializationHandlerFactory,
+        )
+
+        # Prepare data for CloudPickle format
+        data = {
+            "type": self.get_preprocessor_class_id(),
+            "version": self.get_version(),
+            "fields": self._get_serializable_fields(),
+            "stats": self._get_stats(),
+            # The `serializer_format_version` field is for versioning the structure of this
+            # dictionary. It is separate from the preprocessor's own version and is not used currently.
+            "serializer_format_version": self.SERIALIZER_FORMAT_VERSION,
+        }
+
+        return SerializationHandlerFactory.get_handler(
+            format_identifier=HandlerFormatName.CLOUDPICKLE
+        ).serialize(data)
+
+    @final
+    @staticmethod
+    @DeveloperAPI
+    def deserialize(serialized: Union[str, bytes]) -> "Preprocessor":
+        """Deserialize a preprocessor from serialized data.
+
+        **⚠️ DO NOT OVERRIDE THIS METHOD IN SUBCLASSES ⚠️**
+
+        This method is marked as ``@final`` in the concrete implementation and handles
+        the complete deserialization orchestration. Subclasses should implement the
+        abstract methods instead: ``_set_serializable_fields()`` and ``_set_stats()``.
+
+        **Deserialization Process:**
+
+        1. Detects format from magic bytes in serialized data
+        2. Delegates to ``SerializationHandlerFactory`` for format-specific parsing
+        3. Extracts metadata (type, version, fields, stats)
+        4. Looks up preprocessor class from registry
+        5. Creates new instance and restores state via abstract methods
+        6. Returns fully reconstructed preprocessor instance
+
+        **Format Detection:**
+
+        The method automatically detects the serialization format:
+        - ``CPKL:`` → CloudPickle format
+        - Base64 string → Legacy Pickle format
+
+        **Error Handling:**
+
+        Provides comprehensive error handling for:
+        - Unknown serialization formats
+        - Corrupted or invalid data
+        - Missing preprocessor types
+        - Version compatibility issues
+
+        Args:
+            serialized: Serialized preprocessor data (bytes or str)
+
+        Returns:
+            Reconstructed preprocessor instance
+
+        Raises:
+            ValueError: If the serialized data is corrupted or format is unrecognized
+            UnknownPreprocessorError: If the preprocessor type is not registered
+        """
+        from ray.data.preprocessors.serialization_handlers import (
+            PickleSerializationHandler,
+            SerializationHandlerFactory,
+        )
+        from ray.data.preprocessors.version_support import (
+            UnknownPreprocessorError,
+            _lookup_class,
+        )
+
+        try:
+            # Use factory to deserialize all formats (auto-detects format)
+            handler = SerializationHandlerFactory.get_handler(data=serialized)
+            meta = handler.deserialize(serialized)
+
+            # Handle pickle specially - it returns the object directly
+            if isinstance(handler, PickleSerializationHandler):
+                return meta  # For pickle, meta is actually the deserialized object
+
+            # Reconstruct the preprocessor object for structured formats
+            cls = _lookup_class(meta["type"])
+
+            # Validate metadata
+            if meta["serializer_format_version"] != cls.SERIALIZER_FORMAT_VERSION:
+                raise ValueError(
+                    f"Unsupported serializer format version: {meta['serializer_format_version']}"
+                )
+
+            obj = cls.__new__(cls)
+
+            # handle base class fields here
+            from ray.data.preprocessors.utils import StatComputationPlan
+
+            obj.stat_computation_plan = StatComputationPlan()
+
+            obj._set_serializable_fields(fields=meta["fields"], version=meta["version"])
+
+            obj._set_stats(stats=meta["stats"])
+            return obj
+        except UnknownPreprocessorError:
+            # Let UnknownPreprocessorError pass through unchanged for specific error handling
+            raise
+        except Exception as e:
+            # Provide more helpful error message for other exception types
+            raise ValueError(
+                f"Failed to deserialize preprocessor. Data preview: {serialized[:50]}..."
+            ) from e
+
+
+SerializationFormat = SerializablePreprocessorBase.SerializationFormat

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -676,7 +676,7 @@ class SerializablePreprocessorBase(Preprocessor, abc.ABC):
 
         Raises:
             ValueError: If the serialized data is corrupted or format is unrecognized
-            ray.data.preprocessors.version_support.UnknownPreprocessorError: If the preprocessor type is not registered
+            UnknownPreprocessorError: If the preprocessor type is not registered
         """
         from ray.data.preprocessors.serialization_handlers import (
             PickleSerializationHandler,

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -676,7 +676,7 @@ class SerializablePreprocessorBase(Preprocessor, abc.ABC):
 
         Raises:
             ValueError: If the serialized data is corrupted or format is unrecognized
-            UnknownPreprocessorError: If the preprocessor type is not registered
+            ray.data.preprocessors.version_support.UnknownPreprocessorError: If the preprocessor type is not registered
         """
         from ray.data.preprocessors.serialization_handlers import (
             PickleSerializationHandler,

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -607,9 +607,6 @@ class SerializablePreprocessorBase(Preprocessor, abc.ABC):
         - **CloudPickle** (default):
         - **Pickle** (legacy): Backward compatibility for existing serialized data
 
-        Args:
-            output_format: The serialization format to use
-
         Returns:
             Serialized preprocessor data (bytes for CloudPickle, str for legacy Pickle)
 

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -153,3 +153,10 @@ class Concatenator(Preprocessor):
                 non_default_arguments.append(f"{parameter}={value}")
 
         return f"{self.__class__.__name__}({', '.join(non_default_arguments)})"
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        super().__setstate__(state)
+        # flatten is a recent field, to ensure backwards compatibility
+        # assign a default in case it is missing in the serialized state
+        if not hasattr(self, "flatten"):
+            self.flatten = False

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -1,10 +1,11 @@
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 
 from ray.data.aggregate import AbsMax, ApproximateQuantile, Max, Mean, Min, Std
-from ray.data.preprocessor import Preprocessor
+from ray.data.preprocessor import Preprocessor, SerializablePreprocessorBase
+from ray.data.preprocessors.version_support import SerializablePreprocessor
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
@@ -12,7 +13,8 @@ if TYPE_CHECKING:
 
 
 @PublicAPI(stability="alpha")
-class StandardScaler(Preprocessor):
+@SerializablePreprocessor(version=1, identifier="io.ray.preprocessors.standard_scaler")
+class StandardScaler(SerializablePreprocessorBase):
     r"""Translate and scale each column by its mean and standard deviation,
     respectively.
 
@@ -117,12 +119,27 @@ class StandardScaler(Preprocessor):
         df[self.output_columns] = df[self.columns].transform(column_standard_scaler)
         return df
 
+    def _get_serializable_fields(self) -> Dict[str, Any]:
+        return {
+            "columns": self.columns,
+            "output_columns": self.output_columns,
+            "_fitted": getattr(self, "_fitted", None),
+        }
+
+    def _set_serializable_fields(self, fields: Dict[str, Any], version: int):
+        # required fields
+        self.columns = fields["columns"]
+        self.output_columns = fields["output_columns"]
+        # optional fields
+        self._fitted = fields.get("_fitted")
+
     def __repr__(self):
         return f"{self.__class__.__name__}(columns={self.columns!r}, output_columns={self.output_columns!r})"
 
 
 @PublicAPI(stability="alpha")
-class MinMaxScaler(Preprocessor):
+@SerializablePreprocessor(version=1, identifier="io.ray.preprocessors.min_max_scaler")
+class MinMaxScaler(SerializablePreprocessorBase):
     r"""Scale each column by its range.
 
     The general formula is given by
@@ -214,12 +231,27 @@ class MinMaxScaler(Preprocessor):
         df[self.output_columns] = df[self.columns].transform(column_min_max_scaler)
         return df
 
+    def _get_serializable_fields(self) -> Dict[str, Any]:
+        return {
+            "columns": self.columns,
+            "output_columns": self.output_columns,
+            "_fitted": getattr(self, "_fitted", None),
+        }
+
+    def _set_serializable_fields(self, fields: Dict[str, Any], version: int):
+        # required fields
+        self.columns = fields["columns"]
+        self.output_columns = fields["output_columns"]
+        # optional fields
+        self._fitted = fields.get("_fitted")
+
     def __repr__(self):
         return f"{self.__class__.__name__}(columns={self.columns!r}, output_columns={self.output_columns!r})"
 
 
 @PublicAPI(stability="alpha")
-class MaxAbsScaler(Preprocessor):
+@SerializablePreprocessor(version=1, identifier="io.ray.preprocessors.max_abs_scaler")
+class MaxAbsScaler(SerializablePreprocessorBase):
     r"""Scale each column by its absolute max value.
 
     The general formula is given by
@@ -305,12 +337,27 @@ class MaxAbsScaler(Preprocessor):
         df[self.output_columns] = df[self.columns].transform(column_abs_max_scaler)
         return df
 
+    def _get_serializable_fields(self) -> Dict[str, Any]:
+        return {
+            "columns": self.columns,
+            "output_columns": self.output_columns,
+            "_fitted": getattr(self, "_fitted", None),
+        }
+
+    def _set_serializable_fields(self, fields: Dict[str, Any], version: int):
+        # required fields
+        self.columns = fields["columns"]
+        self.output_columns = fields["output_columns"]
+        # optional fields
+        self._fitted = fields.get("_fitted")
+
     def __repr__(self):
         return f"{self.__class__.__name__}(columns={self.columns!r}, output_columns={self.output_columns!r})"
 
 
 @PublicAPI(stability="alpha")
-class RobustScaler(Preprocessor):
+@SerializablePreprocessor(version=1, identifier="io.ray.preprocessors.robust_scaler")
+class RobustScaler(SerializablePreprocessorBase):
     r"""Scale and translate each column using approximate quantiles.
 
     The general formula is given by
@@ -445,6 +492,22 @@ class RobustScaler(Preprocessor):
 
         df[self.output_columns] = df[self.columns].transform(column_robust_scaler)
         return df
+
+    def _get_serializable_fields(self) -> Dict[str, Any]:
+        return {
+            "columns": self.columns,
+            "output_columns": self.output_columns,
+            "quantile_range": self.quantile_range,
+            "_fitted": getattr(self, "_fitted", None),
+        }
+
+    def _set_serializable_fields(self, fields: Dict[str, Any], version: int):
+        # required fields
+        self.columns = fields["columns"]
+        self.output_columns = fields["output_columns"]
+        self.quantile_range = fields["quantile_range"]
+        # optional fields
+        self._fitted = fields.get("_fitted")
 
     def __repr__(self):
         return (

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -498,6 +498,7 @@ class RobustScaler(SerializablePreprocessorBase):
             "columns": self.columns,
             "output_columns": self.output_columns,
             "quantile_range": self.quantile_range,
+            "quantile_precision": self.quantile_precision,
             "_fitted": getattr(self, "_fitted", None),
         }
 
@@ -506,6 +507,7 @@ class RobustScaler(SerializablePreprocessorBase):
         self.columns = fields["columns"]
         self.output_columns = fields["output_columns"]
         self.quantile_range = fields["quantile_range"]
+        self.quantile_precision = fields["quantile_precision"]
         # optional fields
         self._fitted = fields.get("_fitted")
 

--- a/python/ray/data/preprocessors/serialization_handlers.py
+++ b/python/ray/data/preprocessors/serialization_handlers.py
@@ -1,0 +1,193 @@
+"""
+Serialization handlers for preprocessor save/load functionality.
+
+This module implements a factory pattern to abstract different serialization formats,
+making it easier to add new formats and maintain existing ones.
+"""
+
+import abc
+import base64
+import pickle
+from enum import Enum
+from typing import Any, Dict, Optional, Union
+
+from ray.cloudpickle import cloudpickle
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class HandlerFormatName(Enum):
+    """Enum for consistent format naming in the factory."""
+
+    CLOUDPICKLE = "cloudpickle"
+    PICKLE = "pickle"
+
+
+@DeveloperAPI
+class SerializationHandler(abc.ABC):
+    """Abstract base class for handling preprocessor serialization formats."""
+
+    @abc.abstractmethod
+    def serialize(
+        self, data: Union["Preprocessor", Dict[str, Any]]  # noqa: F821
+    ) -> Union[str, bytes]:
+        """Serialize preprocessor data to the specific format.
+
+        Args:
+            data: Dictionary containing preprocessor metadata and stats
+
+        Returns:
+            Serialized data in format-specific representation
+        """
+        pass
+
+    @abc.abstractmethod
+    def deserialize(self, serialized: Union[str, bytes]) -> Any:
+        """Deserialize data from the specific format.
+
+        Args:
+            serialized: Serialized data in format-specific representation
+
+        Returns:
+            For structured formats (CloudPickle/JSON/MessagePack): Dictionary containing preprocessor metadata and stats
+            For pickle format: The actual deserialized object
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_magic_bytes(self) -> Union[str, bytes]:
+        """Get the magic bytes/prefix for this format."""
+        pass
+
+    def strip_magic_bytes(self, serialized: Union[str, bytes]) -> Union[str, bytes]:
+        """Remove magic bytes from serialized data."""
+        magic = self.get_magic_bytes()
+        if isinstance(serialized, (str, bytes)) and serialized.startswith(magic):
+            return serialized[len(magic) :]
+        return serialized
+
+
+@DeveloperAPI
+class CloudPickleSerializationHandler(SerializationHandler):
+    """Handler for CloudPickle serialization format."""
+
+    MAGIC_CLOUDPICKLE = b"CPKL:"
+
+    def serialize(
+        self, data: Union["Preprocessor", Dict[str, Any]]  # noqa: F821
+    ) -> bytes:
+        """Serialize to CloudPickle format with magic prefix."""
+        return self.MAGIC_CLOUDPICKLE + cloudpickle.dumps(data)
+
+    def deserialize(self, serialized: bytes) -> Dict[str, Any]:
+        """Deserialize from CloudPickle format."""
+        if not isinstance(serialized, bytes):
+            raise ValueError(
+                f"Expected bytes for CloudPickle deserialization, got {type(serialized)}"
+            )
+
+        if not serialized.startswith(self.MAGIC_CLOUDPICKLE):
+            raise ValueError(f"Invalid CloudPickle magic bytes: {serialized[:10]}")
+
+        cloudpickle_data = self.strip_magic_bytes(serialized)
+        return cloudpickle.loads(cloudpickle_data)
+
+    def get_magic_bytes(self) -> bytes:
+        return self.MAGIC_CLOUDPICKLE
+
+
+@DeveloperAPI
+class PickleSerializationHandler(SerializationHandler):
+    """Handler for legacy Pickle serialization format."""
+
+    def serialize(
+        self, data: Union["Preprocessor", Dict[str, Any]]  # noqa: F821
+    ) -> str:
+        """
+        Serialize using pickle format (for backward compatibility).
+        data is ignored, but kept for consistency
+
+        """
+        return base64.b64encode(pickle.dumps(data)).decode("ascii")
+
+    def deserialize(
+        self, serialized: str
+    ) -> Any:  # Returns the actual object, not metadata
+        """Deserialize from pickle format (legacy support)."""
+        # For pickle, we return the actual deserialized object directly
+        return pickle.loads(base64.b64decode(serialized))
+
+    def get_magic_bytes(self) -> str:
+        return ""  # Pickle format doesn't use magic bytes
+
+
+class SerializationHandlerFactory:
+    """Factory class for creating appropriate serialization handlers."""
+
+    _handlers = {
+        HandlerFormatName.CLOUDPICKLE: CloudPickleSerializationHandler,
+        HandlerFormatName.PICKLE: PickleSerializationHandler,
+    }
+
+    @classmethod
+    def register_handler(cls, format_name: HandlerFormatName, handler_class: type):
+        """Register a new serialization handler."""
+        cls._handlers[format_name] = handler_class
+
+    @classmethod
+    def get_handler(
+        cls,
+        format_identifier: Optional[HandlerFormatName] = None,
+        data: Optional[Union[str, bytes]] = None,
+        **kwargs,
+    ) -> SerializationHandler:
+        """Get the appropriate serialization handler for a format or serialized data.
+
+        Args:
+
+
+        Returns:
+            SerializationHandler instance for the format
+
+        Raises:
+            ValueError: If format is not supported or cannot be detected
+        """
+        # If it's already a format enum, use it directly
+        if not format_identifier:
+            format_identifier = cls.detect_format(data)
+
+        if format_identifier not in cls._handlers:
+            raise ValueError(
+                f"Unsupported serialization format: {format_identifier.value}. "
+                f"Supported formats: {list(cls._handlers.keys())}"
+            )
+
+        handler_class = cls._handlers[format_identifier]
+        return handler_class()
+
+    @classmethod
+    def detect_format(cls, serialized: Union[str, bytes]) -> HandlerFormatName:
+        """Detect the serialization format from the magic bytes.
+
+        Args:
+            serialized: Serialized data
+
+        Returns:
+            Format name enum
+
+        Raises:
+            ValueError: If format cannot be detected
+        """
+        # Check for CloudPickle first (binary format)
+        if isinstance(serialized, bytes) and serialized.startswith(
+            CloudPickleSerializationHandler.MAGIC_CLOUDPICKLE
+        ):
+            return HandlerFormatName.CLOUDPICKLE
+
+        # Check for legacy pickle format (no magic bytes, should be base64 encoded)
+        if isinstance(serialized, str):
+            return HandlerFormatName.PICKLE
+
+        raise ValueError(
+            f"Cannot detect serialization format from: {serialized[:20]}..."
+        )

--- a/python/ray/data/preprocessors/serialization_handlers.py
+++ b/python/ray/data/preprocessors/serialization_handlers.py
@@ -144,7 +144,9 @@ class SerializationHandlerFactory:
         """Get the appropriate serialization handler for a format or serialized data.
 
         Args:
-
+            format_identifier: The format to use for serialization. If None, will detect from data.
+            data: Serialized data to detect format from (used when format_identifier is None).
+            **kwargs: Additional keyword arguments (currently unused).
 
         Returns:
             SerializationHandler instance for the format

--- a/python/ray/data/preprocessors/version_support.py
+++ b/python/ray/data/preprocessors/version_support.py
@@ -1,0 +1,83 @@
+class UnknownPreprocessorError(ValueError):
+    """Raised when attempting to deserialize an unknown/unregistered preprocessor type."""
+
+    def __init__(self, preprocessor_type: str):
+        self.preprocessor_type = preprocessor_type
+        super().__init__(f"Unknown preprocessor type: {preprocessor_type}")
+
+
+_PREPROCESSOR_REGISTRY = {}
+
+
+def SerializablePreprocessor(version: int, identifier: str):
+    """Register a preprocessor class for serialization.
+
+    This decorator registers a preprocessor class in the serialization registry,
+    enabling it to be serialized and deserialized. The decorated class MUST inherit
+    from SerializablePreprocessor.
+
+    Args:
+        version: Version number for this preprocessor's serialization format
+        identifier: Stable identifier for serialization. This identifier will be used
+            in serialized data. Using an explicit identifier allows classes to be
+            renamed without breaking compatibility with existing serialized data.
+
+    Raises:
+        TypeError: If the decorated class does not inherit from SerializablePreprocessor
+
+    Note:
+        If a class with the same identifier is already registered, logs an info message
+        and overwrites the previous registration.
+
+    Examples:
+        @SerializablePreprocessor(version=1, identifier="my_preprocessor_v1")
+        class MyPreprocessor(SerializablePreprocessor):
+            pass
+    """
+
+    def decorator(cls):
+        import logging
+
+        from ray.data.preprocessor import SerializablePreprocessorBase
+
+        # Verify that the class inherits from SerializablePreprocessor
+        if not issubclass(cls, SerializablePreprocessorBase):
+            raise TypeError(
+                f"Class {cls.__module__}.{cls.__qualname__} must inherit from "
+                f"SerializablePreprocessor to use @SerializablePreprocessor decorator."
+            )
+
+        cls.set_version(version)
+        cls.set_preprocessor_class_id(identifier)
+
+        # Check for collisions and log info message
+        if identifier in _PREPROCESSOR_REGISTRY:
+            existing = _PREPROCESSOR_REGISTRY[identifier]
+            if existing != cls:
+                logging.info(
+                    f"Preprocessor id collision: '{identifier}' was already registered "
+                    f"by {existing.__module__}.{existing.__qualname__}. "
+                    f"Overwriting with {cls.__module__}.{cls.__qualname__}."
+                )
+
+        _PREPROCESSOR_REGISTRY[identifier] = cls
+        return cls
+
+    return decorator
+
+
+def _lookup_class(serialization_id: str):
+    """Look up a preprocessor class by its serialization ID.
+
+    Args:
+        serialization_id: The serialization ID of the preprocessor (either explicit or class name)
+
+    Returns:
+        The registered preprocessor class
+
+    Raises:
+        UnknownPreprocessorError: If the serialization ID is not registered
+    """
+    if serialization_id not in _PREPROCESSOR_REGISTRY:
+        raise UnknownPreprocessorError(serialization_id)
+    return _PREPROCESSOR_REGISTRY[serialization_id]

--- a/python/ray/data/preprocessors/version_support.py
+++ b/python/ray/data/preprocessors/version_support.py
@@ -22,6 +22,9 @@ def SerializablePreprocessor(version: int, identifier: str):
             in serialized data. Using an explicit identifier allows classes to be
             renamed without breaking compatibility with existing serialized data.
 
+    Returns:
+        A decorator function that registers the class and returns it unchanged.
+
     Raises:
         TypeError: If the decorated class does not inherit from SerializablePreprocessor
 

--- a/python/ray/data/preprocessors/version_support.py
+++ b/python/ray/data/preprocessors/version_support.py
@@ -79,7 +79,7 @@ def _lookup_class(serialization_id: str):
         The registered preprocessor class
 
     Raises:
-        UnknownPreprocessorError: If the serialization ID is not registered
+        ray.data.preprocessors.version_support.UnknownPreprocessorError: If the serialization ID is not registered
     """
     if serialization_id not in _PREPROCESSOR_REGISTRY:
         raise UnknownPreprocessorError(serialization_id)

--- a/python/ray/data/preprocessors/version_support.py
+++ b/python/ray/data/preprocessors/version_support.py
@@ -79,7 +79,7 @@ def _lookup_class(serialization_id: str):
         The registered preprocessor class
 
     Raises:
-        ray.data.preprocessors.version_support.UnknownPreprocessorError: If the serialization ID is not registered
+        UnknownPreprocessorError: If the serialization ID is not registered
     """
     if serialization_id not in _PREPROCESSOR_REGISTRY:
         raise UnknownPreprocessorError(serialization_id)

--- a/python/ray/data/tests/preprocessors/test_concatenator.py
+++ b/python/ray/data/tests/preprocessors/test_concatenator.py
@@ -175,6 +175,14 @@ class TestConcatenator:
             with pytest.raises(ValueError):
                 pd_ds = prep._transform_pandas(df)
 
+    def test_concatenator_deserialize_backward_compat(self):
+        p1 = Concatenator(columns=["A"], flatten=True)
+        delattr(p1, "flatten")
+        data = p1.serialize()
+        p2 = Concatenator.deserialize(data)
+        assert isinstance(p2, Concatenator)
+        assert p2.flatten is False
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/data/tests/preprocessors/test_imputer.py
+++ b/python/ray/data/tests/preprocessors/test_imputer.py
@@ -1,10 +1,24 @@
+"""
+Tests for SimpleImputer functionality and serialization.
+
+This file contains:
+1. Basic functional tests for SimpleImputer operations
+2. Comprehensive serialization/deserialization tests
+"""
+import tempfile
+import time
+
 import numpy as np
 import pandas as pd
 import pytest
 
 import ray
-from ray.data.preprocessor import PreprocessorNotFittedException
+from ray.data.preprocessor import (
+    PreprocessorNotFittedException,
+    SerializablePreprocessorBase,
+)
 from ray.data.preprocessors import SimpleImputer
+from ray.data.preprocessors.version_support import UnknownPreprocessorError
 
 
 def test_simple_imputer():
@@ -206,6 +220,405 @@ def test_imputer_constant_categorical():
 
     for column in df:
         np.testing.assert_array_equal(transformed_df[column].values, expected[column])
+
+
+class TestSimpleImputerSerialization:
+    """Test CloudPickle-based serialization/deserialization functionality for SimpleImputer."""
+
+    def setup_method(self):
+        """Set up test data."""
+        self.df_numeric = pd.DataFrame(
+            {
+                "temp": [20.0, 25.0, None, 30.0, None],
+                "humidity": [60.0, None, 70.0, 80.0, 65.0],
+                "other": ["a", "b", "c", "d", "e"],  # Non-processed column
+            }
+        )
+
+    def test_basic_serialization(self):
+        """Test basic serialization and deserialization functionality."""
+        # Create and fit a simple imputer
+        imputer = SimpleImputer(columns=["temp", "humidity"], strategy="mean")
+
+        # Create test data
+        df = pd.DataFrame(
+            {
+                "temp": [1.0, 2.0, None, 4.0],
+                "humidity": [None, 2.0, 3.0, 4.0],
+                "other": [1, 2, 3, 4],
+            }
+        )
+
+        # Fit the imputer
+        dataset = ray.data.from_pandas(df)
+        fitted_imputer = imputer.fit(dataset)
+
+        # Serialize using CloudPickle (primary format)
+        serialized = fitted_imputer.serialize()
+
+        # Verify it's binary CloudPickle format
+        assert isinstance(serialized, bytes)
+        assert serialized.startswith(SerializablePreprocessorBase.MAGIC_CLOUDPICKLE)
+
+        # Deserialize
+        deserialized = SimpleImputer.deserialize(serialized)
+
+        # Verify type and state
+        assert isinstance(deserialized, SimpleImputer)
+        assert deserialized._fitted
+        assert deserialized.columns == ["temp", "humidity"]
+        assert deserialized.strategy == "mean"
+
+        # Verify stats are preserved
+        assert "mean(temp)" in deserialized.stats_
+        assert "mean(humidity)" in deserialized.stats_
+        assert abs(deserialized.stats_["mean(temp)"] - 2.333333) < 0.001
+        assert abs(deserialized.stats_["mean(humidity)"] - 3.0) < 0.001
+
+    def test_serialization_formats(self):
+        """Test serialization and deserialization."""
+        imputer = SimpleImputer(columns=["temp"], strategy="mean")
+        dataset = ray.data.from_pandas(self.df_numeric)
+        fitted_imputer = imputer.fit(dataset)
+
+        # Test CloudPickle format (default)
+        serialized = fitted_imputer.serialize()
+        assert isinstance(serialized, bytes)
+        assert serialized.startswith(SerializablePreprocessorBase.MAGIC_CLOUDPICKLE)
+
+        # Deserialize and verify it works
+        deserialized = SimpleImputer.deserialize(serialized)
+
+        # Verify it works correctly
+        test_df = pd.DataFrame({"temp": [None, 35.0], "other": [1, 2]})
+        result = deserialized.transform_batch(test_df.copy())
+
+        # Verify the result has the expected structure
+        assert "temp" in result.columns
+        assert "other" in result.columns
+
+    def test_functional_equivalence(self):
+        """Test that deserialized SimpleImputer works identically to original."""
+        # Create and fit original
+        imputer = SimpleImputer(columns=["value"], strategy="mean")
+        train_df = pd.DataFrame({"value": [10, 20, None, 40], "id": [1, 2, 3, 4]})
+        train_dataset = ray.data.from_pandas(train_df)
+        fitted_imputer = imputer.fit(train_dataset)
+
+        # Test data
+        test_df = pd.DataFrame({"value": [None, 50, None], "id": [5, 6, 7]})
+
+        # Transform with original
+        original_result = fitted_imputer.transform_batch(test_df.copy())
+
+        # Serialize, deserialize, and transform (using CloudPickle)
+        serialized = fitted_imputer.serialize()
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+        deserialized_result = deserialized.transform_batch(test_df.copy())
+
+        # Results should be identical
+        pd.testing.assert_frame_equal(original_result, deserialized_result)
+
+        # Verify specific values
+        expected_mean = (10 + 20 + 40) / 3  # 23.333...
+        assert abs(original_result.iloc[0]["value"] - expected_mean) < 1e-10
+        assert abs(deserialized_result.iloc[0]["value"] - expected_mean) < 1e-10
+
+    def test_complex_stats_preservation(self):
+        """Test that CloudPickle perfectly preserves complex stats with various key types."""
+        imputer = SimpleImputer(columns=["A"], strategy="mean")
+
+        # Manually set complex stats that would be problematic for other formats
+        imputer.stats_ = {
+            # Simple stats
+            "mean(A)": 5.0,
+            "count(A)": 100,
+            # Complex key types that CloudPickle handles natively
+            "unique_values(ints)": {1: 0, 2: 1, 3: 2, 4: 3, 5: 4},  # int keys
+            "unique_values(floats)": {1.1: 0, 2.2: 1, 3.3: 2},  # float keys
+            "unique_values(bools)": {True: 0, False: 1},  # bool keys
+            "unique_values(none)": {None: 0},  # None keys
+            "unique_values(tuples)": {
+                ("red", "car"): 0,
+                ("blue", "bike"): 1,
+                (1, 2, 3): 2,
+                ("nested", ("inner", "tuple")): 3,
+            },
+            "unique_values(sets)": {
+                frozenset([1, 2, 3]): 0,
+                frozenset(["a", "b"]): 1,
+            },
+            "unique_values(mixed)": {
+                "string": 0,
+                42: 1,
+                (1, 2): 2,
+                frozenset([3, 4]): 3,
+                None: 4,
+                True: 5,
+            },
+        }
+        imputer._fitted = True
+
+        # Serialize and deserialize (using CloudPickle)
+        serialized = imputer.serialize()
+        deserialized = SimpleImputer.deserialize(serialized)
+
+        # Verify ALL stats are perfectly preserved
+        assert deserialized.stats_ == imputer.stats_
+
+        # Verify specific complex key preservation
+        for stat_name, stat_dict in imputer.stats_.items():
+            if isinstance(stat_dict, dict):
+                original_keys = set(stat_dict.keys())
+                restored_keys = set(deserialized.stats_[stat_name].keys())
+
+                # Keys should be identical (including types)
+                assert original_keys == restored_keys
+
+                # Values should be identical
+                for key in original_keys:
+                    assert stat_dict[key] == deserialized.stats_[stat_name][key]
+
+                # Key types should be preserved
+                for orig_key, rest_key in zip(original_keys, restored_keys):
+                    if orig_key == rest_key:  # Same key
+                        assert type(orig_key) is type(rest_key)
+
+    def test_performance_comparison(self):
+        """Test CloudPickle performance and simplicity."""
+        # Create a large imputer with many stats
+        imputer = SimpleImputer(
+            columns=[f"col_{i}" for i in range(10)], strategy="mean"
+        )
+
+        # Create large stats dictionary
+        large_stats = {}
+        for i in range(10):
+            large_stats[f"mean(col_{i})"] = float(i)
+            large_stats[f"count(col_{i})"] = 1000 + i
+
+            # Add complex key stats that CloudPickle handles natively
+            large_stats[f"unique_values(col_{i})"] = {
+                (f"key_{j}", j): j for j in range(100)  # 100 tuple keys per column
+            }
+
+        imputer.stats_ = large_stats
+        imputer._fitted = True
+
+        # Test serialization performance and correctness (using CloudPickle)
+        start_time = time.time()
+        serialized = imputer.serialize()
+        serialize_time = time.time() - start_time
+
+        start_time = time.time()
+        deserialized = SimpleImputer.deserialize(serialized)
+        deserialize_time = time.time() - start_time
+
+        # Verify correctness
+        assert deserialized.stats_ == imputer.stats_
+        assert len(deserialized.stats_) == len(imputer.stats_)
+
+        # Performance should be reasonable (less than 1 second for this size)
+        assert serialize_time < 1.0
+        assert deserialize_time < 1.0
+
+        # Verify no data loss with complex keys
+        for stat_name in large_stats:
+            if "unique_values" in stat_name:
+                original_keys = set(large_stats[stat_name].keys())
+                restored_keys = set(deserialized.stats_[stat_name].keys())
+                assert original_keys == restored_keys
+
+    def test_cloudpickle_native_support(self):
+        """Test that CloudPickle handles all Python types natively without transformation."""
+        imputer = SimpleImputer(columns=["A"], strategy="mean")
+
+        # Test all the key types that used to require custom transformation
+        test_keys = [
+            # Basic types
+            "string_key",
+            42,  # int
+            3.14,  # float
+            True,  # bool
+            False,  # bool
+            None,  # None
+            # Complex types that CloudPickle handles natively
+            (1, 2, 3),  # tuple
+            ("nested", ("inner", "tuple")),  # nested tuple
+            frozenset([1, 2, 3]),  # frozenset
+            frozenset(["a", "b"]),  # frozenset with strings
+        ]
+
+        # Create stats with all these key types
+        imputer.stats_ = {
+            "test_dict": {key: f"value_{i}" for i, key in enumerate(test_keys)}
+        }
+        imputer._fitted = True
+
+        # Serialize and deserialize (using CloudPickle)
+        serialized = imputer.serialize()
+        deserialized = SimpleImputer.deserialize(serialized)
+
+        # Verify perfect preservation
+        original_dict = imputer.stats_["test_dict"]
+        restored_dict = deserialized.stats_["test_dict"]
+
+        assert len(original_dict) == len(restored_dict)
+
+        # Check each key-value pair and key type preservation
+        for orig_key, orig_value in original_dict.items():
+            # Key should exist and have same value
+            assert orig_key in restored_dict
+            assert restored_dict[orig_key] == orig_value
+
+            # Find the corresponding restored key to check type
+            for rest_key in restored_dict.keys():
+                if rest_key == orig_key:
+                    assert type(orig_key) is type(rest_key)
+                    break
+
+    def test_edge_case_empty_stats(self):
+        """Test serialization with empty stats."""
+        imputer = SimpleImputer(columns=["A"], strategy="constant", fill_value=0)
+        # Constant strategy doesn't need fitting, so stats will be empty
+
+        serialized = imputer.serialize()
+        deserialized = SimpleImputer.deserialize(serialized)
+
+        assert deserialized.stats_ == {}
+        assert deserialized.strategy == "constant"
+        assert deserialized.fill_value == 0
+        assert deserialized._is_fittable is False
+
+    def test_edge_case_none_values(self):
+        """Test serialization with None values in stats."""
+        imputer = SimpleImputer(columns=["A"], strategy="mean")
+        imputer._fitted = True
+        imputer.stats_ = {
+            "mean(A)": None,
+            "count(A)": 0,
+            "complex_dict": {
+                None: "none_key",
+                "none_value": None,
+                (None, "tuple"): "tuple_with_none",
+            },
+        }
+
+        serialized = imputer.serialize()
+        deserialized = SimpleImputer.deserialize(serialized)
+
+        assert deserialized.stats_ == imputer.stats_
+        assert deserialized.stats_["mean(A)"] is None
+        assert None in deserialized.stats_["complex_dict"]
+
+    def test_nested_complex_structures(self):
+        """Test deeply nested complex data structures."""
+        imputer = SimpleImputer(columns=["A"], strategy="mean")
+        imputer._fitted = True
+
+        # Create deeply nested structure with various key types
+        imputer.stats_ = {
+            "nested_structure": {
+                ("level1", "tuple"): {
+                    frozenset([1, 2]): "frozenset_key",
+                    42: {"nested_dict": "value"},
+                    None: [1, 2, 3],
+                    True: {"another": {"level": "deep"}},
+                }
+            }
+        }
+
+        serialized = imputer.serialize()
+        deserialized = SimpleImputer.deserialize(serialized)
+
+        assert deserialized.stats_ == imputer.stats_
+
+        # Verify specific nested access works
+        nested = deserialized.stats_["nested_structure"]
+        tuple_key = ("level1", "tuple")
+        assert tuple_key in nested
+        assert frozenset([1, 2]) in nested[tuple_key]
+
+    def test_unknown_preprocessor_type(self):
+        """Test error when trying to deserialize unknown preprocessor type."""
+        import cloudpickle
+
+        # Create fake serialized data with unknown type
+        unknown_data = {
+            "type": "NonExistentPreprocessor",
+            "version": 1,
+            "fields": {"columns": ["test"]},
+            "stats": {},
+            "stats_type": "cloudpickle",
+        }
+
+        fake_serialized = (
+            SerializablePreprocessorBase.MAGIC_CLOUDPICKLE
+            + cloudpickle.dumps(unknown_data)
+        )
+
+        with pytest.raises(UnknownPreprocessorError) as exc_info:
+            SerializablePreprocessorBase.deserialize(fake_serialized)
+
+        # Verify the exception contains the correct preprocessor type
+        assert exc_info.value.preprocessor_type == "NonExistentPreprocessor"
+        assert "Unknown preprocessor type: NonExistentPreprocessor" in str(
+            exc_info.value
+        )
+
+    def test_file_system_integration(self):
+        """Test integration with file system operations."""
+        imputer = SimpleImputer(columns=["value"], strategy="mean")
+        df = pd.DataFrame({"value": [1, 2, None, 4]})
+        dataset = ray.data.from_pandas(df)
+        fitted = imputer.fit(dataset)
+
+        # Test with binary files (CloudPickle)
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".cloudpickle") as f:
+            # Save as CloudPickle
+            serialized = fitted.serialize()
+            f.write(serialized)
+            f.flush()
+
+            # Load from file
+            with open(f.name, "rb") as read_f:
+                loaded_data = read_f.read()
+
+            deserialized = SerializablePreprocessorBase.deserialize(loaded_data)
+            assert isinstance(deserialized, SimpleImputer)
+            assert abs(deserialized.stats_["mean(value)"] - 2.333333333333333) < 1e-10
+
+    def test_special_numeric_values(self):
+        """Test serialization with inf, -inf, and NaN values."""
+        # Test with inf fill_value
+        imputer1 = SimpleImputer(columns=["col"], strategy="mean")
+        imputer1.stats_ = {"mean(col)": float("inf")}
+        imputer1._fitted = True
+
+        serialized = imputer1.serialize()
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+        assert np.isinf(deserialized.stats_["mean(col)"])
+
+        # Test with -inf fill_value
+        imputer2 = SimpleImputer(columns=["col"], strategy="mean")
+        imputer2.stats_ = {"mean(col)": float("-inf")}
+        imputer2._fitted = True
+
+        serialized = imputer2.serialize()
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+        assert (
+            np.isinf(deserialized.stats_["mean(col)"])
+            and deserialized.stats_["mean(col)"] < 0
+        )
+
+        # Test with NaN fill_value
+        imputer3 = SimpleImputer(columns=["col"], strategy="mean")
+        imputer3.stats_ = {"mean(col)": float("nan")}
+        imputer3._fitted = True
+
+        serialized = imputer3.serialize()
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+        assert np.isnan(deserialized.stats_["mean(col)"])
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -417,6 +417,50 @@ def test_numpy_pandas_support_transform_batch_tensor(create_dummy_preprocessors)
     )
 
 
+def test_get_input_output_columns():
+    """Tests get_input_columns() and get_output_columns() methods."""
+    # Test with preprocessors that have columns attribute
+    scaler = StandardScaler(columns=["A", "B"])
+    assert scaler.get_input_columns() == ["A", "B"]
+    assert scaler.get_output_columns() == ["A", "B"]
+
+    # Test with output_columns specified
+    scaler_with_output = StandardScaler(
+        columns=["A", "B"], output_columns=["A_scaled", "B_scaled"]
+    )
+    assert scaler_with_output.get_input_columns() == ["A", "B"]
+    assert scaler_with_output.get_output_columns() == ["A_scaled", "B_scaled"]
+
+    # Test with encoders
+    encoder = OneHotEncoder(columns=["X", "Y"])
+    assert encoder.get_input_columns() == ["X", "Y"]
+    assert encoder.get_output_columns() == ["X", "Y"]
+
+    encoder_with_output = OneHotEncoder(
+        columns=["X", "Y"], output_columns=["X_encoded", "Y_encoded"]
+    )
+    assert encoder_with_output.get_input_columns() == ["X", "Y"]
+    assert encoder_with_output.get_output_columns() == ["X_encoded", "Y_encoded"]
+
+    # Test LabelEncoder without output_column (in-place transformation)
+    label_encoder = LabelEncoder(label_column="target")
+    assert label_encoder.get_input_columns() == ["target"]
+    assert label_encoder.get_output_columns() == ["target"]
+
+    # Test LabelEncoder with output_column (append mode)
+    label_encoder = LabelEncoder(label_column="target", output_column="target_encoded")
+    assert label_encoder.get_input_columns() == ["target"]
+    assert label_encoder.get_output_columns() == ["target_encoded"]
+
+    # Test with preprocessor without columns attribute
+    class CustomPreprocessor(Preprocessor):
+        _is_fittable = False
+
+    custom = CustomPreprocessor()
+    assert custom.get_input_columns() == []
+    assert custom.get_output_columns() == []
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/preprocessors/test_scaler.py
+++ b/python/ray/data/tests/preprocessors/test_scaler.py
@@ -3,7 +3,10 @@ import pandas as pd
 import pytest
 
 import ray
-from ray.data.preprocessor import PreprocessorNotFittedException
+from ray.data.preprocessor import (
+    PreprocessorNotFittedException,
+    SerializablePreprocessorBase,
+)
 from ray.data.preprocessors import (
     MaxAbsScaler,
     MinMaxScaler,
@@ -363,6 +366,298 @@ def test_standard_scaler():
     )
 
     pd.testing.assert_frame_equal(pred_out_df, pred_expected_df, check_like=True)
+
+
+class TestScalerSerialization:
+    """Test serialization/deserialization functionality for scaler preprocessors."""
+
+    def setup_method(self):
+        """Set up test data."""
+        self.test_df = pd.DataFrame(
+            {
+                "feature1": [1, 2, 3, 4, 5],
+                "feature2": [10, 20, 30, 40, 50],
+                "feature3": [100, 200, 300, 400, 500],
+                "other": ["a", "b", "c", "d", "e"],
+            }
+        )
+        self.test_dataset = ray.data.from_pandas(self.test_df)
+
+    @pytest.mark.parametrize(
+        "scaler_class,fit_data,expected_stats,transform_data",
+        [
+            (
+                StandardScaler,
+                None,  # Use default self.test_df
+                {
+                    "mean(feature1)": 3.0,
+                    "mean(feature2)": 30.0,
+                    "std(feature1)": np.sqrt(2.0),
+                    "std(feature2)": np.sqrt(200.0),
+                },
+                pd.DataFrame(
+                    {
+                        "feature1": [6, 7, 8],
+                        "feature2": [60, 70, 80],
+                        "other": ["f", "g", "h"],
+                    }
+                ),
+            ),
+            (
+                MinMaxScaler,
+                None,  # Use default self.test_df
+                {
+                    "min(feature1)": 1,
+                    "min(feature2)": 10,
+                    "max(feature1)": 5,
+                    "max(feature2)": 50,
+                },
+                pd.DataFrame(
+                    {
+                        "feature1": [6, 7, 8],
+                        "feature2": [60, 70, 80],
+                        "other": ["f", "g", "h"],
+                    }
+                ),
+            ),
+            (
+                MaxAbsScaler,
+                pd.DataFrame(
+                    {
+                        "feature1": [-5, -2, 0, 2, 5],
+                        "feature2": [-50, -20, 0, 20, 50],
+                        "other": ["a", "b", "c", "d", "e"],
+                    }
+                ),
+                {
+                    "abs_max(feature1)": 5,
+                    "abs_max(feature2)": 50,
+                },
+                pd.DataFrame(
+                    {
+                        "feature1": [-6, 0, 6],
+                        "feature2": [-60, 0, 60],
+                        "other": ["f", "g", "h"],
+                    }
+                ),
+            ),
+            (
+                RobustScaler,
+                None,  # Use default self.test_df
+                {
+                    "low_quantile(feature1)": 2.0,
+                    "median(feature1)": 3.0,
+                    "high_quantile(feature1)": 4.0,
+                    "low_quantile(feature2)": 20.0,
+                    "median(feature2)": 30.0,
+                    "high_quantile(feature2)": 40.0,
+                },
+                pd.DataFrame(
+                    {
+                        "feature1": [6, 7, 8],
+                        "feature2": [60, 70, 80],
+                        "other": ["f", "g", "h"],
+                    }
+                ),
+            ),
+        ],
+        ids=["StandardScaler", "MinMaxScaler", "MaxAbsScaler", "RobustScaler"],
+    )
+    def test_scaler_serialization(
+        self, scaler_class, fit_data, expected_stats, transform_data
+    ):
+        """Test scaler serialization for all scaler types."""
+        # Use custom fit data if provided, otherwise use default test dataset
+        if fit_data is not None:
+            fit_dataset = ray.data.from_pandas(fit_data)
+        else:
+            fit_dataset = self.test_dataset
+
+        # Create and fit scaler
+        scaler = scaler_class(columns=["feature1", "feature2"])
+        fitted_scaler = scaler.fit(fit_dataset)
+
+        # Verify fitted stats match expected values
+        assert fitted_scaler.stats_ == expected_stats, (
+            f"Stats mismatch for {scaler_class.__name__}:\n"
+            f"Expected: {expected_stats}\n"
+            f"Got: {fitted_scaler.stats_}"
+        )
+
+        # Test CloudPickle serialization
+        serialized = fitted_scaler.serialize()
+        assert isinstance(serialized, bytes)
+        assert serialized.startswith(SerializablePreprocessorBase.MAGIC_CLOUDPICKLE)
+
+        # Test deserialization
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+        assert deserialized.__class__.__name__ == scaler_class.__name__
+        assert deserialized.columns == ["feature1", "feature2"]
+        assert deserialized._fitted
+
+        # Verify stats are preserved after deserialization
+        assert deserialized.stats_ == expected_stats, (
+            f"Deserialized stats mismatch for {scaler_class.__name__}:\n"
+            f"Expected: {expected_stats}\n"
+            f"Got: {deserialized.stats_}"
+        )
+
+        # Verify each stat key exists and has correct value
+        for stat_key, stat_value in expected_stats.items():
+            assert stat_key in deserialized.stats_
+            if isinstance(stat_value, float):
+                assert np.isclose(deserialized.stats_[stat_key], stat_value)
+            else:
+                assert deserialized.stats_[stat_key] == stat_value
+
+        # Test functional equivalence
+        original_result = fitted_scaler.transform_batch(transform_data.copy())
+        deserialized_result = deserialized.transform_batch(transform_data.copy())
+
+        pd.testing.assert_frame_equal(original_result, deserialized_result)
+
+    def test_scaler_with_output_columns_serialization(self):
+        """Test scaler serialization with custom output columns."""
+        # Test with StandardScaler and output columns
+        scaler = StandardScaler(
+            columns=["feature1", "feature2"],
+            output_columns=["scaled_feature1", "scaled_feature2"],
+        )
+        fitted_scaler = scaler.fit(self.test_dataset)
+
+        # Serialize and deserialize
+        serialized = fitted_scaler.serialize()
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+
+        # Verify output columns are preserved
+        assert deserialized.output_columns == ["scaled_feature1", "scaled_feature2"]
+
+        # Test functional equivalence
+        test_df = pd.DataFrame(
+            {"feature1": [6, 7, 8], "feature2": [60, 70, 80], "other": ["f", "g", "h"]}
+        )
+
+        original_result = fitted_scaler.transform_batch(test_df.copy())
+        deserialized_result = deserialized.transform_batch(test_df.copy())
+
+        pd.testing.assert_frame_equal(original_result, deserialized_result)
+
+    @pytest.mark.parametrize(
+        "scaler_class",
+        [StandardScaler, MinMaxScaler, MaxAbsScaler, RobustScaler],
+        ids=["StandardScaler", "MinMaxScaler", "MaxAbsScaler", "RobustScaler"],
+    )
+    def test_unfitted_scaler_serialization(self, scaler_class):
+        """Test serialization of unfitted scalers."""
+        # Test unfitted scaler
+        scaler = scaler_class(columns=["feature1", "feature2"])
+
+        # Serialize unfitted scaler
+        serialized = scaler.serialize()
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+
+        # Verify it's still unfitted
+        assert not deserialized._fitted
+        assert deserialized.columns == ["feature1", "feature2"]
+        assert deserialized.__class__.__name__ == scaler_class.__name__
+
+        # Should raise error when trying to transform
+        test_df = pd.DataFrame({"feature1": [1, 2, 3], "feature2": [10, 20, 30]})
+        with pytest.raises(PreprocessorNotFittedException):
+            deserialized.transform_batch(test_df)
+
+    @pytest.mark.parametrize(
+        "scaler_class,expected_stats",
+        [
+            (
+                StandardScaler,
+                {
+                    "mean(feature1)": 3.0,
+                    "std(feature1)": np.sqrt(2.0),
+                },
+            ),
+            (
+                MinMaxScaler,
+                {
+                    "min(feature1)": 1,
+                    "max(feature1)": 5,
+                },
+            ),
+            (
+                MaxAbsScaler,
+                {
+                    "abs_max(feature1)": 5,
+                },
+            ),
+            (
+                RobustScaler,
+                {
+                    "low_quantile(feature1)": 2.0,
+                    "median(feature1)": 3.0,
+                    "high_quantile(feature1)": 4.0,
+                },
+            ),
+        ],
+        ids=["StandardScaler", "MinMaxScaler", "MaxAbsScaler", "RobustScaler"],
+    )
+    def test_scaler_stats_preservation(self, scaler_class, expected_stats):
+        """Test that scaler statistics are perfectly preserved during serialization."""
+        # Create scaler with known stats
+        scaler = scaler_class(columns=["feature1"])
+        fitted_scaler = scaler.fit(self.test_dataset)
+
+        # Verify fitted stats match expected values
+        for stat_key, stat_value in expected_stats.items():
+            assert stat_key in fitted_scaler.stats_
+            if isinstance(stat_value, float):
+                assert np.isclose(fitted_scaler.stats_[stat_key], stat_value)
+            else:
+                assert fitted_scaler.stats_[stat_key] == stat_value
+
+        # Get original stats
+        original_stats = fitted_scaler.stats_.copy()
+
+        # Serialize and deserialize
+        serialized = fitted_scaler.serialize()
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+
+        # Verify stats are identical
+        assert deserialized.stats_ == original_stats
+
+        # Verify expected stat values are preserved
+        for stat_key, stat_value in expected_stats.items():
+            assert stat_key in deserialized.stats_
+            if isinstance(stat_value, float):
+                assert np.isclose(deserialized.stats_[stat_key], stat_value)
+            else:
+                assert deserialized.stats_[stat_key] == stat_value
+
+    @pytest.mark.parametrize(
+        "scaler_class",
+        [StandardScaler, MinMaxScaler, MaxAbsScaler, RobustScaler],
+        ids=["StandardScaler", "MinMaxScaler", "MaxAbsScaler", "RobustScaler"],
+    )
+    def test_scaler_version_compatibility(self, scaler_class):
+        """Test that scalers can be deserialized with version support."""
+        # Create and fit scaler
+        scaler = scaler_class(columns=["feature1", "feature2"])
+        fitted_scaler = scaler.fit(self.test_dataset)
+
+        # Serialize
+        serialized = fitted_scaler.serialize()
+
+        # Deserialize and verify version handling
+        deserialized = SerializablePreprocessorBase.deserialize(serialized)
+        assert deserialized.__class__.__name__ == scaler_class.__name__
+        assert deserialized._fitted
+
+        # Test that it works correctly
+        test_df = pd.DataFrame({"feature1": [6, 7, 8], "feature2": [60, 70, 80]})
+
+        result = deserialized.transform_batch(test_df)
+        assert len(result.columns) == 2  # Should have the scaled columns
+        assert "feature1" in result.columns
+        assert "feature2" in result.columns
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This commit introduces a new serialization system for Ray Data preprocessors that improves maintainability, extensibility, and backward compatibility.

Key changes:

1. New serialization infrastructure:
   - Add serialization_handlers.py with factory pattern for format handling
   - Implement CloudPickleSerializationHandler (primary format)
   - Support legacy PickleSerializationHandler for backward compatibility
   - Add format auto-detection via magic bytes (CPKL:)

2. New preprocessor base class:
   - Add SerializablePreprocessorBase abstract class
   - Define serialization interface via abstract methods:
     * _get_serializable_fields() / _set_serializable_fields()
     * _get_stats() / _set_stats()
   - Mark serialize() and deserialize() as @final to prevent overrides

3. Preprocessor registration system:
   - Add version_support.py with @SerializablePreprocessor decorator
   - Enable versioned serialization with stable identifiers
   - Support class registration and lookup
   - Add UnknownPreprocessorError for missing types

4. Migrate preprocessors to new framework:
   - SimpleImputer
   - OrdinalEncoder
   - OneHotEncoder
   - MultiHotEncoder
   - LabelEncoder
   - Categorizer
   - StandardScaler
   - MinMaxScaler
   - MaxAbsScaler
    - RobustScaler

5. Enhanced Preprocessor base class:
   - Add get_input_columns() and get_output_columns() methods (for future use)
   - Add has_stats() (for future use)
   - Add type hints to __getstate__() and __setstate__()

6. Backward compatibility improvements to Concatenator for existing functionality:
   - Add __setstate__ override in Concatenator for flatten field
   - Handle missing fields gracefully during deserialization

The new architecture makes it easier to:
- Add new serialization formats without modifying core logic
- Maintain backward compatibility with existing serialized data
- Handle version migrations for preprocessor schemas
- Register new preprocessors with stable identifiers
