### PR TITLE
[serve][llm] Fix: Allow unregistered KV connectors without setup requirements

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/base.py
@@ -62,7 +62,6 @@ class BaseConnectorBackend(abc.ABC):
 
         return 0
 
-    @abc.abstractmethod
     def setup(self) -> None:
         """Setup the connector backend.
 

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/factory.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/factory.py
@@ -7,12 +7,16 @@ This avoids circular import issues and improves startup performance.
 
 import importlib
 from typing import TYPE_CHECKING, Callable, Type
+from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
+    BaseConnectorBackend,
+)
+from ray.llm._internal.serve.observability.logging import get_logger
 
 if TYPE_CHECKING:
     from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
-    from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
-        BaseConnectorBackend,
-    )
+
+
+logger = get_logger(__name__)
 
 
 class KVConnectorBackendFactory:
@@ -42,6 +46,11 @@ class KVConnectorBackendFactory:
     def get_backend_class(cls, name: str) -> Type["BaseConnectorBackend"]:
         """Get the connector backend class by name.
 
+        For registered connectors, returns the registered backend class.
+        For unregistered connectors, returns BaseConnectorBackend which has
+        a no-op setup() method, allowing connectors that don't require
+        Ray Serve orchestration to work without registration.
+
         Args:
             name: The name of the connector backend
 
@@ -49,14 +58,15 @@ class KVConnectorBackendFactory:
             The connector backend class
 
         Raises:
-            ValueError: If the connector backend isn't registered
-            ImportError: If the backend fails to load
+            ImportError: If a registered backend fails to load
         """
         if name not in cls._registry:
-            raise ValueError(
+            logger.warning(
                 f"Unsupported connector backend: {name}. "
-                f"Registered backends: {list(cls._registry.keys())}"
+                f"Registered backends: {list(cls._registry.keys())}."
+                f"Using default backend: {BaseConnectorBackend.__name__}."
             )
+            return BaseConnectorBackend
         try:
             return cls._registry[name]()
         except (ImportError, AttributeError) as e:

--- a/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/factory.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/kv_transfer/factory.py
@@ -7,6 +7,7 @@ This avoids circular import issues and improves startup performance.
 
 import importlib
 from typing import TYPE_CHECKING, Callable, Type
+
 from ray.llm._internal.serve.engines.vllm.kv_transfer.base import (
     BaseConnectorBackend,
 )

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_factory.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_factory.py
@@ -31,7 +31,9 @@ class TestKVConnectorBackendFactory:
 
     def test_get_backend_class_not_registered_returns_base(self):
         """Test that getting a non-registered backend returns BaseConnectorBackend."""
-        backend_class = KVConnectorBackendFactory.get_backend_class("UnregisteredConnector")
+        backend_class = KVConnectorBackendFactory.get_backend_class(
+            "UnregisteredConnector"
+        )
         assert backend_class == BaseConnectorBackend
         assert issubclass(backend_class, BaseConnectorBackend)
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_factory.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_factory.py
@@ -29,10 +29,11 @@ class TestKVConnectorBackendFactory:
         assert backend_class is not None
         assert hasattr(backend_class, "setup")
 
-    def test_get_backend_class_not_registered_raises_error(self):
-        """Test that getting a non-registered backend raises ValueError."""
-        with pytest.raises(ValueError, match="Unsupported connector backend"):
-            KVConnectorBackendFactory.get_backend_class("NonExistentBackend")
+    def test_get_backend_class_not_registered_returns_base(self):
+        """Test that getting a non-registered backend returns BaseConnectorBackend."""
+        backend_class = KVConnectorBackendFactory.get_backend_class("UnregisteredConnector")
+        assert backend_class == BaseConnectorBackend
+        assert issubclass(backend_class, BaseConnectorBackend)
 
     def test_create_backend_success(self):
         """Test successful creation of a backend instance."""
@@ -74,6 +75,20 @@ class TestKVConnectorBackendFactory:
             ImportError, match="Failed to load connector backend 'BadBackend'"
         ):
             KVConnectorBackendFactory.get_backend_class("BadBackend")
+
+    def test_unregistered_connector_with_llm_config_setup(self):
+        """Test that unregistered connectors work with LLMConfig.setup_engine_backend()."""
+        llm_config = LLMConfig(
+            model_loading_config=dict(model_id="test-model"),
+            engine_kwargs=dict(
+                kv_transfer_config=dict(
+                    kv_connector="SharedStorageConnector",
+                    kv_role="kv_both",
+                )
+            ),
+        )
+        # Should not raise an error
+        llm_config.setup_engine_backend()
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_multi_connector.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/vllm/kv_transfer_backends/test_multi_connector.py
@@ -82,26 +82,6 @@ class TestMultiConnectorBackend:
         with pytest.raises(ValueError, match="kv_connector is not set"):
             backend.setup()
 
-    def test_setup_with_invalid_connector_type(self):
-        """Test setup with an invalid connector type."""
-        llm_config = LLMConfig(
-            model_loading_config=dict(model_id="test-model"),
-            engine_kwargs=dict(
-                kv_transfer_config=dict(
-                    kv_connector="MultiConnector",
-                    kv_connector_extra_config=dict(
-                        connectors=[
-                            {"kv_connector": "InvalidConnector"},
-                        ]
-                    ),
-                )
-            ),
-        )
-        backend = MultiConnectorBackend(llm_config)
-
-        with pytest.raises(ValueError, match="Unsupported connector backend"):
-            backend.setup()
-
     def test_setup_with_nested_multi_connector_raises_error(self):
         """Test that nesting MultiConnector raises a ValueError."""
         llm_config = LLMConfig(


### PR DESCRIPTION
## Problem

Ray Serve's KV connector backend factory currently requires all connectors to be registered, but vLLM connectors (e.g., `SharedStorageConnector`) are dynamic and don't need registration unless they require Ray Serve orchestration setup.

## Solution

- `factory.py`: `get_backend_class()` now returns `BaseConnectorBackend` (no-op `setup()`) for unregistered connectors instead of raising `ValueError`. Logs a warning.
- `base.py`: Removed `@abc.abstractmethod` from `setup()` to make it a concrete no-op method.

## Testing

Previously failed with unregistered connectors like `SharedStorageConnector`:
```python

from ray.serve.llm import LLMConfig, build_openai_app

llm_config = LLMConfig(
    model_loading_config=dict(
        model_id="Qwen/Qwen2.5-0.5B-Instruct"
    ),
    engine_kwargs={
        "enforce_eager": True,
        "kv_transfer_config": {
            "kv_connector": "SharedStorageConnector", 
            "kv_role": "kv_both"
        }
    },
)

app = build_openai_app({"llm_configs": [llm_config]})
serve.run(app, blocking=True)
```

Now works correctly using `BaseConnectorBackend`'s no-op `setup()`.
