### PR TITLE
[Dashboard] Add dark mode support

### DIFF
--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -155,7 +155,10 @@ const App = () => {
       return stored;
     }
     // Fall back to system preference
-    if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
       return "dark";
     }
     return "light";

--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -198,9 +198,11 @@ const App = () => {
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const handleChange = (e: MediaQueryListEvent) => {
-      // Only update if user hasn't explicitly set a preference
+      // Only update if user hasn't explicitly set a preference via localStorage or URL
       const stored = localStorage.getItem("themeMode");
-      if (!stored) {
+      const urlParams = new URLSearchParams(window.location.search);
+      const urlTheme = urlParams.get("theme");
+      if (!stored && !urlTheme) {
         setThemeMode(e.matches ? "dark" : "light");
       }
     };

--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -149,7 +149,13 @@ export const GlobalContext = React.createContext<GlobalContextType>({
 const App = () => {
   const [currentTimeZone, setCurrentTimeZone] = useState<string>();
   const [themeMode, setThemeMode] = useState<"light" | "dark">(() => {
-    // Check localStorage first
+    // Check URL query param first (for embedded views)
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlTheme = urlParams.get("theme");
+    if (urlTheme === "dark" || urlTheme === "light") {
+      return urlTheme;
+    }
+    // Then check localStorage
     const stored = localStorage.getItem("themeMode");
     if (stored === "dark" || stored === "light") {
       return stored;

--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -196,16 +196,8 @@ const App = () => {
       }
     };
 
-    // Modern browsers
-    if (mediaQuery.addEventListener) {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    // Older browsers
-    else if (mediaQuery.addListener) {
-      mediaQuery.addListener(handleChange);
-      return () => mediaQuery.removeListener(handleChange);
-    }
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, []);
 
   // Authentication state

--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -62,7 +62,7 @@ import {
 } from "./pages/serve/ServeSystemDetailPage";
 import { TaskPage } from "./pages/task/TaskPage";
 import { getNodeList } from "./service/node";
-import { lightTheme } from "./theme";
+import { darkTheme, lightTheme } from "./theme";
 
 dayjs.extend(duration);
 
@@ -118,6 +118,14 @@ export type GlobalContextType = {
    * The globally selected current time zone.
    */
   currentTimeZone: string | undefined;
+  /**
+   * The current theme mode (light or dark)
+   */
+  themeMode: "light" | "dark";
+  /**
+   * Function to toggle between light and dark mode
+   */
+  toggleTheme: () => void;
 };
 export const GlobalContext = React.createContext<GlobalContextType>({
   nodeMap: {},
@@ -133,12 +141,19 @@ export const GlobalContext = React.createContext<GlobalContextType>({
   dashboardDatasource: undefined,
   serverTimeZone: undefined,
   currentTimeZone: undefined,
+  themeMode: "light",
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleTheme: () => {},
 });
 
 const App = () => {
   const [currentTimeZone, setCurrentTimeZone] = useState<string>();
+  const [themeMode, setThemeMode] = useState<"light" | "dark">(() => {
+    const stored = localStorage.getItem("themeMode");
+    return stored === "dark" ? "dark" : "light";
+  });
   const [context, setContext] = useState<
-    Omit<GlobalContextType, "currentTimeZone">
+    Omit<GlobalContextType, "currentTimeZone" | "themeMode" | "toggleTheme">
   >({
     nodeMap: {},
     nodeMapByIp: {},
@@ -153,6 +168,14 @@ const App = () => {
     dashboardDatasource: undefined,
     serverTimeZone: undefined,
   });
+
+  const toggleTheme = () => {
+    setThemeMode((prevMode) => {
+      const newMode = prevMode === "light" ? "dark" : "light";
+      localStorage.setItem("themeMode", newMode);
+      return newMode;
+    });
+  };
 
   // Authentication state
   const [authenticationDialogOpen, setAuthenticationDialogOpen] =
@@ -307,11 +330,15 @@ const App = () => {
     }
   };
 
+  const currentTheme = themeMode === "dark" ? darkTheme : lightTheme;
+
   return (
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={lightTheme}>
+      <ThemeProvider theme={currentTheme}>
         <Suspense fallback={Loading}>
-          <GlobalContext.Provider value={{ ...context, currentTimeZone }}>
+          <GlobalContext.Provider
+            value={{ ...context, currentTimeZone, themeMode, toggleTheme }}
+          >
             <CssBaseline />
             <TokenAuthenticationDialog
               open={authenticationDialogOpen}

--- a/python/ray/dashboard/client/src/authentication/TokenAuthenticationDialog.tsx
+++ b/python/ray/dashboard/client/src/authentication/TokenAuthenticationDialog.tsx
@@ -118,7 +118,7 @@ export const TokenAuthenticationDialog: React.FC<TokenAuthenticationDialogProps>
                     edge="end"
                     disabled={isSubmitting}
                   >
-                    {showToken ? <VisibilityOff /> : <Visibility />}
+                    {showToken ? <VisibilityOff sx={(theme) => ({ color: theme.palette.text.secondary })} /> : <Visibility sx={(theme) => ({ color: theme.palette.text.secondary })} />}
                   </IconButton>
                 </InputAdornment>
               ),

--- a/python/ray/dashboard/client/src/authentication/TokenAuthenticationDialog.tsx
+++ b/python/ray/dashboard/client/src/authentication/TokenAuthenticationDialog.tsx
@@ -118,7 +118,19 @@ export const TokenAuthenticationDialog: React.FC<TokenAuthenticationDialogProps>
                     edge="end"
                     disabled={isSubmitting}
                   >
-                    {showToken ? <VisibilityOff sx={(theme) => ({ color: theme.palette.text.secondary })} /> : <Visibility sx={(theme) => ({ color: theme.palette.text.secondary })} />}
+                    {showToken ? (
+                      <VisibilityOff
+                        sx={(theme) => ({
+                          color: theme.palette.text.secondary,
+                        })}
+                      />
+                    ) : (
+                      <Visibility
+                        sx={(theme) => ({
+                          color: theme.palette.text.secondary,
+                        })}
+                      />
+                    )}
                   </IconButton>
                 </InputAdornment>
               ),

--- a/python/ray/dashboard/client/src/common/DialogWithTitle.tsx
+++ b/python/ray/dashboard/client/src/common/DialogWithTitle.tsx
@@ -29,7 +29,9 @@ class DialogWithTitle extends React.Component<PropsWithChildren<Props>> {
           onClick={handleClose}
           size="large"
         >
-          <CloseIcon sx={(theme) => ({ color: theme.palette.text.secondary })} />
+          <CloseIcon
+            sx={(theme) => ({ color: theme.palette.text.secondary })}
+          />
         </IconButton>
         <Typography
           sx={(theme) => ({

--- a/python/ray/dashboard/client/src/common/DialogWithTitle.tsx
+++ b/python/ray/dashboard/client/src/common/DialogWithTitle.tsx
@@ -29,7 +29,7 @@ class DialogWithTitle extends React.Component<PropsWithChildren<Props>> {
           onClick={handleClose}
           size="large"
         >
-          <CloseIcon />
+          <CloseIcon sx={(theme) => ({ color: theme.palette.text.secondary })} />
         </IconButton>
         <Typography
           sx={(theme) => ({

--- a/python/ray/dashboard/client/src/common/ExpandControls.tsx
+++ b/python/ray/dashboard/client/src/common/ExpandControls.tsx
@@ -11,9 +11,9 @@ type ExpanderProps = {
 };
 
 export const Minimizer: React.FC<MinimizerProps> = ({ onClick }) => (
-  <ExpandLessIcon onClick={onClick} />
+  <ExpandLessIcon onClick={onClick} sx={(theme) => ({ color: theme.palette.text.secondary })} />
 );
 
 export const Expander: React.FC<ExpanderProps> = ({ onClick }) => (
-  <ExpandMoreIcon onClick={onClick} />
+  <ExpandMoreIcon onClick={onClick} sx={(theme) => ({ color: theme.palette.text.secondary })} />
 );

--- a/python/ray/dashboard/client/src/common/ExpandControls.tsx
+++ b/python/ray/dashboard/client/src/common/ExpandControls.tsx
@@ -11,9 +11,15 @@ type ExpanderProps = {
 };
 
 export const Minimizer: React.FC<MinimizerProps> = ({ onClick }) => (
-  <ExpandLessIcon onClick={onClick} sx={(theme) => ({ color: theme.palette.text.secondary })} />
+  <ExpandLessIcon
+    onClick={onClick}
+    sx={(theme) => ({ color: theme.palette.text.secondary })}
+  />
 );
 
 export const Expander: React.FC<ExpanderProps> = ({ onClick }) => (
-  <ExpandMoreIcon onClick={onClick} sx={(theme) => ({ color: theme.palette.text.secondary })} />
+  <ExpandMoreIcon
+    onClick={onClick}
+    sx={(theme) => ({ color: theme.palette.text.secondary })}
+  />
 );

--- a/python/ray/dashboard/client/src/common/JobStatus.tsx
+++ b/python/ray/dashboard/client/src/common/JobStatus.tsx
@@ -38,7 +38,7 @@ export const JobRunningIcon = ({
         {
           width: small ? 16 : 20,
           height: small ? 16 : 20,
-          color: "#1E88E5",
+          color: (theme) => theme.palette.primary.main,
           animation: `${spinner} 1s linear infinite`,
         },
         ...(Array.isArray(sx) ? sx : [sx]),
@@ -101,7 +101,7 @@ export const JobStatusIcon = ({
             {
               width: small ? 16 : 20,
               height: small ? 16 : 20,
-              color: "#757575",
+              color: (theme) => theme.palette.text.secondary,
             },
             ...(Array.isArray(sx) ? sx : [sx]),
           ]}

--- a/python/ray/dashboard/client/src/common/LabeledDatum.tsx
+++ b/python/ray/dashboard/client/src/common/LabeledDatum.tsx
@@ -16,11 +16,11 @@ const LabeledDatum: React.FC<LabeledDatumProps> = ({
     <Grid container item xs={12}>
       <Grid item xs={6}>
         <Box
-          sx={
+          sx={(theme) =>
             tooltip
               ? {
                   textDecorationLine: "underline",
-                  textDecorationColor: "#a6c3e3",
+                  textDecorationColor: theme.palette.primary.light,
                   textDecorationThickness: "1px",
                   textDecorationStyle: "dotted",
                   cursor: "help",

--- a/python/ray/dashboard/client/src/common/MultiTabLogViewer.tsx
+++ b/python/ray/dashboard/client/src/common/MultiTabLogViewer.tsx
@@ -132,6 +132,7 @@ export const MultiTabLogViewer = ({
             setExpanded(!expanded);
           }}
           size="large"
+          sx={{ '& svg': { color: 'text.secondary' } }}
         >
           {expanded ? <RiSortAsc /> : <RiSortDesc />}
         </IconButton>

--- a/python/ray/dashboard/client/src/common/MultiTabLogViewer.tsx
+++ b/python/ray/dashboard/client/src/common/MultiTabLogViewer.tsx
@@ -132,7 +132,7 @@ export const MultiTabLogViewer = ({
             setExpanded(!expanded);
           }}
           size="large"
-          sx={(theme) => ({ '& svg': { color: theme.palette.text.secondary } })}
+          sx={(theme) => ({ "& svg": { color: theme.palette.text.secondary } })}
         >
           {expanded ? <RiSortAsc /> : <RiSortDesc />}
         </IconButton>

--- a/python/ray/dashboard/client/src/common/MultiTabLogViewer.tsx
+++ b/python/ray/dashboard/client/src/common/MultiTabLogViewer.tsx
@@ -132,7 +132,7 @@ export const MultiTabLogViewer = ({
             setExpanded(!expanded);
           }}
           size="large"
-          sx={{ '& svg': { color: 'text.secondary' } }}
+          sx={(theme) => ({ '& svg': { color: theme.palette.text.secondary } })}
         >
           {expanded ? <RiSortAsc /> : <RiSortDesc />}
         </IconButton>

--- a/python/ray/dashboard/client/src/common/ProfilingLink.tsx
+++ b/python/ray/dashboard/client/src/common/ProfilingLink.tsx
@@ -257,7 +257,7 @@ export const ProfilerButton = ({
           <Button
             onClick={handleClose}
             variant="text"
-            sx={{ textTransform: "capitalize", color: "#5F6469" }}
+            sx={(theme) => ({ textTransform: "capitalize", color: theme.palette.text.secondary })}
           >
             Cancel
           </Button>

--- a/python/ray/dashboard/client/src/common/ProfilingLink.tsx
+++ b/python/ray/dashboard/client/src/common/ProfilingLink.tsx
@@ -257,7 +257,10 @@ export const ProfilerButton = ({
           <Button
             onClick={handleClose}
             variant="text"
-            sx={(theme) => ({ textTransform: "capitalize", color: theme.palette.text.secondary })}
+            sx={(theme) => ({
+              textTransform: "capitalize",
+              color: theme.palette.text.secondary,
+            })}
           >
             Cancel
           </Button>

--- a/python/ray/dashboard/client/src/common/SortableTableHead.tsx
+++ b/python/ray/dashboard/client/src/common/SortableTableHead.tsx
@@ -39,7 +39,7 @@ const SortableTableHead = <T,>(props: SortableTableHeadProps<T>) => {
                   active={orderBy === headerInfo.id}
                   direction={orderBy === headerInfo.id ? order : "asc"}
                   onClick={createSortHandler(headerInfo.id)}
-                  sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+                  sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
                 >
                   {headerInfo.label}
                   {orderBy === headerInfo.id ? (

--- a/python/ray/dashboard/client/src/common/SortableTableHead.tsx
+++ b/python/ray/dashboard/client/src/common/SortableTableHead.tsx
@@ -39,7 +39,11 @@ const SortableTableHead = <T,>(props: SortableTableHeadProps<T>) => {
                   active={orderBy === headerInfo.id}
                   direction={orderBy === headerInfo.id ? order : "asc"}
                   onClick={createSortHandler(headerInfo.id)}
-                  sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
+                  sx={(theme) => ({
+                    "& .MuiSvgIcon-root": {
+                      color: theme.palette.text.secondary,
+                    },
+                  })}
                 >
                   {headerInfo.label}
                   {orderBy === headerInfo.id ? (

--- a/python/ray/dashboard/client/src/common/SortableTableHead.tsx
+++ b/python/ray/dashboard/client/src/common/SortableTableHead.tsx
@@ -39,6 +39,7 @@ const SortableTableHead = <T,>(props: SortableTableHeadProps<T>) => {
                   active={orderBy === headerInfo.id}
                   direction={orderBy === headerInfo.id ? order : "asc"}
                   onClick={createSortHandler(headerInfo.id)}
+                  sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
                 >
                   {headerInfo.label}
                   {orderBy === headerInfo.id ? (

--- a/python/ray/dashboard/client/src/components/ActorTable.component.test.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.component.test.tsx
@@ -232,7 +232,7 @@ describe("ActorTable", () => {
       - Used memory: Actor 1 memory > Actor 2 memory --> Actor 1 row before Actor 2 row
       - Uptime: Actor 2 uptime < Actor 1 uptime --> Actor 2 row before Actor 1 row
       - GPU Utilization: Actor 1 GPU > Actor 2 GPU --> Actor 1 row before Actor 2 row
-      - VRAM Utilization: Actor 2 VRAM > Actor 1 VRAM --> Actor 2 row before Actor 1 row
+      - GRAM Utilization: Actor 2 GRAM > Actor 1 GRAM --> Actor 2 row before Actor 1 row
     */
     const RUNNING_ACTORS = {
       ...MOCK_ACTORS,
@@ -373,18 +373,18 @@ describe("ActorTable", () => {
       Node.DOCUMENT_POSITION_FOLLOWING,
     ); // actor1Row appear before actor2Row
 
-    // Sort by VRAM usage
+    // Sort by GRAM usage
     await user.click(screen.getByRole("combobox", { name: /Sort By/ }));
-    await user.click(screen.getByRole("option", { name: /VRAM Usage/ }));
-    const actor1VRAMRow = screen.getByRole("row", {
+    await user.click(screen.getByRole("option", { name: /GRAM Usage/ }));
+    const actor1GRAMRow = screen.getByRole("row", {
       name: /ACTOR_1/,
     });
-    const actor2VRAMRow = screen.getByRole("row", {
+    const actor2GRAMRow = screen.getByRole("row", {
       name: /ACTOR_2/,
     });
-    expect(within(actor1VRAMRow).getByText("ACTOR_1")).toBeInTheDocument();
-    expect(within(actor2VRAMRow).getByText("ACTOR_2")).toBeInTheDocument();
-    expect(actor2VRAMRow.compareDocumentPosition(actor1VRAMRow)).toBe(
+    expect(within(actor1GRAMRow).getByText("ACTOR_1")).toBeInTheDocument();
+    expect(within(actor2GRAMRow).getByText("ACTOR_2")).toBeInTheDocument();
+    expect(actor2GRAMRow.compareDocumentPosition(actor1GRAMRow)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     ); // actor2Row appear before actor1Row
   });

--- a/python/ray/dashboard/client/src/components/ActorTable.component.test.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.component.test.tsx
@@ -232,7 +232,7 @@ describe("ActorTable", () => {
       - Used memory: Actor 1 memory > Actor 2 memory --> Actor 1 row before Actor 2 row
       - Uptime: Actor 2 uptime < Actor 1 uptime --> Actor 2 row before Actor 1 row
       - GPU Utilization: Actor 1 GPU > Actor 2 GPU --> Actor 1 row before Actor 2 row
-      - GRAM Utilization: Actor 2 GRAM > Actor 1 GRAM --> Actor 2 row before Actor 1 row
+      - VRAM Utilization: Actor 2 VRAM > Actor 1 VRAM --> Actor 2 row before Actor 1 row
     */
     const RUNNING_ACTORS = {
       ...MOCK_ACTORS,
@@ -373,18 +373,18 @@ describe("ActorTable", () => {
       Node.DOCUMENT_POSITION_FOLLOWING,
     ); // actor1Row appear before actor2Row
 
-    // Sort by GRAM usage
+    // Sort by VRAM usage
     await user.click(screen.getByRole("combobox", { name: /Sort By/ }));
-    await user.click(screen.getByRole("option", { name: /GRAM Usage/ }));
-    const actor1GRAMRow = screen.getByRole("row", {
+    await user.click(screen.getByRole("option", { name: /VRAM Usage/ }));
+    const actor1VRAMRow = screen.getByRole("row", {
       name: /ACTOR_1/,
     });
-    const actor2GRAMRow = screen.getByRole("row", {
+    const actor2VRAMRow = screen.getByRole("row", {
       name: /ACTOR_2/,
     });
-    expect(within(actor1GRAMRow).getByText("ACTOR_1")).toBeInTheDocument();
-    expect(within(actor2GRAMRow).getByText("ACTOR_2")).toBeInTheDocument();
-    expect(actor2GRAMRow.compareDocumentPosition(actor1GRAMRow)).toBe(
+    expect(within(actor1VRAMRow).getByText("ACTOR_1")).toBeInTheDocument();
+    expect(within(actor2VRAMRow).getByText("ACTOR_2")).toBeInTheDocument();
+    expect(actor2VRAMRow.compareDocumentPosition(actor1VRAMRow)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     ); // actor2Row appear before actor1Row
   });

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -346,6 +346,7 @@ const ActorTable = ({
       <Box sx={{ display: "flex", flex: 1, alignItems: "center" }}>
         <Autocomplete
           style={{ margin: 8, width: 120 }}
+          sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.state)),
           )}
@@ -358,6 +359,7 @@ const ActorTable = ({
         />
         <Autocomplete
           style={{ margin: 8, width: 150 }}
+          sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
           defaultValue={filterToActorId === undefined ? jobId : undefined}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.jobId)),
@@ -371,6 +373,7 @@ const ActorTable = ({
         />
         <Autocomplete
           style={{ margin: 8, width: 150 }}
+          sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.address?.ipAddress)),
           )}
@@ -384,6 +387,7 @@ const ActorTable = ({
         <Autocomplete
           data-testid="nodeIdFilter"
           style={{ margin: 8, width: 150 }}
+          sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.address?.nodeId)),
           )}
@@ -404,7 +408,7 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined />
+                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
               </InputAdornment>
             ),
           }}
@@ -421,7 +425,7 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined />
+                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
               </InputAdornment>
             ),
           }}
@@ -436,7 +440,7 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined />
+                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
               </InputAdornment>
             ),
           }}
@@ -451,7 +455,7 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined />
+                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
               </InputAdornment>
             ),
           }}
@@ -466,7 +470,7 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined />
+                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
               </InputAdornment>
             ),
           }}
@@ -483,7 +487,7 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined />
+                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
               </InputAdornment>
             ),
           }}

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -346,7 +346,9 @@ const ActorTable = ({
       <Box sx={{ display: "flex", flex: 1, alignItems: "center" }}>
         <Autocomplete
           style={{ margin: 8, width: 120 }}
-          sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
+          sx={(theme) => ({
+            "& .MuiSvgIcon-root": { color: theme.palette.text.secondary },
+          })}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.state)),
           )}
@@ -359,7 +361,9 @@ const ActorTable = ({
         />
         <Autocomplete
           style={{ margin: 8, width: 150 }}
-          sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
+          sx={(theme) => ({
+            "& .MuiSvgIcon-root": { color: theme.palette.text.secondary },
+          })}
           defaultValue={filterToActorId === undefined ? jobId : undefined}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.jobId)),
@@ -373,7 +377,9 @@ const ActorTable = ({
         />
         <Autocomplete
           style={{ margin: 8, width: 150 }}
-          sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
+          sx={(theme) => ({
+            "& .MuiSvgIcon-root": { color: theme.palette.text.secondary },
+          })}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.address?.ipAddress)),
           )}
@@ -387,7 +393,9 @@ const ActorTable = ({
         <Autocomplete
           data-testid="nodeIdFilter"
           style={{ margin: 8, width: 150 }}
-          sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
+          sx={(theme) => ({
+            "& .MuiSvgIcon-root": { color: theme.palette.text.secondary },
+          })}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.address?.nodeId)),
           )}
@@ -408,7 +416,9 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+                <SearchOutlined
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                />
               </InputAdornment>
             ),
           }}
@@ -425,7 +435,9 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+                <SearchOutlined
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                />
               </InputAdornment>
             ),
           }}
@@ -440,7 +452,9 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+                <SearchOutlined
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                />
               </InputAdornment>
             ),
           }}
@@ -455,7 +469,9 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+                <SearchOutlined
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                />
               </InputAdornment>
             ),
           }}
@@ -470,7 +486,9 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+                <SearchOutlined
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                />
               </InputAdornment>
             ),
           }}
@@ -487,7 +505,9 @@ const ActorTable = ({
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+                <SearchOutlined
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                />
               </InputAdornment>
             ),
           }}

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -31,7 +31,7 @@ import {
 import rowStyles from "../common/RowStyles";
 import { sliceToPage } from "../common/util";
 import { getSumGpuUtilization, WorkerGpuRow } from "../pages/node/GPUColumn";
-import { getSumVRAMUsage, WorkerVRAM } from "../pages/node/VRAMColumn";
+import { getSumGRAMUsage, WorkerGRAM } from "../pages/node/GRAMColumn";
 import { ActorDetail, ActorEnum } from "../type/actor";
 import { Worker } from "../type/worker";
 import { memoryConverter } from "../util/converter";
@@ -112,7 +112,7 @@ const ActorTable = ({
     const actorList = Object.values(actors || {}).filter(filterFunc);
     let actorsSortedUserKey = actorList;
     if (aggregateUserSortKeys.includes(sorterKey)) {
-      // Uptime, GPU utilization, and VRAM usage are user specified sort keys but require an aggregate function
+      // Uptime, GPU utilization, and GRAM usage are user specified sort keys but require an aggregate function
       // over the actor attribute, so sorting with sortBy
       actorsSortedUserKey = _.sortBy(actorList, (actor) => {
         const descMultiplier = descVal ? 1 : -1;
@@ -137,8 +137,8 @@ const ActorTable = ({
             );
             return sumGpuUtilization * descMultiplier;
           case gramUsageSorterKey:
-            const sumVRAMUsage = getSumVRAMUsage(actor.pid, actor.gpus);
-            return sumVRAMUsage * descMultiplier;
+            const sumGRAMUsage = getSumGRAMUsage(actor.pid, actor.gpus);
+            return sumGRAMUsage * descMultiplier;
           default:
             return 0;
         }
@@ -285,10 +285,10 @@ const ActorTable = ({
       ),
     },
     {
-      label: "VRAM",
+      label: "GRAM",
       helpInfo: (
         <Typography>
-          Actor's VRAM usage (from Worker Process). <br />
+          Actor's GRAM usage (from Worker Process). <br />
         </Typography>
       ),
     },
@@ -535,9 +535,9 @@ const ActorTable = ({
               ["mem[0]", "Total Memory"],
               ["processStats.cpuPercent", "CPU"],
               // Fake attribute key used when sorting by GPU utilization and
-              // VRAM usage because aggregate function required on actor key before sorting.
+              // GRAM usage because aggregate function required on actor key before sorting.
               [gpuUtilizationSorterKey, "GPU Utilization"],
-              [gramUsageSorterKey, "VRAM Usage"],
+              [gramUsageSorterKey, "GRAM Usage"],
             ]}
             onChange={(val) => setSortKey(val)}
             showAllOption={false}
@@ -751,7 +751,7 @@ const ActorTable = ({
                     <WorkerGpuRow workerPID={pid} gpus={gpus} />
                   </TableCell>
                   <TableCell>
-                    <WorkerVRAM workerPID={pid} gpus={gpus} />
+                    <WorkerGRAM workerPID={pid} gpus={gpus} />
                   </TableCell>
                   <TableCell
                     align="center"

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -31,7 +31,7 @@ import {
 import rowStyles from "../common/RowStyles";
 import { sliceToPage } from "../common/util";
 import { getSumGpuUtilization, WorkerGpuRow } from "../pages/node/GPUColumn";
-import { getSumGRAMUsage, WorkerGRAM } from "../pages/node/GRAMColumn";
+import { getSumVRAMUsage, WorkerVRAM } from "../pages/node/VRAMColumn";
 import { ActorDetail, ActorEnum } from "../type/actor";
 import { Worker } from "../type/worker";
 import { memoryConverter } from "../util/converter";
@@ -137,8 +137,8 @@ const ActorTable = ({
             );
             return sumGpuUtilization * descMultiplier;
           case gramUsageSorterKey:
-            const sumGRAMUsage = getSumGRAMUsage(actor.pid, actor.gpus);
-            return sumGRAMUsage * descMultiplier;
+            const sumVRAMUsage = getSumVRAMUsage(actor.pid, actor.gpus);
+            return sumVRAMUsage * descMultiplier;
           default:
             return 0;
         }
@@ -731,7 +731,7 @@ const ActorTable = ({
                     <WorkerGpuRow workerPID={pid} gpus={gpus} />
                   </TableCell>
                   <TableCell>
-                    <WorkerGRAM workerPID={pid} gpus={gpus} />
+                    <WorkerVRAM workerPID={pid} gpus={gpus} />
                   </TableCell>
                   <TableCell
                     align="center"

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -112,7 +112,7 @@ const ActorTable = ({
     const actorList = Object.values(actors || {}).filter(filterFunc);
     let actorsSortedUserKey = actorList;
     if (aggregateUserSortKeys.includes(sorterKey)) {
-      // Uptime, GPU utilization, and GRAM usage are user specified sort keys but require an aggregate function
+      // Uptime, GPU utilization, and VRAM usage are user specified sort keys but require an aggregate function
       // over the actor attribute, so sorting with sortBy
       actorsSortedUserKey = _.sortBy(actorList, (actor) => {
         const descMultiplier = descVal ? 1 : -1;
@@ -285,10 +285,10 @@ const ActorTable = ({
       ),
     },
     {
-      label: "GRAM",
+      label: "VRAM",
       helpInfo: (
         <Typography>
-          Actor's GRAM usage (from Worker Process). <br />
+          Actor's VRAM usage (from Worker Process). <br />
         </Typography>
       ),
     },
@@ -515,9 +515,9 @@ const ActorTable = ({
               ["mem[0]", "Total Memory"],
               ["processStats.cpuPercent", "CPU"],
               // Fake attribute key used when sorting by GPU utilization and
-              // GRAM usage because aggregate function required on actor key before sorting.
+              // VRAM usage because aggregate function required on actor key before sorting.
               [gpuUtilizationSorterKey, "GPU Utilization"],
-              [gramUsageSorterKey, "GRAM Usage"],
+              [gramUsageSorterKey, "VRAM Usage"],
             ]}
             onChange={(val) => setSortKey(val)}
             showAllOption={false}

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -346,7 +346,7 @@ const ActorTable = ({
       <Box sx={{ display: "flex", flex: 1, alignItems: "center" }}>
         <Autocomplete
           style={{ margin: 8, width: 120 }}
-          sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+          sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.state)),
           )}
@@ -359,7 +359,7 @@ const ActorTable = ({
         />
         <Autocomplete
           style={{ margin: 8, width: 150 }}
-          sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+          sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
           defaultValue={filterToActorId === undefined ? jobId : undefined}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.jobId)),
@@ -373,7 +373,7 @@ const ActorTable = ({
         />
         <Autocomplete
           style={{ margin: 8, width: 150 }}
-          sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+          sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.address?.ipAddress)),
           )}
@@ -387,7 +387,7 @@ const ActorTable = ({
         <Autocomplete
           data-testid="nodeIdFilter"
           style={{ margin: 8, width: 150 }}
-          sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+          sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
           options={Array.from(
             new Set(Object.values(actors).map((e) => e.address?.nodeId)),
           )}

--- a/python/ray/dashboard/client/src/components/EventTable.tsx
+++ b/python/ray/dashboard/client/src/components/EventTable.tsx
@@ -140,7 +140,7 @@ const EventTable = (props: EventTableProps) => {
         }}
       >
         <Autocomplete
-          sx={{ margin: 1, display: "inline-block", fontSize: 12 }}
+          sx={{ margin: 1, display: "inline-block", fontSize: 12, '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
           style={{ width: 200 }}
           options={labelOptions}
           onInputChange={(_: any, value: string) => {
@@ -151,7 +151,7 @@ const EventTable = (props: EventTableProps) => {
           )}
         />
         <Autocomplete
-          sx={{ margin: 1, display: "inline-block", fontSize: 12 }}
+          sx={{ margin: 1, display: "inline-block", fontSize: 12, '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
           style={{ width: 200 }}
           options={hostOptions}
           onInputChange={(_: any, value: string) => {
@@ -162,7 +162,7 @@ const EventTable = (props: EventTableProps) => {
           )}
         />
         <Autocomplete
-          sx={{ margin: 1, display: "inline-block", fontSize: 12 }}
+          sx={{ margin: 1, display: "inline-block", fontSize: 12, '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
           style={{ width: 100 }}
           options={sourceOptions}
           onInputChange={(_: any, value: string) => {
@@ -173,7 +173,7 @@ const EventTable = (props: EventTableProps) => {
           )}
         />
         <Autocomplete
-          sx={{ margin: 1, display: "inline-block", fontSize: 12 }}
+          sx={{ margin: 1, display: "inline-block", fontSize: 12, '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
           style={{ width: 140 }}
           options={severityOptions}
           onInputChange={(_: any, value: string) => {
@@ -192,7 +192,7 @@ const EventTable = (props: EventTableProps) => {
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined />
+                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
               </InputAdornment>
             ),
           }}

--- a/python/ray/dashboard/client/src/components/EventTable.tsx
+++ b/python/ray/dashboard/client/src/components/EventTable.tsx
@@ -140,7 +140,12 @@ const EventTable = (props: EventTableProps) => {
         }}
       >
         <Autocomplete
-          sx={{ margin: 1, display: "inline-block", fontSize: 12, '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+          sx={{
+            margin: 1,
+            display: "inline-block",
+            fontSize: 12,
+            "& .MuiSvgIcon-root": { color: "text.secondary" },
+          }}
           style={{ width: 200 }}
           options={labelOptions}
           onInputChange={(_: any, value: string) => {
@@ -151,7 +156,12 @@ const EventTable = (props: EventTableProps) => {
           )}
         />
         <Autocomplete
-          sx={{ margin: 1, display: "inline-block", fontSize: 12, '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+          sx={{
+            margin: 1,
+            display: "inline-block",
+            fontSize: 12,
+            "& .MuiSvgIcon-root": { color: "text.secondary" },
+          }}
           style={{ width: 200 }}
           options={hostOptions}
           onInputChange={(_: any, value: string) => {
@@ -162,7 +172,12 @@ const EventTable = (props: EventTableProps) => {
           )}
         />
         <Autocomplete
-          sx={{ margin: 1, display: "inline-block", fontSize: 12, '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+          sx={{
+            margin: 1,
+            display: "inline-block",
+            fontSize: 12,
+            "& .MuiSvgIcon-root": { color: "text.secondary" },
+          }}
           style={{ width: 100 }}
           options={sourceOptions}
           onInputChange={(_: any, value: string) => {
@@ -173,7 +188,12 @@ const EventTable = (props: EventTableProps) => {
           )}
         />
         <Autocomplete
-          sx={{ margin: 1, display: "inline-block", fontSize: 12, '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+          sx={{
+            margin: 1,
+            display: "inline-block",
+            fontSize: 12,
+            "& .MuiSvgIcon-root": { color: "text.secondary" },
+          }}
           style={{ width: 140 }}
           options={severityOptions}
           onInputChange={(_: any, value: string) => {
@@ -192,7 +212,9 @@ const EventTable = (props: EventTableProps) => {
             },
             endAdornment: (
               <InputAdornment position="end">
-                <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+                <SearchOutlined
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                />
               </InputAdornment>
             ),
           }}

--- a/python/ray/dashboard/client/src/components/ListItemCard.tsx
+++ b/python/ray/dashboard/client/src/components/ListItemCard.tsx
@@ -101,7 +101,10 @@ const ListItem = ({
           width: `calc(100% - calc(${theme.spacing(1)} + 20px))`,
         })}
       >
-        <Typography sx={(theme) => ({ color: theme.palette.primary.main })} variant="body2">
+        <Typography
+          sx={(theme) => ({ color: theme.palette.primary.main })}
+          variant="body2"
+        >
           {title}
         </Typography>
         <Typography

--- a/python/ray/dashboard/client/src/components/ListItemCard.tsx
+++ b/python/ray/dashboard/client/src/components/ListItemCard.tsx
@@ -101,7 +101,7 @@ const ListItem = ({
           width: `calc(100% - calc(${theme.spacing(1)} + 20px))`,
         })}
       >
-        <Typography sx={{ color: "#036DCF" }} variant="body2">
+        <Typography sx={(theme) => ({ color: theme.palette.primary.main }} variant="body2">
           {title}
         </Typography>
         <Typography

--- a/python/ray/dashboard/client/src/components/ListItemCard.tsx
+++ b/python/ray/dashboard/client/src/components/ListItemCard.tsx
@@ -101,7 +101,7 @@ const ListItem = ({
           width: `calc(100% - calc(${theme.spacing(1)} + 20px))`,
         })}
       >
-        <Typography sx={(theme) => ({ color: theme.palette.primary.main }} variant="body2">
+        <Typography sx={(theme) => ({ color: theme.palette.primary.main })} variant="body2">
           {title}
         </Typography>
         <Typography

--- a/python/ray/dashboard/client/src/components/ListItemCard.tsx
+++ b/python/ray/dashboard/client/src/components/ListItemCard.tsx
@@ -105,12 +105,12 @@ const ListItem = ({
           {title}
         </Typography>
         <Typography
-          sx={{
+          sx={(theme) => ({
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
-            color: "#5F6469",
-          }}
+            color: theme.palette.text.secondary,
+          })}
           title={subtitle}
           variant="caption"
         >

--- a/python/ray/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/python/ray/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -132,7 +132,10 @@ const LogLineDetailDialog = ({
               <Box
                 sx={(theme) => ({
                   padding: 1,
-                  bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[200],
+                  bgcolor:
+                    theme.palette.mode === "dark"
+                      ? theme.palette.grey[900]
+                      : theme.palette.grey[200],
                   borderRadius: 1,
                   border: `1px solid ${theme.palette.divider}`,
                   marginBottom: 2,
@@ -164,7 +167,10 @@ const LogLineDetailDialog = ({
           <Box
             sx={(theme) => ({
               padding: 1,
-              bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[200],
+              bgcolor:
+                theme.palette.mode === "dark"
+                  ? theme.palette.grey[900]
+                  : theme.palette.grey[200],
               borderRadius: 1,
               border: `1px solid ${theme.palette.divider}`,
             })}

--- a/python/ray/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/python/ray/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -132,7 +132,7 @@ const LogLineDetailDialog = ({
               <Box
                 sx={(theme) => ({
                   padding: 1,
-                  bgcolor: "#EEEEEE",
+                  bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[200],
                   borderRadius: 1,
                   border: `1px solid ${theme.palette.divider}`,
                   marginBottom: 2,
@@ -164,7 +164,7 @@ const LogLineDetailDialog = ({
           <Box
             sx={(theme) => ({
               padding: 1,
-              bgcolor: "#EEEEEE",
+              bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[200],
               borderRadius: 1,
               border: `1px solid ${theme.palette.divider}`,
             })}
@@ -254,13 +254,13 @@ const LogVirtualView: React.FC<LogVirtualViewProps> = ({
         sx={{
           overflowX: "visible",
           whiteSpace: "nowrap",
-          "&::before": {
+          "&::before": (theme) => ({
             content: `"${i + 1}"`,
             marginRight: 0.5,
             width: `${logs.length}`.length * 6 + 4,
-            color: "#999",
+            color: theme.palette.text.disabled,
             display: "inline-block",
-          },
+          }),
         }}
         onClick={() => {
           if ((window.getSelection()?.toString().length ?? 0) === 0) {

--- a/python/ray/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/python/ray/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -251,17 +251,17 @@ const LogVirtualView: React.FC<LogVirtualViewProps> = ({
       <Box
         key={`${index}list`}
         style={style}
-        sx={{
+        sx={(theme) => ({
           overflowX: "visible",
           whiteSpace: "nowrap",
-          "&::before": (theme) => ({
+          "&::before": {
             content: `"${i + 1}"`,
             marginRight: 0.5,
             width: `${logs.length}`.length * 6 + 4,
             color: theme.palette.text.disabled,
             display: "inline-block",
-          }),
-        }}
+          },
+        })}
         onClick={() => {
           if ((window.getSelection()?.toString().length ?? 0) === 0) {
             // Only open if user is not selecting text

--- a/python/ray/dashboard/client/src/components/LogView/index.css
+++ b/python/ray/dashboard/client/src/components/LogView/index.css
@@ -1,11 +1,10 @@
-span.find-kws {
+/* Light mode - default yellow highlight */
+.hljs-light span.find-kws {
   background-color: #ffd800;
 }
 
-/* Dark mode support for find keywords */
-@media (prefers-color-scheme: dark) {
-  span.find-kws {
-    background-color: #b89700;
-    color: #ffffff;
-  }
+/* Dark mode - darker yellow with white text for better contrast */
+.hljs-dark span.find-kws {
+  background-color: #b89700;
+  color: #ffffff;
 }

--- a/python/ray/dashboard/client/src/components/LogView/index.css
+++ b/python/ray/dashboard/client/src/components/LogView/index.css
@@ -1,3 +1,11 @@
 span.find-kws {
   background-color: #ffd800;
 }
+
+/* Dark mode support for find keywords */
+@media (prefers-color-scheme: dark) {
+  span.find-kws {
+    background-color: #b89700;
+    color: #ffffff;
+  }
+}

--- a/python/ray/dashboard/client/src/components/MetadataSection/MetadataSection.tsx
+++ b/python/ray/dashboard/client/src/components/MetadataSection/MetadataSection.tsx
@@ -84,7 +84,7 @@ export const MetadataContentField: React.FC<{
         onMouseEnter={() => setCopyIconClicked(false)}
         onMouseLeave={() => setTimeout(() => setCopyIconClicked(false), 333)}
         size="small"
-        sx={{ color: "black", marginLeft: 0.5 }}
+        sx={(theme) => ({ color: theme.palette.text.secondary, marginLeft: 0.5 })}
       >
         <RiFileCopyLine />
       </IconButton>

--- a/python/ray/dashboard/client/src/components/MetadataSection/MetadataSection.tsx
+++ b/python/ray/dashboard/client/src/components/MetadataSection/MetadataSection.tsx
@@ -84,7 +84,10 @@ export const MetadataContentField: React.FC<{
         onMouseEnter={() => setCopyIconClicked(false)}
         onMouseLeave={() => setTimeout(() => setCopyIconClicked(false), 333)}
         size="small"
-        sx={(theme) => ({ color: theme.palette.text.secondary, marginLeft: 0.5 })}
+        sx={(theme) => ({
+          color: theme.palette.text.secondary,
+          marginLeft: 0.5,
+        })}
       >
         <RiFileCopyLine />
       </IconButton>

--- a/python/ray/dashboard/client/src/components/OverflowCollapsibleCell.tsx
+++ b/python/ray/dashboard/client/src/components/OverflowCollapsibleCell.tsx
@@ -54,7 +54,15 @@ const OverflowCollapsibleCell = ({
           onClick={() => setOpen(!open)}
           sx={{ display: isOverflow ? "block" : "none" }}
         >
-          {open ? <KeyboardArrowDownIcon sx={(theme) => ({ color: theme.palette.text.secondary })} /> : <KeyboardArrowRightIcon sx={(theme) => ({ color: theme.palette.text.secondary })} />}
+          {open ? (
+            <KeyboardArrowDownIcon
+              sx={(theme) => ({ color: theme.palette.text.secondary })}
+            />
+          ) : (
+            <KeyboardArrowRightIcon
+              sx={(theme) => ({ color: theme.palette.text.secondary })}
+            />
+          )}
         </IconButton>
       </Box>
     </Tooltip>

--- a/python/ray/dashboard/client/src/components/OverflowCollapsibleCell.tsx
+++ b/python/ray/dashboard/client/src/components/OverflowCollapsibleCell.tsx
@@ -54,7 +54,7 @@ const OverflowCollapsibleCell = ({
           onClick={() => setOpen(!open)}
           sx={{ display: isOverflow ? "block" : "none" }}
         >
-          {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
+          {open ? <KeyboardArrowDownIcon sx={(theme) => ({ color: theme.palette.text.secondary })} /> : <KeyboardArrowRightIcon sx={(theme) => ({ color: theme.palette.text.secondary })} />}
         </IconButton>
       </Box>
     </Tooltip>

--- a/python/ray/dashboard/client/src/components/PercentageBar.tsx
+++ b/python/ray/dashboard/client/src/components/PercentageBar.tsx
@@ -13,7 +13,7 @@ const PercentageBar = (
       sx={{
         background: theme.palette.mode === 'dark'
           ? "linear-gradient(45deg, #0D47A1ee 30%, #01579Bee 90%)"
-          : "linear-gradient(45deg, #21CBF3ee 30%, #21CBF3ee 90%)",
+          : "linear-gradient(45deg, #21CBF3ee 30%, #2196F3ee 90%)",
         border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.divider : '#ffffffbb'}`,
         padding: "0 12px",
         height: 18,

--- a/python/ray/dashboard/client/src/components/PercentageBar.tsx
+++ b/python/ray/dashboard/client/src/components/PercentageBar.tsx
@@ -11,10 +11,13 @@ const PercentageBar = (
   return (
     <Box
       sx={{
-        background: theme.palette.mode === 'dark'
-          ? "linear-gradient(45deg, #0D47A1ee 30%, #01579Bee 90%)"
-          : "linear-gradient(45deg, #21CBF3ee 30%, #2196F3ee 90%)",
-        border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.divider : '#ffffffbb'}`,
+        background:
+          theme.palette.mode === "dark"
+            ? "linear-gradient(45deg, #0D47A1ee 30%, #01579Bee 90%)"
+            : "linear-gradient(45deg, #21CBF3ee 30%, #2196F3ee 90%)",
+        border: `1px solid ${
+          theme.palette.mode === "dark" ? theme.palette.divider : "#ffffffbb"
+        }`,
         padding: "0 12px",
         height: 18,
         lineHeight: "18px",

--- a/python/ray/dashboard/client/src/components/PercentageBar.tsx
+++ b/python/ray/dashboard/client/src/components/PercentageBar.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, useTheme } from "@mui/material";
 import React, { PropsWithChildren } from "react";
 
 const PercentageBar = (
@@ -6,12 +6,13 @@ const PercentageBar = (
 ) => {
   const { num, total } = props;
   const per = Math.round((num / total) * 100);
+  const theme = useTheme();
 
   return (
     <Box
       sx={{
         background: "linear-gradient(45deg, #21CBF3ee 30%, #2196F3ee 90%)",
-        border: `1px solid #ffffffbb`,
+        border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.divider : '#ffffffbb'}`,
         padding: "0 12px",
         height: 18,
         lineHeight: "18px",

--- a/python/ray/dashboard/client/src/components/PercentageBar.tsx
+++ b/python/ray/dashboard/client/src/components/PercentageBar.tsx
@@ -11,7 +11,9 @@ const PercentageBar = (
   return (
     <Box
       sx={{
-        background: "linear-gradient(45deg, #21CBF3ee 30%, #2196F3ee 90%)",
+        background: theme.palette.mode === 'dark'
+          ? "linear-gradient(45deg, #0D47A1ee 30%, #01579Bee 90%)"
+          : "linear-gradient(45deg, #21CBF3ee 30%, #21CBF3ee 90%)",
         border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.divider : '#ffffffbb'}`,
         padding: "0 12px",
         height: 18,

--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
@@ -94,7 +94,10 @@ export const ProgressBar = ({
             value: finalTotal - segmentTotal,
             label: unaccountedLabel ?? "Unaccounted",
             hint: "Unaccounted tasks can happen when there are too many tasks. Ray drops older tasks to conserve memory.",
-            color: theme.palette.mode === 'dark' ? theme.palette.grey[700] : theme.palette.grey[300],
+            color:
+              theme.palette.mode === "dark"
+                ? theme.palette.grey[700]
+                : theme.palette.grey[300],
           },
         ]
       : progress;
@@ -213,9 +216,12 @@ export const ProgressBar = ({
               height: 8,
               borderRadius: "6px",
               overflow: "hidden",
-              backgroundColor: segmentTotal === 0
-                ? theme.palette.grey[400]
-                : theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[100],
+              backgroundColor:
+                segmentTotal === 0
+                  ? theme.palette.grey[400]
+                  : theme.palette.mode === "dark"
+                  ? theme.palette.grey[800]
+                  : theme.palette.grey[100],
             }}
           >
             {filteredSegments.map(({ color, label, value }) => (

--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
@@ -181,22 +181,22 @@ export const ProgressBar = ({
           (expanded ? (
             <Box
               component={RiArrowDownSLine}
-              sx={{
+              sx={(theme) => ({
                 width: 16,
                 height: 16,
                 marginRight: 1,
-                color: 'text.secondary',
-              }}
+                color: theme.palette.text.secondary,
+              })}
             />
           ) : (
             <Box
               component={RiArrowRightSLine}
-              sx={{
+              sx={(theme) => ({
                 width: 16,
                 height: 16,
                 marginRight: 1,
-                color: 'text.secondary',
-              }}
+                color: theme.palette.text.secondary,
+              })}
             />
           ))}
         <LegendTooltip

--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import { Box, TooltipProps, Typography } from "@mui/material";
+import { Box, TooltipProps, Typography, useTheme } from "@mui/material";
 import React from "react";
 import { RiArrowDownSLine, RiArrowRightSLine } from "react-icons/ri";
 import { HelpInfo, StyledTooltip } from "../Tooltip";
@@ -81,6 +81,7 @@ export const ProgressBar = ({
   onClick,
   controls,
 }: ProgressBarProps) => {
+  const theme = useTheme();
   const segmentTotal = progress.reduce((acc, { value }) => acc + value, 0);
   const finalTotal = total ?? segmentTotal;
 
@@ -93,7 +94,7 @@ export const ProgressBar = ({
             value: finalTotal - segmentTotal,
             label: unaccountedLabel ?? "Unaccounted",
             hint: "Unaccounted tasks can happen when there are too many tasks. Ray drops older tasks to conserve memory.",
-            color: "#EEEEEE",
+            color: theme.palette.mode === 'dark' ? theme.palette.grey[700] : theme.palette.grey[300],
           },
         ]
       : progress;
@@ -210,7 +211,9 @@ export const ProgressBar = ({
               height: 8,
               borderRadius: "6px",
               overflow: "hidden",
-              backgroundColor: segmentTotal === 0 ? "lightGrey" : "white",
+              backgroundColor: segmentTotal === 0
+                ? theme.palette.grey[400]
+                : theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[100],
             }}
           >
             {filteredSegments.map(({ color, label, value }) => (

--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
@@ -185,6 +185,7 @@ export const ProgressBar = ({
                 width: 16,
                 height: 16,
                 marginRight: 1,
+                color: 'text.secondary',
               }}
             />
           ) : (
@@ -194,6 +195,7 @@ export const ProgressBar = ({
                 width: 16,
                 height: 16,
                 marginRight: 1,
+                color: 'text.secondary',
               }}
             />
           ))}

--- a/python/ray/dashboard/client/src/components/SearchComponent.tsx
+++ b/python/ray/dashboard/client/src/components/SearchComponent.tsx
@@ -72,7 +72,7 @@ export const SearchSelect = ({
           width: 100,
         },
       }}
-      sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+      sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
       defaultValue={defaultValue || ""}
     >
       {showAllOption ? <MenuItem value="">All</MenuItem> : null}

--- a/python/ray/dashboard/client/src/components/SearchComponent.tsx
+++ b/python/ray/dashboard/client/src/components/SearchComponent.tsx
@@ -36,7 +36,7 @@ export const SearchInput = ({
         defaultValue,
         endAdornment: (
           <InputAdornment position="end">
-            <SearchOutlined />
+            <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
           </InputAdornment>
         ),
       }}
@@ -177,7 +177,7 @@ export const SearchTimezone = ({
           <Typography component="span" sx={{ marginRight: 1 }}>
             {option.country}
           </Typography>
-          <Typography sx={{ color: "#8C9196" }} component="span">
+          <Typography sx={(theme) => ({ color: theme.palette.text.secondary })} component="span">
             {option.value}
           </Typography>
           <Box sx={{ flexGrow: 1 }} />
@@ -200,7 +200,7 @@ export const SearchTimezone = ({
       )}
       renderGroup={(params) => (
         <li>
-          <Typography sx={{ color: "#5F6469", paddingX: 2, paddingY: "6px" }}>
+          <Typography sx={(theme) => ({ color: theme.palette.text.secondary, paddingX: 2, paddingY: "6px" })}>
             {params.group}
           </Typography>
           <Box

--- a/python/ray/dashboard/client/src/components/SearchComponent.tsx
+++ b/python/ray/dashboard/client/src/components/SearchComponent.tsx
@@ -72,6 +72,7 @@ export const SearchSelect = ({
           width: 100,
         },
       }}
+      sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
       defaultValue={defaultValue || ""}
     >
       {showAllOption ? <MenuItem value="">All</MenuItem> : null}

--- a/python/ray/dashboard/client/src/components/SearchComponent.tsx
+++ b/python/ray/dashboard/client/src/components/SearchComponent.tsx
@@ -190,12 +190,12 @@ export const SearchTimezone = ({
       renderInput={(params) => (
         <TextField
           {...params}
-          sx={{
+          sx={(theme) => ({
             width: 120,
             "& .MuiOutlinedInput-notchedOutline": {
-              borderColor: "#D2DCE6",
+              borderColor: theme.palette.divider,
             },
-          }}
+          })}
           placeholder={curUtc}
         />
       )}

--- a/python/ray/dashboard/client/src/components/SearchComponent.tsx
+++ b/python/ray/dashboard/client/src/components/SearchComponent.tsx
@@ -36,7 +36,9 @@ export const SearchInput = ({
         defaultValue,
         endAdornment: (
           <InputAdornment position="end">
-            <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+            <SearchOutlined
+              sx={(theme) => ({ color: theme.palette.text.secondary })}
+            />
           </InputAdornment>
         ),
       }}
@@ -72,7 +74,9 @@ export const SearchSelect = ({
           width: 100,
         },
       }}
-      sx={(theme) => ({ '& .MuiSvgIcon-root': { color: theme.palette.text.secondary } })}
+      sx={(theme) => ({
+        "& .MuiSvgIcon-root": { color: theme.palette.text.secondary },
+      })}
       defaultValue={defaultValue || ""}
     >
       {showAllOption ? <MenuItem value="">All</MenuItem> : null}
@@ -178,7 +182,10 @@ export const SearchTimezone = ({
           <Typography component="span" sx={{ marginRight: 1 }}>
             {option.country}
           </Typography>
-          <Typography sx={(theme) => ({ color: theme.palette.text.secondary })} component="span">
+          <Typography
+            sx={(theme) => ({ color: theme.palette.text.secondary })}
+            component="span"
+          >
             {option.value}
           </Typography>
           <Box sx={{ flexGrow: 1 }} />
@@ -201,7 +208,13 @@ export const SearchTimezone = ({
       )}
       renderGroup={(params) => (
         <li>
-          <Typography sx={(theme) => ({ color: theme.palette.text.secondary, paddingX: 2, paddingY: "6px" })}>
+          <Typography
+            sx={(theme) => ({
+              color: theme.palette.text.secondary,
+              paddingX: 2,
+              paddingY: "6px",
+            })}
+          >
             {params.group}
           </Typography>
           <Box

--- a/python/ray/dashboard/client/src/components/StatusChip.tsx
+++ b/python/ray/dashboard/client/src/components/StatusChip.tsx
@@ -18,80 +18,81 @@ const getStatusColors = (themeMode: "light" | "dark") => ({
   grey: themeMode === "dark" ? "#8A8F94" : "#5F6469",
 });
 
-const getColorMap = (orange: string, grey: string) => ({
-  node: {
-    ALIVE: green,
-    DEAD: grey,
-  },
-  worker: {
-    ALIVE: green,
-    DEAD: grey,
-  },
-  actor: {
-    [ActorEnum.ALIVE]: green,
-    [ActorEnum.DEAD]: grey,
-    [ActorEnum.DEPENDENCIES_UNREADY]: orange,
-    [ActorEnum.PENDING_CREATION]: orange,
-    [ActorEnum.RESTARTING]: orange,
-  },
-  task: {
-    [TaskStatus.FAILED]: red,
-    [TaskStatus.FINISHED]: green,
-    [TaskStatus.RUNNING]: blue,
-    [TaskStatus.SUBMITTED_TO_WORKER]: orange,
-    [TaskStatus.PENDING_NODE_ASSIGNMENT]: orange,
-    [TaskStatus.PENDING_ARGS_AVAIL]: orange,
-    [TaskStatus.UNKNOWN]: grey,
-  },
-  job: {
-    [JobStatus.PENDING]: orange,
-    [JobStatus.RUNNING]: blue,
-    [JobStatus.STOPPED]: grey,
-    [JobStatus.SUCCEEDED]: green,
-    [JobStatus.FAILED]: red,
-  },
-  placementGroup: {
-    [PlacementGroupState.PENDING]: orange,
-    [PlacementGroupState.CREATED]: green,
-    [PlacementGroupState.REMOVED]: grey,
-    [PlacementGroupState.RESCHEDULING]: orange,
-  },
-  serveApplication: {
-    [ServeApplicationStatus.NOT_STARTED]: grey,
-    [ServeApplicationStatus.DEPLOYING]: orange,
-    [ServeApplicationStatus.RUNNING]: green,
-    [ServeApplicationStatus.DEPLOY_FAILED]: red,
-    [ServeApplicationStatus.DELETING]: orange,
-    [ServeApplicationStatus.UNHEALTHY]: red,
-  },
-  serveDeployment: {
-    [ServeDeploymentStatus.UPDATING]: orange,
-    [ServeDeploymentStatus.HEALTHY]: green,
-    [ServeDeploymentStatus.UNHEALTHY]: red,
-  },
-  serveReplica: {
-    [ServeReplicaState.STARTING]: orange,
-    [ServeReplicaState.UPDATING]: orange,
-    [ServeReplicaState.RECOVERING]: orange,
-    [ServeReplicaState.RUNNING]: green,
-    [ServeReplicaState.STOPPING]: red,
-  },
-  serveProxy: {
-    [ServeSystemActorStatus.HEALTHY]: green,
-    [ServeSystemActorStatus.UNHEALTHY]: red,
-    [ServeSystemActorStatus.STARTING]: orange,
-    [ServeSystemActorStatus.DRAINING]: blueGrey,
-  },
-  serveController: {
-    [ServeSystemActorStatus.HEALTHY]: green,
-    [ServeSystemActorStatus.UNHEALTHY]: red,
-    [ServeSystemActorStatus.STARTING]: orange,
-  },
-} as {
-  [key: string]: {
-    [key: string]: Color | string;
-  };
-});
+const getColorMap = (orange: string, grey: string) =>
+  ({
+    node: {
+      ALIVE: green,
+      DEAD: grey,
+    },
+    worker: {
+      ALIVE: green,
+      DEAD: grey,
+    },
+    actor: {
+      [ActorEnum.ALIVE]: green,
+      [ActorEnum.DEAD]: grey,
+      [ActorEnum.DEPENDENCIES_UNREADY]: orange,
+      [ActorEnum.PENDING_CREATION]: orange,
+      [ActorEnum.RESTARTING]: orange,
+    },
+    task: {
+      [TaskStatus.FAILED]: red,
+      [TaskStatus.FINISHED]: green,
+      [TaskStatus.RUNNING]: blue,
+      [TaskStatus.SUBMITTED_TO_WORKER]: orange,
+      [TaskStatus.PENDING_NODE_ASSIGNMENT]: orange,
+      [TaskStatus.PENDING_ARGS_AVAIL]: orange,
+      [TaskStatus.UNKNOWN]: grey,
+    },
+    job: {
+      [JobStatus.PENDING]: orange,
+      [JobStatus.RUNNING]: blue,
+      [JobStatus.STOPPED]: grey,
+      [JobStatus.SUCCEEDED]: green,
+      [JobStatus.FAILED]: red,
+    },
+    placementGroup: {
+      [PlacementGroupState.PENDING]: orange,
+      [PlacementGroupState.CREATED]: green,
+      [PlacementGroupState.REMOVED]: grey,
+      [PlacementGroupState.RESCHEDULING]: orange,
+    },
+    serveApplication: {
+      [ServeApplicationStatus.NOT_STARTED]: grey,
+      [ServeApplicationStatus.DEPLOYING]: orange,
+      [ServeApplicationStatus.RUNNING]: green,
+      [ServeApplicationStatus.DEPLOY_FAILED]: red,
+      [ServeApplicationStatus.DELETING]: orange,
+      [ServeApplicationStatus.UNHEALTHY]: red,
+    },
+    serveDeployment: {
+      [ServeDeploymentStatus.UPDATING]: orange,
+      [ServeDeploymentStatus.HEALTHY]: green,
+      [ServeDeploymentStatus.UNHEALTHY]: red,
+    },
+    serveReplica: {
+      [ServeReplicaState.STARTING]: orange,
+      [ServeReplicaState.UPDATING]: orange,
+      [ServeReplicaState.RECOVERING]: orange,
+      [ServeReplicaState.RUNNING]: green,
+      [ServeReplicaState.STOPPING]: red,
+    },
+    serveProxy: {
+      [ServeSystemActorStatus.HEALTHY]: green,
+      [ServeSystemActorStatus.UNHEALTHY]: red,
+      [ServeSystemActorStatus.STARTING]: orange,
+      [ServeSystemActorStatus.DRAINING]: blueGrey,
+    },
+    serveController: {
+      [ServeSystemActorStatus.HEALTHY]: green,
+      [ServeSystemActorStatus.UNHEALTHY]: red,
+      [ServeSystemActorStatus.STARTING]: orange,
+    },
+  } as {
+    [key: string]: {
+      [key: string]: Color | string;
+    };
+  });
 
 const typeMap = {
   deps: blue,

--- a/python/ray/dashboard/client/src/components/StatusChip.tsx
+++ b/python/ray/dashboard/client/src/components/StatusChip.tsx
@@ -1,4 +1,4 @@
-import { Box, Color } from "@mui/material";
+import { Box, Color, useTheme } from "@mui/material";
 import { blue, blueGrey, cyan, green, red } from "@mui/material/colors";
 import React, { CSSProperties, ReactNode } from "react";
 import { TaskStatus } from "../pages/job/hook/useJobProgress";
@@ -12,10 +12,13 @@ import {
   ServeSystemActorStatus,
 } from "../type/serve";
 
-const orange = "#DB6D00";
-const grey = "#5F6469";
+// Use theme-aware colors for better accessibility
+const getStatusColors = (themeMode: "light" | "dark") => ({
+  orange: themeMode === "dark" ? "#FF8C1A" : "#DB6D00",
+  grey: themeMode === "dark" ? "#8A8F94" : "#5F6469",
+});
 
-const colorMap = {
+const getColorMap = (orange: string, grey: string) => ({
   node: {
     ALIVE: green,
     DEAD: grey,
@@ -88,7 +91,7 @@ const colorMap = {
   [key: string]: {
     [key: string]: Color | string;
   };
-};
+});
 
 const typeMap = {
   deps: blue,
@@ -106,6 +109,10 @@ export type StatusChipProps = {
 };
 
 export const StatusChip = ({ type, status, suffix, icon }: StatusChipProps) => {
+  const theme = useTheme();
+  const { orange, grey } = getStatusColors(theme.palette.mode);
+  const colorMap = getColorMap(orange, grey);
+
   let color: Color | string = blueGrey;
 
   if (typeMap[type]) {

--- a/python/ray/dashboard/client/src/components/StatusChip.tsx
+++ b/python/ray/dashboard/client/src/components/StatusChip.tsx
@@ -102,7 +102,7 @@ const typeMap = {
 };
 
 export type StatusChipProps = {
-  type: keyof typeof colorMap;
+  type: keyof ReturnType<typeof getColorMap>;
   status: string | ActorEnum | ReactNode;
   suffix?: ReactNode;
   icon?: ReactNode;

--- a/python/ray/dashboard/client/src/components/Tooltip.tsx
+++ b/python/ray/dashboard/client/src/components/Tooltip.tsx
@@ -32,7 +32,7 @@ export const HelpInfo = ({ children, className, sx }: HelpInfoProps) => {
       <HelpOutlineIcon
         fontSize="small"
         sx={[
-          { color: (theme) => theme.palette.grey[500] },
+          { color: (theme) => theme.palette.text.secondary },
           ...(Array.isArray(sx) ? sx : [sx]),
         ]}
       />

--- a/python/ray/dashboard/client/src/components/Tooltip.tsx
+++ b/python/ray/dashboard/client/src/components/Tooltip.tsx
@@ -9,7 +9,7 @@ export const StyledTooltip = (props: TooltipProps) => {
         tooltip: {
           sx: (theme) => ({
             backgroundColor: theme.palette.background.paper,
-            border: "1px solid #dadde9",
+            border: `1px solid ${theme.palette.divider}`,
             color: theme.palette.text.primary,
             padding: 1,
           }),

--- a/python/ray/dashboard/client/src/components/WorkerTable.tsx
+++ b/python/ray/dashboard/client/src/components/WorkerTable.tsx
@@ -72,7 +72,7 @@ export const ExpandableTableRow = ({
             size="large"
           >
             {length}
-            {isExpanded ? <KeyboardArrowDown /> : <KeyboardArrowRight />}
+            {isExpanded ? <KeyboardArrowDown sx={(theme) => ({ color: theme.palette.text.secondary })} /> : <KeyboardArrowRight sx={(theme) => ({ color: theme.palette.text.secondary })} />}
           </IconButton>
         </TableCell>
         {children}

--- a/python/ray/dashboard/client/src/components/WorkerTable.tsx
+++ b/python/ray/dashboard/client/src/components/WorkerTable.tsx
@@ -72,7 +72,15 @@ export const ExpandableTableRow = ({
             size="large"
           >
             {length}
-            {isExpanded ? <KeyboardArrowDown sx={(theme) => ({ color: theme.palette.text.secondary })} /> : <KeyboardArrowRight sx={(theme) => ({ color: theme.palette.text.secondary })} />}
+            {isExpanded ? (
+              <KeyboardArrowDown
+                sx={(theme) => ({ color: theme.palette.text.secondary })}
+              />
+            ) : (
+              <KeyboardArrowRight
+                sx={(theme) => ({ color: theme.palette.text.secondary })}
+              />
+            )}
           </IconButton>
         </TableCell>
         {children}

--- a/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
+++ b/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
@@ -55,7 +55,7 @@ const ActorDetailPage = () => {
 
   if (isLoading || actorDetail === undefined) {
     return (
-      <Box sx={{ padding: 2, backgroundColor: "white" }}>
+      <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
         <Loading loading={isLoading} />
         <TitleCard title={`ACTOR - ${params.actorId}`}>
           <StatusChip type="actor" status="LOADING" />
@@ -67,7 +67,7 @@ const ActorDetailPage = () => {
   }
 
   return (
-    <Box sx={{ padding: 2, backgroundColor: "white" }}>
+    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
       <MetadataSection
         metadataList={[
           {

--- a/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
+++ b/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
@@ -55,7 +55,12 @@ const ActorDetailPage = () => {
 
   if (isLoading || actorDetail === undefined) {
     return (
-      <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
+      <Box
+        sx={(theme) => ({
+          padding: 2,
+          backgroundColor: theme.palette.background.paper,
+        })}
+      >
         <Loading loading={isLoading} />
         <TitleCard title={`ACTOR - ${params.actorId}`}>
           <StatusChip type="actor" status="LOADING" />
@@ -67,7 +72,12 @@ const ActorDetailPage = () => {
   }
 
   return (
-    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
+    <Box
+      sx={(theme) => ({
+        padding: 2,
+        backgroundColor: theme.palette.background.paper,
+      })}
+    >
       <MetadataSection
         metadataList={[
           {

--- a/python/ray/dashboard/client/src/pages/actor/index.tsx
+++ b/python/ray/dashboard/client/src/pages/actor/index.tsx
@@ -8,11 +8,11 @@ import ActorList from "./ActorList";
 const Actors = () => {
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         padding: 2,
         width: "100%",
-        backgroundColor: "white",
-      }}
+        backgroundColor: theme.palette.background.paper,
+      })}
     >
       <ActorList />
     </Box>

--- a/python/ray/dashboard/client/src/pages/cmd/CMDResult.tsx
+++ b/python/ray/dashboard/client/src/pages/cmd/CMDResult.tsx
@@ -72,7 +72,7 @@ const CMDResult = () => {
                 <Select
                   value={option}
                   onChange={(e) => setOption(e.target.value as string)}
-                  sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
+                  sx={{ "& .MuiSvgIcon-root": { color: "text.secondary" } }}
                 >
                   {[
                     "class",

--- a/python/ray/dashboard/client/src/pages/cmd/CMDResult.tsx
+++ b/python/ray/dashboard/client/src/pages/cmd/CMDResult.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Grid, MenuItem, Select } from "@mui/material";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { GlobalContext } from "../../App";
 import LogVirtualView from "../../components/LogView/LogVirtualView";
 import TitleCard from "../../components/TitleCard";
 import { getJmap, getJstack, getJstat } from "../../service/util";
@@ -13,6 +14,7 @@ const CMDResult = () => {
   };
   const [result, setResult] = useState<string>();
   const [option, setOption] = useState("gcutil");
+  const { themeMode } = useContext(GlobalContext);
   const executeJstat = useCallback(
     () =>
       getJstat(ip, pid, option)
@@ -70,6 +72,7 @@ const CMDResult = () => {
                 <Select
                   value={option}
                   onChange={(e) => setOption(e.target.value as string)}
+                  sx={{ '& .MuiSvgIcon-root': { color: 'text.secondary' } }}
                 >
                   {[
                     "class",
@@ -101,6 +104,7 @@ const CMDResult = () => {
           content={result || "loading"}
           language="prolog"
           height={800}
+          theme={themeMode}
         />
       </TitleCard>
     </Box>

--- a/python/ray/dashboard/client/src/pages/error/404.tsx
+++ b/python/ray/dashboard/client/src/pages/error/404.tsx
@@ -17,7 +17,10 @@ const Error404 = () => {
     >
       <div style={{ height: 400 }}>
         <Typography variant="h2">
-          <HelpOutlineOutlined fontSize="large" sx={(theme) => ({ color: theme.palette.text.secondary })} />
+          <HelpOutlineOutlined
+            fontSize="large"
+            sx={(theme) => ({ color: theme.palette.text.secondary })}
+          />
         </Typography>
         <Typography variant="h6">404 NOT FOUND</Typography>
         <p>

--- a/python/ray/dashboard/client/src/pages/error/404.tsx
+++ b/python/ray/dashboard/client/src/pages/error/404.tsx
@@ -17,7 +17,7 @@ const Error404 = () => {
     >
       <div style={{ height: 400 }}>
         <Typography variant="h2">
-          <HelpOutlineOutlined fontSize="large" />
+          <HelpOutlineOutlined fontSize="large" sx={(theme) => ({ color: theme.palette.text.secondary })} />
         </Typography>
         <Typography variant="h6">404 NOT FOUND</Typography>
         <p>

--- a/python/ray/dashboard/client/src/pages/job/AdvancedProgressBar/AdvancedProgressBar.tsx
+++ b/python/ray/dashboard/client/src/pages/job/AdvancedProgressBar/AdvancedProgressBar.tsx
@@ -156,7 +156,7 @@ export const AdvancedProgressBarSegment = ({
                   sx={{
                     border: "none",
                     cursor: "pointer",
-                    color: "#036DCF",
+                    color: theme.palette.primary.main,
                     textDecoration: "underline",
                     background: "none",
                   }}
@@ -173,7 +173,7 @@ export const AdvancedProgressBarSegment = ({
                   sx={{
                     border: "none",
                     cursor: "pointer",
-                    color: "#036DCF",
+                    color: theme.palette.primary.main,
                     textDecoration: "underline",
                     background: "none",
                   }}
@@ -187,14 +187,14 @@ export const AdvancedProgressBarSegment = ({
             )}
             {isGroup && (
               <React.Fragment>
-                <Box component="span" sx={{ width: 4 }} />
+                <Box component="span" sx={(theme) => ({ width: 4 }} />
                 {"("}
                 <RiCloseLine /> {children.length}
                 {")"}
               </React.Fragment>
             )}
           </TableCell>
-          <TableCell sx={{ width: "100%", paddingRight: 0 }}>
+          <TableCell sx={(theme) => ({ width: "100%", paddingRight: 0 })}
             <MiniTaskProgressBar {...progress} showTotal />
           </TableCell>
         </TableRow>

--- a/python/ray/dashboard/client/src/pages/job/AdvancedProgressBar/AdvancedProgressBar.tsx
+++ b/python/ray/dashboard/client/src/pages/job/AdvancedProgressBar/AdvancedProgressBar.tsx
@@ -153,13 +153,13 @@ export const AdvancedProgressBarSegment = ({
               link.type === "actor" ? (
                 <Box
                   component="button"
-                  sx={{
+                  sx={(theme) => ({
                     border: "none",
                     cursor: "pointer",
                     color: theme.palette.primary.main,
                     textDecoration: "underline",
                     background: "none",
-                  }}
+                  })}
                   onClick={(event) => {
                     onClickLink?.(link);
                     event.stopPropagation();
@@ -170,13 +170,13 @@ export const AdvancedProgressBarSegment = ({
               ) : (
                 <Link
                   component={RouterLink}
-                  sx={{
+                  sx={(theme) => ({
                     border: "none",
                     cursor: "pointer",
                     color: theme.palette.primary.main,
                     textDecoration: "underline",
                     background: "none",
-                  }}
+                  })}
                   to={`tasks/${link.id}`}
                 >
                   {name}
@@ -187,14 +187,14 @@ export const AdvancedProgressBarSegment = ({
             )}
             {isGroup && (
               <React.Fragment>
-                <Box component="span" sx={(theme) => ({ width: 4 }} />
+                <Box component="span" sx={{ width: 4 }} />
                 {"("}
                 <RiCloseLine /> {children.length}
                 {")"}
               </React.Fragment>
             )}
           </TableCell>
-          <TableCell sx={(theme) => ({ width: "100%", paddingRight: 0 })}
+          <TableCell sx={{ width: "100%", paddingRight: 0 }}>
             <MiniTaskProgressBar {...progress} showTotal />
           </TableCell>
         </TableRow>

--- a/python/ray/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobDetail.tsx
@@ -51,7 +51,7 @@ export const JobDetailChartsPage = () => {
 
   if (!job) {
     return (
-      <Box sx={{ padding: 2, backgroundColor: "white" }}>
+      <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
         <Loading loading={isLoading} />
         <TitleCard title={`JOB - ${params.id}`}>
           <StatusChip type="job" status="LOADING" />
@@ -97,7 +97,7 @@ export const JobDetailChartsPage = () => {
   };
 
   return (
-    <Box sx={{ padding: 2, backgroundColor: "white" }}>
+    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
       <JobMetadataSection job={job} />
 
       {data?.datasets && data.datasets.length > 0 && (

--- a/python/ray/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobDetail.tsx
@@ -51,7 +51,12 @@ export const JobDetailChartsPage = () => {
 
   if (!job) {
     return (
-      <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
+      <Box
+        sx={(theme) => ({
+          padding: 2,
+          backgroundColor: theme.palette.background.paper,
+        })}
+      >
         <Loading loading={isLoading} />
         <TitleCard title={`JOB - ${params.id}`}>
           <StatusChip type="job" status="LOADING" />
@@ -97,7 +102,12 @@ export const JobDetailChartsPage = () => {
   };
 
   return (
-    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
+    <Box
+      sx={(theme) => ({
+        padding: 2,
+        backgroundColor: theme.palette.background.paper,
+      })}
+    >
       <JobMetadataSection job={job} />
 
       {data?.datasets && data.datasets.length > 0 && (

--- a/python/ray/dashboard/client/src/pages/job/JobDetailActorPage.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobDetailActorPage.tsx
@@ -10,7 +10,12 @@ export const JobDetailActorsPage = () => {
   const { params } = useJobDetail();
 
   return (
-    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
+    <Box
+      sx={(theme) => ({
+        padding: 2,
+        backgroundColor: theme.palette.background.paper,
+      })}
+    >
       <MainNavPageInfo
         pageInfo={{
           title: "Actors",

--- a/python/ray/dashboard/client/src/pages/job/JobDetailActorPage.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobDetailActorPage.tsx
@@ -10,7 +10,7 @@ export const JobDetailActorsPage = () => {
   const { params } = useJobDetail();
 
   return (
-    <Box sx={{ padding: 2, backgroundColor: "white" }}>
+    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
       <MainNavPageInfo
         pageInfo={{
           title: "Actors",

--- a/python/ray/dashboard/client/src/pages/job/JobDetailInfoPage.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobDetailInfoPage.tsx
@@ -29,7 +29,12 @@ export const JobDetailInfoPage = () => {
 
   if (!job) {
     return (
-      <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
+      <Box
+        sx={(theme) => ({
+          padding: 2,
+          backgroundColor: theme.palette.background.paper,
+        })}
+      >
         <MainNavPageInfo
           pageInfo={{
             title: "Info",
@@ -48,7 +53,12 @@ export const JobDetailInfoPage = () => {
   }
 
   return (
-    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
+    <Box
+      sx={(theme) => ({
+        padding: 2,
+        backgroundColor: theme.palette.background.paper,
+      })}
+    >
       <MainNavPageInfo
         pageInfo={{
           title: "Info",

--- a/python/ray/dashboard/client/src/pages/job/JobDetailInfoPage.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobDetailInfoPage.tsx
@@ -29,7 +29,7 @@ export const JobDetailInfoPage = () => {
 
   if (!job) {
     return (
-      <Box sx={{ padding: 2, backgroundColor: "white" }}>
+      <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
         <MainNavPageInfo
           pageInfo={{
             title: "Info",
@@ -48,7 +48,7 @@ export const JobDetailInfoPage = () => {
   }
 
   return (
-    <Box sx={{ padding: 2, backgroundColor: "white" }}>
+    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
       <MainNavPageInfo
         pageInfo={{
           title: "Info",

--- a/python/ray/dashboard/client/src/pages/job/TaskProgressBar.tsx
+++ b/python/ray/dashboard/client/src/pages/job/TaskProgressBar.tsx
@@ -50,7 +50,7 @@ export const TaskProgressBar = ({
     {
       label: "Waiting for scheduling",
       value: numPendingNodeAssignment + numSubmittedToWorker,
-      color: theme.palette.mode === 'dark' ? '#d4d424' : '#cfcf08',
+      color: theme.palette.warning.light,
     },
     {
       label: "Waiting for dependencies",
@@ -158,7 +158,7 @@ export const MiniTaskProgressBar = ({
       {
         label: "Waiting for scheduling",
         value: numPendingNodeAssignment + numSubmittedToWorker,
-        color: theme.palette.mode === 'dark' ? '#d4d424' : '#cfcf08',
+        color: theme.palette.warning.light,
       },
       {
         label: "Waiting for dependencies",

--- a/python/ray/dashboard/client/src/pages/job/TaskProgressBar.tsx
+++ b/python/ray/dashboard/client/src/pages/job/TaskProgressBar.tsx
@@ -50,12 +50,12 @@ export const TaskProgressBar = ({
     {
       label: "Waiting for scheduling",
       value: numPendingNodeAssignment + numSubmittedToWorker,
-      color: "#cfcf08",
+      color: theme.palette.mode === 'dark' ? '#d4d424' : '#cfcf08',
     },
     {
       label: "Waiting for dependencies",
       value: numPendingArgsAvail,
-      color: "#f79e02",
+      color: theme.palette.warning.main,
     },
     {
       label: "Cancelled",
@@ -65,7 +65,7 @@ export const TaskProgressBar = ({
     {
       label: "Unknown",
       value: numUnknown,
-      color: "#5f6469",
+      color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[600],
     },
   ];
   return (
@@ -158,17 +158,17 @@ export const MiniTaskProgressBar = ({
       {
         label: "Waiting for scheduling",
         value: numPendingNodeAssignment + numSubmittedToWorker,
-        color: "#cfcf08",
+        color: theme.palette.mode === 'dark' ? '#d4d424' : '#cfcf08',
       },
       {
         label: "Waiting for dependencies",
         value: numPendingArgsAvail,
-        color: "#f79e02",
+        color: theme.palette.warning.main,
       },
       {
         label: "Unknown",
         value: numUnknown,
-        color: "#5f6469",
+        color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[600],
       },
     ];
     return (

--- a/python/ray/dashboard/client/src/pages/job/TaskProgressBar.tsx
+++ b/python/ray/dashboard/client/src/pages/job/TaskProgressBar.tsx
@@ -65,7 +65,10 @@ export const TaskProgressBar = ({
     {
       label: "Unknown",
       value: numUnknown,
-      color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[600],
+      color:
+        theme.palette.mode === "dark"
+          ? theme.palette.grey[500]
+          : theme.palette.grey[600],
     },
   ];
   return (
@@ -168,7 +171,10 @@ export const MiniTaskProgressBar = ({
       {
         label: "Unknown",
         value: numUnknown,
-        color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[600],
+        color:
+          theme.palette.mode === "dark"
+            ? theme.palette.grey[500]
+            : theme.palette.grey[600],
       },
     ];
     return (

--- a/python/ray/dashboard/client/src/pages/job/TaskTimeline.tsx
+++ b/python/ray/dashboard/client/src/pages/job/TaskTimeline.tsx
@@ -41,7 +41,10 @@ const TimelineDownloadButton = ({
 }: TimelineDownloadButtonProps) => {
   return (
     <Button
-      sx={sx}
+      sx={[
+        { '& svg': { color: 'text.secondary' } },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
       className={className}
       variant="outlined"
       startIcon={<RiDownload2Line />}

--- a/python/ray/dashboard/client/src/pages/job/TaskTimeline.tsx
+++ b/python/ray/dashboard/client/src/pages/job/TaskTimeline.tsx
@@ -42,7 +42,7 @@ const TimelineDownloadButton = ({
   return (
     <Button
       sx={[
-        { '& svg': { color: 'text.secondary' } },
+        { "& svg": { color: "text.secondary" } },
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
       className={className}

--- a/python/ray/dashboard/client/src/pages/job/index.tsx
+++ b/python/ray/dashboard/client/src/pages/job/index.tsx
@@ -115,7 +115,13 @@ const JobList = () => {
               }}
             />
             <Autocomplete
-              sx={{ height: 35, width: 150 }}
+              sx={{
+                height: 35,
+                width: 150,
+                '& .MuiSvgIcon-root': {
+                  color: 'text.secondary'
+                }
+              }}
               options={["PENDING", "RUNNING", "SUCCEEDED", "STOPPED", "FAILED"]}
               onInputChange={(event, value) =>
                 changeFilter("status", value.trim())

--- a/python/ray/dashboard/client/src/pages/job/index.tsx
+++ b/python/ray/dashboard/client/src/pages/job/index.tsx
@@ -118,8 +118,8 @@ const JobList = () => {
               sx={{
                 height: 35,
                 width: 150,
-                '& .MuiSvgIcon-root': {
-                  color: 'text.secondary',
+                "& .MuiSvgIcon-root": {
+                  color: "text.secondary",
                 },
               }}
               options={["PENDING", "RUNNING", "SUCCEEDED", "STOPPED", "FAILED"]}

--- a/python/ray/dashboard/client/src/pages/job/index.tsx
+++ b/python/ray/dashboard/client/src/pages/job/index.tsx
@@ -119,8 +119,8 @@ const JobList = () => {
                 height: 35,
                 width: 150,
                 '& .MuiSvgIcon-root': {
-                  color: 'text.secondary'
-                }
+                  color: 'text.secondary',
+                },
               }}
               options={["PENDING", "RUNNING", "SUCCEEDED", "STOPPED", "FAILED"]}
               onInputChange={(event, value) =>

--- a/python/ray/dashboard/client/src/pages/layout/MainNavLayout.tsx
+++ b/python/ray/dashboard/client/src/pages/layout/MainNavLayout.tsx
@@ -1,6 +1,11 @@
 import { Box, IconButton, Link, Tooltip, Typography } from "@mui/material";
 import React, { useContext } from "react";
-import { RiBookMarkLine, RiFeedbackLine } from "react-icons/ri/";
+import {
+  RiBookMarkLine,
+  RiFeedbackLine,
+  RiMoonLine,
+  RiSunLine,
+} from "react-icons/ri/";
 import { Outlet, Link as RouterLink } from "react-router-dom";
 import { GlobalContext } from "../../App";
 import { SearchTimezone } from "../../components/SearchComponent";
@@ -32,12 +37,12 @@ export const MainNavLayout = () => {
     <MainNavContext.Provider value={mainNavContextState}>
       <Box
         component="nav"
-        sx={{
+        sx={(theme) => ({
           position: "fixed",
           width: "100%",
-          backgroundColor: "white",
+          backgroundColor: theme.palette.background.paper,
           zIndex: 1000,
-        }}
+        })}
       >
         <MainNavBar />
         <MainNavBreadcrumbs />
@@ -107,8 +112,14 @@ const NAV_ITEMS = [
 const MainNavBar = () => {
   const { mainNavPageHierarchy } = useContext(MainNavContext);
   const rootRouteId = mainNavPageHierarchy[0]?.id;
-  const { metricsContextLoaded, grafanaHost, serverTimeZone, currentTimeZone } =
-    useContext(GlobalContext);
+  const {
+    metricsContextLoaded,
+    grafanaHost,
+    serverTimeZone,
+    currentTimeZone,
+    themeMode,
+    toggleTheme,
+  } = useContext(GlobalContext);
 
   let navItems = NAV_ITEMS;
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {
@@ -117,15 +128,15 @@ const MainNavBar = () => {
 
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         display: "flex",
         flexDirection: "row",
         flexWrap: "nowrap",
         height: 56,
-        backgroundColor: "white",
+        backgroundColor: theme.palette.background.paper,
         alignItems: "center",
-        boxShadow: "0px 1px 0px #D2DCE6",
-      }}
+        borderBottom: `1px solid ${theme.palette.divider}`,
+      })}
     >
       <Link
         component={RouterLink}
@@ -143,13 +154,16 @@ const MainNavBar = () => {
         <Typography key={id}>
           <Link
             component={RouterLink}
-            sx={{
+            sx={(theme) => ({
               marginRight: 6,
               fontSize: "1rem",
               fontWeight: 500,
-              color: rootRouteId === id ? "#036DCF" : "black",
+              color:
+                rootRouteId === id
+                  ? theme.palette.primary.main
+                  : theme.palette.text.primary,
               textDecoration: "none",
-            }}
+            })}
             to={path}
           >
             {title}
@@ -158,9 +172,18 @@ const MainNavBar = () => {
       ))}
       <Box sx={{ flexGrow: 1 }}></Box>
       <Box sx={{ marginRight: 2 }}>
+        <Tooltip title={themeMode === "light" ? "Dark mode" : "Light mode"}>
+          <IconButton
+            onClick={toggleTheme}
+            sx={(theme) => ({ color: theme.palette.text.secondary })}
+            size="large"
+          >
+            {themeMode === "light" ? <RiMoonLine /> : <RiSunLine />}
+          </IconButton>
+        </Tooltip>
         <Tooltip title="Docs">
           <IconButton
-            sx={{ color: "#5F6469" }}
+            sx={(theme) => ({ color: theme.palette.text.secondary })}
             href="https://docs.ray.io/en/latest/ray-core/ray-dashboard.html"
             target="_blank"
             rel="noopener noreferrer"
@@ -171,7 +194,7 @@ const MainNavBar = () => {
         </Tooltip>
         <Tooltip title="Leave feedback">
           <IconButton
-            sx={{ color: "#5F6469" }}
+            sx={(theme) => ({ color: theme.palette.text.secondary })}
             href="https://github.com/ray-project/ray/issues/new?assignees=&labels=bug%2Ctriage%2Cdashboard&template=bug-report.yml&title=%5BDashboard%5D+%3CTitle%3E"
             target="_blank"
             rel="noopener noreferrer"
@@ -208,7 +231,7 @@ const MainNavBreadcrumbs = () => {
 
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         display: "flex",
         flexDirection: "row",
         flexWrap: "nowrap",
@@ -216,10 +239,10 @@ const MainNavBreadcrumbs = () => {
         marginTop: "1px",
         paddingLeft: 2,
         paddingRight: 2,
-        backgroundColor: "white",
+        backgroundColor: theme.palette.background.paper,
         alignItems: "center",
-        boxShadow: "0px 1px 0px #D2DCE6",
-      }}
+        borderBottom: `1px solid ${theme.palette.divider}`,
+      })}
     >
       {mainNavPageHierarchy.map(({ title, id, path }, index) => {
         if (path) {
@@ -232,11 +255,13 @@ const MainNavBreadcrumbs = () => {
         const linkOrText = path ? (
           <Link
             component={RouterLink}
-            sx={{
+            sx={(theme) => ({
               textDecoration: "none",
               color:
-                index === mainNavPageHierarchy.length - 1 ? "black" : "#8C9196",
-            }}
+                index === mainNavPageHierarchy.length - 1
+                  ? theme.palette.text.primary
+                  : theme.palette.text.secondary,
+            })}
             to={currentPath}
           >
             {title}
@@ -248,13 +273,13 @@ const MainNavBreadcrumbs = () => {
           return (
             <Typography
               key={id}
-              sx={{
+              sx={(theme) => ({
                 fontWeight: 500,
-                color: "#8C9196",
+                color: theme.palette.text.secondary,
                 "&:not(:first-child)": {
                   marginLeft: 1,
                 },
-              }}
+              })}
               variant="body2"
             >
               {linkOrText}
@@ -264,25 +289,25 @@ const MainNavBreadcrumbs = () => {
           return (
             <React.Fragment key={id}>
               <Typography
-                sx={{
+                sx={(theme) => ({
                   fontWeight: 500,
-                  color: "#8C9196",
+                  color: theme.palette.text.secondary,
                   "&:not(:first-child)": {
                     marginLeft: 1,
                   },
-                }}
+                })}
                 variant="body2"
               >
                 {"/"}
               </Typography>
               <Typography
-                sx={{
+                sx={(theme) => ({
                   fontWeight: 500,
-                  color: "#8C9196",
+                  color: theme.palette.text.secondary,
                   "&:not(:first-child)": {
                     marginLeft: 1,
                   },
-                }}
+                })}
                 variant="body2"
               >
                 {linkOrText}

--- a/python/ray/dashboard/client/src/pages/layout/MainNavLayout.tsx
+++ b/python/ray/dashboard/client/src/pages/layout/MainNavLayout.tsx
@@ -121,6 +121,8 @@ const MainNavBar = () => {
     toggleTheme,
   } = useContext(GlobalContext);
 
+  const urlTheme = new URLSearchParams(window.location.search).get("theme");
+
   let navItems = NAV_ITEMS;
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {
     navItems = navItems.filter(({ id }) => id !== "metrics");
@@ -172,15 +174,17 @@ const MainNavBar = () => {
       ))}
       <Box sx={{ flexGrow: 1 }}></Box>
       <Box sx={{ marginRight: 2 }}>
-        <Tooltip title={themeMode === "light" ? "Dark mode" : "Light mode"}>
-          <IconButton
-            onClick={toggleTheme}
-            sx={(theme) => ({ color: theme.palette.text.secondary })}
-            size="large"
-          >
-            {themeMode === "light" ? <RiMoonLine /> : <RiSunLine />}
-          </IconButton>
-        </Tooltip>
+        {!urlTheme && (
+          <Tooltip title={themeMode === "light" ? "Dark mode" : "Light mode"}>
+            <IconButton
+              onClick={toggleTheme}
+              sx={(theme) => ({ color: theme.palette.text.secondary })}
+              size="large"
+            >
+              {themeMode === "light" ? <RiMoonLine /> : <RiSunLine />}
+            </IconButton>
+          </Tooltip>
+        )}
         <Tooltip title="Docs">
           <IconButton
             sx={(theme) => ({ color: theme.palette.text.secondary })}

--- a/python/ray/dashboard/client/src/pages/layout/SideTabLayout.tsx
+++ b/python/ray/dashboard/client/src/pages/layout/SideTabLayout.tsx
@@ -26,7 +26,7 @@ export const SideTabLayout = ({ children }: PropsWithChildren<{}>) => {
     <SideTabContext.Provider value={sideTabState}>
       <Box>
         <Box
-          sx={{
+          sx={(theme) => ({
             position: "fixed",
             height: "100%",
             width: 64,
@@ -36,9 +36,9 @@ export const SideTabLayout = ({ children }: PropsWithChildren<{}>) => {
             alignItems: "center",
             paddingTop: 1,
             paddingBottom: 2,
-            background: "white",
-            borderRight: "1px solid #D2DCE6",
-          }}
+            background: theme.palette.background.paper,
+            borderRight: `1px solid ${theme.palette.divider}`,
+          })}
         >
           {children}
         </Box>
@@ -74,20 +74,22 @@ export const SideTab = ({ tabId, title, Icon }: SideTabProps) => {
         id={tabId}
         role="tab"
         aria-selected={isSelected}
-        sx={{
+        sx={(theme) => ({
           width: 40,
           height: 40,
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-          color: isSelected ? "#036DCF" : "#5F6469",
-          backgroundColor: isSelected ? "#EBF3FB" : null,
+          color: isSelected
+            ? theme.palette.primary.main
+            : theme.palette.text.secondary,
+          backgroundColor: isSelected ? theme.palette.action.selected : null,
           borderRadius: "4px",
           marginTop: 1,
           "&:hover": {
-            backgroundColor: "#EBF3FB",
+            backgroundColor: theme.palette.action.hover,
           },
-        }}
+        })}
       >
         {Icon ? <Box component={Icon} sx={{ width: 24, height: 24 }} /> : tabId}
       </Box>

--- a/python/ray/dashboard/client/src/pages/log/LogViewer.tsx
+++ b/python/ray/dashboard/client/src/pages/log/LogViewer.tsx
@@ -71,7 +71,11 @@ export const LogViewer = memo(
                   type: "",
                   endAdornment: (
                     <InputAdornment position="end">
-                      <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
+                      <SearchOutlined
+                        sx={(theme) => ({
+                          color: theme.palette.text.secondary,
+                        })}
+                      />
                     </InputAdornment>
                   ),
                 }}

--- a/python/ray/dashboard/client/src/pages/log/LogViewer.tsx
+++ b/python/ray/dashboard/client/src/pages/log/LogViewer.tsx
@@ -7,7 +7,8 @@ import {
   Switch,
   TextField,
 } from "@mui/material";
-import React, { memo, useState } from "react";
+import React, { memo, useContext, useState } from "react";
+import { GlobalContext } from "../../App";
 import LogVirtualView from "../../components/LogView/LogVirtualView";
 
 const useLogViewer = () => {
@@ -53,6 +54,7 @@ export const LogViewer = memo(
   }: LogViewerProps) => {
     const { search, setSearch, startTime, setStart, endTime, setEnd } =
       useLogViewer();
+    const { themeMode } = useContext(GlobalContext);
 
     return (
       <React.Fragment>
@@ -69,7 +71,7 @@ export const LogViewer = memo(
                   type: "",
                   endAdornment: (
                     <InputAdornment position="end">
-                      <SearchOutlined />
+                      <SearchOutlined sx={(theme) => ({ color: theme.palette.text.secondary })} />
                     </InputAdornment>
                   ),
                 }}
@@ -144,6 +146,7 @@ export const LogViewer = memo(
               fontSize={search?.fontSize || 12}
               content={log}
               language="prolog"
+              theme={themeMode}
               startTime={startTime}
               endTime={endTime}
             />

--- a/python/ray/dashboard/client/src/pages/log/Logs.tsx
+++ b/python/ray/dashboard/client/src/pages/log/Logs.tsx
@@ -219,7 +219,7 @@ export const StateApiLogsFilesList = ({
                       size="small"
                       sx={{
                         verticalAlign: "baseline",
-                        '& svg': { color: 'text.secondary' }
+                        '& svg': { color: 'text.secondary' },
                       }}
                     >
                       <RiDownload2Line size={16} />

--- a/python/ray/dashboard/client/src/pages/log/Logs.tsx
+++ b/python/ray/dashboard/client/src/pages/log/Logs.tsx
@@ -8,7 +8,6 @@ import {
   Paper,
   Typography,
 } from "@mui/material";
-import { grey } from "@mui/material/colors";
 import React, { useMemo, useState } from "react";
 import { RiDownload2Line } from "react-icons/ri";
 import { Outlet, Link as RouterLink, useSearchParams } from "react-router-dom";
@@ -218,7 +217,10 @@ export const StateApiLogsFilesList = ({
                       href={downloadUrl}
                       download={fileName}
                       size="small"
-                      sx={{ verticalAlign: "baseline", color: grey[700] }}
+                      sx={{
+                        verticalAlign: "baseline",
+                        '& svg': { color: 'text.secondary' }
+                      }}
                     >
                       <RiDownload2Line size={16} />
                     </IconButton>

--- a/python/ray/dashboard/client/src/pages/log/Logs.tsx
+++ b/python/ray/dashboard/client/src/pages/log/Logs.tsx
@@ -219,7 +219,7 @@ export const StateApiLogsFilesList = ({
                       size="small"
                       sx={{
                         verticalAlign: "baseline",
-                        '& svg': { color: 'text.secondary' },
+                        "& svg": { color: "text.secondary" },
                       }}
                     >
                       <RiDownload2Line size={16} />

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
@@ -27,6 +27,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         serverTimeZone: undefined,
         currentTimeZone: undefined,
         themeMode: "light",
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         toggleTheme: () => {},
       }}
     >
@@ -58,6 +59,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         serverTimeZone: undefined,
         currentTimeZone: undefined,
         themeMode: "light",
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         toggleTheme: () => {},
       }}
     >
@@ -148,6 +150,7 @@ describe("Metrics", () => {
             serverTimeZone: undefined,
             currentTimeZone: undefined,
             themeMode: "light",
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
             toggleTheme: () => {},
           }}
         >

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
@@ -26,6 +26,8 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         dashboardDatasource: "Prometheus",
         serverTimeZone: undefined,
         currentTimeZone: undefined,
+        themeMode: "light",
+        toggleTheme: () => {},
       }}
     >
       <STYLE_WRAPPER>{children}</STYLE_WRAPPER>
@@ -55,6 +57,8 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         dashboardDatasource: "Prometheus",
         serverTimeZone: undefined,
         currentTimeZone: undefined,
+        themeMode: "light",
+        toggleTheme: () => {},
       }}
     >
       <STYLE_WRAPPER>{children}</STYLE_WRAPPER>
@@ -143,6 +147,8 @@ describe("Metrics", () => {
             dashboardDatasource: "Prometheus",
             serverTimeZone: undefined,
             currentTimeZone: undefined,
+            themeMode: "light",
+            toggleTheme: () => {},
           }}
         >
           <STYLE_WRAPPER>{children}</STYLE_WRAPPER>

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -89,6 +89,7 @@ export const Metrics = () => {
     dashboardDatasource,
     sessionName,
     currentTimeZone,
+    themeMode,
   } = useContext(GlobalContext);
 
   const grafanaDefaultDashboardUid =
@@ -114,7 +115,7 @@ export const Metrics = () => {
 
         const params = new URLSearchParams();
         params.set("orgId", grafanaOrgIdParam);
-        params.set("theme", "light");
+        params.set("theme", themeMode);
 
         if (kiosk) {
           params.set("kiosk", "1");
@@ -144,6 +145,7 @@ export const Metrics = () => {
       grafanaDataDashboardUid,
       grafanaDefaultDashboardUid,
       grafanaOrgIdParam,
+      themeMode,
       currentTimeZone,
       sessionName,
       grafanaDefaultDatasource,

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -177,7 +177,7 @@ export const Metrics = () => {
       ) : (
         <React.Fragment>
           <Paper
-            sx={{
+            sx={(theme) => ({
               position: "sticky",
               top: MAIN_NAV_HEIGHT,
               width: "100%",
@@ -185,10 +185,10 @@ export const Metrics = () => {
               flexDirection: "row",
               alignItems: "center",
               justifyContent: "space-between",
-              boxShadow: "0px 1px 0px #D2DCE6",
+              boxShadow: `0px 1px 0px ${theme.palette.divider}`,
               zIndex: 1,
               flexShrink: 0,
-            }}
+            })}
           >
             <Tabs
               value={selectedTab}

--- a/python/ray/dashboard/client/src/pages/node/GRAMColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/GRAMColumn.tsx
@@ -4,10 +4,10 @@ import { RightPaddedTypography } from "../../common/CustomTypography";
 import PercentageBar from "../../components/PercentageBar";
 import { GPUStats, NodeDetail } from "../../type/node";
 
-const VRAM_COL_WIDTH = 120;
+const GRAM_COL_WIDTH = 120;
 
-export const NodeVRAM = ({ node }: { node: NodeDetail }) => {
-  const nodeVRAMEntries = (node.gpus ?? []).map((gpu, i) => {
+export const NodeGRAM = ({ node }: { node: NodeDetail }) => {
+  const nodeGRAMEntries = (node.gpus ?? []).map((gpu, i) => {
     const props = {
       key: gpu.uuid,
       gpuName: gpu.name,
@@ -15,29 +15,29 @@ export const NodeVRAM = ({ node }: { node: NodeDetail }) => {
       total: gpu.memoryTotal,
       slot: gpu.index,
     };
-    return <VRAMEntry {...props} />;
+    return <GRAMEntry {...props} />;
   });
   return (
     <div style={{ minWidth: 60 }}>
-      {nodeVRAMEntries.length === 0 ? (
+      {nodeGRAMEntries.length === 0 ? (
         <Typography color="textSecondary" component="span" variant="inherit">
           N/A
         </Typography>
       ) : (
-        <div style={{ minWidth: VRAM_COL_WIDTH }}>{nodeVRAMEntries}</div>
+        <div style={{ minWidth: GRAM_COL_WIDTH }}>{nodeGRAMEntries}</div>
       )}
     </div>
   );
 };
 
-export const WorkerVRAM = ({
+export const WorkerGRAM = ({
   workerPID,
   gpus,
 }: {
   workerPID: number | null;
   gpus?: GPUStats[];
 }) => {
-  const workerVRAMEntries = (gpus ?? [])
+  const workerGRAMEntries = (gpus ?? [])
     .map((gpu, i) => {
       const process = gpu.processesPids?.find(
         (process) => workerPID && process.pid === workerPID,
@@ -52,26 +52,26 @@ export const WorkerVRAM = ({
         utilization: process.gpuMemoryUsage,
         slot: gpu.index,
       };
-      return <VRAMEntry {...props} />;
+      return <GRAMEntry {...props} />;
     })
     .filter((entry) => entry !== undefined);
 
-  return workerVRAMEntries.length === 0 ? (
+  return workerGRAMEntries.length === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       N/A
     </Typography>
   ) : (
-    <div style={{ minWidth: VRAM_COL_WIDTH }}>{workerVRAMEntries}</div>
+    <div style={{ minWidth: GRAM_COL_WIDTH }}>{workerGRAMEntries}</div>
   );
 };
 
-export const getSumVRAMUsage = (
+export const getSumGRAMUsage = (
   workerPID: number | null,
   gpus?: GPUStats[],
 ) => {
-  // Get sum of all VRAM usage values for this worker PID. This is an
-  // aggregate of WorkerVRAM and follows the same logic.
-  const workerVRAMEntries = (gpus ?? [])
+  // Get sum of all GRAM usage values for this worker PID. This is an
+  // aggregate of WorkerGRAM and follows the same logic.
+  const workerGRAMEntries = (gpus ?? [])
     .map((gpu, i) => {
       const process = gpu.processesPids?.find(
         (process) => workerPID && process.pid === workerPID,
@@ -82,20 +82,20 @@ export const getSumVRAMUsage = (
       return process.gpuMemoryUsage;
     })
     .filter((entry) => entry !== undefined);
-  return workerVRAMEntries.reduce((a, b) => a + b, 0);
+  return workerGRAMEntries.reduce((a, b) => a + b, 0);
 };
 
 const getMiBRatioNoPercent = (used: number, total: number) =>
   `${used}MiB/${total}MiB`;
 
-type VRAMEntryProps = {
+type GRAMEntryProps = {
   gpuName: string;
   slot: number;
   utilization: number;
   total: number;
 };
 
-const VRAMEntry: React.FC<VRAMEntryProps> = ({
+const GRAMEntry: React.FC<GRAMEntryProps> = ({
   gpuName,
   slot,
   utilization,
@@ -103,7 +103,7 @@ const VRAMEntry: React.FC<VRAMEntryProps> = ({
 }) => {
   const ratioStr = getMiBRatioNoPercent(utilization, total);
   return (
-    <Box display="flex" flexWrap="nowrap" style={{ minWidth: VRAM_COL_WIDTH }}>
+    <Box display="flex" flexWrap="nowrap" style={{ minWidth: GRAM_COL_WIDTH }}>
       <Tooltip title={gpuName}>
         <Box display="flex" flexWrap="nowrap" flexGrow={1}>
           <RightPaddedTypography variant="body1">

--- a/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
@@ -26,7 +26,7 @@ import { NodeDetail } from "../../type/node";
 import { Worker } from "../../type/worker";
 import { memoryConverter } from "../../util/converter";
 import { NodeGPUView, WorkerGpuRow } from "./GPUColumn";
-import { NodeGRAM, WorkerGRAM } from "./GRAMColumn";
+import { NodeVRAM, WorkerVRAM } from "./VRAMColumn";
 
 const TEXT_COL_MIN_WIDTH = 100;
 
@@ -161,7 +161,7 @@ export const NodeRow = ({
         <NodeGPUView node={node} />
       </TableCell>
       <TableCell>
-        <NodeGRAM node={node} />
+        <NodeVRAM node={node} />
       </TableCell>
       <TableCell>
         {raylet && objectStoreTotalMemory && (
@@ -301,7 +301,7 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         <WorkerGpuRow workerPID={pid} gpus={node.gpus} />
       </TableCell>
       <TableCell>
-        <WorkerGRAM workerPID={pid} gpus={node.gpus} />
+        <WorkerVRAM workerPID={pid} gpus={node.gpus} />
       </TableCell>
       <TableCell>N/A</TableCell>
       <TableCell>N/A</TableCell>

--- a/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
@@ -26,7 +26,7 @@ import { NodeDetail } from "../../type/node";
 import { Worker } from "../../type/worker";
 import { memoryConverter } from "../../util/converter";
 import { NodeGPUView, WorkerGpuRow } from "./GPUColumn";
-import { NodeVRAM, WorkerVRAM } from "./VRAMColumn";
+import { NodeGRAM, WorkerGRAM } from "./GRAMColumn";
 
 const TEXT_COL_MIN_WIDTH = 100;
 
@@ -161,7 +161,7 @@ export const NodeRow = ({
         <NodeGPUView node={node} />
       </TableCell>
       <TableCell>
-        <NodeVRAM node={node} />
+        <NodeGRAM node={node} />
       </TableCell>
       <TableCell>
         {raylet && objectStoreTotalMemory && (
@@ -301,7 +301,7 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         <WorkerGpuRow workerPID={pid} gpus={node.gpus} />
       </TableCell>
       <TableCell>
-        <WorkerVRAM workerPID={pid} gpus={node.gpus} />
+        <WorkerGRAM workerPID={pid} gpus={node.gpus} />
       </TableCell>
       <TableCell>N/A</TableCell>
       <TableCell>N/A</TableCell>

--- a/python/ray/dashboard/client/src/pages/node/VRAMColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/VRAMColumn.tsx
@@ -4,10 +4,10 @@ import { RightPaddedTypography } from "../../common/CustomTypography";
 import PercentageBar from "../../components/PercentageBar";
 import { GPUStats, NodeDetail } from "../../type/node";
 
-const GRAM_COL_WIDTH = 120;
+const VRAM_COL_WIDTH = 120;
 
-export const NodeGRAM = ({ node }: { node: NodeDetail }) => {
-  const nodeGRAMEntries = (node.gpus ?? []).map((gpu, i) => {
+export const NodeVRAM = ({ node }: { node: NodeDetail }) => {
+  const nodeVRAMEntries = (node.gpus ?? []).map((gpu, i) => {
     const props = {
       key: gpu.uuid,
       gpuName: gpu.name,
@@ -15,29 +15,29 @@ export const NodeGRAM = ({ node }: { node: NodeDetail }) => {
       total: gpu.memoryTotal,
       slot: gpu.index,
     };
-    return <GRAMEntry {...props} />;
+    return <VRAMEntry {...props} />;
   });
   return (
     <div style={{ minWidth: 60 }}>
-      {nodeGRAMEntries.length === 0 ? (
+      {nodeVRAMEntries.length === 0 ? (
         <Typography color="textSecondary" component="span" variant="inherit">
           N/A
         </Typography>
       ) : (
-        <div style={{ minWidth: GRAM_COL_WIDTH }}>{nodeGRAMEntries}</div>
+        <div style={{ minWidth: VRAM_COL_WIDTH }}>{nodeVRAMEntries}</div>
       )}
     </div>
   );
 };
 
-export const WorkerGRAM = ({
+export const WorkerVRAM = ({
   workerPID,
   gpus,
 }: {
   workerPID: number | null;
   gpus?: GPUStats[];
 }) => {
-  const workerGRAMEntries = (gpus ?? [])
+  const workerVRAMEntries = (gpus ?? [])
     .map((gpu, i) => {
       const process = gpu.processesPids?.find(
         (process) => workerPID && process.pid === workerPID,
@@ -52,26 +52,26 @@ export const WorkerGRAM = ({
         utilization: process.gpuMemoryUsage,
         slot: gpu.index,
       };
-      return <GRAMEntry {...props} />;
+      return <VRAMEntry {...props} />;
     })
     .filter((entry) => entry !== undefined);
 
-  return workerGRAMEntries.length === 0 ? (
+  return workerVRAMEntries.length === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       N/A
     </Typography>
   ) : (
-    <div style={{ minWidth: GRAM_COL_WIDTH }}>{workerGRAMEntries}</div>
+    <div style={{ minWidth: VRAM_COL_WIDTH }}>{workerVRAMEntries}</div>
   );
 };
 
-export const getSumGRAMUsage = (
+export const getSumVRAMUsage = (
   workerPID: number | null,
   gpus?: GPUStats[],
 ) => {
-  // Get sum of all GRAM usage values for this worker PID. This is an
-  // aggregate of WorkerGRAM and follows the same logic.
-  const workerGRAMEntries = (gpus ?? [])
+  // Get sum of all VRAM usage values for this worker PID. This is an
+  // aggregate of WorkerVRAM and follows the same logic.
+  const workerVRAMEntries = (gpus ?? [])
     .map((gpu, i) => {
       const process = gpu.processesPids?.find(
         (process) => workerPID && process.pid === workerPID,
@@ -82,20 +82,20 @@ export const getSumGRAMUsage = (
       return process.gpuMemoryUsage;
     })
     .filter((entry) => entry !== undefined);
-  return workerGRAMEntries.reduce((a, b) => a + b, 0);
+  return workerVRAMEntries.reduce((a, b) => a + b, 0);
 };
 
 const getMiBRatioNoPercent = (used: number, total: number) =>
   `${used}MiB/${total}MiB`;
 
-type GRAMEntryProps = {
+type VRAMEntryProps = {
   gpuName: string;
   slot: number;
   utilization: number;
   total: number;
 };
 
-const GRAMEntry: React.FC<GRAMEntryProps> = ({
+const VRAMEntry: React.FC<VRAMEntryProps> = ({
   gpuName,
   slot,
   utilization,
@@ -103,7 +103,7 @@ const GRAMEntry: React.FC<GRAMEntryProps> = ({
 }) => {
   const ratioStr = getMiBRatioNoPercent(utilization, total);
   return (
-    <Box display="flex" flexWrap="nowrap" style={{ minWidth: GRAM_COL_WIDTH }}>
+    <Box display="flex" flexWrap="nowrap" style={{ minWidth: VRAM_COL_WIDTH }}>
       <Tooltip title={gpuName}>
         <Box display="flex" flexWrap="nowrap" flexGrow={1}>
           <RightPaddedTypography variant="body1">

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -86,7 +86,7 @@ const columns = [
       </Typography>
     ),
   },
-  { label: "VRAM" },
+  { label: "GRAM" },
   { label: "Object Store Memory" },
   {
     label: "Disk(root)",

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -86,7 +86,7 @@ const columns = [
       </Typography>
     ),
   },
-  { label: "GRAM" },
+  { label: "VRAM" },
   { label: "Object Store Memory" },
   {
     label: "Disk(root)",

--- a/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
@@ -99,6 +99,7 @@ const Wrapper =
               serverTimeZone: undefined,
               currentTimeZone: undefined,
               themeMode: "light",
+              // eslint-disable-next-line @typescript-eslint/no-empty-function
               toggleTheme: () => {},
             }}
           >

--- a/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
@@ -98,6 +98,8 @@ const Wrapper =
               dashboardDatasource: "Prometheus",
               serverTimeZone: undefined,
               currentTimeZone: undefined,
+              themeMode: "light",
+              toggleTheme: () => {},
             }}
           >
             {children}

--- a/python/ray/dashboard/client/src/pages/overview/OverviewPage.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/OverviewPage.tsx
@@ -23,18 +23,18 @@ const styles = {
       maxWidth: `calc((100% - ${theme.spacing(3)} * 2) / 3)`,
     },
   }),
-  autoscalerCard: {
-    backgroundColor: "white",
+  autoscalerCard: (theme: Theme) => ({
+    backgroundColor: theme.palette.background.paper,
     paddingX: 3,
     paddingY: 2,
-  },
+  }),
 };
 
 export const OverviewPage = () => {
   const { clusterStatus } = useRayStatus();
 
   return (
-    <Box sx={{ padding: 3, backgroundColor: "white" }}>
+    <Box sx={(theme) => ({ padding: 3, backgroundColor: theme.palette.background.default })}>
       <MainNavPageInfo
         pageInfo={{ title: "Overview", id: "overview", path: "/overview" }}
       />

--- a/python/ray/dashboard/client/src/pages/overview/OverviewPage.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/OverviewPage.tsx
@@ -34,7 +34,12 @@ export const OverviewPage = () => {
   const { clusterStatus } = useRayStatus();
 
   return (
-    <Box sx={(theme) => ({ padding: 3, backgroundColor: theme.palette.background.default })}>
+    <Box
+      sx={(theme) => ({
+        padding: 3,
+        backgroundColor: theme.palette.background.default,
+      })}
+    >
       <MainNavPageInfo
         pageInfo={{ title: "Overview", id: "overview", path: "/overview" }}
       />

--- a/python/ray/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
@@ -22,10 +22,11 @@ export const ClusterUtilizationCard = ({
     dashboardUids,
     dashboardDatasource,
     currentTimeZone,
+    themeMode,
   } = useContext(GlobalContext);
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
-  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=${grafanaOrgId}&theme=light&panelId=41&var-datasource=${dashboardDatasource}`;
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=${grafanaOrgId}&theme=${themeMode}&panelId=41&var-datasource=${dashboardDatasource}`;
   const timeRangeParams = "&from=now-1h&to=now";
 
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {

--- a/python/ray/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
@@ -19,10 +19,11 @@ export const NodeCountCard = ({ className, sx }: NodeCountCardProps) => {
     dashboardUids,
     dashboardDatasource,
     currentTimeZone,
+    themeMode,
   } = useContext(GlobalContext);
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
-  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=${grafanaOrgId}&theme=light&panelId=24&var-datasource=${dashboardDatasource}`;
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=${grafanaOrgId}&theme=${themeMode}&panelId=24&var-datasource=${dashboardDatasource}`;
   const timeRangeParams = "&from=now-1h&to=now";
 
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {

--- a/python/ray/dashboard/client/src/pages/overview/cards/OverviewCard.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/cards/OverviewCard.tsx
@@ -36,14 +36,14 @@ export const LinkWithArrow = ({ text, to }: LinkWithArrowProps) => {
   return (
     <Link
       component={RouterLink}
-      sx={{
+      sx={(theme) => ({
         color: theme.palette.primary.main,
         textDecoration: "none",
         display: "flex",
         flexDirection: "row",
         flexWrap: "nowrap",
         alignItems: "center",
-      }}
+      })}
       to={to}
     >
       <Typography variant="h4">{text}</Typography>

--- a/python/ray/dashboard/client/src/pages/overview/cards/OverviewCard.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/cards/OverviewCard.tsx
@@ -37,7 +37,7 @@ export const LinkWithArrow = ({ text, to }: LinkWithArrowProps) => {
     <Link
       component={RouterLink}
       sx={{
-        color: "#036DCF",
+        color: theme.palette.primary.main,
         textDecoration: "none",
         display: "flex",
         flexDirection: "row",

--- a/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
@@ -27,6 +27,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         serverTimeZone: undefined,
         currentTimeZone: undefined,
         themeMode: "light",
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         toggleTheme: () => {},
       }}
     >
@@ -58,6 +59,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         serverTimeZone: undefined,
         currentTimeZone: undefined,
         themeMode: "light",
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         toggleTheme: () => {},
       }}
     >

--- a/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
@@ -26,6 +26,8 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         dashboardDatasource: "Prometheus",
         serverTimeZone: undefined,
         currentTimeZone: undefined,
+        themeMode: "light",
+        toggleTheme: () => {},
       }}
     >
       <STYLE_WRAPPER>{children}</STYLE_WRAPPER>
@@ -55,6 +57,8 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         dashboardDatasource: "Prometheus",
         serverTimeZone: undefined,
         currentTimeZone: undefined,
+        themeMode: "light",
+        toggleTheme: () => {},
       }}
     >
       <STYLE_WRAPPER>{children}</STYLE_WRAPPER>

--- a/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -27,15 +27,15 @@ import {
 const METRICS_CONFIG: MetricConfig[] = [
   {
     title: "QPS per replica",
-    pathParams: "theme=light&panelId=2",
+    pathParams: "panelId=2",
   },
   {
     title: "Error QPS per replica",
-    pathParams: "&theme=light&panelId=3",
+    pathParams: "panelId=3",
   },
   {
     title: "P90 latency per replica",
-    pathParams: "&theme=light&panelId=5",
+    pathParams: "panelId=5",
   },
 ];
 
@@ -58,6 +58,7 @@ export const ServeReplicaMetricsSection = ({
     dashboardUids,
     dashboardDatasource,
     currentTimeZone,
+    themeMode,
   } = useContext(GlobalContext);
   const grafanaServeDashboardUid =
     dashboardUids?.serveDeployment ?? "rayServeDashboard";
@@ -184,7 +185,7 @@ export const ServeReplicaMetricsSection = ({
         >
           {METRICS_CONFIG.map(({ title, pathParams }) => {
             const path =
-              `/d-solo/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&${pathParams}` +
+              `/d-solo/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&theme=${themeMode}&${pathParams}` +
               `${refreshParams}&timezone=${currentTimeZone}${timeRangeParams}&var-Deployment=${encodeURIComponent(
                 deploymentName,
               )}&var-Replica=${encodeURIComponent(

--- a/python/ray/dashboard/client/src/pages/serve/ServeLayout.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeLayout.tsx
@@ -8,7 +8,13 @@ import { SideTabLayout, SideTabRouteLink } from "../layout/SideTabLayout";
 export const ServeLayout = () => {
   const theme = useTheme();
   return (
-    <Box sx={{ width: "100%", minHeight: 800, background: theme.palette.background.default }}>
+    <Box
+      sx={{
+        width: "100%",
+        minHeight: 800,
+        background: theme.palette.background.default,
+      }}
+    >
       <MainNavPageInfo
         pageInfo={{
           id: "serve",

--- a/python/ray/dashboard/client/src/pages/serve/ServeLayout.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeLayout.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, useTheme } from "@mui/material";
 import React from "react";
 import { RiInformationLine, RiTableLine } from "react-icons/ri";
 import { Outlet } from "react-router-dom";
@@ -6,8 +6,9 @@ import { MainNavPageInfo } from "../layout/mainNavContext";
 import { SideTabLayout, SideTabRouteLink } from "../layout/SideTabLayout";
 
 export const ServeLayout = () => {
+  const theme = useTheme();
   return (
-    <Box sx={{ width: "100%", minHeight: 800, background: "white" }}>
+    <Box sx={{ width: "100%", minHeight: 800, background: theme.palette.background.default }}>
       <MainNavPageInfo
         pageInfo={{
           id: "serve",

--- a/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -31,6 +31,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         serverTimeZone: undefined,
         currentTimeZone: undefined,
         themeMode: "light",
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         toggleTheme: () => {},
       }}
     >
@@ -62,6 +63,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         serverTimeZone: undefined,
         currentTimeZone: undefined,
         themeMode: "light",
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         toggleTheme: () => {},
       }}
     >

--- a/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -30,6 +30,8 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         dashboardDatasource: "Prometheus",
         serverTimeZone: undefined,
         currentTimeZone: undefined,
+        themeMode: "light",
+        toggleTheme: () => {},
       }}
     >
       <STYLE_WRAPPER>{children}</STYLE_WRAPPER>
@@ -59,6 +61,8 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         dashboardDatasource: "Prometheus",
         serverTimeZone: undefined,
         currentTimeZone: undefined,
+        themeMode: "light",
+        toggleTheme: () => {},
       }}
     >
       <STYLE_WRAPPER>{children}</STYLE_WRAPPER>

--- a/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -27,15 +27,15 @@ import {
 export const APPS_METRICS_CONFIG: MetricConfig[] = [
   {
     title: "QPS per application",
-    pathParams: "theme=light&panelId=7",
+    pathParams: "panelId=7",
   },
   {
     title: "Error QPS per application",
-    pathParams: "theme=light&panelId=8",
+    pathParams: "panelId=8",
   },
   {
     title: "P90 latency per application",
-    pathParams: "theme=light&panelId=15",
+    pathParams: "panelId=15",
   },
 ];
 
@@ -43,27 +43,27 @@ export const APPS_METRICS_CONFIG: MetricConfig[] = [
 export const SERVE_SYSTEM_METRICS_CONFIG: MetricConfig[] = [
   {
     title: "Ongoing HTTP Requests",
-    pathParams: "theme=light&panelId=20",
+    pathParams: "panelId=20",
   },
   {
     title: "Ongoing gRPC Requests",
-    pathParams: "theme=light&panelId=21",
+    pathParams: "panelId=21",
   },
   {
     title: "Scheduling Tasks",
-    pathParams: "theme=light&panelId=22",
+    pathParams: "panelId=22",
   },
   {
     title: "Scheduling Tasks in Backoff",
-    pathParams: "theme=light&panelId=23",
+    pathParams: "panelId=23",
   },
   {
     title: "Controller Control Loop Duration",
-    pathParams: "theme=light&panelId=24",
+    pathParams: "panelId=24",
   },
   {
     title: "Number of Control Loops",
-    pathParams: "theme=light&panelId=25",
+    pathParams: "panelId=25",
   },
 ];
 
@@ -84,6 +84,7 @@ export const ServeMetricsSection = ({
     dashboardUids,
     dashboardDatasource,
     currentTimeZone,
+    themeMode,
   } = useContext(GlobalContext);
   const grafanaServeDashboardUid = dashboardUids?.serve ?? "rayServeDashboard";
   const [refreshOption, setRefreshOption] = useState<RefreshOptions>(
@@ -201,7 +202,7 @@ export const ServeMetricsSection = ({
         >
           {metricsConfig.map(({ title, pathParams }) => {
             const path =
-              `/d-solo/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&${pathParams}` +
+              `/d-solo/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&theme=${themeMode}&${pathParams}` +
               `${refreshParams}&timezone=${currentTimeZone}${timeRangeParams}&var-datasource=${dashboardDatasource}`;
             return (
               <Paper

--- a/python/ray/dashboard/client/src/pages/task/TaskPage.tsx
+++ b/python/ray/dashboard/client/src/pages/task/TaskPage.tsx
@@ -31,7 +31,12 @@ export const TaskPage = () => {
   const { task, isLoading } = useStateApiTask(taskId);
 
   return (
-    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
+    <Box
+      sx={(theme) => ({
+        padding: 2,
+        backgroundColor: theme.palette.background.paper,
+      })}
+    >
       <MainNavPageInfo
         pageInfo={
           task

--- a/python/ray/dashboard/client/src/pages/task/TaskPage.tsx
+++ b/python/ray/dashboard/client/src/pages/task/TaskPage.tsx
@@ -31,7 +31,7 @@ export const TaskPage = () => {
   const { task, isLoading } = useStateApiTask(taskId);
 
   return (
-    <Box sx={{ padding: 2, backgroundColor: "white" }}>
+    <Box sx={(theme) => ({ padding: 2, backgroundColor: theme.palette.background.paper })}>
       <MainNavPageInfo
         pageInfo={
           task

--- a/python/ray/dashboard/client/src/theme.ts
+++ b/python/ray/dashboard/client/src/theme.ts
@@ -98,6 +98,9 @@ export const lightTheme = createTheme(basicTheme, {
     error: {
       main: "#D32F2F",
     },
+    warning: {
+      light: "#cfcf08",
+    },
     text: {
       primary: grey[900],
       secondary: grey[800],
@@ -142,6 +145,7 @@ export const darkTheme = createTheme(basicTheme, {
     },
     warning: {
       main: "#FF8C1A",
+      light: "#E8E850",
     },
     text: {
       primary: "#E8EAED",

--- a/python/ray/dashboard/client/src/theme.ts
+++ b/python/ray/dashboard/client/src/theme.ts
@@ -54,15 +54,6 @@ const basicTheme: ThemeOptions = {
         size: "small",
       },
     },
-    MuiCssBaseline: {
-      styleOverrides: {
-        "@global": {
-          a: {
-            color: "#036DCF",
-          },
-        },
-      },
-    },
     MuiTextField: {
       defaultProps: {
         size: "small",
@@ -87,7 +78,6 @@ const basicTheme: ThemeOptions = {
     MuiPaper: {
       styleOverrides: {
         outlined: {
-          borderColor: "#D2DCE6",
           borderRadius: 8,
         },
       },
@@ -97,6 +87,7 @@ const basicTheme: ThemeOptions = {
 
 export const lightTheme = createTheme(basicTheme, {
   palette: {
+    mode: "light",
     primary: {
       main: "#036DCF",
     },
@@ -109,38 +100,71 @@ export const lightTheme = createTheme(basicTheme, {
     },
     text: {
       primary: grey[900],
-      secondary: grey[800],
+      secondary: grey[700],
       disabled: grey[400],
-      hint: grey[300],
     },
     background: {
       paper: "#fff",
       default: blueGrey[50],
+    },
+    divider: "#D2DCE6",
+  },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        a: {
+          color: "#036DCF",
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        outlined: {
+          borderColor: "#D2DCE6",
+        },
+      },
     },
   },
 });
 
 export const darkTheme = createTheme(basicTheme, {
   palette: {
+    mode: "dark",
     primary: {
-      main: "#538DF9",
+      main: "#5B9BFF",
     },
     secondary: lightBlue,
     success: {
-      main: "#43A047",
+      main: "#66BB6A",
     },
     error: {
-      main: "#D32F2F",
+      main: "#EF5350",
     },
     text: {
-      primary: blueGrey[50],
-      secondary: blueGrey[100],
-      disabled: blueGrey[200],
-      hint: blueGrey[300],
+      primary: "#E8EAED",
+      secondary: "#9AA0A6",
+      disabled: "#5F6368",
     },
     background: {
-      paper: grey[800],
-      default: grey[900],
+      paper: "#1A1A1A",
+      default: "#0F0F0F",
+    },
+    divider: "rgba(255, 255, 255, 0.12)",
+  },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        a: {
+          color: "#5B9BFF",
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        outlined: {
+          borderColor: "rgba(255, 255, 255, 0.12)",
+        },
+      },
     },
   },
 });

--- a/python/ray/dashboard/client/src/theme.ts
+++ b/python/ray/dashboard/client/src/theme.ts
@@ -140,10 +140,13 @@ export const darkTheme = createTheme(basicTheme, {
     error: {
       main: "#EF5350",
     },
+    warning: {
+      main: "#FF8C1A",
+    },
     text: {
       primary: "#E8EAED",
       secondary: "#9AA0A6",
-      disabled: "#5F6368",
+      disabled: "#8A8E93",
     },
     background: {
       paper: "#1A1A1A",

--- a/python/ray/dashboard/client/src/theme.ts
+++ b/python/ray/dashboard/client/src/theme.ts
@@ -100,7 +100,7 @@ export const lightTheme = createTheme(basicTheme, {
     },
     text: {
       primary: grey[900],
-      secondary: grey[700],
+      secondary: grey[800],
       disabled: grey[400],
     },
     background: {

--- a/python/ray/dashboard/client/src/theme.ts
+++ b/python/ray/dashboard/client/src/theme.ts
@@ -99,6 +99,7 @@ export const lightTheme = createTheme(basicTheme, {
       main: "#D32F2F",
     },
     warning: {
+      main: "#ED6C02",
       light: "#cfcf08",
     },
     text: {

--- a/python/ray/dashboard/client/src/util/test-utils.tsx
+++ b/python/ray/dashboard/client/src/util/test-utils.tsx
@@ -26,6 +26,7 @@ export const TEST_APP_WRAPPER = ({ children }: PropsWithChildren<{}>) => {
     serverTimeZone: undefined,
     currentTimeZone: undefined,
     themeMode: "light",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     toggleTheme: () => {},
   };
 

--- a/python/ray/dashboard/client/src/util/test-utils.tsx
+++ b/python/ray/dashboard/client/src/util/test-utils.tsx
@@ -25,6 +25,8 @@ export const TEST_APP_WRAPPER = ({ children }: PropsWithChildren<{}>) => {
     dashboardDatasource: "Prometheus",
     serverTimeZone: undefined,
     currentTimeZone: undefined,
+    themeMode: "light",
+    toggleTheme: () => {},
   };
 
   return (


### PR DESCRIPTION
## Description

Implements dark mode for the Ray Dashboard.

- Toggle button in nav bar switches between light/dark themes
- Preference saved to localStorage and persists across sessions
- Respects system theme preference on first load
- 57 files updated to replace hardcoded colors with theme palette values
- All components work properly in both modes (icons, charts, embedded Grafana)

## Related issues

Closes #49075

## Additional information

### Note about PR #54783

Started this before discovering #54783. This PR covers more components (57 vs 21 files) and integrates into existing GlobalContext. Happy to collaborate with @ddishi if needed.

### Implementation

- Added `themeMode` and `toggleTheme` to GlobalContext in `App.tsx`
- Theme definitions in `theme.ts` with full palettes for both modes
- Dark theme uses deep blacks (#0F0F0F, #1A1A1A)
- Replaced hardcoded colors with theme values (`theme.palette.*`)
- ~~Renamed GRAM to VRAM for standard terminology~~

### Screenshots

![Cluster Dark](https://github.com/user-attachments/assets/115b73d6-bca5-4a91-9e95-bb66f85012b3)

<details>
<summary><b>Overview Page</b></summary>

![Overview Light](https://github.com/user-attachments/assets/f1e79b17-edb7-4290-939e-62ef491662ea)
![Overview Dark](https://github.com/user-attachments/assets/31dce618-50d7-49a5-8ef2-cf1db86eb01c)

</details>

<details>
<summary><b>Cluster/Nodes Page</b></summary>

![Cluster Light](https://github.com/user-attachments/assets/a7a9a743-cd46-485a-aa72-09862d62a3f1)![Cluster Dark](https://github.com/user-attachments/assets/115b73d6-bca5-4a91-9e95-bb66f85012b3)

</details>

<details>
<summary><b>Jobs Page</b></summary>

![Jobs Light](https://github.com/user-attachments/assets/421f7990-e213-4eac-9906-e448539133a4)
![Jobs Dark](https://github.com/user-attachments/assets/bb1acb95-423a-455b-bedd-ae2e6829a0e4)

</details>

<details>
<summary><b>Actors Page</b></summary>

![Actors Light](https://github.com/user-attachments/assets/4bfd0905-dce6-4150-9f4a-4da50227ed7a)
![Actors Dark](https://github.com/user-attachments/assets/736f97f4-a8a0-4e1e-a993-4a5c07f6c0af)

</details>

<details>
<summary><b>Serve Deployments Page</b></summary>

![Serve Light](https://github.com/user-attachments/assets/c0e2866f-1bac-4705-bc5a-78120d8e4aaa)
![Serve Dark](https://github.com/user-attachments/assets/42b26cd4-7ac8-48e9-825f-0120247a2874)

</details>

<details>
<summary><b>Metrics Page</b></summary>

![Metrics Light](https://github.com/user-attachments/assets/369a2f05-a488-4c72-9368-3b5e7d2bb3ae)
![Metrics Dark](https://github.com/user-attachments/assets/6d2b81d0-53a3-4728-9583-1cc10330825a)

</details>

<details>
<summary><b>Logs Page</b></summary>


![Logs Light](https://github.com/user-attachments/assets/74ded09c-e8e1-44c3-8453-2484e93c0d1e)
![Logs Dark](https://github.com/user-attachments/assets/892dfcec-7308-4f4d-99d0-7eb6e61f4c39)

</details>

### Testing

Manually tested all pages in both themes. Toggle works without refresh, preference persists, system detection works (at least on my machine :D) . 

Given the scope, I likely missed some edge cases or specific components. Happy to fix anything that comes up in review.
