### PR TITLE
[Data] Attempt to deflake `test_backpressure_e2e`

### DIFF
--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -287,7 +287,6 @@ def test_input_backpressure_e2e(restore_data_context, shutdown_only):  # noqa: F
     it = iter(ds.iter_batches(batch_size=None, prefetch_batches=0))
     next(it)
     time.sleep(3)
-    del it, ds
     launched = ray.get(source.counter.get.remote())
 
     # If backpressure is broken we'll launch 15+.


### PR DESCRIPTION
## Description

`test_backpressure_e2e` occasionally fails with a bug like this:
```
[2025-11-26T17:33:36Z] PASSED[2025-11-26 17:27:35,172 E 550 12058] core_worker_process.cc:986: The core worker has already been shutdown. This happens when the language frontend accesses the Ray's worker after it is shutdown. The process will exit
```

This PR attempt to deflake it by removing an unnecessary `del`

(Long-term, we should rewrite or remove this test. This PR is a mitigation)