### PR TITLE
[train] Add bundle_label_selector to ScalingConfig

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1946,9 +1946,6 @@ python/ray/train/v2/_internal/execution/worker_group/worker_group.py
     DOC103: Method `WorkerGroup._assign_worker_ranks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [workers: List[Worker]].
     DOC101: Method `WorkerGroup._decorate_worker_log_file_paths`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `WorkerGroup._decorate_worker_log_file_paths`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [workers: List[Worker]].
-    DOC101: Method `WorkerGroup._sort_workers_by_node_id_and_gpu_id`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `WorkerGroup._sort_workers_by_node_id_and_gpu_id`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [workers: List[Worker]].
-    DOC201: Method `WorkerGroup._sort_workers_by_node_id_and_gpu_id` does not have a return section in docstring
 --------------------
 python/ray/train/v2/_internal/metrics/base.py
     DOC201: Method `EnumMetric.record` does not have a return section in docstring

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -308,8 +308,8 @@ class TrainController:
             bundle_label_selector = scaling_config.bundle_label_selector
         elif isinstance(scaling_config.bundle_label_selector, dict):
             bundle_label_selector = [
-                scaling_config.bundle_label_selector.copy()
-            ] * num_workers
+                scaling_config.bundle_label_selector.copy() for _ in range(num_workers)
+            ]
         elif scaling_config.bundle_label_selector is not None:
             raise ValueError(
                 "`bundle_label_selector` must be a list of dictionaries or a single dictionary."
@@ -325,7 +325,9 @@ class TrainController:
                             "Cannot set `ScalingConfig.bundle_label_selector` and "
                             "add a callback that returns a bundle_label_selector."
                         )
-                    bundle_label_selector = [selector.copy()] * num_workers
+                    bundle_label_selector = [
+                        selector.copy() for _ in range(num_workers)
+                    ]
                     break
         except Exception as e:
             return ControllerError(e)

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -310,10 +310,6 @@ class TrainController:
             bundle_label_selector = [
                 scaling_config.bundle_label_selector.copy() for _ in range(num_workers)
             ]
-        elif scaling_config.bundle_label_selector is not None:
-            raise ValueError(
-                "`bundle_label_selector` must be a list of dictionaries or a single dictionary."
-            )
         try:
             for callback in self._controller_callbacks:
                 selector = callback.on_controller_start_worker_group(

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -305,7 +305,7 @@ class TrainController:
         # Check for `bundle_label_selector` to influence WorkerGroup scheduling.
         bundle_label_selector = None
         if isinstance(scaling_config.bundle_label_selector, list):
-            bundle_label_selector = scaling_config.bundle_label_selector
+            bundle_label_selector = scaling_config.bundle_label_selector[:num_workers]
         elif isinstance(scaling_config.bundle_label_selector, dict):
             bundle_label_selector = [
                 scaling_config.bundle_label_selector.copy() for _ in range(num_workers)

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -321,9 +321,9 @@ class TrainController:
                 )
                 if selector:
                     if bundle_label_selector:
-                        raise ValueError(
-                            "Cannot set `ScalingConfig.bundle_label_selector` and "
-                            "add a callback that returns a bundle_label_selector."
+                        logger.warning(
+                            f"Overriding `ScalingConfig.bundle_label_selector` {bundle_label_selector} "
+                            f"with bundle_label_selector returned by user-specified callback {selector}"
                         )
                     bundle_label_selector = [
                         selector.copy() for _ in range(num_workers)

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -98,7 +98,7 @@ class WorkerGroupContext:
     num_workers: int
     resources_per_worker: Dict[str, float]
     placement_strategy: str = "PACK"
-    bundle_label_selector: Optional[Dict[str, str]] = None
+    bundle_label_selector: Optional[List[Dict[str, str]]] = None
 
 
 class WorkerGroup(BaseWorkerGroup):
@@ -266,19 +266,12 @@ class WorkerGroup(BaseWorkerGroup):
         ):
             for callback in self._callbacks:
                 callback.before_worker_group_start(worker_group_context)
-
-            bundle_label_selector = (
-                [worker_group_context.bundle_label_selector.copy()]
-                * worker_group_context.num_workers
-                if worker_group_context.bundle_label_selector
-                else None
-            )
-
             pg = placement_group(
+                # TODO: support heterogeneous workers and placement
                 bundles=[worker_group_context.resources_per_worker]
                 * worker_group_context.num_workers,
                 strategy=worker_group_context.placement_strategy,
-                bundle_label_selector=bundle_label_selector,
+                bundle_label_selector=worker_group_context.bundle_label_selector,
             )
             logger.info(
                 f"Attempting to start training worker group of size {worker_group_context.num_workers} with "

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
 import pyarrow.fs
 
@@ -48,6 +48,9 @@ class ScalingConfig(ScalingConfigV1):
         placement_strategy: The placement strategy to use for the
             placement group of the Ray actors. See :ref:`Placement Group
             Strategies <pgroup-strategy>` for the possible options.
+        bundle_label_selector: A list of label selectors for Ray Train worker placement.
+            If a single label selector is provided, it will be applied to all Ray Train workers.
+            If a list is provided, it must be the same length as the max number of Ray Train workers.
         accelerator_type: [Experimental] If specified, Ray Train will launch the
             training coordinator and workers on the nodes with the specified type
             of accelerators.
@@ -69,6 +72,7 @@ class ScalingConfig(ScalingConfigV1):
     trainer_resources: Optional[dict] = None
     use_tpu: Union[bool] = False
     topology: Optional[str] = None
+    bundle_label_selector: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None
 
     def __post_init__(self):
         if self.trainer_resources is not None:
@@ -103,6 +107,20 @@ class ScalingConfig(ScalingConfigV1):
                     "`accelerator_type` must be specified in ScalingConfig when "
                     "`use_tpu=True` and `num_workers` > 1."
                 )
+            if self.bundle_label_selector:
+                raise ValueError(
+                    "Cannot set `bundle_label_selector` when `use_tpu=True` because "
+                    "Ray Train automatically reserves a TPU slice with a predefined label."
+                )
+
+        if (
+            isinstance(self.bundle_label_selector, list)
+            and isinstance(self.num_workers, int)
+            and len(self.bundle_label_selector) != self.num_workers
+        ):
+            raise ValueError(
+                "If `bundle_label_selector` is a list, it must be the same length as `num_workers`."
+            )
 
         if self.num_workers == 0:
             logger.info(

--- a/python/ray/train/v2/tests/test_config.py
+++ b/python/ray/train/v2/tests/test_config.py
@@ -16,17 +16,6 @@ def test_scaling_config_validation():
         ScalingConfig(num_workers=2, use_gpu=True, use_tpu=True)
 
     with pytest.raises(
-        ValueError, match="Cannot set `bundle_label_selector` when `use_tpu=True`"
-    ):
-        ScalingConfig(
-            num_workers=2,
-            use_tpu=True,
-            topology="2x2x2",
-            accelerator_type="TPU-V4",
-            bundle_label_selector={"subcluster": "my_subcluster"},
-        )
-
-    with pytest.raises(
         ValueError,
         match="If `bundle_label_selector` is a list, it must be the same length as `num_workers`",
     ):

--- a/python/ray/train/v2/tests/test_config.py
+++ b/python/ray/train/v2/tests/test_config.py
@@ -15,6 +15,25 @@ def test_scaling_config_validation():
     with pytest.raises(ValueError, match="Cannot specify both"):
         ScalingConfig(num_workers=2, use_gpu=True, use_tpu=True)
 
+    with pytest.raises(
+        ValueError, match="Cannot set `bundle_label_selector` when `use_tpu=True`"
+    ):
+        ScalingConfig(
+            num_workers=2,
+            use_tpu=True,
+            topology="2x2x2",
+            accelerator_type="TPU-V4",
+            bundle_label_selector={"subcluster": "my_subcluster"},
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="If `bundle_label_selector` is a list, it must be the same length as `num_workers`",
+    ):
+        ScalingConfig(
+            num_workers=2, bundle_label_selector=[{"subcluster": "my_subcluster"}]
+        )
+
 
 def test_scaling_config_accelerator_type():
     scaling_config = ScalingConfig(num_workers=2, use_gpu=True, accelerator_type="A100")

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -225,36 +225,6 @@ async def test_worker_group_start_failure(error_type):
 
 
 @pytest.mark.asyncio
-async def test_double_define_bundle_label_selector():
-    class BundleLabelSelectorCallback(ControllerCallback):
-        def on_controller_start_worker_group(self, *, scaling_config, num_workers):
-            return {"subcluster": "my_subcluster"}
-
-    scaling_config = ScalingConfig(
-        bundle_label_selector={"subcluster": "my_subcluster"},
-    )
-    scaling_policy = MockScalingPolicy(scaling_config=scaling_config)
-    scaling_policy.queue_recovery_decision(
-        ResizeDecision(num_workers=2, resources_per_worker={})
-    )
-    failure_policy = MockFailurePolicy(failure_config=None)
-    failure_policy.queue_decision(FailureDecision.RAISE)
-    train_run_context = create_dummy_run_context(scaling_config=scaling_config)
-    controller = TrainController(
-        train_fn_ref=DummyObjectRefWrapper(lambda: None),
-        train_run_context=train_run_context,
-        scaling_policy=scaling_policy,
-        failure_policy=failure_policy,
-        callbacks=[BundleLabelSelectorCallback()],
-    )
-    assert isinstance(controller.get_state(), InitializingState)
-    await controller._run_control_loop_iteration()
-    assert isinstance(controller.get_state(), SchedulingState)
-    await controller._run_control_loop_iteration()
-    assert isinstance(controller.get_state(), ShuttingDownState)
-
-
-@pytest.mark.asyncio
 async def test_poll_frequency(monkeypatch):
     monkeypatch.setenv(HEALTH_CHECK_INTERVAL_S_ENV_VAR, "1")
 

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -134,6 +134,19 @@ def test_minimal_multihost(ray_tpu_multi_host, tmp_path):
     assert len(labeled_nodes) == 2
 
 
+def test_scaling_config_validation():
+    with pytest.raises(
+        ValueError, match="Cannot set `bundle_label_selector` when `use_tpu=True`"
+    ):
+        ScalingConfig(
+            num_workers=2,
+            use_tpu=True,
+            topology="2x2x2",
+            accelerator_type="TPU-V4",
+            bundle_label_selector={"subcluster": "my_subcluster"},
+        )
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/v2/tests/test_scheduling.py
+++ b/python/ray/train/v2/tests/test_scheduling.py
@@ -133,3 +133,9 @@ def test_bundle_label_selector(
     trainer = DataParallelTrainer(train_fn, scaling_config=scaling_config)
     trainer.fit()
     assert ray.get(counter.get.remote()) == expected_subcluster_counts
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_scheduling.py
+++ b/python/ray/train/v2/tests/test_scheduling.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import pytest
 
 import ray
@@ -13,6 +15,20 @@ def multi_cpu_node_cluster():
     cluster = Cluster()
     for _ in range(4):
         cluster.add_node(num_cpus=4)
+    cluster.wait_for_nodes()
+    cluster.connect()
+    yield cluster
+    ray.shutdown()
+    cluster.shutdown()
+
+
+@pytest.fixture
+def multi_cpu_node_labeled_cluster():
+    cluster = Cluster()
+    for _ in range(2):
+        cluster.add_node(num_cpus=4, labels={"subcluster": "my_subcluster"})
+    for _ in range(2):
+        cluster.add_node(num_cpus=4, labels={"subcluster": "other_subcluster"})
     cluster.wait_for_nodes()
     cluster.connect()
     yield cluster
@@ -73,7 +89,47 @@ def test_infeasible_placement_strategy(
     ray.get(future)
 
 
-if __name__ == "__main__":
-    import sys
+@pytest.mark.parametrize(
+    "bundle_label_selector, expected_subcluster_counts",
+    [
+        ({"subcluster": "my_subcluster"}, {"my_subcluster": 2}),
+        (
+            [{"subcluster": "my_subcluster"}, {"subcluster": "my_subcluster"}],
+            {"my_subcluster": 2},
+        ),
+        (
+            [{"subcluster": "my_subcluster"}, {"subcluster": "other_subcluster"}],
+            {"my_subcluster": 1, "other_subcluster": 1},
+        ),
+    ],
+)
+def test_bundle_label_selector(
+    multi_cpu_node_labeled_cluster, bundle_label_selector, expected_subcluster_counts
+):
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.subcluster_counts = defaultdict(int)
 
-    sys.exit(pytest.main(["-v", "-x", __file__]))
+        def increment(self, subcluster):
+            self.subcluster_counts[subcluster] += 1
+
+        def get(self):
+            return self.subcluster_counts
+
+    counter = Counter.remote()
+    scaling_config = ScalingConfig(
+        num_workers=2,
+        bundle_label_selector=bundle_label_selector,
+    )
+
+    def train_fn():
+        ray.get(
+            counter.increment.remote(
+                ray.get_runtime_context().get_node_labels()["subcluster"]
+            )
+        )
+
+    trainer = DataParallelTrainer(train_fn, scaling_config=scaling_config)
+    trainer.fit()
+    assert ray.get(counter.get.remote()) == expected_subcluster_counts

--- a/python/ray/train/v2/tests/test_worker_group.py
+++ b/python/ray/train/v2/tests/test_worker_group.py
@@ -342,7 +342,7 @@ def test_group_workers_by_ip():
         ]
 
     workers = create_workers(["2", "3", "1", "4", "2", "1", "3", "3", "4", "2"])
-    workers = WorkerGroup._sort_workers_by_node_id_and_gpu_id(workers)
+    workers = WorkerGroup._sort_workers_by_gpu_id_grouped_by_node(workers)
     expected = ["2", "2", "2", "3", "3", "3", "1", "1", "4", "4"]
     ips = [w.metadata.node_id for w in workers]
     assert ips == expected, (
@@ -351,7 +351,9 @@ def test_group_workers_by_ip():
     )
 
     workers = create_workers(["2", "3", "1", "4", "2", "1", "3", "3", "4", "2"])
-    workers = WorkerGroup._sort_workers_by_node_id_and_gpu_id(workers, _first_id="1")
+    workers = WorkerGroup._sort_workers_by_gpu_id_grouped_by_node(
+        workers, _first_id="1"
+    )
     expected = ["1", "1", "2", "2", "2", "3", "3", "3", "4", "4"]
     ips = [w.metadata.node_id for w in workers]
     assert (
@@ -388,7 +390,7 @@ def test_local_rank_assignment():
                 expected local rank.
         """
         workers = create_workers(pids=pids, node_ids=node_ids, gpu_ids=gpu_ids)
-        workers = WorkerGroup._sort_workers_by_node_id_and_gpu_id(workers)
+        workers = WorkerGroup._sort_workers_by_gpu_id_grouped_by_node(workers)
 
         # Build local ranks according to the logics in
         # TODO: Replace this with the actual implementation later


### PR DESCRIPTION
# Summary

This PR adds a `bundle_label_selector` argument to the `ScalingConfig` that allows Ray Train workers to be placed on nodes with particular labels. The previous workaround, namely using `resources_per_worker`, is less flexible.

`bundle_label_selector` can either be a single dict, in which case it will apply to all the workers, or a list of length `num_workers`, in which case each item in the list will correspond to one of the workers.

I added verification to the controller instead of validating that none of the callbacks have `on_controller_start_worker_group` when `bundle_label_selector` is set because we might change `on_controller_start_worker_group` in the future. We can revisit this issue then.

# Testing

Unit tests