### PR TITLE
[data] Add num_cpus and memory argument to read_webdataset.

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2311,6 +2311,7 @@ def read_webdataset(
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
     num_cpus: Optional[float] = None,
+    num_gpus: Optional[float] = None,
     memory: Optional[float] = None,
     expand_json: bool = False,
 ) -> Dataset:
@@ -2354,6 +2355,9 @@ def read_webdataset(
             input data size and available resources. You shouldn't manually set this
             value in most cases.
         num_cpus: The number of CPUs to reserve for each parallel read worker.
+        num_gpus: The number of GPUs to reserve for each parallel read worker. For
+            example, specify `num_gpus=1` to request 1 GPU for each parallel read
+            worker.
         memory: The heap memory in bytes to reserve for each parallel read worker.
         expand_json: If ``True``, expand JSON objects into individual samples.
             Defaults to ``False``.
@@ -2391,6 +2395,7 @@ def read_webdataset(
         datasource,
         parallelism=parallelism,
         num_cpus=num_cpus,
+        num_gpus=num_gpus,
         memory=memory,
         concurrency=concurrency,
         override_num_blocks=override_num_blocks,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2310,6 +2310,8 @@ def read_webdataset(
     file_extensions: Optional[List[str]] = None,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
+    num_cpus: Optional[float] = None,
+    memory: Optional[float] = None,
     expand_json: bool = False,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from
@@ -2351,6 +2353,8 @@ def read_webdataset(
             By default, the number of output blocks is dynamically decided based on
             input data size and available resources. You shouldn't manually set this
             value in most cases.
+        num_cpus: The number of CPUs to reserve for each parallel read worker.
+        memory: The heap memory in bytes to reserve for each parallel read worker.
         expand_json: If ``True``, expand JSON objects into individual samples.
             Defaults to ``False``.
 
@@ -2386,6 +2390,8 @@ def read_webdataset(
     return read_datasource(
         datasource,
         parallelism=parallelism,
+        num_cpus=num_cpus,
+        memory=memory,
         concurrency=concurrency,
         override_num_blocks=override_num_blocks,
     )

--- a/python/ray/data/tests/test_webdataset.py
+++ b/python/ray/data/tests/test_webdataset.py
@@ -336,7 +336,11 @@ def test_read_webdataset_resource_integration(ray_start_2_cpus, tmp_path):
     # Verify the data is correct
     for i, sample in enumerate(samples):
         assert sample["__key__"] == str(i)
-        assert sample["txt"].decode("utf-8") == f"sample {i}"
+        txt_value = sample["txt"]
+        # Handle both bytes and string (webdataset may auto-decode .txt files)
+        if isinstance(txt_value, bytes):
+            txt_value = txt_value.decode("utf-8")
+        assert txt_value == f"sample {i}"
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_webdataset.py
+++ b/python/ray/data/tests/test_webdataset.py
@@ -272,22 +272,21 @@ def test_write_min_rows_per_file(tmp_path, ray_start_regular_shared, min_rows_pe
         assert len(list(dataset)) == min_rows_per_file
 
 
-@pytest.mark.parametrize("num_cpus", [None, 1, 2])
+@pytest.mark.parametrize("num_cpus", [None, 1, 0.5])
 @pytest.mark.parametrize("memory", [None, 1024 * 1024 * 1024])  # 1GB
 def test_read_webdataset_resource_args(
     ray_start_2_cpus, tmp_path, mocker, num_cpus, memory
 ):
     """Test that num_cpus and memory parameters are correctly passed to read_datasource."""
+    from unittest.mock import MagicMock
+
     # Create a simple webdataset file
     path = os.path.join(tmp_path, "test_000000.tar")
     with TarWriter(path) as tf:
         tf.write("0.txt", b"test data")
 
-    # Mock read_datasource to capture the arguments
     mock_read_datasource = mocker.patch("ray.data.read_api.read_datasource")
-    mock_read_datasource.return_value = ray.data.from_items(
-        [{"__key__": "0", "txt": b"test data"}]
-    )
+    mock_read_datasource.return_value = MagicMock()
 
     # Call read_webdataset with resource parameters
     kwargs = {"paths": [str(tmp_path)]}

--- a/python/ray/data/tests/test_webdataset.py
+++ b/python/ray/data/tests/test_webdataset.py
@@ -275,7 +275,7 @@ def test_write_min_rows_per_file(tmp_path, ray_start_regular_shared, min_rows_pe
 @pytest.mark.parametrize("num_cpus", [None, 1, 0.5])
 @pytest.mark.parametrize("memory", [None, 1024 * 1024 * 1024])  # 1GB
 def test_read_webdataset_resource_args(
-    ray_start_2_cpus, tmp_path, mocker, num_cpus, memory
+    ray_start_regular_shared, tmp_path, mocker, num_cpus, memory
 ):
     """Test that num_cpus and memory parameters are correctly passed to read_datasource."""
     from unittest.mock import MagicMock
@@ -313,7 +313,7 @@ def test_read_webdataset_resource_args(
         assert call_kwargs["memory"] is None
 
 
-def test_read_webdataset_resource_integration(ray_start_2_cpus, tmp_path):
+def test_read_webdataset_resource_integration(ray_start_regular_shared, tmp_path):
     """Integration test to verify num_cpus and memory parameters work end-to-end."""
     # Create a simple webdataset file
     path = os.path.join(tmp_path, "integration_000000.tar")


### PR DESCRIPTION

## Description
Adds num_cpus, memory and num_gpus to match with other existing datasource options. This datasource is often network bound, so often uses less than a full cpu.
## Related issues

## Additional information
