### PR TITLE
Add perf metrics for 2.52.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 104.996864,
+    "_dashboard_memory_usage_mb": 109.3632,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.81,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1132\t7.8GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3490\t2.13GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5530\t0.95GiB\tpython distributed/test_many_actors.py\n2919\t0.38GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3716\t0.26GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n585\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4196\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3066\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3620\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4198\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
-    "actors_per_second": 387.1219957094043,
+    "_peak_memory": 4.6,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3285\t2.23GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5814\t0.82GiB\tpython distributed/test_many_actors.py\n2864\t0.41GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3502\t0.2GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3985\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2823\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1140\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3987\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3415\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5610\t0.07GiB\tray::JobSupervisor",
+    "actors_per_second": 403.10794652127487,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 387.1219957094043
+            "perf_metric_value": 403.10794652127487
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.836
+            "perf_metric_value": 20.494
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3829.61
+            "perf_metric_value": 3843.186
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4098.851
+            "perf_metric_value": 7078.797
         }
     ],
-    "time": 25.831650257110596
+    "time": 24.8072509765625
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 90.251264,
+    "_dashboard_memory_usage_mb": 93.167616,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.42,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3297\t0.64GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2878\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5295\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3510\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n1172\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3996\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2813\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3998\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3427\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n5522\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 2.41,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3099\t0.69GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2648\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4521\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3312\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3795\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2691\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1086\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3229\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3797\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n4762\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 355.96107999624206
+            "perf_metric_value": 390.190063861316
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.475
+            "perf_metric_value": 6.037
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.834
+            "perf_metric_value": 17.15
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 67.355
+            "perf_metric_value": 49.411
         }
     ],
-    "tasks_per_second": 355.96107999624206,
-    "time": 302.80929589271545,
+    "tasks_per_second": 390.190063861316,
+    "time": 302.5628535747528,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 99.979264,
+    "_dashboard_memory_usage_mb": 89.985024,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.94,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1126\t7.66GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3490\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5004\t0.36GiB\tpython distributed/test_many_pgs.py\n3037\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n583\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4206\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3720\t0.11GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n2924\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4208\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3623\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
+    "_peak_memory": 2.85,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3274\t1.08GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n4694\t0.36GiB\tpython distributed/test_many_pgs.py\n2853\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n579\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3980\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2807\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3494\t0.09GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n1152\t0.08GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3982\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n2605\t0.08GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 17.897951502183457
+            "perf_metric_value": 17.630807526575012
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.128
+            "perf_metric_value": 3.91
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 54.16
+            "perf_metric_value": 17.033
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1212.615
+            "perf_metric_value": 382.069
         }
     ],
-    "pgs_per_second": 17.897951502183457,
-    "time": 55.872315883636475
+    "pgs_per_second": 17.630807526575012,
+    "time": 56.7188994884491
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 104.124416,
+    "_dashboard_memory_usage_mb": 90.853376,
     "_dashboard_test_success": true,
-    "_peak_memory": 6.24,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3751\t2.0GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import sp\n3524\t1.95GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5011\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3015\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n582\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n1163\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3754\t0.11GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c \"from multiprocessing.spawn import s\n4237\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3147\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3654\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
+    "_peak_memory": 5.63,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3270\t2.24GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3490\t1.06GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4675\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2831\t0.3GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3493\t0.16GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n3970\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2790\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3400\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n1114\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3972\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 571.2270630108624
+            "perf_metric_value": 552.9028002075252
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.284
+            "perf_metric_value": 5.264
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 947.76
+            "perf_metric_value": 915.177
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3041.184
+            "perf_metric_value": 2840.518
         }
     ],
