### PR TITLE
[Core] Update the attempt number of the actor creation task when actor restart

### DIFF
--- a/python/ray/tests/test_ray_event_export_task_events.py
+++ b/python/ray/tests/test_ray_event_export_task_events.py
@@ -119,7 +119,7 @@ def get_job_id_and_driver_script_task_id_from_events(
 
 
 def check_task_event_base_fields(
-    event: json, preserve_proto_field_name: bool, head_node_id: str = None
+    event: json, preserve_proto_field_name: bool, head_node_id: str
 ):
     assert event["timestamp"] is not None
     assert event["severity"] == "INFO"
@@ -127,16 +127,14 @@ def check_task_event_base_fields(
         assert event["event_id"] is not None
         assert event["source_type"] == "CORE_WORKER"
         assert event["session_name"] is not None
-        if head_node_id is not None:
-            assert "node_id" in event
-            assert base64.b64decode(event["node_id"]).hex() == head_node_id
+        assert "node_id" in event
+        assert base64.b64decode(event["node_id"]).hex() == head_node_id
     else:
         assert event["eventId"] is not None
         assert event["sourceType"] == "CORE_WORKER"
         assert event["sessionName"] is not None
-        if head_node_id is not None:
-            assert "nodeId" in event
-            assert base64.b64decode(event["nodeId"]).hex() == head_node_id
+        assert "nodeId" in event
+        assert base64.b64decode(event["nodeId"]).hex() == head_node_id
 
 
 def check_task_lifecycle_event_states_and_error_info(
@@ -1775,7 +1773,7 @@ class TestActorTaskEvents:
 
         actor_creation_task_id = None
 
-        def validate_actor_creation(events: json):
+        def validate_actor_creation(events: json, head_node_id):
             nonlocal actor_creation_task_id
             (
                 driver_script_job_id,
@@ -1789,7 +1787,9 @@ class TestActorTaskEvents:
             for event in events:
                 if preserve_proto_field_name:
                     if event["event_type"] == "TASK_DEFINITION_EVENT":
-                        check_task_event_base_fields(event, preserve_proto_field_name)
+                        check_task_event_base_fields(
+                            event, preserve_proto_field_name, head_node_id
+                        )
 
                         if event["task_definition_event"]["task_type"] == "DRIVER_TASK":
                             driver_task_definition_received = True
@@ -1856,7 +1856,9 @@ class TestActorTaskEvents:
                         assert event["event_type"] == "TASK_LIFECYCLE_EVENT"
                 else:
                     if event["eventType"] == "TASK_DEFINITION_EVENT":
-                        check_task_event_base_fields(event, preserve_proto_field_name)
+                        check_task_event_base_fields(
+                            event, preserve_proto_field_name, head_node_id
+                        )
 
                         if event["taskDefinitionEvent"]["taskType"] == "DRIVER_TASK":
                             driver_task_definition_received = True

--- a/python/ray/tests/test_ray_event_export_task_events.py
+++ b/python/ray/tests/test_ray_event_export_task_events.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+import textwrap
 from typing import Optional
 
 import grpc
@@ -247,15 +248,17 @@ class TestNormalTaskEvents:
         httpserver,
         preserve_proto_field_name,
     ):
-        script = """
-import ray
-ray.init()
+        script = textwrap.dedent(
+            """
+            import ray
+            ray.init()
 
-@ray.remote
-def normal_task():
-    pass
-ray.get(normal_task.remote())
-    """
+            @ray.remote
+            def normal_task():
+                pass
+            ray.get(normal_task.remote())
+            """
+        )
 
         def validate_events(events, head_node_id):
             (
@@ -431,19 +434,21 @@ ray.get(normal_task.remote())
         httpserver,
         preserve_proto_field_name,
     ):
-        script = """
-import ray
+        script = textwrap.dedent(
+            """
+            import ray
 
-ray.init()
+            ray.init()
 
-@ray.remote(max_retries=1, retry_exceptions=[Exception])
-def normal_task():
-    raise Exception("test error")
-try:
-    ray.get(normal_task.remote())
-except Exception as e:
-    pass
-        """
+            @ray.remote(max_retries=1, retry_exceptions=[Exception])
+            def normal_task():
+                raise Exception("test error")
+            try:
+                ray.get(normal_task.remote())
+            except Exception as e:
+                pass
+            """
+        )
 
         def validate_events(events: json, head_node_id):
             (
@@ -656,21 +661,24 @@ except Exception as e:
         cluster = ray_start_cluster_head_with_env_vars
         node = cluster.add_node(num_cpus=2)
 
-        script = """
-import ray
-ray.init()
+        script = textwrap.dedent(
+            """
+            import ray
+            ray.init()
 
-@ray.remote(num_cpus=2, max_retries=0)
-def sleep():
-    import time
-    time.sleep(999)
+            @ray.remote(num_cpus=2, max_retries=0)
+            def sleep():
+                import time
+                time.sleep(999)
 
-x = sleep.options(name="node-killed").remote()
-try:
-    ray.get(x)
-except Exception as e:
-    pass
-        """
+            x = sleep.options(name="node-killed").remote()
+            try:
+                ray.get(x)
+            except Exception as e:
+                pass
+            """
+        )
+
         # Run the driver script and wait for the sleep task to be executing
         def validate_task_running(events: json, head_node_id):
             # Obtain the task id of the sleep task
@@ -914,22 +922,24 @@ class TestActorTaskEvents:
         httpserver,
         preserve_proto_field_name,
     ):
