### PR TITLE
[Data] Extract StreamingExecutor gauge init in separate func

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -117,7 +117,6 @@ class StreamingExecutor(Executor, threading.Thread):
         # by comparing it with the current timestamp.
         self._metrics_last_updated: float = 0.0
 
-        # Initialize metrics gauges
         self._initialize_metrics_gauges()
 
         Executor.__init__(self, self._data_context.execution_options)

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -117,6 +117,15 @@ class StreamingExecutor(Executor, threading.Thread):
         # by comparing it with the current timestamp.
         self._metrics_last_updated: float = 0.0
 
+        # Initialize metrics gauges
+        self._initialize_metrics_gauges()
+
+        Executor.__init__(self, self._data_context.execution_options)
+        thread_name = f"StreamingExecutor-{self._dataset_id}"
+        threading.Thread.__init__(self, daemon=True, name=thread_name)
+
+    def _initialize_metrics_gauges(self) -> None:
+        """Initialize all Prometheus-style metrics gauges for monitoring execution."""
         self._sched_loop_duration_s = Gauge(
             "data_sched_loop_duration_s",
             description="Duration of the scheduling loop in seconds",
@@ -148,10 +157,6 @@ class StreamingExecutor(Executor, threading.Thread):
             description="Maximum bytes to read from streaming generator buffer.",
             tag_keys=("dataset", "operator"),
         )
-
-        Executor.__init__(self, self._data_context.execution_options)
-        thread_name = f"StreamingExecutor-{self._dataset_id}"
-        threading.Thread.__init__(self, daemon=True, name=thread_name)
 
     def execute(
         self, dag: PhysicalOperator, initial_stats: Optional[DatasetStats] = None


### PR DESCRIPTION
## Description 

Extracts ~30 lines of gauge initialization code from `StreamingExecutor.__init__()` 
into `_initialize_metrics_gauges()` for better code organization and readability.