### PR TITLE
[data][air]: fix the non-existent TRACE log level which may lead to  large amounts of inferred dtype logs

### DIFF
--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -238,7 +238,7 @@ def _convert_to_pyarrow_native_array(
                 )
 
         logger.log(
-            logging.getLevelName("TRACE"),
+            logging.DEBUG,
             f"Inferred dtype of '{pa_type}' for column '{column_name}'",
         )
 


### PR DESCRIPTION
## Description
> Briefly describe what this PR accomplishes and why it's needed.

Fix the non-existent `TRACE` log level which may lead to  large amounts of inferred dtype logs, even if higher levels such as `WARNING` are configured through `logging.basicConfig`. This problem was introduced since b5934e54c446fd4f5c28cf9b848c402f9a044357.

Please refer to: [Python Logging Levels](https://docs.python.org/3.11/library/logging.html#logging-levels)
- `logging.NOTSET`
- `logging.DEBUG`
- `logging.INFO`
- `logging.WARNING`
- `logging.ERROR`
- `logging.CRITICAL`