-    "tasks_per_second": 571.2270630108624,
-    "time": 317.5061733722687,
+    "tasks_per_second": 552.9028002075252,
+    "time": 318.0863616466522,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.51.0"}
+{"release_version": "2.52.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8399.403184470113,
-        136.21707407297257
+        8479.131512159902,
+        449.64091460972287
     ],
     "1_1_actor_calls_concurrent": [
-        4647.56843532278,
-        63.094751150482914
+        5629.888924437268,
+        234.90676364325793
     ],
     "1_1_actor_calls_sync": [
-        1839.4898060940372,
-        14.066274815453491
+        1894.334713622146,
+        24.612801215171302
     ],
     "1_1_async_actor_calls_async": [
-        3995.0258578261814,
-        144.46958633072862
+        4314.570035703319,
+        304.5453646146402
     ],
     "1_1_async_actor_calls_sync": [
-        1343.0595085140048,
-        19.829689965062563
+        1425.2460291392301,
+        10.972434631632895
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2589.906655726785,
-        39.65780957989427
+        2762.9385297368535,
+        126.75534928061596
     ],
     "1_n_actor_calls_async": [
-        7345.613928457275,
-        58.71993585889256
+        7818.847120700663,
+        64.99608921713438
     ],
     "1_n_async_actor_calls_async": [
-        6492.653462688266,
-        95.60615046682146
+        6913.550938819563,
+        98.3567118445223
     ],
     "client__1_1_actor_calls_async": [
-        883.7347522770161,
-        12.199594413954227
+        1152.0966726586987,
+        5.949648400768134
     ],
     "client__1_1_actor_calls_concurrent": [
-        889.14113884267,
-        17.47600076704852
+        1146.7134222243185,
+        6.42547694106721
     ],
     "client__1_1_actor_calls_sync": [
-        483.38098840508496,
-        15.957964297181181
+        576.2018967799997,
+        10.50153867932314
     ],
     "client__get_calls": [
-        831.689705073893,
-        28.771286733299675
+        1033.7763022350296,
+        5.34524244588223
     ],
     "client__put_calls": [
-        713.82381443796,
-        9.228828102434214
+        821.8214713340072,
+        6.060117412244701
     ],
     "client__put_gigabytes": [
-        0.10173890088342342,
-        0.00033582555733193726
+        0.10220457395600176,
+        0.0007220930561878849
     ],
     "client__tasks_and_get_batch": [
-        0.8264370292993273,
-        0.01727144267367441
+        1.0755792867557323,
+        0.013832969422864473
     ],
     "client__tasks_and_put_batch": [
-        9085.541921590711,
-        165.7954798461543
+        11657.102874288967,
+        208.2074750539261
     ],
     "multi_client_put_calls_Plasma_Store": [
-        9952.762154617178,
-        38.41564361532616
+        13260.224066162647,
+        116.63110628919485
     ],
     "multi_client_put_gigabytes": [
-        27.49866375110667,
-        0.5825571491197781
+        47.62336463265461,
+        4.1367625605785605
     ],
     "multi_client_tasks_async": [
-        20210.985366169363,
-        2479.1473885161845
+        20569.559125979922,
+        1553.3544021601588
     ],
     "n_n_actor_calls_async": [
-        23225.920055471943,
-        1333.629196021959
+        24531.521409406632,
+        1132.8337423991986
     ],
     "n_n_actor_calls_with_arg_async": [
-        2723.9690685388855,
-        13.543227804321521
+        3353.6340010226468,
+        26.1884248878178
     ],
     "n_n_async_actor_calls_async": [
-        20513.389244097456,
-        579.320086028046
+        21866.061040938854,
+        575.3937912232543
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4030.5453313124744
+            "perf_metric_value": 9541.420239681218
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4171.572402867286
+            "perf_metric_value": 4686.60144219099
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9952.762154617178
+            "perf_metric_value": 13260.224066162647
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.324991353469613
+            "perf_metric_value": 10.83745250237838
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6.510453684729034
+            "perf_metric_value": 6.5168926025589275
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27.49866375110667
+            "perf_metric_value": 47.62336463265461
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11.296427707979271
+            "perf_metric_value": 12.697911312818526
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.396844484606209
+            "perf_metric_value": 4.803898199921876
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 829.8982620271383
+            "perf_metric_value": 872.2036137608502
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5868.239300602419
+            "perf_metric_value": 6961.354217387221
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20210.985366169363
+            "perf_metric_value": 20569.559125979922
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1839.4898060940372
+            "perf_metric_value": 1894.334713622146
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8399.403184470113
+            "perf_metric_value": 8479.131512159902
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4647.56843532278
+            "perf_metric_value": 5629.888924437268
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7345.613928457275
+            "perf_metric_value": 7818.847120700663
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23225.920055471943
+            "perf_metric_value": 24531.521409406632
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2723.9690685388855
+            "perf_metric_value": 3353.6340010226468
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1343.0595085140048
+            "perf_metric_value": 1425.2460291392301
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3995.0258578261814
+            "perf_metric_value": 4314.570035703319
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2589.906655726785
+            "perf_metric_value": 2762.9385297368535
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6492.653462688266
+            "perf_metric_value": 6913.550938819563
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20513.389244097456
+            "perf_metric_value": 21866.061040938854
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 666.3527476116307
+            "perf_metric_value": 685.9076055741489
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 831.689705073893
+            "perf_metric_value": 1033.7763022350296
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 713.82381443796
+            "perf_metric_value": 821.8214713340072
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.10173890088342342
+            "perf_metric_value": 0.10220457395600176
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9085.541921590711
+            "perf_metric_value": 11657.102874288967
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 483.38098840508496
+            "perf_metric_value": 576.2018967799997
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 883.7347522770161
+            "perf_metric_value": 1152.0966726586987
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 889.14113884267
+            "perf_metric_value": 1146.7134222243185
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8264370292993273
+            "perf_metric_value": 1.0755792867557323
         }
     ],
     "placement_group_create/removal": [
-        666.3527476116307,
-        2.878579109687689
+        685.9076055741489,
+        10.053761287925537
     ],
     "single_client_get_calls_Plasma_Store": [
-        4030.5453313124744,
-        83.4215261086502
+        9541.420239681218,
+        526.7310377593739
     ],
     "single_client_get_object_containing_10k_refs": [
-        11.296427707979271,
-        0.4257563799134317
+        12.697911312818526,
+        0.6476957042464793
     ],
     "single_client_put_calls_Plasma_Store": [
-        4171.572402867286,
-        20.59644183305974
+        4686.60144219099,
+        37.15917359963806
     ],
     "single_client_put_gigabytes": [
-        18.324991353469613,
-        8.294696979749455
+        10.83745250237838,
+        11.421048565096807
     ],
     "single_client_tasks_and_get_batch": [
-        6.510453684729034,
-        0.12028674905547897
+        6.5168926025589275,
+        0.5072828248370477
     ],
     "single_client_tasks_async": [
-        5868.239300602419,
-        440.56084088533567
+        6961.354217387221,
+        386.1156802835829
     ],
     "single_client_tasks_sync": [
-        829.8982620271383,
-        4.841633368636976
+        872.2036137608502,
+        14.19648045767642
     ],
     "single_client_wait_1k_refs": [
-        4.396844484606209,
-        0.025462969222988033
+        4.803898199921876,
+        0.048573156597531704
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 14.81957527099999,
+    "broadcast_time": 12.110535204000001,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.81957527099999
+            "perf_metric_value": 12.110535204000001
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.013926726999998,
-    "get_time": 25.508083513999992,
+    "args_time": 17.502108547999995,
+    "get_time": 23.5936516,
     "large_object_size": 107374182400,
-    "large_object_time": 29.76057439500005,
+    "large_object_time": 29.36838078400001,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.013926726999998
+            "perf_metric_value": 17.502108547999995
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.417386639000014
+            "perf_metric_value": 5.539246789999993
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.508083513999992
+            "perf_metric_value": 23.5936516
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 186.835615278
+            "perf_metric_value": 177.25064926800002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.76057439500005
+            "perf_metric_value": 29.36838078400001
         }
     ],
