### PR TITLE
[core] Fix crash when using jvm HDFS by adding RAY_DISABLE_FAILURE_SIGNAL_HANDLER option

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -55,6 +55,13 @@ def env_set_by_user(key):
 # Whether event logging to driver is enabled. Set to 0 to disable.
 AUTOSCALER_EVENTS = env_integer("RAY_SCHEDULER_EVENTS", 1)
 
+# Whether to disable the C++ failure signal handler that provides stack traces
+# on crashes. Disabling this is necessary when using Java libraries
+# because Ray's signal handler conflicts with the JVM's signal handling.
+RAY_DISABLE_FAILURE_SIGNAL_HANDLER = env_bool(
+    "RAY_DISABLE_FAILURE_SIGNAL_HANDLER", False
+)
+
 RAY_LOG_TO_DRIVER = env_bool("RAY_LOG_TO_DRIVER", True)
 
 # Filter level under which events will be filtered out, i.e. not printing to driver

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2665,7 +2665,7 @@ cdef class CoreWorker:
         options.enable_logging = True
         options.log_dir = log_dir.encode("utf-8")
         options.install_failure_signal_handler = (
-            os.environ.get("RAY_DISABLE_FAILURE_SIGNAL_HANDLER", "0") != "1"
+            not ray_constants.RAY_DISABLE_FAILURE_SIGNAL_HANDLER
         )
         # https://stackoverflow.com/questions/2356399/tell-if-python-is-in-interactive-mode
         options.interactive = hasattr(sys, "ps1")

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2664,7 +2664,9 @@ cdef class CoreWorker:
         options.gcs_options = gcs_options.native()[0]
         options.enable_logging = True
         options.log_dir = log_dir.encode("utf-8")
-        options.install_failure_signal_handler = True
+        options.install_failure_signal_handler = (
+            os.environ.get("RAY_DISABLE_FAILURE_SIGNAL_HANDLER", "0") != "1"
+        )
         # https://stackoverflow.com/questions/2356399/tell-if-python-is-in-interactive-mode
         options.interactive = hasattr(sys, "ps1")
         options.node_ip_address = node_ip_address.encode("utf-8")


### PR DESCRIPTION
## Description
Ray's Abseil failure signal handler conflicts with JVM's internal signal handling. When PyArrow's HadoopFileSystem starts a JVM, and then Ray installs its signal handler, JVM's normal internal operations (for safepoint synchronization) trigger Ray's handler, causing a crash.

It seems we already have some code which disables this for java bindings (there's a todo about in io_ray_runtime_RayNativeRuntime.cc). This is all well and good when we realize we're running in a java runtime, but for the bug report I'm not sure how obvious it is (maybe we should consider doing something like this in data itself automatically?) Unsure.  For our part if we know the datasource is form hdfs, that seems just as likely as any that this might be happening. But it's only relevant if you're running the jvm in the same process (I was only able to reproduce this by running everything in the same process).  One of the comments in the bug ticket points out they're able to skirt the error by doing process isolaiton (which ended up being the hint I needed).

**What's the catch?**
When this config is set we essentially won't call WriteFailureMessage() on a crash, which means we won't get a full trace on termination or flush full logs.  So just setting this all the time isn't a great solution (and essentially why I've thrown it behind a config).  We might want to revisit this for HDFS users.  That said.  The JVM core dump info is somewhat decent.  So we're not totally in the dark.

## Related issues

Fixes https://github.com/ray-project/ray/issues/36415

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
