### PR TITLE
[Data] - Fix TPCH Q1 Release test

### DIFF
--- a/release/nightly_tests/dataset/tpch_q1.py
+++ b/release/nightly_tests/dataset/tpch_q1.py
@@ -97,9 +97,6 @@ def main(args):
     benchmark.run_fn("main", benchmark_fn)
     benchmark.write_result()
 
-    benchmark.run_fn("main", benchmark_fn)
-    benchmark.write_result()
-
 
 if __name__ == "__main__":
     ray.init()


### PR DESCRIPTION
## Description
Need to fix `read_parquet -> rename_columns  -> select_columns` scenario in Projection pushdown. Until then, I'm going to revert to referring to the un-renamed column in the release test to unblock it.

Release test: https://buildkite.com/ray-project/release/builds/67016#019a6f72-2647-4111-9209-5939e247547c
## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
