### PR TITLE
[doc] fix invalid syntax in label_selector

### DIFF
--- a/doc/source/ray-core/scheduling/labels.md
+++ b/doc/source/ray-core/scheduling/labels.md
@@ -134,13 +134,13 @@ Use the `bundle_label_selector` option to add label selector to placement group 
 # All bundles require the same labels:
 ray.util.placement_group(
     bundles=[{"GPU": 1}, {"GPU": 1}],
-    bundle_label_selector=[{"ray.io/accelerator-type": "H100"} * 2],
+    bundle_label_selector=[{"ray.io/accelerator-type": "H100"}] * 2,
 )
 
 # Bundles require different labels:
 ray.util.placement_group(
-    bundles=[{"CPU": 1}] + [{"GPU": 1} * 2],
-    bundle_label_selector=[{"ray.io/market-type": "spot"}] + [{"ray.io/accelerator-type": "H100"} * 2]
+    bundles=[{"CPU": 1}] + [{"GPU": 1}] * 2,
+    bundle_label_selector=[{"ray.io/market-type": "spot"}] + [{"ray.io/accelerator-type": "H100"}] * 2
 )
 ```
 ## Using labels with autoscaler


### PR DESCRIPTION
The current examples describe that label bundles are written as:

`[{"ray.io/accelerator-type": "H100"}* 2]`, i.e. a dict * integer.
This is wrong it has to be the list that is multiplied.
This PR fixes this.