### PR TITLE
[Data] Improve memory leak test robustness

### DIFF
--- a/python/ray/data/tests/unit/test_arrow_type_conversion.py
+++ b/python/ray/data/tests/unit/test_arrow_type_conversion.py
@@ -137,7 +137,7 @@ def test_infer_type_does_not_leak_memory(dtype):
     before = process.memory_info().rss
 
     # Call the function several times. If there's a memory leak, this loop will leak
-    # as much as 1 GiB of memory. 8 was chosen arbitrarily.
+    # as much as 1 GiB of memory with 8 repetitions. 8 was chosen arbitrarily.
     num_repetitions = 8
     for _ in range(num_repetitions):
         _infer_pyarrow_type(ndarray)

--- a/python/ray/data/tests/unit/test_arrow_type_conversion.py
+++ b/python/ray/data/tests/unit/test_arrow_type_conversion.py
@@ -17,7 +17,6 @@ from ray.air.util.tensor_extensions.arrow import (
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data import DataContext
 from ray.data._internal.execution.util import memory_string
-from ray.data._internal.util import MiB
 from ray.tests.conftest import *  # noqa
 
 import psutil
@@ -139,14 +138,15 @@ def test_infer_type_does_not_leak_memory(dtype):
 
     # Call the function several times. If there's a memory leak, this loop will leak
     # as much as 1 GiB of memory. 8 was chosen arbitrarily.
-    for _ in range(8):
+    num_repetitions = 8
+    for _ in range(num_repetitions):
         _infer_pyarrow_type(ndarray)
 
     gc.collect()
     pa.default_memory_pool().release_unused()
     after = process.memory_info().rss
 
-    margin_of_error = 64 * MiB
+    margin_of_error = ndarray.nbytes * num_repetitions
     assert after - before < margin_of_error, memory_string(after - before)
 
 

--- a/python/ray/data/tests/unit/test_arrow_type_conversion.py
+++ b/python/ray/data/tests/unit/test_arrow_type_conversion.py
@@ -138,7 +138,7 @@ def test_infer_type_does_not_leak_memory(dtype):
     before = process.memory_info().rss
 
     # Call the function several times. If there's a memory leak, this loop will leak
-    # as much as 1 GiB of memory.
+    # as much as 1 GiB of memory. 8 was chosen arbitrarily.
     for _ in range(8):
         _infer_pyarrow_type(ndarray)
 
@@ -146,7 +146,8 @@ def test_infer_type_does_not_leak_memory(dtype):
     pa.default_memory_pool().release_unused()
     after = process.memory_info().rss
 
-    assert after - before < 64 * MiB, memory_string(after - before)
+    margin_of_error = 64 * MiB
+    assert after - before < margin_of_error, memory_string(after - before)
 
 
 def test_pa_infer_type_failing_to_infer():

--- a/python/ray/data/tests/unit/test_arrow_type_conversion.py
+++ b/python/ray/data/tests/unit/test_arrow_type_conversion.py
@@ -17,6 +17,7 @@ from ray.air.util.tensor_extensions.arrow import (
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data import DataContext
 from ray.data._internal.execution.util import memory_string
+from ray.data._internal.util import MiB
 from ray.tests.conftest import *  # noqa
 
 import psutil
@@ -146,7 +147,7 @@ def test_infer_type_does_not_leak_memory(dtype):
     pa.default_memory_pool().release_unused()
     after = process.memory_info().rss
 
-    margin_of_error = ndarray.nbytes * num_repetitions
+    margin_of_error = 64 * MiB
     assert after - before < margin_of_error, memory_string(after - before)
 
 

--- a/python/ray/data/tests/unit/test_arrow_type_conversion.py
+++ b/python/ray/data/tests/unit/test_arrow_type_conversion.py
@@ -16,6 +16,8 @@ from ray.air.util.tensor_extensions.arrow import (
 )
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data import DataContext
+from ray.data._internal.execution.util import memory_string
+from ray.data._internal.util import MiB
 from ray.tests.conftest import *  # noqa
 
 import psutil
@@ -125,9 +127,8 @@ def test_convert_datetime_array(
     assert expected == converted
 
 
-@pytest.mark.parametrize("arg_type", ["list", "ndarray"])
 @pytest.mark.parametrize("dtype", ["int64", "float64", "datetime64[ns]"])
-def test_infer_type_does_not_leak_memory(arg_type, dtype):
+def test_infer_type_does_not_leak_memory(dtype):
     # Test for https://github.com/apache/arrow/issues/45493.
     ndarray = np.zeros(923040, dtype=dtype)  # A ~7 MiB column
 
@@ -136,20 +137,16 @@ def test_infer_type_does_not_leak_memory(arg_type, dtype):
     pa.default_memory_pool().release_unused()
     before = process.memory_info().rss
 
-    if arg_type == "ndarray":
-        column_values = ndarray
-    elif arg_type == "list":
-        column_values = [ndarray]
-    else:
-        pytest.fail(f"Unknown type: {arg_type}")
-
-    _infer_pyarrow_type(column_values)
+    # Call the function several times. If there's a memory leak, this loop will leak
+    # as much as 1 GiB of memory.
+    for _ in range(8):
+        _infer_pyarrow_type(ndarray)
 
     gc.collect()
     pa.default_memory_pool().release_unused()
     after = process.memory_info().rss
 
-    assert after - before < 1024 * 1024, after - before
+    assert after - before < 64 * MiB, memory_string(after - before)
 
 
 def test_pa_infer_type_failing_to_infer():


### PR DESCRIPTION
## Why are these changes needed?

The memory leak being tested ([apache/arrow#45493](https://github.com/apache/arrow/issues/45493)) specifically occurs when inferring types from **ndarray objects**, not from lists containing ndarrays. Testing the `list` case added no value since the leak doesn't manifest there—it only added execution time and obscured the test's purpose.

More importantly, the previous 1 MiB threshold was too tight and caused flaky failures. Memory measurements via RSS are inherently noisy due to OS-level allocation behavior, garbage collection timing, and memory fragmentation. A test that occasionally uses 1.1 MiB would fail despite no actual leak.

The new approach:
- **Calls `_infer_pyarrow_type` 8 times in a loop**, which leaks 1 GiB without Ray Data's workaround (admittedly, 8 is a magic number here)
- **Uses a 64 MiB threshold**, providing a much larger margin above normal variation while still catching any real leak with a clear signal

This creates a much stronger test: if the leak exists, we'd see memory growth approaching 1 GiB (with repeated runs), making failures unambiguous. Meanwhile, normal RSS fluctuations of a few MiB won't trigger false positives.