### PR TITLE
[release] python 3.10 for long running tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -807,6 +807,7 @@
 #######################
 
 - name: long_running_actor_deaths
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -848,6 +849,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_impala
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -889,6 +891,7 @@
         cluster_compute: tpl_cpu_1_large_gce.yaml
 
 - name: long_running_many_actor_tasks
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -975,6 +978,7 @@
         cluster_compute: tpl_cpu_4_gce.yaml
 
 - name: long_running_many_ppo
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1021,6 +1025,7 @@
         cluster_compute: many_ppo_gce.yaml
 
 - name: long_running_many_tasks
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1063,6 +1068,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_tasks_serialized_ids
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1104,6 +1110,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_node_failures
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1146,6 +1153,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_serve
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1187,6 +1195,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_serve_failure
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1230,6 +1239,7 @@
         cluster_compute: tpl_cpu_1_c5_gce.yaml
 
 - name: long_running_many_jobs
+  python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -839,7 +839,6 @@
 
   variations:
     - __suffix__: aws
-      python: "3.10"
     - __suffix__: gce
       env: gce
       frequency: manual
@@ -922,7 +921,6 @@
 
   variations:
     - __suffix__: aws
-      python: "3.10"
     - __suffix__: gce
       env: gce
       frequency: manual
@@ -1056,7 +1054,6 @@
 
   variations:
     - __suffix__: aws
-      python: "3.10"
     - __suffix__: gce
       env: gce
       frequency: manual
@@ -1141,7 +1138,6 @@
 
   variations:
     - __suffix__: aws
-      python: "3.10"
     - __suffix__: gce
       env: gce
       frequency: manual


### PR DESCRIPTION
upgrading long running tests to run on py3.10
Successful release test build: https://buildkite.com/ray-project/release/builds/66618