### PR TITLE
Improve instructions for reading Hugging Face datasets with Ray Data

### DIFF
--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -652,6 +652,17 @@ Ray Data interoperates with distributed data processing frameworks like `Daft <h
             {'col1': 1, 'col2': '1'}
             {'col1': 2, 'col2': '2'}
 
+.. _loading_huggingface_datasets:
+
+Loading Hugging Face datasets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To read datasets from the Hugging Face Hub, use :func:`~ray.data.read_parquet` (or other
+read functions) with the ``HfFileSystem`` filesystem. This approach provides better
+performance and scalability than loading datasets into memory first.
+
+First, install the required dependencies
+
 .. _loading_datasets_from_ml_libraries:
 
 Loading data from ML libraries

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -703,53 +703,6 @@ read from the dataset path:
     title   string
     text    string
 
-If you need to filter by split (train, test, validation, etc.) or parse filenames,
-you can use the ``datasets`` library to discover files:
-
-.. testcode::
-    :skipif: True
-
-    import os
-    import ray
-    import datasets
-    from huggingface_hub import HfFileSystem
-
-    # Specify the dataset and the split name.
-    dataset_name = "wikimedia/wikipedia"
-    split = "train"
-
-    # Fetch the dataset files.
-    base_path = f"hf://datasets/{dataset_name}"
-    patterns = datasets.data_files.get_data_patterns(base_path)
-    data_files_with_splits = datasets.data_files.DataFilesDict.from_patterns(
-        patterns,
-        base_path=base_path,
-        allowed_extensions=datasets.load.ALL_ALLOWED_EXTENSIONS,
-    )
-    data_files = data_files_with_splits["train"]
-
-    # Read those files into Ray Data.
-    ds = ray.data.read_parquet(
-        data_files,
-        file_extensions=["parquet"],
-        filesystem=HfFileSystem(token=os.environ["HF_TOKEN"]),
-    )
-
-    print(f"Dataset count: {ds.count()}")
-
-.. testoutput::
-    :options: +MOCK
-
-    Dataset count: 61614907
-
-.. tip::
-
-    For datasets that aren't in Parquet format, use the appropriate read function:
-    :func:`~ray.data.read_json` for JSON files, or :func:`~ray.data.read_binary_files`
-    for binary files like audio archives.
-
-For a complete example script that loads many different Hugging Face datasets, see
-:download:`load_data_from_hf.py <doc_code/load_data_from_hf.py>`.
 
 .. _loading_datasets_from_ml_libraries:
 

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -667,7 +667,8 @@ First, install the required dependencies:
 
     pip install huggingface_hub
 
-Then, authenticate using your Hugging Face token:
+Set your Hugging Face token to authenticate. While public datasets can be read without
+a token, you will suffer aggressive rate limiting without a token.
 
 .. code-block:: console
 

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -754,7 +754,7 @@ For a complete example script that loads many different Hugging Face datasets, s
 .. _loading_datasets_from_ml_libraries:
 
 Loading data from ML libraries
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Ray Data interoperates with PyTorch and TensorFlow datasets.
 

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -695,7 +695,6 @@ read from the dataset path:
     print(ds.schema())
 
 .. testoutput::
-    :options: +MOCK
 
     Dataset count: 61614907
     Column  Type

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -652,59 +652,6 @@ Ray Data interoperates with distributed data processing frameworks like `Daft <h
             {'col1': 1, 'col2': '1'}
             {'col1': 2, 'col2': '2'}
 
-.. _loading_huggingface_datasets:
-
-Loading Hugging Face datasets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To read datasets from the Hugging Face Hub, use :func:`~ray.data.read_parquet` (or other
-read functions) with the ``HfFileSystem`` filesystem. This approach provides better
-performance and scalability than loading datasets into memory first.
-
-First, install the required dependencies:
-
-.. code-block:: console
-
-    pip install huggingface_hub
-
-Set your Hugging Face token to authenticate. While public datasets can be read without
-a token, Hugging Face rate limits are more aggressive without a token. To read Hugging
-Face datasets without a token, simply set the filesystem argument to ``HfFileSystem()``.
-
-.. code-block:: console
-
-    export HF_TOKEN=<YOUR HUGGING FACE TOKEN>
-
-For most Hugging Face datasets, the data is stored in Parquet files. You can directly
-read from the dataset path:
-
-.. testcode::
-    :skipif: True
-
-    import os
-    import ray
-    from huggingface_hub import HfFileSystem
-
-    ds = ray.data.read_parquet(
-        "hf://datasets/wikimedia/wikipedia",
-        file_extensions=["parquet"],
-        filesystem=HfFileSystem(token=os.environ["HF_TOKEN"]),
-    )
-
-    print(f"Dataset count: {ds.count()}")
-    print(ds.schema())
-
-.. testoutput::
-
-    Dataset count: 61614907
-    Column  Type
-    ------  ----
-    id      string
-    url     string
-    title   string
-    text    string
-
-
 .. _loading_datasets_from_ml_libraries:
 
 Loading data from ML libraries

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -668,7 +668,8 @@ First, install the required dependencies:
     pip install huggingface_hub
 
 Set your Hugging Face token to authenticate. While public datasets can be read without
-a token, you will suffer aggressive rate limiting without a token.
+a token, Hugging Face rate limits are more aggressive without a token. To read Hugging
+Face datasets without a token, simply set the filesystem arguemnt to ``HfFileSystem()``.
 
 .. code-block:: console
 

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -669,7 +669,7 @@ First, install the required dependencies:
 
 Set your Hugging Face token to authenticate. While public datasets can be read without
 a token, Hugging Face rate limits are more aggressive without a token. To read Hugging
-Face datasets without a token, simply set the filesystem arguemnt to ``HfFileSystem()``.
+Face datasets without a token, simply set the filesystem argument to ``HfFileSystem()``.
 
 .. code-block:: console
 


### PR DESCRIPTION
This pull request updates the documentation for reading Hugging Face datasets, recommending the use of ray.data.read_parquet with HfFileSystem for better performance and scalability. 