### PR TITLE
[RLlib] Fix MultiAgentEpisode.get_infos() to include __common__ key

### DIFF
--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -1022,6 +1022,12 @@ class MultiAgentEpisode:
         # successor.
         successor._hanging_rewards_begin = self._hanging_rewards_end.copy()
 
+        # Copy over hanging infos (including __common__) to successor.
+        if "__common__" in self._hanging_infos_end:
+            successor._hanging_infos_end["__common__"] = copy.deepcopy(
+                self._hanging_infos_end["__common__"]
+            )
+
         # Deepcopy all custom data in `self` to be continued in the cut episode.
         successor._custom_data = copy.deepcopy(self.custom_data)
 
@@ -2201,6 +2207,10 @@ class MultiAgentEpisode:
                 else {}
             )
             rew = rewards[data_idx] if len(rewards) > data_idx else {}
+
+            # Extract and preserve __common__ infos if present.
+            if "__common__" in inf:
+                self._hanging_infos_end["__common__"] = inf["__common__"]
 
             for agent_id, agent_obs in obs.items():
                 all_agent_ids.add(agent_id)

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -321,6 +321,11 @@ class MultiAgentEpisode:
         assert self.env_t == self.env_t_started == 0
         infos = infos or {}
 
+        # Extract and store the "__common__" key from infos if present.
+        # This key contains infos that are common to all agents.
+        if "__common__" in infos:
+            self._hanging_infos_end["__common__"] = infos.pop("__common__")
+
         # Note, all agents will have an initial observation, some may have an initial
         # info dict as well.
         for agent_id, agent_obs in observations.items():

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -2215,7 +2215,7 @@ class MultiAgentEpisode:
 
             # Extract and preserve __common__ infos if present.
             if "__common__" in inf:
-                self._hanging_infos_end["__common__"] = inf["__common__"]
+                self._hanging_infos_end["__common__"] = inf.pop("__common__")
 
             for agent_id, agent_obs in obs.items():
                 all_agent_ids.add(agent_id)

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -899,6 +899,12 @@ class MultiAgentEpisode:
         elif other.is_truncated:
             self.is_truncated = True
 
+        # Copy __common__ infos from other (more recent chunk).
+        if "__common__" in other._hanging_infos_end:
+            self._hanging_infos_end["__common__"] = copy.deepcopy(
+                other._hanging_infos_end["__common__"]
+            )
+
         # Merge with `other`'s custom_data, but give `other` priority b/c we assume
         # that as a follow-up chunk of `self` other has a more complete version of
         # `custom_data`.
@@ -1736,6 +1742,7 @@ class MultiAgentEpisode:
             "env_t_to_agent_t": self.env_t_to_agent_t,
             "_hanging_actions_end": self._hanging_actions_end,
             "_hanging_extra_model_outputs_end": self._hanging_extra_model_outputs_end,
+            "_hanging_infos_end": self._hanging_infos_end,
             "_hanging_rewards_end": self._hanging_rewards_end,
             "_hanging_rewards_begin": self._hanging_rewards_begin,
             "is_terminated": self.is_terminated,
@@ -1782,6 +1789,7 @@ class MultiAgentEpisode:
         episode._hanging_extra_model_outputs_end = state[
             "_hanging_extra_model_outputs_end"
         ]
+        episode._hanging_infos_end = state.get("_hanging_infos_end", {})
         episode._hanging_rewards_end = state["_hanging_rewards_end"]
         episode._hanging_rewards_begin = state["_hanging_rewards_begin"]
         episode.is_terminated = state["is_terminated"]

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -71,6 +71,7 @@ class MultiAgentEpisode:
         "env_t_to_agent_t",
         "_hanging_actions_end",
         "_hanging_extra_model_outputs_end",
+        "_hanging_infos_end",
         "_hanging_rewards_end",
         "_hanging_rewards_begin",
         "is_terminated",
