### PR TITLE
[core] stop exporting metric before shutting down node manager

### DIFF
--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -422,9 +422,9 @@ int main(int argc, char *argv[]) {
                                          &object_manager_rpc_threads]() {
           // We should stop the service and remove the local socket
           // file.
+          ray::stats::Shutdown();
           node_manager->Stop();
           gcs_client->Disconnect();
-          ray::stats::Shutdown();
           main_service.stop();
           for (size_t i = 0; i < object_manager_rpc_threads.size(); i++) {
             if (object_manager_rpc_threads[i].joinable()) {


### PR DESCRIPTION
Currently, Ray metrics are exported through a centralized process called the Dashboard Agent. This process functions as a gRPC server, receiving data from all other components (GCS, Raylet, workers, etc.). However, during a node shutdown, the Dashboard Agent may terminate before the other components, resulting in gRPC errors and potential loss of metrics and events.

This PR fixes the shutdown issue for raylet. In particular, it will terminate metric exporting before shutting down node manager (which is what sends the SIGTERM to the dashboard agent).

Test:
- CI