### PR TITLE
fix:[58485] Make AggregationFunction yaml dumper friendly

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -453,8 +453,8 @@ class AutoscalingConfig(BaseModel):
     @validator("aggregation_function", always=True)
     def aggregation_function_valid(cls, v: Union[str, AggregationFunction]):
         if isinstance(v, AggregationFunction):
-            return v
-        return AggregationFunction(str(v).lower())
+            return v.value
+        return AggregationFunction(str(v).lower()).value
 
     @classmethod
     def default(cls):


### PR DESCRIPTION
## Description
In this fix, I'm changing the validator function to always return the value of enum.
This should fix the yaml dumper issue that we are having with serve build

## Related issues
Fixes #58485

## Additional information
Since the class is a subclass of both str and Enum, the validator can always return the str value and yaml compatibility can be maintained
