### PR TITLE
[Data] Use ApproximateTopK and Unique Aggregators for Encoders

### DIFF
--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -947,7 +947,7 @@ class Unique(AggregateFnV2[Set[Any], List[Any]]):
                 col = pc.list_flatten(col)
             else:
                 py_list = col.to_pylist()
-                str_list = [str(v) for v in py_list]
+                str_list = [None if v is None else str(v) for v in py_list]
                 col = pyarrow.array(str_list, type=pyarrow.string())
         return pc.unique(col).to_pylist()
 

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -916,6 +916,10 @@ class Unique(AggregateFnV2[Set[Any], List[Any]]):
         ignore_nulls: Whether to ignore null values when collecting unique items.
                       Default is True (nulls are excluded).
         alias_name: Optional name for the resulting column.
+        encode_lists: If ``True``, encode list elements.  If ``False``, encode
+            whole lists (i.e., the entire list is considered as a single object).
+            ``False`` by default. To encode list elements, each individual
+            element must be of the same type.
     """
 
     def __init__(
@@ -923,6 +927,7 @@ class Unique(AggregateFnV2[Set[Any], List[Any]]):
         on: Optional[str] = None,
         ignore_nulls: bool = True,
         alias_name: Optional[str] = None,
+        encode_lists: bool = False,
     ):
         super().__init__(
             alias_name if alias_name else f"unique({str(on)})",
@@ -930,6 +935,7 @@ class Unique(AggregateFnV2[Set[Any], List[Any]]):
             ignore_nulls=ignore_nulls,
             zero_factory=set,
         )
+        self.encode_lists = encode_lists
 
     def combine(self, current_accumulator: Set[Any], new: Set[Any]) -> Set[Any]:
         return self._to_set(current_accumulator) | self._to_set(new)
@@ -937,9 +943,12 @@ class Unique(AggregateFnV2[Set[Any], List[Any]]):
     def aggregate_block(self, block: Block) -> List[Any]:
         col = BlockAccessor.for_block(block).to_arrow().column(self._target_col_name)
         if pyarrow.types.is_list(col.type):
-            py_list = col.to_pylist()
-            str_list = [str(v) for v in py_list]
-            col = pyarrow.array(str_list, type=pyarrow.string())
+            if self.encode_lists:
+                col = pc.list_flatten(col)
+            else:
+                py_list = col.to_pylist()
+                str_list = [str(v) for v in py_list]
+                col = pyarrow.array(str_list, type=pyarrow.string())
         return pc.unique(col).to_pylist()
 
     @staticmethod
@@ -1453,6 +1462,7 @@ class ApproximateTopK(AggregateFnV2):
         k: int,
         log_capacity: int = 15,
         alias_name: Optional[str] = None,
+        encode_lists: bool = False,
     ):
         """
         Computes the approximate top k items in a column by using a datasketches frequent_strings_sketch.
@@ -1489,11 +1499,15 @@ class ApproximateTopK(AggregateFnV2):
             log_capacity: Base 2 logarithm of the maximum size of the internal hash map.
                 Higher values increase accuracy but use more memory. Defaults to 15.
             alias_name: The name of the aggregate. Defaults to None.
