### PR TITLE
[Data] Refactor path resolution and download operations and add exception handling

### DIFF
--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -191,7 +191,7 @@ def download_bytes_threaded(
             for uri in uri_iterator:
                 read_bytes = None
                 try:
-                    # Lazy resolution: use cached FS if available, fallback to full resolution
+                    # Use cached FS if available, otherwise resolve the filesystem for the uri.
                     resolved_paths, resolved_fs = _resolve_paths_and_filesystem(
                         uri, filesystem=cached_fs
                     )
@@ -201,8 +201,11 @@ def download_bytes_threaded(
                     fs = RetryingPyFileSystem.wrap(
                         resolved_fs, retryable_errors=data_context.retried_io_errors
                     )
-                    # We only pass one uri to resolve and unwrap it from the list of resolved paths
+                    # We only pass one uri to resolve and unwrap it from the list of resolved paths,
+                    # if fails, we will catch the index error and log it.
                     resolved_path = resolved_paths[0]
+                    if resolved_path is None:
+                        continue
 
                     # Download bytes
                     # Use open_input_stream to handle the rare scenario where the data source is not seekable.

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -181,37 +181,54 @@ def download_bytes_threaded(
         if len(uris) == 0:
             continue
 
-        paths, fs = _resolve_paths_and_filesystem(uris)
-        fs = RetryingPyFileSystem.wrap(
-            fs, retryable_errors=data_context.retried_io_errors
-        )
+        def load_uri_bytes(uri_iterator):
+            """Resolve filesystem and download bytes for each URI.
 
-        def load_uri_bytes(uri_path_iterator):
-            """Function that takes an iterator of URI paths and yields downloaded bytes for each."""
-            for uri_path in uri_path_iterator:
+            Takes an iterator of URIs and yields bytes for each.
+            Uses lazy filesystem resolution - resolves once and reuses for subsequent URIs.
+            """
+            cached_fs = None
+            for uri in uri_iterator:
                 read_bytes = None
                 try:
+                    # Lazy resolution: use cached FS if available, fallback to full resolution
+                    resolved_paths, resolved_fs = _resolve_paths_and_filesystem(
+                        uri, filesystem=cached_fs
+                    )
+                    cached_fs = resolved_fs
+
+                    # Wrap with retrying filesystem
+                    fs = RetryingPyFileSystem.wrap(
+                        resolved_fs, retryable_errors=data_context.retried_io_errors
+                    )
+                    resolved_path = resolved_paths[0]
+
+                    # Download bytes
                     # Use open_input_stream to handle the rare scenario where the data source is not seekable.
-                    with fs.open_input_stream(uri_path) as f:
+                    with fs.open_input_stream(resolved_path) as f:
                         read_bytes = f.read()
                 except OSError as e:
                     logger.debug(
-                        f"OSError reading uri '{uri_path}' for column '{uri_column_name}': {e}"
+                        f"OSError reading uri '{uri}' for column '{uri_column_name}': {e}"
                     )
+                    # Reset cache on error to ensure fresh resolution for next URI
+                    cached_fs = None
                 except Exception as e:
                     # Catch unexpected errors like pyarrow.lib.ArrowInvalid caused by an invalid uri like
                     # `foo://bar` to avoid failing because of one invalid uri.
                     logger.warning(
-                        f"Unexpected error reading uri '{uri_path}' for column '{uri_column_name}': {e}"
+                        f"Unexpected error reading uri '{uri}' for column '{uri_column_name}': {e}"
                     )
+                    # Reset cache on error to ensure fresh resolution for next URI
+                    cached_fs = None
                 finally:
                     yield read_bytes
 
-        # Use make_async_gen to download URI bytes concurrently
-        # This preserves the order of results to match the input URIs
+        # Use make_async_gen to resolve and download URI bytes concurrently
+        # preserve_ordering=True ensures results are returned in the same order as input URIs
         uri_bytes = list(
             make_async_gen(
-                base_iterator=iter(paths),
+                base_iterator=iter(uris),
                 fn=load_uri_bytes,
                 preserve_ordering=True,
                 num_workers=URI_DOWNLOAD_MAX_WORKERS,
@@ -319,11 +336,16 @@ class PartitionActor:
         if not uris:
             return []
 
-        # Get the filesystem from the first URI
-        paths, fs = _resolve_paths_and_filesystem(uris)
-        fs = RetryingPyFileSystem.wrap(
-            fs, retryable_errors=self._data_context.retried_io_errors
-        )
+        # Get the filesystem from the URIs (assumes all URIs use same filesystem for sampling)
+        try:
+            paths, fs = _resolve_paths_and_filesystem(uris)
+            fs = RetryingPyFileSystem.wrap(
+                fs, retryable_errors=self._data_context.retried_io_errors
+            )
+        except Exception as e:
+            logger.warning(f"Failed to resolve URIs for size sampling: {e}")
+            # Return zeros for all URIs if resolution fails
+            return [0] * len(uris)
 
         # Use ThreadPoolExecutor for concurrent size fetching
         file_sizes = [None] * len(paths)


### PR DESCRIPTION
This commit refactors the path resolution and download functionality to improve code quality, error handling, and maintainability:

## Changes to path_util.py:
- Added helper functions to eliminate fsspec import duplication:
  - `_get_fsspec_http_filesystem()`: Centralized fsspec HTTP filesystem creation
  - `_wrap_fsspec_filesystem()`: Validates and wraps fsspec filesystems
  - `_try_resolve_with_encoding()`: Handles URI parsing errors via URL encoding
  - `_try_resolve_with_http_fsspec()`: Handles HTTP(S) URIs with fsspec fallback
- Improved error handling in `_resolve_paths_and_filesystem()`:
  - Better error messages with URI context
  - Extracted error recovery logic into helper functions
  - More specific exception types (ValueError, ImportError)

## Changes to plan_download_op.py:
- Simplified `download_bytes_threaded()` to resolve filesystem and download in a single loop
- Each URI is now processed independently (resolve -> download)
- Removed unnecessary index tracking (preserve_ordering=True handles it)
- Better error handling with graceful fallback for failed URIs
- Improved error messages in `_sample_sizes()` method

## Benefits:
- Eliminated 3x fsspec import duplication across the codebase
- Supports mixed filesystem URIs (S3, GCS, local, HTTP) in a single list
- Better error messages that show which specific URI failed and why
- Cleaner, more maintainable code
- Maintains backward compatibility