### PR TITLE
[doc][train] Recommend `tree_learner="data_parallel"` in examples to enable distributed lightgbm training

### DIFF
--- a/doc/source/train/doc_code/lightgbm_quickstart.py
+++ b/doc/source/train/doc_code/lightgbm_quickstart.py
@@ -84,8 +84,10 @@ def train_func():
         "feature_fraction": 0.9,
         "bagging_fraction": 0.8,
         "bagging_freq": 5,
-        # Adding the line below is the only change needed
+        # Adding the lines below are the only changes needed
         # for your `lgb.train` call!
+        "tree_learner": "data_parallel",
+        "pre_partition": True,
         **ray.train.lightgbm.get_network_params(),
     }
 

--- a/doc/source/train/getting-started-lightgbm.rst
+++ b/doc/source/train/getting-started-lightgbm.rst
@@ -125,6 +125,8 @@ This function automatically configures the necessary network settings for worker
          params = {
              # Your LightGBM training parameters here
              ...
+    +        "tree_learner": "data_parallel",
+    +        "pre_partition": True,
     +        **ray.train.lightgbm.get_network_params(),
          }
          
@@ -133,6 +135,10 @@ This function automatically configures the necessary network settings for worker
              ...
          )
          ...
+
+.. note::
+    Make sure to set ``tree_learner`` to enable distributed training. See the `LightGBM documentation <https://lightgbm.readthedocs.io/en/latest/Parallel-Learning-Guide.html#tree-learner>`_ for more details.
+    You should also set ``pre_partition=True`` if using Ray Data to load and shard your dataset, as shown in the quickstart example.
 
 Report metrics and save checkpoints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -73,6 +73,8 @@ def _lightgbm_train_fn_per_worker(
 
     # Add network params of the worker group to enable distributed training.
     config.update(ray.train.lightgbm.get_network_params())
+    config.setdefault("tree_learner", "data_parallel")
+    config.setdefault("pre_partition", True)
 
     lightgbm.train(
         params=config,

--- a/python/ray/train/v2/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/v2/lightgbm/lightgbm_trainer.py
@@ -53,8 +53,10 @@ class LightGBMTrainer(DataParallelTrainer):
             # to set up the data parallel training worker group on your Ray cluster.
             params = {
                 "objective": "regression",
-                # Adding the line below is the only change needed
+                # Adding the lines below are the only changes needed
                 # for your `lgb.train` call!
+                "tree_learner": "data_parallel",
+                "pre_partition": True,
                 **ray.train.lightgbm.get_network_params(),
             }
             lgb.train(


### PR DESCRIPTION
## Description

The default is tree_learner=”serial”, which trains a separate model per worker. Users should set tree_learner in order to configure lightgbm to train a single model across all the dataset shards. `pre_partition` should also be set if using Ray Data to shard the dataset.

## Additional information

See here: https://lightgbm.readthedocs.io/en/stable/Parallel-Learning-Guide.html
