### PR TITLE
[wheel] stop building python 3.9 wheels on the pipelines

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -42,7 +42,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture x86_64 --upload
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -32,7 +32,6 @@ steps:
       - docker
     wanda: docker/base-deps/cpu.wanda.yaml
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -45,7 +44,6 @@ steps:
     label: "wanda: ray.py{{matrix}}.cpu.base-extra (aarch64)"
     wanda: docker/base-extra/cpu.wanda.yaml
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -66,7 +64,6 @@ steps:
     matrix:
       setup:
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -91,7 +88,6 @@ steps:
     matrix:
       setup:
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -138,7 +134,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture aarch64 --upload
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -170,7 +165,6 @@ steps:
       - raycpubaseextra-aarch64
     job_env: forge-aarch64
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -197,7 +191,6 @@ steps:
       - raycpubase-aarch64
     job_env: forge-aarch64
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -24,7 +24,6 @@ steps:
       - bash ci/ray_ci/windows/install_tools.sh
       - bazel run //ci/ray_ci:build_in_docker_windows -- wheel --python-version {{matrix}} --operating-system windows --upload
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"


### PR DESCRIPTION
also stops building python 3.9 aarch64 images
