### PR TITLE
[Core] Remove add_command_alias

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import logging
 import os

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2768,6 +2768,7 @@ def get_auth_token(generate):
     # Print token to stdout (for piping) without newline
     click.echo(token, nl=False)
 
+
 cli.add_command(dashboard)
 cli.add_command(debug)
 cli.add_command(start)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2769,29 +2769,16 @@ def get_auth_token(generate):
     # Print token to stdout (for piping) without newline
     click.echo(token, nl=False)
 
-
-def add_command_alias(command, name, hidden):
-    new_command = copy.deepcopy(command)
-    new_command.hidden = hidden
-    cli.add_command(new_command, name=name)
-
-
 cli.add_command(dashboard)
 cli.add_command(debug)
 cli.add_command(start)
 cli.add_command(stop)
 cli.add_command(up)
-add_command_alias(up, name="create_or_update", hidden=True)
 cli.add_command(attach)
 cli.add_command(exec)
-add_command_alias(exec, name="exec_cmd", hidden=True)
-add_command_alias(rsync_down, name="rsync_down", hidden=True)
-add_command_alias(rsync_up, name="rsync_up", hidden=True)
 cli.add_command(submit)
 cli.add_command(down)
-add_command_alias(down, name="teardown", hidden=True)
 cli.add_command(kill_random_node)
-add_command_alias(get_head_ip, name="get_head_ip", hidden=True)
 cli.add_command(get_worker_ips)
 cli.add_command(microbenchmark)
 cli.add_command(stack)
@@ -2822,8 +2809,8 @@ try:
 
     cli.add_command(ray_list, name="list")
     cli.add_command(ray_get, name="get")
-    add_command_alias(summary_state_cli_group, name="summary", hidden=False)
-    add_command_alias(logs_state_cli_group, name="logs", hidden=False)
+    cli.add_command(summary_state_cli_group, name="summary")
+    cli.add_command(logs_state_cli_group, name="logs")
 except ImportError as e:
     logger.debug(f"Integrating ray state command line tool failed: {e}")
 
@@ -2831,7 +2818,7 @@ except ImportError as e:
 try:
     from ray.dashboard.modules.job.cli import job_cli_group
 
-    add_command_alias(job_cli_group, name="job", hidden=False)
+    cli.add_command(job_cli_group, name="job")
 except Exception as e:
     logger.debug(f"Integrating ray jobs command line tool failed with {e}")
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,9 +7,7 @@
 # You can obtain this list from the ray.egg-info/requires.txt
 
 ## setup.py install_requires
-# Click 8.3.* does not work with copy.deepcopy on Python 3.10
-# TODO(aslonnie): https://github.com/ray-project/ray/issues/56747
-click>=7.0, !=8.3.*
+click>=7.0
 cupy-cuda12x; sys_platform != 'darwin'
 filelock
 jsonschema

--- a/python/setup.py
+++ b/python/setup.py
@@ -402,9 +402,7 @@ if setup_spec.type == SetupType.RAY:
 # new releases candidates.
 if setup_spec.type == SetupType.RAY:
     setup_spec.install_requires = [
-        # Click 8.3.* does not work with copy.deepcopy on Python 3.10
-        # TODO(aslonnie): https://github.com/ray-project/ray/issues/56747
-        "click>=7.0, !=8.3.*",
+        "click>=7.0",
         "filelock",
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",


### PR DESCRIPTION
## Description
`add_command_alias` deepcopy the `Command` object but it's no longer deep-copyable: https://github.com/pallets/click/issues/3065#issuecomment-3309192371. We can remove it completely since it just creates some command aliases that have been deprecated for 5+ years.

## Related issues
Closes #56747