### PR TITLE
[ci] mark github.Repository as typechecking

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -8,12 +8,14 @@ import subprocess
 import time
 from dataclasses import dataclass
 from itertools import chain
-from typing import Awaitable, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Awaitable, Dict, List, Optional, Set
 
 import aioboto3
 import boto3
 from botocore.exceptions import ClientError
-from github import Repository
+
+if TYPE_CHECKING:
+    from github import Repository
 
 from ray_release.aws import s3_put_rayci_test_data
 from ray_release.configs.global_config import get_global_config
@@ -355,7 +357,7 @@ class Test(dict):
         except subprocess.CalledProcessError:
             return set()
 
-    def is_jailed_with_open_issue(self, ray_github: Repository) -> bool:
+    def is_jailed_with_open_issue(self, ray_github: "Repository") -> bool:
         """
         Returns whether this test is jailed with open issue.
         """


### PR DESCRIPTION
so that importing test.py does not always import github

github repo imports jwt, which then imports cryptography and can lead to issues on windows.
