### PR TITLE
[release auto] add uv and default python in forge

### DIFF
--- a/.buildkite/release-automation/forge_arm64.Dockerfile
+++ b/.buildkite/release-automation/forge_arm64.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -16,16 +16,36 @@ apt-get install -y curl zip clang-12
 ln -s /usr/bin/clang-12 /usr/bin/clang
 
 # Install miniforge3
-curl -sfL https://github.com/conda-forge/miniforge/releases/download/25.3.0-1/Miniforge3-25.3.0-1-Linux-aarch64.sh > /tmp/miniforge3.sh
+curl -fsSL https://github.com/conda-forge/miniforge/releases/download/25.3.0-1/Miniforge3-25.3.0-1-Linux-aarch64.sh > /tmp/miniforge3.sh
 bash /tmp/miniforge3.sh -b -u -p /usr/local/bin/miniforge3
 rm /tmp/miniforge3.sh
 /usr/local/bin/miniforge3/bin/conda init bash
 
 # Install Bazelisk
-curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-arm64 --output /usr/local/bin/bazelisk
+curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-arm64 --output /usr/local/bin/bazelisk
 chmod +x /usr/local/bin/bazelisk
 
 ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
+
+# Install uv
+curl -fsSL https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+
+mkdir -p /usr/local/python
+# Install Python using uv
+UV_PYTHON_VERSION=3.10
+uv python install --install-dir /usr/local/python "$UV_PYTHON_VERSION"
+
+export UV_PYTHON_INSTALL_DIR=/usr/local/python
+# Make Python from uv the default by creating symlinks
+UV_PYTHON_BIN="$(uv python find --no-project "$UV_PYTHON_VERSION")"
+echo "uv python binary location: $UV_PYTHON_BIN"
+ln -s "$UV_PYTHON_BIN" "/usr/local/bin/python${UV_PYTHON_VERSION}"
+ln -s "$UV_PYTHON_BIN" /usr/local/bin/python3
+ln -s "$UV_PYTHON_BIN" /usr/local/bin/python
+
+# As a convention, we pin all python packages to a specific version. This
+# is to to make sure we can control version upgrades through code changes.
+uv pip install --system pip==25.2 cffi==1.16.0
 
 EOF
 

--- a/.buildkite/release-automation/forge_x86_64.Dockerfile
+++ b/.buildkite/release-automation/forge_x86_64.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -21,16 +21,36 @@ addgroup --gid 992 docker1 # docker group on buildkite AMI as of 2025-06-07
 ln -s /usr/bin/clang-12 /usr/bin/clang
 
 # Install miniforge3
-curl -sfL https://github.com/conda-forge/miniforge/releases/download/25.3.0-1/Miniforge3-25.3.0-1-Linux-x86_64.sh > /tmp/miniforge3.sh
+curl -fsSL https://github.com/conda-forge/miniforge/releases/download/25.3.0-1/Miniforge3-25.3.0-1-Linux-x86_64.sh > /tmp/miniforge3.sh
 bash /tmp/miniforge3.sh -b -u -p /usr/local/bin/miniforge3
 rm /tmp/miniforge3.sh
 /usr/local/bin/miniforge3/bin/conda init bash
 
 # Install Bazelisk
-curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 --output /usr/local/bin/bazelisk
+curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 --output /usr/local/bin/bazelisk
 chmod +x /usr/local/bin/bazelisk
 
 ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
+
+# Install uv
+curl -fsSL https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+
+mkdir -p /usr/local/python
+# Install Python using uv
+UV_PYTHON_VERSION=3.10
+uv python install --install-dir /usr/local/python "$UV_PYTHON_VERSION"
+
+export UV_PYTHON_INSTALL_DIR=/usr/local/python
+# Make Python from uv the default by creating symlinks
+UV_PYTHON_BIN="$(uv python find --no-project "$UV_PYTHON_VERSION")"
+echo "uv python binary location: $UV_PYTHON_BIN"
+ln -s "$UV_PYTHON_BIN" "/usr/local/bin/python${UV_PYTHON_VERSION}"
+ln -s "$UV_PYTHON_BIN" /usr/local/bin/python3
+ln -s "$UV_PYTHON_BIN" /usr/local/bin/python
+
+# As a convention, we pin all python packages to a specific version. This
+# is to to make sure we can control version upgrades through code changes.
+uv pip install --system pip==25.2 cffi==1.16.0
 
 # A non-root user. Use 2000, which is the same as our buildkite agent VM uses.
 adduser --home /home/forge --uid 2000 forge --gid 100

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -24,14 +24,14 @@ apt-get install -y ca-certificates curl zip unzip sudo gnupg tzdata git apt-tran
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 # Download and install Microsoft signing key
-curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc |
   gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null
 chmod go+r /etc/apt/keyrings/microsoft.gpg
 
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # Add NodeJS APT repository
 curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
@@ -45,7 +45,7 @@ URIs: https://packages.microsoft.com/repos/azure-cli/
 Suites: ${AZ_DIST}
 Components: main
 Architectures: $(dpkg --print-architecture)
-Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+Signed-by: /etc/apt/keyrings/microsoft.gpg" | tee /etc/apt/sources.list.d/azure-cli.sources
 
 # Install packages
 
@@ -57,10 +57,10 @@ apt-get install -y \
   azure-cli="${AZ_VER}"-1~"${AZ_DIST}"
 
 # Install uv
-wget -qO- https://astral.sh/uv/install.sh | sudo env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+curl -fsSL https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
 
 mkdir -p /usr/local/python
-# Install Python 3.9 using uv
+# Install Python using uv
 UV_PYTHON_VERSION=3.10
 uv python install --install-dir /usr/local/python "$UV_PYTHON_VERSION"
 


### PR DESCRIPTION
also uses `curl -fsSL` as much as possible

otherwise the release blocker checker is not working.

also removes unnecessary sudos.