### PR TITLE
[Data] Convert rST-style to Google-style docstrings in `ray.data`

### DIFF
--- a/python/ray/data/_internal/datasource/delta_sharing_datasource.py
+++ b/python/ray/data/_internal/datasource/delta_sharing_datasource.py
@@ -49,8 +49,12 @@ class DeltaSharingDatasource(Datasource):
         """
         Set up delta sharing connections based on the url.
 
-        :param url: a url under the format "<profile>#<share>.<schema>.<table>"
-        :
+        Args:
+            url: A URL under the format "<profile>#<share>.<schema>.<table>"
+
+        Returns:
+            A tuple of (table, rest_client) where table is a delta_sharing Table
+            object and rest_client is a DataSharingRestClient instance.
         """
         from delta_sharing.protocol import DeltaSharingProfile, Table
         from delta_sharing.rest_client import DataSharingRestClient

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -703,8 +703,9 @@ class BlockColumnAccessor:
         Internally, Polars is used to compute row-level hashes even when the original column
         is backed by Pandas or PyArrow.
 
-        :return: A column of 64-bit integer hashes, returned in the same format as the underlying backend
-             (e.g., Pandas Series or PyArrow Array).
+        Returns:
+            A column of 64-bit integer hashes, returned in the same format as the
+            underlying backend (e.g., Pandas Series or PyArrow Array).
         """
         raise NotImplementedError()
 
@@ -720,10 +721,13 @@ class BlockColumnAccessor:
         """
         Checks whether the column is composed of list-like elements.
 
-        :param types: Optional tuple of backend-specific types to check against.
-                      If not provided, defaults to list-like types appropriate
-                      for the underlying backend (e.g., PyArrow list types).
-        :return: True if the column is made up of list-like values; False otherwise.
+        Args:
+            types: Optional tuple of backend-specific types to check against.
+                If not provided, defaults to list-like types appropriate
+                for the underlying backend (e.g., PyArrow list types).
+
+        Returns:
+            True if the column is made up of list-like values; False otherwise.
         """
         raise NotImplementedError()
 

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -789,10 +789,13 @@ def unique_post_fn(drop_na_values: bool = False) -> Callable[[Set], Dict[str, in
     Returns a post-processing function that generates an encoding map by
     sorting the unique values produced during aggregation or stats computation.
 
-    :param drop_na_values: If True, NA/null values will be silently dropped from the encoding map.
-                           If False, raises an error if any NA/null values are present.
-    :return: A callable that takes a set of unique values and returns a dictionary
-             mapping each value to a unique integer index.
+    Args:
+        drop_na_values: If True, NA/null values will be silently dropped from the
+            encoding map. If False, raises an error if any NA/null values are present.
+
+    Returns:
+        A callable that takes a set of unique values and returns a dictionary
+        mapping each value to a unique integer index.
     """
 
     def gen_value_index(values: Set) -> Dict[str, int]:

--- a/python/ray/data/preprocessors/utils.py
+++ b/python/ray/data/preprocessors/utils.py
@@ -134,11 +134,12 @@ class StatComputationPlan:
         This supports legacy use cases where arbitrary callables are needed
         and cannot be run via Dataset.aggregate().
 
-        :param post_key_fn:
-        :param stat_fn: A zero-argument callable that returns the stat.
-        :param post_process_fn: Function to apply to the result.
-        :param columns:
-        :param stat_key_fn:
+        Args:
+            stat_fn: A zero-argument callable that returns the stat.
+            post_process_fn: Function to apply to the result.
+            stat_key_fn:
+            post_key_fn:
+            columns:
         """
         self._aggregators.append(
             CallableStatSpec(


### PR DESCRIPTION
## Description

This PR improves documentation consistency in the `python/ray/data` module by converting all remaining rST-style docstrings (`:param:`, `:return:`, etc.) to Google-style format (`Args:`, `Returns:`, etc.).

## Additional information

**Files modified:**
- `python/ray/data/preprocessors/utils.py` - Converted `StatComputationPlan.add_callable_stat()`
- `python/ray/data/preprocessors/encoder.py` - Converted `unique_post_fn()`
- `python/ray/data/block.py` - Converted `BlockColumnAccessor.hash()` and `BlockColumnAccessor.is_composed_of_lists()`
- `python/ray/data/_internal/datasource/delta_sharing_datasource.py` - Converted `DeltaSharingDatasource.setup_delta_sharing_connections()`