### PR TITLE
[Serve.LLM] Add avg prompt length metric

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -225,7 +225,7 @@ SERVE_LLM_GRAFANA_PANELS = [
             ),
             Target(
                 expr='(sum by(model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="Avg-{{model_name}}-{{WorkerId}}",
+                legend="Average-{{model_name}}-{{WorkerId}}",
             ),
         ],
         fill=1,

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -223,6 +223,10 @@ SERVE_LLM_GRAFANA_PANELS = [
                 expr='histogram_quantile(0.90, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
                 legend="P90-{{model_name}}-{{WorkerId}}",
             ),
+            Target(
+                expr='(sum by(model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
+                legend="Avg-{{model_name}}-{{WorkerId}}",
+            ),
         ],
         fill=1,
         linewidth=1,


### PR DESCRIPTION
## Description
Add avg prompt length metric

When using uniform prompt length (especially in testing), the P50 and P90 computations are skewed due to the 1_2_5 buckets used in vLLM. Average prompt length provides another useful dimension to look at and validate.

For example, using uniformly ISL=5000, P50 shows 7200 and P90 shows 9400, and avg accurately shows 5000.

<img width="1186" height="466" alt="image" src="https://github.com/user-attachments/assets/4615c3ca-2e15-4236-97f9-72bc63ef9d1a" />
 

## Related issues

## Additional information
