### PR TITLE
Update dashboard metrics to use new cluster metrics

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -42,16 +42,16 @@ OVERVIEW_AND_HEALTH_PANELS = [
         unit="nodes",
         targets=[
             Target(
-                expr="sum(autoscaler_active_nodes{{{global_filters}}}) by (NodeType)",
-                legend="Active Nodes: {{NodeType}}",
+                expr="sum(ray_cluster_active_nodes{{{global_filters}}}) by (node_type)",
+                legend="Active Nodes: {{node_type}}",
             ),
             Target(
-                expr="sum(autoscaler_recently_failed_nodes{{{global_filters}}}) by (NodeType)",
-                legend="Failed Nodes: {{NodeType}}",
+                expr="sum(ray_cluster_failed_nodes{{{global_filters}}}) by (node_type)",
+                legend="Failed Nodes: {{node_type}}",
             ),
             Target(
-                expr="sum(autoscaler_pending_nodes{{{global_filters}}}) by (NodeType)",
-                legend="Pending Nodes: {{NodeType}}",
+                expr="sum(ray_cluster_pending_nodes{{{global_filters}}}) by (node_type)",
+                legend="Pending Nodes: {{node_type}}",
             ),
         ],
     ),

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
@@ -286,18 +286,17 @@ SERVE_GRAFANA_PANELS = [
         description='Number of nodes in this cluster. Ignores "Application" variable.',
         unit="nodes",
         targets=[
-            # TODO(aguo): Update this to use autoscaler metrics instead
             Target(
-                expr="sum(autoscaler_active_nodes{{{global_filters}}}) by (NodeType)",
-                legend="Active Nodes: {{NodeType}}",
+                expr="sum(ray_cluster_active_nodes{{{global_filters}}}) by (node_type)",
+                legend="Active Nodes: {{node_type}}",
             ),
             Target(
-                expr="sum(autoscaler_recently_failed_nodes{{{global_filters}}}) by (NodeType)",
-                legend="Failed Nodes: {{NodeType}}",
+                expr="sum(ray_cluster_failed_nodes{{{global_filters}}}) by (node_type)",
+                legend="Failed Nodes: {{node_type}}",
             ),
             Target(
-                expr="sum(autoscaler_pending_nodes{{{global_filters}}}) by (NodeType)",
-                legend="Pending Nodes: {{NodeType}}",
+                expr="sum(ray_cluster_pending_nodes{{{global_filters}}}) by (node_type)",
+                legend="Pending Nodes: {{node_type}}",
             ),
         ],
         grid_pos=GridPos(8, 5, 8, 8),


### PR DESCRIPTION
Replace autoscaler_* metrics with ray_cluster_* metrics in Grafana dashboards:
- autoscaler_active_nodes -> ray_cluster_active_nodes
- autoscaler_recently_failed_nodes -> ray_cluster_failed_nodes
- autoscaler_pending_nodes -> ray_cluster_pending_nodes

Also update the label name from NodeType to node_type to match the new metrics.

This change aligns the dashboards with the new cluster metrics exported by the reporter agent.

Related discussion: https://discuss.ray.io/t/grafana-dashboard-issues/15609

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
