### PR TITLE
[train] Wrap WorkerGroup shutdown with WorkerGroupError

### DIFF
--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -195,8 +195,8 @@ class TrainController:
                 return self._execute_failure_decision(
                     failure_decision,
                     training_failed_error=optional_worker_group_error,
-                    # Shutdown failures during resize come from a running worker group,
-                    # so treat them as running failures to trigger a restart.
+                    # Worker Group Shutdown failures during resize come from a running worker group,
+                    # so treat them as running failures to trigger a restart instead of rescheduling.
                     failure_context_state=RunningState(),
                 )
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -348,13 +348,16 @@ class TrainController:
             callback.after_controller_start(self._train_run_context)
 
     def _shutdown(self) -> Optional[WorkerGroupError]:
+        optional_worker_group_error = None
         if self._worker_group:
             optional_worker_group_error = self._shutdown_worker_group()
-            if optional_worker_group_error:
-                return optional_worker_group_error
 
+        # Always call before_controller_shutdown callbacks, even if worker group
+        # shutdown failed.
         for callback in self._controller_callbacks:
             callback.before_controller_shutdown()
+
+        return optional_worker_group_error
 
     def _shutdown_worker_group(self) -> Optional[WorkerGroupError]:
         """Shutdown the worker group and set the worker group to None."""

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -364,7 +364,7 @@ class TrainController:
             return None
         except Exception as e:
             self._worker_group = None
-            return WorkerGroupError(e)
+            return WorkerGroupError(error_message=str(e), worker_failures={})
 
     def get_worker_group(self) -> Optional[WorkerGroup]:
         return self._worker_group

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -30,7 +30,6 @@ from ray.train.v2._internal.execution.scaling_policy import (
 )
 from ray.train.v2._internal.execution.worker_group import WorkerGroupPollStatus
 from ray.train.v2.api.config import ScalingConfig
-from ray.train.v2.api.exceptions import WorkerGroupError
 from ray.train.v2.tests.util import (
     DummyObjectRefWrapper,
     DummyWorkerGroup,
@@ -445,10 +444,6 @@ async def test_worker_group_shutdown_error_during_final_shutdown():
     await controller._run_control_loop_iteration()
     # Should transition to ErroredState due to the shutdown failure
     assert isinstance(controller.get_state(), ErroredState)
-    # Verify that the error is a WorkerGroupError
-    training_failed_error = controller.get_training_failed_error()
-    assert isinstance(training_failed_error, WorkerGroupError)
-    assert str(shutdown_error) in str(training_failed_error)
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -400,7 +400,9 @@ async def test_worker_group_shutdown_error_during_resize():
     await controller._run_control_loop_iteration()
     # During execute_resize_decision, shutdown should fail and trigger failure handling
     # The failure policy should be called with WorkerGroupError
-    assert isinstance(controller.get_state(), RestartingState)
+    # Since we're in SchedulingState, RETRY should transition to ReschedulingState
+    # (to retry the scheduling phase) rather than RestartingState
+    assert isinstance(controller.get_state(), ReschedulingState)
 
 
 @pytest.mark.asyncio

--- a/python/ray/train/v2/tests/util.py
+++ b/python/ray/train/v2/tests/util.py
@@ -46,6 +46,7 @@ class DummyWorkerGroup(WorkerGroup):
 
     _start_failure = None
     _poll_failure = None
+    _shutdown_failure = None
 
     # TODO: Clean this up and use Mocks instead.
     def __init__(
@@ -82,6 +83,8 @@ class DummyWorkerGroup(WorkerGroup):
         }
 
     def shutdown(self):
+        if self._shutdown_failure:
+            raise self._shutdown_failure
         self._worker_group_state = None
 
     def abort(self):
@@ -103,6 +106,10 @@ class DummyWorkerGroup(WorkerGroup):
     @classmethod
     def set_poll_failure(cls, poll_failure):
         cls._poll_failure = poll_failure
+
+    @classmethod
+    def set_shutdown_failure(cls, shutdown_failure):
+        cls._shutdown_failure = shutdown_failure
 
 
 class MockScalingPolicy(ScalingPolicy):


### PR DESCRIPTION
## Description
1. try and except the worker group shutdown logic with WorkerGroupError
2. Previous, if we encounter RayTaskError when hook with WorkerGroupCallback before shutdown logic, it will be propagate to controller and crash.
3. This is the catch the worker group shutdown exceptions and wrap with WorkerGroupError and allow controller to transition to ErrorState.

Currently, the worker group shutdown can happen in below places:
**Controller in ShuttingDownState** 

a.  successful run -> shutdown wg -> finished
b.  unsuccessful run -> shutdown wg - > errored. 

**Controller in SchedulingState**

a. successful run ->  from RunningState -> ResizingState     -> shutdown old wg -> start new wg (e.g. elastic training)
b. unsuccessful run -> from RunningState -> RestartingState  -> Shutdown old wg -> start new wg (e.g. failureConfig > 1)

if the shutdown wg failed, the controller will crash.

After this change,
1.a. ErrorState with WorkerGroupError on shutdown
1.b. ErrorState with original training run failure
2.a & 2.b. we consider this WorkerGroupError for FailureDecision and either enter `ReschedulingState` or `ShuttingDownState`

<img width="2878" height="1176" alt="image" src="https://github.com/user-attachments/assets/7fbf7e63-48be-4c6e-bcf5-ce12c5570277" />


## Additional information
unit test added