### PR TITLE
[Data] Allow file extensions starting with '.'

### DIFF
--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -17,6 +17,8 @@ def _has_file_extension(path: str, extensions: Optional[List[str]]) -> bool:
         True
         >>> _has_file_extension("foo.CSV", ["csv"])
         True
+        >>> _has_file_extension("foo.CSV", [".csv"])
+        True
         >>> _has_file_extension("foo.csv", ["json", "jsonl"])
         False
         >>> _has_file_extension("foo.csv", None)
@@ -32,8 +34,11 @@ def _has_file_extension(path: str, extensions: Optional[List[str]]) -> bool:
     if extensions is None:
         return True
 
-    # The user-specified extensions don't contain a leading dot, so we add it here.
-    extensions = [f".{ext.lower()}" for ext in extensions]
+    # If the user-specified extensions don't contain a leading dot, we add it here
+    extensions = [
+        f".{ext.lower()}" if not ext.startswith(".") else ext.lower()
+        for ext in extensions
+    ]
     return any(path.lower().endswith(ext) for ext in extensions)
 
 

--- a/python/ray/data/tests/test_path_util.py
+++ b/python/ray/data/tests/test_path_util.py
@@ -18,6 +18,7 @@ from ray.data.datasource.path_util import (
         ("foo.csv", ["csv"], True),
         ("foo.csv", ["json", "csv"], True),
         ("foo.csv", ["json", "jsonl"], False),
+        ("foo.csv", [".csv"], True),
         ("foo.parquet.crc", ["parquet"], False),
         ("foo.parquet.crc", ["crc"], True),
         ("foo.csv", None, True),


### PR DESCRIPTION
It is sometimes intuitive for users to provide their extensions with '.' at the start. This PR takes care of that and removed the '.' when it is provided.

For example, when using `ray.data.read_parquet`, the parameter `file_extensions` needs to be something like `['parquet']`. However, intuitively some users may interpret this parameter as being able to use `['.parquet']`.

This commit allows users to switch from:

```python
train_data = ray.data.read_parquet(
    'example_parquet_folder/',
    file_extensions=['parquet'],
)
```

to

```python
train_data = ray.data.read_parquet(
    'example_parquet_folder/',
    file_extensions=['.parquet'],  # Now will read files, instead of silently not reading anything
)
```