### PR TITLE
[Fix] Update grpc version in requirements to successfully build in mac

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,7 +24,7 @@ watchfiles
 grpcio >= 1.32.0; python_version < '3.10'
 grpcio >= 1.42.0; python_version >= '3.10'
 # Version used in mac CI; needs upgrade.
-grpcio == 1.54.2; sys_platform == "darwin"
+grpcio >= 1.54.2; sys_platform == "darwin"
 
 numpy>=1.20
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,7 +24,7 @@ watchfiles
 grpcio >= 1.32.0; python_version < '3.10'
 grpcio >= 1.42.0; python_version >= '3.10'
 # Version used in mac CI; needs upgrade.
-grpcio >= 1.54.2; sys_platform == "darwin"
+grpcio >= 1.54.2, != 1.56.0; sys_platform == "darwin"
 
 numpy>=1.20
 


### PR DESCRIPTION
## Description

Getting error when running `uv pip install -r requirements.txt ` on mac following instructions: https://docs.ray.io/en/master/ray-contribute/development.html#building-ray-on-linux-macos-full

```sh
❯ uv pip install grpcio==1.54.2
Using Python 3.12.11 environment at: /Users/nary/workData/open-source/ray/.venv
Resolved 1 package in 3ms
  × Failed to build `grpcio==1.54.2`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
```

Update grpc version in `python/requirements.txt` 

## Related issues

## Additional information

