### PR TITLE
[deps] build linux placeholder wheel on mac

### DIFF
--- a/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
+++ b/ci/raydepsets/pre_hooks/build-placeholder-wheel.sh
@@ -10,4 +10,16 @@ PYTHON_VERSION=$1
 
 export RAY_DEBUG_BUILD=deps-only
 
-uv build --wheel --directory python/ -o ../.whl/ --python "$PYTHON_VERSION"
+UV_BUILD_COMMAND="uv build --wheel --directory python/ -o ../.whl/ --python \"$PYTHON_VERSION\""
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  docker run --rm \
+  -v "$PWD":/ray -w /ray --platform linux/x86_64 \
+  quay.io/pypa/manylinux2014_x86_64 \
+  bash -lc '
+  set -e
+  export RAY_DEBUG_BUILD=deps-only
+  eval "$UV_BUILD_COMMAND"'
+else
+  eval "$UV_BUILD_COMMAND"
+fi


### PR DESCRIPTION
Building linux deps only wheel in manylinux container to enable running raydepsets locally on macos

Current limitation: rayimg.depsets.yaml references linux wheels that are built at runtime (ex. ray[all] @ file://.whl/ray-100.0.0.dev0-cp39-cp39-linux_x86_64.whl)

To build a linux wheel on macos, use manylinux image and build the wheel with uv

Tested on macos and linux