### PR TITLE
[Data] Fix broken `LogicalOperator` abstraction barrier in projection pushdown rule

### DIFF
--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -339,7 +339,7 @@ class ProjectionPushdown(Rule):
                             columns = list(current_projection.values())
                         else:
                             # No existing projection - get all columns from schema
-                            schema = input_op._cached_output_metadata.schema
+                            schema = input_op.infer_schema()
                             if schema is not None:
                                 columns = schema.names
                             else:


### PR DESCRIPTION
## Description

The projection pushdown rule was directly accessing `_cached_output_metadata.schema`, which breaks abstraction barriers by reaching into private implementation details. This violates encapsulation and makes the code fragile to internal changes.

This PR fixes the issue by using the proper `infer_schema()` method instead, which provides a clean public interface for accessing schema information. This respects the operator's abstraction and ensures we get the correct schema through the intended API.


## Additional information

The change is in `projection_pushdown.py:342` where we now call `input_op.infer_schema()` instead of directly accessing `input_op._cached_output_metadata.schema`.