### PR TITLE
[core] (cgroups) Use /proc/mounts if mount file is missing.

### DIFF
--- a/src/ray/common/cgroup2/sysfs_cgroup_driver.cc
+++ b/src/ray/common/cgroup2/sysfs_cgroup_driver.cc
@@ -52,6 +52,12 @@ Status SysFsCgroupDriver::CheckCgroupv2Enabled() {
 
   if (fd == -1) {
     mount_file_path = fallback_mount_file_path_;
+    RAY_LOG(WARNING) << absl::StrFormat(
+        "Failed to open mount fail at %s because of error '%s'. Using fallback mount "
+        "file at %s.",
+        mount_file_path_,
+        strerror(errno),
+        fallback_mount_file_path_);
   } else {
     close(fd);
   }

--- a/src/ray/common/cgroup2/sysfs_cgroup_driver.cc
+++ b/src/ray/common/cgroup2/sysfs_cgroup_driver.cc
@@ -51,7 +51,7 @@ Status SysFsCgroupDriver::CheckCgroupv2Enabled() {
   int fd = open(mount_file_path.c_str(), O_RDONLY);
 
   if (fd == -1) {
-    mount_file_path = kFallbackMountsFilePath;
+    mount_file_path = fallback_mount_file_path_;
   }
 
   close(fd);

--- a/src/ray/common/cgroup2/sysfs_cgroup_driver.cc
+++ b/src/ray/common/cgroup2/sysfs_cgroup_driver.cc
@@ -46,13 +46,23 @@
 
 namespace ray {
 Status SysFsCgroupDriver::CheckCgroupv2Enabled() {
-  FILE *fp = setmntent(mount_file_path_.c_str(), "r");
+  std::string mount_file_path = mount_file_path_;
+
+  int fd = open(mount_file_path.c_str(), O_RDONLY);
+
+  if (fd == -1) {
+    mount_file_path = kFallbackMountsFilePath;
+  }
+
+  close(fd);
+
+  FILE *fp = setmntent(mount_file_path.c_str(), "r");
 
   if (!fp) {
     return Status::Invalid(
         absl::StrFormat("Failed to open mount file at %s. Could not verify that "
                         "cgroupv2 was mounted correctly. \n%s",
-                        mount_file_path_,
+                        mount_file_path,
                         strerror(errno)));
   }
 
@@ -71,7 +81,7 @@ Status SysFsCgroupDriver::CheckCgroupv2Enabled() {
     return Status::Invalid(
         absl::StrFormat("Failed to parse mount file at %s. Could not verify that "
                         "cgroupv2 was mounted correctly.",
-                        mount_file_path_));
+                        mount_file_path));
   }
 
   if (found_cgroupv1 && found_cgroupv2) {

--- a/src/ray/common/cgroup2/sysfs_cgroup_driver.cc
+++ b/src/ray/common/cgroup2/sysfs_cgroup_driver.cc
@@ -52,9 +52,9 @@ Status SysFsCgroupDriver::CheckCgroupv2Enabled() {
 
   if (fd == -1) {
     mount_file_path = fallback_mount_file_path_;
+  } else {
+    close(fd);
   }
-
-  close(fd);
 
   FILE *fp = setmntent(mount_file_path.c_str(), "r");
 

--- a/src/ray/common/cgroup2/sysfs_cgroup_driver.h
+++ b/src/ray/common/cgroup2/sysfs_cgroup_driver.h
@@ -291,5 +291,6 @@ class SysFsCgroupDriver : public CgroupDriverInterface {
   static constexpr std::string_view kCgroupSubtreeControlFilename =
       "cgroup.subtree_control";
   static constexpr std::string_view kCgroupControllersFilename = "cgroup.controllers";
+  static inline std::string kFallbackMountsFilePath = "/proc/mounts";
 };
 }  // namespace ray

--- a/src/ray/common/cgroup2/sysfs_cgroup_driver.h
+++ b/src/ray/common/cgroup2/sysfs_cgroup_driver.h
@@ -41,8 +41,11 @@ class SysFsCgroupDriver : public CgroupDriverInterface {
   /**
    * @param mount_file_path only used for testing.
    */
-  explicit SysFsCgroupDriver(std::string mount_file_path = MOUNTED)
-      : mount_file_path_(std::move(mount_file_path)) {}
+  explicit SysFsCgroupDriver(
+      std::string mount_file_path = MOUNTED,
+      std::string fallback_mount_file_path = kFallbackMountsFilePath)
+      : mount_file_path_(std::move(mount_file_path)),
+        fallback_mount_file_path_(fallback_mount_file_path) {}
 
   ~SysFsCgroupDriver() override = default;
   SysFsCgroupDriver(const SysFsCgroupDriver &other) = delete;
@@ -286,6 +289,7 @@ class SysFsCgroupDriver : public CgroupDriverInterface {
 
   // Used for unit testing through the constructor.
   std::string mount_file_path_;
+  std::string fallback_mount_file_path_;
 
   static constexpr std::string_view kCgroupProcsFilename = "cgroup.procs";
   static constexpr std::string_view kCgroupSubtreeControlFilename =

--- a/src/ray/common/cgroup2/tests/sysfs_cgroup_driver_test.cc
+++ b/src/ray/common/cgroup2/tests/sysfs_cgroup_driver_test.cc
@@ -43,12 +43,6 @@ TEST(SysFsCgroupDriverTest, CheckCgroupv2EnabledFailsIfMalformedMountFile) {
   EXPECT_TRUE(s.IsInvalid()) << s.ToString();
 }
 
-TEST(SysFsCgroupDriverTest, CheckCgroupv2EnabledUsesFallbackIfMountFileDoesNotExist) {
-  SysFsCgroupDriver driver("/does/not/exist");
-  Status s = driver.CheckCgroupv2Enabled();
-  EXPECT_TRUE(s.ok()) << s.ToString();
-}
-
 TEST(SysFsCgroupDriverTest,
      CheckCgroupv2EnabledFailsIfCgroupv1MountedAndCgroupv2NotMounted) {
   TempFile temp_mount_file;
@@ -66,6 +60,15 @@ TEST(SysFsCgroupDriverTest,
   SysFsCgroupDriver driver(temp_mount_file.GetPath());
   Status s = driver.CheckCgroupv2Enabled();
   ASSERT_TRUE(s.IsInvalid()) << s.ToString();
+}
+
+TEST(SysFsCgroupDriverTest,
+     CheckCgroupv2EnabledSucceedsIfMountFileNotFoundButFallbackFileIsCorrect) {
+  TempFile temp_fallback_mount_file;
+  temp_fallback_mount_file.AppendLine("cgroup2 /sys/fs/cgroup cgroup2 rw 0 0\n");
+  SysFsCgroupDriver driver("/does/not/exist", temp_fallback_mount_file.GetPath());
+  Status s = driver.CheckCgroupv2Enabled();
+  EXPECT_TRUE(s.ok()) << s.ToString();
 }
 
 TEST(SysFsCgroupDriverTest, CheckCgroupv2EnabledSucceedsIfOnlyCgroupv2Mounted) {

--- a/src/ray/common/cgroup2/tests/sysfs_cgroup_driver_test.cc
+++ b/src/ray/common/cgroup2/tests/sysfs_cgroup_driver_test.cc
@@ -43,6 +43,12 @@ TEST(SysFsCgroupDriverTest, CheckCgroupv2EnabledFailsIfMalformedMountFile) {
   EXPECT_TRUE(s.IsInvalid()) << s.ToString();
 }
 
+TEST(SysFsCgroupDriverTest, CheckCgroupv2EnabledUsesFallbackIfMountFileDoesNotExist) {
+  SysFsCgroupDriver driver("/does/not/exist");
+  Status s = driver.CheckCgroupv2Enabled();
+  EXPECT_TRUE(s.ok()) << s.ToString();
+}
+
 TEST(SysFsCgroupDriverTest,
      CheckCgroupv2EnabledFailsIfCgroupv1MountedAndCgroupv2NotMounted) {
   TempFile temp_mount_file;


### PR DESCRIPTION
SysFsCgroupDriver uses glibc's `mntent.h` to import the `MOUNTED` symbol for cross-platform support. However, on some environments MOUNTED refers to `/etc/mtab` which is missing. 

`/etc/mtab` is usually a symlink to `/proc/mounts`. If it's missing, SysFsCgroupDriver will now use `/proc/mounts` directly.
