### PR TITLE
[Data] - Make `test_namespace_expressions` + `test_datatype` resilient + `rows_same` handle complex types

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -9,6 +9,7 @@ import sys
 import threading
 import time
 import urllib.parse
+import uuid
 from queue import Empty, Full, Queue
 from types import ModuleType
 from typing import (
@@ -1676,6 +1677,8 @@ def _sort_df(df: pd.DataFrame) -> pd.DataFrame:
             return tuple(to_sortable(i) for i in x)
         if isinstance(x, dict):
             return tuple(sorted((k, to_sortable(v)) for k, v in x.items()))
+        if isinstance(x, set):
+            return tuple(sorted(to_sortable(i) for i in x))
         return x
 
     sort_cols = []
@@ -1686,7 +1689,8 @@ def _sort_df(df: pd.DataFrame) -> pd.DataFrame:
     for col in columns:
         if df[col].dtype == "object":
             # Create a temporary column for sorting to handle unhashable types.
-            temp_col = f"__sort_proxy_{col}__"
+            # Use UUID to avoid collisions with existing column names.
+            temp_col = f"__sort_proxy_{uuid.uuid4().hex}_{col}__"
             df[temp_col] = df[col].map(to_sortable)
             sort_cols.append(temp_col)
             temp_cols.append(temp_col)

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1669,7 +1669,7 @@ def unzip(data: List[Tuple[Any, ...]]) -> Tuple[List[Any], ...]:
 
 
 def _sort_df(df: pd.DataFrame) -> pd.DataFrame:
-    """Sort DataFrame by all columns, handling unhashable types."""
+    """Sort DataFrame by columns and rows, and also handle unhashable types."""
     df = df.copy()
 
     def to_sortable(x):

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1677,8 +1677,6 @@ def _sort_df(df: pd.DataFrame) -> pd.DataFrame:
             return tuple(to_sortable(i) for i in x)
         if isinstance(x, dict):
             return tuple(sorted((k, to_sortable(v)) for k, v in x.items()))
-        if isinstance(x, set):
-            return tuple(sorted(to_sortable(i) for i in x))
         return x
 
     sort_cols = []

--- a/python/ray/data/tests/test_namespace_expressions.py
+++ b/python/ray/data/tests/test_namespace_expressions.py
@@ -9,10 +9,16 @@ from typing import Any
 import pandas as pd
 import pyarrow as pa
 import pytest
+from packaging import version
 
 import ray
 from ray.data._internal.util import rows_same
 from ray.data.expressions import col
+
+pytestmark = pytest.mark.skipif(
+    version.parse(pa.__version__) < version.parse("19.0.0"),
+    reason="Namespace expressions tests require PyArrow >= 19.0",
+)
 
 
 def _create_dataset(

--- a/python/ray/data/tests/test_namespace_expressions.py
+++ b/python/ray/data/tests/test_namespace_expressions.py
@@ -11,12 +11,8 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data._internal.util import rows_same
 from ray.data.expressions import col
-
-
-def assert_df_equal(result: pd.DataFrame, expected: pd.DataFrame):
-    """Assert dataframes are equal, ignoring dtype differences."""
-    pd.testing.assert_frame_equal(result, expected, check_dtype=False)
 
 
 def _create_dataset(
@@ -70,7 +66,7 @@ class TestListNamespace:
                 "len": [3, 2, 0],
             }
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_list_get(self, dataset_format):
         """Test list.get() extracts element at index."""
@@ -87,7 +83,7 @@ class TestListNamespace:
                 "first": [10, 40],
             }
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_list_bracket_index(self, dataset_format):
         """Test list[i] bracket notation for element access."""
@@ -101,7 +97,7 @@ class TestListNamespace:
                 "elem": [20],
             }
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 # ──────────────────────────────────────
@@ -132,7 +128,7 @@ class TestStringLength:
         result = ds.with_column("result", method()).to_pandas()
 
         expected = pd.DataFrame({"name": input_values, "result": expected_results})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 @pytest.mark.parametrize("dataset_format", DATASET_FORMATS)
@@ -161,7 +157,7 @@ class TestStringCase:
         result = ds.with_column("result", method()).to_pandas()
 
         expected = pd.DataFrame({"name": input_values, "result": expected_values})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 @pytest.mark.parametrize("dataset_format", DATASET_FORMATS)
@@ -193,7 +189,7 @@ class TestStringPredicates:
         result = ds.with_column("result", method()).to_pandas()
 
         expected = pd.DataFrame({"val": input_values, "result": expected_results})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 @pytest.mark.parametrize("dataset_format", DATASET_FORMATS)
@@ -221,7 +217,7 @@ class TestStringTrimming:
         result = ds.with_column("result", method(*method_args)).to_pandas()
 
         expected = pd.DataFrame({"val": input_values, "result": expected_values})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 @pytest.mark.parametrize("dataset_format", DATASET_FORMATS)
@@ -249,7 +245,7 @@ class TestStringPadding:
         result = ds.with_column("result", method(**method_kwargs)).to_pandas()
 
         expected = pd.DataFrame({"val": ["hi"], "result": [expected_value]})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 @pytest.mark.parametrize("dataset_format", DATASET_FORMATS)
