### PR TITLE
[core] Fix auth test import

### DIFF
--- a/python/ray/tests/test_grpc_authentication_server_interceptor.py
+++ b/python/ray/tests/test_grpc_authentication_server_interceptor.py
@@ -9,15 +9,15 @@ from grpc import aio as aiogrpc
 from ray._private.authentication.grpc_authentication_server_interceptor import (
     AsyncAuthenticationServerInterceptor,
 )
-
-# Create a simple test service for testing
-from ray.core.generated import reporter_pb2, reporter_pb2_grpc
-from ray.tests.authentication_test_utils import (
+from ray._private.authentication_test_utils import (
     authentication_env_guard,
     reset_auth_token_state,
     set_auth_mode,
     set_env_auth_token,
 )
+
+# Create a simple test service for testing
+from ray.core.generated import reporter_pb2, reporter_pb2_grpc
 
 
 class TestReporterServicer(reporter_pb2_grpc.ReporterServiceServicer):


### PR DESCRIPTION
## Description
The python test step is failing on master now because of this. Probably a logical merge conflict.
```
FAILED: //python/ray/tests:test_grpc_authentication_server_interceptor (Summary)
...

[2025-11-11T22:11:54Z]     from ray.tests.authentication_test_utils import (
--
  | [2025-11-11T22:11:54Z] ModuleNotFoundError: No module named 'ray.tests.authentication_test_utils'
```
