### PR TITLE
[Data] Handle prefetches buffering in iter_batches

### DIFF
--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -6,9 +6,10 @@ import pandas as pd
 import pyarrow
 import torch
 
-from ray._private.ray_constants import env_bool
+from ray._private.ray_constants import env_bool, env_integer
 from ray.air._internal.device_manager import get_torch_device_manager_by_context
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
+from ray.data._internal.util import make_async_gen
 from ray.data.collate_fn import (
     TensorBatchReturnType,
     TensorBatchType,
@@ -23,6 +24,12 @@ from ray.data.collate_fn import (
 DEFAULT_TENSOR_NON_BLOCKING_TRANSFER = env_bool(
     "RAY_AIR_DEFAULT_TENSOR_NON_BLOCKING_TRANSFER",
     True,
+)
+
+# Default number of workers for parallel tensor conversion.
+DEFAULT_TENSOR_CONVERSION_NUM_WORKERS = env_integer(
+    "RAY_AIR_DEFAULT_TENSOR_CONVERSION_NUM_WORKERS",
+    4,
 )
 
 
@@ -389,23 +396,95 @@ def arrow_batch_to_tensors(
 
     if combine_chunks:
         numpy_batch = ArrowBlockAccessor(batch).to_batch_format("numpy")
-        return {
-            col_name: convert_ndarray_batch_to_torch_tensor_batch(
-                col_array,
-                dtypes=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
-                pin_memory=pin_memory,
+        num_columns = len(numpy_batch)
+        num_workers = min(num_columns, DEFAULT_TENSOR_CONVERSION_NUM_WORKERS)
+
+        if num_workers > 1 and num_columns > 1:
+            # Process columns in parallel
+            def process_columns(col_items_iter):
+                """Process column items (col_name, col_array) from iterator."""
+                for col_name, col_array in col_items_iter:
+                    yield (
+                        col_name,
+                        convert_ndarray_batch_to_torch_tensor_batch(
+                            col_array,
+                            dtypes=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
+                            pin_memory=pin_memory,
+                        ),
+                    )
+
+            # Use make_async_gen to parallelize column processing
+            processed_cols = make_async_gen(
+                base_iterator=iter(numpy_batch.items()),
+                fn=process_columns,
+                preserve_ordering=False,
+                num_workers=num_workers,
             )
-            for col_name, col_array in numpy_batch.items()
-        }
+            return dict(processed_cols)
+        else:
+            # Sequential processing for single column or single worker
+            return {
+                col_name: convert_ndarray_batch_to_torch_tensor_batch(
+                    col_array,
+                    dtypes=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
+                    pin_memory=pin_memory,
+                )
+                for col_name, col_array in numpy_batch.items()
+            }
     else:
         numpy_list = transform_pyarrow.table_to_numpy_dict_chunked(
             batch,
         )
-        return convert_ndarray_list_to_torch_tensor_list(
-            numpy_list,
-            dtypes=dtypes,
-            pin_memory=pin_memory,
-        )
+        # Count total number of arrays across all columns
+        total_arrays = sum(len(arrays) for arrays in numpy_list.values())
+        num_columns = len(numpy_list)
+        num_workers = min(max(total_arrays, num_columns), DEFAULT_TENSOR_CONVERSION_NUM_WORKERS)
+
+        if num_workers > 1 and total_arrays > 1:
+            # Process arrays in parallel
+            def process_arrays(array_items_iter):
+                """Process array items (col_name, array_index, array) from iterator."""
+                for col_name, array_index, array in array_items_iter:
+                    yield (
+                        col_name,
+                        array_index,
+                        convert_ndarray_batch_to_torch_tensor_batch(
+                            array,
+                            dtypes=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
+                            pin_memory=pin_memory,
+                        ),
+                    )
+
+            # Flatten arrays with column name and index for parallel processing
+            array_items = [
+                (col_name, idx, array)
+                for col_name, arrays in numpy_list.items()
+                for idx, array in enumerate(arrays)
+            ]
+
+            # Use make_async_gen to parallelize array processing
+            processed_arrays = make_async_gen(
+                base_iterator=iter(array_items),
+                fn=process_arrays,
+                preserve_ordering=False,
+                num_workers=num_workers,
+            )
+
+            # Reconstruct the dictionary structure
+            result: Dict[str, List[torch.Tensor]] = {}
+            for col_name, array_index, tensor in processed_arrays:
+                if col_name not in result:
+                    result[col_name] = [None] * len(numpy_list[col_name])
+                result[col_name][array_index] = tensor
+
+            return result
+        else:
+            # Sequential processing
+            return convert_ndarray_list_to_torch_tensor_list(
+                numpy_list,
+                dtypes=dtypes,
+                pin_memory=pin_memory,
+            )
 
 
 @torch.no_grad()

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -408,7 +408,9 @@ def arrow_batch_to_tensors(
                         col_name,
                         convert_ndarray_batch_to_torch_tensor_batch(
                             col_array,
-                            dtypes=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
+                            dtypes=dtypes[col_name]
+                            if isinstance(dtypes, dict)
+                            else dtypes,
                             pin_memory=pin_memory,
                         ),
                     )
@@ -438,7 +440,9 @@ def arrow_batch_to_tensors(
         # Count total number of arrays across all columns
         total_arrays = sum(len(arrays) for arrays in numpy_list.values())
         num_columns = len(numpy_list)
-        num_workers = min(max(total_arrays, num_columns), DEFAULT_TENSOR_CONVERSION_NUM_WORKERS)
+        num_workers = min(
+            max(total_arrays, num_columns), DEFAULT_TENSOR_CONVERSION_NUM_WORKERS
+        )
 
         if num_workers > 1 and total_arrays > 1:
             # Process arrays in parallel
@@ -450,7 +454,9 @@ def arrow_batch_to_tensors(
                         array_index,
                         convert_ndarray_batch_to_torch_tensor_batch(
                             array,
-                            dtypes=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
+                            dtypes=dtypes[col_name]
+                            if isinstance(dtypes, dict)
+                            else dtypes,
                             pin_memory=pin_memory,
                         ),
                     )

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -420,7 +420,8 @@ def arrow_batch_to_tensors(
                 base_iterator=iter(numpy_batch.items()),
                 fn=process_columns,
                 preserve_ordering=False,
-                num_workers=num_workers,
+                num_workers=max(num_workers, 1),
+                buffer_size=max(num_workers, 1),
             )
             return dict(processed_cols)
         else:
@@ -473,7 +474,8 @@ def arrow_batch_to_tensors(
                 base_iterator=iter(array_items),
                 fn=process_arrays,
                 preserve_ordering=False,
-                num_workers=num_workers,
+                num_workers=max(num_workers, 1),
+                buffer_size=max(num_workers, 1),
             )
 
             # Reconstruct the dictionary structure

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -6,10 +6,9 @@ import pandas as pd
 import pyarrow
 import torch
 
-from ray._private.ray_constants import env_bool, env_integer
+from ray._private.ray_constants import env_bool
 from ray.air._internal.device_manager import get_torch_device_manager_by_context
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
-from ray.data._internal.util import make_async_gen
 from ray.data.collate_fn import (
     TensorBatchReturnType,
     TensorBatchType,
@@ -24,12 +23,6 @@ from ray.data.collate_fn import (
 DEFAULT_TENSOR_NON_BLOCKING_TRANSFER = env_bool(
     "RAY_AIR_DEFAULT_TENSOR_NON_BLOCKING_TRANSFER",
     True,
-)
-
-# Default number of workers for parallel tensor conversion.
-DEFAULT_TENSOR_CONVERSION_NUM_WORKERS = env_integer(
-    "RAY_AIR_DEFAULT_TENSOR_CONVERSION_NUM_WORKERS",
-    4,
 )
 
 
@@ -396,103 +389,23 @@ def arrow_batch_to_tensors(
 
     if combine_chunks:
         numpy_batch = ArrowBlockAccessor(batch).to_batch_format("numpy")
-        num_columns = len(numpy_batch)
-        num_workers = min(num_columns, DEFAULT_TENSOR_CONVERSION_NUM_WORKERS)
-
-        if num_workers > 1 and num_columns > 1:
-            # Process columns in parallel
-            def process_columns(col_items_iter):
-                """Process column items (col_name, col_array) from iterator."""
-                for col_name, col_array in col_items_iter:
-                    yield (
-                        col_name,
-                        convert_ndarray_batch_to_torch_tensor_batch(
-                            col_array,
-                            dtypes=dtypes[col_name]
-                            if isinstance(dtypes, dict)
-                            else dtypes,
-                            pin_memory=pin_memory,
-                        ),
-                    )
-
-            # Use make_async_gen to parallelize column processing
-            processed_cols = make_async_gen(
-                base_iterator=iter(numpy_batch.items()),
-                fn=process_columns,
-                preserve_ordering=False,
-                num_workers=max(num_workers, 1),
-                buffer_size=max(num_workers, 1),
+        return {
+            col_name: convert_ndarray_batch_to_torch_tensor_batch(
+                col_array,
+                dtypes=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
+                pin_memory=pin_memory,
             )
-            return dict(processed_cols)
-        else:
-            # Sequential processing for single column or single worker
-            return {
-                col_name: convert_ndarray_batch_to_torch_tensor_batch(
-                    col_array,
-                    dtypes=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
-                    pin_memory=pin_memory,
-                )
-                for col_name, col_array in numpy_batch.items()
-            }
+            for col_name, col_array in numpy_batch.items()
+        }
     else:
         numpy_list = transform_pyarrow.table_to_numpy_dict_chunked(
             batch,
         )
-        # Count total number of arrays across all columns
-        total_arrays = sum(len(arrays) for arrays in numpy_list.values())
-        num_columns = len(numpy_list)
-        num_workers = min(
-            max(total_arrays, num_columns), DEFAULT_TENSOR_CONVERSION_NUM_WORKERS
+        return convert_ndarray_list_to_torch_tensor_list(
+            numpy_list,
+            dtypes=dtypes,
+            pin_memory=pin_memory,
         )
-
-        if num_workers > 1 and total_arrays > 1:
-            # Process arrays in parallel
-            def process_arrays(array_items_iter):
-                """Process array items (col_name, array_index, array) from iterator."""
-                for col_name, array_index, array in array_items_iter:
-                    yield (
-                        col_name,
-                        array_index,
-                        convert_ndarray_batch_to_torch_tensor_batch(
-                            array,
-                            dtypes=dtypes[col_name]
-                            if isinstance(dtypes, dict)
-                            else dtypes,
-                            pin_memory=pin_memory,
-                        ),
-                    )
-
-            # Flatten arrays with column name and index for parallel processing
-            array_items = [
-                (col_name, idx, array)
-                for col_name, arrays in numpy_list.items()
-                for idx, array in enumerate(arrays)
-            ]
-
-            # Use make_async_gen to parallelize array processing
-            processed_arrays = make_async_gen(
-                base_iterator=iter(array_items),
-                fn=process_arrays,
-                preserve_ordering=False,
-                num_workers=max(num_workers, 1),
-                buffer_size=max(num_workers, 1),
-            )
-
-            # Reconstruct the dictionary structure
-            result: Dict[str, List[torch.Tensor]] = {}
-            for col_name, array_index, tensor in processed_arrays:
-                if col_name not in result:
-                    result[col_name] = [None] * len(numpy_list[col_name])
-                result[col_name][array_index] = tensor
-
-            return result
-        else:
-            # Sequential processing
-            return convert_ndarray_list_to_torch_tensor_list(
-                numpy_list,
-                dtypes=dtypes,
-                pin_memory=pin_memory,
-            )
 
 
 @torch.no_grad()

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -182,21 +182,12 @@ class BatchIterator:
         num_threadpool_workers = min(
             DEFAULT_FORMAT_THREADPOOL_NUM_WORKERS, self._prefetch_batches
         )
-        per_thread_buffer_size = (
-            (
-                (self._prefetch_batches + num_threadpool_workers - 1)
-                // num_threadpool_workers
-            )
-            if num_threadpool_workers > 0
-            else 0
-        )
         return _format_in_threadpool(
             batch_iter=batches,
             stats=self._stats,
             batch_format=self._batch_format,
             collate_fn=self._collate_fn,
             num_threadpool_workers=num_threadpool_workers,
-            per_thread_buffer_size=per_thread_buffer_size,
         )
 
     def _finalize_batches(
@@ -309,7 +300,6 @@ def _format_in_threadpool(
     batch_format: Optional[str],
     collate_fn: Optional[Callable[[DataBatch], Any]],
     num_threadpool_workers: int,
-    per_thread_buffer_size: int,
 ) -> Iterator[Batch]:
     """Executes the batching, formatting, and collation logic in a threadpool.
 
@@ -324,7 +314,6 @@ def _format_in_threadpool(
             as batches.
         collate_fn: A function to apply to each data batch before returning it.
         num_threadpool_workers: The number of threads to use in the threadpool.
-        per_thread_buffer_size: The number of batches to buffer per thread.
     """
 
     def threadpool_computations_format_collate(
@@ -348,7 +337,6 @@ def _format_in_threadpool(
             fn=threadpool_computations_format_collate,
             preserve_ordering=False,
             num_workers=num_threadpool_workers,
-            buffer_size=per_thread_buffer_size,
         )
     else:
         collated_iter = threadpool_computations_format_collate(batch_iter)

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -23,8 +23,8 @@ from ray.data.block import Block, DataBatch
 from ray.data.context import DataContext
 from ray.types import ObjectRef
 
-DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS = env_integer(
-    "RAY_DATA_MAX_FORMAT_THEADPOOL_NUM_WORKERS", 4
+DEFAULT_FORMAT_THREADPOOL_NUM_WORKERS = env_integer(
+    "RAY_DATA_MAX_FORMAT_THREADPOOL_NUM_WORKERS", 4
 )
 
 
@@ -180,7 +180,7 @@ class BatchIterator:
 
     def _format_batches(self, batches: Iterator[Batch]) -> Iterator[Batch]:
         num_threadpool_workers = min(
-            DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS, self._prefetch_batches
+            DEFAULT_FORMAT_THREADPOOL_NUM_WORKERS, self._prefetch_batches
         )
         per_thread_buffer_size = (
             (

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager, nullcontext
 from typing import Any, Callable, Dict, Iterator, Optional
 
 import ray
+from ray._private.ray_constants import env_integer
 from ray.data._internal.block_batching.interfaces import Batch, BlockPrefetcher
 from ray.data._internal.block_batching.util import (
     ActorBlockPrefetcher,
@@ -20,9 +21,7 @@ from ray.data._internal.stats import DatasetStats, _StatsManager
 from ray.data._internal.util import make_async_gen
 from ray.data.block import Block, DataBatch
 from ray.data.context import DataContext
-from ray._private.ray_constants import env_integer
 from ray.types import ObjectRef
-
 
 DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS = env_integer(
     "RAY_DATA_DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS", 4

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -20,7 +20,13 @@ from ray.data._internal.stats import DatasetStats, _StatsManager
 from ray.data._internal.util import make_async_gen
 from ray.data.block import Block, DataBatch
 from ray.data.context import DataContext
+from ray._private.ray_constants import env_integer
 from ray.types import ObjectRef
+
+
+DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS = env_integer(
+    "RAY_DATA_DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS", 4
+)
 
 
 class BatchIterator:
@@ -332,7 +338,7 @@ def _format_in_threadpool(
             base_iterator=batch_iter,
             fn=threadpool_computations_format_collate,
             preserve_ordering=False,
-            num_workers=1,
+            num_workers=min(DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS, prefetch_batches),
             buffer_size=max(prefetch_batches, 1),
         )
     else:

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -184,6 +184,9 @@ class BatchIterator:
             stats=self._stats,
             batch_format=self._batch_format,
             collate_fn=self._collate_fn,
+            num_threadpool_workers=min(
+                DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS, self._prefetch_batches
+            ),
             prefetch_batches=self._prefetch_batches,
         )
 
@@ -296,6 +299,7 @@ def _format_in_threadpool(
     stats: DatasetStats,
     batch_format: Optional[str],
     collate_fn: Optional[Callable[[DataBatch], Any]],
+    num_threadpool_workers: int,
     prefetch_batches: int,
 ) -> Iterator[Batch]:
     """Executes the batching, formatting, and collation logic in a threadpool.
@@ -310,6 +314,7 @@ def _format_in_threadpool(
             ``pyarrow.Table``, or None to use entire blocks
             as batches.
         collate_fn: A function to apply to each data batch before returning it.
+        num_threadpool_workers: The number of threads to use in the threadpool.
         prefetch_batches: The number of batches to fetch ahead of the current batch to
             process. If set to greater than 0, a separate thread will be used to fetch
             the specified amount of formatted batches from blocks. This improves
@@ -332,13 +337,16 @@ def _format_in_threadpool(
             )
         yield from formatted_batch_iter
 
-    if prefetch_batches > 0:
+    if num_threadpool_workers > 0:
+        buffer_size = (
+            prefetch_batches + num_threadpool_workers - 1
+        ) // num_threadpool_workers
         collated_iter = make_async_gen(
             base_iterator=batch_iter,
             fn=threadpool_computations_format_collate,
             preserve_ordering=False,
-            num_workers=min(DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS, prefetch_batches),
-            buffer_size=max(prefetch_batches, 1),
+            num_workers=num_threadpool_workers,
+            buffer_size=buffer_size,
         )
     else:
         collated_iter = threadpool_computations_format_collate(batch_iter)

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -24,7 +24,7 @@ from ray.data.context import DataContext
 from ray.types import ObjectRef
 
 DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS = env_integer(
-    "RAY_DATA_DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS", 4
+    "RAY_DATA_MAX_FORMAT_THEADPOOL_NUM_WORKERS", 4
 )
 
 

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -183,8 +183,13 @@ class BatchIterator:
             DEFAULT_FORMAT_THEADPOOL_NUM_WORKERS, self._prefetch_batches
         )
         per_thread_buffer_size = (
-            self._prefetch_batches + num_threadpool_workers - 1
-        ) // num_threadpool_workers
+            (
+                (self._prefetch_batches + num_threadpool_workers - 1)
+                // num_threadpool_workers
+            )
+            if num_threadpool_workers > 0
+            else 0
+        )
         return _format_in_threadpool(
             batch_iter=batches,
             stats=self._stats,


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

### [Data] Handle prefetches buffering in iter_batches

**Requirements**
- Consumer of `iter_batches` requires predictable latency on batches, though overall Data Pipeline is optimized for maximizing throughput and utilization.
- Essentially prefetching is used by the Consumer to impedance match Latency requirement with the Throughput optimized datapipeline.

**Issue**
- Queuing/buffering was not set up in `_iter_batches` to match prefetching.
- Multiple Workers were set up for `_format_in_threadpool` as f(prefetch_count) which adds to latency variance on `_iter_batches`.

**Fix**
- In `_iter_batches`, set up queue depth for buffering in `make_async_gen` to honor prefetching.
- In `_format_in_threadpool`, restrict to maximum of 4 workers by default, so as to optimize for `iter_batches` latency.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
