### PR TITLE
[data] Clear queue for manually mark_execution_finished operators

### DIFF
--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -47,7 +47,7 @@ class InternalQueueOperatorMixin(PhysicalOperator, abc.ABC):
     def mark_execution_finished(self) -> None:
         """Mark execution as finished and clear internal queues.
 
-        This default implementation calls the parent's mark_execution_finished()
+        This default implementation calls the parent's mark_execution_finished()Fclass OneToOneOperator(P
         and then clears internal queues via clear_internal_queues().
         """
         super().mark_execution_finished()
@@ -154,18 +154,6 @@ class AllToAllOperator(
 
     def internal_output_queue_num_bytes(self) -> int:
         return sum(bundle.size_bytes() for bundle in self._output_buffer)
-
-    def clear_internal_queues(self) -> None:
-        """Clear all internal input and output queues."""
-        # Clear internal input queue
-        while self._input_buffer:
-            bundle = self._input_buffer.pop()
-            self._metrics.on_input_dequeued(bundle)
-
-        # Clear internal output queue
-        while self._output_buffer:
-            bundle = self._output_buffer.pop()
-            self._metrics.on_output_dequeued(bundle)
 
     def all_inputs_done(self) -> None:
         ctx = TaskContext(

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -35,6 +35,24 @@ class InternalQueueOperatorMixin(PhysicalOperator, abc.ABC):
         """Returns Operator's internal output queue size (in bytes)"""
         ...
 
+    @abc.abstractmethod
+    def clear_internal_queues(self) -> None:
+        """Clear all internal input and output queues.
+
+        This should drain all buffered bundles and update metrics appropriately
+        by calling on_input_dequeued() and on_output_dequeued().
+        """
+        ...
+
+    def mark_execution_finished(self) -> None:
+        """Mark execution as finished and clear internal queues.
+
+        This default implementation calls the parent's mark_execution_finished()
+        and then clears internal queues via clear_internal_queues().
+        """
+        super().mark_execution_finished()
+        self.clear_internal_queues()
+
 
 class OneToOneOperator(PhysicalOperator):
     """An operator that has one input and one output dependency.
@@ -136,6 +154,18 @@ class AllToAllOperator(
 
     def internal_output_queue_num_bytes(self) -> int:
         return sum(bundle.size_bytes() for bundle in self._output_buffer)
+
+    def clear_internal_queues(self) -> None:
+        """Clear all internal input and output queues."""
+        # Clear internal input queue
+        while self._input_buffer:
+            bundle = self._input_buffer.pop()
+            self._metrics.on_input_dequeued(bundle)
+
+        # Clear internal output queue
+        while self._output_buffer:
+            bundle = self._output_buffer.pop()
+            self._metrics.on_output_dequeued(bundle)
 
     def all_inputs_done(self) -> None:
         ctx = TaskContext(

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -108,7 +108,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         self._block_ref_bundler = _BlockRefBundler(min_rows_per_bundle)
 
         # Queue for task outputs, either ordered or unordered (this is set by start()).
-        self._output_queue: _OutputQueue = None
+        self._output_queue: Optional[_OutputQueue] = None
         # Output metadata, added to on get_next().
         self._output_blocks_stats: List[BlockStats] = []
         # All active `DataOpTask`s.

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -165,14 +165,14 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     def internal_output_queue_num_bytes(self) -> int:
         return self._output_queue.size_bytes()
 
-    def clear_internal_queues(self) -> None:
-        """Clear all internal input and output queues."""
-        # Clear internal input queue (block ref bundler)
+    def clear_internal_input_queue(self) -> None:
+        """Clear internal input queue (block ref bundler)."""
         while self._block_ref_bundler.has_bundle():
             (_, bundle) = self._block_ref_bundler.get_next_bundle()
             self._metrics.on_input_dequeued(bundle)
 
-        # Clear internal output queue
+    def clear_internal_output_queue(self) -> None:
+        """Clear internal output queue."""
         while self._output_queue.has_next():
             bundle = self._output_queue.get_next()
             self._metrics.on_output_dequeued(bundle)

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -168,8 +168,9 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     def clear_internal_input_queue(self) -> None:
         """Clear internal input queue (block ref bundler)."""
         while self._block_ref_bundler.has_bundle():
-            (_, bundle) = self._block_ref_bundler.get_next_bundle()
-            self._metrics.on_input_dequeued(bundle)
+            (input_bundles, _) = self._block_ref_bundler.get_next_bundle()
+            for input_bundle in input_bundles:
+                self._metrics.on_input_dequeued(input_bundle)
 
     def clear_internal_output_queue(self) -> None:
         """Clear internal output queue."""

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -170,6 +170,18 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
     def internal_output_queue_num_bytes(self) -> int:
         return sum(b.size_bytes() for b in self._output_queue)
 
+    def clear_internal_queues(self) -> None:
+        """Clear all internal input and output queues."""
+        # Clear internal input queue
+        while self._buffer:
+            bundle = self._buffer.pop()
+            self._metrics.on_input_dequeued(bundle)
+
+        # Clear internal output queue
+        while self._output_queue:
+            bundle = self._output_queue.popleft()
+            self._metrics.on_output_dequeued(bundle)
+
     def progress_str(self) -> str:
         if self._locality_hints:
             return locality_string(self._locality_hits, self._locality_misses)

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -170,14 +170,14 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
     def internal_output_queue_num_bytes(self) -> int:
         return sum(b.size_bytes() for b in self._output_queue)
 
-    def clear_internal_queues(self) -> None:
-        """Clear all internal input and output queues."""
-        # Clear internal input queue
+    def clear_internal_input_queue(self) -> None:
+        """Clear internal input queue."""
         while self._buffer:
             bundle = self._buffer.pop()
             self._metrics.on_input_dequeued(bundle)
 
-        # Clear internal output queue
+    def clear_internal_output_queue(self) -> None:
+        """Clear internal output queue."""
         while self._output_queue:
             bundle = self._output_queue.popleft()
             self._metrics.on_output_dequeued(bundle)

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -85,15 +85,15 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def internal_output_queue_num_bytes(self) -> int:
         return sum(q.size_bytes() for q in self._output_buffer)
 
-    def clear_internal_queues(self) -> None:
-        """Clear all internal input and output queues."""
-        # Clear internal input queues
+    def clear_internal_input_queue(self) -> None:
+        """Clear internal input queues."""
         for input_buffer in self._input_buffers:
             while input_buffer:
                 bundle = input_buffer.get_next()
                 self._metrics.on_input_dequeued(bundle)
 
-        # Clear internal output queue
+    def clear_internal_output_queue(self) -> None:
+        """Clear internal output queue."""
         while self._output_buffer:
             bundle = self._output_buffer.popleft()
             self._metrics.on_output_dequeued(bundle)

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -85,6 +85,19 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def internal_output_queue_num_bytes(self) -> int:
         return sum(q.size_bytes() for q in self._output_buffer)
 
+    def clear_internal_queues(self) -> None:
+        """Clear all internal input and output queues."""
+        # Clear internal input queues
+        for input_buffer in self._input_buffers:
+            while input_buffer:
+                bundle = input_buffer.get_next()
+                self._metrics.on_input_dequeued(bundle)
+
+        # Clear internal output queue
+        while self._output_buffer:
+            bundle = self._output_buffer.popleft()
+            self._metrics.on_output_dequeued(bundle)
+
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         assert not self.completed()
         assert 0 <= input_index <= len(self._input_dependencies), input_index

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -93,15 +93,15 @@ class ZipOperator(InternalQueueOperatorMixin, NAryOperator):
     def internal_output_queue_num_bytes(self) -> int:
         return sum(bundle.size_bytes() for bundle in self._output_buffer)
 
-    def clear_internal_queues(self) -> None:
-        """Clear all internal input and output queues."""
-        # Clear internal input queues
+    def clear_internal_input_queue(self) -> None:
+        """Clear internal input queues."""
         for input_buffer in self._input_buffers:
             while input_buffer:
                 bundle = input_buffer.popleft()
                 self._metrics.on_input_dequeued(bundle)
 
-        # Clear internal output queue
+    def clear_internal_output_queue(self) -> None:
+        """Clear internal output queue."""
         while self._output_buffer:
             bundle = self._output_buffer.popleft()
             self._metrics.on_output_dequeued(bundle)

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -93,6 +93,19 @@ class ZipOperator(InternalQueueOperatorMixin, NAryOperator):
     def internal_output_queue_num_bytes(self) -> int:
         return sum(bundle.size_bytes() for bundle in self._output_buffer)
 
+    def clear_internal_queues(self) -> None:
+        """Clear all internal input and output queues."""
+        # Clear internal input queues
+        for input_buffer in self._input_buffers:
+            while input_buffer:
+                bundle = input_buffer.popleft()
+                self._metrics.on_input_dequeued(bundle)
+
+        # Clear internal output queue
+        while self._output_buffer:
+            bundle = self._output_buffer.popleft()
+            self._metrics.on_output_dequeued(bundle)
+
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         assert not self.completed()
         assert 0 <= input_index <= len(self._input_dependencies), input_index

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -15,7 +15,9 @@ from ray.data._internal.execution.interfaces.execution_options import (
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.join import JoinOperator
 from ray.data._internal.execution.operators.limit_operator import LimitOperator
-from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_operator import (
+    MapOperator,
+)
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.resource_manager import (
     ReservationOpResourceAllocator,
@@ -44,7 +46,7 @@ def mock_map_op(
         compute_strategy=compute_strategy,
         name=name,
     )
-    op.start = MagicMock(side_effect=lambda _: None)
+    op.start(ExecutionOptions())
     if incremental_resource_usage is not None:
         op.incremental_resource_usage = MagicMock(
             return_value=incremental_resource_usage

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -15,9 +15,7 @@ from ray.data._internal.execution.interfaces.execution_options import (
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.join import JoinOperator
 from ray.data._internal.execution.operators.limit_operator import LimitOperator
-from ray.data._internal.execution.operators.map_operator import (
-    MapOperator,
-)
+from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.resource_manager import (
     ReservationOpResourceAllocator,


### PR DESCRIPTION
## Description
Currently, we clear _external_ queues when an operator is manually marked as finished. But we don't clear their _internal_ queues. This PR fixes that
## Related issues
Fixes this test https://buildkite.com/ray-project/postmerge/builds/14223#019a5791-3d46-4ab8-9f97-e03ea1c04bb0/642-736
## Additional information
