### PR TITLE
[core] Use graceful actor shutdown when GCS polling detects actor ref deleted

### DIFF
--- a/src/ray/gcs/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_actor_manager.cc
@@ -970,9 +970,12 @@ void GcsActorManager::PollOwnerForActorRefDeleted(
         if (node_it != owners_.end() && node_it->second.count(owner_id)) {
           // Only destroy the actor if its owner is still alive. The actor may
           // have already been destroyed if the owner died.
+          int64_t timeout_ms = RayConfig::instance().actor_graceful_shutdown_timeout_ms();
           DestroyActor(actor_id,
                        GenActorRefDeletedCause(GetActor(actor_id)),
-                       /*force_kill=*/true);
+                       /*force_kill=*/false,
+                       nullptr,
+                       timeout_ms);
         }
       });
 }


### PR DESCRIPTION
The tests that exercised actor failures when they go out of scope, such as `test_actor_ray_shutdown_called_on_del` and `test_actor_ray_shutdown_called_on_scope_exit` [were flaky](https://buildkite.com/ray-project/postmerge/builds/14336#019a7abe-73d3-46e0-8dc2-13351e12b7c3/613-1919). This PR fixes the flakiness by ensuring actors use graceful shutdown when GCS polling detects actor refs are deleted.

**Problem**
When actors go out of scope, GCS uses two mechanisms to detect reference deletion:
1. Push model (`GcsActorManager::HandleReportActorOutOfScope`) - already fixed in #57090
2. Pull model (`GcsActorManager::PollOwnerForActorRefDeleted`) - was still using force kill

The pull model was calling DestroyActor(..., force_kill=true), which skips `__ray_shutdown__` and immediately terminates the actor. This created a race condition: whichever mechanism completed first determined whether cleanup callbacks ran, causing test flakiness.

To fix the issue, changed `PollOwnerForActorRefDeleted` to use graceful shutdown with timeout (same as `HandleReportActorOutOfScope`). I ran all the actor failure tests that exercise this shutdown path 20 times locally, and where they failed 3/20 previously, they succeeded everytime after the fix.