### PR TITLE
[serve][llm] update vllm_engine.py to check for VLLM_USE_V1 attribute

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -134,8 +134,7 @@ class VLLMEngine(LLMEngine):
             )
         from vllm import envs as vllm_envs
 
-        # TODO (Kourosh): Remove this after a few releases.
-        if not vllm_envs.VLLM_USE_V1:
+        if hasattr(vllm_envs, "VLLM_USE_V1") and not vllm_envs.VLLM_USE_V1:
             logger.error(
                 "vLLM v0 is fully deprecated. As a result in Ray Serve LLM only v1 is supported."
             )


### PR DESCRIPTION
## Description
vLLM 0.11.1 has removed the use vLLM v1 flag, and this causes serve to crash when using LLMConfig.

## Related issues
TODO: I will look for related or open an issue.

## Additional information
Are there additional checks that should happen?
