### PR TITLE
[Serve] add telemetry for custom autoscaling usage

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -23,6 +23,7 @@ from ray.serve._private.metrics_utils import (
     aggregate_timeseries,
     merge_instantaneous_total,
 )
+from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import get_capacity_adjusted_num_replicas
 from ray.serve.config import AutoscalingContext, AutoscalingPolicy
 
@@ -87,6 +88,8 @@ class DeploymentAutoscalingState:
                 f"Using custom autoscaling policy '{self._config.policy.policy_function}' "
                 f"for deployment '{self._deployment_id}'."
             )
+            # Record telemetry for custom autoscaling policy usage
+            ServeUsageTag.CUSTOM_AUTOSCALING_POLICY_USED.record("1")
 
         return self.apply_bounds(target_num_replicas)
 
@@ -685,6 +688,8 @@ class ApplicationAutoscalingState:
                 f"Using custom autoscaling policy '{autoscaling_policy.policy_function}' "
                 f"for application '{self._app_name}'."
             )
+            # Record telemetry for custom autoscaling policy usage
+            ServeUsageTag.CUSTOM_AUTOSCALING_POLICY_USED.record("1")
 
     def has_policy(self) -> bool:
         return self._policy is not None

--- a/python/ray/serve/_private/usage.py
+++ b/python/ray/serve/_private/usage.py
@@ -41,6 +41,7 @@ class ServeUsageTag(Enum):
     NUM_REPLICAS_USING_ASYNCHRONOUS_INFERENCE = (
         TagKey.SERVE_NUM_REPLICAS_USING_ASYNCHRONOUS_INFERENCE
     )
+    CUSTOM_AUTOSCALING_POLICY_USED = TagKey.SERVE_CUSTOM_AUTOSCALING_POLICY_USED
 
     def record(self, value: str):
         """Record telemetry value."""

--- a/src/ray/protobuf/usage.proto
+++ b/src/ray/protobuf/usage.proto
@@ -104,6 +104,8 @@ enum TagKey {
   SERVE_NUM_REPLICAS_VIA_API_CALL_UPDATED = 33;
   // Whether task consumer wrapper was used ("1" if used)
   SERVE_NUM_REPLICAS_USING_ASYNCHRONOUS_INFERENCE = 34;
+  // Whether a custom autoscaling policy was used ("1" if used)
+  SERVE_CUSTOM_AUTOSCALING_POLICY_USED = 35;
 
   // Ray Core State API
   // NOTE(rickyxx): Currently only setting "1" for tracking existence of


### PR DESCRIPTION
support for custom autoscaling policy was added in the last release of serve, but I forgot to add telemetry information inorder to track the usefulness of this feature.