### PR TITLE
[core] remove cluster_full_of_actors_detected_* as autoscaler v2 doesn't use them

### DIFF
--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -78,7 +78,6 @@ class LoadMetrics:
         self.infeasible_bundles = []
         self.pending_placement_groups = []
         self.resource_requests = []
-        self.cluster_full_of_actors_detected = False
         self.ray_nodes_last_used_time_by_ip = {}
 
     def __bool__(self):
@@ -97,11 +96,9 @@ class LoadMetrics:
         waiting_bundles: List[Dict[str, float]] = None,
         infeasible_bundles: List[Dict[str, float]] = None,
         pending_placement_groups: List[PlacementGroupTableData] = None,
-        cluster_full_of_actors_detected: bool = False,
     ):
         self.static_resources_by_ip[ip] = static_resources
         self.node_id_by_ip[ip] = node_id
-        self.cluster_full_of_actors_detected = cluster_full_of_actors_detected
 
         if not waiting_bundles:
             waiting_bundles = []

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -268,19 +268,6 @@ class Monitor:
             self.autoscaler.provider._set_nodes(new_nodes)
 
         mirror_node_types = {}
-        legacy_cluster_full_detected = any(
-            getattr(entry, "cluster_full_of_actors_detected", False)
-            for entry in resources_batch_data.batch
-        )
-        cluster_full = legacy_cluster_full_detected or getattr(
-            response, "cluster_full_of_actors_detected_by_gcs", False
-        )
-        if (
-            hasattr(response, "cluster_full_of_actors_detected_by_gcs")
-            and response.cluster_full_of_actors_detected_by_gcs
-        ):
-            # GCS has detected the cluster full of actors.
-            cluster_full = True
         for resource_message in cluster_resource_state.node_states:
             node_id = resource_message.node_id
             # Generate node type config based on GCS reported node list.
@@ -341,7 +328,6 @@ class Monitor:
                 waiting_bundles,
                 infeasible_bundles,
                 pending_placement_groups,
-                cluster_full,
             )
         if self.readonly_config:
             self.readonly_config["available_node_types"].update(mirror_node_types)

--- a/src/ray/gcs/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_resource_manager.h
@@ -138,13 +138,6 @@ class GcsResourceManager : public rpc::NodeResourceInfoGcsServiceHandler,
       const NodeID &node_id,
       const syncer::ResourceViewSyncMessage &resource_view_sync_message);
 
-  /// Update the resource usage of a node from syncer COMMANDS
-  ///
-  /// This is currently used for setting cluster full of actors info from syncer.
-  /// \param data The resource report.
-  void UpdateClusterFullOfActorsDetected(const NodeID &node_id,
-                                         bool cluster_full_of_actors_detected);
-
   /// Update the placement group load information so that it will be reported through
   /// heartbeat.
   ///