-        script = """
-import ray
-ray.init()
+        script = textwrap.dedent(
+            """
+            import ray
+            ray.init()
 
-@ray.remote(num_cpus=1)
-class Actor:
-    def __init__(self):
-        pass
+            @ray.remote(num_cpus=1)
+            class Actor:
+                def __init__(self):
+                    pass
 
-    def task(self, arg):
-        pass
+                def task(self, arg):
+                    pass
 
-actor = Actor.remote()
-obj = ray.put("test")
-ray.get(actor.task.remote(obj))
-        """
+            actor = Actor.remote()
+            obj = ray.put("test")
+            ray.get(actor.task.remote(obj))
+            """
+        )
 
         def validate_events(events: json, head_node_id):
             (
@@ -1217,25 +1227,27 @@ ray.get(actor.task.remote(obj))
         httpserver,
         preserve_proto_field_name,
     ):
-        script = """
-import ray
-import ray.util.state
-from ray._common.test_utils import wait_for_condition
-import time
+        script = textwrap.dedent(
+            """
+            import ray
+            import ray.util.state
+            from ray._common.test_utils import wait_for_condition
+            import time
 
-@ray.remote(num_cpus=1)
-class Actor:
-    def __init__(self):
-        time.sleep(1)
-        raise Exception("actor creation error")
+            @ray.remote(num_cpus=1)
+            class Actor:
+                def __init__(self):
+                    time.sleep(1)
+                    raise Exception("actor creation error")
 
-    def task(self):
-        pass
+                def task(self):
+                    pass
 
-actor = Actor.remote()
-wait_for_condition(lambda: ray.util.state.list_actors(filters=[("class_name", "=", "Actor")])[0]["state"] == "DEAD")
-ray.get(actor.task.options().remote())
-        """
+            actor = Actor.remote()
+            wait_for_condition(lambda: ray.util.state.list_actors(filters=[("class_name", "=", "Actor")])[0]["state"] == "DEAD")
+            ray.get(actor.task.options().remote())
+            """
+        )
 
         def validate_events(events: json, head_node_id):
             (
@@ -1535,21 +1547,23 @@ ray.get(actor.task.options().remote())
         httpserver,
         preserve_proto_field_name,
     ):
-        script = """
-import ray
-ray.init()
+        script = textwrap.dedent(
+            """
+            import ray
+            ray.init()
 
-@ray.remote(num_cpus=2)
-class Actor:
-    def __init__(self):
-        pass
+            @ray.remote(num_cpus=2)
+            class Actor:
+                def __init__(self):
+                    pass
 
-    def task(self):
-        pass
+                def task(self):
+                    pass
 
-actor = Actor.remote()
-ray.kill(actor)
-        """
+            actor = Actor.remote()
+            ray.kill(actor)
+            """
+        )
 
         def validate_events(events: json, head_node_id):
             (
@@ -1740,22 +1754,24 @@ ray.kill(actor)
         httpserver,
         preserve_proto_field_name,
     ):
-        script = """
-import ray
-import time
-ray.init()
+        script = textwrap.dedent(
+            """
+            import ray
+            import time
+            ray.init()
 
-@ray.remote(num_cpus=2, max_restarts=-1, max_task_retries=-1)
-class Actor:
-    def __init__(self):
-        pass
+            @ray.remote(num_cpus=2, max_restarts=-1, max_task_retries=-1)
+            class Actor:
+                def __init__(self):
+                    pass
 
-    def actor_task(self):
-        pass
+                def actor_task(self):
+                    pass
 
-actor = Actor.remote()
-time.sleep(999) # Keep the actor alive
-        """
+            actor = Actor.remote()
+            time.sleep(999) # Keep the actor alive
+            """
+        )
 
         actor_creation_task_id = None
 
