### PR TITLE
Fix uv run to access system-installed packages

### DIFF
--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -334,7 +334,10 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     parser.add_argument("-m", "--module")
     _, remaining_uv_run_args = parser.parse_known_args(uv_run_args)
 
-    runtime_env["py_executable"] = " ".join(remaining_uv_run_args)
+    # Ensure .venv is created with --system-site-packages for access to pre-installed packages
+    uv_run_cmd = " ".join(remaining_uv_run_args)
+    wrapper = f"bash -c 'test -d .venv || uv venv --system-site-packages .venv >/dev/null 2>&1; exec {uv_run_cmd} \"$@\"' bash"
+    runtime_env["py_executable"] = wrapper
 
     # If the user specified a working_dir, we always honor it, otherwise
     # use the same working_dir that uv run would use


### PR DESCRIPTION
## Description

Enable uv run to work with system-installed packages (Ray, PyTorch, pandas, etc.) in Docker images by ensuring virtual environments are created with --system-site-packages.

This fix wraps the uv run command to check if .venv exists, and if not, creates it with --system-site-packages before executing the command. This allows Ray workers to access both:
1. System packages pre-installed in Docker images (Ray, PyTorch, pandas, sklearn)
2. User packages added via uv add in pyproject.toml

Before: Workers fail with ModuleNotFoundError for system packages like Ray
After: Workers can import both system and user packages

## Related issues
Related to https://github.com/ray-project/ray/issues/55898 since avoiding reinstalling system packages can help with the disk usage

## Additional information
Many production ML workflows deploy Ray clusters using Docker images with pre-installed packages (Ray, PyTorch, pandas, scikit-learn). These packages are large (PyTorch alone is ~2GB), expensive to download repeatedly, and slow to install. The current `uv run` integration forces workers to either:

1. **Re-download everything** - Users add `ray`, `torch`, `pandas` to `pyproject.toml`, causing workers to download gigabytes on every autoscale event
2. **Can't access pre-installed packages** - Workers fail with `ModuleNotFoundError: No module named 'ray'` because the venv isolates them from the Docker image

**Ray's own UV plugin uses `--system-site-packages`** ([`virtualenv_utils.py:101`](https://github.com/ray-project/ray/blob/master/python/ray/_private/runtime_env/virtualenv_utils.py#L101)):

```python
create_venv_cmd = [
    python,
    "-m",
    "virtualenv",
    "--system-site-packages",  # Ray's UV plugin includes this!
    virtualenv_path,
]
```

When users explicitly set `runtime_env={"uv": ["plotly"]}`, Ray correctly creates venvs with system package access. However, the `uv_runtime_env_hook` (for `uv run` detection) bypasses this plugin and directly passes `uv run` to `py_executable`, which creates isolated venvs without system packages.

