### PR TITLE
[Docs][data] fix normalize_features demo

### DIFF
--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -403,8 +403,9 @@ Then, call :meth:`~ray.data.grouped_data.GroupedData.map_groups` to execute a tr
             import ray
 
             def normalize_features(group: pd.DataFrame) -> pd.DataFrame:
-                target = group.drop("target")
-                group = (group - group.min()) / group.std()
+                target = group["target"]
+                group = group.drop(columns=["target"])
+                group = (group - group.mean()) / group.std()
                 group["target"] = target
                 return group
 

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -405,7 +405,7 @@ Then, call :meth:`~ray.data.grouped_data.GroupedData.map_groups` to execute a tr
             def normalize_features(group: pd.DataFrame) -> pd.DataFrame:
                 target = group["target"]
                 group = group.drop(columns=["target"])
-                group = (group - group.mean()) / group.std()
+                group = (group - group.mean()) / group.std().replace(0, 1)
                 group["target"] = target
                 return group
 


### PR DESCRIPTION
## Description
Before: KeyError: "['target'] not found in axis".
- Change to `group = group.drop(columns=["target"])`
- The corrected formula is `(group - group.mean()) / group.std()`

## Related issues


## Additional information

