### PR TITLE
[Data] Fix empty block sort in hash shuffle operator

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -178,7 +178,7 @@ class Concat(StatefulShuffleAggregation):
     def finalize(self, partition_id: int) -> Block:
         block = self._partition_block_builders[partition_id].build()
 
-        if self._should_sort:
+        if self._should_sort and len(block) > 0:
             block = block.sort_by([(k, "ascending") for k in self._key_columns])
 
         return block


### PR DESCRIPTION
## Description

Prevent calling `sort_by` on empty blocks in the `Concat.finalize` method. Attempting to sort an empty block can cause unnecessary overhead. This change adds a check to ensure the block has data before attempting to sort.