### PR TITLE
[Doc][Core] Add Documentation for Zero-Copy Tensor Serialization

### DIFF
--- a/doc/source/ray-core/objects/serialization.rst
+++ b/doc/source/ray-core/objects/serialization.rst
@@ -79,6 +79,52 @@ Serialization notes
 
 - Lock objects are mostly unserializable, because copying a lock is meaningless and could cause serious concurrency problems. You may have to come up with a workaround if your object contains a lock.
 
+Zero-Copy Serialization for Read-Only Tensors
+----------------------------------------------
+Ray provides zero-copy serialization for read-only PyTorch tensors. 
+Ray serializes these tensors by converting them to NumPy arrays and leveraging pickle5's zero-copy buffer sharing. 
+This avoids copying the underlying tensor data, which can improve performance when passing large tensors across tasks or actors.
+
+This feature is disabled by default.
+You can enable it by setting the environment variable `RAY_ENABLE_ZERO_COPY_TORCH_TENSORS = 1`.
+Here is an example:
+
+.. testcode::
+
+    import os
+
+    # Must be set before `import ray` to ensure that the feature is enabled in driver.
+    os.environ["RAY_ENABLE_ZERO_COPY_TORCH_TENSORS"] = "1"
+
+    import ray
+    import torch
+
+    ray.init(runtime_env={"env_vars": {"RAY_ENABLE_ZERO_COPY_TORCH_TENSORS": "1"}})
+
+    @ray.remote
+    def process(tensor):
+        return tensor.sum()
+
+    x = torch.ones(1024, 1024, 256)
+    result = ray.get(process.remote(x))
+
+Note that this should be used with caution as Ray won't copy and allow a write to shared memory.
+One process changing a tensor after `ray.get()` could be reflected in another process.
+This feature works best under the following conditions:
+
+- The tensor has `requires_grad=False` (i.e., is detached from the autograd graph).
+
+- The tensor is contiguous in memory.
+
+- Performance benefits from this are larger if the tensor resides in CPU memory.
+
+- You are not using Ray Direct Transport.
+
+Tensors on GPU or non-contiguous tensors are still supported.
+Ray automatically moves them to CPU and/or make them contiguous as needed.
+While this incurs an initial copy, subsequent serialization may still benefit from reduced overhead compared to the default path.
+Use with caution and ensure tensors meet the above criteria before enabling.
+
 Customized Serialization
 ------------------------
 

--- a/doc/source/ray-core/objects/serialization.rst
+++ b/doc/source/ray-core/objects/serialization.rst
@@ -90,6 +90,11 @@ You can enable it by setting the environment variable `RAY_ENABLE_ZERO_COPY_TORC
 Here is an example:
 
 .. testcode::
+    :hide:
+
+    ray.shutdown()
+
+.. testcode::
 
     import os
 

--- a/doc/source/ray-core/objects/serialization.rst
+++ b/doc/source/ray-core/objects/serialization.rst
@@ -86,7 +86,7 @@ Ray serializes these tensors by converting them to NumPy arrays and leveraging p
 This avoids copying the underlying tensor data, which can improve performance when passing large tensors across tasks or actors.
 
 This feature is disabled by default.
-You can enable it by setting the environment variable `RAY_ENABLE_ZERO_COPY_TORCH_TENSORS = 1`.
+You can enable it by setting the environment variable `RAY_ENABLE_ZERO_COPY_TORCH_TENSORS = "1"`.
 Here is an example:
 
 .. testcode::
@@ -117,7 +117,7 @@ Note that this should be used with caution as Ray won't copy and allow a write t
 One process changing a tensor after `ray.get()` could be reflected in another process.
 This feature works best under the following conditions:
 
-- The tensor has `requires_grad=False` (i.e., is detached from the autograd graph).
+- The tensor has `requires_grad = False` (i.e., is detached from the autograd graph).
 
 - The tensor is contiguous in memory.
 


### PR DESCRIPTION
## Description
The [PR](https://github.com/ray-project/ray/pull/57639) supporting zero-copy serialization for read-only tensors has been merged. We need to add documentation to inform users about this new feature. 

The docs should mention that torch tensors are not zero-copy by default, show an example of how to enable zero-copy, and most importantly explain the limitations and possible issues

@tianyi-ge 

## Related issues
Closes #59081
