### PR TITLE
[train][jax] Enable Jax trainer on GPU

### DIFF
--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -246,6 +246,22 @@ py_test(
 )
 
 py_test(
+    name = "test_jax_gpu",
+    size = "medium",
+    srcs = ["tests/test_jax_gpu.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2_gpu",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_lightgbm_trainer",
     size = "small",
     srcs = ["tests/test_lightgbm_trainer.py"],

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -110,7 +110,6 @@ class _JaxBackend(Backend):
                     use_tpu=backend_config.use_tpu,
                     use_gpu=backend_config.use_gpu,
                     resources_per_worker=worker_group.get_resources_per_worker(),
-                )
             )
         ray.get(setup_futures)
 

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -57,14 +57,12 @@ def _setup_jax_distributed_environment(
         os.environ["JAX_PLATFORMS"] = "tpu"
         jax_platforms = "tpu"
 
-    if use_gpu:
-        if not os.environ.get("JAX_PLATFORMS"):
-            os.environ["JAX_PLATFORMS"] = "cuda"
+    if not jax_platforms and use_gpu:
+        os.environ["JAX_PLATFORMS"] = "cuda"
 
-            num_gpus = resources_per_worker.get("GPU", 0)
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(
-                str(i) for i in range(num_gpus)
-            )
+        num_gpus = resources_per_worker.get("GPU", 0)
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(num_gpus))
+        jax_platforms = "cuda"
 
     import jax
 

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -26,7 +26,6 @@ class JaxConfig(BackendConfig):
     def backend_cls(self):
         return _JaxBackend
 
-
 def _setup_jax_distributed_environment(
     master_addr_with_port: str, num_workers: int, index: int, use_tpu: bool
 ):
