### PR TITLE
[deps][ci] correctly checking for valid subset

### DIFF
--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -399,7 +399,7 @@ class DependencySetManager:
 
     def check_subset_exists(self, source_depset: Depset, requirements: List[str]):
         for req in requirements:
-            if req not in source_depset.requirements:
+            if req not in self.get_expanded_depset_requirements(source_depset.name, []):
                 raise RuntimeError(
                     f"Requirement {req} is not a subset of {source_depset.name} in config {source_depset.config_name}"
                 )

--- a/ci/raydepsets/configs/rayllm.depsets.yaml
+++ b/ci/raydepsets/configs/rayllm.depsets.yaml
@@ -37,10 +37,9 @@ depsets:
   - name: compiled_ray_llm_test_depset_${PYTHON_VERSION}_${CUDA_CODE}
     <<: *common_settings
     operation: expand
+    depsets:
+      - ray_base_test_depset_${PYTHON_VERSION}_${CUDA_CODE}
     requirements:
-      - python/requirements.txt
-      - python/requirements/cloud-requirements.txt
-      - python/requirements/base-test-requirements.txt
       - python/requirements/llm/llm-requirements.txt
       - python/requirements/llm/llm-test-requirements.txt
     constraints:

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -155,14 +155,19 @@ class TestCli(unittest.TestCase):
                 constraints=["requirement_constraints_test.txt"],
                 requirements=["requirements_test.txt"],
                 append_flags=["--no-annotate", "--python-version 3.10"],
-                override_flags=["--extra-index-url https://dummyurl.com"],
+                override_flags=[
+                    "--extra-index-url https://download.pytorch.org/whl/cu124"
+                ],
                 name="ray_base_test_depset",
                 output="requirements_compiled.txt",
             )
             output_file = Path(tmpdir) / "requirements_compiled.txt"
             output_text = output_file.read_text()
             assert "--python-version 3.10" in output_text
-            assert "--extra-index-url https://dummyurl.com" in output_text
+            assert (
+                "--extra-index-url https://download.pytorch.org/whl/cu124"
+                in output_text
+            )
             assert (
                 "--extra-index-url https://download.pytorch.org/whl/cu128"
                 not in output_text
@@ -242,6 +247,40 @@ class TestCli(unittest.TestCase):
                 "Requirement requirements_compiled_test.txt is not a subset of general_depset__py311_cpu in config test.depsets.yaml"
                 in str(e.exception)
             )
+
+    def test_subset_with_expanded_depsettest_subset_with_expanded_depset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir)
+            compile_depset = Depset(
+                name="compile_depset",
+                operation="compile",
+                requirements=["requirements_test.txt"],
+                output="requirements_compiled.txt",
+                config_name="test.depsets.yaml",
+            )
+            expand_depset = Depset(
+                name="expand_depset",
+                operation="expand",
+                depsets=["compile_depset"],
+                requirements=["requirements_compiled_test_expand.txt"],
+                output="requirements_compiled_expanded.txt",
+                config_name="test.depsets.yaml",
+            )
+            nested_expand_subset = Depset(
+                name="nested_expand_subset_depset",
+                operation="subset",
+                source_depset="expand_depset",
+                requirements=["requirements_test.txt"],
+                output="requirements_compiled_subset_nested_expand.txt",
+                config_name="test.depsets.yaml",
+            )
+            write_to_config_file(
+                tmpdir,
+                [compile_depset, expand_depset, nested_expand_subset],
+                "test.depsets.yaml",
+            )
+            manager = _create_test_manager(tmpdir, build_all_configs=True)
+            manager.check_subset_exists(expand_depset, ["requirements_test.txt"])
 
     def test_check_if_subset_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -457,7 +496,7 @@ class TestCli(unittest.TestCase):
                 output="requirements_compiled_invalid_op.txt",
                 config_name="test.depsets.yaml",
             )
-            write_to_config_file(tmpdir, depset, "test.depsets.yaml")
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
             with self.assertRaises(ValueError) as e:
                 _create_test_manager(tmpdir)
             assert (
@@ -624,7 +663,7 @@ class TestCli(unittest.TestCase):
                 output="requirements_compiled_test.txt",
                 config_name="test.depsets.yaml",
             )
-            write_to_config_file(tmpdir, depset, "test.depsets.yaml")
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
             save_file_as(
                 Path(tmpdir) / "requirements_compiled_test.txt",
                 Path(tmpdir) / "requirements_compiled.txt",
@@ -653,7 +692,7 @@ class TestCli(unittest.TestCase):
                 output="requirements_compiled_test.txt",
                 config_name="test.depsets.yaml",
             )
-            write_to_config_file(tmpdir, depset, "test.depsets.yaml")
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
             manager = _create_test_manager(tmpdir, check=True)
             manager.compile(
                 constraints=["requirement_constraints_test.txt"],
@@ -688,7 +727,7 @@ class TestCli(unittest.TestCase):
                 output="requirements_compiled_test.txt",
                 config_name="test.depsets.yaml",
             )
-            write_to_config_file(tmpdir, depset, "test.depsets.yaml")
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
             manager = _create_test_manager(tmpdir, check=True)
             manager.compile(
                 constraints=["requirement_constraints_test.txt"],
@@ -852,4 +891,4 @@ class TestCli(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(["-vv", __file__]))
+    sys.exit(pytest.main(["-vvv", __file__]))

--- a/ci/raydepsets/tests/test_workspace.py
+++ b/ci/raydepsets/tests/test_workspace.py
@@ -165,7 +165,7 @@ def test_invalid_build_arg_set_in_config():
         )
         write_to_config_file(
             tmpdir,
-            depset,
+            [depset],
             "test.depsets.yaml",
             build_arg_sets=["invalid_build_arg_set"],
         )

--- a/ci/raydepsets/tests/utils.py
+++ b/ci/raydepsets/tests/utils.py
@@ -57,12 +57,20 @@ def get_depset_by_name(depsets, name):
 
 
 def write_to_config_file(
-    tmpdir: str, depset: Depset, config_name: str, build_arg_sets: List[str] = None
+    tmpdir: str,
+    depsets: List[Depset],
+    config_name: str,
+    build_arg_sets: List[str] = None,
 ):
     with open(Path(tmpdir) / config_name, "w") as f:
         f.write(
-            f"""
-depsets:
+            """
+depsets:\n"""
+        )
+
+        for depset in depsets:
+            f.write(
+                f"""\n
     - name: {depset.name}
       operation: {depset.operation}
       {f"constraints: {depset.constraints}" if depset.constraints else ""}
@@ -71,10 +79,9 @@ depsets:
       {f"pre_hooks: {depset.pre_hooks}" if depset.pre_hooks else ""}
       {f"depsets: {depset.depsets}" if depset.depsets else ""}
       {f"source_depset: {depset.source_depset}" if depset.source_depset else ""}
-      {f"config_name: {depset.config_name}" if depset.config_name else ""}
       {f"append_flags: {depset.append_flags}" if depset.append_flags else ""}
       {f"override_flags: {depset.override_flags}" if depset.override_flags else ""}
       {f"packages: {depset.packages}" if depset.packages else ""}
       {f"build_arg_sets: {build_arg_sets}" if build_arg_sets else ""}
                 """
-        )
+            )


### PR DESCRIPTION
updating logic for checking valid subsets of expanded depsets

Ex. original depset -> expanded depset -> subsetted depset

if the subsetted depset containers reuirement files that are in the original depset raydepsets will throw an error

This pr is to fix the logic and consider the original depset requirement files to determine whether the subsetted depset is a valid subset

Updated unit tests