### PR TITLE
[Data] Update the export API to remove the redundant data context and op args when refreshing metadata

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -704,7 +704,12 @@ class _StatsActor:
                     operator.execution_end_time = update_time
 
         self.dataset_metadatas[dataset_id] = updated_dataset_metadata
-        self._metadata_exporter.export_dataset_metadata(updated_dataset_metadata)
+        if self._metadata_exporter is not None:
+            self._metadata_exporter.export_dataset_metadata(
+                updated_dataset_metadata,
+                include_data_context=False,
+                include_op_args=False,
+            )
 
     def update_dataset_metadata_operator_states(
         self, dataset_id: str, operator_states: Dict[str, str]
@@ -746,7 +751,12 @@ class _StatsActor:
                         operator.execution_start_time = update_time
 
         self.dataset_metadatas[dataset_id] = updated_dataset_metadata
-        self._metadata_exporter.export_dataset_metadata(updated_dataset_metadata)
+        if self._metadata_exporter is not None:
+            self._metadata_exporter.export_dataset_metadata(
+                updated_dataset_metadata,
+                include_data_context=False,
+                include_op_args=False,
+            )
 
     def _create_tags(
         self,


### PR DESCRIPTION
## Description
We export dataset and operator metadata whenever there is a state change. However, the size of the export file can be very large because the metadata also includes the DataContext config and operator args, which does not change over time, and they will be written multiple times to the file. To reduce the file size and remove redundant info, we can only export DataContext and operator args when the dataset is [registered](https://github.com/ray-project/ray/blob/d1cce8c9dc8411fad7cfbd619350bec6f19839a3/python/ray/data/_internal/stats.py#L621), and avoid them in the later state updates. 

## Related issues
Related previous PRs: [55355](https://github.com/ray-project/ray/pull/55355), [53554](https://github.com/ray-project/ray/pull/53554)

