### PR TITLE
[deps] raydepsets: allowing users to build linux (deps only) wheel on macos

### DIFF
--- a/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
+++ b/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
@@ -10,4 +10,15 @@ PYTHON_VERSION=$1
 
 export RAY_DEBUG_BUILD=deps-only
 
-uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  docker run --rm \
+  -v "$PWD":/ray -w /ray --platform linux/x86_64 \
+  quay.io/pypa/manylinux2014_x86_64 \
+  bash -lc '
+  set -e
+  export RAY_DEBUG_BUILD=deps-only
+  uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"'
+else
+  uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"
+fi

--- a/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
+++ b/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
@@ -9,7 +9,7 @@ fi
 PYTHON_VERSION=$1
 
 export RAY_DEBUG_BUILD=deps-only
-
+UV_BUILD_COMMAND="uv build --wheel --directory python/ -o ../.whl/ --python \"$PYTHON_VERSION\""
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   docker run --rm \
@@ -18,7 +18,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   bash -lc '
   set -e
   export RAY_DEBUG_BUILD=deps-only
-  uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"'
+  eval "$UV_BUILD_COMMAND"'
 else
-  uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"
+  eval "$UV_BUILD_COMMAND"
 fi

--- a/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
+++ b/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
@@ -10,6 +10,7 @@ PYTHON_VERSION=$1
 
 export RAY_DEBUG_BUILD=deps-only
 
+UV_BUILD_COMMAND="uv build --wheel --directory python/ -o ../.whl/ --python \"$PYTHON_VERSION\""
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   docker run --rm \
@@ -18,7 +19,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   bash -lc '
   set -e
   export RAY_DEBUG_BUILD=deps-only
-  uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"'
+  eval "$UV_BUILD_COMMAND"'
 else
-  uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"
+  eval "$UV_BUILD_COMMAND"
 fi

--- a/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
+++ b/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
@@ -9,7 +9,7 @@ fi
 PYTHON_VERSION=$1
 
 export RAY_DEBUG_BUILD=deps-only
-UV_BUILD_COMMAND="uv build --wheel --directory python/ -o ../.whl/ --python \"$PYTHON_VERSION\""
+
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   docker run --rm \
@@ -18,7 +18,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   bash -lc '
   set -e
   export RAY_DEBUG_BUILD=deps-only
-  eval "$UV_BUILD_COMMAND"'
+  uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"'
 else
-  eval "$UV_BUILD_COMMAND"
+  uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"
 fi

--- a/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.md
@@ -54,6 +54,7 @@ To understand the following content better, you should understand the difference
     * `K8sJobMode`: The KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.
     * `HTTPMode`: The KubeRay operator sends a request to the RayCluster to create a Ray job.
     * `InteractiveMode`: The KubeRay operator waits for the user to submit a job to the RayCluster. This mode is currently in alpha and the [KubeRay kubectl plugin](kubectl-plugin) relies on it.
+    * `SidecarMode`: The KubeRay operator injects a container into the Ray head Pod to submit the Ray job. This mode does not support `clusterSelector`, `submitterPodTemplate`, and `submitterConfig`, and requires the head Pod's restart policy to be `Never`.
   * `submitterPodTemplate` (Optional): Defines the Pod template for the submitter Kubernetes Job. This field is only effective when `submissionMode` is "K8sJobMode".
     * `RAY_DASHBOARD_ADDRESS` - The KubeRay operator injects this environment variable to the submitter Pod. The value is `$HEAD_SERVICE:$DASHBOARD_PORT`.
     * `RAY_JOB_SUBMISSION_ID` - The KubeRay operator injects this environment variable to the submitter Pod. The value is the `RayJob.Status.JobId` of the RayJob.

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -528,13 +528,22 @@ class TestPandasJSONDatasource:
         [{"a": []}, {"a": [1]}, {"a": [1, 2, 3]}],
         ids=["empty", "single", "multiple"],
     )
+    @pytest.mark.parametrize(
+        "compression,filename",
+        [("gzip", "test.json.gz"), ("infer", "test.json")],  # infer = default
+    )
     def test_read_stream(
-        self, data, tmp_path, target_max_block_size_infinite_or_default
+        self,
+        data,
+        tmp_path,
+        compression,
+        filename,
+        target_max_block_size_infinite_or_default,
     ):
         # Setup test file.
         df = pd.DataFrame(data)
-        path = os.path.join(tmp_path, "test.json")
-        df.to_json(path, orient="records", lines=True)
+        path = os.path.join(tmp_path, filename)
+        df.to_json(path, orient="records", lines=True, compression=compression)
 
         # Setup datasource.
         local_filesystem = fs.LocalFileSystem()

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -538,6 +538,13 @@ class ApplicationState:
 
         if deployment_info.route_prefix is not None:
             config = deployment_info.deployment_config
+            # Try to get route_patterns from deployment state first (most up-to-date),
+            # otherwise fall back to existing endpoint patterns
+            route_patterns = (
+                self._deployment_state_manager.get_deployment_route_patterns(
+                    deployment_id
+                )
+            )
             self._endpoint_state.update_endpoint(
                 deployment_id,
                 # The current meaning of the "is_cross_language" field is ambiguous.
@@ -550,6 +557,7 @@ class ApplicationState:
                     route=deployment_info.route_prefix,
                     app_is_cross_language=config.deployment_language
                     != DeploymentLanguage.PYTHON,
+                    route_patterns=route_patterns,
                 ),
             )
         else:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -20,6 +20,7 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    List,
     Optional,
     Tuple,
     Union,
@@ -93,7 +94,10 @@ from ray.serve._private.logging_utils import (
 )
 from ray.serve._private.metrics_utils import InMemoryMetricsStore, MetricsPusher
 from ray.serve._private.task_consumer import TaskConsumerWrapper
