### PR TITLE
[data] Remove dead FastFileMetadataProvider code

### DIFF
--- a/doc/source/data/api/input_output.rst
+++ b/doc/source/data/api/input_output.rst
@@ -427,7 +427,6 @@ MetadataProvider API
    datasource.FileMetadataProvider
    datasource.BaseFileMetadataProvider
    datasource.DefaultFileMetadataProvider
-   datasource.FastFileMetadataProvider
 
 Shuffling API
 -------------

--- a/python/ray/data/_internal/datasource/image_datasource.py
+++ b/python/ray/data/_internal/datasource/image_datasource.py
@@ -100,8 +100,8 @@ class ImageDatasource(FileBasedDatasource):
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0
         for file_size in self._file_sizes():
-            # NOTE: check if file size is not None, because some metadata provider
-            # such as FastFileMetadataProvider does not provide file size information.
+            # NOTE: check if file size is not None, because some metadata providers
+            # may not provide file size information.
             if file_size is not None:
                 total_size += file_size
         return total_size * self._encoding_ratio

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -31,7 +31,6 @@ from ray.data.datasource.file_datasink import (
 from ray.data.datasource.file_meta_provider import (
     BaseFileMetadataProvider,
     DefaultFileMetadataProvider,
-    FastFileMetadataProvider,
     FileMetadataProvider,
 )
 from ray.data.datasource.filename_provider import FilenameProvider
@@ -53,7 +52,6 @@ __all__ = [
     "DefaultFileMetadataProvider",
     "DeltaSharingDatasource",
     "DummyOutputDatasink",
-    "FastFileMetadataProvider",
     "FileBasedDatasource",
     "FileShuffleConfig",
     "FileMetadataProvider",

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -170,44 +170,6 @@ class DefaultFileMetadataProvider(BaseFileMetadataProvider):
         yield from _expand_paths(paths, filesystem, partitioning, ignore_missing_paths)
 
 
-@DeveloperAPI
-class FastFileMetadataProvider(DefaultFileMetadataProvider):
-    """Fast Metadata provider for
-    :class:`~ray.data.datasource.file_based_datasource.FileBasedDatasource`
-    implementations.
-
-    Offers improved performance vs.
-    :class:`DefaultFileMetadataProvider`
-    by skipping directory path expansion and file size collection.
-    While this performance improvement may be negligible for local filesystems,
-    it can be substantial for cloud storage service providers.
-
-    This should only be used when all input paths exist and are known to be files.
-    """
-
-    def expand_paths(
-        self,
-        paths: List[str],
-        filesystem: "RetryingPyFileSystem",
-        partitioning: Optional[Partitioning] = None,
-        ignore_missing_paths: bool = False,
-    ) -> Iterator[Tuple[str, int]]:
-        if ignore_missing_paths:
-            raise ValueError(
-                "`ignore_missing_paths` cannot be set when used with "
-                "`FastFileMetadataProvider`. All paths must exist when "
-                "using `FastFileMetadataProvider`."
-            )
-
-        logger.warning(
-            f"Skipping expansion of {len(paths)} path(s). If your paths contain "
-            f"directories or if file size collection is required, try rerunning this "
-            f"read with `meta_provider=DefaultFileMetadataProvider()`."
-        )
-
-        yield from zip(paths, itertools.repeat(None, len(paths)))
-
-
 def _handle_read_os_error(error: OSError, paths: Union[str, List[str]]) -> str:
     # NOTE: this is not comprehensive yet, and should be extended as more errors arise.
     # NOTE: The latter patterns are raised in Arrow 10+, while the former is raised in

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -10,6 +10,9 @@ import ray
 from ray.data.datasource import (
     BaseFileMetadataProvider,
 )
+from ray.data.datasource.file_meta_provider import (
+    DefaultFileMetadataProvider,
+)
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
 from ray.data.tests.util import extract_values, gen_bin_files
@@ -86,6 +89,12 @@ def test_read_binary_meta_provider(
         byte_str = "hello, world".encode()
         bytes = BytesIO(byte_str)
         snappy.stream_compress(bytes, f)
+    ds = ray.data.read_binary_files(
+        path,
+        arrow_open_stream_args=dict(compression="snappy"),
+        meta_provider=DefaultFileMetadataProvider(),
+    )
+    assert sorted(extract_values("bytes", ds.take())) == [byte_str]
 
     with pytest.raises(NotImplementedError):
         ray.data.read_binary_files(

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -9,7 +9,6 @@ import snappy
 import ray
 from ray.data.datasource import (
     BaseFileMetadataProvider,
-    FastFileMetadataProvider,
 )
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
@@ -87,12 +86,6 @@ def test_read_binary_meta_provider(
         byte_str = "hello, world".encode()
         bytes = BytesIO(byte_str)
         snappy.stream_compress(bytes, f)
-    ds = ray.data.read_binary_files(
-        path,
-        arrow_open_stream_args=dict(compression="snappy"),
-        meta_provider=FastFileMetadataProvider(),
-    )
-    assert sorted(extract_values("bytes", ds.take())) == [byte_str]
 
     with pytest.raises(NotImplementedError):
         ray.data.read_binary_files(

--- a/python/ray/data/tests/test_csv.py
+++ b/python/ray/data/tests/test_csv.py
@@ -13,7 +13,6 @@ from ray.data._internal.util import rows_same
 from ray.data.block import BlockAccessor
 from ray.data.datasource import (
     BaseFileMetadataProvider,
-    FastFileMetadataProvider,
 )
 from ray.data.datasource.file_based_datasource import (
     FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
@@ -150,18 +149,6 @@ def test_csv_read_meta_provider(ray_start_regular_shared, tmp_path):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     path1 = os.path.join(tmp_path, "test1.csv")
     df1.to_csv(path1, index=False)
-    ds = ray.data.read_csv(
-        path1,
-        meta_provider=FastFileMetadataProvider(),
-    )
-
-    dsdf = ds.to_pandas()
-    assert df1.equals(dsdf)
-
-    # Expect to lazily compute all metadata correctly.
-    assert ds.count() == 3
-    assert ds.input_files() == [_unwrap_protocol(path1)]
-    assert ds.schema() == Schema(pa.schema([("one", pa.int64()), ("two", pa.string())]))
 
     with pytest.raises(NotImplementedError):
         ray.data.read_csv(

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -15,7 +15,6 @@ from ray.data._internal.datasource.image_datasource import (
 from ray.data._internal.tensor_extensions.arrow import (
     get_arrow_extension_fixed_shape_tensor_types,
 )
-from ray.data.datasource.file_meta_provider import FastFileMetadataProvider
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
 from ray.tests.conftest import *  # noqa
@@ -57,17 +56,6 @@ class TestReadImages:
             ]
         )
         assert ds.count() == 2
-
-    def test_file_metadata_provider(self, ray_start_regular_shared):
-        ds = ray.data.read_images(
-            paths=[
-                "example://image-datasets/simple/image1.jpg",
-                "example://image-datasets/simple/image2.jpg",
-                "example://image-datasets/simple/image2.jpg",
-            ],
-            meta_provider=FastFileMetadataProvider(),
-        )
-        assert ds.count() == 3
 
     def test_filtering(self, ray_start_regular_shared):
         # "different-extensions" contains three images and two non-images.
@@ -233,13 +221,6 @@ class TestReadImages:
         with tempfile.NamedTemporaryFile(suffix=".png") as file:
             with pytest.raises(ValueError):
                 ray.data.read_images(paths=file.name).materialize()
-
-    def test_custom_meta_provider_emits_deprecation_warning(ray_start_regular_shared):
-        with pytest.warns(DeprecationWarning):
-            ray.data.read_images(
-                paths=["example://image-datasets/simple/image1.jpg"],
-                meta_provider=FastFileMetadataProvider(),
-            )
 
 
 class TestWriteImages:

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -15,6 +15,9 @@ from ray.data._internal.datasource.image_datasource import (
 from ray.data._internal.tensor_extensions.arrow import (
     get_arrow_extension_fixed_shape_tensor_types,
 )
+from ray.data.datasource.file_meta_provider import (
+    DefaultFileMetadataProvider,
+)
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
 from ray.tests.conftest import *  # noqa
@@ -56,6 +59,17 @@ class TestReadImages:
             ]
         )
         assert ds.count() == 2
+
+    def test_file_metadata_provider(self, ray_start_regular_shared):
+        ds = ray.data.read_images(
+            paths=[
+                "example://image-datasets/simple/image1.jpg",
+                "example://image-datasets/simple/image2.jpg",
+                "example://image-datasets/simple/image2.jpg",
+            ],
+            meta_provider=DefaultFileMetadataProvider(),
+        )
+        assert ds.count() == 3
 
     def test_filtering(self, ray_start_regular_shared):
         # "different-extensions" contains three images and two non-images.
@@ -221,6 +235,13 @@ class TestReadImages:
         with tempfile.NamedTemporaryFile(suffix=".png") as file:
             with pytest.raises(ValueError):
                 ray.data.read_images(paths=file.name).materialize()
+
+    def test_custom_meta_provider_emits_deprecation_warning(ray_start_regular_shared):
+        with pytest.warns(DeprecationWarning):
+            ray.data.read_images(
+                paths=["example://image-datasets/simple/image1.jpg"],
+                meta_provider=DefaultFileMetadataProvider(),
+            )
 
 
 class TestWriteImages:

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -21,6 +21,9 @@ from ray.data.datasource import (
 from ray.data.datasource.file_based_datasource import (
     FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
 )
+from ray.data.datasource.file_meta_provider import (
+    DefaultFileMetadataProvider,
+)
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
@@ -211,6 +214,15 @@ def test_json_read_meta_provider(
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     path1 = os.path.join(tmp_path, "test1.json")
     df1.to_json(path1, orient="records", lines=True)
+    ds = ray.data.read_json(
+        path1,
+        meta_provider=DefaultFileMetadataProvider(),
+    )
+
+    # Expect to lazily compute all metadata correctly.
+    assert ds.count() == 3
+    assert ds.input_files() == [path1]
+    assert ds.schema() == Schema(pa.schema([("one", pa.int64()), ("two", pa.string())]))
 
     with pytest.raises(NotImplementedError):
         ray.data.read_json(

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -17,7 +17,6 @@ from ray.data._internal.util import rows_same
 from ray.data.block import BlockAccessor
 from ray.data.datasource import (
     BaseFileMetadataProvider,
-    FastFileMetadataProvider,
 )
 from ray.data.datasource.file_based_datasource import (
     FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
@@ -212,15 +211,6 @@ def test_json_read_meta_provider(
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     path1 = os.path.join(tmp_path, "test1.json")
     df1.to_json(path1, orient="records", lines=True)
-    ds = ray.data.read_json(
-        path1,
-        meta_provider=FastFileMetadataProvider(),
-    )
-
-    # Expect to lazily compute all metadata correctly.
-    assert ds.count() == 3
-    assert ds.input_files() == [path1]
-    assert ds.schema() == Schema(pa.schema([("one", pa.int64()), ("two", pa.string())]))
 
     with pytest.raises(NotImplementedError):
         ray.data.read_json(

--- a/python/ray/data/tests/test_numpy.py
+++ b/python/ray/data/tests/test_numpy.py
@@ -12,6 +12,9 @@ from ray.data.dataset import Schema
 from ray.data.datasource import (
     BaseFileMetadataProvider,
 )
+from ray.data.datasource.file_meta_provider import (
+    DefaultFileMetadataProvider,
+)
 from ray.data.extensions.tensor_extension import ArrowTensorType
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
@@ -131,10 +134,20 @@ def test_numpy_read_x(ray_start_regular_shared, tmp_path):
 
 
 def test_numpy_read_meta_provider(ray_start_regular_shared, tmp_path):
+    tensor_type = _get_tensor_type()
+
     path = os.path.join(tmp_path, "test_np_dir")
     os.mkdir(path)
     path = os.path.join(path, "test.npy")
     np.save(path, np.expand_dims(np.arange(0, 10), 1))
+    ds = ray.data.read_numpy(
+        path, meta_provider=DefaultFileMetadataProvider(), override_num_blocks=1
+    )
+    assert ds.count() == 10
+    assert ds.schema() == Schema(pa.schema([("data", tensor_type((1,), pa.int64()))]))
+    np.testing.assert_equal(
+        extract_values("data", ds.take(2)), [np.array([0]), np.array([1])]
+    )
 
     with pytest.raises(NotImplementedError):
         ray.data.read_binary_files(

--- a/python/ray/data/tests/test_numpy.py
+++ b/python/ray/data/tests/test_numpy.py
@@ -11,7 +11,6 @@ from ray.data.context import DataContext
 from ray.data.dataset import Schema
 from ray.data.datasource import (
     BaseFileMetadataProvider,
-    FastFileMetadataProvider,
 )
 from ray.data.extensions.tensor_extension import ArrowTensorType
 from ray.data.tests.conftest import *  # noqa
@@ -132,20 +131,10 @@ def test_numpy_read_x(ray_start_regular_shared, tmp_path):
 
 
 def test_numpy_read_meta_provider(ray_start_regular_shared, tmp_path):
-    tensor_type = _get_tensor_type()
-
     path = os.path.join(tmp_path, "test_np_dir")
     os.mkdir(path)
     path = os.path.join(path, "test.npy")
     np.save(path, np.expand_dims(np.arange(0, 10), 1))
-    ds = ray.data.read_numpy(
-        path, meta_provider=FastFileMetadataProvider(), override_num_blocks=1
-    )
-    assert ds.count() == 10
-    assert ds.schema() == Schema(pa.schema([("data", tensor_type((1,), pa.int64()))]))
-    np.testing.assert_equal(
-        extract_values("data", ds.take(2)), [np.array([0]), np.array([1])]
-    )
 
     with pytest.raises(NotImplementedError):
         ray.data.read_binary_files(

--- a/python/ray/data/tests/test_text.py
+++ b/python/ray/data/tests/test_text.py
@@ -8,7 +8,6 @@ from ray.data._internal.execution.interfaces.ref_bundle import (
 )
 from ray.data.datasource import (
     BaseFileMetadataProvider,
-    FastFileMetadataProvider,
 )
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
@@ -59,10 +58,6 @@ def test_read_text_meta_provider(
         f.write("world\n")
         f.write("goodbye\n")
         f.write("ray\n")
-    ds = ray.data.read_text(path, meta_provider=FastFileMetadataProvider())
-    assert sorted(_to_lines(ds.take())) == ["goodbye", "hello", "ray", "world"]
-    ds = ray.data.read_text(path, drop_empty_lines=False)
-    assert ds.count() == 4
 
     with pytest.raises(NotImplementedError):
         ray.data.read_text(

--- a/python/ray/data/tests/test_text.py
+++ b/python/ray/data/tests/test_text.py
@@ -9,6 +9,9 @@ from ray.data._internal.execution.interfaces.ref_bundle import (
 from ray.data.datasource import (
     BaseFileMetadataProvider,
 )
+from ray.data.datasource.file_meta_provider import (
+    DefaultFileMetadataProvider,
+)
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
 from ray.tests.conftest import *  # noqa
@@ -58,6 +61,10 @@ def test_read_text_meta_provider(
         f.write("world\n")
         f.write("goodbye\n")
         f.write("ray\n")
+    ds = ray.data.read_text(path, meta_provider=DefaultFileMetadataProvider())
+    assert sorted(_to_lines(ds.take())) == ["goodbye", "hello", "ray", "world"]
+    ds = ray.data.read_text(path, drop_empty_lines=False)
+    assert ds.count() == 4
 
     with pytest.raises(NotImplementedError):
         ray.data.read_text(


### PR DESCRIPTION
## Description
After removing the deprecated `read_parquet_bulk` API, `FastFileMetadataProvider` became dead code with no remaining usage in the codebase.

This commit removes:
- FastFileMetadataProvider class implementation
- All imports and exports of FastFileMetadataProvider
- Tests that specifically tested FastFileMetadataProvider
- Documentation references to FastFileMetadataProvider
- Code comments mentioning FastFileMetadataProvider

## Related issues
> Fixes #59010
