### PR TITLE
[Data][Flaky] fix test_limit_pushdown_conservative fails due to non-deterministic task ordering

### DIFF
--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -7,6 +7,7 @@ import pytest
 import ray
 from ray.data import Dataset
 from ray.data._internal.logical.interfaces import Plan
+from ray.data._internal.util import rows_same
 from ray.data.block import BlockMetadata
 from ray.data.datasource import Datasource
 from ray.data.datasource.datasource import ReadTask

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -25,7 +25,6 @@ def _check_valid_plan_and_result(
     if check_ordering:
         assert actual_result == expected_result
     else:
-        # When ordering doesn't matter, compare as multisets.
         assert rows_same(pd.DataFrame(actual_result), pd.DataFrame(expected_result))
     assert ds._plan._logical_plan.dag.dag_str == expected_plan
 

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -26,14 +26,7 @@ def _check_valid_plan_and_result(
         assert actual_result == expected_result
     else:
         # When ordering doesn't matter, compare as multisets.
-        from collections import Counter
-
-        def to_hashable(d):
-            return tuple(sorted(d.items()))
-
-        assert Counter(map(to_hashable, actual_result)) == Counter(
-            map(to_hashable, expected_result)
-        )
+        assert rows_same(pd.DataFrame(actual_result), pd.DataFrame(expected_result))
     assert ds._plan._logical_plan.dag.dag_str == expected_plan
 
     expected_physical_plan_ops = expected_physical_plan_ops or []


### PR DESCRIPTION
## Description
I add a param that can determin whether we should check the order or not, release restriction for flaky tests.

## Related issues
Closes #58561

## Additional information

I ran test 20 times using a simple script that rans `python -m pytest python/ray/data/tests/test_execution_optimizer_limit_pushdown.py::test_limit_pushdown_conservative`:

- master: `Passed: 18, Failed: 2`
- feature/flaky-test_limit_pushdown_conservative: `Passed: 20, Failed: 0`
