### PR TITLE
[core][autoscaler] Fix RAY_NODE_TYPE_NAME handling when autoscaler is in read-only mode

### DIFF
--- a/python/ray/autoscaler/_private/readonly/defaults.yaml
+++ b/python/ray/autoscaler/_private/readonly/defaults.yaml
@@ -13,7 +13,6 @@ available_node_types:
         max_workers: 0
 head_node_type: ray.head.default
 upscaling_speed: 1.0
-idle_timeout_minutes: 0
 #
 # !!! Configurations below are not supported in fake cluster mode !!!
 #

--- a/python/ray/autoscaler/v2/instance_manager/config.py
+++ b/python/ray/autoscaler/v2/instance_manager/config.py
@@ -522,16 +522,23 @@ class ReadOnlyProviderConfigReader(IConfigReader):
 
         head_node_type = None
         for node_state in ray_cluster_resource_state.node_states:
-            node_type = format_readonly_node_type(binary_to_hex(node_state.node_id))
+            node_type = node_state.ray_node_type_name
+            if not node_type:
+                node_type = format_readonly_node_type(binary_to_hex(node_state.node_id))
+
             if is_head_node(node_state):
                 head_node_type = node_type
 
-            available_node_types[node_type] = {
-                "resources": dict(node_state.total_resources),
-                "min_workers": 0,
-                "max_workers": 0 if is_head_node(node_state) else 1,
-                "node_config": {},
-            }
+            if node_type not in available_node_types:
+                available_node_types[node_type] = {
+                    "resources": dict(node_state.total_resources),
+                    "min_workers": 0,
+                    "max_workers": 0 if is_head_node(node_state) else 1,
+                    "node_config": {},
+                }
+            elif not is_head_node(node_state):
+                available_node_types[node_type]["max_workers"] += 1
+
         if available_node_types:
             self._configs["available_node_types"].update(available_node_types)
             self._configs["max_workers"] = len(available_node_types)


### PR DESCRIPTION
This ensures node type names are correctly reported even when the autoscaler is disabled (read-only mode).

## Description

Autoscaler v2 fails to report prometheus metrics when operating in read-only mode on KubeRay with the following KeyError error:

```
2025-11-08 12:06:57,402	ERROR autoscaler.py:215 -- 'small-group'
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/autoscaler/v2/autoscaler.py", line 200, in update_autoscaling_state
    return Reconciler.reconcile(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 120, in reconcile
    Reconciler._step_next(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 275, in _step_next
    Reconciler._scale_cluster(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 1125, in _scale_cluster
    reply = scheduler.schedule(sched_request)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/autoscaler/v2/scheduler.py", line 933, in schedule
    ResourceDemandScheduler._enforce_max_workers_per_type(ctx)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/autoscaler/v2/scheduler.py", line 1006, in _enforce_max_workers_per_type
    node_config = ctx.get_node_type_configs()[node_type]
KeyError: 'small-group'
```

This happens because the `ReadOnlyProviderConfigReader` populates `ctx.get_node_type_configs()` using node IDs as node types, which is correct for local Ray (where local ray does not have `RAY_NODE_TYPE_NAME` set), but incorrect for KubeRay where `ray_node_type_name` is present and expected with `RAY_NODE_TYPE_NAME` set.

As a result, in read-only mode the scheduler sees a node type name (ex. small-group) that never exists in the populated configs.

This PR fixes the issue by using `ray_node_type_name` when it exists, and only falling back to node ID when it does not.
## Related issues
Fixes https://github.com/ray-project/ray/issues/58227
