### PR TITLE
[data][llm] Expose vision_preprocess and vision_postprocess in VLM docs

### DIFF
--- a/doc/source/data/doc_code/working-with-llms/vlm_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_example.py
@@ -59,6 +59,7 @@ vision_processor_config = vLLMEngineProcessorConfig(
 # __vlm_config_example_end__
 
 
+# __vlm_preprocess_example_start__
 def vision_preprocess(row: dict) -> dict:
     """
     Preprocessing function for vision-language model inputs.
@@ -126,6 +127,8 @@ def vision_postprocess(row: dict) -> dict:
     }
 
 
+# __vlm_preprocess_example_end__
+
 vision_processor = build_llm_processor(
     vision_processor_config,
     preprocess=vision_preprocess,
@@ -189,8 +192,10 @@ def run_vlm_example():
     vision_dataset = load_vision_dataset()
 
     if vision_dataset:
-        # Build processor with preprocessing
-        processor = build_llm_processor(config, preprocess=vision_preprocess)
+        # Build processor with preprocessing and postprocessing
+        processor = build_llm_processor(
+            config, preprocess=vision_preprocess, postprocess=vision_postprocess
+        )
 
         print("VLM processor configured successfully")
         print(f"Model: {config.model_source}")

--- a/doc/source/data/doc_code/working-with-llms/vlm_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_example.py
@@ -202,6 +202,7 @@ def run_vlm_example():
         print(f"Has image support: {config.has_image}")
         result = processor(vision_dataset).take_all()
         return config, processor, result
+    # __vlm_run_example_end__
     return None, None, None
 
 

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -166,6 +166,14 @@ Next, configure the VLM processor with the essential settings:
     :start-after: __vlm_config_example_start__
     :end-before: __vlm_config_example_end__
 
+Define preprocessing and postprocessing functions to convert dataset rows into
+the format expected by the VLM and extract model responses:
+
+.. literalinclude:: doc_code/working-with-llms/vlm_example.py
+    :language: python
+    :start-after: __vlm_preprocess_example_start__
+    :end-before: __vlm_preprocess_example_end__
+
 For a more comprehensive VLM configuration with advanced options:
 
 .. literalinclude:: doc_code/working-with-llms/vlm_example.py

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -187,7 +187,7 @@ Finally, run the VLM inference:
 .. literalinclude:: doc_code/working-with-llms/vlm_example.py
     :language: python
     :start-after: def run_vlm_example():
-    :end-before: # __vlm_example_end__
+    :end-before: # __vlm_run_example_end__
     :dedent: 0
 
 .. _embedding_models:


### PR DESCRIPTION
Previous refactors caused the pre/post processing details to be omitted from the working with llms guide

<img width="655" height="891" alt="image" src="https://github.com/user-attachments/assets/71cce1f6-3ebb-4f0f-ba32-eff8bb68de0a" />
