### PR TITLE
[Dashboard] Optimize the get_all_jobs function

### DIFF
--- a/python/ray/dashboard/modules/job/common.py
+++ b/python/ray/dashboard/modules/job/common.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import time
@@ -398,21 +397,23 @@ class JobInfoStorageClient:
             namespace=ray_constants.KV_NAMESPACE_JOB,
             timeout=timeout,
         )
-        job_ids_with_prefixes = [
-            job_id.decode() for job_id in raw_job_ids_with_prefixes
-        ]
-        job_ids = []
-        for job_id_with_prefix in job_ids_with_prefixes:
+
+        obj_info_dict = await self._gcs_client.async_internal_kv_multi_get(
+            raw_job_ids_with_prefixes,
+            namespace=ray_constants.KV_NAMESPACE_JOB,
+            timeout=timeout,
+        )
+        result = {}
+        for job_id_with_prefix, job_info in obj_info_dict.items():
+            if job_info is None:
+                continue
+            job_id_with_prefix = job_id_with_prefix.decode()
             assert job_id_with_prefix.startswith(
                 self.JOB_DATA_KEY_PREFIX
             ), "Unexpected format for internal_kv key for Job submission"
-            job_ids.append(job_id_with_prefix[len(self.JOB_DATA_KEY_PREFIX) :])
-
-        async def get_job_info(job_id: str):
-            job_info = await self.get_info(job_id, timeout)
-            return job_id, job_info
-
-        return dict(await asyncio.gather(*[get_job_info(job_id) for job_id in job_ids]))
+            job_id = job_id_with_prefix[len(self.JOB_DATA_KEY_PREFIX) :]
+            result[job_id] = JobInfo.from_json(json.loads(job_info))
+        return result
 
 
 def uri_to_http_components(package_uri: str) -> Tuple[str, str]:


### PR DESCRIPTION
## Description
The current implementation of the `get_all_jobs` function involves retrieving all `submission_id`s and asynchronously fetching Job data one by one. However, this approach becomes less efficient as the number of Jobs increases.
Therefore, we switched to the `async_internal_kv_multi_get` function to batch fetch job data, thereby enhancing the performance of the function.

## Related issues

## Additional information

