### PR TITLE
[Data][Flaky] Ensure `ActorPoolMapOperator` clears all queues on completion

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -404,24 +404,14 @@ class ActorPoolMapOperator(MapOperator):
     def clear_internal_input_queue(self) -> None:
         """Clear internal input queues for the actor-pool map operator.
 
-        This includes:
-        * The local bundle queue used to stage input bundles for actors.
-        * The shared block ref bundler inherited from MapOperator.
+        In addition to clearing the base class' internal queues, this method clears
+        the local bundle queue used to stage input bundles for actors.
         """
+        super().clear_internal_input_queue()
+
         while self._bundle_queue.has_next():
             bundle = self._bundle_queue.get_next()
             self._metrics.on_input_dequeued(bundle)
-
-        while self._block_ref_bundler.has_bundle():
-            input_bundles, _ = self._block_ref_bundler.get_next_bundle()
-            for input_bundle in input_bundles:
-                self._metrics.on_input_dequeued(input_bundle)
-
-    def clear_internal_output_queue(self) -> None:
-        """Clear internal output queue for the actor-pool map operator."""
-        while self._output_queue.has_next():
-            bundle = self._output_queue.get_next()
-            self._metrics.on_output_dequeued(bundle)
 
     def _do_shutdown(self, force: bool = False):
         self._actor_pool.shutdown(force=force)

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -206,19 +206,6 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     def internal_output_queue_num_bytes(self) -> int:
         return self._output_queue.size_bytes()
 
-    def clear_internal_input_queue(self) -> None:
-        """Clear internal input queue (block ref bundler)."""
-        while self._block_ref_bundler.has_bundle():
-            (input_bundles, _) = self._block_ref_bundler.get_next_bundle()
-            for input_bundle in input_bundles:
-                self._metrics.on_input_dequeued(input_bundle)
-
-    def clear_internal_output_queue(self) -> None:
-        """Clear internal output queue."""
-        while self._output_queue.has_next():
-            bundle = self._output_queue.get_next()
-            self._metrics.on_output_dequeued(bundle)
-
     @property
     def name(self) -> str:
         name = super().name

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -206,13 +206,6 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     def internal_output_queue_num_bytes(self) -> int:
         return self._output_queue.size_bytes()
 
-    @property
-    def name(self) -> str:
-        name = super().name
-        if self._additional_split_factor is not None:
-            name += f"->SplitBlocks({self._additional_split_factor})"
-        return name
-
     def clear_internal_input_queue(self) -> None:
         """Clear internal input queue (block ref bundler)."""
         self._block_ref_bundler.done_adding_bundles()
@@ -226,6 +219,13 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         while self._output_queue.has_next():
             bundle = self._output_queue.get_next()
             self._metrics.on_output_dequeued(bundle)
+
+    @property
+    def name(self) -> str:
+        name = super().name
+        if self._additional_split_factor is not None:
+            name += f"->SplitBlocks({self._additional_split_factor})"
+        return name
 
     @classmethod
     def create(

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -175,16 +175,3 @@ class TaskPoolMapOperator(MapOperator):
                 "to increase the number of concurrent tasks by configuring "
                 "`override_num_blocks` earlier in the pipeline."
             )
-
-    def clear_internal_input_queue(self) -> None:
-        """Clear internal input queue (block ref bundler)."""
-        while self._block_ref_bundler.has_bundle():
-            input_bundles, _ = self._block_ref_bundler.get_next_bundle()
-            for input_bundle in input_bundles:
-                self._metrics.on_input_dequeued(input_bundle)
-
-    def clear_internal_output_queue(self) -> None:
-        """Clear internal output queue."""
-        while self._output_queue.has_next():
-            bundle = self._output_queue.get_next()
-            self._metrics.on_output_dequeued(bundle)

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -175,3 +175,16 @@ class TaskPoolMapOperator(MapOperator):
                 "to increase the number of concurrent tasks by configuring "
                 "`override_num_blocks` earlier in the pipeline."
             )
+
+    def clear_internal_input_queue(self) -> None:
+        """Clear internal input queue (block ref bundler)."""
+        while self._block_ref_bundler.has_bundle():
+            input_bundles, _ = self._block_ref_bundler.get_next_bundle()
+            for input_bundle in input_bundles:
+                self._metrics.on_input_dequeued(input_bundle)
+
+    def clear_internal_output_queue(self) -> None:
+        """Clear internal output queue."""
+        while self._output_queue.has_next():
+            bundle = self._output_queue.get_next()
+            self._metrics.on_output_dequeued(bundle)

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -637,7 +637,9 @@ def _create_bundle_with_single_row(row):
 
 
 @pytest.mark.parametrize("min_rows_per_bundle", [2, None])
-def test_internal_input_queue_is_empty_after_early_completion(min_rows_per_bundle):
+def test_internal_input_queue_is_empty_after_early_completion(
+    ray_start_regular_shared, min_rows_per_bundle
+):
     data_context = ray.data.DataContext.get_current()
     op = ActorPoolMapOperator(
         map_transformer=MagicMock(),

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 from typing import Any, Callable, Dict, Optional, Tuple
 from unittest.mock import MagicMock
 
+import pyarrow as pa
 import pytest
 from freezegun import freeze_time
 
@@ -39,7 +40,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     update_operator_states,
 )
 from ray.data._internal.execution.util import make_ref_bundles
-from ray.data.block import Block, BlockMetadata
+from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.tests.conftest import *  # noqa
 from ray.types import ObjectRef
 
@@ -625,6 +626,36 @@ def test_setting_initial_size_for_actor_pool():
         running=0, pending=2, restarting=0
     )
     ray.shutdown()
+
+
+def _create_bundle_with_single_row(row):
+    block = pa.Table.from_pylist([row])
+    block_ref = ray.put(block)
+    metadata = BlockAccessor.for_block(block).get_metadata()
+    schema = BlockAccessor.for_block(block).schema()
+    return RefBundle([(block_ref, metadata)], owns_blocks=False, schema=schema)
+
+
+@pytest.mark.parametrize("min_rows_per_bundle", [2, None])
+def test_internal_input_queue_is_empty_after_early_completion(min_rows_per_bundle):
+    data_context = ray.data.DataContext.get_current()
+    op = ActorPoolMapOperator(
+        map_transformer=MagicMock(),
+        input_op=InputDataBuffer(data_context, input_data=MagicMock()),
+        data_context=data_context,
+        compute_strategy=ray.data.ActorPoolStrategy(size=1),
+        min_rows_per_bundle=min_rows_per_bundle,
+    )
+    op.start(ExecutionOptions())
+
+    ref_bundle = _create_bundle_with_single_row({"id": 0})
+    op.add_input(ref_bundle, 0)
+
+    op.mark_execution_finished()
+
+    assert (
+        op.internal_input_queue_num_blocks() == 0
+    ), op.internal_input_queue_num_blocks()
 
 
 def test_min_max_resource_requirements(restore_data_context):


### PR DESCRIPTION
## Description

One of the PyTorch examples intermittently fails with an error like this:
```
AssertionError: Expected Internal Input Queue for MapBatches(ResnetModel) to be empty, but found 1 bundles
```

This assertion can fail because of two bugs:
1. We don't call `done_adding_bundles` before clearing the block ref bundler 
2. We don't clean the actor pool's bundle queue

This PR fixes those bugs and deflakes the test.
 
## Related issues
Closes #58546 

## Additional information
