### PR TITLE
[Docs] Update KubeRay authentication doc to use new token authentication

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -109,3 +109,16 @@ Tailing logs until the job exits (disable with --no-wait):
 Job 'raysubmit_...' succeeded
 ------------------------------------------
 ```
+
+## Viewing the Ray dashboard (optional)
+To view the Ray dashboard from your browser, first port forward to from your local machine to the cluster:
+
+```bash
+kubectl port-forward svc/ray-cluster-with-auth-head-svc 8265:8265 &
+```
+
+Then open `localhost:8265` in your browser. You will be prompted to provide the auth token for the cluster, which can be retrieved with:
+
+```bash
+kubectl get secrets ray-cluster-with-auth --template={{.data.auth_token}} | base64 -d
+```

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -1,10 +1,8 @@
 (kuberay-auth)=
 
-# Configure Ray clusters with authentication and access control using KubeRay
+# Configure Ray clusters with token authentication
 
-This guide demonstrates how to secure Ray clusters deployed with KubeRay by enabling authentication and access control using Kubernetes Role-Based Access Control (RBAC).
-
-> **Note:** This guide is only supported for the RayCluster custom resource.
+This guide demonstrates how to enable Ray token authentication with KubeRay.
 
 ## Prerequisites
 
@@ -12,7 +10,7 @@ This guide demonstrates how to secure Ray clusters deployed with KubeRay by enab
 * `kubectl` installed and configured to interact with your cluster.
 * `gcloud` CLI installed and configured, if using GKE.
 * [Helm](https://helm.sh/) installed.
-* Ray installed locally.
+* Ray 2.52.0 or newer.
 
 ## Create or use an existing GKE Cluster
 
@@ -27,20 +25,25 @@ gcloud container clusters create kuberay-cluster \
 
 Follow [Deploy a KubeRay operator](kuberay-operator-deploy) to install the latest stable KubeRay operator from the Helm repository.
 
-## Deploy a Ray cluster with authentication enabled
+## Deploy a Ray cluster with token authentication
 
-Deploy a RayCluster configured with `kube-rbac-proxy` for authentication and authorization:
-
-```bash
+If you are using KubeRay v1.5.1 or newer, you can use the `authOptions` API in RayCluster to enable token authentication:
+```
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.auth.yaml
 ```
 
-This command deploys:
-* A `RayCluster` resource with a `kube-rbac-proxy` sidecar container on the Head Pod. This proxy handles authentication and authorization.
-* A `ConfigMap` for kube-rbac-proxy, containing resource attributes required for authorization.
-* A `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` that allow the `kube-rbac-proxy` to access the Kubernetes TokenReview and SubjectAccessReview APIs.
+When enabled, the KubeRay operator will:
+* Create a Kubernetes Secret containing a randomly generated token.
+* Automatically set the `RAY_AUTH_TOKEN` and `RAY_AUTH_MODE` environment variables on all Ray containers.
 
-## Verify initial unauthorized access
+If you are using a KubeRay version older than v1.5.1, you can enable token authentication by creating a Kubernetes Secret containing
+your token and configuring the RAY_AUTH_MODE and RAY_AUTH_TOKEN environment variables.
+```
+kubectl create secret generic ray-cluster-with-auth --from-literal=auth_token=$(openssl rand -base64 32)
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.auth-manual.yaml
+```
+
+## Verify initial unauthenticated access
 
 Attempt to submit a Ray job to the cluster to verify that authentication is required. You should receive a `401 Unauthorized` error:
 
@@ -53,99 +56,30 @@ You may see an error similar to this:
 
 ```
 ...
-requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: http://localhost:8265/api/version
+...
+RuntimeError: Authentication required: Unauthorized: Missing authentication token
+
+The Ray cluster requires authentication, but no token was provided.
+
+Please provide an authentication token using one of these methods:
+  1. Set the RAY_AUTH_TOKEN environment variable
+  2. Set the RAY_AUTH_TOKEN_PATH environment variable (pointing to a token file)
+  3. Create a token file at the default location: ~/.ray/auth_token
 ```
 
 This error confirms that the Ray cluster requires authentication.
 
-## Configure Kubernetes RBAC for access control
+## Accessing your Ray cluster with Ray CLI
 
-To access the RayCluster, you need:
-*  **Authentication:** Provide a valid authentication token (e.g., a Kubernetes service account token or a cloud IAM token) in the request headers.
-*  **Authorization:** Your authenticated user or service account must have the necessary Kubernetes RBAC permissions to access the `RayCluster` resource.
+To access your Ray cluster using Ray CLI, you need to configure the following environment variables:
+* RAY_AUTH_MODE: this configures the Ray CLI to set the necessary authorization headers for token authentication
+* RAY_AUTH_TOKEN: this contains the token that will be used for authentication. 
+* RAY_AUTH_TOKEN_PATH: if RAY_AUTH_TOKEN is not set, Ray CLI will check the path in this environment variable for tokens.   
 
