### PR TITLE
[core] Improve kill actor logs

### DIFF
--- a/src/ray/gcs/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_actor_manager.cc
@@ -1756,7 +1756,7 @@ void GcsActorManager::NotifyRayletToKillActor(const std::shared_ptr<GcsActor> &a
   request.set_force_kill(force_kill);
   if (!actor->LocalRayletAddress()) {
     RAY_LOG(INFO).WithField(actor->GetActorID())
-        << "Not sending KillLocalActorRequeset because Actor has not been assigned a "
+        << "Not sending KillLocalActorRequest because Actor has not been assigned a "
            "lease";
     return;
   }
@@ -1773,8 +1773,7 @@ void GcsActorManager::NotifyRayletToKillActor(const std::shared_ptr<GcsActor> &a
           const ray::Status &status, rpc::KillLocalActorReply &&reply) {
         if (!status.ok()) {
           RAY_LOG(INFO).WithField(actor_id).WithField(node_id)
-              << "Node with actor is already dead, "
-              << "return status: " << status.ToString();
+              << "Node with actor is already dead, return status: " << status.ToString();
         } else {
           RAY_LOG(INFO).WithField(actor_id) << "Killed actor successfully.";
         }

--- a/src/ray/gcs/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_actor_manager.cc
@@ -1755,7 +1755,9 @@ void GcsActorManager::NotifyRayletToKillActor(const std::shared_ptr<GcsActor> &a
   request.mutable_death_cause()->CopyFrom(death_cause);
   request.set_force_kill(force_kill);
   if (!actor->LocalRayletAddress()) {
-    RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << " has not been assigned a lease";
+    RAY_LOG(INFO).WithField(actor->GetActorID())
+        << "Not sending KillLocalActorRequeset because Actor has not been assigned a "
+           "lease";
     return;
   }
   auto actor_raylet_client =
@@ -1767,13 +1769,14 @@ void GcsActorManager::NotifyRayletToKillActor(const std::shared_ptr<GcsActor> &a
       << "Send request to kill actor to worker at node";
   actor_raylet_client->KillLocalActor(
       request,
-      [actor_id = actor->GetActorID()](const ray::Status &status,
-                                       rpc::KillLocalActorReply &&reply) {
+      [node_id = actor->GetNodeID(), actor_id = actor->GetActorID()](
+          const ray::Status &status, rpc::KillLocalActorReply &&reply) {
         if (!status.ok()) {
-          RAY_LOG(ERROR) << "Failed to kill actor " << actor_id
-                         << ", return status: " << status.ToString();
+          RAY_LOG(INFO).WithField(actor_id).WithField(node_id)
+              << "Node with actor is already dead, "
+              << "return status: " << status.ToString();
         } else {
-          RAY_LOG(INFO) << "Killed actor " << actor_id << " successfully.";
+          RAY_LOG(INFO).WithField(actor_id) << "Killed actor successfully.";
         }
       });
 }


### PR DESCRIPTION
## Description
After making KillActor fault tolerant here https://github.com/ray-project/ray/pull/57648

We don't need to propagate this error log to the user here, because getting !status.ok just means the raylet is dead.

I was getting concerning looking logs like this when testing other things out.
```
(pid=gcs_server) [2025-11-11 18:59:30,227 E 201623 201623] (gcs_server) gcs_actor_manager.cc:1773: Failed to kill actor
94ae464171c220ccbf858e4401000000, return status: Invalid: KillActor RPC failed for actor
94ae464171c220ccbf858e4401000000: RpcError: RPC Error message: Socket closed; RPC Error details:  rpc_code: 14
```