### PR TITLE
[Data] Add preprocessor utility methods for column tracking

### DIFF
--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -94,8 +94,8 @@ class Concatenator(Preprocessor):
         raise_if_missing: bool = False,
         flatten: bool = False,
     ):
+        super().__init__()
         self.columns = columns
-
         self.output_column_name = output_column_name
         self.dtype = dtype
         self.raise_if_missing = raise_if_missing
@@ -136,6 +136,12 @@ class Concatenator(Preprocessor):
         # behavior across Pandas versions.
         df.loc[:, self.output_column_name] = pd.Series(list(concatenated))
         return df
+
+    def get_input_columns(self) -> List[str]:
+        return self.columns
+
+    def get_output_columns(self) -> List[str]:
+        return [self.output_column_name]
 
     def __repr__(self):
         default_values = {

--- a/python/ray/data/preprocessors/hasher.py
+++ b/python/ray/data/preprocessors/hasher.py
@@ -82,6 +82,7 @@ class FeatureHasher(Preprocessor):
         num_features: int,
         output_column: str,
     ):
+        super().__init__()
         self.columns = columns
         # TODO(matt): Set default number of features.
         # This likely requires sparse matrix support to avoid explosion of columns.
@@ -109,6 +110,12 @@ class FeatureHasher(Preprocessor):
         df.loc[:, self.output_column] = pd.Series(list(concatenated))
 
         return df
+
+    def get_input_columns(self) -> List[str]:
+        return self.columns
+
+    def get_output_columns(self) -> List[str]:
+        return [self.output_column]
 
     def __repr__(self):
         return (

--- a/python/ray/data/preprocessors/normalizer.py
+++ b/python/ray/data/preprocessors/normalizer.py
@@ -103,6 +103,7 @@ class Normalizer(Preprocessor):
         *,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.norm = norm
 

--- a/python/ray/data/preprocessors/tokenizer.py
+++ b/python/ray/data/preprocessors/tokenizer.py
@@ -69,6 +69,7 @@ class Tokenizer(Preprocessor):
         tokenization_fn: Optional[Callable[[str], List[str]]] = None,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         # TODO(matt): Add a more robust default tokenizer.
         self.tokenization_fn = tokenization_fn or simple_split_tokenizer

--- a/python/ray/data/preprocessors/torch.py
+++ b/python/ray/data/preprocessors/torch.py
@@ -84,6 +84,7 @@ class TorchVisionPreprocessor(Preprocessor):
         output_columns: Optional[List[str]] = None,
         batched: bool = False,
     ):
+        super().__init__()
         if not output_columns:
             output_columns = columns
         if len(columns) != len(output_columns):
@@ -144,6 +145,12 @@ class TorchVisionPreprocessor(Preprocessor):
             data_batch = transform_batch(data_batch)
 
         return data_batch
+
+    def get_input_columns(self) -> List[str]:
+        return self._columns
+
+    def get_output_columns(self) -> List[str]:
+        return self._output_columns
 
     def preferred_batch_format(cls) -> BatchFormat:
         return BatchFormat.NUMPY

--- a/python/ray/data/preprocessors/transformer.py
+++ b/python/ray/data/preprocessors/transformer.py
@@ -52,6 +52,7 @@ class PowerTransformer(Preprocessor):
         *,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.method = method
         self.power = power

--- a/python/ray/data/preprocessors/utils.py
+++ b/python/ray/data/preprocessors/utils.py
@@ -205,6 +205,9 @@ class StatComputationPlan:
             spec for spec in self._aggregators if isinstance(spec, CallableStatSpec)
         ]
 
+    def has_custom_stat_fn(self):
+        return len(self._get_custom_stat_fn_specs()) > 0
+
     def __iter__(self):
         """
         Iterates over all AggregatorSpecs.

--- a/python/ray/data/preprocessors/vectorizer.py
+++ b/python/ray/data/preprocessors/vectorizer.py
@@ -130,6 +130,7 @@ class HashingVectorizer(Preprocessor):
         *,
         output_columns: Optional[List[str]] = None,
     ):
+        super().__init__()
         self.columns = columns
         self.num_features = num_features
         self.tokenization_fn = tokenization_fn or simple_split_tokenizer

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -31,6 +31,7 @@ from ray.data.preprocessors import (
     SimpleImputer,
     StandardScaler,
     Tokenizer,
+    TorchVisionPreprocessor,
 )
 
 
@@ -451,6 +452,37 @@ def test_get_input_output_columns():
     label_encoder = LabelEncoder(label_column="target", output_column="target_encoded")
     assert label_encoder.get_input_columns() == ["target"]
     assert label_encoder.get_output_columns() == ["target_encoded"]
+
+    # Test Concatenator (uses output_column_name instead of output_columns)
+    concatenator = Concatenator(columns=["A", "B"])
+    assert concatenator.get_input_columns() == ["A", "B"]
+    assert concatenator.get_output_columns() == ["concat_out"]
+
+    concatenator_with_output = Concatenator(
+        columns=["A", "B"], output_column_name="AB_concat"
+    )
+    assert concatenator_with_output.get_input_columns() == ["A", "B"]
+    assert concatenator_with_output.get_output_columns() == ["AB_concat"]
+
+    # Test FeatureHasher (uses output_column instead of output_columns)
+    feature_hasher = FeatureHasher(
+        columns=["token1", "token2"], num_features=8, output_column="hashed"
+    )
+    assert feature_hasher.get_input_columns() == ["token1", "token2"]
+    assert feature_hasher.get_output_columns() == ["hashed"]
+
+    # Test TorchVisionPreprocessor (uses _columns and _output_columns)
+    torch_preprocessor = TorchVisionPreprocessor(
+        columns=["image"], transform=lambda x: x
+    )
+    assert torch_preprocessor.get_input_columns() == ["image"]
+    assert torch_preprocessor.get_output_columns() == ["image"]
+
+    torch_preprocessor_with_output = TorchVisionPreprocessor(
+        columns=["image"], transform=lambda x: x, output_columns=["image_transformed"]
+    )
+    assert torch_preprocessor_with_output.get_input_columns() == ["image"]
+    assert torch_preprocessor_with_output.get_output_columns() == ["image_transformed"]
 
     # Test with preprocessor without columns attribute
     class CustomPreprocessor(Preprocessor):


### PR DESCRIPTION
* Override get_input_columns() and get_output_columns() in preprocessors with non-standard column field names (Concatenator, FeatureHasher, TorchVisionPreprocessor)
* Add super().__init__() calls in preprocessor constructors to ensure proper initialization (Concatenator, FeatureHasher, Normalizer, Tokenizer, TorchVisionPreprocessor, PowerTransformer, HashingVectorizer)
* Add has_custom_stat_fn() utility method to StatComputationPlan
* Add comprehensive test coverage for all preprocessors in Chain

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
