### PR TITLE
[Core] Fix the issue of duplicate keys in the SendRedisCmdWithKeys function

### DIFF
--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -272,6 +272,11 @@ void RedisStoreClient::SendRedisCmdArgsAsKeys(RedisCommand command,
 void RedisStoreClient::SendRedisCmdWithKeys(std::vector<std::string> keys,
                                             RedisCommand command,
                                             RedisCallback redis_callback) {
+  // When duplicate elements appear in the keys array, the following code will fail
+  // to be executed. Therefore, duplicate elements in keys need to be removed.
+  std::set<std::string> uniqueKeys(keys.begin(), keys.end());
+  keys.assign(uniqueKeys.begin(), uniqueKeys.end());
+
   RAY_CHECK(!keys.empty());
   auto concurrency_keys =
       ray::move_mapped(std::move(keys), [&command](std::string &&key) {


### PR DESCRIPTION
## Description
This issue arises when using Redis as the external storage. When a submission task contains multiple `ray.init` instances, duplicate keys may occur, leading to GCS being stuck. Duplicate keys can also be reproduced when calling the `internal_kv_multi_get` function.

## Related issues


## Additional information

