### PR TITLE
[core] fix grpc_authentication_server_interceptors streaming response handling

### DIFF
--- a/python/ray/_private/authentication/grpc_authentication_client_interceptor.py
+++ b/python/ray/_private/authentication/grpc_authentication_client_interceptor.py
@@ -79,44 +79,77 @@ class SyncAuthenticationMetadataClientInterceptor(
         return continuation(new_details, request_iterator)
 
 
-class AsyncAuthenticationMetadataClientInterceptor(
-    aiogrpc.UnaryUnaryClientInterceptor,
-    aiogrpc.UnaryStreamClientInterceptor,
-    aiogrpc.StreamUnaryClientInterceptor,
-    aiogrpc.StreamStreamClientInterceptor,
-):
-    """Async gRPC client interceptor that adds authentication metadata."""
+def _intercept_call_details_async(client_call_details):
+    """Helper to add authentication metadata to client call details (async version)."""
+    metadata = list(client_call_details.metadata or [])
+    metadata.extend(_get_authentication_metadata_tuple())
 
-    def _intercept_call_details(self, client_call_details):
-        """Helper method to add authentication metadata to client call details."""
-        metadata = list(client_call_details.metadata or [])
-        metadata.extend(_get_authentication_metadata_tuple())
+    return _ClientCallDetails(
+        method=client_call_details.method,
+        timeout=client_call_details.timeout,
+        metadata=metadata,
+        credentials=client_call_details.credentials,
+        wait_for_ready=getattr(client_call_details, "wait_for_ready", None),
+        compression=getattr(client_call_details, "compression", None),
+    )
 
-        return _ClientCallDetails(
-            method=client_call_details.method,
-            timeout=client_call_details.timeout,
-            metadata=metadata,
-            credentials=client_call_details.credentials,
-            wait_for_ready=getattr(client_call_details, "wait_for_ready", None),
-            compression=getattr(client_call_details, "compression", None),
-        )
+
+# NOTE: gRPC aio's Channel.__init__ uses if-elif chains to categorize interceptors,
+# so a single class inheriting from multiple interceptor types will only be registered
+# for the first matching type. We must use separate classes for each RPC type.
+# See: https://github.com/grpc/grpc/blob/master/src/python/grpcio/grpc/aio/_channel.py
+
+
+class _AsyncUnaryUnaryAuthInterceptor(aiogrpc.UnaryUnaryClientInterceptor):
+    """Async unary-unary interceptor that adds authentication metadata."""
 
     async def intercept_unary_unary(self, continuation, client_call_details, request):
-        new_details = self._intercept_call_details(client_call_details)
+        new_details = _intercept_call_details_async(client_call_details)
         return await continuation(new_details, request)
 
+
+class _AsyncUnaryStreamAuthInterceptor(aiogrpc.UnaryStreamClientInterceptor):
+    """Async unary-stream interceptor that adds authentication metadata."""
+
     async def intercept_unary_stream(self, continuation, client_call_details, request):
-        new_details = self._intercept_call_details(client_call_details)
+        new_details = _intercept_call_details_async(client_call_details)
         return await continuation(new_details, request)
+
+
+class _AsyncStreamUnaryAuthInterceptor(aiogrpc.StreamUnaryClientInterceptor):
+    """Async stream-unary interceptor that adds authentication metadata."""
 
     async def intercept_stream_unary(
         self, continuation, client_call_details, request_iterator
     ):
-        new_details = self._intercept_call_details(client_call_details)
+        new_details = _intercept_call_details_async(client_call_details)
         return await continuation(new_details, request_iterator)
+
+
+class _AsyncStreamStreamAuthInterceptor(aiogrpc.StreamStreamClientInterceptor):
+    """Async stream-stream interceptor that adds authentication metadata."""
 
     async def intercept_stream_stream(
         self, continuation, client_call_details, request_iterator
     ):
-        new_details = self._intercept_call_details(client_call_details)
+        new_details = _intercept_call_details_async(client_call_details)
         return await continuation(new_details, request_iterator)
+
+
+def get_async_auth_interceptors():
+    """Get a list of async authentication interceptors for all RPC types.
+
+    Returns a list of separate interceptor instances, one for each RPC type,
+    because gRPC aio channels only register multi-inheritance interceptors
+    for the first matching type.
+
+    Returns:
+        List of interceptor instances for unary-unary, unary-stream,
+        stream-unary, and stream-stream RPCs.
+    """
+    return [
+        _AsyncUnaryUnaryAuthInterceptor(),
+        _AsyncUnaryStreamAuthInterceptor(),
+        _AsyncStreamUnaryAuthInterceptor(),
+        _AsyncStreamStreamAuthInterceptor(),
+    ]

--- a/python/ray/_private/authentication/grpc_authentication_server_interceptor.py
+++ b/python/ray/_private/authentication/grpc_authentication_server_interceptor.py
@@ -71,6 +71,14 @@ class AsyncAuthenticationServerInterceptor(aiogrpc.ServerInterceptor):
         if handler is None:
             return None
 
+        async def _abort_if_unauthenticated(context):
+            """Abort the RPC if authentication fails."""
+            if not _authenticate_request(context.invocation_metadata()):
+                await context.abort(
+                    grpc.StatusCode.UNAUTHENTICATED,
+                    "Invalid or missing authentication token",
+                )
+
         # Wrap the RPC behavior with authentication check
         def wrap_unary_response(behavior):
             """Wrap a unary response RPC method to validate authentication first."""
@@ -78,11 +86,7 @@ class AsyncAuthenticationServerInterceptor(aiogrpc.ServerInterceptor):
                 return None
 
             async def wrapped(request_or_iterator, context):
-                if not _authenticate_request(context.invocation_metadata()):
-                    await context.abort(
-                        grpc.StatusCode.UNAUTHENTICATED,
-                        "Invalid or missing authentication token",
-                    )
+                await _abort_if_unauthenticated(context)
                 return await behavior(request_or_iterator, context)
 
             return wrapped
@@ -93,11 +97,7 @@ class AsyncAuthenticationServerInterceptor(aiogrpc.ServerInterceptor):
                 return None
 
             async def wrapped(request_or_iterator, context):
-                if not _authenticate_request(context.invocation_metadata()):
-                    await context.abort(
-                        grpc.StatusCode.UNAUTHENTICATED,
-                        "Invalid or missing authentication token",
-                    )
+                await _abort_if_unauthenticated(context)
                 async for response in behavior(request_or_iterator, context):
                     yield response
 

--- a/python/ray/_private/authentication/grpc_authentication_server_interceptor.py
+++ b/python/ray/_private/authentication/grpc_authentication_server_interceptor.py
@@ -72,8 +72,8 @@ class AsyncAuthenticationServerInterceptor(aiogrpc.ServerInterceptor):
             return None
 
         # Wrap the RPC behavior with authentication check
-        def wrap_rpc_behavior(behavior):
-            """Wrap an RPC method to validate authentication first."""
+        def wrap_unary_response(behavior):
+            """Wrap a unary response RPC method to validate authentication first."""
             if behavior is None:
                 return None
 
@@ -87,13 +87,32 @@ class AsyncAuthenticationServerInterceptor(aiogrpc.ServerInterceptor):
 
             return wrapped
 
+        def wrap_stream_response(behavior):
+            """Wrap a streaming response RPC method to validate authentication first."""
+            if behavior is None:
+                return None
+
+            async def wrapped(request_or_iterator, context):
+                if not _authenticate_request(context.invocation_metadata()):
+                    await context.abort(
+                        grpc.StatusCode.UNAUTHENTICATED,
+                        "Invalid or missing authentication token",
+                    )
+                async for response in behavior(request_or_iterator, context):
+                    yield response
+
+            return wrapped
+
         # Create a wrapper class that implements RpcMethodHandler interface
         class AuthenticatedHandler:
             """Wrapper handler that validates authentication."""
 
-            def __init__(self, original_handler, wrapper_func):
+            def __init__(
+                self, original_handler, unary_wrapper_func, stream_wrapper_func
+            ):
                 self._original = original_handler
-                self._wrap = wrapper_func
+                self._wrap_unary = unary_wrapper_func
+                self._wrap_stream = stream_wrapper_func
 
             @property
             def request_streaming(self):
@@ -113,21 +132,21 @@ class AsyncAuthenticationServerInterceptor(aiogrpc.ServerInterceptor):
 
             @property
             def unary_unary(self):
-                return self._wrap(self._original.unary_unary)
+                return self._wrap_unary(self._original.unary_unary)
 
             @property
             def unary_stream(self):
-                return self._wrap(self._original.unary_stream)
+                return self._wrap_stream(self._original.unary_stream)
 
             @property
             def stream_unary(self):
-                return self._wrap(self._original.stream_unary)
+                return self._wrap_unary(self._original.stream_unary)
 
             @property
             def stream_stream(self):
-                return self._wrap(self._original.stream_stream)
+                return self._wrap_stream(self._original.stream_stream)
 
-        return AuthenticatedHandler(handler, wrap_rpc_behavior)
+        return AuthenticatedHandler(handler, wrap_unary_response, wrap_stream_response)
 
 
 class SyncAuthenticationServerInterceptor(grpc.ServerInterceptor):

--- a/python/ray/_private/grpc_utils.py
+++ b/python/ray/_private/grpc_utils.py
@@ -50,12 +50,12 @@ def init_grpc_channel(
     interceptors = []
     if authentication_utils.is_token_auth_enabled():
         from ray._private.authentication.grpc_authentication_client_interceptor import (
-            AsyncAuthenticationMetadataClientInterceptor,
             SyncAuthenticationMetadataClientInterceptor,
+            get_async_auth_interceptors,
         )
 
         if asynchronous:
-            interceptors.append(AsyncAuthenticationMetadataClientInterceptor())
+            interceptors.extend(get_async_auth_interceptors())
         else:
             interceptors.append(SyncAuthenticationMetadataClientInterceptor())
 


### PR DESCRIPTION
## Description
Fix async gRPC server interceptor for streaming responses The AsyncAuthenticationServerInterceptor was incorrectly using `await behavior(...)` for all RPC types. For streaming responses (`unary_stream`, `stream_stream`), the handler returns an async generator which cannot be awaited—it must be iterated with` async for`. This caused `StreamLog` and other streaming RPCs to fail with:

`TypeError: object async_generator can't be used in 'await' expression`

Fix: Split the wrapper into `wrap_unary_response` (uses await) and `wrap_stream_response` (uses async for ... yield), applied based on response type. 
Tests: Added streaming RPC tests for both sync and async interceptors.
