### PR TITLE
[Serve] remove route matching logic from replica and bug fix with route matching

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1,13 +1,14 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from starlette.types import Scope
 
 import ray
 from ray.actor import ActorHandle
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
+from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 from ray.serve.generated.serve_pb2 import (
     DeploymentStatus as DeploymentStatusProto,
     DeploymentStatusInfo as DeploymentStatusInfoProto,
@@ -124,9 +125,11 @@ class EndpointInfo:
         app_is_cross_language: Whether the deployment uses a different language
             than the proxy (e.g., Java deployment with Python proxy). This affects
             how the proxy serializes/deserializes requests.
-        route_patterns: List of (methods, path) tuples for ASGI route patterns.
-            methods is None for routes without method restrictions, or a list of HTTP methods.
-            Examples: [(["GET", "POST"], "/"), (["PUT"], "/users/{id}"), (None, "/websocket")]
+        route_patterns: List of RoutePattern objects for ASGI route patterns.
+            Each RoutePattern has methods (list of HTTP methods or None) and path.
+            Examples: [RoutePattern(methods=["GET", "POST"], path="/"),
+                      RoutePattern(methods=["PUT"], path="/users/{id}"),
+                      RoutePattern(methods=None, path="/websocket")]
             Used by proxies to match incoming requests to specific route patterns
             for accurate metrics tagging. This avoids high cardinality by using
             parameterized patterns instead of individual request paths.
@@ -135,7 +138,7 @@ class EndpointInfo:
 
     route: str
     app_is_cross_language: bool = False
-    route_patterns: Optional[List[Tuple[Optional[List[str]], str]]] = None
+    route_patterns: Optional[List["RoutePattern"]] = None
 
 
 # Keep in sync with ServeReplicaState in dashboard/client/src/type/serve.ts

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from starlette.types import Scope
 
@@ -124,8 +124,9 @@ class EndpointInfo:
         app_is_cross_language: Whether the deployment uses a different language
             than the proxy (e.g., Java deployment with Python proxy). This affects
             how the proxy serializes/deserializes requests.
-        route_patterns: List of all ASGI route patterns for this deployment
-            (e.g., ["/", "/users/{user_id}", "/items/{item_id}/details"]).
+        route_patterns: List of (methods, path) tuples for ASGI route patterns.
+            methods is None for routes without method restrictions, or a list of HTTP methods.
+            Examples: [(["GET", "POST"], "/"), (["PUT"], "/users/{id}"), (None, "/websocket")]
             Used by proxies to match incoming requests to specific route patterns
             for accurate metrics tagging. This avoids high cardinality by using
             parameterized patterns instead of individual request paths.
@@ -134,7 +135,7 @@ class EndpointInfo:
 
     route: str
     app_is_cross_language: bool = False
-    route_patterns: Optional[List[str]] = None
+    route_patterns: Optional[List[Tuple[Optional[List[str]], str]]] = None
 
 
 # Keep in sync with ServeReplicaState in dashboard/client/src/type/serve.ts

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -221,8 +221,8 @@ class ProxyRouter:
                     pass
 
                 routes = [
-                    Route(path, dummy_endpoint, methods=methods)
-                    for methods, path in patterns
+                    Route(pattern.path, dummy_endpoint, methods=pattern.methods)
+                    for pattern in patterns
                 ]
                 mock_app = Starlette(routes=routes)
 

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -8,7 +8,10 @@ from starlette.types import Scope
 
 from ray.serve._private.common import ApplicationName, DeploymentID, EndpointInfo
 from ray.serve._private.constants import SERVE_LOGGER_NAME
-from ray.serve._private.thirdparty.get_asgi_route_name import get_asgi_route_name
+from ray.serve._private.thirdparty.get_asgi_route_name import (
+    RoutePattern,
+    get_asgi_route_name,
+)
 from ray.serve.handle import DeploymentHandle
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -46,7 +49,8 @@ class ProxyRouter:
 
         # Map of route prefix to list of route patterns for that endpoint
         # Used to match incoming requests to ASGI route patterns for metrics
-        self.route_patterns: Dict[str, List[str]] = dict()
+        # Route patterns are tuples of (methods, path) where methods can be None
+        self.route_patterns: Dict[str, List[RoutePattern]] = dict()
         # Cache of mock Starlette apps for route pattern matching
         # Key: route prefix, Value: pre-built Starlette app with routes
         self._route_pattern_apps: Dict[str, Any] = dict()
@@ -216,7 +220,10 @@ class ProxyRouter:
                 async def dummy_endpoint(request: Request):
                     pass
 
-                routes = [Route(pattern, dummy_endpoint) for pattern in patterns]
+                routes = [
+                    Route(path, dummy_endpoint, methods=methods)
+                    for methods, path in patterns
+                ]
                 mock_app = Starlette(routes=routes)
 
                 # Cache the mock app for future requests

--- a/python/ray/serve/_private/thirdparty/get_asgi_route_name.py
+++ b/python/ray/serve/_private/thirdparty/get_asgi_route_name.py
@@ -31,10 +31,14 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 from starlette.routing import Match, Mount, Route
 from starlette.types import ASGIApp, Scope
+
+# Type alias for route pattern: (methods, path)
+# methods is None if the route accepts all HTTP methods, otherwise a list of methods
+RoutePattern = Tuple[Optional[List[str]], str]
 
 
 def _get_route_name(
@@ -91,7 +95,7 @@ def get_asgi_route_name(app: ASGIApp, scope: Scope) -> Optional[str]:
     return route_name
 
 
-def extract_route_patterns(app: ASGIApp) -> List[str]:
+def extract_route_patterns(app: ASGIApp) -> List[RoutePattern]:
     """Extracts all route patterns from an ASGI app.
 
     This function recursively traverses the app's routes (including mounted apps)
@@ -102,9 +106,15 @@ def extract_route_patterns(app: ASGIApp) -> List[str]:
         app: The ASGI application (typically FastAPI or Starlette)
 
     Returns:
-        List of route patterns, e.g., ["/", "/api/{user_id}", "/items/{item_id}"]
+        List of (methods, path) tuples. Examples:
+        - (["GET", "POST"], "/"): GET and POST requests to root
+        - (["GET"], "/users/{id}"): GET request to users endpoint
+        - (None, "/websocket"): Route with no method restriction (e.g., WebSocket, ASGI app)
     """
-    patterns: Set[str] = set()
+    # Use a dict to store path -> set of methods mapping
+    # This allows us to track which methods apply to each path
+    # Use None as a sentinel value to indicate "no method restrictions"
+    path_methods: Dict[str, Optional[Set[str]]] = {}
 
     def _extract_from_routes(routes: List[Route], prefix: str = "") -> None:
         for route in routes:
@@ -115,11 +125,22 @@ def extract_route_patterns(app: ASGIApp) -> List[str]:
                 if hasattr(route, "routes") and route.routes:
                     _extract_from_routes(route.routes, route_path)
                 else:
-                    # Mount without sub-routes
-                    patterns.add(route_path)
+                    # Mount without sub-routes - no method restrictions
+                    if route_path not in path_methods:
+                        path_methods[route_path] = None
             else:
-                # Regular route
-                patterns.add(route_path)
+                # Regular route - extract methods if available
+                if hasattr(route, "methods") and route.methods:
+                    # Route has specific methods
+                    if route_path not in path_methods:
+                        path_methods[route_path] = set()
+                    # Only add methods if we haven't already marked this path as "all methods"
+                    if path_methods[route_path] is not None:
+                        path_methods[route_path].update(route.methods)
+                else:
+                    # Route has no method restrictions (accepts all methods)
+                    # Mark this path as accepting all methods (None)
+                    path_methods[route_path] = None
 
     try:
         if hasattr(app, "routes"):
@@ -128,13 +149,30 @@ def extract_route_patterns(app: ASGIApp) -> List[str]:
             # Handle root_path if present
             if hasattr(app, "root_path") and app.root_path:
                 root_path = app.root_path.rstrip("/")
-                patterns = {
-                    root_path + "/" + p.lstrip("/") if p != "/" else root_path + p
-                    for p in patterns
-                }
+                adjusted_path_methods = {}
+                for path, methods in path_methods.items():
+                    adjusted_path = (
+                        root_path + "/" + path.lstrip("/")
+                        if path != "/"
+                        else root_path + path
+                    )
+                    adjusted_path_methods[adjusted_path] = methods
+                path_methods = adjusted_path_methods
     except Exception:
         # If extraction fails for any reason, return empty list
         # This shouldn't break the system
         return []
 
-    return sorted(patterns)
+    # Convert path_methods dict to list of (methods, path) tuples
+    patterns: List[RoutePattern] = []
+    for path, methods in path_methods.items():
+        if methods is None:
+            # No method restrictions - add as (None, path)
+            patterns.append((None, path))
+        else:
+            # Convert set to sorted list for consistent ordering
+            methods_list = sorted(methods)
+            patterns.append((methods_list, path))
+
+    # Sort by path for consistent ordering
+    return sorted(patterns, key=lambda x: x[1])

--- a/python/ray/serve/tests/unit/test_extract_route_patterns.py
+++ b/python/ray/serve/tests/unit/test_extract_route_patterns.py
@@ -4,19 +4,21 @@ from fastapi import FastAPI
 from starlette.applications import Starlette
 from starlette.routing import Mount, Route
 
-from ray.serve._private.thirdparty.get_asgi_route_name import extract_route_patterns
+from ray.serve._private.thirdparty.get_asgi_route_name import (
+    extract_route_patterns,
+)
 
 
 def has_path(patterns, path):
     """Helper to check if a path exists in patterns list."""
-    return any(p == path for methods, p in patterns)
+    return any(pattern.path == path for pattern in patterns)
 
 
 def get_methods_for_path(patterns, path):
     """Helper to get methods for a specific path."""
-    for methods, p in patterns:
-        if p == path:
-            return methods
+    for pattern in patterns:
+        if pattern.path == path:
+            return pattern.methods
     return None
 
 
@@ -202,7 +204,7 @@ def test_extract_route_patterns_multiple_methods_same_path():
     patterns = extract_route_patterns(app)
 
     # Path should appear only once with all methods grouped
-    path_count = sum(1 for methods, p in patterns if p == "/items/{item_id}")
+    path_count = sum(1 for pattern in patterns if pattern.path == "/items/{item_id}")
     assert path_count == 1
 
     # Check that all methods are present
@@ -270,7 +272,7 @@ def test_extract_route_patterns_sorted_output():
     patterns = extract_route_patterns(app)
 
     # Extract just the paths
-    paths = [p for methods, p in patterns]
+    paths = [pattern.path for pattern in patterns]
 
     # Find the user-defined routes
     user_routes = [p for p in paths if p in ["/zebra", "/apple", "/banana"]]
@@ -294,7 +296,7 @@ def test_extract_route_patterns_special_characters():
     patterns = extract_route_patterns(app)
 
     # Extract just the paths
-    paths = [p for methods, p in patterns]
+    paths = [pattern.path for pattern in patterns]
 
     # FastAPI converts these to standard patterns
     assert any("user_id" in p for p in paths)

--- a/python/ray/serve/tests/unit/test_extract_route_patterns.py
+++ b/python/ray/serve/tests/unit/test_extract_route_patterns.py
@@ -7,6 +7,19 @@ from starlette.routing import Mount, Route
 from ray.serve._private.thirdparty.get_asgi_route_name import extract_route_patterns
 
 
+def has_path(patterns, path):
+    """Helper to check if a path exists in patterns list."""
+    return any(p == path for methods, p in patterns)
+
+
+def get_methods_for_path(patterns, path):
+    """Helper to get methods for a specific path."""
+    for methods, p in patterns:
+        if p == path:
+            return methods
+    return None
+
+
 def test_extract_route_patterns_fastapi_simple():
     """Test extracting route patterns from a simple FastAPI app."""
     app = FastAPI()
@@ -26,12 +39,12 @@ def test_extract_route_patterns_fastapi_simple():
     patterns = extract_route_patterns(app)
 
     # FastAPI automatically adds some default routes
-    assert "/" in patterns
-    assert "/users/{user_id}" in patterns
-    assert "/items/{item_id}" in patterns
+    assert has_path(patterns, "/")
+    assert has_path(patterns, "/users/{user_id}")
+    assert has_path(patterns, "/items/{item_id}")
     # FastAPI adds OpenAPI routes
-    assert "/openapi.json" in patterns
-    assert "/docs" in patterns
+    assert has_path(patterns, "/openapi.json")
+    assert has_path(patterns, "/docs")
 
 
 def test_extract_route_patterns_nested_paths():
@@ -48,8 +61,8 @@ def test_extract_route_patterns_nested_paths():
 
     patterns = extract_route_patterns(app)
 
-    assert "/api/v1/users/{user_id}/posts/{post_id}" in patterns
-    assert "/api/v1/users/{user_id}/settings" in patterns
+    assert has_path(patterns, "/api/v1/users/{user_id}/posts/{post_id}")
+    assert has_path(patterns, "/api/v1/users/{user_id}/settings")
 
 
 def test_extract_route_patterns_with_mounts():
@@ -72,9 +85,9 @@ def test_extract_route_patterns_with_mounts():
 
     patterns = extract_route_patterns(app)
 
-    assert "/" in patterns
-    assert "/admin/health" in patterns
-    assert "/admin/status" in patterns
+    assert has_path(patterns, "/")
+    assert has_path(patterns, "/admin/health")
+    assert has_path(patterns, "/admin/status")
 
 
 def test_extract_route_patterns_nested_mounts():
@@ -104,9 +117,9 @@ def test_extract_route_patterns_nested_mounts():
 
     patterns = extract_route_patterns(app)
 
-    assert "/" in patterns
-    assert "/api/v1/list" in patterns
-    assert "/api/v1/item/details" in patterns
+    assert has_path(patterns, "/")
+    assert has_path(patterns, "/api/v1/list")
+    assert has_path(patterns, "/api/v1/item/details")
 
 
 def test_extract_route_patterns_with_root_path():
@@ -128,9 +141,9 @@ def test_extract_route_patterns_with_root_path():
     patterns = extract_route_patterns(app)
 
     # Root path should be prepended to all routes
-    assert "/v1/" in patterns  # Root route
-    assert "/v1/users" in patterns
-    assert "/v1/items/{item_id}" in patterns
+    assert has_path(patterns, "/v1/")  # Root route
+    assert has_path(patterns, "/v1/users")
+    assert has_path(patterns, "/v1/items/{item_id}")
 
 
 def test_extract_route_patterns_empty_app():
@@ -141,8 +154,8 @@ def test_extract_route_patterns_empty_app():
     patterns = extract_route_patterns(app)
 
     # Should still have FastAPI defaults
-    assert "/openapi.json" in patterns
-    assert "/docs" in patterns
+    assert has_path(patterns, "/openapi.json")
+    assert has_path(patterns, "/docs")
     # May or may not have "/" depending on FastAPI version
 
 
@@ -164,14 +177,14 @@ def test_extract_route_patterns_starlette():
 
     patterns = extract_route_patterns(app)
 
-    assert "/" in patterns
-    assert "/users/{user_id}" in patterns
+    assert has_path(patterns, "/")
+    assert has_path(patterns, "/users/{user_id}")
     # Starlette shouldn't have OpenAPI routes
-    assert "/openapi.json" not in patterns
+    assert not has_path(patterns, "/openapi.json")
 
 
 def test_extract_route_patterns_multiple_methods_same_path():
-    """Test that patterns are deduplicated when multiple methods use same path."""
+    """Test that methods are grouped when multiple methods use same path."""
     app = FastAPI()
 
     @app.get("/items/{item_id}")
@@ -188,9 +201,16 @@ def test_extract_route_patterns_multiple_methods_same_path():
 
     patterns = extract_route_patterns(app)
 
-    # Should appear only once even though 3 methods use it
-    pattern_count = patterns.count("/items/{item_id}")
-    assert pattern_count == 1
+    # Path should appear only once with all methods grouped
+    path_count = sum(1 for methods, p in patterns if p == "/items/{item_id}")
+    assert path_count == 1
+
+    # Check that all methods are present
+    methods = get_methods_for_path(patterns, "/items/{item_id}")
+    assert methods is not None
+    assert "GET" in methods
+    assert "PUT" in methods
+    assert "DELETE" in methods
 
 
 def test_extract_route_patterns_invalid_app():
@@ -225,12 +245,14 @@ def test_extract_route_patterns_mount_without_routes():
 
     patterns = extract_route_patterns(app)
 
-    assert "/" in patterns
-    assert "/custom" in patterns
+    assert has_path(patterns, "/")
+    assert has_path(patterns, "/custom")
+    # Custom mount has no method restrictions
+    assert get_methods_for_path(patterns, "/custom") is None
 
 
 def test_extract_route_patterns_sorted_output():
-    """Test that output is sorted alphabetically."""
+    """Test that output is sorted by path."""
     app = FastAPI()
 
     @app.get("/zebra")
@@ -247,8 +269,11 @@ def test_extract_route_patterns_sorted_output():
 
     patterns = extract_route_patterns(app)
 
+    # Extract just the paths
+    paths = [p for methods, p in patterns]
+
     # Find the user-defined routes
-    user_routes = [p for p in patterns if p in ["/zebra", "/apple", "/banana"]]
+    user_routes = [p for p in paths if p in ["/zebra", "/apple", "/banana"]]
 
     # Should be sorted
     assert user_routes == ["/apple", "/banana", "/zebra"]
@@ -268,9 +293,12 @@ def test_extract_route_patterns_special_characters():
 
     patterns = extract_route_patterns(app)
 
+    # Extract just the paths
+    paths = [p for methods, p in patterns]
+
     # FastAPI converts these to standard patterns
-    assert any("user_id" in p for p in patterns)
-    assert any("item_id" in p for p in patterns)
+    assert any("user_id" in p for p in paths)
+    assert any("item_id" in p for p in paths)
 
 
 def test_extract_route_patterns_websocket_routes():
@@ -288,8 +316,11 @@ def test_extract_route_patterns_websocket_routes():
 
     patterns = extract_route_patterns(app)
 
-    assert "/http" in patterns
-    assert "/ws" in patterns
+    assert has_path(patterns, "/http")
+    assert has_path(patterns, "/ws")
+
+    # WebSocket route should have no method restrictions
+    assert get_methods_for_path(patterns, "/ws") is None
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_proxy.py
+++ b/python/ray/serve/tests/unit/test_proxy.py
@@ -23,6 +23,7 @@ from ray.serve._private.proxy_router import (
     ProxyRouter,
 )
 from ray.serve._private.test_utils import FakeGrpcContext, MockDeploymentHandle
+from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 from ray.serve.generated import serve_pb2
 from ray.serve.grpc_util import RayServegRPCContext
 
@@ -829,9 +830,9 @@ class TestProxyRouterMatchRoutePattern:
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
                     route_patterns=[
-                        (None, "/api/"),
-                        (None, "/api/users/{user_id}"),
-                        (None, "/api/items/{item_id}/details"),
+                        RoutePattern(methods=None, path="/api/"),
+                        RoutePattern(methods=None, path="/api/users/{user_id}"),
+                        RoutePattern(methods=None, path="/api/items/{item_id}/details"),
                     ],
                 )
             }