+            encode_lists: If ``True``, encode list elements.  If ``False``, encode
+                whole lists (i.e., the entire list is considered as a single object).
+                ``False`` by default.
         """
 
         self.k = k
         self._log_capacity = log_capacity
         self._frequent_strings_sketch = self._require_datasketches()
+        self.encode_lists = encode_lists
         super().__init__(
             alias_name if alias_name else f"approx_topk({str(on)})",
             on=on,
@@ -1511,7 +1525,12 @@ class ApproximateTopK(AggregateFnV2):
         sketch = self.zero(self._log_capacity)
         for value in column:
             if value.as_py() is not None:
-                sketch.update(str(value.as_py()))
+                py_value = value.as_py()
+                if self.encode_lists and isinstance(py_value, list):
+                    for item in py_value:
+                        sketch.update(str(item))
+                else:
+                    sketch.update(str(py_value))
         return sketch.serialize()
 
     def combine(self, current_accumulator: bytes, new: bytes) -> bytes:

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -243,7 +243,7 @@ class OneHotEncoder(Preprocessor):
         output_columns: The names of the transformed columns. If None, the transformed
             columns will be the same as the input columns. If not None, the length of
             ``output_columns`` must match the length of ``columns``, othwerwise an error
-            will be raised.'
+            will be raised.
         log_capacity: Base 2 logarithm of the maximum size of the internal hash map for
             top-K calculation. Higher values increase accuracy but use more memory.
             Defaults to 11 (2048 categories).

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -336,7 +336,6 @@ class OneHotEncoder(Preprocessor):
 
     def _transform_pandas(self, df: pd.DataFrame):
         _validate_df(df, *self.columns)
-        print(f"!!!{self.stats_}")
 
         # Compute new one-hot encoded columns
         for column, output_column in zip(self.columns, self.output_columns):

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -530,14 +530,11 @@ class LabelEncoder(Preprocessor):
         self.output_column = output_column or label_column
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self.stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=[self.label_column],
-                key_gen=key_gen,
+        self.stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Unique(
+                col, ignore_nulls=False, encode_lists=True
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
             post_key_fn=lambda col: f"unique_values({col})",
             columns=[self.label_column],
         )
@@ -687,17 +684,14 @@ class Categorizer(Preprocessor):
         def callback(unique_indices: Dict[str, Dict]) -> pd.CategoricalDtype:
             return pd.CategoricalDtype(unique_indices.keys())
 
-        self.stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=columns_to_get,
-                key_gen=key_gen,
+        self.stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Unique(
+                col, ignore_nulls=False, encode_lists=True
             ),
             post_process_fn=make_post_processor(
                 base_fn=unique_post_fn(drop_na_values=True),
                 callbacks=[callback],
             ),
-            stat_key_fn=lambda col: f"unique({col})",
             post_key_fn=lambda col: col,
             columns=columns_to_get,
         )
@@ -712,72 +706,6 @@ class Categorizer(Preprocessor):
             f"{self.__class__.__name__}(columns={self.columns!r}, "
             f"dtypes={self.dtypes!r}, output_columns={self.output_columns!r})"
         )
-
-
-def compute_unique_value_indices(
-    *,
-    dataset: "Dataset",
-    columns: List[str],
-    key_gen: Callable,
-    encode_lists: bool = True,
-    max_categories: Optional[Dict[str, int]] = None,
-):
-    if max_categories is None:
-        max_categories = {}
-    columns_set = set(columns)
-    for column in max_categories:
-        if column not in columns_set:
-            raise ValueError(
-                f"You set `max_categories` for {column}, which is not present in "
-                f"{columns}."
-            )
-
-    def get_pd_value_counts_per_column(col: pd.Series) -> Dict:
-        # special handling for lists
-        if _is_series_composed_of_lists(col):
-            if encode_lists:
-                counter = Counter()
-
-                def update_counter(element):
-                    counter.update(element)
-                    return element
-
-                col.map(update_counter)
-                return counter
-            else:
-                # convert to tuples to make lists hashable
-                col = col.map(lambda x: tuple(x))
-        return Counter(col.value_counts(dropna=False).to_dict())
-
-    def get_pd_value_counts(df: pd.DataFrame) -> Dict[str, List[Dict]]:
-
-        df_columns = df.columns.tolist()
-        result = {}
-        for col in columns:
-            if col in df_columns:
-                result[col] = [get_pd_value_counts_per_column(df[col])]
-            else:
-                raise ValueError(
-                    f"Column '{col}' does not exist in DataFrame, which has columns: {df_columns}"  # noqa: E501
-                )
-        return result
-
-    value_counts_ds = dataset.map_batches(get_pd_value_counts, batch_format="pandas")
-    unique_values_by_col: Dict[str, Set] = {key_gen(col): set() for col in columns}
-    for batch in value_counts_ds.iter_batches(batch_size=None):
-        for col, counters in batch.items():
-            for counter in counters:
-                counter: Dict[Any, int] = {
-                    k: v for k, v in counter.items() if v is not None
-                }
-                if col in max_categories:
-                    counter: Dict[Any, int] = dict(
-                        Counter(counter).most_common(max_categories[col])
-                    )
-                # add only column values since frequencies are needed beyond this point
-                unique_values_by_col[key_gen(col)].update(counter.keys())
-
-    return unique_values_by_col
 
 
 def fit_hot_encoders(

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -719,6 +719,15 @@ def fit_hot_encoders(
     Fits OneHotEncoders and MultiHotEncoders. Refer to argument descriptions for OneHot
     and MultiHot encoders.
     """
