### PR TITLE
[rllib] Prevent double calling connectors for `MultiAgentEnvRunner`'s completed episodes when sampling a fixed number of episodes

### DIFF
--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -458,19 +458,26 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
                     # Run a last time the `env_to_module` pipeline for these episodes
                     # to postprocess artifacts (e.g. observations to one-hot).
                     done_episodes_to_run_env_to_module.append(episodes[env_index])
-                    # Also early-out if we reach the number of episodes within this
-                    # for-loop.
-                    if eps == num_episodes:
-                        break
 
                     old_episode_id = episodes[env_index].id_
-                    # Create a new episode object with no data in it and execute
-                    # `on_episode_created` callback (before the `env.reset()` call).
-                    self._new_episode(env_index, episodes)
+                    # Create a new episode object with no data in it.
+                    # Note: If we're about to break (reached target num_episodes), skip
+                    # the `on_episode_created` callback since this episode will never be
+                    # used (it gets discarded on the next sample() call).
+                    self._new_episode(
+                        env_index,
+                        episodes,
+                        call_on_episode_created=(eps != num_episodes)
+                    )
                     # Register the mapping of new episode ID to old episode ID.
                     shared_data["vector_env_episodes_map"].update(
                         {old_episode_id: episodes[env_index].id_}
                     )
+
+                    # Also early-out if we reach the number of episodes within this
+                    # for-loop.
+                    if eps == num_episodes:
+                        break
 
             # Env-to-module connector pass (cache results as we will do the RLModule
             # forward pass only in the next `while`-iteration).
@@ -929,7 +936,7 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
             EpisodeID, List[MultiAgentEpisode]
         ] = defaultdict(list)
 
-    def _new_episode(self, env_index, episodes=None):
+    def _new_episode(self, env_index, episodes=None, call_on_episode_created=True):
         episodes = episodes if episodes is not None else self._episodes
         episodes[env_index] = MultiAgentEpisode(
             observation_space={
@@ -942,7 +949,8 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
             },
             agent_to_module_mapping_fn=self.config.policy_mapping_fn,
         )
-        self._make_on_episode_callback("on_episode_created", env_index, episodes)
+        if call_on_episode_created:
+            self._make_on_episode_callback("on_episode_created", env_index, episodes)
 
     def _make_on_episode_callback(
         self, which: str, idx: int, episodes: List[MultiAgentEpisode]

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -467,7 +467,7 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
                     self._new_episode(
                         env_index,
                         episodes,
-                        call_on_episode_created=(eps != num_episodes)
+                        call_on_episode_created=(eps != num_episodes),
                     )
                     # Register the mapping of new episode ID to old episode ID.
                     shared_data["vector_env_episodes_map"].update(

--- a/rllib/env/tests/test_multi_agent_env_runner.py
+++ b/rllib/env/tests/test_multi_agent_env_runner.py
@@ -2,9 +2,40 @@ import unittest
 
 import ray
 from ray.rllib.algorithms.ppo.ppo import PPOConfig
+from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.env.multi_agent_env_runner import MultiAgentEnvRunner
+from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
+from ray.rllib.utils import override
 from ray.rllib.utils.test_utils import check
+
+
+class EpisodeTracker(ConnectorV2):
+    def __init__(self, env, spaces, device):
+        super().__init__(env.observation_space, env.action_space)
+
+        self.episode_end_counter = 0
+        self.episodes_encountered_list = list()
+        self.episodes_encountered_set = set()
+
+    @override(ConnectorV2)
+    def __call__(
+        self,
+        *,
+        rl_module,
+        batch,
+        episodes: list[MultiAgentEpisode],
+        explore,
+        shared_data,
+        metrics,
+        **kwargs,
+    ):
+        if all(e.is_done for e in episodes):
+            self.episode_end_counter += len(episodes)
+            for episode in episodes:
+                self.episodes_encountered_list.append(episode.id_)
+                self.episodes_encountered_set.add(episode.id_)
+        return batch
 
 
 class TestMultiAgentEnvRunner(unittest.TestCase):
@@ -127,6 +158,46 @@ class TestMultiAgentEnvRunner(unittest.TestCase):
         )
 
         return config
+
+    def test_on_episode_end_callback(self):
+        """Check that callback only happens once for each completed episode.
+
+        Related to https://github.com/ray-project/ray/issues/55452
+        """
+        config = (
+            PPOConfig()
+            .environment(
+                MultiAgentCartPole,
+                env_config={"num_agents": 1},
+            )
+            .multi_agent(
+                policies={"p0"}, policy_mapping_fn=(lambda aid, *args, **kwargs: "p0")
+            )
+            .env_runners(
+                env_to_module_connector=EpisodeTracker,
+            )
+        )
+
+        for num_envs, num_episodes in [(1, 1), (4, 4), (1, 4)]:
+            config.env_runners(num_envs_per_env_runner=num_envs)
+
+            env_runner = MultiAgentEnvRunner(config=config)
+
+            self.assertTrue(
+                isinstance(env_runner._env_to_module.connectors[0], EpisodeTracker)
+            )
+            self.assertEquals(
+                env_runner._env_to_module.connectors[0].episode_end_counter, 0
+            )
+
+            sampled_episodes = env_runner.sample(
+                num_episodes=num_episodes, random_actions=True
+            )
+            self.assertEquals(len(sampled_episodes), num_episodes)
+            self.assertEquals(
+                env_runner._env_to_module.connectors[0].episode_end_counter,
+                num_episodes,
+            )
 
 
 if __name__ == "__main__":

--- a/rllib/env/tests/test_multi_agent_env_runner.py
+++ b/rllib/env/tests/test_multi_agent_env_runner.py
@@ -186,15 +186,15 @@ class TestMultiAgentEnvRunner(unittest.TestCase):
             self.assertTrue(
                 isinstance(env_runner._env_to_module.connectors[0], EpisodeTracker)
             )
-            self.assertEquals(
+            self.assertEqual(
                 env_runner._env_to_module.connectors[0].episode_end_counter, 0
             )
 
             sampled_episodes = env_runner.sample(
                 num_episodes=num_episodes, random_actions=True
             )
-            self.assertEquals(len(sampled_episodes), num_episodes)
-            self.assertEquals(
+            self.assertEqual(len(sampled_episodes), num_episodes)
+            self.assertEqual(
                 env_runner._env_to_module.connectors[0].episode_end_counter,
                 num_episodes,
             )


### PR DESCRIPTION
## Description
The `MultiAgentEnvRunner` would previously call the callback twice for the final episode of a batch (when sampling a fixed number of episodes). This PR fixes this problem ensuring that the callback only happens once for finished episode

## Related issues
Closes https://github.com/ray-project/ray/issues/55452