### PR TITLE
[Docs] fix pattern_async_actor demo typo

### DIFF
--- a/doc/source/ray-core/doc_code/pattern_async_actor.py
+++ b/doc/source/ray-core/doc_code/pattern_async_actor.py
@@ -51,7 +51,7 @@ class AsyncTaskExecutor:
             # Here we use await instead of ray.get() to
             # wait for the next task and it will yield
             # the control while waiting.
-            task = await task_store.get_next_task.remote()
+            task = await self.task_store.get_next_task.remote()
             self._execute_task(task)
 
     def _execute_task(self, task):

--- a/doc/source/ray-core/doc_code/pattern_async_actor.py
+++ b/doc/source/ray-core/doc_code/pattern_async_actor.py
@@ -16,7 +16,7 @@ class TaskExecutor:
 
     def run(self):
         while True:
-            task = ray.get(task_store.get_next_task.remote())
+            task = ray.get(self.task_store.get_next_task.remote())
             self._execute_task(task)
 
     def _execute_task(self, task):


### PR DESCRIPTION
## Description

fix pattern_async_actor demo typo. Add `self.`.

## Related issues


## Additional information

