### PR TITLE
[core] fix leaking metric recorder in tests

### DIFF
--- a/src/ray/observability/open_telemetry_metric_recorder.cc
+++ b/src/ray/observability/open_telemetry_metric_recorder.cc
@@ -62,10 +62,9 @@ OpenTelemetryMetricRecorder &OpenTelemetryMetricRecorder::GetInstance() {
   return *instance;
 }
 
-void OpenTelemetryMetricRecorder::RegisterGrpcExporter(
-    const std::string &endpoint,
-    std::chrono::milliseconds interval,
-    std::chrono::milliseconds timeout) {
+void OpenTelemetryMetricRecorder::Start(const std::string &endpoint,
+                                        std::chrono::milliseconds interval,
+                                        std::chrono::milliseconds timeout) {
   // Create an OTLP exporter
   opentelemetry::exporter::otlp::OtlpGrpcMetricExporterOptions exporter_options;
   exporter_options.endpoint = endpoint;
@@ -85,6 +84,16 @@ void OpenTelemetryMetricRecorder::RegisterGrpcExporter(
   auto reader =
       std::make_unique<opentelemetry::sdk::metrics::PeriodicExportingMetricReader>(
           std::move(exporter), reader_options);
+  // Reset the is_shutdown_ flag to false to ensure the newly added metric reader will
+  // be shut down correctly.
+  //
+  // In most cases, OpenTelemetryMetricRecorder is initialized and shut down only once
+  // per process, so setting this to false is effectively a no-op. However, in the driver
+  // process, the recorder may be initialized and shut down multiple times (e.g., repeated
+  // calls to ray.init() and ray.shutdown()). In such cases, is_shutdown_ may already be
+  // true when we reach this point (leaking from the previous ray cluster). Resetting it
+  // to false ensures that the newly added metric reader will be shut down correctly.
+  is_shutdown_ = false;
   meter_provider_->AddMetricReader(std::move(reader));
 }
 

--- a/src/ray/observability/open_telemetry_metric_recorder.h
+++ b/src/ray/observability/open_telemetry_metric_recorder.h
@@ -41,10 +41,12 @@ namespace observability {
 // This API is thread-safe. Usage:
 //
 // 1. Register the OpenTelemetryMetricRecorder with the specified grpc endpoint,
-//    interval and timeout via RegisterGrpcExporter(). This should be called only once
-//    per process. It is recommended to call this in the main function. Note: this step
-//    does not need to be called before step 2 and 3. Registered metrics and
-//    recorded values from step 2 and 3 will be preserved in memory by open
+//    interval and timeout via Start(). This should be called only once
+//    per active instance (an instance that has not been Shutdown()). It is recommended to
+//    call this in the main function. Note: this step does not need to be called before
+//    step 2 and 3. Registered metrics and recorded values from step 2 and 3 will be
+//    preserved in memory by open telemetry until the GrpcExporter is created and
+//    registered. recorded values from step 2 and 3 will be preserved in memory by open
 //    telemetry until the GrpcExporter is created and registered
 // 2. Register the metrics to be recorded via RegisterGaugeMetric() etc.
 // 3. Record the metrics via SetMetricValue().
@@ -59,11 +61,12 @@ class OpenTelemetryMetricRecorder {
   // called after Register() to ensure the instance is initialized.
   static OpenTelemetryMetricRecorder &GetInstance();
 
-  // Registers the OpenTelemetryMetricRecorder with the specified grpc endpoint,
-  // interval and timeout. This should be called only once per process.
-  void RegisterGrpcExporter(const std::string &endpoint,
-                            std::chrono::milliseconds interval,
-                            std::chrono::milliseconds timeout);
+  // Start the OpenTelemetryMetricRecorder with the specified grpc endpoint,
+  // interval and timeout. This should be called only once per active instance (an
+  // instance that has not been Shutdown()).
+  void Start(const std::string &endpoint,
+             std::chrono::milliseconds interval,
+             std::chrono::milliseconds timeout);
 
   // Flush the remaining metrics. Note that this is a reset rather than a complete
   // shutdown, so it can be consistent with the shutdown behavior of stats.h.

--- a/src/ray/observability/tests/open_telemetry_metric_recorder_test.cc
+++ b/src/ray/observability/tests/open_telemetry_metric_recorder_test.cc
@@ -26,10 +26,9 @@ class OpenTelemetryMetricRecorderTest : public ::testing::Test {
 
   static void SetUpTestSuite() {
     // Initialize the OpenTelemetryMetricRecorder with a mock endpoint and intervals
-    OpenTelemetryMetricRecorder::GetInstance().RegisterGrpcExporter(
-        "localhost:1234",
-        std::chrono::milliseconds(10000),
-        std::chrono::milliseconds(5000));
+    OpenTelemetryMetricRecorder::GetInstance().Start("localhost:1234",
+                                                     std::chrono::milliseconds(10000),
+                                                     std::chrono::milliseconds(5000));
   }
 
   static void TearDownTestSuite() {

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -117,7 +117,7 @@ static inline void InitOpenTelemetryExporter(const int metrics_agent_port) {
   if (!RayConfig::instance().enable_open_telemetry()) {
     return;
   }
-  OpenTelemetryMetricRecorder::GetInstance().RegisterGrpcExporter(
+  OpenTelemetryMetricRecorder::GetInstance().Start(
       /*endpoint=*/std::string("127.0.0.1:") + std::to_string(metrics_agent_port),
       /*interval=*/
       std::chrono::milliseconds(


### PR DESCRIPTION
In most cases, OpenTelemetryMetricRecorder is initialized and shut down only once per process, so setting `is_shutdown_` to false on metric reader registration is effectively a no-op. However, in the driver process, the recorder may be initialized and shut down multiple times (e.g., repeated calls to ray.init() and ray.shutdown()). In such cases, `is_shutdown_` may already be true when we reach this point (leaking from the previous ray cluster). Resetting it to false ensures that the newly added metric reader will shut down correctly.

This ensures that the metric reader will be probably flushed for each test, reducing flakiness.

Test:
- CI

Run the flaky tests 50 times; previously failed consistently, and is now passing consistently

```
python/ray/tests/test_scheduling_2.py::test_workload_placement_metrics[50-50] ✓                                                           100% ██████████

Results (574.67s):
      50 passed
     700 deselected
```