### PR TITLE
[data] drain buffer on finalize for block ref bundler

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -748,6 +748,7 @@ class BlockRefBundler(BaseRefBundler):
                 output_buffer_size += bundle_size
             else:
                 remainder = self._bundle_buffer[idx:]
+                break
 
         self._bundle_buffer = remainder
         self._bundle_buffer_size = sum(

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -545,7 +545,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
 
     def all_inputs_done(self):
         self._block_ref_bundler.done_adding_bundles()
-        if self._block_ref_bundler.has_bundle():
+        while self._block_ref_bundler.has_bundle():
             # Handle any leftover bundles in the bundler.
             (
                 _,

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -1325,7 +1325,6 @@ def test_block_ref_bundler_finalize_drains_all():
     pre_bundles = [[i] * size for i, size in enumerate(bundle_sizes)]
     bundles = make_ref_bundles(pre_bundles)
 
-    # Add all bundles WITHOUT draining (no while loop here)
     for bundle in bundles:
         bundler.add_bundle(bundle)
 


### PR DESCRIPTION
## Description
Context: https://github.com/ray-project/ray/pull/58694#discussion_r2558054556
PR that changed this behavior: https://github.com/ray-project/ray/pull/52806/files

Before the PR, the `BlockRefBundler` can silently drop bundles on `finalize`, but due to the way we use it*, it is not possible. However, I still think we should fix it to make it more explicit. I added a break statement when the bundle target size is met.

*Context: The current behavior of `TaskPoolMapOperator` and `ActorPoolMapOperator` is that a bundle is queued and will eagerly try to launch a task with the bundled input. The bundled input will always contain all the existing bundles in `BlockRefBundler` due to the current behavior above(you can think of it as the `BlockRefBundler` doesn't have time to store a backlog of bundles, because once it has a ready bundle it is launched). SO there are never remainders (see code) remaining, and hence it never reaches the else statement on line map_operator.py:750 in `BlockRefBundler`.

## Related issues

## Additional information
