### PR TITLE
[ci] updating core ci tests to py3.10

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -198,10 +198,9 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker --
         python/ray/tests/modin/... core
         --install-mask all-ray-libraries
-        --build-name databuild-py3.10
-        --python-version 3.10
+        --build-name datalbuild
     depends_on:
-      - datalbuild-multipy
+      - datalbuild
       - forge
 
   - label: ":ray: core: dashboard tests"

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -443,13 +443,13 @@ steps:
       - docker
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu --canonical-tag ha_integration --python-version 3.10
+      - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu --canonical-tag ha_integration
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core --only-tags ha_integration
     depends_on:
       - manylinux
       - forge
       - raycpubase
-      - corebuild-multipy
+      - corebuild
 
   - label: ":ray: core: runtime env container tests"
     tags:

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -1,7 +1,7 @@
 group: core tests
 depends_on:
   - forge
-  - oss-ci-base_build
+  - oss-ci-base_build-multipy
   - ray-core-build
   - ray-dashboard-build
 steps:
@@ -14,20 +14,23 @@ steps:
       IMAGE_TO: corebuild
       RAYCI_IS_GPU_BUILD: "false"
 
-  - name: coregpubuild
-    wanda: ci/docker/core.build.py39.wanda.yaml
+  - name: coregpubuild-multipy
+    label: "wanda: coregpubuild-py{{matrix}}"
+    wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
-    depends_on: oss-ci-base_gpu
     env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_gpu
-      IMAGE_TO: coregpubuild
+      PYTHON: "{{matrix}}"
       RAYCI_IS_GPU_BUILD: "true"
+    matrix:
+      - "3.10"
+    depends_on: oss-ci-base_gpu-multipy
 
   - name: corebuild-multipy
     label: "wanda: corebuild-py{{matrix}}"
     wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
     matrix:
+      - "3.10"
       - "3.12"
     env:
       PYTHON: "{{matrix}}"
@@ -38,7 +41,6 @@ steps:
     wanda: ci/docker/min.build.wanda.yaml
     tags: cibase
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -49,7 +51,7 @@ steps:
 
   - wait: ~
     depends_on:
-      - corebuild
+      - corebuild-multipy
 
   # tests
   - label: ":ray: core: python tests"
@@ -119,7 +121,8 @@ steps:
       - pip install -e python[client]
       - bazel test --config=ci --jobs=1 $(./ci/run/bazel_export_options)
         --test_tag_filters=mem_pressure -- //python/ray/tests/...
-    job_env: corebuild
+    job_env: corebuild-multipy-py3.10
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: out of disk tests"
     tags:
@@ -151,17 +154,25 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/... //doc/... core
         --only-tags doctest
         --parallelism-per-worker 3
+        --build-name corebuild-py3.10
+        --python-version 3.10
       # doc examples
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... core
         --install-mask all-ray-libraries
         --except-tags doctest,post_wheel_build,gpu,multi_gpu,mem_pressure
         --parallelism-per-worker 3
+        --build-name corebuild-py3.10
+        --python-version 3.10
         --skip-ray-installation
       # doc memory pressure example
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... core
         --only-tags mem_pressure
         --except-tags gpu
+        --build-name corebuild-py3.10
+        --python-version 3.10
         --skip-ray-installation
+    depends_on:
+      - corebuild-multipy
 
   - label: ":ray: core: dask tests"
     tags:
@@ -185,9 +196,9 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker --
         python/ray/tests/modin/... core
         --install-mask all-ray-libraries
-        --build-name datalbuild
+        --build-name databuild-py3.10
     depends_on:
-      - datalbuild
+      - datalbuild-multipy
       - forge
 
   - label: ":ray: core: dashboard tests"
@@ -239,9 +250,11 @@ steps:
         --parallelism-per-worker 3
         --only-tags post_wheel_build
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
+        --build-name corebuild-py3.10
+        --python-version 3.10
     depends_on:
       - manylinux
