### PR TITLE
[ci][docs] upgrading api_policy_check & api_annotations jobs python version

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -52,7 +52,7 @@ steps:
     key: lint-medium
     instance_type: medium
     depends_on: docbuild
-    job_env: docbuild-py3.9
+    job_env: docbuild-py3.10
     commands:
       - ./ci/lint/lint.sh {{matrix}}
     matrix:

--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -52,7 +52,7 @@ steps:
     key: lint-medium
     instance_type: medium
     depends_on: docbuild
-    job_env: docbuild-py3.10
+    job_env: docbuild-py3.12
     commands:
       - ./ci/lint/lint.sh {{matrix}}
     matrix:


### PR DESCRIPTION
Upgrading the docbuild to python ver 3.12 for **api_policy_check** & **api_annotations** 