@@ -52,6 +51,7 @@ def _setup_jax_distributed_environment(
     # TODO(lehui): Add env vars for JAX on GPU.
 
     import jax
+
 
     if "tpu" in jax_platforms.split(","):
         jax.distributed.initialize(master_addr_with_port, num_workers, index)

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -71,6 +71,7 @@ def _setup_jax_distributed_environment(
 
     if "tpu" in jax_platforms.split(","):
         jax.distributed.initialize(master_addr_with_port, num_workers, index)
+        logger.info("Initialized JAX distributed on TPU.")
 
     if "cuda" in jax_platforms.split(","):
         if num_gpus_per_worker > 0:
@@ -80,7 +81,7 @@ def _setup_jax_distributed_environment(
         jax.distributed.initialize(
             master_addr_with_port, num_workers, index, local_device_ids
         )
-    logger.info("Initialized JAX distributed.")
+        logger.info("Initialized JAX distributed on CUDA.")
 
 
 def _shutdown_jax_distributed():

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -124,7 +124,7 @@ class _JaxBackend(Backend):
 
     def on_shutdown(self, worker_group: WorkerGroup, backend_config: JaxConfig):
         """Cleanup JAX distributed resources when shutting down worker group."""
-        if not backend_config.use_tpu or not backend_config.use_gpu:
+        if not backend_config.use_tpu and not backend_config.use_gpu:
             return
 
         # Shutdown JAX distributed on all workers

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -55,8 +55,9 @@ def _setup_jax_distributed_environment(
     if use_gpu:
         if not os.environ.get("JAX_PLATFORMS"):
             os.environ["JAX_PLATFORMS"] = "cuda"
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(list(range(resources_per_worker.get("GPU", 0))))
-    # TODO(lehui): Add env vars for JAX on GPU.
+
+            num_gpus = resources_per_worker.get("GPU", 0)
+            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(num_gpus))
 
     import jax
 

--- a/python/ray/train/v2/jax/config.py
+++ b/python/ray/train/v2/jax/config.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class JaxConfig(BackendConfig):
     use_tpu: bool = False
+    use_gpu: bool = False
 
     @property
     def backend_cls(self):
@@ -79,7 +80,6 @@ class _JaxBackend(Backend):
         master_addr_with_port = f"{master_addr}:{master_port}"
 
         # Set up JAX distributed environment on all workers
-        # This sets JAX_PLATFORMS env var and initializes JAX distributed
         setup_futures = []
         for i in range(len(worker_group)):
             setup_futures.append(
@@ -90,6 +90,7 @@ class _JaxBackend(Backend):
                     num_workers=len(worker_group),
                     index=i,
                     use_tpu=backend_config.use_tpu,
+                    use_gpu=backend_config.use_gpu,
                 )
             )
         ray.get(setup_futures)

--- a/python/ray/train/v2/jax/jax_trainer.py
+++ b/python/ray/train/v2/jax/jax_trainer.py
@@ -132,6 +132,7 @@ class JaxTrainer(DataParallelTrainer):
         if not jax_config:
             jax_config = JaxConfig(
                 use_tpu=scaling_config.use_tpu,
+                use_gpu=scaling_config.use_gpu,
             )
         super(JaxTrainer, self).__init__(
             train_loop_per_worker=train_loop_per_worker,

--- a/python/ray/train/v2/tests/test_jax_gpu.py
+++ b/python/ray/train/v2/tests/test_jax_gpu.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from ray.train import RunConfig, ScalingConfig
@@ -16,6 +18,7 @@ def reduce_health_check_interval(monkeypatch):
     yield
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="JAX GPU not supported on macOS")
 def test_jax_distributed_gpu_training(ray_start_4_cpus_2_gpus, tmp_path):
     """Test multi-GPU JAX distributed training.
 

--- a/python/ray/train/v2/tests/test_jax_gpu.py
+++ b/python/ray/train/v2/tests/test_jax_gpu.py
@@ -1,0 +1,62 @@
+import pytest
+
+from ray.train import RunConfig, ScalingConfig
+from ray.train.v2._internal.constants import (
+    HEALTH_CHECK_INTERVAL_S_ENV_VAR,
+    is_v2_enabled,
+)
+from ray.train.v2.jax import JaxTrainer
+
+assert is_v2_enabled()
+
+
+@pytest.fixture(autouse=True)
+def reduce_health_check_interval(monkeypatch):
+    monkeypatch.setenv(HEALTH_CHECK_INTERVAL_S_ENV_VAR, "0.2")
+    yield
+
+
+def test_jax_distributed_gpu_training(ray_start_4_cpus_2_gpus, tmp_path):
+    """Test multi-GPU JAX distributed training.
+
+    This test verifies that JAX distributed initialization works correctly
+    across multiple GPU workers and that they can coordinate.
+    """
+
+    def train_func():
+        import jax
+
+        from ray import train
+
+        # Get JAX distributed info
+        devices = jax.devices()
+        world_rank = train.get_context().get_world_rank()
+        world_size = train.get_context().get_world_size()
+
+        # Verify distributed setup
+        assert world_size == 2, f"Expected world size 2, got {world_size}"
+        assert world_rank in [0, 1], f"Invalid rank {world_rank}"
+        assert len(devices) == 2, f"Expected 2 devices, got {len(devices)}"
+
+        train.report(
+            {
+                "world_rank": world_rank,
+                "world_size": world_size,
+                "num_devices": len(devices),
+            }
+        )
+
+    trainer = JaxTrainer(
+        train_func,
+        scaling_config=ScalingConfig(num_workers=2, use_gpu=True),
+        run_config=RunConfig(storage_path=str(tmp_path)),
+    )
+
+    result = trainer.fit()
+    assert result.error is None
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -87,6 +87,11 @@ def mock_jax_distributed(monkeypatch):
 
 
 def train_func():
+    import os
+
+    # Set JAX_PLATFORMS to cpu for testing (avoid TPU initialization without hardware)
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
     import jax
 
     from ray import train

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -63,6 +63,29 @@ def reduce_health_check_interval(monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def mock_jax_distributed(monkeypatch):
+    """Mock JAX distributed setup/shutdown to avoid TPU initialization in tests.
+
+    This prevents the RuntimeError: Unable to initialize backend 'tpu' error
+    in test environments without actual TPU hardware.
+    """
+    # Mock the setup and shutdown functions to prevent JAX TPU initialization
+    mock_setup = mock.MagicMock()
+    mock_shutdown = mock.MagicMock()
+
+    monkeypatch.setattr(
+        "ray.train.v2.jax.config._setup_jax_distributed_environment",
+        mock_setup,
+    )
+    monkeypatch.setattr(
+        "ray.train.v2.jax.config._shutdown_jax_distributed",
+        mock_shutdown,
+    )
+
+    yield
+
+
 def train_func():
     import jax
 
@@ -173,28 +196,24 @@ def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
-    # Mock JAX distributed setup to avoid TPU initialization
-    with mock.patch(
-        "ray.train.v2.jax.config._setup_jax_distributed_environment"
-    ), mock.patch("ray.train.v2.jax.config._shutdown_jax_distributed"):
-        trainer = JaxTrainer(
-            train_loop_per_worker=train_func_check_env,
-            scaling_config=ScalingConfig(
-                num_workers=1,
-                resources_per_worker={"TPU": 8},
-                use_tpu=True,
-                accelerator_type="TPU-V6E",
-            ),
-            run_config=RunConfig(
-                storage_path=str(tmp_path),
-                worker_runtime_env={
-                    "env_vars": {
-                        "JAX_PLATFORMS": "tpu,cpu",
-                    },
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_func_check_env,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            resources_per_worker={"TPU": 8},
+            use_tpu=True,
+            accelerator_type="TPU-V6E",
+        ),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+            worker_runtime_env={
+                "env_vars": {
+                    "JAX_PLATFORMS": "tpu,cpu",
                 },
-            ),
-        )
-        trainer.fit()
+            },
+        ),
+    )
+    trainer.fit()
 
 
 def test_jax_platforms_env_var_with_existing_other(
@@ -209,28 +228,24 @@ def test_jax_platforms_env_var_with_existing_other(
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
-    # Mock JAX distributed setup to avoid TPU initialization
-    with mock.patch(
-        "ray.train.v2.jax.config._setup_jax_distributed_environment"
-    ), mock.patch("ray.train.v2.jax.config._shutdown_jax_distributed"):
-        trainer = JaxTrainer(
-            train_loop_per_worker=train_func_check_env,
-            scaling_config=ScalingConfig(
-                num_workers=1,
-                resources_per_worker={"TPU": 8},
-                use_tpu=True,
-                accelerator_type="TPU-V6E",
-            ),
-            run_config=RunConfig(
-                storage_path=str(tmp_path),
-                worker_runtime_env={
-                    "env_vars": {
-                        "JAX_PLATFORMS": "cpu",
-                    },
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_func_check_env,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            resources_per_worker={"TPU": 8},
+            use_tpu=True,
+            accelerator_type="TPU-V6E",
+        ),
+        run_config=RunConfig(
+            storage_path=str(tmp_path),
+            worker_runtime_env={
+                "env_vars": {
+                    "JAX_PLATFORMS": "cpu",
                 },
-            ),
-        )
-        trainer.fit()
+            },
+        ),
+    )
+    trainer.fit()
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -171,6 +171,7 @@ def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
+
     trainer = JaxTrainer(
         train_loop_per_worker=train_func_check_env,
         scaling_config=ScalingConfig(

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -171,7 +171,6 @@ def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
         jax_platforms = os.environ.get("JAX_PLATFORMS", "")
         assert jax_platforms == "tpu,cpu"
 
-
     trainer = JaxTrainer(
         train_loop_per_worker=train_func_check_env,
         scaling_config=ScalingConfig(

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 import ray
@@ -63,35 +61,7 @@ def reduce_health_check_interval(monkeypatch):
     yield
 
 
-@pytest.fixture(autouse=True)
-def mock_jax_distributed(monkeypatch):
-    """Mock JAX distributed setup/shutdown to avoid TPU initialization in tests.
-
-    This prevents the RuntimeError: Unable to initialize backend 'tpu' error
-    in test environments without actual TPU hardware.
-    """
-    # Mock the setup and shutdown functions to prevent JAX TPU initialization
-    mock_setup = mock.MagicMock()
-    mock_shutdown = mock.MagicMock()
-
-    monkeypatch.setattr(
-        "ray.train.v2.jax.config._setup_jax_distributed_environment",
-        mock_setup,
-    )
-    monkeypatch.setattr(
-        "ray.train.v2.jax.config._shutdown_jax_distributed",
-        mock_shutdown,
-    )
-
-    yield
-
-
 def train_func():
-    import os
-
-    # Set JAX_PLATFORMS to cpu for testing (avoid TPU initialization without hardware)
-    os.environ["JAX_PLATFORMS"] = "cpu"
-
     import jax
 
     from ray import train
@@ -162,95 +132,6 @@ def test_minimal_multihost(ray_tpu_multi_host, tmp_path):
         if node["Alive"] and node["Labels"].get("ray.io/tpu-slice-name") == slice_label
     ]
     assert len(labeled_nodes) == 2
-
-
-def test_jax_platforms_env_var_no_existing(ray_tpu_single_host, tmp_path, monkeypatch):
-    """Test that JAX_PLATFORMS is set to 'tpu' when use_tpu=True and no existing value."""
-    # Ensure JAX_PLATFORMS is not set
-    monkeypatch.delenv("JAX_PLATFORMS", raising=False)
-
-    def train_func_check_env():
-        """Training function to verify JAX_PLATFORMS env var is set."""
-        import os
-
-        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
-        assert jax_platforms == "tpu"
-
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=True,
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-        ),
-    )
-    trainer.fit()
-
-
-def test_jax_platforms_env_var_with_existing_tpu(ray_tpu_single_host, tmp_path):
-    """Test that JAX_PLATFORMS is not modified when 'tpu' is already present."""
-
-    def train_func_check_env():
-        """Training function to verify JAX_PLATFORMS env var is set."""
-        import os
-
-        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
-        assert jax_platforms == "tpu,cpu"
-
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=True,
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-            worker_runtime_env={
-                "env_vars": {
-                    "JAX_PLATFORMS": "tpu,cpu",
-                },
-            },
-        ),
-    )
-    trainer.fit()
-
-
-def test_jax_platforms_env_var_with_existing_other(
-    ray_tpu_single_host, tmp_path, monkeypatch
-):
-    """Test that 'tpu' is prepended when JAX_PLATFORMS contains other platforms."""
-
-    def train_func_check_env():
-        """Training function to verify JAX_PLATFORMS env var is set."""
-        import os
-
-        jax_platforms = os.environ.get("JAX_PLATFORMS", "")
-        assert jax_platforms == "tpu,cpu"
-
-    trainer = JaxTrainer(
-        train_loop_per_worker=train_func_check_env,
-        scaling_config=ScalingConfig(
-            num_workers=1,
-            resources_per_worker={"TPU": 8},
-            use_tpu=True,
-            accelerator_type="TPU-V6E",
-        ),
-        run_config=RunConfig(
-            storage_path=str(tmp_path),
-            worker_runtime_env={
-                "env_vars": {
-                    "JAX_PLATFORMS": "cpu",
-                },
-            },
-        ),
-    )
-    trainer.fit()
 
 
 if __name__ == "__main__":

--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -27,3 +27,7 @@ torch-spline-conv==1.2.2
 torch-geometric==2.5.3
 
 cupy-cuda12x==13.1.0; sys_platform != 'darwin'
+
+# Keep JAX version consistent with dl-gpu-requirements.txt
+jax==0.4.20
+jaxlib==0.4.20

--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -29,5 +29,5 @@ torch-geometric==2.5.3
 cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 
 # Keep JAX version consistent with dl-gpu-requirements.txt
-jax==0.4.20
-jaxlib==0.4.20
+jax==0.3.27
+jaxlib==0.3.27

--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -29,5 +29,5 @@ torch-geometric==2.5.3
 cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 
 # Keep JAX version consistent with dl-gpu-requirements.txt
-jax==0.4.13
-jaxlib==0.4.13
+jax==0.4.13; python_version < '3.12' and sys_platform != 'darwin'
+jaxlib==0.4.13; python_version < '3.12' and sys_platform != 'darwin'

--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -29,5 +29,5 @@ torch-geometric==2.5.3
 cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 
 # Keep JAX version consistent with dl-gpu-requirements.txt
-jax==0.3.27
-jaxlib==0.3.27
+jax==0.4.13
+jaxlib==0.4.13

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -18,7 +18,7 @@ torch-spline-conv==1.2.2+pt23cu121
 cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 nixl==0.4.0; sys_platform != 'darwin'
 
--find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+--find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 # Downgrading to JAX 0.4.20 to be compatible with CUDA 12.1 (which is older than what JAX 0.4.23+ expects)
 jax==0.4.20; sys_platform != 'darwin'
 jaxlib==0.4.20+cuda12.cudnn89; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -17,3 +17,7 @@ torch-spline-conv==1.2.2+pt23cu121
 
 cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 nixl==0.4.0; sys_platform != 'darwin'
+
+--find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+# Need to explicitly request jax[cuda12] to force upgrade from cpu version to cuda version
+jax[cuda12]==0.4.25; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -20,5 +20,5 @@ nixl==0.4.0; sys_platform != 'darwin'
 
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 # Downgrading to JAX 0.4.20 to be compatible with CUDA 12.1 (which is older than what JAX 0.4.23+ expects)
-jax==0.3.27; sys_platform != 'darwin'
-jaxlib==0.3.27+cuda12.cudnn89; sys_platform != 'darwin'
+jax==0.4.13; sys_platform != 'darwin'
+jaxlib==0.4.13+cuda12.cudnn89; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -18,7 +18,7 @@ torch-spline-conv==1.2.2+pt23cu121
 cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 nixl==0.4.0; sys_platform != 'darwin'
 
-# JAX 0.4.25+ only supports CUDA 12.3+
---find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax==0.4.23; sys_platform != 'darwin'
-jaxlib==0.4.23+cuda12.cudnn89; sys_platform != 'darwin'
+-find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+# Downgrading to JAX 0.4.20 to be compatible with CUDA 12.1 (which is older than what JAX 0.4.23+ expects)
+jax==0.4.20; sys_platform != 'darwin'
+jaxlib==0.4.20+cuda12.cudnn89; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -18,6 +18,7 @@ torch-spline-conv==1.2.2+pt23cu121
 cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 nixl==0.4.0; sys_platform != 'darwin'
 
+# JAX 0.4.25+ only supports CUDA 12.3+
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-# Install jaxlib directly to avoid pulling in conflicting nvidia-* packages via jax[cuda12]
-jaxlib==0.4.25+cuda12.cudnn89; sys_platform != 'darwin'
+jax==0.4.23; sys_platform != 'darwin'
+jaxlib==0.4.23+cuda12.cudnn89; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -19,6 +19,5 @@ cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 nixl==0.4.0; sys_platform != 'darwin'
 
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-# Downgrading to JAX 0.4.20 to be compatible with CUDA 12.1 (which is older than what JAX 0.4.23+ expects)
-jax==0.4.13; sys_platform != 'darwin'
+# Downgrading to JAX 0.4.13 to be compatible with CUDA 12.1
 jaxlib==0.4.13+cuda12.cudnn89; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -20,4 +20,4 @@ nixl==0.4.0; sys_platform != 'darwin'
 
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 # Downgrading to JAX 0.4.13 to be compatible with CUDA 12.1
-jaxlib==0.4.13+cuda12.cudnn89; sys_platform != 'darwin'
+jaxlib==0.4.13+cuda12.cudnn89; python_version < '3.12' and sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -20,5 +20,5 @@ nixl==0.4.0; sys_platform != 'darwin'
 
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 # Downgrading to JAX 0.4.20 to be compatible with CUDA 12.1 (which is older than what JAX 0.4.23+ expects)
-jax==0.4.20; sys_platform != 'darwin'
-jaxlib==0.4.20+cuda12.cudnn89; sys_platform != 'darwin'
+jax==0.3.27; sys_platform != 'darwin'
+jaxlib==0.3.27+cuda12.cudnn89; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -19,5 +19,5 @@ cupy-cuda12x==13.1.0; sys_platform != 'darwin'
 nixl==0.4.0; sys_platform != 'darwin'
 
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-# Need to explicitly request jax[cuda12] to force upgrade from cpu version to cuda version
-jax[cuda12]==0.4.25; sys_platform != 'darwin'
+# Install jaxlib directly to avoid pulling in conflicting nvidia-* packages via jax[cuda12]
+jaxlib==0.4.25+cuda12.cudnn89; sys_platform != 'darwin'

--- a/python/requirements/ml/train-test-requirements.txt
+++ b/python/requirements/ml/train-test-requirements.txt
@@ -1,6 +1,4 @@
 evaluate==0.4.3
 mosaicml; python_version < "3.12"
 sentencepiece==0.1.96
-jax==0.4.23
-jaxlib==0.4.23
 s3torchconnector==1.4.3

--- a/python/requirements/ml/train-test-requirements.txt
+++ b/python/requirements/ml/train-test-requirements.txt
@@ -1,6 +1,4 @@
 evaluate==0.4.3
 mosaicml; python_version < "3.12"
-jax==0.4.13
-jaxlib==0.4.13
 sentencepiece==0.1.96
 s3torchconnector==1.4.3

--- a/python/requirements/ml/train-test-requirements.txt
+++ b/python/requirements/ml/train-test-requirements.txt
@@ -1,6 +1,6 @@
 evaluate==0.4.3
 mosaicml; python_version < "3.12"
-jax==0.4.23
-jaxlib==0.4.23
+jax==0.4.20
+jaxlib==0.4.20
 sentencepiece==0.1.96
 s3torchconnector==1.4.3

--- a/python/requirements/ml/train-test-requirements.txt
+++ b/python/requirements/ml/train-test-requirements.txt
@@ -1,6 +1,6 @@
 evaluate==0.4.3
 mosaicml; python_version < "3.12"
-jax==0.4.20
-jaxlib==0.4.20
+jax==0.3.27
+jaxlib==0.3.27
 sentencepiece==0.1.96
 s3torchconnector==1.4.3

--- a/python/requirements/ml/train-test-requirements.txt
+++ b/python/requirements/ml/train-test-requirements.txt
@@ -1,4 +1,6 @@
 evaluate==0.4.3
 mosaicml; python_version < "3.12"
+jax==0.4.23
+jaxlib==0.4.23
 sentencepiece==0.1.96
 s3torchconnector==1.4.3

--- a/python/requirements/ml/train-test-requirements.txt
+++ b/python/requirements/ml/train-test-requirements.txt
@@ -1,6 +1,6 @@
 evaluate==0.4.3
 mosaicml; python_version < "3.12"
-jax==0.3.27
-jaxlib==0.3.27
+jax==0.4.13
+jaxlib==0.4.13
 sentencepiece==0.1.96
 s3torchconnector==1.4.3

--- a/python/requirements/ml/train-test-requirements.txt
+++ b/python/requirements/ml/train-test-requirements.txt
@@ -1,6 +1,6 @@
 evaluate==0.4.3
 mosaicml; python_version < "3.12"
 sentencepiece==0.1.96
-jax==0.4.25
-jaxlib==0.4.25
+jax==0.4.23
+jaxlib==0.4.23
 s3torchconnector==1.4.3

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -862,9 +862,9 @@ isoduration==20.11.0
     # via jsonschema
 itsdangerous==2.1.2
     # via flask
-jax==0.4.25
+jax==0.4.23
     # via -r python/requirements/ml/train-test-requirements.txt
-jaxlib==0.4.25
+jaxlib==0.4.23
     # via -r python/requirements/ml/train-test-requirements.txt
 jedi==0.19.1
     # via ipython

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -862,9 +862,9 @@ isoduration==20.11.0
     # via jsonschema
 itsdangerous==2.1.2
     # via flask
-jax==0.4.13
+jax==0.4.13 ; python_version < "3.12" and sys_platform != "darwin"
     # via -r python/requirements/ml/dl-cpu-requirements.txt
-jaxlib==0.4.13
+jaxlib==0.4.13 ; python_version < "3.12" and sys_platform != "darwin"
     # via -r python/requirements/ml/dl-cpu-requirements.txt
 jedi==0.19.1
     # via ipython

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -865,9 +865,7 @@ itsdangerous==2.1.2
 jax==0.4.13
     # via -r python/requirements/ml/dl-cpu-requirements.txt
 jaxlib==0.4.13
-    # via
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-    #   -r python/requirements/ml/train-test-requirements.txt
+    # via -r python/requirements/ml/dl-cpu-requirements.txt
 jedi==0.19.1
     # via ipython
 jinja2==3.1.6

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -863,9 +863,13 @@ isoduration==20.11.0
 itsdangerous==2.1.2
     # via flask
 jax==0.4.20
-    # via -r python/requirements/ml/train-test-requirements.txt
+    # via
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+    #   -r python/requirements/ml/train-test-requirements.txt
 jaxlib==0.4.20
-    # via -r python/requirements/ml/train-test-requirements.txt
+    # via
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+    #   -r python/requirements/ml/train-test-requirements.txt
 jedi==0.19.1
     # via ipython
 jinja2==3.1.6

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -862,9 +862,9 @@ isoduration==20.11.0
     # via jsonschema
 itsdangerous==2.1.2
     # via flask
-jax==0.4.23
+jax==0.4.20
     # via -r python/requirements/ml/train-test-requirements.txt
-jaxlib==0.4.23
+jaxlib==0.4.20
     # via -r python/requirements/ml/train-test-requirements.txt
 jedi==0.19.1
     # via ipython

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -863,9 +863,7 @@ isoduration==20.11.0
 itsdangerous==2.1.2
     # via flask
 jax==0.4.13
-    # via
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-    #   -r python/requirements/ml/train-test-requirements.txt
+    # via -r python/requirements/ml/dl-cpu-requirements.txt
 jaxlib==0.4.13
     # via
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -862,11 +862,11 @@ isoduration==20.11.0
     # via jsonschema
 itsdangerous==2.1.2
     # via flask
-jax==0.4.20
+jax==0.4.13
     # via
     #   -r python/requirements/ml/dl-cpu-requirements.txt
     #   -r python/requirements/ml/train-test-requirements.txt
-jaxlib==0.4.20
+jaxlib==0.4.13
     # via
     #   -r python/requirements/ml/dl-cpu-requirements.txt
     #   -r python/requirements/ml/train-test-requirements.txt


### PR DESCRIPTION
## Description
1. this PR added multihost GPU support for Ray Train JaxTrainer
2. Following Jax [GPU distributed doc](https://docs.jax.dev/en/latest/multi_process.html#gpu-example): if `ScalingConfig.use_gpu == True`, we add "cuda" as JAX_PLATFORMS.
3. if cuda is the jax platform, add CUDA_VISIBLE_DEVICES and initialize jax distributed with https://docs.jax.dev/en/latest/_autosummary/jax.distributed.initialize.html#jax.distributed.initialize

## Related issues

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
1. Tested with script here: https://gist.github.com/liulehui/b0b25065d48b730f2898b712aa92e06e

