### PR TITLE
[serve][llm] Fix import path in muli-node release test

### DIFF
--- a/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
@@ -3,11 +3,11 @@ import pytest
 import ray
 from ray import serve
 from ray.serve.llm import (
+    build_dp_deployment,
+    build_openai_app,
     LLMConfig,
     LLMServingArgs,
     ModelLoadingConfig,
-    build_openai_app,
-    build_dp_deployment,
 )
 
 

--- a/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
@@ -98,6 +98,9 @@ def test_llm_serve_data_parallelism():
             max_num_batched_tokens=256,
             enforce_eager=True,
         ),
+        experimental_configs=dict(
+            dp_size_per_node=2,
+        ),
         placement_group_config=placement_group_config,
         runtime_env={"env_vars": {"VLLM_DISABLE_COMPILE_CACHE": "1"}},
     )

--- a/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
@@ -7,8 +7,6 @@ from ray.serve.llm import (
     LLMServingArgs,
     ModelLoadingConfig,
     build_openai_app,
-)
-from ray.llm._internal.serve.serving_patterns.data_parallel.dp_server import (
     build_dp_deployment,
 )
 


### PR DESCRIPTION

## Description
```
test_llm_serve_multi_node_integration.py:11: in <module>
    from ray.llm._internal.serve.serving_patterns.data_parallel.dp_server import (
E   ImportError: cannot import name 'build_dp_deployment' from 'ray.llm._internal.serve.serving_patterns.data_parallel.dp_server'
```

## Related issues
Fix https://github.com/ray-project/ray/issues/58476

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
