### PR TITLE
[core] Throw AuthenticationError from python for token loading errors

### DIFF
--- a/python/ray/_private/authentication/authentication_token_setup.py
+++ b/python/ray/_private/authentication/authentication_token_setup.py
@@ -90,7 +90,7 @@ def ensure_token_if_auth_enabled(
 
     token_loader = AuthenticationTokenLoader.instance()
 
-    if not token_loader.has_token():
+    if not token_loader.has_token(ignore_auth_mode=True):
         if create_token_if_missing:
             # Generate a new token.
             generate_and_save_token()

--- a/python/ray/_private/authentication_test_utils.py
+++ b/python/ray/_private/authentication_test_utils.py
@@ -36,8 +36,9 @@ def set_auth_token_path(token: str, path: Path) -> None:
     """Write the authentication token to a specific path and point the loader to it."""
 
     token_path = Path(path)
-    token_path.parent.mkdir(parents=True, exist_ok=True)
-    token_path.write_text(token)
+    if token is not None:
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text(token)
     os.environ["RAY_AUTH_TOKEN_PATH"] = str(token_path)
     os.environ.pop("RAY_AUTH_TOKEN", None)
 
@@ -112,6 +113,12 @@ class AuthenticationEnvSnapshot:
 
     def restore(self) -> None:
         """Restore the captured environment, HOME, and default token file state."""
+        # delete any custom token files that may have been created during the test
+        custom_token_path = os.environ.get("RAY_AUTH_TOKEN_PATH")
+        if custom_token_path is not None:
+            custom_token_path = Path(custom_token_path)
+            if custom_token_path.exists():
+                custom_token_path.unlink(missing_ok=True)
 
         for var, value in self.original_env.items():
             if value is None:

--- a/python/ray/includes/rpc_token_authentication.pxd
+++ b/python/ray/includes/rpc_token_authentication.pxd
@@ -31,7 +31,6 @@ cdef extern from "ray/rpc/authentication/authentication_token_loader.h" namespac
     cdef cppclass CAuthenticationTokenLoader "ray::rpc::AuthenticationTokenLoader":
         @staticmethod
         CAuthenticationTokenLoader& instance()
-        c_bool HasToken(c_bool ignore_auth_mode)
         void ResetCache()
         optional[CAuthenticationToken] GetToken(c_bool ignore_auth_mode)
         CTokenLoadResult TryLoadToken(c_bool ignore_auth_mode)

--- a/python/ray/includes/rpc_token_authentication.pxd
+++ b/python/ray/includes/rpc_token_authentication.pxd
@@ -23,12 +23,18 @@ cdef extern from "ray/rpc/authentication/authentication_token.h" namespace "ray:
         CAuthenticationToken FromMetadata(string metadata_value)
 
 cdef extern from "ray/rpc/authentication/authentication_token_loader.h" namespace "ray::rpc" nogil:
+    cdef cppclass CTokenLoadResult "ray::rpc::TokenLoadResult":
+        optional[CAuthenticationToken] token
+        string error_message
+        c_bool hasError()
+
     cdef cppclass CAuthenticationTokenLoader "ray::rpc::AuthenticationTokenLoader":
         @staticmethod
         CAuthenticationTokenLoader& instance()
         c_bool HasToken(c_bool ignore_auth_mode)
         void ResetCache()
         optional[CAuthenticationToken] GetToken(c_bool ignore_auth_mode)
+        CTokenLoadResult TryLoadToken(c_bool ignore_auth_mode)
 
 cdef extern from "ray/rpc/authentication/authentication_token_validator.h" namespace "ray::rpc" nogil:
     cdef cppclass CAuthenticationTokenValidator "ray::rpc::AuthenticationTokenValidator":

--- a/python/ray/tests/test_token_auth_integration.py
+++ b/python/ray/tests/test_token_auth_integration.py
@@ -425,20 +425,19 @@ def test_e2e_operations_with_token_auth(setup_cluster_with_token_auth):
     from ray.util.state import list_actors, list_nodes, list_tasks
 
     # List nodes - should include at least the head node
-    nodes = list_nodes()
-    assert len(nodes) >= 1, f"Expected at least 1 node, got {len(nodes)}"
+    wait_for_condition(lambda: len(list_nodes()) >= 1)
 
     # List actors - should include our SimpleActor
-    actors = list_actors()
-    assert len(actors) >= 1, f"Expected at least 1 actor, got {len(actors)}"
-    actor_classes = [a.class_name for a in actors]
-    assert (
-        "SimpleActor" in actor_classes[0]
-    ), f"SimpleActor not found in {actor_classes}"
+    def check_actors():
+        actors = list_actors()
+        if len(actors) < 1:
+            return False
+        return "SimpleActor" in actors[0].class_name
+
+    wait_for_condition(check_actors)
 
     # List tasks - should include completed tasks
-    tasks = list_tasks()
-    assert len(tasks) >= 1, f"Expected at least 1 task, got {len(tasks)}"
+    wait_for_condition(lambda: len(list_tasks()) >= 1)
 
     # Test 4: Submit a job and wait for completion
     from ray.job_submission import JobSubmissionClient

--- a/python/ray/tests/test_token_auth_integration.py
+++ b/python/ray/tests/test_token_auth_integration.py
@@ -595,11 +595,12 @@ def test_missing_token_file_raises_authentication_error():
 )
 def test_empty_token_file_raises_authentication_error(tmp_path):
     """Test that RAY_AUTH_TOKEN_PATH pointing to empty file raises AuthenticationError."""
