### PR TITLE
[core] Use `shared_ptr` for `pins_in_flight_` instead of `shared_from_this`

### DIFF
--- a/src/ray/raylet_rpc_client/raylet_client.cc
+++ b/src/ray/raylet_rpc_client/raylet_client.cc
@@ -47,7 +47,8 @@ RayletClient::RayletClient(const rpc::Address &address,
           ::RayConfig::instance().raylet_rpc_server_reconnect_timeout_max_s(),
           /*server_unavailable_timeout_callback=*/
           std::move(raylet_unavailable_timeout_callback),
-          /*server_name=*/std::string("Raylet ") + address.ip_address())) {}
+          /*server_name=*/std::string("Raylet ") + address.ip_address())),
+          pins_in_flight_(std::make_shared<std::atomic<int64_t>>(0)) {}
 
 void RayletClient::RequestWorkerLease(
     const rpc::LeaseSpec &lease_spec,
@@ -335,11 +336,10 @@ void RayletClient::PinObjectIDs(
   if (!generator_id.IsNil()) {
     request.set_generator_id(generator_id.Binary());
   }
-  auto self = shared_from_this();
-  pins_in_flight_++;
-  auto rpc_callback = [self, callback = std::move(callback)](
+  pins_in_flight_->fetch_add(1);
+  auto rpc_callback = [callback = std::move(callback), pins_in_flight = pins_in_flight_](
                           Status status, rpc::PinObjectIDsReply &&reply) {
-    self->pins_in_flight_--;
+    pins_in_flight->fetch_sub(1);
     callback(status, std::move(reply));
   };
   INVOKE_RETRYABLE_RPC_CALL(retryable_grpc_client_,

--- a/src/ray/raylet_rpc_client/raylet_client.cc
+++ b/src/ray/raylet_rpc_client/raylet_client.cc
@@ -48,7 +48,7 @@ RayletClient::RayletClient(const rpc::Address &address,
           /*server_unavailable_timeout_callback=*/
           std::move(raylet_unavailable_timeout_callback),
           /*server_name=*/std::string("Raylet ") + address.ip_address())),
-          pins_in_flight_(std::make_shared<std::atomic<int64_t>>(0)) {}
+      pins_in_flight_(std::make_shared<std::atomic<int64_t>>(0)) {}
 
 void RayletClient::RequestWorkerLease(
     const rpc::LeaseSpec &lease_spec,

--- a/src/ray/raylet_rpc_client/raylet_client.cc
+++ b/src/ray/raylet_rpc_client/raylet_client.cc
@@ -336,6 +336,9 @@ void RayletClient::PinObjectIDs(
   if (!generator_id.IsNil()) {
     request.set_generator_id(generator_id.Binary());
   }
+
+  // NOTE: this callback can execute after the RayletClient instance is destroyed, so
+  // we capture the shared_ptr to `pins_in_flight_` instead of `this`.
   pins_in_flight_->fetch_add(1);
   auto rpc_callback = [callback, pins_in_flight = pins_in_flight_](
                           Status status, rpc::PinObjectIDsReply &&reply) {

--- a/src/ray/raylet_rpc_client/raylet_client.cc
+++ b/src/ray/raylet_rpc_client/raylet_client.cc
@@ -337,7 +337,7 @@ void RayletClient::PinObjectIDs(
     request.set_generator_id(generator_id.Binary());
   }
   pins_in_flight_->fetch_add(1);
-  auto rpc_callback = [callback = std::move(callback), pins_in_flight = pins_in_flight_](
+  auto rpc_callback = [callback, pins_in_flight = pins_in_flight_](
                           Status status, rpc::PinObjectIDsReply &&reply) {
     pins_in_flight->fetch_sub(1);
     callback(status, std::move(reply));

--- a/src/ray/raylet_rpc_client/raylet_client.h
+++ b/src/ray/raylet_rpc_client/raylet_client.h
@@ -187,7 +187,8 @@ class RayletClient : public RayletClientInterface {
   ResourceMappingType resource_ids_;
 
   /// The number of object ID pin RPCs currently in flight.
-  /// NOTE: `shared_ptr` because it is captured in a callback that can outlive this instance.
+  /// NOTE: `shared_ptr` because it is captured in a callback that can outlive this
+  /// instance.
   std::shared_ptr<std::atomic<int64_t>> pins_in_flight_;
 };
 

--- a/src/ray/raylet_rpc_client/raylet_client.h
+++ b/src/ray/raylet_rpc_client/raylet_client.h
@@ -39,8 +39,7 @@ namespace rpc {
 
 /// Raylet client is responsible for communication with raylet. It implements
 /// [RayletClientInterface] and works on worker registration, lease management, etc.
-class RayletClient : public RayletClientInterface,
-                     public std::enable_shared_from_this<RayletClient> {
+class RayletClient : public RayletClientInterface {
  public:
   /// Connect to the raylet.
   ///

--- a/src/ray/raylet_rpc_client/raylet_client.h
+++ b/src/ray/raylet_rpc_client/raylet_client.h
@@ -160,7 +160,7 @@ class RayletClient : public RayletClientInterface,
 
   const ResourceMappingType &GetResourceIDs() const { return resource_ids_; }
 
-  int64_t GetPinsInFlight() const override { return pins_in_flight_.load(); }
+  int64_t GetPinsInFlight() const override { return pins_in_flight_->load(); }
 
   void GetNodeStats(const rpc::GetNodeStatsRequest &request,
                     const rpc::ClientCallback<rpc::GetNodeStatsReply> &callback) override;
@@ -188,7 +188,8 @@ class RayletClient : public RayletClientInterface,
   ResourceMappingType resource_ids_;
 
   /// The number of object ID pin RPCs currently in flight.
-  std::atomic<int64_t> pins_in_flight_ = 0;
+  /// NOTE: `shared_ptr` because it is captured in a callback that can outlive this instance.
+  std::shared_ptr<std::atomic<int64_t>> pins_in_flight_;
 };
 
 }  // namespace rpc


### PR DESCRIPTION
While writing the [follow up](https://github.com/ray-project/ray/pull/58660/files#r2538761540) to ban stack-allocated `RayletClient` instances, @dayshah proposed a simpler solution: make the counter a shared_ptr instead of capturing the entire class.