### PR TITLE
[core] Augment browser request validation using `CORS` header checks

### DIFF
--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -130,21 +130,28 @@ def aiohttp_cache(
 def is_browser_request(req: Request) -> bool:
     """Best-effort detection if the request was made by a browser.
 
-    Uses two heuristics:
+    Uses three heuristics:
         1) If the `User-Agent` header starts with 'Mozilla'. This heuristic is weak,
         but hard for a browser to bypass e.g., fetch/xhr and friends cannot alter the
         user agent, but requests made with an HTTP library can stumble into this if
         they choose to user a browser-like user agent. At the time of writing, all
         common browsers' user agents start with 'Mozilla'.
         2) If any of the `Sec-Fetch-*` headers are present.
+        3) If any of the various CORS headers are present
     """
     return req.headers.get("User-Agent", "").startswith("Mozilla") or any(
         h in req.headers
         for h in (
+            "Origin",
+            # Sec-Fetch headers are sent with many but not all `fetch`
+            # requests, and will eventually be sent on all requests.
             "Sec-Fetch-Mode",
             "Sec-Fetch-Dest",
             "Sec-Fetch-Site",
             "Sec-Fetch-User",
+            # CORS headers specifying which other headers are modified
+            "Access-Control-Request-Method",
+            "Access-Control-Request-Headers",
         )
     )
 

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -419,6 +419,234 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
     webui_url = format_web_url(webui_url)
 
+    testcases = (
+        # chrome-invalid-tls.json
+        {
+            "Host": "localtest.me",
+            "Connection": "keep-alive",
+            "Content-Length": "0",
+            "Sec-Ch-Ua-Platform": '"macOS"',
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+            "Sec-Ch-Ua": '"Chromium";v="142", "Google Chrome";v="142", "Not_A Brand";v="99"',
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Accept": "*/*",
+            "Origin": "https://localtest.me",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+            "Referer": "https://localtest.me/",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Accept-Language": "en-US,en;q=0.9",
+        },
+        # chrome-localhost-notls.json
+        {
+            "Host": "localhost:5000",
+            "Connection": "keep-alive",
+            "Content-Length": "0",
+            "Sec-Ch-Ua-Platform": '"macOS"',
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+            "Sec-Ch-Ua": '"Chromium";v="142", "Google Chrome";v="142", "Not_A Brand";v="99"',
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Accept": "*/*",
+            "Origin": "http://localhost:5000",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+            "Referer": "http://localhost:5000/",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Accept-Language": "en-US,en;q=0.9",
+        },
+        # chrome-notlocalhost-notls.json
+        {
+            "Host": "localtest.me:5000",
+            "Connection": "keep-alive",
+            "Content-Length": "0",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+            "Accept": "*/*",
+            "Origin": "http://localtest.me:5000",
+            "Referer": "http://localtest.me:5000/",
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "en-US,en;q=0.9",
+        },
+        # chrome-notlocalhost-port80-notls.json
+        {
+            "Host": "localtest.me",
+            "Connection": "keep-alive",
+            "Content-Length": "0",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+            "Accept": "*/*",
+            "Origin": "http://localtest.me",
+            "Referer": "http://localtest.me/",
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "en-US,en;q=0.9",
+        },
+        # firefox-invalid-tls.json
+        {
+            "Host": "localtest.me",
+            "User-Agent": "Fake",
+            "Accept": "*/*",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Referer": "https://localtest.me/",
+            "Origin": "https://localtest.me",
+            "Connection": "keep-alive",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            "Priority": "u=0",
+            "Content-Length": "0",
+        },
+        # firefox-localhost-notls.json
+        {
+            "Host": "localhost:5000",
+            "User-Agent": "Fake",
+            "Accept": "*/*",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Referer": "http://localhost:5000/",
+            "Origin": "http://localhost:5000",
+            "Connection": "keep-alive",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            "Priority": "u=0",
+            "Content-Length": "0",
+        },
+        # firefox-notlocalhost-notls.json
+        {
+            "Host": "localtest.me:5000",
+            "User-Agent": "Fake",
+            "Accept": "*/*",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate",
+            "Referer": "http://localtest.me:5000/",
+            "Origin": "http://localtest.me:5000",
+            "Connection": "keep-alive",
+            "Priority": "u=0",
+            "Content-Length": "0",
+        },
+        # firefox-notlocalhost-port80-notls.json
+        {
+            "Host": "localtest.me",
+            "User-Agent": "Fake",
+            "Accept": "*/*",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate",
+            "Referer": "http://localtest.me/",
+            "Origin": "http://localtest.me",
+            "Connection": "keep-alive",
+            "Priority": "u=0",
+            "Content-Length": "0",
+        },
+        # safari-invalid-tls.json
+        {
+            "Host": "localtest.me",
+            "Accept": "*/*",
+            "Origin": "https://localtest.me",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "User-Agent": "Fake",
+            "Referer": "https://localtest.me/",
+            "Sec-Fetch-Dest": "empty",
+            "Content-Length": "0",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Priority": "u=3, i",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Connection": "keep-alive",
+        },
+        # safari-localhost-notls.json
+        {
+            "Host": "localhost:5000",
+            "Accept": "*/*",
+            "Origin": "http://localhost:5000",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "User-Agent": "Fake",
+            "Referer": "http://localhost:5000/",
+            "Sec-Fetch-Dest": "empty",
+            "Content-Length": "0",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Priority": "u=3, i",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
+        },
+        # safari-notlocalhost-notls.json
+        {
+            "Host": "localtest.me:5000",
+            "User-Agent": "Fake",
+            "Accept": "*/*",
+            "Content-Length": "0",
+            "Referer": "http://localtest.me:5000/",
+            "Origin": "http://localtest.me:5000",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Priority": "u=3, i",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
+        },
+        # safari-notlocalhost-port80-notls.json
+        {
+            "Host": "localtest.me",
+            "User-Agent": "Fake",
+            "Accept": "*/*",
+            "Content-Length": "0",
+            "Referer": "http://localtest.me/",
+            "Origin": "http://localtest.me",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Priority": "u=3, i",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
+        },
+        # edge-valid-tls.json
+        {
+            "Content-Length": "0",
+            "Sec-Ch-Ua-Platform": '"Windows"',
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+            "Sec-Ch-Ua": '"Chromium";v="142", "Microsoft Edge";v="142", "Not_A Brand";v="99"',
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Accept": "*/*",
+            "Origin": "https://testing-dark-field-5895.fly.dev",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+            "Referer": "https://testing-dark-field-5895.fly.dev/",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Priority": "u=1, i",
+            "X-Request-Start": "t=1764259434792741",
+            "Host": "testing-dark-field-5895.fly.dev",
+        },
+        # edge-notlocalhost-notls
+        {
+            "Host": "localtest.me:5000",
+            "Connection": "keep-alive",
+            "Content-Length": "0",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+            "Accept": "*/*",
+            "Origin": "http://localtest.me:5000",
+            "Referer": "http://localtest.me:5000/",
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "en-US,en;q=0.9",
+        },
+        # edge-localhost-notls
+        {
+            "Host": "localhost:5000",
+            "Connection": "keep-alive",
+            "Content-Length": "0",
+            "Sec-Ch-Ua-Platform": '"Windows"',
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+            "Sec-Ch-Ua": '"Chromium";v="142", "Microsoft Edge";v="142", "Not_A Brand";v="99"',
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Accept": "*/*",
+            "Origin": "http://localhost:5000",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+            "Referer": "http://localhost:5000/",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Accept-Language": "en-US,en;q=0.9",
+        },
+    )
+
     def dashboard_available():
         try:
             return requests.get(webui_url).status_code == 200
@@ -434,19 +662,14 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
     response.raise_for_status()
 
     # Starting job should be blocked for browsers
-    response = requests.post(
-        webui_url + "/api/jobs/",
-        json={"entrypoint": "ls"},
-        headers={
-            "User-Agent": (
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "Chrome/119.0.0.0 Safari/537.36"
-            )
-        },
-    )
-    with pytest.raises(HTTPError):
-        response.raise_for_status()
+    for testcase in testcases:
+        response = requests.post(
+            webui_url + "/api/jobs/",
+            json={"entrypoint": "ls"},
+            headers=testcase,
+        )
+        with pytest.raises(HTTPError):
+            response.raise_for_status()
 
     # Getting jobs should be fine for browsers
     response = requests.get(webui_url + "/api/jobs/")


### PR DESCRIPTION
Rejects requests containing ` "Access-Control-Request-Method"` or `"Access-Control-Request-Headers"` headers.