### PR TITLE
[release] updating read data release tests

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -20,7 +20,7 @@
 ###############
 
 - name: "read_parquet_{{scaling}}"
-
+  python: "3.10"
   cluster:
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 
@@ -36,7 +36,7 @@
       --iter-bundles
 
 - name: "read_large_parquet_{{scaling}}"
-
+  python: "3.10"
   cluster:
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 
@@ -52,7 +52,7 @@
       --iter-bundles
 
 - name: "read_images_{{scaling}}"
-
+  python: "3.10"
   cluster:
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 
@@ -75,7 +75,7 @@
       --iter-bundles
 
 - name: "read_from_uris_{{scaling}}"
-
+  python: "3.10"
   cluster:
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 


### PR DESCRIPTION
Upgrading read release tests to python 3.10

successful release test: https://buildkite.com/ray-project/release/builds/70449