@@ -250,6 +251,7 @@ class MultiAgentEpisode:
         # until the next observation is received.
         self._hanging_actions_end = {}
         self._hanging_extra_model_outputs_end = defaultdict(dict)
+        self._hanging_infos_end = {}
         self._hanging_rewards_end = defaultdict(float)
 
         # In case of a `cut()` or `slice()`, we also need to store the hanging actions,
@@ -395,6 +397,11 @@ class MultiAgentEpisode:
         terminateds = terminateds or {}
         truncateds = truncateds or {}
         extra_model_outputs = extra_model_outputs or {}
+
+        # Extract and store the "__common__" key from infos if present.
+        # This key contains infos that are common to all agents.
+        if "__common__" in infos:
+            self._hanging_infos_end["__common__"] = infos.pop("__common__")
 
         # Increase (global) env step by one.
         self.env_t += 1
@@ -2395,6 +2402,11 @@ class MultiAgentEpisode:
             if agent_value is None or agent_value == []:
                 continue
             ret[agent_id] = agent_value
+
+        # If retrieving infos, include the "__common__" key if it exists.
+        if what == "infos" and "__common__" in self._hanging_infos_end:
+            ret["__common__"] = self._hanging_infos_end["__common__"]
+
         return ret
 
     def _get_data_by_env_steps_as_list(
@@ -2458,6 +2470,11 @@ class MultiAgentEpisode:
                 )
                 if agent_value is not None:
                     ret2[agent_id] = agent_value
+
+            # If retrieving infos, include the "__common__" key if it exists.
+            if what == "infos" and "__common__" in self._hanging_infos_end:
+                ret2["__common__"] = self._hanging_infos_end["__common__"]
+
             ret.append(ret2)
         return ret
 
@@ -2519,6 +2536,11 @@ class MultiAgentEpisode:
                 )
                 if agent_values is not None:
                     ret[agent_id] = agent_values
+
+        # If retrieving infos, include the "__common__" key if it exists.
+        if what == "infos" and "__common__" in self._hanging_infos_end:
+            ret["__common__"] = self._hanging_infos_end["__common__"]
+
         return ret
 
     def _get_single_agent_data_by_index(


### PR DESCRIPTION
Fixes #58668

## Summary

The `MultiAgentEpisode.get_infos()` method was excluding the `__common__` key from the infos dictionary returned to the caller. This key is used in multi-agent environments to store information that is common to all agents.

## Problem

When an environment's `step()` method returns infos with a `__common__` key like this:

```python
infos = {
    "player1": {"player1_data": "foo"},
    "player2": {"player2_data": "bar"},
    "__common__": {"common_data": "baz"},
}
```

The `__common__` key was being lost because:
1. In `add_env_step()`, only agent IDs appearing in observations, actions, rewards, or terminateds/truncateds were processed
2. The `__common__` key only appears in infos, so it was never included in the `agent_ids_with_data` set
3. As a result, `__common__` infos were silently dropped and not stored anywhere

## Solution

This fix follows the same pattern used for the `__all__` key in terminateds/truncateds:

1. **Added storage**: Added `_hanging_infos_end` field to `__slots__` and initialized it in `__init__`
2. **Extract on add**: In `add_env_step()`, extract and store the `__common__` key from the infos dict before processing agent-specific infos
3. **Include on get**: Modified all three retrieval code paths to include the `__common__` key in the returned dictionary:
   - `_get_data_by_agent_steps()` (when `env_steps=False`)
   - `_get_data_by_env_steps()` (default case)
   - `_get_data_by_env_steps_as_list()` (when `return_list=True`)

## Testing

The fix can be verified with the reproduction script from the issue. After this change, calling `episode.get_infos()` will correctly include the `__common__` key in the returned dictionary.

## Changes

- Added `_hanging_infos_end` to `__slots__`
- Initialized `_hanging_infos_end = {}` in `__init__()`
- Extract `__common__` from infos in `add_env_step()` and store it in `_hanging_infos_end`
- Include `__common__` in returned dict from all `get_infos()` code paths