### PR TITLE
[train] Raise ValueError when checkpoint_upload_fn does not return a checkpoint

### DIFF
--- a/python/ray/train/v2/_internal/execution/context.py
+++ b/python/ray/train/v2/_internal/execution/context.py
@@ -258,6 +258,8 @@ class TrainContext:
                 persisted_checkpoint = checkpoint_upload_fn(
                     checkpoint, checkpoint_dir_name
                 )
+                if not persisted_checkpoint:
+                    raise ValueError("checkpoint_upload_fn must return a checkpoint")
             else:
                 persisted_checkpoint = self.storage_context.persist_current_checkpoint(
                     checkpoint, checkpoint_dir_name

--- a/python/ray/train/v2/_internal/execution/context.py
+++ b/python/ray/train/v2/_internal/execution/context.py
@@ -258,8 +258,12 @@ class TrainContext:
                 persisted_checkpoint = checkpoint_upload_fn(
                     checkpoint, checkpoint_dir_name
                 )
-                if not persisted_checkpoint:
-                    raise ValueError("checkpoint_upload_fn must return a checkpoint")
+                if persisted_checkpoint is None or not isinstance(
+                    persisted_checkpoint, ray.train.Checkpoint
+                ):
+                    raise ValueError(
+                        "checkpoint_upload_fn must return a `ray.train.Checkpoint`."
+                    )
             else:
                 persisted_checkpoint = self.storage_context.persist_current_checkpoint(
                     checkpoint, checkpoint_dir_name

--- a/python/ray/train/v2/tests/test_async_checkpointing_validation.py
+++ b/python/ray/train/v2/tests/test_async_checkpointing_validation.py
@@ -371,19 +371,16 @@ def test_report_checkpoint_upload_fn(tmp_path):
 
 def test_checkpoint_upload_fn_returns_checkpoint():
     def train_fn():
-        if ray.train.get_context().get_world_rank() == 0:
-            with create_dict_checkpoint({}) as checkpoint:
-                ray.train.report(
-                    metrics={},
-                    checkpoint=checkpoint,
-                    checkpoint_upload_fn=lambda x, y: None,
-                )
-        else:
-            ray.train.report(metrics={}, checkpoint=None)
+        with create_dict_checkpoint({}) as checkpoint:
+            ray.train.report(
+                metrics={},
+                checkpoint=checkpoint,
+                checkpoint_upload_fn=lambda x, y: None,
+            )
 
     trainer = DataParallelTrainer(
         train_fn,
-        scaling_config=ScalingConfig(num_workers=2),
+        scaling_config=ScalingConfig(num_workers=1),
     )
     with pytest.raises(
         WorkerGroupError, match="checkpoint_upload_fn must return a checkpoint"

--- a/python/ray/train/v2/tests/test_async_checkpointing_validation.py
+++ b/python/ray/train/v2/tests/test_async_checkpointing_validation.py
@@ -383,7 +383,8 @@ def test_checkpoint_upload_fn_returns_checkpoint():
         scaling_config=ScalingConfig(num_workers=1),
     )
     with pytest.raises(
-        WorkerGroupError, match="checkpoint_upload_fn must return a checkpoint"
+        WorkerGroupError,
+        match="checkpoint_upload_fn must return a `ray.train.Checkpoint`",
     ):
         trainer.fit()
 


### PR DESCRIPTION
# Summary

Fail fast if the users forgets to return a checkpoint in their `checkpoint_upload_fn`. This also causes unexpected issues like `get_all_reported_checkpoints` stalling indefinitely because the counter is misaligned, which I can also fix in a separate PR. 

# Testing

Unit tests