### PR TITLE
Add denial of fetch headers

### DIFF
--- a/python/ray/dashboard/http_server_head.py
+++ b/python/ray/dashboard/http_server_head.py
@@ -305,7 +305,10 @@ class HttpServerDashboardHead:
             if (
                 # A best effort test for browser traffic. All common browsers
                 # start with Mozilla at the time of writing.
-                dashboard_optional_utils.is_browser_request(request)
+                (
+                    dashboard_optional_utils.is_browser_request(request)
+                    or dashboard_optional_utils.has_sec_fetch_headers(request)
+                )
                 and request.method in [hdrs.METH_POST, hdrs.METH_PUT]
             ):
                 return aiohttp.web.Response(

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -137,11 +137,19 @@ def is_browser_request(req: Request) -> bool:
     """
     return req.headers["User-Agent"].startswith("Mozilla")
 
-def has_sec_fetch_headers(req: Request) -> bool:
-    """Checks for the existance of any of the sec-fetch-* headers.
 
-    """
-    return any(h in req.headers for h in ("Sec-Fetch-Mode", "Sec-Fetch-Dest", "Sec-Fetch-Site", "Sec-Fetch-User"))
+def has_sec_fetch_headers(req: Request) -> bool:
+    """Checks for the existance of any of the sec-fetch-* headers"""
+    return any(
+        h in req.headers
+        for h in (
+            "Sec-Fetch-Mode",
+            "Sec-Fetch-Dest",
+            "Sec-Fetch-Site",
+            "Sec-Fetch-User",
+        )
+    )
+
 
 def deny_browser_requests() -> Callable:
     """Reject any requests that appear to be made by a browser"""

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -141,10 +141,7 @@ def has_sec_fetch_headers(req: Request) -> bool:
     """Checks for the existance of any of the sec-fetch-* headers.
 
     """
-    for header in ("Sec-Fetch-Mode", "Sec-Fetch-Dest", "Sec-Fetch-Site", "Sec-Fetch-User"):
-        if header in req.headers:
-            return True
-    return False
+    return any(h in req.headers for h in ("Sec-Fetch-Mode", "Sec-Fetch-Dest", "Sec-Fetch-Site", "Sec-Fetch-User"))
 
 def deny_browser_requests() -> Callable:
     """Reject any requests that appear to be made by a browser"""

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -457,6 +457,50 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
             if time.time() > start_time + timeout_seconds:
                 raise Exception("Timed out while testing.")
 
+def test_deny_fetch_requests(enable_test_module, ray_start_with_dashboard):
+    assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
+    webui_url = ray_start_with_dashboard["webui_url"]
+    webui_url = format_web_url(webui_url)
+
+    timeout_seconds = 30
+    start_time = time.time()
+    while True:
+        time.sleep(3)
+        try:
+            # Starting and getting jobs should be fine from API clients
+            response = requests.post(
+                webui_url + "/api/jobs/", json={"entrypoint": "ls"}
+            )
+            response.raise_for_status()
+            response = requests.get(webui_url + "/api/jobs/")
+            response.raise_for_status()
+
+            # Starting job should be blocked for browsers
+            response = requests.post(
+                webui_url + "/api/jobs/",
+                json={"entrypoint": "ls"},
+                headers={
+                    "User-Agent": (
+                        "Spurious User Agent"
+                    ),
+                    "Sec-Fetch-Site": (
+                        "cross-site"
+                    )
+                },
+            )
+            with pytest.raises(HTTPError):
+                response.raise_for_status()
+
+            # Getting jobs should be fine for browsers
+            response = requests.get(webui_url + "/api/jobs/")
+            response.raise_for_status()
+            break
+        except (AssertionError, requests.exceptions.ConnectionError) as e:
+            logger.info("Retry because of %s", e)
+        finally:
+            if time.time() > start_time + timeout_seconds:
+                raise Exception("Timed out while testing.")
+
 
 @pytest.mark.skipif(
     os.environ.get("RAY_MINIMAL") == "1",

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -419,10 +419,16 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
     webui_url = format_web_url(webui_url)
 
+    def dashboard_available():
+        try:
+            return requests.get(webui_url).status_code == 200
+        except Exception:
+            return False
+
     timeout_seconds = 30
     start_time = time.time()
     while True:
-        time.sleep(3)
+        wait_for_condition(dashboard_available)
         try:
             # Starting and getting jobs should be fine from API clients
             response = requests.post(
@@ -462,10 +468,16 @@ def test_deny_fetch_requests(enable_test_module, ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
     webui_url = format_web_url(webui_url)
 
+    def dashboard_available():
+        try:
+            return requests.get(webui_url).status_code == 200
+        except Exception:
+            return False
+
     timeout_seconds = 30
     start_time = time.time()
     while True:
-        time.sleep(3)
+        wait_for_condition(dashboard_available)
         try:
             # Starting and getting jobs should be fine from API clients
             response = requests.post(

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -463,6 +463,7 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
             if time.time() > start_time + timeout_seconds:
                 raise Exception("Timed out while testing.")
 
+
 def test_deny_fetch_requests(enable_test_module, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
     webui_url = ray_start_with_dashboard["webui_url"]
@@ -492,12 +493,8 @@ def test_deny_fetch_requests(enable_test_module, ray_start_with_dashboard):
                 webui_url + "/api/jobs/",
                 json={"entrypoint": "ls"},
                 headers={
-                    "User-Agent": (
-                        "Spurious User Agent"
-                    ),
-                    "Sec-Fetch-Site": (
-                        "cross-site"
-                    )
+                    "User-Agent": ("Spurious User Agent"),
+                    "Sec-Fetch-Site": ("cross-site"),
                 },
             )
             with pytest.raises(HTTPError):

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -464,6 +464,10 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
                 raise Exception("Timed out while testing.")
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
 def test_deny_fetch_requests(enable_test_module, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
     webui_url = ray_start_with_dashboard["webui_url"]

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -427,8 +427,8 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
 
     timeout_seconds = 30
     start_time = time.time()
+    wait_for_condition(dashboard_available)
     while True:
-        wait_for_condition(dashboard_available)
         try:
             # Starting and getting jobs should be fine from API clients
             response = requests.post(
@@ -481,8 +481,8 @@ def test_deny_fetch_requests(enable_test_module, ray_start_with_dashboard):
 
     timeout_seconds = 30
     start_time = time.time()
+    wait_for_condition(dashboard_available)
     while True:
-        wait_for_condition(dashboard_available)
         try:
             # Starting and getting jobs should be fine from API clients
             response = requests.post(


### PR DESCRIPTION
This causes the dashboard to be more thorough in it's attempts to deny browsers access to the job creation APIs