### PR TITLE
[doc] use python 3.12 to perform policy check 

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -76,8 +76,7 @@ steps:
     key: doc_api_policy_check
     instance_type: medium
     depends_on: docbuild
-    # TODO(aslonnie): migrate to Python 3.12
-    job_env: docbuild-py3.9
+    job_env: docbuild-py3.12
     commands:
       - bash ci/lint/lint.sh api_policy_check
 

--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -11,7 +11,10 @@ py_binary(
     name = "cmd_build",
     srcs = ["cmd_build.py"],
     exec_compatible_with = ["//:hermetic_python"],
-    deps = [":doc"],
+    deps = [
+        ci_require("click"),
+        ":doc",
+    ],
 )
 
 py_library(
@@ -23,9 +26,8 @@ py_library(
             "cmd_*.py",
         ],
     ),
-    visibility = ["//ci/ray_ci/doc:__subpackages__"],
     deps = [
-        "//ci/ray_ci:ray_ci_lib",
+        ci_require("boto3"),
         ci_require("sphinx"),
         ci_require("myst_parser"),
         ci_require("myst-nb"),

--- a/ci/ray_ci/doc/cmd_build.py
+++ b/ci/ray_ci/doc/cmd_build.py
@@ -1,12 +1,10 @@
 import os
 import subprocess
+import sys
 
 import click
 
 from ci.ray_ci.doc.build_cache import BuildCache
-from ci.ray_ci.utils import ci_init, logger
-
-from ray_release.configs.global_config import get_global_config
 
 
 @click.command()
@@ -18,36 +16,31 @@ def main(ray_checkout_dir: str) -> None:
     """
     This script builds ray doc and upload build artifacts to S3.
     """
-    ci_init()
     # Add the safe.directory config to the global git config so that the doc build
     subprocess.run(
         ["git", "config", "--global", "--add", "safe.directory", ray_checkout_dir],
         check=True,
     )
 
-    logger.info("Building ray doc.")
+    print("--- Building ray doc.", file=sys.stderr)
     _build(ray_checkout_dir)
 
     dry_run = False
-    if (
-        os.environ.get("BUILDKITE_PIPELINE_ID")
-        not in get_global_config()["ci_pipeline_postmerge"]
-    ):
+    if os.environ.get("RAYCI_STAGE", "") != "postmerge":
         dry_run = True
-        logger.info(
-            "Not uploading build artifacts because this is not a postmerge pipeline."
+        print(
+            "Not uploading build artifacts because this is not a postmerge pipeline.",
+            file=sys.stderr,
+        )
+    elif os.environ.get("BUILDKITE_BRANCH") != "master":
+        dry_run = True
+        print(
+            "Not uploading build artifacts because this is not the master branch.",
+            file=sys.stderr,
         )
 
-    if os.environ.get("BUILDKITE_BRANCH") != "master":
-        dry_run = True
-        logger.info(
-            "Not uploading build artifacts because this is not the master branch."
-        )
-
-    logger.info("Uploading build artifacts to S3.")
+    print("--- Uploading build artifacts to S3.", file=sys.stderr)
     BuildCache(os.path.join(ray_checkout_dir, "doc")).upload(dry_run=dry_run)
-
-    return
 
 
 def _build(ray_checkout_dir):

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -1,9 +1,10 @@
+import sys
+
 import click
 
 from ci.ray_ci.doc.api import API
 from ci.ray_ci.doc.autodoc import Autodoc
 from ci.ray_ci.doc.module import Module
-from ci.ray_ci.utils import logger
 
 TEAM_API_CONFIGS = {
     "data": {
@@ -102,24 +103,28 @@ def _check_team(ray_checkout_dir: str, team: str) -> bool:
     white_list_apis = TEAM_API_CONFIGS[team]["white_list_apis"]
 
     # Policy 01: all public APIs should be documented
-    logger.info(f"Validating that public {team} APIs should be documented...")
+    print(
+        f"--- Validating that public {team} APIs should be documented...",
+        file=sys.stderr,
+    )
     good_apis, bad_apis = API.split_good_and_bad_apis(
         api_in_codes, api_in_docs, white_list_apis
     )
 
     if good_apis:
-        logger.info("Public APIs that are documented:")
+        print("Public APIs that are documented:", file=sys.stderr)
         for api in good_apis:
-            logger.info(f"\t{api}")
+            print(f"\t{api}", file=sys.stderr)
 
     if bad_apis:
-        logger.info("Public APIs that are NOT documented:")
+        print("Public APIs that are NOT documented:", file=sys.stderr)
         for api in bad_apis:
-            logger.info(f"\t{api}")
+            print(f"\t{api}", file=sys.stderr)
 
     if bad_apis:
-        logger.info(
-            f"Some public {team} APIs are not documented. Please document them."
+        print(
+            f"Some public {team} APIs are not documented. Please document them.",
+            file=sys.stderr,
         )
         return False
     return True


### PR DESCRIPTION
It is technically still using the resolved dependencies of python
3.9, but all libraries used are version agnostic, it should run.