### PR TITLE
[Data] Allow `Unique` and `ApproximateTopK` to encode list values

### DIFF
--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -948,7 +948,11 @@ class Unique(AggregateFnV2[Set[Any], List[Any]]):
                 col = pc.list_flatten(col)
             else:
                 py_list = col.to_pylist()
-                str_list = [None if v is None else str(v) for v in py_list]
+                str_list = [
+                    None if v is None else str(v)
+                    for v in py_list
+                    if not self._ignore_nulls or v is not None
+                ]
                 col = pa.array(str_list, type=pa.string())
 
         return pc.unique(col).to_pylist()
@@ -1529,7 +1533,8 @@ class ApproximateTopK(AggregateFnV2):
             py_value = value.as_py()
             if self._encode_lists and isinstance(py_value, list):
                 for item in py_value:
-                    sketch.update(str(item))
+                    if item is not None:
+                        sketch.update(str(item))
             else:
                 sketch.update(str(py_value))
         return sketch.serialize()

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -946,6 +946,8 @@ class Unique(AggregateFnV2[Set[Any], List[Any]]):
         if pa.types.is_list(col.type):
             if self._encode_lists:
                 col = pc.list_flatten(col)
+                if self._ignore_nulls:
+                    col = pc.drop_null(col)
             else:
                 py_list = col.to_pylist()
                 str_list = [

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1537,7 +1537,7 @@ class ApproximateTopK(AggregateFnV2):
                 for item in py_value:
                     if item is not None:
                         sketch.update(str(item))
-            else:
+            elif py_value is not None:
                 sketch.update(str(py_value))
         return sketch.serialize()
 

--- a/python/ray/data/tests/test_custom_agg.py
+++ b/python/ray/data/tests/test_custom_agg.py
@@ -464,10 +464,11 @@ class TestApproximateTopK:
         """Test that aggregator correctly encodes list values."""
         data = [{"id": ["a", "b", "c"]}, {"id": ["a", "a", "a", "b"]}]
         ds = ray.data.from_items(data)
-        result = ds.aggregate(Unique(on="id", encode_lists=True))
+        result = ds.aggregate(ApproximateTopK(on="id", k=2, encode_lists=True))
 
         # Should encode list items, so "a" should be most frequent
-        assert sorted(result["unique(id)"])[0] == "a"
+        assert result["approx_topk(id)"][0] == {"id": "a", "count": 4}
+        assert result["approx_topk(id)"][1] == {"id": "b", "count": 2}
 
 
 class TestUnique:


### PR DESCRIPTION
## Description
Related to #58450 - this is the first out of three PRs.

Previous behavior:
- Unique: when list was passed, the program errors because pyarrow compute cannot run the `unique` method on lists.
- ApproximateTopK: when list was passed, it was cast to string via `str`

Notes on current behavior:
- Encode lists will not support heterogenous list element types (eg: lists with numbers and strings). ApproximateTopK uses `frequent_strings_sketch` so it force-converts everything to string (this is true for original implementation anyways), and Unique will error because pyarrow doesn't allow heterogenous list element types. 

## Related issues
N/A

## Additional information
N/A