### PR TITLE
[scripts] ban click 8.3.*

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,9 +7,9 @@
 # You can obtain this list from the ray.egg-info/requires.txt
 
 ## setup.py install_requires
-# Click 8.3.0 does not work with copy.deepcopy on Python 3.10
+# Click 8.3.* does not work with copy.deepcopy on Python 3.10
 # TODO(aslonnie): https://github.com/ray-project/ray/issues/56747
-click>=7.0, !=8.3.0
+click>=7.0, !=8.3.*
 cupy-cuda12x; sys_platform != 'darwin'
 filelock
 jsonschema

--- a/python/setup.py
+++ b/python/setup.py
@@ -402,9 +402,9 @@ if setup_spec.type == SetupType.RAY:
 # new releases candidates.
 if setup_spec.type == SetupType.RAY:
     setup_spec.install_requires = [
-        # Click 8.3.0 does not work with copy.deepcopy on Python 3.10
+        # Click 8.3.* does not work with copy.deepcopy on Python 3.10
         # TODO(aslonnie): https://github.com/ray-project/ray/issues/56747
-        "click>=7.0, !=8.3.0",
+        "click>=7.0, !=8.3.*",
         "filelock",
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",


### PR DESCRIPTION
it uses `enum.Enum` that are not deepcopy-able
