### PR TITLE
[Data] Allow specifying partitioning style or flavor in write_parquet()

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4029,10 +4029,10 @@ class Dataset:
             options to pyarrow, there are some special cases:
 
             - `partitioning_flavor`: if it's not provided, default is "hive" in Ray Data.
-              Otherwise, it follows pyarrow's behavior: None for pyarrow's DirectoryPartitioning,
+              Otherwise, it follows pyarrow's behavior: `None` for pyarrow's DirectoryPartitioning,
               "hive" for HivePartitioning, and "filename" for FilenamePartitioning.
               See `pyarrow.dataset.partitioning` <https://arrow.apache.org/docs/python/generated/pyarrow.dataset.partitioning.html>_.
-            - `row_group_size`: if it's provided, it will be passed to
+            - `row_group_size`: if provided, it's passed to
               `pyarrow.parquet.ParquetWriter.write_table() <https:/\
                   /arrow.apache.org/docs/python/generated/pyarrow\
                       .parquet.ParquetWriter.html\

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3989,15 +3989,10 @@ class Dataset:
                     /arrow.apache.org/docs/python/generated/\
                         pyarrow.parquet.ParquetWriter.html>`_
                 when writing each block to a file. Overrides
-                any duplicate keys from ``arrow_parquet_args``. If `row_group_size` is
-                provided, it will be passed to
-                `pyarrow.parquet.ParquetWriter.write_table() <https:/\
-                    /arrow.apache.org/docs/python/generated/pyarrow\
-                        .parquet.ParquetWriter.html\
-                        #pyarrow.parquet.ParquetWriter.write_table>`_. Use this argument
+                any duplicate keys from ``arrow_parquet_args``. Use this argument
                 instead of ``arrow_parquet_args`` if any of your write arguments
                 can't pickled, or if you'd like to lazily resolve the write
-                arguments for each dataset block.
+                arguments for each dataset block. See the note below for more details.
             min_rows_per_file: [Experimental] The target minimum number of rows to write
                 to each file. If ``None``, Ray Data writes a system-chosen number of
                 rows to each file. If the number of rows per block is larger than the
@@ -4027,6 +4022,22 @@ class Dataset:
                 "ignore", "append". Defaults to "append".
                 NOTE: This method isn't atomic. "Overwrite" first deletes all the data
                 before writing to `path`.
+
+        .. note::
+
+            When using `arrow_parquet_args` or `arrow_parquet_args_fn` to pass extra
+            options to pyarrow, there are some special cases:
+
+            - `partitioning_flavor`: if it's not provided, default is "hive" in Ray Data.
+              Otherwise, it follows pyarrow's behavior: None for pyarrow's DirectoryPartitioning,
+              "hive" for HivePartitioning, and "filename" for FilenamePartitioning.
+              See `pyarrow.dataset.partitioning` <https://arrow.apache.org/docs/python/generated/pyarrow.dataset.partitioning.html>_.
+            - `row_group_size`: if it's provided, it will be passed to
+              `pyarrow.parquet.ParquetWriter.write_table() <https:/\
+                  /arrow.apache.org/docs/python/generated/pyarrow\
+                      .parquet.ParquetWriter.html\
+                      #pyarrow.parquet.ParquetWriter.write_table>`_.
+
         """  # noqa: E501
         if arrow_parquet_args_fn is None:
             arrow_parquet_args_fn = lambda: {}  # noqa: E731


### PR DESCRIPTION
## Description
Currently, `write_parquet` has been hard-coded to use `hive` partititoning. This PR allows passing `partitioning_flavor` via `arrow_parquet_args`/`arrow_parquet_args_fn`.

Since the default behaviors are different between Ray Data and pyarrow:
- Ray Data defaults to "hive", which is the case when we do not specify this `partitioning_flavor`
- pyarrow uses `None` to represent dictionary partitioning. So we can use partitioning_flavor=None

Also, I did not use the Partitioning class in `ray.data.read_parquet`, which seems to be overkill (e.g., we exposed `partition_cols` as top-level args here..)

Finally, I have rearranged the docstring a little bit.

## Related issues
NA

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
