### PR TITLE
[core][rdt] Asyncio / out of order actor RDT support

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1180,7 +1180,8 @@ def _process_option_dict(actor_options, has_tensor_transport_methods):
         if _filled_options.get("concurrency_groups", None) is None:
             _filled_options["concurrency_groups"] = {}
         _filled_options["concurrency_groups"]["_ray_system"] = 1
-        _filled_options["concurrency_groups"]["_ray_system_error"] = 1
+        _filled_options["concurrency_groups"]["_ray_system_rdt_metadata"] = 1
+        _filled_options["concurrency_groups"]["_ray_system_rdt_error"] = 1
 
     return _filled_options
 

--- a/python/ray/experimental/collective/collective_tensor_transport.py
+++ b/python/ray/experimental/collective/collective_tensor_transport.py
@@ -86,9 +86,9 @@ class CollectiveTensorTransport(TensorTransportManager):
         # NOTE(swang): We put this task on the background thread to avoid tasks
         # executing on the main thread blocking this task.
 
-        return src_actor.__ray_call__.options(concurrency_group="_ray_system").remote(
-            __ray_get_tensor_transport_metadata__, obj_id
-        )
+        return src_actor.__ray_call__.options(
+            concurrency_group="_ray_system_rdt_metadata"
+        ).remote(__ray_get_tensor_transport_metadata__, obj_id)
 
     @staticmethod
     def get_communicator_metadata(

--- a/python/ray/experimental/collective/nixl_tensor_transport.py
+++ b/python/ray/experimental/collective/nixl_tensor_transport.py
@@ -118,9 +118,9 @@ class NixlTensorTransport(TensorTransportManager):
         # NOTE(swang): We put this task on the background thread to avoid tasks
         # executing on the main thread blocking this task.
 
-        return src_actor.__ray_call__.options(concurrency_group="_ray_system").remote(
-            __ray_get_tensor_transport_metadata__, obj_id
-        )
+        return src_actor.__ray_call__.options(
+            concurrency_group="_ray_system_rdt_metadata"
+        ).remote(__ray_get_tensor_transport_metadata__, obj_id)
 
     @staticmethod
     def get_communicator_metadata(

--- a/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_manager.py
@@ -203,14 +203,14 @@ class GPUObjectManager:
                 # This is dead code until we implement a NCCL abort since NIXL
                 # is the only abortable transport for now and is one-sided.
                 ref_info.src_actor.__ray_call__.options(
-                    concurrency_group="_ray_system_error"
+                    concurrency_group="_ray_system_rdt_error"
                 ).remote(
                     __ray_abort_transport__,
                     ref_info.obj_id,
                     ref_info.communicator_meta,
                 )
             ref_info.dst_actor.__ray_call__.options(
-                concurrency_group="_ray_system_error"
+                concurrency_group="_ray_system_rdt_error"
             ).remote(
                 __ray_abort_transport__,
                 ref_info.obj_id,

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -621,7 +621,6 @@ py_test_module_list(
     size = "large",
     files = [
         "gpu_objects/test_gpu_objects_gloo.py",
-        "gpu_objects/test_rdt_all_transports.py",
     ],
     tags = [
         "exclusive",

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -616,10 +616,12 @@ py_test_module_list(
     ],
 )
 
+# NO GPU RDT TESTS
 py_test_module_list(
     size = "large",
     files = [
         "gpu_objects/test_gpu_objects_gloo.py",
+        "gpu_objects/test_rdt_all_transports.py",
     ],
     tags = [
         "exclusive",
@@ -633,12 +635,14 @@ py_test_module_list(
     ],
 )
 
+# GPU RDT TESTS
 py_test_module_list(
     size = "medium",
     env = {"RAY_PYTEST_USE_GPU": "1"},
     files = [
         "gpu_objects/test_gpu_objects_nccl.py",
         "gpu_objects/test_gpu_objects_nixl.py",
+        "gpu_objects/test_rdt_all_transports.py",
     ],
     tags = [
         "custom_setup",

--- a/python/ray/tests/gpu_objects/test_rdt_all_transports.py
+++ b/python/ray/tests/gpu_objects/test_rdt_all_transports.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+import pytest
+import torch
+
+import ray
+from ray.experimental.collective import create_collective_group
+
+USE_GPU = bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))
+TRANSPORTS_AND_DEVICES = (
+    [("nixl", "cuda"), ("nccl", "cuda")] if USE_GPU else [("gloo", "cpu")]
+)
+
+
+@ray.remote(num_cpus=0, num_gpus=1 if USE_GPU else 0, enable_tensor_transport=True)
+class AsyncActor:
+    async def send(self, data, device):
+        device_data = data.to(device)
+        return device_data
+
+    async def intermediate(self, device_data):
+        return device_data
+
+    async def recv(self, device_data):
+        return device_data
+
+
+@pytest.mark.parametrize("ray_start_regular_shared", [{"num_gpus": 4}], indirect=True)
+@pytest.mark.parametrize("transport, device", TRANSPORTS_AND_DEVICES)
+def test_rdt_async_chain(ray_start_regular_shared, transport, device):
+    actors = [AsyncActor.remote() for _ in range(3)]
+    create_collective_group(actors, transport)
+    data = torch.randn(100, 100)
+    send_ref = actors[0].send.options(tensor_transport=transport).remote(data, device)
+    int_ref = (
+        actors[1].intermediate.options(tensor_transport=transport).remote(send_ref)
+    )
+    recv_ref = actors[2].recv.remote(int_ref)
+    data = ray.get(recv_ref)
+    assert data.device.type == device
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
## Description
Before a simple script like this would hang forever on asyncio actors or any actor that doesn't enforce submission order task execution.
```
@ray.remote(num_gpus=1)
class TestActor:
    @ray.method(tensor_transport="nccl")
    def send(self, data):
        return data.to("cuda")

    @ray.method(tensor_transport="nccl")
    def intermediate(self, gpu_data):
        return gpu_data

    async def recv(self, gpu_data):
        pass

actors = [TestActor.remote() for _ in range(3)]
create_collective_group(actors, backend="nccl")

data = torch.tensor([1, 2, 3])
send_ref = actors[0].send.remote(data)
int_ref = actors[1].intermediate.remote(send_ref)
recv_ref = actors[2].recv.remote(int_ref)
print("done", ray.get(recv_ref))
```

This is because the intermediate actor would be a receiver for the 1st obj and a sender for the 2nd obj. This means we'll submit a `__ray_recv__` for obj 1 and `__ray_get_tensor_transport_metadata__` for obj 2. Both tasks execute on the same `_ray_system` concurrency group and therefore can block the other from executing. On an out of order actor `__ray_get_tensor_transport_metadata__` for obj 2 can start executing before the recv and it will wait until obj 2 arrives in the gpu object store. And the creation of obj 2 relies on obj 1 being received, so it'll just wait forever.

The solution here is to simply just put `__ray_get_tensor_transport_metadata__` on a separate concurrency group so it doesn't block any recv's.

Note that the nixl abort PR https://github.com/ray-project/ray/pull/56783 actually makes it so that I can't repro the hang reliably anymore because the recv usually starts executing before the metadata get now that we pass `tensor_transport_meta` as a list of refs instead of just the ref. Passing `tensor_transport_meta` directly to recv will make it consistently hang on master.
https://github.com/ray-project/ray/blob/df65225e4f98bce2b45405b1cf89fb70556e2871/python/ray/experimental/gpu_object_manager/gpu_object_manager.py#L507-L509

## Related issues
https://github.com/ray-project/ray/issues/56398
