### PR TITLE
[release] keep building python 3.9 wheel for internal testing

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -42,6 +42,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture x86_64 --upload
     matrix:
+      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"


### PR DESCRIPTION
still used in some of the release tests
