### PR TITLE
[spark] Fix RuntimeError in SparkJobServer.shutdown() during dict iteration

### DIFF
--- a/python/ray/autoscaler/_private/spark/spark_job_server.py
+++ b/python/ray/autoscaler/_private/spark/spark_job_server.py
@@ -221,7 +221,7 @@ class SparkJobServer(ThreadingHTTPServer):
 
     def shutdown(self) -> None:
         super().shutdown()
-        for spark_job_group_id in self.task_status_dict:
+        for spark_job_group_id in list(self.task_status_dict.keys()):
             self.spark.sparkContext.cancelJobGroup(spark_job_group_id)
         # Sleep 1 second to wait for all spark job cancellation
         # The spark job cancellation will do things asyncly in a background thread,


### PR DESCRIPTION
## Description
> Fixed "dictionary changed size during iteration" error that occurs when shutdown() iterates over task_status_dict while background threads modify it concurrently. 

## Additional information
> Why not use thread lock? The bug is in the shutdown part, and no other parts iterate it.
