### PR TITLE
[Data] Decrease scale of `map_groups` release test

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -193,7 +193,7 @@
   run:
     timeout: 3600
     script: >
-      python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
+      python groupby_benchmark.py --sf 10 --map-groups --group-by {{columns}}
       --shuffle-strategy {{shuffle_strategy}}
 
 ###############


### PR DESCRIPTION
## Description

https://github.com/ray-project/ray/pull/58234 increased the scale of the `map_groups` release test from SF 10 to SF 100. Since then, the release test has been consistently failing (see https://github.com/ray-project/ray/issues/58312). 

To avoid a perpetually broken release test, this PR reverts the scale to SF 10 while we investigate and fix the scalability issue.

## Related issues

https://github.com/ray-project/ray/issues/58312
