### PR TITLE
[core] change RAY_metric_cardinality_level default to recommended

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -578,7 +578,10 @@ RAY_ENABLE_UV_RUN_RUNTIME_ENV = env_bool("RAY_ENABLE_UV_RUN_RUNTIME_ENV", True)
 #   the component, including WorkerId, (task or actor) Name, etc. This is the default.
 # Recommended: report only the node level metrics to prometheus. This means that the
 #   WorkerId will be removed from all metrics.
-RAY_METRIC_CARDINALITY_LEVEL = os.environ.get("RAY_metric_cardinality_level", "legacy")
+# Low: Same as recommended, but also drop the Name label for tasks and actors.
+RAY_METRIC_CARDINALITY_LEVEL = os.environ.get(
+    "RAY_metric_cardinality_level", "recommended"
+)
 
 # Whether enable OpenTelemetry as the metrics collection backend. The default is
 # using OpenCensus.

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -77,10 +77,18 @@ import time
 ray.init("auto")
 
 @ray.remote
-def f():
+def a():
     time.sleep(999)
-a = [f.remote() for _ in range(10)]
-ray.get(a)
+
+@ray.remote
+def b():
+    time.sleep(999)
+
+@ray.remote
+def c():
+    time.sleep(999)
+
+ray.get([a.remote(), b.remote()] + [c.remote() for _ in range(8)])
 """
     proc = run_string_as_driver_nonblocking(driver)
     timeseries = PrometheusTimeseries()
@@ -94,8 +102,9 @@ ray.get(a)
         retry_interval_ms=500,
     )
     assert tasks_by_name_and_state(info, timeseries) == {
-        ("f", "RUNNING"): 2.0,
-        ("f", "PENDING_NODE_ASSIGNMENT"): 8.0,
+        ("a", "RUNNING"): 1.0,
+        ("b", "RUNNING"): 1.0,
+        ("c", "PENDING_NODE_ASSIGNMENT"): 8.0,
     }
     proc.kill()
 
@@ -110,12 +119,16 @@ import time
 ray.init("auto")
 
 @ray.remote(num_cpus=0)
-def f():
+def {func_name}():
     time.sleep(999)
-a = [f.remote() for _ in range(1)]
+a = [{func_name}.remote() for _ in range(1)]
 ray.get(a)
 """
-    procs = [run_string_as_driver_nonblocking(driver) for _ in range(3)]
+    # We make sure the task name is unique for each job so that we can distinguish the metric sample by task name across jobs.
+    procs = [
+        run_string_as_driver_nonblocking(driver.format(func_name=f"f_{i}"))
+        for i in range(3)
+    ]
 
     expected = {
         "RUNNING": 3.0,
@@ -150,10 +163,18 @@ ray.init("auto")
 @ray.remote(num_cpus=0)
 def wrapper():
     @ray.remote
-    def f():
+    def a():
         time.sleep(999)
 
-    ray.get([f.remote() for _ in range(10)])
+    @ray.remote
+    def b():
+        time.sleep(999)
+
+    @ray.remote
+    def c():
+        time.sleep(999)
+
+    ray.get([a.remote(), b.remote()] + [c.remote() for _ in range(8)])
 
 w = wrapper.remote()
 ray.get(w)
@@ -171,13 +192,14 @@ ray.get(w)
 
     wait_for_assertion(
         check_task_state,
-        timeout=20,
+        timeout=30,
         retry_interval_ms=2000,
     )
     assert tasks_by_name_and_state(info, timeseries) == {
         ("wrapper", "RUNNING_IN_RAY_GET"): 1.0,
-        ("f", "RUNNING"): 2.0,
-        ("f", "PENDING_NODE_ASSIGNMENT"): 8.0,
+        ("a", "RUNNING"): 1.0,
+        ("b", "RUNNING"): 1.0,
+        ("c", "PENDING_NODE_ASSIGNMENT"): 8.0,
     }
     proc.kill()
 
@@ -194,10 +216,18 @@ ray.init("auto")
 @ray.remote(num_cpus=0)
 def wrapper():
     @ray.remote
-    def f():
+    def a():
         time.sleep(999)
 
-    ray.wait([f.remote() for _ in range(10)])
+    @ray.remote
+    def b():
+        time.sleep(999)
+
+    @ray.remote
+    def c():
+        time.sleep(999)
+
+    ray.wait([a.remote(), b.remote()] + [c.remote() for _ in range(8)])
 
 w = wrapper.remote()
 ray.get(w)
@@ -215,13 +245,14 @@ ray.get(w)
 
     wait_for_assertion(
         check_task_state,
-        timeout=20,
+        timeout=30,
         retry_interval_ms=2000,
     )
     assert tasks_by_name_and_state(info, timeseries) == {
         ("wrapper", "RUNNING_IN_RAY_WAIT"): 1.0,
-        ("f", "RUNNING"): 2.0,
-        ("f", "PENDING_NODE_ASSIGNMENT"): 8.0,
+        ("a", "RUNNING"): 1.0,
+        ("b", "RUNNING"): 1.0,
+        ("c", "PENDING_NODE_ASSIGNMENT"): 8.0,
     }
     proc.kill()
 
@@ -583,17 +614,18 @@ import time
 ray.init("auto")
 
 @ray.remote
-def f():
+def {func_name}():
     pass
-a = [f.remote() for _ in range(10)]
+a = [{func_name}.remote() for _ in range(10)]
 ray.get(a)
 """
 
     # If force export at process death is broken, we won't see the recently completed
-    # tasks from the drivers.
+    # tasks from the drivers. We also make sure the task name is unique for each job so
+    # that we can distinguish the metric sample by task name across jobs.
     for i in range(10):
         print("Run job", i)
-        run_string_as_driver(driver)
+        run_string_as_driver(driver.format(func_name=f"f_{i}"))
         tasks_by_state(info, timeseries)
 
     expected = {
@@ -624,10 +656,19 @@ for _ in range(100):
     buf.append(ray.put(np.ones(10 * 1024 * 1024, dtype=np.uint8)))
 
 @ray.remote
-def f(x):
+def a(x):
     time.sleep(999)
 
-ray.get([f.remote(x) for x in buf])"""
+@ray.remote
+def b(x):
+    time.sleep(999)
+
+@ray.remote
+def c(x):
+    time.sleep(999)
+
+ray.get([a.remote(buf[0]), b.remote(buf[1])] + [c.remote(x) for x in buf[2:]])
+"""
 
     proc = run_string_as_driver_nonblocking(driver)
 


### PR DESCRIPTION
Change the default value of `RAY_metric_cardinality_level` to be recommended. Since `recommended` drops the `worker_id` label in `ray_tasks` and `ray_actors` metrics, some tests that rely on the uniqueness of labels to distinguish samples fail. To fix it, I force them to have unique task name, so that the sample can be uniquely identified by label set.

Test:
- CI