### PR TITLE
[serve] removes python 3.9 base image

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -10,7 +10,6 @@ steps:
     label: "wanda: servebuild-py{{matrix}}"
     wanda: ci/docker/serve.build.wanda.yaml
     matrix:
-      - "3.9"
       - "3.10"
       - "3.12"
     env:


### PR DESCRIPTION
not used any more; all tests moved to python 3.10