+
+    def make_aggregator_function(k: int):
+        return lambda col: ApproximateTopK(
+            col,
+            k=k,
+            log_capacity=log_capacity,
+            encode_lists=encode_lists,
+        )
+
     to_aggregate_unique = []
 
     for col in columns:
@@ -731,12 +740,7 @@ def fit_hot_encoders(
                     f"`log_capacity` to at least {math.ceil(math.log2(k))}."
                 )
             stat_computation_plan.add_aggregator(
-                aggregator_fn=lambda col: ApproximateTopK(
-                    col,
-                    k=k,
-                    log_capacity=log_capacity,
-                    encode_lists=encode_lists,
-                ),
+                aggregator_fn=make_aggregator_function(k),
                 post_process_fn=approx_top_k_post_fn(col),
                 post_key_fn=lambda col: f"unique_values({col})",
                 columns=[col],

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -788,10 +788,9 @@ def approx_top_k_post_fn(col: str):
     sorting the unique values produced during aggregation or stats computation,
     specifically for results from the ApproximateTopK aggregator.
 
-    :param drop_na_values: If True, NA/null values will be silently dropped from the encoding map.
-                           If False, raises an error if any NA/null values are present.
-    :return: A callable that takes a set of unique values and returns a dictionary
-             mapping each value to a unique integer index.
+    :return: A callable that takes a list of dictionaries (the output of
+        ApproximateTopK) and returns a dictionary mapping each value to a
+        unique integer index.
     """
 
     def gen_value_index(values: List[Dict[str, Any]]):

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -382,7 +382,7 @@ def test_one_hot_encoder_mixed_data_types():
 
     test_inputs = {"category": ["1", [1]]}
     test_pd_df = pd.DataFrame(test_inputs)
-    test_data_for_fitting = {"category": ["1", "[1]", "a", "[]", "True"]}
+    test_data_for_fitting = {"category": ["1", "a", "[]", "True"]}
     test_ray_dataset_for_fitting = ray.data.from_pandas(
         pd.DataFrame(test_data_for_fitting)
     )
@@ -391,7 +391,7 @@ def test_one_hot_encoder_mixed_data_types():
     encoder.fit(test_ray_dataset_for_fitting)
 
     pandas_output = encoder.transform_batch(test_pd_df)
-    expected_output = pd.DataFrame({"category": [[1, 0, 0, 0, 0], [0, 0, 0, 0, 0]]})
+    expected_output = pd.DataFrame({"category": [[1, 0, 0, 0], [0, 0, 0, 0]]})
 
     pd.testing.assert_frame_equal(pandas_output, expected_output)
 


### PR DESCRIPTION
## Description
Currently, Ray Data encoder preprocessors will count the number of occurrences per distinct item, regardless of whether we actually need the top-k information. This is inefficient for couple reasons:
1. For most encoders, we don't need this count information. We just need the unique values.
2. For encoders that use `max_categories` (OneHot, MultiHot), there are still columns not included in `max_categories`, and even if they are included, calculating exact top-k is inefficient.

Therefore, this PR changes the encoders to use `Unique` aggregator when possible, and to use `ApproximateTopK` aggregator when `max_categories` is set for OneHot and MultiHot encoders.

Considerations:
Because now we are using aggregations, we do expect lists to have homogenous datatypes when using `OneHotEncoder`. Basically:
```
df = pd.DataFrame({
    "name": ["Shaolin Soccer", "Moana", "The Smartest Guys in the Room"],
    "genre": [
        ["comedy", "action", "sports"],
        ["animation", 2,  "action"], # <- notice the integer here
        ["documentary"],
    ],
})
ds = ray.data.from_pandas(df)  
encoder = OneHotEncoder(columns=["genre"])
pdf = encoder.fit_transform(ds).to_pandas() 
print(pdf)
```
This is not possible.

Note that such semantics were already not possible for preprocessors that encode lists, like `MultiHotEncoder`, `OrdinalEncoder` (with `encode_lists=True`)

## Related issues
N/A

## Additional information
N/A