### PR TITLE
[core] Fix flaky recursive cancel test

### DIFF
--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -467,8 +467,7 @@ def test_recursive_cancel(shutdown_only, use_force):
 
     @ray.remote(num_cpus=1)
     def outer():
-        x = [inner.remote()]
-        print(x)
+        _ = inner.remote()
         while True:
             time.sleep(0.1)
 
@@ -480,11 +479,11 @@ def test_recursive_cancel(shutdown_only, use_force):
     many_fut = many_resources.remote()
     with pytest.raises(GetTimeoutError):
         ray.get(many_fut, timeout=1)
-    ray.cancel(outer_fut)
+    ray.cancel(outer_fut, force=use_force)
     with pytest.raises(valid_exceptions(use_force)):
         ray.get(outer_fut, timeout=10)
 
-    assert ray.get(many_fut, timeout=30)
+    assert ray.get(many_fut, timeout=30) == 300
 
 
 def test_recursive_cancel_actor_task(shutdown_only):

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -458,7 +458,7 @@ def test_remote_cancel(ray_start_cluster, use_force):
 
 @pytest.mark.parametrize("use_force", [True, False])
 def test_recursive_cancel(shutdown_only, use_force):
-    ray.init(num_cpus=4)
+    ray.init(num_cpus=2)
 
     @ray.remote(num_cpus=1)
     def inner():
@@ -471,9 +471,9 @@ def test_recursive_cancel(shutdown_only, use_force):
         while True:
             time.sleep(0.1)
 
-    @ray.remote(num_cpus=4)
+    @ray.remote(num_cpus=2)
     def many_resources():
-        return 300
+        return True
 
     outer_fut = outer.remote()
     many_fut = many_resources.remote()
@@ -483,7 +483,7 @@ def test_recursive_cancel(shutdown_only, use_force):
     with pytest.raises(valid_exceptions(use_force)):
         ray.get(outer_fut, timeout=10)
 
-    assert ray.get(many_fut, timeout=30) == 300
+    assert ray.get(many_fut, timeout=30)
 
 
 def test_recursive_cancel_actor_task(shutdown_only):


### PR DESCRIPTION
## Description
This test was flaky before, making it more deterministic now by cancelling only once the outer and inner task are both running and making sure they're running before launching the many_resources task.

The flaky failure was the ray.get on many_resources returning before the cancel.
https://buildkite.com/ray-project/postmerge/builds/14463#019a99a6-acf2-4e28-89d3-2abc99eb93ac/609-913