### PR TITLE
[doc] run api policy check in python 3.10

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -75,8 +75,7 @@ steps:
     key: doc_api_policy_check
     instance_type: medium
     depends_on: docbuild
-    # TODO(aslonnie): migrate to Python 3.12
-    job_env: docbuild-py3.9
+    job_env: docbuild-py3.10
     commands:
       - bash ci/lint/lint.sh api_policy_check
 


### PR DESCRIPTION
the requirements should be mostly compatible?
