### PR TITLE
Add pydantic to Ray Tune requirements

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -279,6 +279,7 @@ if setup_spec.type == SetupType.RAY:
         ],
         "tune": [
             "pandas",
+            pydantic_dep,
             "tensorboardX>=1.9",
             "requests",
             *pyarrow_deps,

--- a/python/setup.py
+++ b/python/setup.py
@@ -279,6 +279,7 @@ if setup_spec.type == SetupType.RAY:
         ],
         "tune": [
             "pandas",
+            # TODO: Remove pydantic dependency from tune once tune doesn't import train
             pydantic_dep,
             "tensorboardX>=1.9",
             "requests",


### PR DESCRIPTION
Currently, users that import ray.tune can run into an ImportError if they do not have pydantic installed. This is because ray.tune imports ray.train, which requires pydantic. This PR prevents this error by adding pydantic as a ray tune dependency. 

Relevant user issue: https://github.com/ray-project/ray/issues/58280