### PR TITLE
[core] deprecate raw_metrics api in tests

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1065,20 +1065,6 @@ def fetch_prometheus_metric_timeseries(
     return samples_by_name
 
 
-def raw_metrics(info: RayContext) -> Dict[str, List[Any]]:
-    """Return prometheus metrics from a RayContext
-
-    Args:
-        info: Ray context returned from ray.init()
-
-    Returns:
-        Dict from metric name to a list of samples for the metrics
-    """
-    metrics_page = "localhost:{}".format(info.address_info["metrics_export_port"])
-    print("Fetch metrics from", metrics_page)
-    return fetch_prometheus_metrics([metrics_page])
-
-
 def raw_metric_timeseries(
     info: RayContext, result: PrometheusTimeseries
 ) -> Dict[str, List[Any]]:

--- a/python/ray/tests/test_placement_group_metrics.py
+++ b/python/ray/tests/test_placement_group_metrics.py
@@ -7,7 +7,8 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray._private.test_utils import (
-    raw_metrics,
+    PrometheusTimeseries,
+    raw_metric_timeseries,
 )
 from ray._private.worker import RayContext
 from ray.util.placement_group import remove_placement_group
@@ -17,8 +18,8 @@ _SYSTEM_CONFIG = {
 }
 
 
-def groups_by_state(info: RayContext) -> Dict:
-    res = raw_metrics(info)
+def groups_by_state(info: RayContext, timeseries: PrometheusTimeseries) -> Dict:
+    res = raw_metric_timeseries(info, timeseries)
     info = defaultdict(int)
     if "ray_placement_groups" in res:
         for sample in res["ray_placement_groups"]:
@@ -42,8 +43,9 @@ def test_basic_states(shutdown_only):
         "CREATED": 2,
         "PENDING": 1,
     }
+    timeseries = PrometheusTimeseries()
     wait_for_condition(
-        lambda: groups_by_state(info) == expected,
+        lambda: groups_by_state(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )
@@ -55,8 +57,9 @@ def test_basic_states(shutdown_only):
     expected = {
         "REMOVED": 3,
     }
+    timeseries = PrometheusTimeseries()
     wait_for_condition(
-        lambda: groups_by_state(info) == expected,
+        lambda: groups_by_state(info, timeseries) == expected,
         timeout=20,
         retry_interval_ms=500,
     )

--- a/python/ray/tests/test_system_metrics.py
+++ b/python/ray/tests/test_system_metrics.py
@@ -7,7 +7,8 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray._private.test_utils import (
-    raw_metrics,
+    PrometheusTimeseries,
+    raw_metric_timeseries,
 )
 
 METRIC_CONFIG = {
@@ -32,8 +33,10 @@ def test_unintentional_worker_failures_metric(shutdown_only):
     # unintentional
     actor2.exit.remote()
 
+    timeseries = PrometheusTimeseries()
+
     def verify():
-        metrics = raw_metrics(context)
+        metrics = raw_metric_timeseries(context, timeseries)
         for sample in metrics["ray_unintentional_worker_failures_total"]:
             assert sample.value == 1
         return True


### PR DESCRIPTION
Deprecate `raw_metrics` API and replace them all with the `raw_metric_timeseries` API. `raw_metrics` returns the current snapshot of a set of metrics, while `raw_metric_timeseries` returns the full time series. The later is more reliable when checking the latest instance of several independent metrics. 

Test:
- CI