@@ -288,7 +284,7 @@ class TestStringSearch:
         ).to_pandas()
 
         expected = pd.DataFrame({"val": input_values, "result": expected_results})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 @pytest.mark.parametrize("dataset_format", DATASET_FORMATS)
@@ -302,7 +298,7 @@ class TestStringTransform:
         ds = _create_dataset(data, dataset_format)
         result = ds.with_column("rev", col("val").str.reverse()).to_pandas()
         expected = pd.DataFrame({"val": ["hello", "world"], "rev": ["olleh", "dlrow"]})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_slice(self, dataset_format):
         """Test str.slice() extracts substring."""
@@ -311,7 +307,7 @@ class TestStringTransform:
         ds = _create_dataset(data, dataset_format)
         result = ds.with_column("sliced", col("val").str.slice(1, 4)).to_pandas()
         expected = pd.DataFrame({"val": ["hello"], "sliced": ["ell"]})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_replace(self, dataset_format):
         """Test str.replace() replaces substring."""
@@ -324,7 +320,7 @@ class TestStringTransform:
         expected = pd.DataFrame(
             {"val": ["hello world"], "replaced": ["hello universe"]}
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_replace_with_max(self, dataset_format):
         """Test str.replace() with max_replacements."""
@@ -335,7 +331,7 @@ class TestStringTransform:
             "replaced", col("val").str.replace("a", "X", max_replacements=2)
         ).to_pandas()
         expected = pd.DataFrame({"val": ["aaa"], "replaced": ["XXa"]})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_repeat(self, dataset_format):
         """Test str.repeat() repeats strings."""
@@ -344,7 +340,7 @@ class TestStringTransform:
         ds = _create_dataset(data, dataset_format)
         result = ds.with_column("repeated", col("val").str.repeat(3)).to_pandas()
         expected = pd.DataFrame({"val": ["A"], "repeated": ["AAA"]})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 # ──────────────────────────────────────
@@ -390,7 +386,7 @@ class TestStructNamespace:
                 "age": [30, 25],
             }
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_struct_bracket(self, dataset_format):
         """Test struct['field'] bracket notation."""
@@ -424,7 +420,7 @@ class TestStructNamespace:
                 "name": ["Alice", "Bob"],
             }
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_struct_nested_field(self, dataset_format):
         """Test nested struct field access with .field()."""
@@ -471,7 +467,7 @@ class TestStructNamespace:
                 "city": ["NYC", "LA"],
             }
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_struct_nested_bracket(self, dataset_format):
         """Test nested struct field access with brackets."""
@@ -518,7 +514,7 @@ class TestStructNamespace:
                 "zip": ["10001", "90001"],
             }
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 # ──────────────────────────────────────
@@ -537,7 +533,7 @@ class TestNamespaceIntegration:
         ds = _create_dataset(data, dataset_format)
         result = ds.with_column("len_plus_one", col("items").list.len() + 1).to_pandas()
         expected = pd.DataFrame({"items": [[1, 2, 3]], "len_plus_one": [4]})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_string_with_comparison(self, dataset_format):
         """Test string operations combined with comparison."""
@@ -546,7 +542,7 @@ class TestNamespaceIntegration:
         ds = _create_dataset(data, dataset_format)
         result = ds.with_column("long_name", col("name").str.len() > 3).to_pandas()
         expected = pd.DataFrame({"name": ["Alice", "Bo"], "long_name": [True, False]})
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
     def test_multiple_operations(self, dataset_format):
         """Test multiple namespace operations in single pipeline."""
@@ -567,7 +563,7 @@ class TestNamespaceIntegration:
                 "starts_a": [True],
             }
         )
-        assert_df_equal(result, expected)
+        assert rows_same(result, expected)
 
 
 # ──────────────────────────────────────

--- a/python/ray/data/tests/unit/test_datatype.py
+++ b/python/ray/data/tests/unit/test_datatype.py
@@ -1,12 +1,14 @@
 import numpy as np
 import pyarrow as pa
 import pytest
+from packaging import version
 
 from ray.data.datatype import DataType
 
 # Skip all tests if PyArrow version is less than 19.0
 pytestmark = pytest.mark.skipif(
-    pa.__version__ < "19.0", reason="DataType tests require PyArrow >= 19.0"
+    version.parse(pa.__version__) < version.parse("19.0.0"),
+    reason="DataType tests require PyArrow >= 19.0",
 )
 
 

--- a/python/ray/data/tests/unit/test_datatype.py
+++ b/python/ray/data/tests/unit/test_datatype.py
@@ -4,6 +4,11 @@ import pytest
 
 from ray.data.datatype import DataType
 
+# Skip all tests if PyArrow version is less than 19.0
+pytestmark = pytest.mark.skipif(
+    pa.__version__ < "19.0", reason="DataType tests require PyArrow >= 19.0"
+)
+
 
 class TestDataTypeFactoryMethods:
     """Test the generated factory methods."""


### PR DESCRIPTION
## Description
1. Make `rows_same` handle unhashable types
2. Use that in `test_namespace_expressions`
3. Guard `test_datatype` tests to use pyarrow >= 19.0

## Related issues
Closes #58727 

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
