### PR TITLE
[spark] Validation of the Ray-on-Spark-on-YARN mode to enable it to run.

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -843,11 +843,12 @@ def _setup_ray_cluster_internal(
     if not (
         spark_master.startswith("spark://")
         or spark_master.startswith("local-cluster[")
+        or spark_master == "yarn"
         or is_spark_local_mode
     ):
         raise RuntimeError(
             "Ray on Spark only supports spark cluster in standalone mode, "
-            "local-cluster mode or spark local mode."
+            "local-cluster mode, spark on yarn mode or spark local mode."
         )
 
     if is_spark_local_mode:


### PR DESCRIPTION
## Description
> Add spark master model validation to let Ray run on Spark-On-YARN mode.

## Why need this?
> If we directly run Ray on a YARN cluster, we need to do more tests and integration, and also need to setup related tools and environments. If support ray-on-spark-on-yarn and we already have Spark envs setup, we don't need to do other things, can use Spark and let the user run pyspark.