-      - corebuild
+      - corebuild-multipy
       - forge
 
   - label: ":ray: core: minimal tests {{matrix}}"
@@ -293,7 +306,6 @@ steps:
     depends_on:
       - minbuild-core
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -314,7 +326,7 @@ steps:
     instance_type: medium
     commands:
       - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup --build-type clang
-        --cache-test-results --parallelism-per-worker 2
+        --cache-test-results --parallelism-per-worker 2 --python-version 3.10
 
   # block on premerge and microcheck
   - block: "run cpp sanitizer tests"
@@ -327,10 +339,10 @@ steps:
     instance_type: medium
     commands:
       - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup
-        --build-type asan-clang --cache-test-results --parallelism-per-worker 2
+        --build-type asan-clang --cache-test-results --parallelism-per-worker 2 --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild
+      - corebuild-multipy
 
   - label: ":ray: core: cpp ubsan tests"
     tags: core_cpp
@@ -338,10 +350,10 @@ steps:
     commands:
       - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
         --build-type ubsan --except-tags no_ubsan,cgroup
-        --cache-test-results --parallelism-per-worker 2
+        --cache-test-results --parallelism-per-worker 2 --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild
+      - corebuild-multipy
 
   - label: ":ray: core: cpp tsan tests"
     tags: core_cpp
@@ -349,10 +361,10 @@ steps:
     commands:
       - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
         --build-type tsan-clang --except-tags no_tsan,cgroup
-        --cache-test-results --parallelism-per-worker 2
+        --cache-test-results --parallelism-per-worker 2 --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild
+      - corebuild-multipy
 
   - label: ":ray: core: flaky tests"
     key: core_flaky_tests
@@ -367,8 +379,10 @@ steps:
         --install-mask all-ray-libraries
         --run-flaky-tests
         --except-tags multi_gpu,cgroup
+        --build-name corebuild-py3.10
+        --python-version 3.10
     depends_on:
-      - corebuild
+      - corebuild-multipy
 
   - label: ":ray: core: flaky gpu tests"
     key: core_flaky_gpu_tests
@@ -383,9 +397,10 @@ steps:
         --install-mask all-ray-libraries
         --run-flaky-tests
         --gpus 4
-        --build-name coregpubuild
+        --build-name coregpubuild-py3.10
+        --python-version 3.10
         --only-tags multi_gpu
-    depends_on: coregpubuild
+    depends_on: coregpubuild-multipy
 
   - label: ":ray: core: cpp worker tests"
     tags:
@@ -400,8 +415,8 @@ steps:
       # cpp worker tests has one that tests cross-language with Java.
       - RAY_INSTALL_JAVA=1 ci/ci.sh build
       - ci/ci.sh test_cpp
-    depends_on: oss-ci-base_build
-    job_env: oss-ci-base_build
+    depends_on: oss-ci-base_build-multipy
+    job_env: oss-ci-base_build-py3.10
 
   - label: ":ray: core: java worker tests"
     tags:
@@ -413,7 +428,9 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
         --build-type java
         --only-tags needs_java
-    depends_on: corebuild
+        --python-version 3.10
+        --build-name corebuild-py3.10
+    depends_on: corebuild-multipy
 
   - label: ":ray: core: HA integration tests"
     tags:
@@ -427,7 +444,7 @@ steps:
       - manylinux
       - forge
       - raycpubase
-      - corebuild
+      - corebuild-multipy
 
   - label: ":ray: core: runtime env container tests"
     tags:
@@ -444,11 +461,13 @@ steps:
       - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
         --install-mask all-ray-libraries
         --only-tags runtime_env_container
+        --build-name corebuild-py3.10
+        --python-version 3.10
     depends_on:
       - manylinux
       - forge
       - raycpubase
-      - corebuild
+      - corebuild-multipy
 
   - label: ":core: core: spark-on-ray tests"
     # NOTE: The Spark-on-Ray tests intentionally aren't triggered by the `java` tag to
