### PR TITLE
[serve] fix windows tests

### DIFF
--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -412,7 +412,7 @@ def _reuse_port_is_available():
 
 
 @pytest.mark.skipif(
-    not _reuse_port_is_available(),
+    sys.platform == "win32" or not _reuse_port_is_available(),
     reason=(
         "Port sharing only works on newer verion of Linux. "
         "This test can only be ran when port sharing is supported."


### PR DESCRIPTION
## Description
`test_multiple_routers` is flaky on windows. The multi-cluster setup times out on windows during adding/removing a node to the cluster.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