-from ray.serve._private.thirdparty.get_asgi_route_name import get_asgi_route_name
+from ray.serve._private.thirdparty.get_asgi_route_name import (
+    extract_route_patterns,
+    get_asgi_route_name,
+)
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import (
     Semaphore,
@@ -121,6 +125,9 @@ ReplicaMetadata = Tuple[
     Optional[int],
     Optional[str],
     int,
+    int,
+    int,  # rank
+    Optional[List[str]],  # route_patterns
 ]
 
 
@@ -573,6 +580,14 @@ class ReplicaBase(ABC):
 
     def get_metadata(self) -> ReplicaMetadata:
         current_rank = ray.serve.context._get_internal_replica_context().rank
+        # Extract route patterns from ASGI app if available
+        route_patterns = None
+        if self._user_callable_asgi_app is not None:
+            # _user_callable_asgi_app is the actual ASGI app (FastAPI/Starlette)
+            # It's set when initialize_callable() returns an ASGI app
+            if hasattr(self._user_callable_asgi_app, "routes"):
+                route_patterns = extract_route_patterns(self._user_callable_asgi_app)
+
         return (
             self._version.deployment_config,
             self._version,
@@ -582,6 +597,7 @@ class ReplicaBase(ABC):
             self._http_port,
             self._grpc_port,
             current_rank,
+            route_patterns,
         )
 
     def _set_internal_replica_context(

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -65,7 +65,7 @@ def test_recover_start_from_replica_actor_names(serve_instance, deployment_optio
     replica_version_hash = None
     for replica in deployment_dict[id]:
         ref = replica.actor_handle.initialize_and_get_metadata.remote()
-        _, version, _, _, _, _, _, _ = ray.get(ref)
+        _, version, _, _, _, _, _, _, _ = ray.get(ref)
         if replica_version_hash is None:
             replica_version_hash = hash(version)
         assert replica_version_hash == hash(version), (
@@ -118,7 +118,7 @@ def test_recover_start_from_replica_actor_names(serve_instance, deployment_optio
     for replica_name in recovered_replica_names:
         actor_handle = ray.get_actor(replica_name, namespace=SERVE_NAMESPACE)
         ref = actor_handle.initialize_and_get_metadata.remote()
-        _, version, _, _, _, _, _, _ = ray.get(ref)
+        _, version, _, _, _, _, _, _, _ = ray.get(ref)
         assert replica_version_hash == hash(
             version
         ), "Replica version hash should be the same after recover from actor names"

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -180,6 +180,9 @@ class MockDeploymentStateManager:
         self._scaling_decisions[id] = target_num_replicas
         return True
 
+    def get_deployment_route_patterns(self, id: DeploymentID) -> Optional[List[str]]:
+        return None
+
 
 @pytest.fixture
 def mocked_application_state_manager() -> (

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -310,6 +310,10 @@ class MockReplicaActorWrapper:
     def get_routing_stats(self) -> Dict[str, Any]:
         return {}
 
+    @property
+    def route_patterns(self) -> Optional[List[str]]:
+        return None
+
 
 def deployment_info(
     version: Optional[str] = None,

--- a/python/ray/serve/tests/unit/test_extract_route_patterns.py
+++ b/python/ray/serve/tests/unit/test_extract_route_patterns.py
@@ -1,0 +1,296 @@
+"""Unit tests for extract_route_patterns function."""
+import pytest
+from fastapi import FastAPI
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
+
+from ray.serve._private.thirdparty.get_asgi_route_name import extract_route_patterns
+
+
+def test_extract_route_patterns_fastapi_simple():
+    """Test extracting route patterns from a simple FastAPI app."""
+    app = FastAPI()
+
+    @app.get("/")
+    def root():
+        return {"message": "root"}
+
+    @app.get("/users/{user_id}")
+    def get_user(user_id: str):
+        return {"user_id": user_id}
+
+    @app.post("/items/{item_id}")
+    def create_item(item_id: str):
+        return {"item_id": item_id}
+
+    patterns = extract_route_patterns(app)
+
+    # FastAPI automatically adds some default routes
+    assert "/" in patterns
+    assert "/users/{user_id}" in patterns
+    assert "/items/{item_id}" in patterns
+    # FastAPI adds OpenAPI routes
+    assert "/openapi.json" in patterns
+    assert "/docs" in patterns
+
+
+def test_extract_route_patterns_nested_paths():
+    """Test extracting nested parameterized routes."""
+    app = FastAPI()
+
+    @app.get("/api/v1/users/{user_id}/posts/{post_id}")
+    def get_post(user_id: str, post_id: str):
+        return {"user_id": user_id, "post_id": post_id}
+
+    @app.get("/api/v1/users/{user_id}/settings")
+    def get_settings(user_id: str):
+        return {"user_id": user_id}
+
+    patterns = extract_route_patterns(app)
+
+    assert "/api/v1/users/{user_id}/posts/{post_id}" in patterns
+    assert "/api/v1/users/{user_id}/settings" in patterns
+
+
+def test_extract_route_patterns_with_mounts():
+    """Test extracting route patterns from apps with mounted sub-apps."""
+    # Create a sub-app
+    sub_app = Starlette(
+        routes=[
+            Route("/health", lambda request: None),
+            Route("/status", lambda request: None),
+        ]
+    )
+
+    # Create main app with mounted sub-app
+    app = Starlette(
+        routes=[
+            Route("/", lambda request: None),
+            Mount("/admin", app=sub_app),
+        ]
+    )
+
+    patterns = extract_route_patterns(app)
+
+    assert "/" in patterns
+    assert "/admin/health" in patterns
+    assert "/admin/status" in patterns
+
+
+def test_extract_route_patterns_nested_mounts():
+    """Test extracting patterns from deeply nested mounts."""
+    # Innermost app
+    inner_app = Starlette(
+        routes=[
+            Route("/details", lambda request: None),
+        ]
+    )
+
+    # Middle app
+    middle_app = Starlette(
+        routes=[
+            Route("/list", lambda request: None),
+            Mount("/item", app=inner_app),
+        ]
+    )
+
+    # Main app
+    app = Starlette(
+        routes=[
+            Route("/", lambda request: None),
+            Mount("/api/v1", app=middle_app),
+        ]
+    )
+
+    patterns = extract_route_patterns(app)
+
+    assert "/" in patterns
+    assert "/api/v1/list" in patterns
+    assert "/api/v1/item/details" in patterns
+
+
+def test_extract_route_patterns_with_root_path():
+    """Test extracting patterns from apps with root_path set."""
+    app = FastAPI(root_path="/v1")
+
+    @app.get("/")
+    def root():
+        return {}
+
+    @app.get("/users")
+    def get_users():
+        return []
+
+    @app.get("/items/{item_id}")
+    def get_item(item_id: str):
+        return {"item_id": item_id}
+
+    patterns = extract_route_patterns(app)
+
+    # Root path should be prepended to all routes
+    assert "/v1/" in patterns  # Root route
+    assert "/v1/users" in patterns
+    assert "/v1/items/{item_id}" in patterns
+
+
+def test_extract_route_patterns_empty_app():
+    """Test extracting patterns from an app with no user-defined routes."""
+    app = FastAPI()
+    # Don't define any routes
+
+    patterns = extract_route_patterns(app)
+
+    # Should still have FastAPI defaults
+    assert "/openapi.json" in patterns
+    assert "/docs" in patterns
+    # May or may not have "/" depending on FastAPI version
+
+
+def test_extract_route_patterns_starlette():
+    """Test extracting patterns from a pure Starlette app."""
+
+    async def homepage(request):
+        return None
+
+    async def user_detail(request):
+        return None
+
+    app = Starlette(
+        routes=[
+            Route("/", homepage),
+            Route("/users/{user_id}", user_detail),
+        ]
+    )
+
+    patterns = extract_route_patterns(app)
+
+    assert "/" in patterns
+    assert "/users/{user_id}" in patterns
+    # Starlette shouldn't have OpenAPI routes
+    assert "/openapi.json" not in patterns
+
+
+def test_extract_route_patterns_multiple_methods_same_path():
+    """Test that patterns are deduplicated when multiple methods use same path."""
+    app = FastAPI()
+
+    @app.get("/items/{item_id}")
+    def get_item(item_id: str):
+        return {"item_id": item_id}
+
+    @app.put("/items/{item_id}")
+    def update_item(item_id: str):
+        return {"item_id": item_id}
+
+    @app.delete("/items/{item_id}")
+    def delete_item(item_id: str):
+        return {"item_id": item_id}
+
+    patterns = extract_route_patterns(app)
+
+    # Should appear only once even though 3 methods use it
+    pattern_count = patterns.count("/items/{item_id}")
+    assert pattern_count == 1
+
+
+def test_extract_route_patterns_invalid_app():
+    """Test that invalid apps return empty list gracefully."""
+
+    class FakeApp:
+        """An app without routes attribute."""
+
+        pass
+
+    fake_app = FakeApp()
+
+    # Should return empty list without raising exception
+    patterns = extract_route_patterns(fake_app)
+    assert patterns == []
+
+
+def test_extract_route_patterns_mount_without_routes():
+    """Test handling mounts that don't have sub-routes."""
+    from starlette.responses import PlainTextResponse
+
+    async def custom_mount(scope, receive, send):
+        response = PlainTextResponse("Custom mount")
+        await response(scope, receive, send)
+
+    app = Starlette(
+        routes=[
+            Route("/", lambda request: None),
+            Mount("/custom", app=custom_mount),
+        ]
+    )
+
+    patterns = extract_route_patterns(app)
+
+    assert "/" in patterns
+    assert "/custom" in patterns
+
+
+def test_extract_route_patterns_sorted_output():
+    """Test that output is sorted alphabetically."""
+    app = FastAPI()
+
+    @app.get("/zebra")
+    def zebra():
+        return {}
+
+    @app.get("/apple")
+    def apple():
+        return {}
+
+    @app.get("/banana")
+    def banana():
+        return {}
+
+    patterns = extract_route_patterns(app)
+
+    # Find the user-defined routes
+    user_routes = [p for p in patterns if p in ["/zebra", "/apple", "/banana"]]
+
+    # Should be sorted
+    assert user_routes == ["/apple", "/banana", "/zebra"]
+
+
+def test_extract_route_patterns_special_characters():
+    """Test routes with special regex characters."""
+    app = FastAPI()
+
+    @app.get("/users/{user_id:path}")
+    def get_user_path(user_id: str):
+        return {"user_id": user_id}
+
+    @app.get("/items/{item_id:int}")
+    def get_item_int(item_id: int):
+        return {"item_id": item_id}
+
+    patterns = extract_route_patterns(app)
+
+    # FastAPI converts these to standard patterns
+    assert any("user_id" in p for p in patterns)
+    assert any("item_id" in p for p in patterns)
+
+
+def test_extract_route_patterns_websocket_routes():
+    """Test that WebSocket routes are also extracted."""
+    app = FastAPI()
+
+    @app.get("/http")
+    def http_route():
+        return {}
+
+    @app.websocket("/ws")
+    async def websocket_route(websocket):
+        await websocket.accept()
+        await websocket.close()
+
+    patterns = extract_route_patterns(app)
+
+    assert "/http" in patterns
+    assert "/ws" in patterns
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/ray/common/BUILD.bazel
+++ b/src/ray/common/BUILD.bazel
@@ -234,6 +234,7 @@ ray_cc_library(
         "//src/ray/common/scheduling:resource_set",
         "//src/ray/common/scheduling:scheduling_class_util",
         "//src/ray/flatbuffers:node_manager_generated",
+        "//src/ray/observability:metric_interface",
         "//src/ray/util:container_util",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -425,6 +426,6 @@ ray_cc_library(
     name = "metrics",
     hdrs = ["metrics.h"],
     deps = [
-        "//src/ray/stats:stats_lib",
+        "//src/ray/stats:stats_metric",
     ],
 )

--- a/src/ray/common/metrics.h
+++ b/src/ray/common/metrics.h
@@ -73,4 +73,17 @@ inline ray::stats::Gauge GetObjectStoreMemoryGaugeMetric() {
   };
 }
 
+inline ray::stats::Histogram GetSchedulerPlacementTimeSHistogramMetric() {
+  return ray::stats::Histogram{
+      /*name=*/"scheduler_placement_time_s",
+      /*description=*/
+      "The time it takes for a worklod (task, actor, placement group) to "
+      "be placed. This is the time from when the tasks dependencies are "
+      "resolved to when it actually reserves resources on a node to run.",
+      /*unit=*/"s",
+      /*boundaries=*/{0.1, 1, 10, 100, 1000, 10000},
+      /*tag_keys=*/{"WorkloadType"},
+  };
+}
+
 }  // namespace ray

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -23,7 +23,6 @@
 
 #include "ray/common/ray_config.h"
 #include "ray/common/runtime_env_common.h"
-#include "ray/stats/metric_defs.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -602,17 +601,16 @@ bool TaskSpecification::IsRetriable() const {
   return true;
 }
 
-void TaskSpecification::EmitTaskMetrics() const {
+void TaskSpecification::EmitTaskMetrics(
+    ray::observability::MetricInterface &scheduler_placement_time_s_histogram) const {
   double duration_s = (GetMessage().lease_grant_timestamp_ms() -
                        GetMessage().dependency_resolution_timestamp_ms()) /
                       1000;
 
   if (IsActorCreationTask()) {
-    stats::STATS_scheduler_placement_time_s.Record(duration_s,
-                                                   {{"WorkloadType", "Actor"}});
+    scheduler_placement_time_s_histogram.Record(duration_s, {{"WorkloadType", "Actor"}});
   } else {
-    stats::STATS_scheduler_placement_time_s.Record(duration_s,
-                                                   {{"WorkloadType", "Task"}});
+    scheduler_placement_time_s_histogram.Record(duration_s, {{"WorkloadType", "Task"}});
   }
 }
 

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -29,6 +29,7 @@
 #include "ray/common/scheduling/resource_set.h"
 #include "ray/common/scheduling/scheduling_class_util.h"
 #include "ray/common/task/task_common.h"
+#include "ray/observability/metric_interface.h"
 
 extern "C" {
 #include "ray/thirdparty/sha256.h"
@@ -357,7 +358,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// \return true if the task or actor is retriable.
   bool IsRetriable() const;
 
-  void EmitTaskMetrics() const;
+  void EmitTaskMetrics(
+      ray::observability::MetricInterface &scheduler_placement_time_s_histogram) const;
 
   /// \return true if task events from this task should be reported.
   bool EnableTaskEvents() const;

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -185,8 +185,10 @@ class CoreWorkerProcessImpl {
   /// The client to export metrics to the metrics agent.
   std::unique_ptr<ray::rpc::MetricsAgentClient> metrics_agent_client_;
 
-  ray::stats::Gauge task_by_state_gauge_{GetTaskByStateGaugeMetric()};
-  ray::stats::Gauge actor_by_state_gauge_{GetActorByStateGaugeMetric()};
+  std::unique_ptr<ray::stats::Gauge> task_by_state_gauge_;
+  std::unique_ptr<ray::stats::Gauge> actor_by_state_gauge_;
+  std::unique_ptr<ray::stats::Gauge> total_lineage_bytes_gauge_;
+  std::unique_ptr<ray::stats::Histogram> scheduler_placement_time_s_histogram_;
 };
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/metrics.h
+++ b/src/ray/core_worker/metrics.h
@@ -41,5 +41,15 @@ inline ray::stats::Gauge GetTaskByStateGaugeMetric() {
   };
 }
 
+inline ray::stats::Gauge GetTotalLineageBytesGaugeMetric() {
+  return ray::stats::Gauge{
+      /*name=*/"total_lineage_bytes",
+      /*description=*/
+      "Total amount of memory used to store task specs for lineage reconstruction.",
+      /*unit=*/"",
+      /*tag_keys=*/{},
+  };
+}
+
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1781,7 +1781,7 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
 
 void TaskManager::RecordMetrics() {
   absl::MutexLock lock(&mu_);
-  ray::stats::STATS_total_lineage_bytes.Record(total_lineage_footprint_bytes_);
+  total_lineage_bytes_gauge_.Record(total_lineage_footprint_bytes_);
   task_counter_.FlushOnChangeCallbacks();
 }
 

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -33,7 +33,6 @@
 #include "ray/core_worker_rpc_client/core_worker_client_interface.h"
 #include "ray/gcs_rpc_client/gcs_client.h"
 #include "ray/observability/metric_interface.h"
-#include "ray/stats/metric_defs.h"
 #include "ray/util/counter_map.h"
 #include "src/ray/protobuf/common.pb.h"
 #include "src/ray/protobuf/core_worker.pb.h"
@@ -187,6 +186,7 @@ class TaskManager : public TaskManagerInterface {
           const ActorID &)> get_actor_rpc_client_callback,
       std::shared_ptr<gcs::GcsClient> gcs_client,
       ray::observability::MetricInterface &task_by_state_counter,
+      ray::observability::MetricInterface &total_lineage_bytes_gauge,
       FreeActorObjectCallback free_actor_object_callback)
       : in_memory_store_(in_memory_store),
         reference_counter_(reference_counter),
@@ -199,6 +199,7 @@ class TaskManager : public TaskManagerInterface {
         get_actor_rpc_client_callback_(std::move(get_actor_rpc_client_callback)),
         gcs_client_(std::move(gcs_client)),
         task_by_state_counter_(task_by_state_counter),
+        total_lineage_bytes_gauge_(total_lineage_bytes_gauge),
         free_actor_object_callback_(std::move(free_actor_object_callback)) {
     task_counter_.SetOnChangeCallback(
         [this](const std::tuple<std::string, rpc::TaskStatus, bool> &key)
@@ -811,6 +812,10 @@ class TaskManager : public TaskManagerInterface {
   // - IsRetry: whether the task is a retry
   // - Source: component reporting, e.g., "core_worker", "executor", or "pull_manager"
   observability::MetricInterface &task_by_state_counter_;
+
+  /// Metric to track the total amount of memory used to store task specs for lineage
+  /// reconstruction.
+  observability::MetricInterface &total_lineage_bytes_gauge_;
 
   /// Callback to free GPU object from the in-actor object store.
   FreeActorObjectCallback free_actor_object_callback_;

--- a/src/ray/core_worker/task_submission/normal_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.cc
@@ -177,7 +177,7 @@ void NormalTaskSubmitter::OnWorkerIdle(
       scheduling_key_entry.num_busy_workers++;
 
       task_spec.GetMutableMessage().set_lease_grant_timestamp_ms(current_sys_time_ms());
-      task_spec.EmitTaskMetrics();
+      task_spec.EmitTaskMetrics(scheduler_placement_time_s_histogram_);
 
       executing_tasks_.emplace(task_spec.TaskId(), addr);
       PushNormalTask(

--- a/src/ray/core_worker/task_submission/normal_task_submitter.h
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.h
@@ -95,7 +95,8 @@ class NormalTaskSubmitter {
       const JobID &job_id,
       std::shared_ptr<LeaseRequestRateLimiter> lease_request_rate_limiter,
       const TensorTransportGetter &tensor_transport_getter,
-      boost::asio::steady_timer cancel_timer)
+      boost::asio::steady_timer cancel_timer,
+      ray::observability::MetricInterface &scheduler_placement_time_s_histogram)
       : rpc_address_(std::move(rpc_address)),
         local_raylet_client_(std::move(local_raylet_client)),
         raylet_client_pool_(std::move(raylet_client_pool)),
@@ -109,7 +110,8 @@ class NormalTaskSubmitter {
         core_worker_client_pool_(std::move(core_worker_client_pool)),
         job_id_(job_id),
         lease_request_rate_limiter_(std::move(lease_request_rate_limiter)),
-        cancel_retry_timer_(std::move(cancel_timer)) {}
+        cancel_retry_timer_(std::move(cancel_timer)),
+        scheduler_placement_time_s_histogram_(scheduler_placement_time_s_histogram) {}
 
   /// Schedule a task for direct submission to a worker.
   void SubmitTask(TaskSpecification task_spec);
@@ -362,6 +364,8 @@ class NormalTaskSubmitter {
 
   // Retries cancelation requests if they were not successful.
   boost::asio::steady_timer cancel_retry_timer_ ABSL_GUARDED_BY(mu_);
+
+  ray::observability::MetricInterface &scheduler_placement_time_s_histogram_;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
@@ -32,6 +32,7 @@
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker_rpc_client/core_worker_client_pool.h"
 #include "ray/core_worker_rpc_client/fake_core_worker_client.h"
+#include "ray/observability/fake_metric.h"
 #include "ray/raylet_rpc_client/fake_raylet_client.h"
 #include "ray/raylet_rpc_client/raylet_client_interface.h"
 
@@ -494,7 +495,8 @@ class NormalTaskSubmitterTest : public testing::Test {
         JobID::Nil(),
         rate_limiter,
         [](const ObjectID &object_id) { return rpc::TensorTransport::OBJECT_STORE; },
-        boost::asio::steady_timer(io_context));
+        boost::asio::steady_timer(io_context),
+        fake_scheduler_placement_time_s_histogram_);
   }
 
   NodeID local_node_id;
@@ -511,6 +513,7 @@ class NormalTaskSubmitterTest : public testing::Test {
   std::unique_ptr<MockLeasePolicy> lease_policy;
   MockLeasePolicy *lease_policy_ptr = nullptr;
   instrumented_io_context io_context;
+  ray::observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
 };
 
 TEST_F(NormalTaskSubmitterTest, TestLocalityAwareSubmitOneTask) {
@@ -1430,6 +1433,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
                        const TaskSpecification &same2,
                        const TaskSpecification &different) {
   rpc::Address address;
+  ray::observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
   auto local_node_id = NodeID::FromRandom();
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto raylet_client_pool = std::make_shared<rpc::RayletClientPool>(
@@ -1457,7 +1461,8 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
       JobID::Nil(),
       std::make_shared<StaticLeaseRequestRateLimiter>(1),
       [](const ObjectID &object_id) { return rpc::TensorTransport::OBJECT_STORE; },
-      boost::asio::steady_timer(io_context));
+      boost::asio::steady_timer(io_context),
+      fake_scheduler_placement_time_s_histogram_);
 
   submitter.SubmitTask(same1);
   submitter.SubmitTask(same2);

--- a/src/ray/core_worker/tests/core_worker_test.cc
+++ b/src/ray/core_worker/tests/core_worker_test.cc
@@ -187,6 +187,7 @@ class CoreWorkerTest : public ::testing::Test {
         },
         mock_gcs_client_,
         fake_task_by_state_gauge_,
+        fake_total_lineage_bytes_gauge_,
         /*free_actor_object_callback=*/[](const ObjectID &object_id) {});
 
     auto object_recovery_manager = std::make_unique<ObjectRecoveryManager>(
@@ -222,7 +223,8 @@ class CoreWorkerTest : public ::testing::Test {
         JobID::Nil(),
         lease_request_rate_limiter,
         [](const ObjectID &object_id) { return rpc::TensorTransport::OBJECT_STORE; },
-        boost::asio::steady_timer(io_service_));
+        boost::asio::steady_timer(io_service_),
+        fake_scheduler_placement_time_s_histogram_);
 
     auto actor_task_submitter = std::make_unique<ActorTaskSubmitter>(
         *core_worker_client_pool,
@@ -297,6 +299,8 @@ class CoreWorkerTest : public ::testing::Test {
   std::shared_ptr<CoreWorker> core_worker_;
   ray::observability::FakeGauge fake_task_by_state_gauge_;
   ray::observability::FakeGauge fake_actor_by_state_gauge_;
+  ray::observability::FakeGauge fake_total_lineage_bytes_gauge_;
+  ray::observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
   std::unique_ptr<FakePeriodicalRunner> fake_periodical_runner_;
 
   // Controllable time for testing publisher timeouts

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -183,6 +183,7 @@ class TaskManagerTest : public ::testing::Test {
             },
             mock_gcs_client_,
             fake_task_by_state_counter_,
+            fake_total_lineage_bytes_gauge_,
             /*free_actor_object_callback=*/[](const ObjectID &object_id) {}) {}
 
   virtual void TearDown() { AssertNoLeaks(); }
@@ -230,6 +231,7 @@ class TaskManagerTest : public ::testing::Test {
   uint32_t last_delay_ms_ = 0;
   std::unordered_set<ObjectID> stored_in_plasma;
   ray::observability::FakeGauge fake_task_by_state_counter_;
+  ray::observability::FakeGauge fake_total_lineage_bytes_gauge_;
 };
 
 class TaskManagerLineageTest : public TaskManagerTest {
@@ -1404,6 +1406,7 @@ TEST_F(TaskManagerTest, PlasmaPut_ObjectStoreFull_FailsTaskAndWritesError) {
       },
       mock_gcs_client_,
       fake_task_by_state_counter_,
+      fake_total_lineage_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {});
 
   rpc::Address caller_address;
@@ -1467,6 +1470,7 @@ TEST_F(TaskManagerTest, PlasmaPut_TransientFull_RetriesThenSucceeds) {
       },
       mock_gcs_client_,
       fake_task_by_state_counter_,
+      fake_total_lineage_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {});
 
   rpc::Address caller_address;
@@ -1528,6 +1532,7 @@ TEST_F(TaskManagerTest, DynamicReturn_PlasmaPutFailure_FailsTaskImmediately) {
       },
       mock_gcs_client_,
       fake_task_by_state_counter_,
+      fake_total_lineage_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {});
 
   auto spec = CreateTaskHelper(1, {}, /*dynamic_returns=*/true);
@@ -3016,6 +3021,7 @@ TEST_F(TaskManagerTest, TestRetryErrorMessageSentToCallback) {
           -> std::shared_ptr<ray::rpc::CoreWorkerClientInterface> { return nullptr; },
       mock_gcs_client_,
       fake_task_by_state_counter_,
+      fake_total_lineage_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {});
 
   // Create a task with retries enabled
@@ -3096,6 +3102,7 @@ TEST_F(TaskManagerTest, TestErrorLogWhenPushErrorCallbackFails) {
           -> std::shared_ptr<ray::rpc::CoreWorkerClientInterface> { return nullptr; },
       mock_gcs_client_,
       fake_task_by_state_counter_,
+      fake_total_lineage_bytes_gauge_,
       /*free_actor_object_callback=*/[](const ObjectID &object_id) {});
 
   // Create a task that will be retried

--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -273,6 +273,7 @@ ray_cc_library(
     deps = [
         "//src/ray/common:bundle_spec",
         "//src/ray/common:id",
+        "//src/ray/common:metrics",
         "//src/ray/protobuf:gcs_service_cc_proto",
         "//src/ray/stats:stats_lib",
         "//src/ray/util:counter_map",

--- a/src/ray/gcs/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_actor_scheduler.h
@@ -130,6 +130,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
       GcsActorSchedulerSuccessCallback schedule_success_handler,
       rpc::RayletClientPool &raylet_client_pool,
       rpc::CoreWorkerClientPool &worker_client_pool,
+      ray::observability::MetricInterface &scheduler_placement_time_s_histogram,
       std::function<void(const NodeID &, const rpc::ResourcesData &)>
           normal_task_resources_changed_callback = nullptr);
 
@@ -388,6 +389,8 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
 
   /// The resource changed listeners.
   std::vector<std::function<void()>> resource_changed_listeners_;
+
+  ray::observability::MetricInterface &scheduler_placement_time_s_histogram_;
 
   /// Normal task resources changed callback.
   std::function<void(const NodeID &, const rpc::ResourcesData &)>

--- a/src/ray/gcs/gcs_placement_group.cc
+++ b/src/ray/gcs/gcs_placement_group.cc
@@ -18,8 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "ray/stats/metric_defs.h"
-
 namespace ray {
 namespace gcs {
 
@@ -36,8 +34,8 @@ void GcsPlacementGroup::UpdateState(
              .placement_group_final_bundle_placement_timestamp_ms() -
          placement_group_table_data_.placement_group_creation_timestamp_ms()) /
         1000;
-    stats::STATS_scheduler_placement_time_s.Record(duration_s,
-                                                   {{"WorkloadType", "PlacementGroup"}});
+    scheduler_placement_time_s_histogram_.Record(duration_s,
+                                                 {{"WorkloadType", "PlacementGroup"}});
   }
   placement_group_table_data_.set_state(state);
   RefreshMetrics();

--- a/src/ray/gcs/gcs_placement_group.h
+++ b/src/ray/gcs/gcs_placement_group.h
@@ -23,6 +23,7 @@
 
 #include "ray/common/bundle_spec.h"
 #include "ray/common/id.h"
+#include "ray/common/metrics.h"
 #include "ray/util/counter_map.h"
 #include "ray/util/time.h"
 #include "src/ray/protobuf/gcs_service.pb.h"
@@ -206,6 +207,9 @@ class GcsPlacementGroup {
 
   /// The last recorded metric state.
   std::optional<rpc::PlacementGroupTableData::PlacementGroupState> last_metric_state_;
+
+  ray::stats::Histogram scheduler_placement_time_s_histogram_{
+      ray::GetSchedulerPlacementTimeSHistogramMetric()};
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -523,6 +523,7 @@ void GcsServer::InitGcsActorManager(
       schedule_success_handler,
       raylet_client_pool_,
       worker_client_pool_,
+      metrics_.scheduler_placement_time_s_histogram,
       /*normal_task_resources_changed_callback=*/
       [this](const NodeID &node_id, const rpc::ResourcesData &resources) {
         gcs_resource_manager_->UpdateNodeNormalTaskResources(node_id, resources);

--- a/src/ray/gcs/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server_main.cc
@@ -188,6 +188,8 @@ int main(int argc, char *argv[]) {
       ray::gcs::GetGcsStorageOperationLatencyInMsHistogramMetric();
   auto storage_operation_count_counter =
       ray::gcs::GetGcsStorageOperationCountCounterMetric();
+  auto scheduler_placement_time_s_histogram =
+      ray::GetSchedulerPlacementTimeSHistogramMetric();
 
   // Create the metrics struct
   ray::gcs::GcsServerMetrics gcs_server_metrics{
@@ -209,6 +211,7 @@ int main(int argc, char *argv[]) {
       /*storage_operation_latency_in_ms_histogram=*/
       storage_operation_latency_in_ms_histogram,
       /*storage_operation_count_counter=*/storage_operation_count_counter,
+      scheduler_placement_time_s_histogram,
   };
 
   ray::gcs::GcsServer gcs_server(gcs_server_config, gcs_server_metrics, main_service);

--- a/src/ray/gcs/metrics.h
+++ b/src/ray/gcs/metrics.h
@@ -36,6 +36,7 @@ struct GcsServerMetrics {
   ray::observability::MetricInterface &event_recorder_dropped_events_counter;
   ray::observability::MetricInterface &storage_operation_latency_in_ms_histogram;
   ray::observability::MetricInterface &storage_operation_count_counter;
+  ray::observability::MetricInterface &scheduler_placement_time_s_histogram;
 };
 
 inline ray::stats::Gauge GetRunningJobGaugeMetric() {

--- a/src/ray/gcs/tests/BUILD.bazel
+++ b/src/ray/gcs/tests/BUILD.bazel
@@ -219,6 +219,7 @@ ray_cc_test(
         "//src/ray/gcs:gcs_actor_scheduler",
         "//src/ray/gcs:gcs_resource_manager",
         "//src/ray/gcs/store_client:in_memory_store_client",
+        "//src/ray/observability:fake_metric",
         "//src/ray/observability:fake_ray_event_recorder",
         "//src/ray/raylet_rpc_client:fake_raylet_client",
         "//src/ray/raylet_rpc_client:raylet_client_pool",

--- a/src/ray/gcs/tests/gcs_actor_scheduler_mock_test.cc
+++ b/src/ray/gcs/tests/gcs_actor_scheduler_mock_test.cc
@@ -26,6 +26,7 @@
 #include "ray/core_worker_rpc_client/core_worker_client_pool.h"
 #include "ray/gcs/gcs_actor.h"
 #include "ray/gcs/gcs_actor_scheduler.h"
+#include "ray/observability/fake_metric.h"
 #include "ray/observability/fake_ray_event_recorder.h"
 #include "ray/util/counter_map.h"
 
@@ -84,7 +85,8 @@ class GcsActorSchedulerMockTest : public Test {
         [this](auto a, auto b, auto c) { schedule_failure_handler(a); },
         [this](auto a, const rpc::PushTaskReply) { schedule_success_handler(a); },
         *client_pool,
-        *worker_client_pool_);
+        *worker_client_pool_,
+        fake_scheduler_placement_time_s_histogram_);
     auto node_info = std::make_shared<rpc::GcsNodeInfo>();
     node_info->set_state(rpc::GcsNodeInfo::ALIVE);
     node_id = NodeID::FromRandom();
@@ -105,6 +107,7 @@ class GcsActorSchedulerMockTest : public Test {
   std::unique_ptr<rpc::CoreWorkerClientPool> worker_client_pool_;
   std::unique_ptr<rpc::RayletClientPool> client_pool;
   observability::FakeRayEventRecorder fake_ray_event_recorder_;
+  observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
   std::shared_ptr<CounterMap<std::pair<rpc::ActorTableData::ActorState, std::string>>>
       counter;
   MockCallback schedule_failure_handler;

--- a/src/ray/gcs/tests/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_actor_scheduler_test.cc
@@ -31,6 +31,7 @@
 #include "ray/gcs/gcs_actor_scheduler.h"
 #include "ray/gcs/gcs_resource_manager.h"
 #include "ray/gcs/store_client/in_memory_store_client.h"
+#include "ray/observability/fake_metric.h"
 #include "ray/observability/fake_ray_event_recorder.h"
 #include "ray/raylet_rpc_client/fake_raylet_client.h"
 #include "ray/raylet_rpc_client/raylet_client_pool.h"
@@ -148,6 +149,7 @@ class GcsActorSchedulerTest : public ::testing::Test {
         },
         *raylet_client_pool_,
         *worker_client_pool_,
+        fake_scheduler_placement_time_s_histogram_,
         /*normal_task_resources_changed_callback=*/
         [gcs_resource_manager](const NodeID &node_id,
                                const rpc::ResourcesData &resources) {
@@ -221,6 +223,7 @@ class GcsActorSchedulerTest : public ::testing::Test {
   std::shared_ptr<pubsub::GcsPublisher> gcs_publisher_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<rpc::RayletClientPool> raylet_client_pool_;
+  ray::observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
   NodeID local_node_id_;
 };
 

--- a/src/ray/gcs/tests/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/tests/gcs_server_rpc_test.cc
@@ -49,6 +49,7 @@ class GcsServerTest : public ::testing::Test {
             /*storage_operation_latency_in_ms_histogram=*/
             storage_operation_latency_in_ms_histogram_,
             /*storage_operation_count_counter=*/storage_operation_count_counter_,
+            fake_scheduler_placement_time_s_histogram_,
         } {
     TestSetupUtil::StartUpRedisServers(std::vector<int>());
   }
@@ -268,6 +269,7 @@ class GcsServerTest : public ::testing::Test {
   observability::FakeHistogram storage_operation_latency_in_ms_histogram_;
   observability::FakeCounter storage_operation_count_counter_;
   observability::FakeCounter fake_dropped_events_counter_;
+  observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
 
   // Fake metrics struct
   gcs::GcsServerMetrics fake_metrics_;

--- a/src/ray/gcs_rpc_client/tests/gcs_client_reconnection_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_reconnection_test.cc
@@ -66,6 +66,7 @@ class GcsClientReconnectionTest : public ::testing::Test {
         /*storage_operation_latency_in_ms_histogram=*/
         storage_operation_latency_in_ms_histogram_,
         /*storage_operation_count_counter=*/storage_operation_count_counter_,
+        scheduler_placement_time_s_histogram_,
     };
 
     gcs_server_ = std::make_unique<gcs::GcsServer>(
@@ -199,6 +200,7 @@ class GcsClientReconnectionTest : public ::testing::Test {
   observability::FakeHistogram storage_operation_latency_in_ms_histogram_;
   observability::FakeCounter storage_operation_count_counter_;
   observability::FakeCounter fake_dropped_events_counter_;
+  observability::FakeHistogram scheduler_placement_time_s_histogram_;
 
   // GCS client.
   std::unique_ptr<std::thread> client_io_service_thread_;

--- a/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
@@ -105,6 +105,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
         /*storage_operation_latency_in_ms_histogram=*/
         storage_operation_latency_in_ms_histogram_,
         /*storage_operation_count_counter=*/storage_operation_count_counter_,
+        scheduler_placement_time_s_histogram_,
     };
 
     gcs_server_ = std::make_unique<gcs::GcsServer>(
@@ -192,6 +193,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
         /*storage_operation_latency_in_ms_histogram=*/
         storage_operation_latency_in_ms_histogram_,
         /*storage_operation_count_counter=*/storage_operation_count_counter_,
+        scheduler_placement_time_s_histogram_,
     };
 
     gcs_server_.reset(
@@ -483,6 +485,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
   observability::FakeHistogram storage_operation_latency_in_ms_histogram_;
   observability::FakeCounter storage_operation_count_counter_;
   observability::FakeCounter fake_dropped_events_counter_;
+  observability::FakeHistogram scheduler_placement_time_s_histogram_;
 };
 
 INSTANTIATE_TEST_SUITE_P(RedisMigration, GcsClientTest, testing::Bool());

--- a/src/ray/gcs_rpc_client/tests/global_state_accessor_test.cc
+++ b/src/ray/gcs_rpc_client/tests/global_state_accessor_test.cc
@@ -86,6 +86,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
         /*storage_operation_latency_in_ms_histogram=*/
         fake_storage_operation_latency_in_ms_histogram_,
         /*storage_operation_count_counter=*/fake_storage_operation_count_counter_,
+        fake_scheduler_placement_time_s_histogram_,
     };
 
     gcs_server_.reset(new gcs::GcsServer(config, gcs_server_metrics, *io_service_));
@@ -158,6 +159,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
   observability::FakeGauge fake_task_events_stored_gauge_;
   observability::FakeHistogram fake_storage_operation_latency_in_ms_histogram_;
   observability::FakeCounter fake_storage_operation_count_counter_;
+  observability::FakeHistogram fake_scheduler_placement_time_s_histogram_;
 
   std::unique_ptr<gcs::GlobalStateAccessor> global_state_;
 


### PR DESCRIPTION
Building linux deps only wheel in manylinux container to enable running raydepsets locally on macos

Current limitation: rayimg.depsets.yaml references linux wheels that are built at runtime (ex. ray[all] @ file://.whl/ray-100.0.0.dev0-cp39-cp39-linux_x86_64.whl)

To build a linux wheel on macos, use manylinux image and build the wheel with uv

Tested on macos and linux