### PR TITLE
[release auto] use env var for twine password

### DIFF
--- a/ci/ray_ci/automation/pypi_lib.py
+++ b/ci/ray_ci/automation/pypi_lib.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import sys
-from typing import List
+from typing import Dict, List
 
 from ray_release.aws import get_secret_token
 
@@ -32,8 +32,10 @@ def _get_pypi_token(pypi_env: str) -> str:
     return get_secret_token(AWS_SECRET_PYPI)
 
 
-def _call_subprocess(command: List[str]):
-    subprocess.run(command, check=True)
+def _call_subprocess(command: List[str], add_env: Dict[str, str]):
+    env = os.environ.copy()
+    env.update(add_env)
+    subprocess.run(command, env=env, check=True)
 
 
 def upload_wheels_to_pypi(pypi_env: str, directory_path: str) -> None:
@@ -52,8 +54,6 @@ def upload_wheels_to_pypi(pypi_env: str, directory_path: str) -> None:
             pypi_url,
             "--username",
             "__token__",
-            "--password",
-            pypi_token,
             wheel_path,
         ]
-        _call_subprocess(cmd)
+        _call_subprocess(cmd, add_env={"TWINE_PASSWORD": pypi_token})

--- a/ci/ray_ci/automation/test_pypi_lib.py
+++ b/ci/ray_ci/automation/test_pypi_lib.py
@@ -77,17 +77,20 @@ def test_upload_wheels_to_pypi(mock_subprocess, mock_get_pypi_url, mock_get_pypi
         assert mock_subprocess.call_count == len(wheels)
         for i, call_args in enumerate(mock_subprocess.call_args_list):
             command = call_args[0][0]
-            assert command[0] == sys.executable
-            assert command[1] == "-m"
-            assert command[2] == "twine"
-            assert command[3] == "upload"
-            assert command[4] == "--repository-url"
-            assert command[5] == "test_pypi_url"
-            assert command[6] == "--username"
-            assert command[7] == "__token__"
-            assert command[8] == "--password"
-            assert command[9] == "test_token"
-            assert command[10] in wheel_paths
+            assert command[:-1] == [
+                sys.executable,
+                "-m",
+                "twine",
+                "upload",
+                "--repository-url",
+                "test_pypi_url",
+                "--username",
+                "__token__",
+            ]
+            assert command[-1] in wheel_paths
+
+            add_env = call_args[1]["add_env"]
+            assert add_env["TWINE_PASSWORD"] == "test_token"
 
 
 @mock.patch("ci.ray_ci.automation.pypi_lib._get_pypi_token")


### PR DESCRIPTION
so that failed twine upload subprocess call will not print the token out in logs as part of the exception.
