### PR TITLE
[Core] Add automatic cleaning function for worker data

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -383,6 +383,8 @@ RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_max_interval_ms, 1000)
 RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5)
 /// Maximum number of destroyed actors in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)
+/// Maximum number of dead workers in GCS server storage.
+RAY_CONFIG(uint32_t, maximum_gcs_dead_worker_cached_count, 100000)
 /// Maximum number of dead nodes in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 1000)
 // The interval at which the gcs server will pull a new resource.

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -740,6 +740,7 @@ void GcsServer::InitRuntimeEnvManager() {
 void GcsServer::InitGcsWorkerManager() {
   gcs_worker_manager_ = std::make_unique<GcsWorkerManager>(
       *gcs_table_storage_, io_context_provider_.GetDefaultIOContext(), *gcs_publisher_);
+  gcs_worker_manager_->Initialize();
   rpc_server_.RegisterService(std::make_unique<rpc::WorkerInfoGrpcService>(
       io_context_provider_.GetDefaultIOContext(),
       *gcs_worker_manager_,

--- a/src/ray/gcs/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_worker_manager.h
@@ -35,6 +35,8 @@ class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
         io_context_(io_context),
         gcs_publisher_(gcs_publisher) {}
 
+  void Initialize(void);
+
   void HandleReportWorkerFailure(rpc::ReportWorkerFailureRequest request,
                                  rpc::ReportWorkerFailureReply *reply,
                                  rpc::SendReplyCallback send_reply_callback) override;
@@ -86,6 +88,9 @@ class GcsWorkerManager : public rpc::WorkerInfoGcsServiceHandler {
 
   /// Tracks the number of occurrences of worker crash due to OOM
   int32_t worker_crash_oom_count_ = 0;
+
+  /// The workers are sorted according to the timestamp.
+  std::list<std::pair<WorkerID, int64_t>> sorted_dead_worker_list_;
 
   /// Ray metrics
   ray::stats::Count ray_metric_unintentional_worker_failures_{


### PR DESCRIPTION
## Description
Both Actor and Node data have automatic cleanup mechanisms, but there is no automatic cleanup mechanism for Worker data. As the cluster runs for a long time, this can lead to Worker data occupying a large amount of memory.
Therefore, following the cleanup function of Actor, we have implemented an automatic cleanup function for Worker data.

## Related issues

## Additional information
The maximum number of Workers can be configured using the `RAY_maximum_gcs_dead_worker_cached_count` environment variable, with a default value of 100000.