### PR TITLE
[doc] downgrade readthedocs to use python 3.10

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -30,7 +30,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci/doc:cmd_build
     depends_on: docbuild
-    job_env: docbuild-py3.12
+    job_env: docbuild-py3.10
     tags:
       - oss
       - doc
@@ -54,7 +54,7 @@ steps:
     key: doc_api_annotations
     instance_type: medium
     depends_on: docbuild
-    job_env: docbuild-py3.12
+    job_env: docbuild-py3.10
     commands:
       - bash ci/lint/lint.sh api_annotations
 
@@ -87,7 +87,7 @@ steps:
     commands:
       - make -C doc/ linkcheck_all
     depends_on: docbuild
-    job_env: docbuild-py3.12
+    job_env: docbuild-py3.10
     tags:
       - oss
       - skip-on-premerge

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -20,4 +20,4 @@ sphinx:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: python/deplocks/docs/docbuild_depset_py3.12.lock
+    - requirements: python/deplocks/docs/docbuild_depset_py3.10.lock


### PR DESCRIPTION
be consistent with the default build environment