@@ -859,7 +860,9 @@ class TestProxyRouterMatchRoutePattern:
             {
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
-                    route_patterns=[(None, "/api/users/{user_id}")],
+                    route_patterns=[
+                        RoutePattern(methods=None, path="/api/users/{user_id}")
+                    ],
                 )
             }
         )
@@ -885,7 +888,9 @@ class TestProxyRouterMatchRoutePattern:
             {
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
-                    route_patterns=[(None, "/api/users/{user_id}")],
+                    route_patterns=[
+                        RoutePattern(methods=None, path="/api/users/{user_id}")
+                    ],
                 )
             }
         )
@@ -899,7 +904,9 @@ class TestProxyRouterMatchRoutePattern:
             {
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
-                    route_patterns=[(None, "/api/items/{item_id}")],
+                    route_patterns=[
+                        RoutePattern(methods=None, path="/api/items/{item_id}")
+                    ],
                 )
             }
         )
@@ -927,7 +934,9 @@ class TestProxyRouterMatchRoutePattern:
             {
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
-                    route_patterns=[(None, "/api/users/{user_id}")],
+                    route_patterns=[
+                        RoutePattern(methods=None, path="/api/users/{user_id}")
+                    ],
                 )
             }
         )

--- a/python/ray/serve/tests/unit/test_proxy.py
+++ b/python/ray/serve/tests/unit/test_proxy.py
@@ -829,9 +829,9 @@ class TestProxyRouterMatchRoutePattern:
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
                     route_patterns=[
-                        "/api/",
-                        "/api/users/{user_id}",
-                        "/api/items/{item_id}/details",
+                        (None, "/api/"),
+                        (None, "/api/users/{user_id}"),
+                        (None, "/api/items/{item_id}/details"),
                     ],
                 )
             }
