### PR TITLE
[image] stop building python 3.9 release images

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -97,7 +97,6 @@ steps:
       - raycudabase
       - raycpubase
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -123,7 +122,6 @@ steps:
       - raycpubaseextra
       - raycudabaseextra
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"


### PR DESCRIPTION
python 3.9 is out of support window