-This guide demonstrates granting access using a Kubernetes service account, but the same principles apply to individual Kubernetes users or cloud IAM users.
-
-### Create a Kubernetes service account
-
-Create a service account that represents your Ray job submitter:
-
-```bash
-kubectl create serviceaccount ray-user
+Submit a job with an authenticated Ray CLI:
 ```
-
-Confirm that the service account currently can't access the `RayCluster` resource:
-
-```bash
-kubectl auth can-i get rayclusters.ray.io/ray-cluster-with-auth --as=system:serviceaccount:default:ray-user
-```
-
-The output should be `no`.
-
-### Grant access using Kubernetes RBAC
-
-Create a `Role` and `RoleBinding` to grant the necessary permissions to the `ray-user` service account:
-
-```yaml
-# ray-cluster-rbac.yaml
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: ray-user
-  namespace: default
-rules:
-- apiGroups: ["ray.io"]
-  resources:
-  - 'rayclusters'
-  verbs: ["*"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: ray-user
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ray-user
-subjects:
-- kind: ServiceAccount
-  name: ray-user
-  namespace: default
-```
-
-Apply the RBAC configuration:
-
-```bash
-kubectl apply -f ray-cluster-rbac.yaml
-```
-
-### Verify access
-
-Confirm that the service account now has access to the `RayCluster` resource:
-
-```bash
-kubectl auth can-i get rayclusters.ray.io/ray-cluster-with-auth --as=system:serviceaccount:default:ray-user
-```
-
-The output should be `yes`.
-
-## Submit a Ray job with authentication
-
-Now you can submit a Ray job using the service account's authentication token.
-
-Get a token for the `ray-user` service account and store it in the `RAY_JOB_HEADERS` environment variable:
-
-```bash
-export RAY_JOB_HEADERS="{\"Authorization\": \"Bearer $(kubectl create token ray-user --duration=1h)\"}"
-```
-
-> **Note:** `kubectl create token` command is only available on Kubernetes v1.24+
-
-Submit the Ray job:
-
-```bash
+export RAY_AUTH_MODE=token
+export RAY_AUTH_TOKEN=$(kubectl get secrets ray-cluster-with-auth --template={{.data.auth_token}} | base64 -d)
 ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
 ```
 
@@ -175,33 +109,3 @@ Tailing logs until the job exits (disable with --no-wait):
 Job 'raysubmit_...' succeeded
 ------------------------------------------
 ```
-
-## Verify access using cloud IAM (Optional)
-
-Most cloud providers allow you to authenticate to the Kubernetes cluster as your cloud IAM user. This method is a convenient way to interact with the cluster without managing separate Kubernetes credentials.
-
-**Example using Google Cloud (GKE):**
-
-Get an access token for your Google Cloud user:
-
-```bash
-export RAY_JOB_HEADERS="{\"Authorization\": \"Bearer $(gcloud auth print-access-token)\"}"
-```
-
-Submit a Ray job using the IAM token:
-
-```bash
-ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
-```
-
-The job should succeed if your cloud user has the necessary Kubernetes RBAC permissions. You may need to configure additional RBAC rules for your cloud user.
-
-## View the Ray dashboard (optional)
-
-To view the Ray dashboard from your browser, first configure port-forwarding:
-
-```bash
-kubectl port-forward svc/ray-cluster-with-auth-head-svc 8265:8265 &
-```
-
-Use a Chrome extension like [Requestly](https://requestly.com/) to automatically add authorization headers to requests for the dashboard endpoint `http://localhost:8265`. The authorization header format is: `Authorization: Bearer <token>`.

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -1,6 +1,6 @@
 (kuberay-auth)=
 
-# Configure Ray clusters with token authentication
+# Configure Ray clusters to use token authentication
 
 This guide demonstrates how to enable Ray token authentication with KubeRay.
 
@@ -53,11 +53,9 @@ kubectl port-forward svc/ray-cluster-with-auth-head-svc 8265:8265 &
 ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
 ```
 
-You may see an error similar to this:
+You should see an error similar to this:
 
 ```bash
-...
-...
 RuntimeError: Authentication required: Unauthorized: Missing authentication token
 
 The Ray cluster requires authentication, but no token was provided.
@@ -75,7 +73,7 @@ This error confirms that the Ray cluster requires authentication.
 To access your Ray cluster using the Ray CLI, you need to configure the following environment variables:
 * `RAY_AUTH_MODE`: this configures the Ray CLI to set the necessary authorization headers for token authentication
 * `RAY_AUTH_TOKEN`: this contains the token that will be used for authentication. 
