### PR TITLE
[serve][llm][tests] Fix LLM DP release test

### DIFF
--- a/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
@@ -92,7 +92,7 @@ def test_llm_serve_data_parallelism():
         engine_kwargs=dict(
             tensor_parallel_size=1,
             pipeline_parallel_size=1,
-            data_parallel_size=2,  # 2 DP replicas
+            data_parallel_size=4,  # 4 DP replicas, need to fill 2x4GPU workers
             distributed_executor_backend="ray",
             max_model_len=512,
             max_num_batched_tokens=256,


### PR DESCRIPTION
Failing test:
```
test_llm_serve_multi_node_integration.py::test_llm_serve_data_parallelism
```

Issue:
Test configuration didn't fill 2x worker nodes, leading to flakiness if DP replicas scheduled across nodes.

Fix:
Change test configuration 2 -> 4 replicas to fill 2x worker nodes