### PR TITLE
[Data] Improve Streaming Repartition

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -390,7 +390,10 @@ class StreamingRepartition(AbstractMap):
         input_op: LogicalOperator,
         target_num_rows_per_block: int,
     ):
-        super().__init__("StreamingRepartition", input_op)
+        super().__init__(
+            f"StreamingRepartition[num_rows_per_block={target_num_rows_per_block}]",
+            input_op,
+        )
         self._target_num_rows_per_block = target_num_rows_per_block
 
     @property

--- a/python/ray/data/_internal/streaming_repartition.py
+++ b/python/ray/data/_internal/streaming_repartition.py
@@ -17,6 +17,7 @@ from ray.data._internal.execution.operators.map_operator import BaseRefBundler
     3. Determine the slice needed from the final bundle so the ready bundle holds an exact multiple of the target rows.
     4. Submit that ready bundle to a remote map task; the task slices each block according to the slice metadata stored in the RefBundle (the bundle now contains n × target rows for n ≥ 1).
     5. We configured the `OutputBlockSizeOption.target_num_rows_per_block` to the target number of rows per block in plan_streaming_repartition_op so the output buffer further splits the n × target rows into n blocks of exactly the target size.
+       Note: the output buffer only splits a bundle when its row num exceeds `target_rows × MAX_SAFE_ROWS_PER_BLOCK_FACTOR` (default 1.5). Because we split bundles into target-row blocks, `MAX_SAFE_ROWS_PER_BLOCK_FACTOR` must stay < 2 to output the target-row blocks.
     6. Once upstream input is exhausted, flush any leftover pending bundles and repeat steps 1‑5 for the tail.
     7. The resulting blocks have lengths `[target, …, target, (total_rows % target)]`; ordering isn’t guaranteed, but the remainder block appears near the end.
 

--- a/python/ray/data/_internal/streaming_repartition.py
+++ b/python/ray/data/_internal/streaming_repartition.py
@@ -10,6 +10,16 @@ from ray.data._internal.execution.operators.map_operator import BaseRefBundler
     The task builder submits a map task only after the total number of rows accumulated across pending blocks reaches
     target num rows (except during the final flush, which may emit a smaller tail block). This allows us to create
     target-sized batches without materializing entire large blocks on the driver.
+
+    Detailed Implementation:
+    1. When a new bundle arrives, buffer it in the pending list.
+    2. Whenever the pending total reaches the target row count, try to build a ready bundle.
+    3. Determine the slice needed from the final bundle so the ready bundle holds an exact multiple of the target rows.
+    4. Submit that ready bundle to a remote map task; the task slices each block according to the slice metadata stored in the RefBundle (the bundle now contains n × target rows for n ≥ 1).
+    5. We configured the `OutputBlockSizeOption.target_num_rows_per_block` to the target number of rows per block in plan_streaming_repartition_op so the output buffer further splits the n × target rows into n blocks of exactly the target size.
+    6. Once upstream input is exhausted, flush any leftover pending bundles and repeat steps 1‑5 for the tail.
+    7. The resulting blocks have lengths `[target, …, target, (total_rows % target)]`; ordering isn’t guaranteed, but the remainder block appears near the end.
+
 """
 
 

--- a/python/ray/data/_internal/streaming_repartition.py
+++ b/python/ray/data/_internal/streaming_repartition.py
@@ -13,7 +13,7 @@ from ray.data._internal.execution.operators.map_operator import BaseRefBundler
 
     Detailed Implementation:
     1. When a new bundle arrives, buffer it in the pending list.
-    2. Whenever the pending total reaches the target row count, try to build a ready bundle.
+    2. Whenever the pending bundles reaches the target row count, try to build a ready bundle.
     3. Determine the slice needed from the final bundle so the ready bundle holds an exact multiple of the target rows.
     4. Submit that ready bundle to a remote map task; the task slices each block according to the slice metadata stored in the RefBundle (the bundle now contains n × target rows for n ≥ 1).
     5. We configured the `OutputBlockSizeOption.target_num_rows_per_block` to the target number of rows per block in plan_streaming_repartition_op so the output buffer further splits the n × target rows into n blocks of exactly the target size.

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -276,7 +276,7 @@ def test_streaming_repartition_write_no_operator_fusion(
 
     # Verify that StreamingRepartition physical operator has supports_fusion=False
     up_physical_op = physical_op.input_dependencies[0]
-    assert up_physical_op.name == "StreamingRepartition"
+    assert up_physical_op.name == "StreamingRepartition[num_rows_per_block=20]"
     assert not getattr(
         up_physical_op, "_supports_fusion", True
     ), "StreamingRepartition should have supports_fusion=False"


### PR DESCRIPTION
## Description
 - Document the internal logic of Streaming Repartition Implementation
 - Add `num_rows_per_block` to Streaming Repartition name

## Related issues


## Additional information
