### PR TITLE
[RLlib] Fix access to self._minibatch_size

### DIFF
--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -427,7 +427,7 @@ class IMPALAConfig(AlgorithmConfig):
                 and self.minibatch_size <= self.total_train_batch_size
             ):
                 self._value_error(
-                    f"`minibatch_size` ({self._minibatch_size}) must either be None "
+                    f"`minibatch_size` ({self.minibatch_size}) must either be None "
                     "or a multiple of `rollout_fragment_length` "
                     f"({self.rollout_fragment_length}) while at the same time smaller "
                     "than or equal to `total_train_batch_size` "

--- a/rllib/algorithms/impala/tests/test_impala.py
+++ b/rllib/algorithms/impala/tests/test_impala.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 import ray
 import ray.rllib.algorithms.impala as impala
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
@@ -15,6 +17,20 @@ class TestIMPALA(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         ray.shutdown()
+
+    def test_impala_minibatch_size_check(self):
+        config = (
+            impala.IMPALAConfig()
+            .environment("CartPole-v1")
+            .training(minibatch_size=100)
+            .env_runners(rollout_fragment_length=30)
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"`minibatch_size` \(100\) must either be None or a multiple of `rollout_fragment_length` \(30\)",
+        ):
+            config.validate()
 
     def test_impala_lr_schedule(self):
         # Test whether we correctly ignore the "lr" setting.


### PR DESCRIPTION
## Description

In IMPALA, we access an attribute `self._minibatch_size` which does not exist anymore.
It should be `self._minibatch_size`. While this check is nice, it's effectively untested code.
This PR introduces a test that adds a small test that triggers the relevant code path.