@@ -1943,7 +1959,6 @@ time.sleep(999) # Keep the actor alive
         # Add a node to the cluster and wait for it to be registered
         cluster = ray_start_cluster_head_with_env_vars
         node = cluster.add_node(num_cpus=2)
-        cluster.wait_for_nodes()
 
         # Run the driver script for the actor to be created and actor task to be executed
         run_driver_script_and_wait_for_events(
@@ -1955,7 +1970,6 @@ time.sleep(999) # Keep the actor alive
 
         # Add a second node to the cluster for the actor to be restarted on
         cluster.add_node(num_cpus=2)
-        cluster.wait_for_nodes()
 
         # Kill the first node
         cluster.remove_node(node)

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1524,7 +1524,7 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
                actor_id,
                *actor->GetMutableTaskSpec(),
                {[this, actor, actor_id, mutable_actor_table_data, done_callback](
-                    Status statue) {
+                    Status status) {
                   if (done_callback) {
                     done_callback();
                   }

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1507,8 +1507,10 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
       mutable_actor_table_data->set_num_restarts_due_to_node_preemption(
           num_restarts_due_to_node_preemption + 1);
     }
-    mutable_actor_table_data->set_num_restarts(num_restarts + 1);
+    auto new_attempt_number = num_restarts + 1;
+    mutable_actor_table_data->set_num_restarts(new_attempt_number);
     actor->UpdateState(rpc::ActorTableData::RESTARTING);
+    actor->GetMutableTaskSpec()->set_attempt_number(new_attempt_number);
     // Make sure to reset the address before flushing to GCS. Otherwise,
     // GCS will mistakenly consider this lease request succeeds when restarting.
     actor->UpdateAddress(rpc::Address());

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1519,12 +1519,13 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
     gcs_table_storage_->ActorTable().Put(
         actor_id,
         *mutable_actor_table_data,
-        {[this, actor, actor_id, mutable_actor_table_data, done_callback](Status status) {
+        {[this, actor, actor_id, mutable_actor_table_data, done_callback](
+             Status actor_table_status) {
            gcs_table_storage_->ActorTaskSpecTable().Put(
                actor_id,
                *actor->GetMutableTaskSpec(),
                {[this, actor, actor_id, mutable_actor_table_data, done_callback](
-                    Status status) {
+                    Status actor_task_spec_table_status) {
                   if (done_callback) {
                     done_callback();
                   }

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1507,10 +1507,10 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
       mutable_actor_table_data->set_num_restarts_due_to_node_preemption(
           num_restarts_due_to_node_preemption + 1);
     }
-    auto new_attempt_number = num_restarts + 1;
-    mutable_actor_table_data->set_num_restarts(new_attempt_number);
+    auto new_num_restarts = num_restarts + 1;
+    mutable_actor_table_data->set_num_restarts(new_num_restarts);
     actor->UpdateState(rpc::ActorTableData::RESTARTING);
-    actor->GetMutableTaskSpec()->set_attempt_number(new_attempt_number);
+    actor->GetMutableTaskSpec()->set_attempt_number(new_num_restarts);
     // Make sure to reset the address before flushing to GCS. Otherwise,
     // GCS will mistakenly consider this lease request succeeds when restarting.
     actor->UpdateAddress(rpc::Address());
@@ -1520,12 +1520,19 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
         actor_id,
         *mutable_actor_table_data,
         {[this, actor, actor_id, mutable_actor_table_data, done_callback](Status status) {
-           if (done_callback) {
-             done_callback();
-           }
-           gcs_publisher_->PublishActor(
-               actor_id, GenActorDataOnlyWithStates(*mutable_actor_table_data));
-           actor->WriteActorExportEvent(false);
+           gcs_table_storage_->ActorTaskSpecTable().Put(
+               actor_id,
+               *actor->GetMutableTaskSpec(),
+               {[this, actor, actor_id, mutable_actor_table_data, done_callback](
+                    Status statue) {
+                  if (done_callback) {
+                    done_callback();
+                  }
+                  gcs_publisher_->PublishActor(
+                      actor_id, GenActorDataOnlyWithStates(*mutable_actor_table_data));
+                  actor->WriteActorExportEvent(false);
+                },
+                io_context_});
          },
          io_context_});
     gcs_actor_scheduler_->Schedule(actor);


### PR DESCRIPTION
## Description
Recently, we realized that during actor restarts, we will generate duplicate task events for the same actor creation task id and attempt 0. This is because, the actor restart process happens inside GCS and the corresponding actor creation task TaskSpec won't be updated with the new attempt number. 

This PR adds the logic to update the attempt number to the actor creation task TaskSpec and add a test to verify the change.

## Related issues
N/A

## Additional information
N/A
