### PR TITLE
[core] fix counter metric default branch

### DIFF
--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -198,14 +198,7 @@ class Counter(Metric):
         if self._discard_metric:
             self._metric = None
         else:
-            if env_bool("RAY_enable_open_telemetry", False):
-                """
-                For the previous opencensus implementation, we used Sum to support
-                exporting Counter as a gauge metric. We'll drop that feature in the
-                new opentelemetry implementation.
-                """
-                self._metric = CythonSum(self._name, self._description, self._tag_keys)
-            else:
+            if env_bool("RAY_enable_open_telemetry", True):
                 """
                 For the new opentelemetry implementation, we'll correctly use Counter
                 rather than Sum.
@@ -213,6 +206,13 @@ class Counter(Metric):
                 self._metric = CythonCount(
                     self._name, self._description, self._tag_keys
                 )
+            else:
+                """
+                For the previous opencensus implementation, we used Sum to support
+                exporting Counter as a gauge metric. We'll drop that feature in the
+                new opentelemetry implementation.
+                """
+                self._metric = CythonSum(self._name, self._description, self._tag_keys)
 
     def __reduce__(self):
         deserializer = self.__class__


### PR DESCRIPTION
`RAY_enable_open_telemetry` is now `True` (not `False`) by default. This means that we need to swap these if-branch clause. The current implementation means that if someone set `RAY_enable_open_telemetry=True` manually (which users don't have to but they might), it will go to the incorrect branch.

Test:
- CI