### PR TITLE
[doc] change link check to run on python 3.12

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -62,11 +62,12 @@ steps:
       - api_policy_check
 
   - label: ":book: doc: linkcheck"
+    key: doc_linkcheck
     instance_type: medium
     commands:
       - make -C doc/ linkcheck_all
     depends_on: docbuild
-    job_env: docbuild-py3.10
+    job_env: docbuild-py3.12
     tags:
       - oss
       - skip-on-premerge


### PR DESCRIPTION
migrating all doc related things to run on python 3.12
