### PR TITLE
[Core] Print out detailed exception information when we fail to report events

### DIFF
--- a/python/ray/dashboard/modules/event/event_agent.py
+++ b/python/ray/dashboard/modules/event/event_agent.py
@@ -90,7 +90,7 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
                 self.total_request_sent += 1
                 break
             except Exception as e:
-                logger.warning(f"Report event failed, retrying... {e}")
+                logger.warning("Report event failed, retrying...", exc_info=True)
         else:
             data_str = str(data)
             limit = event_consts.LOG_ERROR_EVENT_STRING_LENGTH_LIMIT


### PR DESCRIPTION
## Description
`exc_info` prints out everything about the exception.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
