### PR TITLE
[wheel] stop uploading python 3.9 wheels on release

### DIFF
--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -8,7 +8,6 @@ from ci.ray_ci.utils import logger
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 
 PYTHON_VERSIONS = [
-    "cp39-cp39",
     "cp310-cp310",
     "cp311-cp311",
     "cp312-cp312",

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -18,11 +18,11 @@ from ci.ray_ci.automation.ray_wheels_lib import (
     download_wheel_from_s3,
 )
 
-SAMPLE_WHEELS = [
-    "ray-1.0.0-cp39-cp39-manylinux2014_x86_64",
-    "ray-1.0.0-cp39-cp39-manylinux2014_aarch64",
-    "ray-1.0.0-cp39-cp39-macosx_12_0_arm64",
-    "ray-1.0.0-cp39-cp39-win_amd64",
+_SAMPLE_WHEELS = [
+    "ray-1.0.0-cp312-cp312-manylinux2014_x86_64",
+    "ray-1.0.0-cp312-cp312-manylinux2014_aarch64",
+    "ray-1.0.0-cp312-cp312-macosx_12_0_arm64",
+    "ray-1.0.0-cp312-cp312-win_amd64",
 ]
 
 
@@ -55,10 +55,10 @@ def test_get_wheel_names():
 def test_check_downloaded_wheels():
     with tempfile.TemporaryDirectory() as tmp_dir:
         wheels = [
-            "ray-1.0.0-cp39-cp39-manylinux2014_x86_64",
-            "ray-1.0.0-cp39-cp39-manylinux2014_aarch64",
-            "ray-1.0.0-cp39-cp39-macosx_12_0_arm64",
-            "ray-1.0.0-cp39-cp39-win_amd64",
+            "ray-1.0.0-cp312-cp312-manylinux2014_x86_64",
+            "ray-1.0.0-cp312-cp312-manylinux2014_aarch64",
+            "ray-1.0.0-cp312-cp312-macosx_12_0_arm64",
+            "ray-1.0.0-cp312-cp312-win_amd64",
         ]
 
         for wheel in wheels:
@@ -71,10 +71,10 @@ def test_check_downloaded_wheels():
 def test_check_downloaded_wheels_fail():
     with tempfile.TemporaryDirectory() as tmp_dir:
         wheels = [
-            "ray-1.0.0-cp39-cp39-manylinux2014_x86_64",
-            "ray-1.0.0-cp39-cp39-manylinux2014_aarch64",
-            "ray-1.0.0-cp39-cp39-macosx_12_0_arm64",
-            "ray-1.0.0-cp39-cp39-win_amd64",
+            "ray-1.0.0-cp312-cp312-manylinux2014_x86_64",
+            "ray-1.0.0-cp312-cp312-manylinux2014_aarch64",
+            "ray-1.0.0-cp312-cp312-macosx_12_0_arm64",
+            "ray-1.0.0-cp312-cp312-win_amd64",
         ]
 
         for wheel in wheels[:3]:
@@ -89,10 +89,10 @@ def test_check_downloaded_wheels_fail():
 def test_download_wheel_from_s3(mock_boto3_client):
     with tempfile.TemporaryDirectory() as tmp_dir:
         keys = [
-            "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-manylinux2014_x86_64.whl",
-            "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-manylinux2014_aarch64.whl",
-            "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-macosx_12_0_arm64.whl",
-            "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-win_amd64.whl",
+            "releases/1.0.0/1234567/ray-1.0.0-cp312-cp312-manylinux2014_x86_64.whl",
+            "releases/1.0.0/1234567/ray-1.0.0-cp312-cp312-manylinux2014_aarch64.whl",
+            "releases/1.0.0/1234567/ray-1.0.0-cp312-cp312-macosx_12_0_arm64.whl",
+            "releases/1.0.0/1234567/ray-1.0.0-cp312-cp312-win_amd64.whl",
         ]
         for key in keys:
             download_wheel_from_s3(key=key, directory_path=tmp_dir)
@@ -115,8 +115,8 @@ def test_download_wheel_from_s3_fail(mock_boto3_client):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         keys = [
-            "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-manylinux2014_x86_64.whl",
-            "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-manylinux2014_aarch64.whl",
+            "releases/1.0.0/1234567/ray-1.0.0-cp312-cp312-manylinux2014_x86_64.whl",
+            "releases/1.0.0/1234567/ray-1.0.0-cp312-cp312-manylinux2014_aarch64.whl",
         ]
         for key in keys:
             with pytest.raises(ClientError, match="Not Found"):
@@ -132,7 +132,7 @@ def test_download_ray_wheels_from_s3(
     commit_hash = "1234567"
     ray_version = "1.0.0"
 
-    mock_get_wheel_names.return_value = SAMPLE_WHEELS
+    mock_get_wheel_names.return_value = _SAMPLE_WHEELS
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         download_ray_wheels_from_s3(
@@ -142,15 +142,15 @@ def test_download_ray_wheels_from_s3(
         )
 
         mock_get_wheel_names.assert_called_with(ray_version=ray_version)
-        assert mock_download_wheel.call_count == len(SAMPLE_WHEELS)
+        assert mock_download_wheel.call_count == len(_SAMPLE_WHEELS)
         for i, call_args in enumerate(mock_download_wheel.call_args_list):
             assert (
                 call_args[0][0]
-                == f"releases/{ray_version}/{commit_hash}/{SAMPLE_WHEELS[i]}.whl"
+                == f"releases/{ray_version}/{commit_hash}/{_SAMPLE_WHEELS[i]}.whl"
             )
             assert call_args[0][1] == tmp_dir
 
-        mock_check_wheels.assert_called_with(tmp_dir, SAMPLE_WHEELS)
+        mock_check_wheels.assert_called_with(tmp_dir, _SAMPLE_WHEELS)
 
 
 @mock.patch("ci.ray_ci.automation.ray_wheels_lib.download_wheel_from_s3")
@@ -162,7 +162,7 @@ def test_download_ray_wheels_from_s3_with_branch(
     commit_hash = "1234567"
     ray_version = "1.0.0"
 
-    mock_get_wheel_names.return_value = SAMPLE_WHEELS
+    mock_get_wheel_names.return_value = _SAMPLE_WHEELS
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         download_ray_wheels_from_s3(
@@ -173,14 +173,15 @@ def test_download_ray_wheels_from_s3_with_branch(
         )
 
         mock_get_wheel_names.assert_called_with(ray_version=ray_version)
-        assert mock_download_wheel.call_count == len(SAMPLE_WHEELS)
+        assert mock_download_wheel.call_count == len(_SAMPLE_WHEELS)
         for i, call_args in enumerate(mock_download_wheel.call_args_list):
             assert (
-                call_args[0][0] == f"custom_branch/{commit_hash}/{SAMPLE_WHEELS[i]}.whl"
+                call_args[0][0]
+                == f"custom_branch/{commit_hash}/{_SAMPLE_WHEELS[i]}.whl"
             )
             assert call_args[0][1] == tmp_dir
 
-        mock_check_wheels.assert_called_with(tmp_dir, SAMPLE_WHEELS)
+        mock_check_wheels.assert_called_with(tmp_dir, _SAMPLE_WHEELS)
 
 
 @mock.patch("ci.ray_ci.automation.ray_wheels_lib.download_wheel_from_s3")
@@ -192,7 +193,7 @@ def test_download_ray_wheels_from_s3_partial_platform(
     commit_hash = "1234567"
     ray_version = "1.1.0"
 
-    mock_get_wheel_names.return_value = SAMPLE_WHEELS
+    mock_get_wheel_names.return_value = _SAMPLE_WHEELS
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         download_ray_wheels_from_s3(
@@ -202,15 +203,15 @@ def test_download_ray_wheels_from_s3_partial_platform(
         )
 
         mock_get_wheel_names.assert_called_with(ray_version=ray_version)
-        assert mock_download_wheel.call_count == len(SAMPLE_WHEELS)
+        assert mock_download_wheel.call_count == len(_SAMPLE_WHEELS)
         for i, call_args in enumerate(mock_download_wheel.call_args_list):
             assert (
                 call_args[0][0]
-                == f"releases/{ray_version}/{commit_hash}/{SAMPLE_WHEELS[i]}.whl"
+                == f"releases/{ray_version}/{commit_hash}/{_SAMPLE_WHEELS[i]}.whl"
             )
             assert call_args[0][1] == tmp_dir
 
-        mock_check_wheels.assert_called_with(tmp_dir, SAMPLE_WHEELS)
+        mock_check_wheels.assert_called_with(tmp_dir, _SAMPLE_WHEELS)
 
 
 @mock.patch("ci.ray_ci.automation.ray_wheels_lib.download_wheel_from_s3")
@@ -222,7 +223,7 @@ def test_download_ray_wheels_from_s3_fail_check_wheels(
     commit_hash = "1234567"
     ray_version = "1.0.0"
 
-    mock_get_wheel_names.return_value = SAMPLE_WHEELS
+    mock_get_wheel_names.return_value = _SAMPLE_WHEELS
     mock_check_wheels.side_effect = AssertionError()
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -230,7 +231,7 @@ def test_download_ray_wheels_from_s3_fail_check_wheels(
             download_ray_wheels_from_s3(
                 commit_hash=commit_hash, ray_version=ray_version, directory_path=tmp_dir
             )
-    assert mock_download_wheel.call_count == len(SAMPLE_WHEELS)
+    assert mock_download_wheel.call_count == len(_SAMPLE_WHEELS)
 
 
 @mock.patch("ci.ray_ci.automation.ray_wheels_lib.download_wheel_from_s3")
@@ -242,7 +243,7 @@ def test_download_ray_wheels_from_s3_fail_download(
     commit_hash = "1234567"
     ray_version = "1.0.0"
 
-    mock_get_wheel_names.return_value = SAMPLE_WHEELS
+    mock_get_wheel_names.return_value = _SAMPLE_WHEELS
     mock_download_wheel.side_effect = ClientError(
         {
             "Error": {
@@ -263,12 +264,12 @@ def test_download_ray_wheels_from_s3_fail_download(
 
 def test_add_build_tag_to_wheel():
     with tempfile.TemporaryDirectory() as tmp_dir:
-        wheel_name = "ray-1.0.0-cp39-cp39-manylinux2014_x86_64.whl"
+        wheel_name = "ray-1.0.0-cp312-cp312-manylinux2014_x86_64.whl"
         wheel_path = os.path.join(tmp_dir, wheel_name)
         with open(wheel_path, "w") as f:
             f.write("")
         add_build_tag_to_wheel(wheel_path=wheel_path, build_tag="123")
-        expected_wheel_name = "ray-1.0.0-123-cp39-cp39-manylinux2014_x86_64.whl"
+        expected_wheel_name = "ray-1.0.0-123-cp312-cp312-manylinux2014_x86_64.whl"
         expected_wheel_path = os.path.join(tmp_dir, expected_wheel_name)
         assert os.path.exists(expected_wheel_path)
 
@@ -276,18 +277,18 @@ def test_add_build_tag_to_wheel():
 def test_add_build_tag_to_wheels():
     with tempfile.TemporaryDirectory() as tmp_dir:
         wheels = [
-            "ray-1.0.0-cp39-cp39-manylinux2014_x86_64.whl",
-            "ray-1.0.0-cp39-cp39-manylinux2014_aarch64.whl",
+            "ray-1.0.0-cp312-cp312-manylinux2014_x86_64.whl",
+            "ray-1.0.0-cp312-cp312-manylinux2014_aarch64.whl",
         ]
         for wheel in wheels:
             with open(os.path.join(tmp_dir, wheel), "w") as f:
                 f.write("")
         add_build_tag_to_wheels(directory_path=tmp_dir, build_tag="123")
         assert os.path.exists(
-            os.path.join(tmp_dir, "ray-1.0.0-123-cp39-cp39-manylinux2014_x86_64.whl")
+            os.path.join(tmp_dir, "ray-1.0.0-123-cp312-cp312-manylinux2014_x86_64.whl")
         )
         assert os.path.exists(
-            os.path.join(tmp_dir, "ray-1.0.0-123-cp39-cp39-manylinux2014_aarch64.whl")
+            os.path.join(tmp_dir, "ray-1.0.0-123-cp312-cp312-manylinux2014_aarch64.whl")
         )
 
 


### PR DESCRIPTION
python 3.9 is now out of the support window

all using python 3.12 wheel names for unit testing