### PR TITLE
[Data] Support Non-String Items for `ApproximateTopK` Aggregator

### DIFF
--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1510,6 +1510,10 @@ class ApproximateTopK(AggregateFnV2):
         return self._frequent_strings_sketch(lg_max_k=log_capacity)
 
     def aggregate_block(self, block: Block) -> bytes:
+        # Note: The datasketches Python bindings only expose frequent_strings_sketch
+        # (not type-specific variants like frequent_ints_sketch). We use pickle
+        # serialization as a workaround, which is less performant than native
+        # type-specific sketches. Revisit if type-specific bindings are added.
         block_acc = BlockAccessor.for_block(block)
         table = block_acc.to_arrow()
         column = table.column(self.get_target_column())

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1547,6 +1547,6 @@ class ApproximateTopK(AggregateFnV2):
         ).get_frequent_items(frequent_items_error_type.NO_FALSE_NEGATIVES)
 
         return [
-            {column: pickle.loads(bytes.fromhex(str(item[0]))), "count": int(item[1])}
+            {column: pickle.loads(bytes.fromhex(item[0])), "count": item[1]}
             for item in frequent_items[: self.k]
         ]

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1547,6 +1547,6 @@ class ApproximateTopK(AggregateFnV2):
         ).get_frequent_items(frequent_items_error_type.NO_FALSE_NEGATIVES)
 
         return [
-            {column: pickle.loads(bytes.fromhex(item[0])), "count": item[1]}
+            {column: pickle.loads(bytes.fromhex(item[0])), "count": int(item[1])}
             for item in frequent_items[: self.k]
         ]

--- a/python/ray/data/tests/test_custom_agg.py
+++ b/python/ray/data/tests/test_custom_agg.py
@@ -459,6 +459,33 @@ class TestApproximateTopK:
             assert result["approx_topk(id)"][0] == {"id": "frequent", "count": 100}
             assert result["approx_topk(id)"][1] == {"id": "common", "count": 50}
 
+    def test_approximate_topk_non_string_datatype(
+        self, ray_start_regular_shared_2_cpus
+    ):
+        """Test that ApproximateTopK works with non-string type elements."""
+        data = [{"id": 1}, {"id": 1}, {"id": 2}]
+        ds = ray.data.from_items(data)
+
+        result = ds.aggregate(ApproximateTopK(on="id", k=1, log_capacity=3))
+        assert result["approx_topk(id)"][0] == {"id": 1, "count": 2}
+
+        data = [{"id": [1, 2, 3]}, {"id": [1, 2, 3]}, {"id": [1, 2]}]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(ApproximateTopK(on="id", k=2, log_capacity=3))
+        assert result["approx_topk(id)"][0] == {"id": [1, 2, 3], "count": 2}
+        assert result["approx_topk(id)"][1] == {"id": [1, 2], "count": 1}
+
+    def test_approximate_topk_encode_lists(self, ray_start_regular_shared_2_cpus):
+        """Test ApproximateTopK list encode feature."""
+        data = [{"id": [1, 1, 1]}, {"id": [2, 2]}, {"id": [3]}]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(
+            ApproximateTopK(on="id", k=4, log_capacity=10, encode_lists=True)
+        )
+        assert result["approx_topk(id)"][0] == {"id": 1, "count": 3}
+        assert result["approx_topk(id)"][0] == {"id": 2, "count": 2}
+        assert result["approx_topk(id)"][0] == {"id": 3, "count": 1}
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/data/tests/test_custom_agg.py
+++ b/python/ray/data/tests/test_custom_agg.py
@@ -483,8 +483,8 @@ class TestApproximateTopK:
             ApproximateTopK(on="id", k=4, log_capacity=10, encode_lists=True)
         )
         assert result["approx_topk(id)"][0] == {"id": 1, "count": 3}
-        assert result["approx_topk(id)"][0] == {"id": 2, "count": 2}
-        assert result["approx_topk(id)"][0] == {"id": 3, "count": 1}
+        assert result["approx_topk(id)"][1] == {"id": 2, "count": 2}
+        assert result["approx_topk(id)"][2] == {"id": 3, "count": 1}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Internally, the `ApproximateTopK` aggregator uses `frequent_strings_sketch` to implement efficient top-k calculations. As hinted in the name `frequent_strings_sketch`, the current implementation casts all data to string before inputting it into the sketch, so the output data is also in string. 

Therefore, when we have numeric data, for instance, we would get:
```
[{"id": "1", "count": 5} ... ]  # notice 1 is not an integer, but string
```
instead of 
```
[{"id": 1, "count": 5} ... ]
```
which would be expected.

Other types, like lists, tuples, etc will also be cast to string, making it hard for users to recover data.

This PR (with offline discussion with some Ray Data team members) attempts to use the `pickle` library to pickle and unpickle data so that when you input the data to `frequent_strings_sketch`, you insert the hex string of the pickle dump. 

As further improvements, this PR also supports `encode_lists` flag to encode individual list values. This will be useful for our encoders (specifically `MultiHotEncoder` and `OrdinalEncoder`) in the future. 

## Related issues
N/A

## Additional information
N/A