-    "queued_time": 186.835615278,
-    "returns_time": 6.417386639000014,
+    "queued_time": 177.25064926800002,
+    "returns_time": 5.539246789999993,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 1.1225671076774597,
-    "max_iteration_time": 28.76371121406555,
-    "min_iteration_time": 0.046108245849609375,
+    "avg_iteration_time": 1.0091288590431213,
+    "max_iteration_time": 4.532180547714233,
+    "min_iteration_time": 0.08194804191589355,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1225671076774597
+            "perf_metric_value": 1.0091288590431213
         }
     ],
-    "total_time": 112.2568371295929
+    "total_time": 100.91300749778748
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.82067084312439
+            "perf_metric_value": 5.6011176109313965
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13.989246034622193
+            "perf_metric_value": 14.045441269874573
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 36.358218574523924
+            "perf_metric_value": 36.306496143341064
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4687559604644775
+            "perf_metric_value": 1.8323874473571777
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1885.3751878738403
+            "perf_metric_value": 1911.0371930599213
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.27532822445545485
+            "perf_metric_value": 0.26078188348514014
         }
     ],
-    "stage_0_time": 5.82067084312439,
-    "stage_1_avg_iteration_time": 13.989246034622193,
-    "stage_1_max_iteration_time": 14.72441577911377,
-    "stage_1_min_iteration_time": 13.083425045013428,
-    "stage_1_time": 139.89252924919128,
-    "stage_2_avg_iteration_time": 36.358218574523924,
-    "stage_2_max_iteration_time": 36.654969453811646,
-    "stage_2_min_iteration_time": 36.18567728996277,
-    "stage_2_time": 181.79162168502808,
-    "stage_3_creation_time": 1.4687559604644775,
-    "stage_3_time": 1885.3751878738403,
-    "stage_4_spread": 0.27532822445545485
+    "stage_0_time": 5.6011176109313965,
+    "stage_1_avg_iteration_time": 14.045441269874573,
+    "stage_1_max_iteration_time": 14.364872932434082,
+    "stage_1_min_iteration_time": 12.86737847328186,
+    "stage_1_time": 140.45464706420898,
+    "stage_2_avg_iteration_time": 36.306496143341064,
+    "stage_2_max_iteration_time": 36.481056928634644,
+    "stage_2_min_iteration_time": 35.84029817581177,
+    "stage_2_time": 181.53298115730286,
+    "stage_3_creation_time": 1.8323874473571777,
+    "stage_3_time": 1911.0371930599213,
+    "stage_4_spread": 0.26078188348514014
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.503374489489326,
-    "avg_pg_remove_time_ms": 1.4678401576576676,
+    "avg_pg_create_time_ms": 1.6386530375375787,
+    "avg_pg_remove_time_ms": 1.4351014099100747,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.503374489489326
+            "perf_metric_value": 1.6386530375375787
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4678401576576676
+            "perf_metric_value": 1.4351014099100747
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 40.86%: single_client_put_gigabytes (THROUGHPUT) regresses from 18.324991353469613 to 10.83745250237838 in microbenchmark.json
REGRESSION 3.21%: tasks_per_second (THROUGHPUT) regresses from 571.2270630108624 to 552.9028002075252 in benchmarks/many_tasks.json
REGRESSION 1.49%: pgs_per_second (THROUGHPUT) regresses from 17.897951502183457 to 17.630807526575012 in benchmarks/many_pgs.json
REGRESSION 72.70%: dashboard_p99_latency_ms (LATENCY) regresses from 4098.851 to 7078.797 in benchmarks/many_actors.json
REGRESSION 24.76%: stage_3_creation_time (LATENCY) regresses from 1.4687559604644775 to 1.8323874473571777 in stress_tests/stress_test_many_tasks.json
REGRESSION 9.00%: avg_pg_create_time_ms (LATENCY) regresses from 1.503374489489326 to 1.6386530375375787 in stress_tests/stress_test_placement_group.json
REGRESSION 1.36%: stage_3_time (LATENCY) regresses from 1885.3751878738403 to 1911.0371930599213 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.40%: stage_1_avg_iteration_time (LATENCY) regresses from 13.989246034622193 to 14.045441269874573 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.35%: dashboard_p95_latency_ms (LATENCY) regresses from 3829.61 to 3843.186 in benchmarks/many_actors.json
```