### PR TITLE
[serve] add result(...) to DeploymentResponseGenerator to fix static typing

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -640,6 +640,27 @@ class DeploymentResponseGenerator(_DeploymentResponseBase):
         replica_result = self._fetch_future_result_sync()
         return replica_result.__next__()
 
+    def result(
+        self,
+        *,
+        timeout_s: Optional[float] = None,
+        _skip_asyncio_check: bool = False,
+    ) -> Any:
+        """This method is not available on DeploymentResponseGenerator.
+
+        DeploymentResponseGenerator is returned when using streaming handles.
+        To get results, iterate over the generator using `for` (outside deployments)
+        or `async for` (inside deployments) instead of calling `.result()`.
+
+        Raises:
+            TypeError: Always raises, as this method is not supported for generators.
+        """
+        raise TypeError(
+            "`DeploymentResponseGenerator` doesn't support `.result()`. "
+            "Use iteration instead: `for item in response` (outside deployments) "
+            "or `async for item in response` (inside deployments)."
+        )
+
     @DeveloperAPI
     async def _to_object_ref_gen(self) -> ObjectRefGenerator:
         """Advanced API to convert the generator to a Ray `ObjectRefGenerator`.

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -652,6 +652,13 @@ class DeploymentResponseGenerator(_DeploymentResponseBase):
         To get results, iterate over the generator using `for` (outside deployments)
         or `async for` (inside deployments) instead of calling `.result()`.
 
+        Args:
+            timeout_s: Present for API parity with non-streaming responses; ignored.
+            _skip_asyncio_check: Present for API parity; ignored.
+
+        Returns:
+            NoReturn: This method always raises a TypeError.
+
         Raises:
             TypeError: Always raises, as this method is not supported for generators.
         """

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -646,21 +646,17 @@ class DeploymentResponseGenerator(_DeploymentResponseBase):
         timeout_s: Optional[float] = None,
         _skip_asyncio_check: bool = False,
     ) -> Any:
-        """This method is not available on DeploymentResponseGenerator.
+        """Not supported on `DeploymentResponseGenerator`.
 
-        DeploymentResponseGenerator is returned when using streaming handles.
-        To get results, iterate over the generator using `for` (outside deployments)
-        or `async for` (inside deployments) instead of calling `.result()`.
+        This method exists only for API parity with `DeploymentResponse.result()` to
+        aid static typing. A `DeploymentResponseGenerator` is returned when using
+        streaming handles (e.g., `handle.options(stream=True)`).
 
-        Args:
-            timeout_s: Present for API parity with non-streaming responses; ignored.
-            _skip_asyncio_check: Present for API parity; ignored.
+        To consume results, iterate over the generator instead of calling `.result()`:
+          - Outside a deployment: use a standard `for` loop
+          - Inside a deployment: use `async for`
 
-        Returns:
-            NoReturn: This method always raises a TypeError.
-
-        Raises:
-            TypeError: Always raises, as this method is not supported for generators.
+        Always raises `TypeError`.
         """
         raise TypeError(
             "`DeploymentResponseGenerator` doesn't support `.result()`. "


### PR DESCRIPTION
## Description
This PR adds a dummy `.result()` API to DeploymentResponseGenerator`.

`DeploymentResponseGenerator` currently doesn't support `.result()`, however when calling `.remote()` on a DeploymentHandle, the return type is a Union of `DeploymentResponseGenerator` and `DeploymentResponse`. Meaning if `.result()` is on the object, a typing error is raised.

Example error without this PR:
<img width="1838" height="1286" alt="image" src="https://github.com/user-attachments/assets/8f6a0b48-2926-4fa0-ad2f-1bd411ff7362" />


## Related issues
fixes https://github.com/ray-project/ray/issues/52493
## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
