### PR TITLE
[Core] Update the Default Value of RAY_metric_cardinality_level to recommended

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -571,7 +571,9 @@ RAY_ENABLE_UV_RUN_RUNTIME_ENV = env_bool("RAY_ENABLE_UV_RUN_RUNTIME_ENV", True)
 #   the component, including WorkerId, (task or actor) Name, etc. This is the default.
 # Recommended: report only the node level metrics to prometheus. This means that the
 #   WorkerId will be removed from all metrics.
-RAY_METRIC_CARDINALITY_LEVEL = os.environ.get("RAY_metric_cardinality_level", "legacy")
+RAY_METRIC_CARDINALITY_LEVEL = os.environ.get(
+    "RAY_metric_cardinality_level", "recommended"
+)
 
 # Whether enable OpenTelemetry as the metrics collection backend. The default is
 # using OpenCensus.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -533,7 +533,7 @@ RAY_CONFIG(bool, enable_metrics_collection, true)
 /// Determine if the high cardinality labels such as WorkerId, task and actor Name
 /// should be used in the metrics. For the complete definition, see
 /// RAY_METRIC_CARDINALITY_LEVEL in ray_constants.py
-RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
+RAY_CONFIG(std::string, metric_cardinality_level, "recommended")
 
 /// Whether enable OpenTelemetry as the metrics collection backend. The default is
 /// using OpenCensus.


### PR DESCRIPTION
## Description

The PR updates the default value of `RAY_metric_cardinality_level` to `recommended`. 

In this way, the metrics are exported with node level granularity by default.

## Related issues
N/A

## Additional information
N/A