### PR TITLE
[Data] - Make Projection pushdown tests non-flaky + predicates through projects

### DIFF
--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -97,8 +97,9 @@ class PredicatePushdown(Rule):
         original_columns_being_renamed = set()
 
         for expr in projection_op.exprs:
-            # Collect output column names
-            output_columns.add(expr.name)
+            if expr.name is not None:
+                # Collect output column names
+                output_columns.add(expr.name)
 
             # Process AliasExpr (computed columns or renames)
             if isinstance(expr, AliasExpr):

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -14,6 +14,7 @@ from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.logical.rules.projection_pushdown import (
     ProjectionPushdown,
 )
+from ray.data._internal.util import rows_same
 from ray.data.context import DataContext
 from ray.data.expressions import DataType, StarExpr, col, star, udf
 
@@ -349,20 +350,12 @@ class TestProjectionFusion:
         for col_name, expr in expressions.items():
             ds_with_column = ds_with_column.with_column(col_name, expr)
 
-        # Convert both to pandas for reliable comparison (avoids take() ordering issues)
-        result_optimal_df = (
-            ds_optimal.to_pandas().sort_values("id").reset_index(drop=True)
-        )
-        result_with_column_df = (
-            ds_with_column.to_pandas().sort_values("id").reset_index(drop=True)
-        )
+        # Convert both to pandas for reliable comparison
+        result_optimal_df = ds_optimal.to_pandas()
+        result_with_column_df = ds_with_column.to_pandas()
 
-        # Compare using pandas testing
-        pd.testing.assert_frame_equal(
-            result_optimal_df.sort_index(axis=1),
-            result_with_column_df.sort_index(axis=1),
-            check_dtype=False,
-        )
+        # Compare using rows_same (deterministic, ignores order)
+        assert rows_same(result_optimal_df, result_with_column_df)
 
     def test_basic_fusion_works(self, ray_start_regular_shared):
         """Test that basic fusion of two independent operations works."""
@@ -390,55 +383,21 @@ class TestProjectionFusion:
             optimized_count == 1
         ), f"Two independent operations should fuse to 1 operator, got {optimized_count}"
 
-        # Verify correctness using pandas comparison
+        # Verify correctness using rows_same
         from ray.data.dataset import Dataset
 
         optimized_ds = Dataset(ds._plan, optimized_plan)
+        result_df = optimized_ds.to_pandas()
 
-        try:
-            result_df = optimized_ds.to_pandas()
-            print(f"Result: {result_df}")
+        expected_df = pd.DataFrame(
+            {
+                "id": [0, 1, 2, 3, 4],
+                "doubled": [0, 2, 4, 6, 8],
+                "plus_one": [1, 2, 3, 4, 5],
+            }
+        )
 
-            expected_df = pd.DataFrame(
-                {
-                    "id": [0, 1, 2, 3, 4],
-                    "doubled": [0, 2, 4, 6, 8],
-                    "plus_one": [1, 2, 3, 4, 5],
-                }
-            )
-            print(f"Expected: {expected_df}")
-
-            # Sort columns for comparison
-            result_sorted = result_df.reindex(sorted(result_df.columns), axis=1)
-            expected_sorted = expected_df.reindex(sorted(expected_df.columns), axis=1)
-
-            pd.testing.assert_frame_equal(
-                result_sorted,
-                expected_sorted,
-                check_dtype=False,
-                check_index_type=False,
-            )
-
-        except Exception as e:
-            print(f"Error in basic fusion test: {e}")
-            # Fallback verification
-            result_list = optimized_ds.take_all()
-            print(f"Result as list: {result_list}")
-
-            expected_list = [
-                {"id": 0, "doubled": 0, "plus_one": 1},
-                {"id": 1, "doubled": 2, "plus_one": 2},
-                {"id": 2, "doubled": 4, "plus_one": 3},
-                {"id": 3, "doubled": 6, "plus_one": 4},
-                {"id": 4, "doubled": 8, "plus_one": 5},
-            ]
-
-            assert len(result_list) == len(expected_list)
-            for actual, expected in zip(result_list, expected_list):
-                for key, expected_val in expected.items():
-                    assert (
-                        actual[key] == expected_val
-                    ), f"Mismatch for key {key}: expected {expected_val}, got {actual[key]}"
+        assert rows_same(result_df, expected_df)
 
     def test_dependency_prevents_fusion(self, ray_start_regular_shared):
         """Test that dependencies are handled in single operator with OrderedDict."""
@@ -468,7 +427,7 @@ class TestProjectionFusion:
             optimized_count == 1
         ), f"All operations should fuse into 1 operator, got {optimized_count}"
 
-        # Verify correctness using pandas comparison
+        # Verify correctness using rows_same
         from ray.data.dataset import Dataset
 
         optimized_ds = Dataset(ds._plan, optimized_plan)
@@ -482,11 +441,7 @@ class TestProjectionFusion:
             }
         )
 
-        pd.testing.assert_frame_equal(
-            result_df.sort_index(axis=1),
-            expected_df.sort_index(axis=1),
-            check_dtype=False,
-        )
+        assert rows_same(result_df, expected_df)
 
     def test_mixed_udf_regular_end_to_end(self, ray_start_regular_shared):
         """Test the exact failing scenario from the original issue."""
@@ -532,11 +487,7 @@ class TestProjectionFusion:
             }
         )
 