-* `RAY_AUTH_TOKEN_PATH`: if `RAY_AUTH_TOKEN` is not set, the Ray CLI will instead read the token from this path.
+* `RAY_AUTH_TOKEN_PATH`: if `RAY_AUTH_TOKEN` is not set, the Ray CLI will instead read the token from this path (defaults to `~/.ray/auth_token`).
 
 Submit a job with an authenticated Ray CLI:
 

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -28,7 +28,7 @@ Follow [Deploy a KubeRay operator](kuberay-operator-deploy) to install the lates
 ## Deploy a Ray cluster with token authentication
 
 If you are using KubeRay v1.5.1 or newer, you can use the `authOptions` API in RayCluster to enable token authentication:
-```
+```bash
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.auth.yaml
 ```
 

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -37,7 +37,8 @@ When enabled, the KubeRay operator will:
 * Automatically set the `RAY_AUTH_TOKEN` and `RAY_AUTH_MODE` environment variables on all Ray containers.
 
 If you are using a KubeRay version older than v1.5.1, you can enable token authentication by creating a Kubernetes Secret containing
-your token and configuring the RAY_AUTH_MODE and RAY_AUTH_TOKEN environment variables.
+your token and configuring the `RAY_AUTH_MODE` and `RAY_AUTH_TOKEN` environment variables.
+
 ```bash
 kubectl create secret generic ray-cluster-with-auth --from-literal=auth_token=$(openssl rand -base64 32)
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.auth-manual.yaml
@@ -54,7 +55,7 @@ ray job submit --address http://localhost:8265  -- python -c "import ray; ray.in
 
 You may see an error similar to this:
 
-```
+```bash
 ...
 ...
 RuntimeError: Authentication required: Unauthorized: Missing authentication token
@@ -62,28 +63,29 @@ RuntimeError: Authentication required: Unauthorized: Missing authentication toke
 The Ray cluster requires authentication, but no token was provided.
 
 Please provide an authentication token using one of these methods:
-  1. Set the RAY_AUTH_TOKEN environment variable
-  2. Set the RAY_AUTH_TOKEN_PATH environment variable (pointing to a token file)
-  3. Create a token file at the default location: ~/.ray/auth_token
+  1. Set the `RAY_AUTH_TOKEN` environment variable.
+  2. Set the `RAY_AUTH_TOKEN_PATH` environment variable (pointing to a file containing the token).
+  3. Create a token file at the default location: `~/.ray/auth_token`.
 ```
 
 This error confirms that the Ray cluster requires authentication.
 
-## Accessing your Ray cluster with Ray CLI
+## Accessing your Ray cluster with the Ray CLI
 
-To access your Ray cluster using Ray CLI, you need to configure the following environment variables:
-* RAY_AUTH_MODE: this configures the Ray CLI to set the necessary authorization headers for token authentication
-* RAY_AUTH_TOKEN: this contains the token that will be used for authentication. 
-* RAY_AUTH_TOKEN_PATH: if RAY_AUTH_TOKEN is not set, Ray CLI will check the path in this environment variable for tokens.   
+To access your Ray cluster using the Ray CLI, you need to configure the following environment variables:
+* `RAY_AUTH_MODE`: this configures the Ray CLI to set the necessary authorization headers for token authentication
+* `RAY_AUTH_TOKEN`: this contains the token that will be used for authentication. 
+* `RAY_AUTH_TOKEN_PATH`: if `RAY_AUTH_TOKEN` is not set, the Ray CLI will instead read the token from this path.
 
 Submit a job with an authenticated Ray CLI:
-```
+
+```bash
 export RAY_AUTH_MODE=token
 export RAY_AUTH_TOKEN=$(kubectl get secrets ray-cluster-with-auth --template={{.data.auth_token}} | base64 -d)
 ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
 ```
 
-The job should now succeed, and you should see output similar to this:
+The job should now succeed and you should see output similar to this:
 
 ```bash
 Job submission server address: http://localhost:8265

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -38,7 +38,7 @@ When enabled, the KubeRay operator will:
 
 If you are using a KubeRay version older than v1.5.1, you can enable token authentication by creating a Kubernetes Secret containing
 your token and configuring the RAY_AUTH_MODE and RAY_AUTH_TOKEN environment variables.
-```
+```bash
 kubectl create secret generic ray-cluster-with-auth --from-literal=auth_token=$(openssl rand -base64 32)
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.auth-manual.yaml
 ```


### PR DESCRIPTION
## Description

Replace existing KubeRay authentication guide based on kube-rbac-proxy with native Ray token authentication being introduced in Ray 2.52.0

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
