### PR TITLE
[train][jax] skipping jax test in test_backend

### DIFF
--- a/python/ray/train/tests/test_backend.py
+++ b/python/ray/train/tests/test_backend.py
@@ -634,6 +634,10 @@ def test_placement_group_parent(ray_4_node_4_cpu, placement_group_capture_child_
 
 
 @pytest.mark.parametrize("timeout_s", [5, 0])
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Current jax version is not supported in python 3.12+",
+)
 def test_jax_distributed_shutdown_timeout(ray_start_2_cpus, monkeypatch, timeout_s):
     """Test that JAX distributed shutdown respects the timeout env var."""
     monkeypatch.setenv(JAX_DISTRIBUTED_SHUTDOWN_TIMEOUT_S, str(timeout_s))


### PR DESCRIPTION
Jax dependency is introduced in https://github.com/ray-project/ray/pull/58322
The current test environment is for CUDA 12.1, which limit jax version below 0.4.14.
jax <= 0.4.14 does not support py 3.12.
skip jax test if it runs against py3.12+.