@@ -463,8 +482,10 @@ steps:
         --test-env=RAY_ON_SPARK_BACKGROUND_JOB_STARTUP_WAIT=1
         --test-env=RAY_ON_SPARK_RAY_WORKER_NODE_STARTUP_INTERVAL=5
         --only-tags spark_on_ray
+        --build-name corebuild-py3.10
+        --python-version 3.10
     depends_on:
-      - corebuild
+      - corebuild-multipy
 
   # block gpu tests on premerge and microcheck
   - block: "run multi gpu tests"
@@ -482,9 +503,9 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //doc/... core
         --gpus 4
-        --build-name coregpubuild
+        --build-name coregpubuild-py3.10
         --only-tags multi_gpu
         --install-mask all-ray-libraries
     depends_on:
       - block-core-gpu-tests
-      - coregpubuild
+      - coregpubuild-multipy

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -66,6 +66,8 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags custom_setup,cgroup
         --install-mask all-ray-libraries
+        --build-name corebuild-py3.10
+        --python-version 3.10
 
   - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
@@ -209,6 +211,8 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- python/ray/dashboard/... core
         --parallelism-per-worker 3
+        --build-name corebuild-py3.10
+        --python-version 3.10
       # ui tests
       - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail
@@ -250,11 +254,11 @@ steps:
         --parallelism-per-worker 3
         --only-tags post_wheel_build
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
-        --build-name corebuild-py3.10
-        --python-version 3.10
+        --build-name corebuild-py3.9
+        --python-version 3.9
     depends_on:
       - manylinux
-      - corebuild-multipy
+      - corebuild
       - forge
 
   - label: ":ray: core: minimal tests {{matrix}}"
@@ -316,9 +320,10 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //python/ray/tests/resource_isolation:test_resource_isolation_integration //python/ray/tests/resource_isolation:test_resource_isolation_config core --privileged --cache-test-results
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/ray/common/cgroup2/tests/...  core --build-type clang --cache-test-results
+        --build-name corebuild-py3.10 --python-version 3.10
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/ray/common/cgroup2/tests/...  core --build-type clang --cache-test-results --build-name corebuild-py3.10 --python-version 3.10
       - docker run --privileged -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
-        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash
+        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash
         "./src/ray/common/cgroup2/integration_tests/sysfs_cgroup_driver_integration_test_entrypoint.sh"
 
   - label: ":ray: core: cpp tests"
@@ -326,7 +331,7 @@ steps:
     instance_type: medium
     commands:
       - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup --build-type clang
-        --cache-test-results --parallelism-per-worker 2 --python-version 3.10
+        --cache-test-results --parallelism-per-worker 2 --build-name corebuild-py3.10 --python-version 3.10
 
   # block on premerge and microcheck
   - block: "run cpp sanitizer tests"
@@ -438,7 +443,7 @@ steps:
       - docker
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu --canonical-tag ha_integration
+      - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu --canonical-tag ha_integration --python-version 3.10
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core --only-tags ha_integration
     depends_on:
       - manylinux

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -211,8 +211,8 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- python/ray/dashboard/... core
         --parallelism-per-worker 3
-        --build-name corebuild-py3.10
-        --python-version 3.10
+        --build-name corebuild-py3.9
+        --python-version 3.9
       # ui tests
       - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -199,6 +199,7 @@ steps:
         python/ray/tests/modin/... core
         --install-mask all-ray-libraries
         --build-name databuild-py3.10
+        --python-version 3.10
     depends_on:
       - datalbuild-multipy
       - forge

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -211,7 +211,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- python/ray/dashboard/... core
         --parallelism-per-worker 3
-        --build-name corebuild-py3.9
+        --build-name corebuild
         --python-version 3.9
       # ui tests
       - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb


### PR DESCRIPTION
updating core ci tests to py310

except for HA integration, Dashboard tests & core modin tests due to errors on the jobs: https://buildkite.com/ray-project/microcheck/builds/30394

Postmerge link: https://buildkite.com/ray-project/postmerge/builds/14201