### PR TITLE
[doc] ci: move doc annotation check to python 3.12

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -36,7 +36,7 @@ steps:
       - doc
       - skip-on-premerge
 
-  - label: ":book: doc: check python API: {{matrix}}"
+  - label: ":book: doc: check API annotations"
     tags:
       - oss
       - python
@@ -51,15 +51,35 @@ steps:
       - rllib
       - rllib_gpu
       - doc
-    key: lint-medium
+    key: doc_api_annotations
     instance_type: medium
     depends_on: docbuild
+    job_env: docbuild-py3.12
+    commands:
+      - bash ci/lint/lint.sh api_annotations
+
+  - label: ":book: doc: check API doc consistency"
+    tags:
+      - oss
+      - python
+      - dashboard
+      - ray_client
+      - data
+      - serve
+      - ml
+      - tune
+      - train
+      - llm
+      - rllib
+      - rllib_gpu
+      - doc
+    key: doc_api_policy_check
+    instance_type: medium
+    depends_on: docbuild
+    # TODO(aslonnie): migrate to Python 3.12
     job_env: docbuild-py3.9
     commands:
-      - ./ci/lint/lint.sh {{matrix}}
-    matrix:
-      - api_annotations
-      - api_policy_check
+      - bash ci/lint/lint.sh api_policy_check
 
   - label: ":book: doc: linkcheck"
     instance_type: medium


### PR DESCRIPTION
be consistent with doc build environment
