### PR TITLE
[Data] - Change MapWorker repr to not be reliant on src_fn_name

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1030,7 +1030,7 @@ class _ActorPool(AutoscalingActorPool):
         """Get the logical IDs for pending and running actors in the actor pool.
 
         We can’t use Ray Core actor IDs because we need to identify actors by labels,
-        but labels must be set before creation, and actor IDs aren't available until
+        but labels must be set before creation, and actor IDs aren’t available until
         after.
         """
         return list(self._actor_to_logical_id.values())

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -166,7 +166,7 @@ class ActorPoolMapOperator(MapOperator):
         self._actor_task_selector = self._create_task_selector(self._actor_pool)
         # A queue of bundles awaiting dispatch to actors.
         self._bundle_queue = create_bundle_queue()
-        # HACK: Without this, all actors show up as `_MapWorker` in Grafana, so we can't
+        # HACK: Without this, all actors show up as `_MapWorker` in Grafana, so we can’t
         # tell which operator they belong to. To fix that, we dynamically create a new
         # class per operator with a unique name.
         self._map_worker_cls = type(f"MapWorker({self.name})", (_MapWorker,), {})
@@ -1029,7 +1029,7 @@ class _ActorPool(AutoscalingActorPool):
     def get_logical_ids(self) -> List[str]:
         """Get the logical IDs for pending and running actors in the actor pool.
 
-        We can't use Ray Core actor IDs because we need to identify actors by labels,
+        We can’t use Ray Core actor IDs because we need to identify actors by labels,
         but labels must be set before creation, and actor IDs aren't available until
         after.
         """

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -166,7 +166,7 @@ class ActorPoolMapOperator(MapOperator):
         self._actor_task_selector = self._create_task_selector(self._actor_pool)
         # A queue of bundles awaiting dispatch to actors.
         self._bundle_queue = create_bundle_queue()
-        # HACK: Without this, all actors show up as `_MapWorker` in Grafana, so we can’t
+        # HACK: Without this, all actors show up as `_MapWorker` in Grafana, so we can't
         # tell which operator they belong to. To fix that, we dynamically create a new
         # class per operator with a unique name.
         self._map_worker_cls = type(f"MapWorker({self.name})", (_MapWorker,), {})
@@ -593,7 +593,9 @@ class _MapWorker:
         )
 
     def __repr__(self):
-        return f"MapWorker({self.src_fn_name})"
+        # Use getattr to handle case where __init__ failed before src_fn_name was set.
+        # This can happen during actor restarts or initialization failures.
+        return f"MapWorker({getattr(self, 'src_fn_name', '<initializing>')})"
 
     def on_exit(self):
         """Called when the actor is about to exist.
@@ -1027,8 +1029,8 @@ class _ActorPool(AutoscalingActorPool):
     def get_logical_ids(self) -> List[str]:
         """Get the logical IDs for pending and running actors in the actor pool.
 
-        We can’t use Ray Core actor IDs because we need to identify actors by labels,
-        but labels must be set before creation, and actor IDs aren’t available until
+        We can't use Ray Core actor IDs because we need to identify actors by labels,
+        but labels must be set before creation, and actor IDs aren't available until
         after.
         """
         return list(self._actor_to_logical_id.values())


### PR DESCRIPTION
## Description
When `max_restarts=-1`, Ray core infinitely tries to restart actors, and if the args aren't recoverable underlying methods could fail. Make `__repr__` of `MapWorker` to not rely on `src_fn_name` if unavailable.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
