### PR TITLE
[data] Extend `DownstreamCapacityBackpressurePolicy` to implement `max_task_output_bytes_to_read`

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
@@ -58,7 +58,6 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
         )
 
     def _max_concurrent_tasks(self, op: "PhysicalOperator") -> int:
-        # This should return values >= 1 to ensure we do not deadlock.
         if isinstance(op, ActorPoolMapOperator):
             return sum(
                 [

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -154,6 +154,13 @@ DEFAULT_ENFORCE_SCHEMAS = env_bool("RAY_DATA_ENFORCE_SCHEMAS", False)
 
 DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS = False
 
+# This default value was chosen to be conservative but to limit runaway
+# queue accumulation when there is a bottleneck operator. The default value
+# essentially means we will allow the queue up to 25x more blocks than the
+# downsteam operator is consuming per unit time. This is done to prevent
+# OOMs on the head node if the queue size grows too large. If the head node
+# is very small or the capcity is relatively very large to the head node
+# memory amount, consider lowering this value.
 DEFAULT_DOWNSTREAM_CAPACITY_OUTPUTS_RATIO: int = env_float(
     "RAY_DATA_DOWNSTREAM_CAPACITY_OUTPUTS_RATIO", 25.0
 )

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -154,6 +154,10 @@ DEFAULT_ENFORCE_SCHEMAS = env_bool("RAY_DATA_ENFORCE_SCHEMAS", False)
 
 DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS = False
 
+DEFAULT_DOWNSTREAM_CAPACITY_OUTPUTS_RATIO: int = env_float(
+    "RAY_DATA_DOWNSTREAM_CAPACITY_OUTPUTS_RATIO", 25.0
+)
+
 
 # `write_file_retry_on_errors` is deprecated in favor of `retried_io_errors`. You
 # shouldn't need to modify `DEFAULT_WRITE_FILE_RETRY_ON_ERRORS`.
@@ -473,6 +477,10 @@ class DataContext:
             later. If `None`, this type of backpressure is disabled.
         downstream_capacity_backpressure_max_queued_bundles: Maximum number of queued
             bundles before applying backpressure. If `None`, no limit is applied.
+        downstream_capacity_outputs_ratio: Ratio for downstream capacity outputs
+            backpressure control. A lower ratio means fewer outputs will be taken
+            causing less build up in operator inqueues. If `None`, this type of
+            backpressure is disabled.
         enable_dynamic_output_queue_size_backpressure: Whether to cap the concurrency
         of an operator based on it's and downstream's queue size.
         enforce_schemas: Whether to enforce schema consistency across dataset operations.
@@ -613,6 +621,7 @@ class DataContext:
 
     downstream_capacity_backpressure_ratio: float = None
     downstream_capacity_backpressure_max_queued_bundles: int = None
+    downstream_capacity_outputs_ratio: float = DEFAULT_DOWNSTREAM_CAPACITY_OUTPUTS_RATIO
 
     enable_dynamic_output_queue_size_backpressure: bool = (
         DEFAULT_ENABLE_DYNAMIC_OUTPUT_QUEUE_SIZE_BACKPRESSURE

--- a/python/ray/data/tests/test_downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/tests/test_downstream_capacity_backpressure_policy.py
@@ -120,6 +120,72 @@ class TestDownstreamCapacityBackpressurePolicy:
             backpressure_ratio is None or max_queued_bundles is None
         ) == policy._backpressure_disabled, test_name
 
+    @pytest.mark.parametrize(
+        "mock_method",
+        [
+            (_mock_operator),
+            (_mock_actor_pool_map_operator),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "num_enqueued, avg_num_inputs_per_task, avg_bytes_per_output, max_concurrent_tasks, outputs_ratio, expected_result, test_name",
+        [
+            # outputs_ratio disabled returns None
+            (0, 10, 1000, 10, None, None, "outputs_ratio_none"),
+            (0, 10, 1000, 10, 0, None, "outputs_ratio_zero"),
+            (0, 10, 1000, 10, -1, None, "outputs_ratio_negative"),
+            # No metrics available returns None
+            (0, None, 1000, 10, 1.0, None, "no_avg_inputs_metric"),
+            (0, 0, 1000, 10, 1.0, None, "zero_avg_inputs_metric"),
+            (0, 10, None, 10, 1.0, None, "no_avg_bytes_metric"),
+            (0, 10, 0, 10, 1.0, None, "zero_avg_bytes_metric"),
+            # No concurrent tasks returns None
+            (0, 10, 1000, 0, 1.0, None, "no_concurrent_tasks"),
+            # At capacity returns 0
+            (100, 10, 1000, 10, 1.0, 0, "at_capacity"),
+            (150, 10, 1000, 10, 1.0, 0, "over_capacity"),
+            # Normal case: remaining_capacity = (max_concurrent * avg_inputs * ratio) - enqueued
+            # = (10 * 10 * 1.0) - 50 = 50 blocks, * 1000 bytes = 50000 bytes
+            (50, 10, 1000, 10, 1.0, 50000, "half_capacity"),
+            # With ratio=2.0: (10 * 10 * 2.0) - 50 = 150 blocks, * 1000 = 150000 bytes
+            (50, 10, 1000, 10, 2.0, 150000, "half_capacity_double_ratio"),
+        ],
+    )
+    def test_max_task_output_bytes_to_read(
+        self,
+        mock_method,
+        num_enqueued,
+        avg_num_inputs_per_task,
+        avg_bytes_per_output,
+        max_concurrent_tasks,
+        outputs_ratio,
+        expected_result,
+        test_name,
+    ):
+        """Parameterized test for max_task_output_bytes_to_read method."""
+        context = DataContext()
+        context.downstream_capacity_outputs_ratio = outputs_ratio
+
+        op, op_state = self._mock_operator(PhysicalOperator)
+        op.metrics.average_bytes_per_output = avg_bytes_per_output
+
+        op_output_dep, op_output_state = mock_method(
+            self,
+            num_enqueued_blocks=num_enqueued,
+            num_task_inputs_processed=0,
+            num_tasks_finished=0,
+            max_concurrent_tasks=max_concurrent_tasks,
+        )
+        op_output_dep.metrics.average_num_inputs_per_task = avg_num_inputs_per_task
+        op.output_dependencies = [op_output_dep]
+
+        policy = self._create_policy(
+            context, topology={op: op_state, op_output_dep: op_output_state}
+        )
+        result = policy.max_task_output_bytes_to_read(op)
+
+        assert result == expected_result, test_name
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Description
The existing `DownstreamCapacityBackpressurePolicy` is designed to backpressure the pipeline based on the downstream capacity. There are cases though, where the pipeline might aggressively queue blocks even though the downstream operators do not have capacity. This extends the existing policy to add `max_task_output_bytes_to_read` which will backpressure on outputs to prevent this buildup in the queue. 

In an example pipeline without this backpressure the inference operator would accumulate a queue of 200k+ blocks and then the head node would be OOMKilled. With this backpressure, the queue can be kept at ~150 blocks while maintaining GPU saturation (this value depends on the value of the ratio). 

Latest benchmark data here: https://docs.google.com/spreadsheets/d/1KXtinRuFuMLS4pF7TqOrhNm4jDxmIvSzTCaRYBwgawk/edit?gid=0#gid=0

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