--- a/src/ray/gcs/tests/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_resource_manager_test.cc
@@ -149,42 +149,13 @@ TEST_F(GcsResourceManagerTest, TestResourceUsageFromDifferentSyncMsgs) {
   resource_view_sync_message.mutable_resources_available()->insert({"CPU", 5});
 
   // Update resource usage from resource view.
-  {
-    ASSERT_FALSE(gcs_resource_manager_->NodeResourceReportView()
-                     .at(NodeID::FromBinary(node->node_id()))
-                     .cluster_full_of_actors_detected());
-    gcs_resource_manager_->UpdateFromResourceView(NodeID::FromBinary(node->node_id()),
-                                                  resource_view_sync_message);
-    ASSERT_EQ(
-        cluster_resource_manager_.GetNodeResources(scheduling::NodeID(node->node_id()))
-            .total.GetResourceMap()
-            .at("CPU"),
-        5);
-
-    ASSERT_FALSE(gcs_resource_manager_->NodeResourceReportView()
-                     .at(NodeID::FromBinary(node->node_id()))
-                     .cluster_full_of_actors_detected());
-  }
-
-  // Update from syncer COMMANDS will not update the resources, but the
-  // cluster_full_of_actors_detected flag. (This is how NodeManager currently
-  // updates potential resources deadlock).
-  {
-    gcs_resource_manager_->UpdateClusterFullOfActorsDetected(
-        NodeID::FromBinary(node->node_id()), true);
-
-    // Still 5 because the syncer COMMANDS message is ignored.
-    ASSERT_EQ(
-        cluster_resource_manager_.GetNodeResources(scheduling::NodeID(node->node_id()))
-            .total.GetResourceMap()
-            .at("CPU"),
-        5);
-
-    // The flag is updated.
-    ASSERT_TRUE(gcs_resource_manager_->NodeResourceReportView()
-                    .at(NodeID::FromBinary(node->node_id()))
-                    .cluster_full_of_actors_detected());
-  }
+  gcs_resource_manager_->UpdateFromResourceView(NodeID::FromBinary(node->node_id()),
+                                                resource_view_sync_message);
+  ASSERT_EQ(
+      cluster_resource_manager_.GetNodeResources(scheduling::NodeID(node->node_id()))
+          .total.GetResourceMap()
+          .at("CPU"),
+      5);
 }
 
 TEST_F(GcsResourceManagerTest, TestSetAvailableResourcesWhenNodeDead) {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -506,7 +506,7 @@ message ResourceLoad {
 }
 
 message ResourcesData {
-  reserved 3, 8, 17;
+  reserved 3, 8, 14, 17;
   // Node id.
   bytes node_id = 1;
   // Resource capacity currently available on this node manager.
@@ -530,8 +530,6 @@ message ResourcesData {
   bool resources_normal_task_changed = 12;
   // The timestamp that normal task resources are measured.
   int64 resources_normal_task_timestamp = 13;
-  // Whether this node has detected a resource deadlock (full of actors).
-  bool cluster_full_of_actors_detected = 14;
   // The duration in ms during which all the node's resources are idle. If the
   // node currently has any resource being used, this will be 0.
   int64 idle_duration_ms = 15;

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -723,10 +723,6 @@ message GetAllResourceUsageRequest {}
 message GetAllResourceUsageReply {
   GcsStatus status = 1;
   ResourceUsageBatchData resource_usage_data = 2;
-  /// True if gcs finds infeasible or pending actor creation tasks
-  /// locally (when gcs actor scheduler is enabled). This field is
-  /// expected to help triggering auto-scaling.
-  bool cluster_full_of_actors_detected_by_gcs = 3;
 }
 
 message GetDrainingNodesRequest {}

--- a/src/ray/protobuf/ray_syncer.proto
+++ b/src/ray/protobuf/ray_syncer.proto
@@ -23,8 +23,6 @@ enum MessageType {
 message CommandsSyncMessage {
   // Whether this node manager is requesting global GC.
   bool should_global_gc = 1;
-  // Whether this node has detected a resource deadlock (full of actors).
-  bool cluster_full_of_actors_detected = 2;
 }
 
 message ResourceViewSyncMessage {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3022,8 +3022,6 @@ std::optional<syncer::RaySyncMessage> NodeManager::CreateSyncMessage(
   std::string serialized_commands_sync_msg;
   syncer::CommandsSyncMessage commands_sync_message;
   commands_sync_message.set_should_global_gc(true);
-  commands_sync_message.set_cluster_full_of_actors_detected(resource_deadlock_warned_ >=
-                                                            1);
   RAY_CHECK(commands_sync_message.SerializeToString(&serialized_commands_sync_msg));
 
   // Populate the sync message.

--- a/src/ray/raylet/scheduling/scheduler_resource_reporter.cc
+++ b/src/ray/raylet/scheduling/scheduler_resource_reporter.cc
@@ -180,7 +180,6 @@ void SchedulerResourceReporter::FillPendingActorCountByShape(
   }
 
   if (!pending_count_by_shape.empty()) {
-    data.set_cluster_full_of_actors_detected(true);
     auto resource_load_by_shape =
         data.mutable_resource_load_by_shape()->mutable_resource_demands();
     for (const auto &shape_entry : pending_count_by_shape) {


### PR DESCRIPTION
## Description

This PR removes the `cluster_full_of_actors_detected` and `cluster_full_of_actors_detected_by_gcs` fields from the protobuf, as they are not used in autoscaler v2, and autoscaler v1 is scheduled for deletion soon.

## Related issues

None

## Additional information

The 2 fields are considered private, so they are deleted without maintaining backward compatibility.