@@ -859,7 +859,7 @@ class TestProxyRouterMatchRoutePattern:
             {
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
-                    route_patterns=["/api/users/{user_id}"],
+                    route_patterns=[(None, "/api/users/{user_id}")],
                 )
             }
         )
@@ -885,7 +885,7 @@ class TestProxyRouterMatchRoutePattern:
             {
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
-                    route_patterns=["/api/users/{user_id}"],
+                    route_patterns=[(None, "/api/users/{user_id}")],
                 )
             }
         )
@@ -899,7 +899,7 @@ class TestProxyRouterMatchRoutePattern:
             {
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
-                    route_patterns=["/api/items/{item_id}"],
+                    route_patterns=[(None, "/api/items/{item_id}")],
                 )
             }
         )
@@ -927,7 +927,7 @@ class TestProxyRouterMatchRoutePattern:
             {
                 DeploymentID("api", "default"): EndpointInfo(
                     route="/api",
-                    route_patterns=["/api/users/{user_id}"],
+                    route_patterns=[(None, "/api/users/{user_id}")],
                 )
             }
         )


### PR DESCRIPTION
The correct route value is already part of RequestMetadata after https://github.com/ray-project/ray/pull/58180, no need to recompute it again.

no observed perf diff in microbenchmark
After
```
Type	Name	# Requests	# Fails	Median (ms)	95%ile (ms)	99%ile (ms)	Average (ms)	Min (ms)	Max (ms)	Average size (bytes)	Current RPS	Current Failures/s
GET	/echo?message=hello	28068	0	200	410	470	228.27	80	592	26	430.3	0
Aggregated	28068	0	200	410	470	228.27	80	592	26	430.3	0
```

Before
```
Type	Name	# Requests	# Fails	Median (ms)	95%ile (ms)	99%ile (ms)	Average (ms)	Min (ms)	Max (ms)	Average size (bytes)	Current RPS	Current Failures/s
GET	/echo?message=hello	27427	0	210	410	470	232.12	76	604	26	429.7	0
Aggregated	27427	0	210	410	470	232.12	76	604	26	429.7	0
```

Additionally, old implementation wrongly assumed that there will only be one method (GET,PUT) corresponding to a route. This PR fixes that assumption and tests for it.