### PR TITLE
[Data] Remove `test_large_args_scheduling_strategy`

### DIFF
--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -250,24 +250,6 @@ STANDARD_EXTRA_METRICS_TASK_BACKPRESSURE = gen_expected_metrics(
     ],
 )
 
-LARGE_ARGS_EXTRA_METRICS = gen_expected_metrics(
-    is_map=True,
-    spilled=False,
-    extra_metrics=[
-        "'ray_remote_args': {'num_cpus': N, 'scheduling_strategy': 'DEFAULT'}"
-    ],
-)
-
-LARGE_ARGS_EXTRA_METRICS_TASK_BACKPRESSURE = gen_expected_metrics(
-    is_map=True,
-    spilled=False,
-    task_backpressure=True,
-    task_output_backpressure=True,
-    extra_metrics=[
-        "'ray_remote_args': {'num_cpus': N, 'scheduling_strategy': 'DEFAULT'}"
-    ],
-)
-
 MEM_SPILLED_EXTRA_METRICS = gen_expected_metrics(
     is_map=True,
     spilled=True,
@@ -447,76 +429,6 @@ Streaming split coordinator overhead time: T
 """
         f"{gen_runtime_metrics_str(['ReadRange->MapBatches(dummy_map_batches)', 'split(N, equal=False)'], True)}"  # noqa: E501
     )
-
-
-@pytest.mark.parametrize("verbose_stats_logs", [True, False])
-def test_large_args_scheduling_strategy(
-    ray_start_regular_shared, verbose_stats_logs, restore_data_context
-):
-    context = DataContext.get_current()
-    context.verbose_stats_logs = verbose_stats_logs
-    ds = ray.data.range_tensor(100, shape=(100000,), override_num_blocks=1)
-    ds = ds.map_batches(dummy_map_batches, num_cpus=0.9).materialize()
-    stats = ds.stats()
-    read_extra_metrics = gen_extra_metrics_str(
-        STANDARD_EXTRA_METRICS_TASK_BACKPRESSURE,
-        verbose_stats_logs,
-    )
-    # if verbose_stats_logs:
-    #     read_extra_metrics = read_extra_metrics#.replace(
-    #         "'obj_store_mem_used': N",
-    #         "'obj_store_mem_used': Z",
-    #     )
-
-    map_extra_metrics = gen_extra_metrics_str(
-        LARGE_ARGS_EXTRA_METRICS,
-        verbose_stats_logs,
-    )
-    # if verbose_stats_logs:
-    #     map_extra_metrics = map_extra_metrics.replace(
-    #         "'obj_store_mem_used': N",
-    #         "'obj_store_mem_used': Z",
-    #     )
-    expected_stats = (
-        f"Operator N ReadRange: {EXECUTION_STRING}\n"
-        f"* Remote wall time: T min, T max, T mean, T total\n"
-        f"* Remote cpu time: T min, T max, T mean, T total\n"
-        f"* UDF time: T min, T max, T mean, T total\n"
-        f"* Peak heap memory usage (MiB): H min, H max, H mean\n"
-        f"* Output num rows per block: N min, N max, N mean, N total\n"
-        f"* Output size bytes per block: N min, N max, N mean, N total\n"
-        f"* Output rows per task: N min, N max, N mean, N tasks used\n"
-        f"* Tasks per node: N min, N max, N mean; N nodes used\n"
-        f"* Operator throughput:\n"
-        f"    * Total input num rows: N rows\n"
-        f"    * Total output num rows: N rows\n"
-        f"    * Ray Data throughput: N rows/s\n"
-        f"    * Estimated single node throughput: N rows/s\n"
-        f"{read_extra_metrics}\n"
-        f"Operator N MapBatches(dummy_map_batches): {EXECUTION_STRING}\n"
-        f"* Remote wall time: T min, T max, T mean, T total\n"
-        f"* Remote cpu time: T min, T max, T mean, T total\n"
-        f"* UDF time: T min, T max, T mean, T total\n"
-        f"* Peak heap memory usage (MiB): H min, H max, H mean\n"
-        f"* Output num rows per block: N min, N max, N mean, N total\n"
-        f"* Output size bytes per block: N min, N max, N mean, N total\n"
-        f"* Output rows per task: N min, N max, N mean, N tasks used\n"
-        f"* Tasks per node: N min, N max, N mean; N nodes used\n"
-        f"* Operator throughput:\n"
-        f"    * Total input num rows: N rows\n"
-        f"    * Total output num rows: N rows\n"
-        f"    * Ray Data throughput: N rows/s\n"
-        f"    * Estimated single node throughput: N rows/s\n"
-        f"{map_extra_metrics}"
-        f"\n"
-        f"Dataset throughput:\n"
-        f"    * Ray Data throughput: N rows/s\n"
-        f"    * Estimated single node throughput: N rows/s\n"
-        f"{gen_runtime_metrics_str(['ReadRange','MapBatches(dummy_map_batches)'], verbose_stats_logs)}"  # noqa: E501
-    )
-    print(canonicalize(stats))
-    print(expected_stats)
-    assert canonicalize(stats) == expected_stats
 
 
 @pytest.mark.parametrize("verbose_stats_logs", [True, False])


### PR DESCRIPTION
## Summary
This PR removes `test_large_args_scheduling_strategy` from `test_stats.py` because its flaky and not worth keeping (It tests implementation details rather than behavior and conflates multiple concerns)

See https://buildkite.com/ray-project/premerge/builds/54495#019ab720-249f-49c5-8e25-5e9005cc41e2

## Motivation

1. **Hardcodes scheduling strategy values** - The test assumes large args use `'DEFAULT'` and small args use `'SPREAD'`. If these defaults change in `context.py`, the test fails even though the system is working correctly.

2. **Tests stats format, not scheduling behavior** - The test doesn't verify that the correct scheduling strategy is actually passed to Ray tasks. It only checks that a specific string appears in stats output.

3. **Mixes two concerns** - The test conflates:
   - Scheduling strategy selection based on data size (belongs in a map-related test)
   - Stats output including scheduling strategy info (belongs in a general stats formatting test)