### PR TITLE
[ci] Upgrade pydoclint to `0.8.3` and revert pydoclint baseline workaround

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,38 +42,10 @@ repos:
       - id: ruff
         args: [ --select, "I", --fix, --exit-non-zero-on-fix ]
 
-  # pydoclint-local is for local commits only due to pre-commit-hook only passing
-  # updated files to the hook and overwriting the baseline text file
   - repo: https://github.com/jsh9/pydoclint
-    rev: "0.8.1"
+    rev: "0.8.3"
     hooks:
       - id: pydoclint
-        name: pydoclint-local
-        stages: [pre-commit, pre-push]
-        args: [
-          --style=google,
-          --baseline=ci/lint/pydoclint-baseline.txt,
-          --exclude=thirdparty|^python/ray/serve/tests/test_config_files/syntax_error\.py$|^python/ray/_private/parameter\.py$,
-          --auto-regenerate-baseline=False,
-          # Current settings (not because we think they're right, but because we
-          # don't want a baseline the size of the codebase)
-          --arg-type-hints-in-docstring=False,
-          --skip-checking-raises=True,
-          --check-return-types=False,
-          --allow-init-docstring=True,
-          --check-class-attributes=False,
-          # --check-style-mismatch=True, # Bring this back once things are a bit cleaner
-        ]
-        types: [python]
-        files: '^python/ray/'
-
-  # pydoclint-ci is for CI, overwrites the baseline text file, and is run with the manual stage flag
-  - repo: https://github.com/jsh9/pydoclint
-    rev: "0.8.1"
-    hooks:
-      - id: pydoclint
-        name: pydoclint-ci
-        stages: [manual]
         args: [
           --style=google,
           --baseline=ci/lint/pydoclint-baseline.txt,

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -49,11 +49,7 @@ pre_commit() {
 pre_commit_pydoclint() {
   # Run pre-commit pydoclint on all files
   pip install -c python/requirements_compiled.txt pre-commit clang-format
-  pre-commit run pydoclint --hook-stage manual --all-files --show-diff-on-failure
-  git diff --quiet -- ci/lint/pydoclint-baseline.txt || {
-  echo "Baseline needs update. Run the CI-style hook: \"pre-commit run pydoclint --hook-stage manual --all-files --show-diff-on-failure\" locally and commit the baseline."
-  exit 1
-  }
+  pre-commit run pydoclint --all-files --show-diff-on-failure
 }
 
 code_format() {


### PR DESCRIPTION
## Description
Remove the dual local/CI hook configuration for pydoclint and simplify back to a single hook. The workaround was needed due to https://github.com/jsh9/pydoclint/issues/274, but this was fixed in pydoclint `0.8.3` 🎉 

- Upgrade pydoclint from `0.8.1` to `0.8.3`
- Remove separate `pydoclint-local` and `pydoclint-ci` hooks
- Simplify CI lint script to use standard pre-commit run


## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