-        pd.testing.assert_frame_equal(
-            result_df.sort_index(axis=1),
-            expected_df.sort_index(axis=1),
-            check_dtype=False,
-        )
+        assert rows_same(result_df, expected_df)
 
         # Verify that we have 1 operator (changed from multiple)
         optimized_count = self._count_project_operators(optimized_plan)
@@ -581,15 +532,11 @@ class TestProjectionFusion:
             apply_all_expressions, batch_format="pyarrow"
         )
 
-        # Compare results using pandas
+        # Compare results using rows_same
         result_optimized = optimized_ds.to_pandas()
         result_optimal = ds_optimal.to_pandas()
 
-        pd.testing.assert_frame_equal(
-            result_optimized.sort_index(axis=1),
-            result_optimal.sort_index(axis=1),
-            check_dtype=False,
-        )
+        assert rows_same(result_optimized, result_optimal)
 
     def test_chained_udf_dependencies(self, ray_start_regular_shared):
         """Test multiple non-vectorized UDFs in a dependency chain."""
@@ -627,11 +574,7 @@ class TestProjectionFusion:
             }
         )
 
-        pd.testing.assert_frame_equal(
-            result_df.sort_index(axis=1),
-            expected_df.sort_index(axis=1),
-            check_dtype=False,
-        )
+        assert rows_same(result_df, expected_df)
 
     def test_performance_impact_of_udf_chains(self, ray_start_regular_shared):
         """Test performance characteristics of UDF dependency chains vs independent UDFs."""
@@ -780,10 +723,13 @@ class TestProjectionFusion:
                 # Special case for expressions referencing columns
                 ds = ds.with_column(op[1], col(op[2]) * op[3])
 
-        # Verify result
-        result = ds.take_all()
-        assert len(result) == 1
-        assert result[0] == expected
+        # Verify result using rows_same
+        result_df = ds.to_pandas()
+        expected_df = pd.DataFrame([expected])
+        # Ensure columns are in the same order for comparison
+        result_df = result_df[sorted(result_df.columns)]
+        expected_df = expected_df[sorted(expected_df.columns)]
+        assert rows_same(result_df, expected_df)
 
     @pytest.mark.parametrize(
         "operations,expected",
@@ -1347,8 +1293,12 @@ class TestProjectionFusion:
                 elif operator == "multiply":
                     ds = ds.with_column(col_name, col(col1) * col(col2))
 
-        result_df = ds.take_all()
-        assert result_df == expected_output
+        result_df = ds.to_pandas()
+        expected_df = pd.DataFrame(expected_output)
+        # Ensure columns are in the same order for comparison
+        result_df = result_df[sorted(result_df.columns)]
+        expected_df = expected_df[sorted(expected_df.columns)]
+        assert rows_same(result_df, expected_df)
 
 
 @pytest.mark.parametrize("flavor", ["project_before", "project_after"])

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -354,6 +354,12 @@ class TestProjectionFusion:
         result_optimal_df = ds_optimal.to_pandas()
         result_with_column_df = ds_with_column.to_pandas()
 
+        # Sort columns before comparison
+        result_optimal_df = result_optimal_df[sorted(result_optimal_df.columns)]
+        result_with_column_df = result_with_column_df[
+            sorted(result_with_column_df.columns)
+        ]
+
         # Compare using rows_same (deterministic, ignores order)
         assert rows_same(result_optimal_df, result_with_column_df)
 
@@ -397,6 +403,9 @@ class TestProjectionFusion:
             }
         )
 
+        # Sort columns before comparison
+        result_df = result_df[sorted(result_df.columns)]
+        expected_df = expected_df[sorted(expected_df.columns)]
         assert rows_same(result_df, expected_df)
 
     def test_dependency_prevents_fusion(self, ray_start_regular_shared):
@@ -441,6 +450,9 @@ class TestProjectionFusion:
             }
         )
 
+        # Sort columns before comparison
+        result_df = result_df[sorted(result_df.columns)]
+        expected_df = expected_df[sorted(expected_df.columns)]
         assert rows_same(result_df, expected_df)
 
     def test_mixed_udf_regular_end_to_end(self, ray_start_regular_shared):
@@ -487,6 +499,9 @@ class TestProjectionFusion:
             }
         )
 
+        # Sort columns before comparison
+        result_df = result_df[sorted(result_df.columns)]
+        expected_df = expected_df[sorted(expected_df.columns)]
         assert rows_same(result_df, expected_df)
 
         # Verify that we have 1 operator (changed from multiple)
@@ -536,6 +551,9 @@ class TestProjectionFusion:
         result_optimized = optimized_ds.to_pandas()
         result_optimal = ds_optimal.to_pandas()
 
+        # Sort columns before comparison
+        result_optimized = result_optimized[sorted(result_optimized.columns)]
+        result_optimal = result_optimal[sorted(result_optimal.columns)]
         assert rows_same(result_optimized, result_optimal)
 
     def test_chained_udf_dependencies(self, ray_start_regular_shared):
@@ -574,6 +592,9 @@ class TestProjectionFusion:
             }
         )
 
+        # Sort columns before comparison
+        result_df = result_df[sorted(result_df.columns)]
+        expected_df = expected_df[sorted(expected_df.columns)]
         assert rows_same(result_df, expected_df)
 
     def test_performance_impact_of_udf_chains(self, ray_start_regular_shared):


### PR DESCRIPTION
## Description
1. Use `rows_same` util for the tests in `test_projection_fusion`
2. Properly handle pushing predicates past projections

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
