### PR TITLE
[whl] keep building python 3.9 wheels for internal testing

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -42,6 +42,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture x86_64 --upload
     matrix:
+      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"


### PR DESCRIPTION
needs to keep this until all release tests are migrated.