+    token_file = tmp_path / "empty_token_file.txt"
     with authentication_env_guard():
         # Clear first, then set up the specific test scenario
         clear_auth_token_sources(remove_default=True)
         set_auth_mode("token")
-        set_auth_token_path("", "empty_token_file.txt")
+        set_auth_token_path("", token_file)
         reset_auth_token_state()
 
         token_loader = AuthenticationTokenLoader.instance()
@@ -607,9 +608,8 @@ def test_empty_token_file_raises_authentication_error(tmp_path):
         with pytest.raises(ray.exceptions.AuthenticationError) as exc_info:
             token_loader.has_token()
 
-        assert "empty" in str(exc_info.value).lower() or "empty_token_file.txt" in str(
-            exc_info.value
-        )
+        assert "cannot be opened or is empty" in str(exc_info.value)
+        assert str(token_file) in str(exc_info.value)
 
 
 @pytest.mark.skipif(

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -35,6 +35,13 @@
 namespace ray {
 namespace rpc {
 
+constexpr const char *kNoTokenErrorMessage =
+    "Token authentication is enabled but Ray couldn't find an "
+    "authentication token. "
+    "Create a token file at ~/.ray/auth_token, "
+    "or store the token in any file and set RAY_AUTH_TOKEN_PATH to point to it, "
+    "or set the RAY_AUTH_TOKEN environment variable.";
+
 AuthenticationTokenLoader &AuthenticationTokenLoader::instance() {
   static AuthenticationTokenLoader instance;
   return instance;
@@ -56,47 +63,121 @@ std::optional<AuthenticationToken> AuthenticationTokenLoader::GetToken(
   }
 
   // Token auth is enabled (or we're ignoring auth mode), try to load from sources
-  AuthenticationToken token = LoadTokenFromSources();
+  TokenLoadResult result = TryLoadTokenFromSources();
+
+  // If there was an error loading (e.g., RAY_AUTH_TOKEN_PATH set but file missing), crash
+  RAY_CHECK(!result.hasError()) << result.error_message;
 
   // If no token found and auth is enabled, fail with RAY_CHECK
-  if (token.empty() && !ignore_auth_mode) {
-    RAY_LOG(FATAL)
-        << "Token authentication is enabled but Ray couldn't find an "
-           "authentication token. "
-        << "Create a token file at ~/.ray/auth_token, "
-           "or store the token in any file and set RAY_AUTH_TOKEN_PATH to point to it, "
-           "or set the RAY_AUTH_TOKEN environment variable.";
-  }
+  bool has_token = result.token.has_value() && !result.token->empty();
+  RAY_CHECK(has_token || ignore_auth_mode) << kNoTokenErrorMessage;
 
   // Cache and return the loaded token
-  cached_token_ = std::move(token);
-  return *cached_token_;
+  if (has_token) {
+    cached_token_ = std::move(result.token);
+    return *cached_token_;
+  }
+  return std::nullopt;
 }
 
-bool AuthenticationTokenLoader::HasToken(bool ignore_auth_mode) {
+TokenLoadResult AuthenticationTokenLoader::TryLoadToken(bool ignore_auth_mode) {
   std::lock_guard<std::mutex> lock(token_mutex_);
+  TokenLoadResult result;
 
-  // If already loaded, check if it's a valid token
+  // If already loaded, return cached value
   if (cached_token_.has_value()) {
-    return !cached_token_->empty();
+    result.token = cached_token_;
+    return result;
   }
 
-  // If token or k8s auth is not enabled, no token needed (unless ignoring auth mode)
+  // If auth is disabled, return nullopt (no token needed)
   if (!ignore_auth_mode && !RequiresTokenAuthentication()) {
     cached_token_ = std::nullopt;
-    return false;
+    result.token = std::nullopt;
+    return result;
   }
 
-  // Token auth is enabled (or we're ignoring auth mode), try to load from sources
-  AuthenticationToken token = LoadTokenFromSources();
-
-  // Cache the result
-  if (token.empty()) {
-    return false;
-  } else {
-    cached_token_ = std::move(token);
-    return true;
+  // Token auth is enabled, try to load from sources
+  result = TryLoadTokenFromSources();
+  if (result.hasError()) {
+    return result;  // Propagate error
   }
+
+  bool no_token = !result.token.has_value() || result.token->empty();
+  if (no_token && ignore_auth_mode) {
+    result.token = std::nullopt;
+    return result;
+  } else if (no_token) {
+    result.error_message = kNoTokenErrorMessage;
+    return result;
+  }
+  // Cache and return success
+  cached_token_ = result.token;
+  return result;
+}
+
+TokenLoadResult AuthenticationTokenLoader::TryLoadTokenFromSources() {
+  TokenLoadResult result;
+
+  // Precedence 1: RAY_AUTH_TOKEN environment variable
+  const char *env_token = std::getenv("RAY_AUTH_TOKEN");
+  if (env_token != nullptr) {
+    std::string token_str(env_token);
+    if (!token_str.empty()) {
+      RAY_LOG(DEBUG) << "Loaded authentication token from RAY_AUTH_TOKEN environment "
+                        "variable";
+      result.token = AuthenticationToken(TrimWhitespace(token_str));
+      return result;
+    }
+  }
+
+  // Precedence 2: RAY_AUTH_TOKEN_PATH environment variable
+  const char *env_token_path = std::getenv("RAY_AUTH_TOKEN_PATH");
+  if (env_token_path != nullptr) {
+    std::string path_str(env_token_path);
+    if (!path_str.empty()) {
+      std::string token_str = TrimWhitespace(ReadTokenFromFile(path_str));
+      if (token_str.empty()) {
+        // Return error message instead of crashing
+        result.error_message =
+            "RAY_AUTH_TOKEN_PATH is set but file cannot be opened or is empty: " +
+            path_str;
+        return result;
+      }
+      RAY_LOG(DEBUG) << "Loaded authentication token from file (RAY_AUTH_TOKEN_PATH): "
+                     << path_str;
+      result.token = AuthenticationToken(token_str);
+      return result;
+    }
+  }
+
+  // Precedence 3 (auth_mode=k8s only): Load Kubernetes service account token
+  if (GetAuthenticationMode() == AuthenticationMode::K8S) {
+    std::string token_str = TrimWhitespace(ReadTokenFromFile(k8s::kK8sSaTokenPath));
+    if (!token_str.empty()) {
+      RAY_LOG(DEBUG)
+          << "Loaded authentication token from Kubernetes service account path: "
+          << k8s::kK8sSaTokenPath;
+      result.token = AuthenticationToken(token_str);
+      return result;
+    }
+    RAY_LOG(DEBUG) << "Kubernetes service account token not found or empty at: "
+                   << k8s::kK8sSaTokenPath;
+  }
+
+  // Precedence 4: Default token path ~/.ray/auth_token
+  std::string default_path = GetDefaultTokenPath();
+  std::string token_str = TrimWhitespace(ReadTokenFromFile(default_path));
+  if (!token_str.empty()) {
+    RAY_LOG(DEBUG) << "Loaded authentication token from default path: " << default_path;
+    result.token = AuthenticationToken(token_str);
+    return result;
+  }
+
+  // No token found - return empty result (caller decides if error)
+  RAY_LOG(DEBUG) << "No authentication token found in any source";
+  result.token = AuthenticationToken();  // Empty token
+  return result;
 }
 
 // Read token from the first line of the file. trim whitespace.
@@ -111,61 +192,6 @@ std::string AuthenticationTokenLoader::ReadTokenFromFile(const std::string &file
   std::getline(token_file, token);
   token_file.close();
   return token;
-}
-
-AuthenticationToken AuthenticationTokenLoader::LoadTokenFromSources() {
-  // Precedence 1: RAY_AUTH_TOKEN environment variable
-  const char *env_token = std::getenv("RAY_AUTH_TOKEN");
-  if (env_token != nullptr) {
-    std::string token_str(env_token);
-    if (!token_str.empty()) {
-      RAY_LOG(INFO) << "Loaded authentication token from RAY_AUTH_TOKEN environment "
-                       "variable";
-      return AuthenticationToken(TrimWhitespace(token_str));
-    }
-  }
-
-  // Precedence 2: RAY_AUTH_TOKEN_PATH environment variable
-  const char *env_token_path = std::getenv("RAY_AUTH_TOKEN_PATH");
-  if (env_token_path != nullptr) {
-    std::string path_str(env_token_path);
-    if (!path_str.empty()) {
-      std::string token_str = TrimWhitespace(ReadTokenFromFile(path_str));
-      if (token_str.empty()) {
-        RAY_LOG(FATAL) << "RAY_AUTH_TOKEN_PATH is set "
-                          "but file cannot be opened or is empty: "
-                       << path_str;
-      }
-      RAY_LOG(INFO) << "Loaded authentication token from file (RAY_AUTH_TOKEN_PATH): "
-                    << path_str;
-      return AuthenticationToken(token_str);
-    }
-  }
-
-  // Precedence 3 (auth_mode=k8s only): Load Kubernetes service account token
-  if (GetAuthenticationMode() == AuthenticationMode::K8S) {
-    std::string token_str = TrimWhitespace(ReadTokenFromFile(k8s::kK8sSaTokenPath));
-    if (!token_str.empty()) {
-      RAY_LOG(INFO)
-          << "Loaded authentication token from Kubernetes service account path: "
-          << k8s::kK8sSaTokenPath;
-      return AuthenticationToken(token_str);
-    }
-    RAY_LOG(DEBUG) << "Kubernetes service account token not found or empty at: "
-                   << k8s::kK8sSaTokenPath;
-  }
-
-  // Precedence 4: Default token path ~/.ray/auth_token
-  std::string default_path = GetDefaultTokenPath();
-  std::string token_str = TrimWhitespace(ReadTokenFromFile(default_path));
-  if (!token_str.empty()) {
-    RAY_LOG(INFO) << "Loaded authentication token from default path: " << default_path;
-    return AuthenticationToken(token_str);
-  }
-
-  // No token found
-  RAY_LOG(DEBUG) << "No authentication token found in any source";
-  return AuthenticationToken();
 }
 
 std::string AuthenticationTokenLoader::GetDefaultTokenPath() {

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -49,7 +49,7 @@ AuthenticationTokenLoader &AuthenticationTokenLoader::instance() {
 
 std::optional<AuthenticationToken> AuthenticationTokenLoader::GetToken(
     bool ignore_auth_mode) {
-  std::lock_guard<std::mutex> lock(token_mutex_);
+  absl::MutexLock lock(&token_mutex_);
 
   // If already loaded, return cached value
   if (cached_token_.has_value()) {
@@ -81,7 +81,7 @@ std::optional<AuthenticationToken> AuthenticationTokenLoader::GetToken(
 }
 
 TokenLoadResult AuthenticationTokenLoader::TryLoadToken(bool ignore_auth_mode) {
-  std::lock_guard<std::mutex> lock(token_mutex_);
+  absl::MutexLock lock(&token_mutex_);
   TokenLoadResult result;
 
   // If already loaded, return cached value

--- a/src/ray/rpc/authentication/authentication_token_loader.h
+++ b/src/ray/rpc/authentication/authentication_token_loader.h
@@ -30,7 +30,7 @@ struct TokenLoadResult {
   std::optional<AuthenticationToken> token;
   std::string error_message;
 
-  /// Returns true if no error occurred.
+  /// Returns true if an error occurred.
   bool hasError() const { return !error_message.empty(); }
 };
 

--- a/src/ray/rpc/authentication/authentication_token_loader.h
+++ b/src/ray/rpc/authentication/authentication_token_loader.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <mutex>
 #include <optional>
 #include <string>
 
+#include "absl/synchronization/mutex.h"
 #include "ray/rpc/authentication/authentication_mode.h"
 #include "ray/rpc/authentication/authentication_token.h"
 
@@ -59,7 +59,7 @@ class AuthenticationTokenLoader {
   TokenLoadResult TryLoadToken(bool ignore_auth_mode = false);
 
   void ResetCache() {
-    std::lock_guard<std::mutex> lock(token_mutex_);
+    absl::MutexLock lock(&token_mutex_);
     cached_token_.reset();
   }
 
@@ -82,7 +82,7 @@ class AuthenticationTokenLoader {
   /// Trim whitespace from the beginning and end of the string.
   std::string TrimWhitespace(const std::string &str);
 
-  std::mutex token_mutex_;
+  absl::Mutex token_mutex_;
   std::optional<AuthenticationToken> cached_token_;
 };
 

--- a/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
+++ b/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
@@ -352,35 +352,6 @@ TEST_F(AuthenticationTokenLoaderTest, TestIgnoreAuthModeGetToken) {
   RayConfig::instance().initialize(R"({"AUTH_MODE": "token"})");
 }
 
-TEST_F(AuthenticationTokenLoaderTest, TestIgnoreAuthModeHasToken) {
-  // Disable auth mode
-  RayConfig::instance().initialize(R"({"AUTH_MODE": "disabled"})");
-  AuthenticationTokenLoader::instance().ResetCache();
-
-  // Set token in environment
-  set_env_var("RAY_AUTH_TOKEN", "test-token-has-ignore");
-
-  auto &loader = AuthenticationTokenLoader::instance();
-
-  // Without ignore_auth_mode, should return false (auth is disabled)
-  EXPECT_FALSE(loader.HasToken());
-
-  // Reset cache to test ignore_auth_mode
-  loader.ResetCache();
-
-  // With ignore_auth_mode=true, should return true despite auth being disabled
-  EXPECT_TRUE(loader.HasToken(true));
-
-  // Also verify we can get the actual token value
-  auto token_opt = loader.GetToken(true);
-  ASSERT_TRUE(token_opt.has_value());
-  AuthenticationToken expected("test-token-has-ignore");
-  EXPECT_TRUE(token_opt->Equals(expected));
-
-  // Re-enable auth for other tests
-  RayConfig::instance().initialize(R"({"AUTH_MODE": "token"})");
-}
-
 }  // namespace rpc
 }  // namespace ray
 


### PR DESCRIPTION
## Description
catch and throw token loading exceptions from the python frontend instead of crashing from c++

eg:
```bash
(ray-dev) ubuntu@devbox:~/clone/ray$ export RAY_AUTH_MODE=token
(ray-dev) ubuntu@devbox:~/clone/ray$ export RAY_AUTH_TOKEN_PATH=missing_file.txt
(ray-dev) ubuntu@devbox:~/clone/ray$ ray start --head
Usage stats collection is enabled. To disable this, add `--disable-usage-stats` to the command that starts the cluster, or run the following command: `ray disable-usage-stats` before starting the cluster. See https://docs.ray.io/en/master/cluster/usage-stats.html for more details.

Local node IP: 172.31.5.49
Traceback (most recent call last):
  File "/home/ubuntu/.conda/envs/ray-dev/bin/ray", line 7, in <module>
    sys.exit(main())
  File "/home/ubuntu/clone/ray/python/ray/scripts/scripts.py", line 2817, in main
    return cli()
  File "/home/ubuntu/.conda/envs/ray-dev/lib/python3.10/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/.conda/envs/ray-dev/lib/python3.10/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/.conda/envs/ray-dev/lib/python3.10/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/.conda/envs/ray-dev/lib/python3.10/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/.conda/envs/ray-dev/lib/python3.10/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/home/ubuntu/clone/ray/python/ray/autoscaler/_private/cli_logger.py", line 823, in wrapper
    return f(*args, **kwargs)
  File "/home/ubuntu/clone/ray/python/ray/scripts/scripts.py", line 945, in start
    ensure_token_if_auth_enabled(system_config, create_token_if_missing=False)
  File "/home/ubuntu/clone/ray/python/ray/_private/authentication/authentication_token_setup.py", line 93, in ensure_token_if_auth_enabled
    if not token_loader.has_token(ignore_auth_mode=True):
  File "python/ray/includes/rpc_token_authentication.pxi", line 90, in ray._raylet.AuthenticationTokenLoader.has_token
    raise AuthenticationError(result.error_message.decode('utf-8'))
ray.exceptions.AuthenticationError: RAY_AUTH_TOKEN_PATH is set but file cannot be opened or is empty: missing_file.txt. Ensure that the token for the cluster is available in a local file (e.g., ~/.ray/auth_token or via RAY_AUTH_TOKEN_PATH) or as the `RAY_AUTH_TOKEN` environment variable. To generate a token for local development, use `ray get-auth-token --generate` For remote clusters, ensure that the token is propagated to all nodes of the cluster when token authentication is enabled. For more information, see: https://docs.ray.io/en/latest/ray-security/auth.html
```

