### PR TITLE
Remove references to deprecated VLLM_USE_V1 env variable

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -134,12 +134,6 @@ class VLLMEngine(LLMEngine):
             )
         from vllm import envs as vllm_envs
 
-        # TODO (Kourosh): Remove this after a few releases.
-        if not vllm_envs.VLLM_USE_V1:
-            logger.error(
-                "vLLM v0 is fully deprecated. As a result in Ray Serve LLM only v1 is supported."
-            )
-
         self.llm_config.setup_engine_backend()
 
         self._running = False


### PR DESCRIPTION
VLLM_USE_V1 is deprecated and no longer used in vllm's env variables. Existing references to this variable are currently causing errors


## Description
This PR removes references to the VLLM_USE_V1 environment variable.

This variable has been deprecated and removed in the upstream vLLM project. Retaining these references in the Ray codebase is currently causing runtime errors when integrating with newer versions of vLLM.
## Related issues
Related to upstream vLLM changes. 

## Additional information
Removed in this commit:
https://github.com/vllm-project/vllm/commit/e1710393c44cff20e481b632b86d157a9d694625
