### PR TITLE
[core] Cleaning up the code to remove support for returning multiple values per streaming generator report.

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3170,10 +3170,11 @@ Status CoreWorker::ReportGeneratorItemReturns(
   request.set_attempt_number(attempt_number);
   auto client = core_worker_client_pool_->GetOrConnect(caller_address);
 
+  // This means it is the last report when the task has finished executing.
   if (!dynamic_return_object.first.IsNil()) {
-    auto return_object_proto = request.add_dynamic_return_objects();
-    SerializeReturnObject(
-        dynamic_return_object.first, dynamic_return_object.second, return_object_proto);
+    SerializeReturnObject(dynamic_return_object.first,
+                          dynamic_return_object.second,
+                          request.mutable_returned_object());
     std::vector<ObjectID> deleted;
     // When we allocate a dynamic return ID (AllocateDynamicReturnId),
     // we borrow the object. When the object value is allocatd, the

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -770,7 +770,7 @@ class CoreWorker {
   /// NOTE: The API doesn't guarantee the ordering of the report. The
   /// caller is supposed to reorder the report based on the item_index.
   ///
-  /// \param[in] dynamic_return_object A intermediate ray object to report
+  /// \param[in] returned_object A intermediate ray object to report
   /// to the caller before the task terminates. This object must have been
   /// created dynamically from this worker via AllocateReturnObject.
   /// If the Object ID is nil, it means it is the end of the task return.
@@ -787,7 +787,7 @@ class CoreWorker {
   /// \param[in] waiter The class to pause the thread if generator backpressure limit
   /// is reached.
   Status ReportGeneratorItemReturns(
-      const std::pair<ObjectID, std::shared_ptr<RayObject>> &dynamic_return_object,
+      const std::pair<ObjectID, std::shared_ptr<RayObject>> &returned_object,
       const ObjectID &generator_id,
       const rpc::Address &caller_address,
       int64_t item_index,

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -811,10 +811,10 @@ bool TaskManager::HandleReportGeneratorItemReturns(
     execution_signal_callback(Status::NotFound("Stream is already deleted"), -1);
     return false;
   }
+  size_t num_objects_written = 0;
 
   if (request.has_returned_object()) {
     const rpc::ReturnObject &returned_object = request.returned_object();
-    size_t num_objects_written = 0;
     const auto object_id = ObjectID::FromBinary(returned_object.object_id());
 
     RAY_LOG(DEBUG) << "Write an object " << object_id

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -812,34 +812,35 @@ bool TaskManager::HandleReportGeneratorItemReturns(
     return false;
   }
 
-  // TODO(sang): Support the regular return values as well.
+  const rpc::ReturnObject &returned_object = request.returned_object();
+
   size_t num_objects_written = 0;
-  for (const auto &return_object : request.dynamic_return_objects()) {
-    const auto object_id = ObjectID::FromBinary(return_object.object_id());
+  // for (const auto &return_object : request.dynamic_return_objects()) {
+  const auto object_id = ObjectID::FromBinary(returned_object.object_id());
 
-    RAY_LOG(DEBUG) << "Write an object " << object_id
-                   << " to the object ref stream of id " << generator_id;
-    auto index_not_used_yet = stream_it->second.InsertToStream(object_id, item_index);
+  RAY_LOG(DEBUG) << "Write an object " << object_id << " to the object ref stream of id "
+                 << generator_id;
+  auto index_not_used_yet = stream_it->second.InsertToStream(object_id, item_index);
 
-    // If the ref was written to a stream, we should also
-    // own the dynamically generated task return.
-    // NOTE: If we call this method while holding a lock, it can deadlock.
-    if (index_not_used_yet) {
-      reference_counter_.OwnDynamicStreamingTaskReturnRef(object_id, generator_id);
-      num_objects_written += 1;
-    }
-    // When an object is reported, the object is ready to be fetched.
-    reference_counter_.UpdateObjectPendingCreation(object_id, false);
-    StatusOr<bool> put_res =
-        HandleTaskReturn(object_id,
-                         return_object,
-                         NodeID::FromBinary(request.worker_addr().node_id()),
-                         /*store_in_plasma=*/store_in_plasma_ids.contains(object_id));
-    if (!put_res.ok()) {
-      RAY_LOG(WARNING).WithField(object_id)
-          << "Failed to handle streaming dynamic return: " << put_res.status();
-    }
+  // If the ref was written to a stream, we should also
+  // own the dynamically generated task return.
+  // NOTE: If we call this method while holding a lock, it can deadlock.
+  if (index_not_used_yet) {
+    reference_counter_.OwnDynamicStreamingTaskReturnRef(object_id, generator_id);
+    num_objects_written += 1;
   }
+  // When an object is reported, the object is ready to be fetched.
+  reference_counter_.UpdateObjectPendingCreation(object_id, false);
+  StatusOr<bool> put_res =
+      HandleTaskReturn(object_id,
+                       returned_object,
+                       NodeID::FromBinary(request.worker_addr().node_id()),
+                       /*store_in_plasma=*/store_in_plasma_ids.contains(object_id));
+  if (!put_res.ok()) {
+    RAY_LOG(WARNING).WithField(object_id)
+        << "Failed to handle streaming dynamic return: " << put_res.status();
+  }
+  // }
 
   // Handle backpressure if needed.
   auto total_generated = stream_it->second.TotalNumObjectWritten();

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -815,7 +815,6 @@ bool TaskManager::HandleReportGeneratorItemReturns(
   const rpc::ReturnObject &returned_object = request.returned_object();
 
   size_t num_objects_written = 0;
-  // for (const auto &return_object : request.dynamic_return_objects()) {
   const auto object_id = ObjectID::FromBinary(returned_object.object_id());
 
   RAY_LOG(DEBUG) << "Write an object " << object_id << " to the object ref stream of id "
@@ -840,7 +839,6 @@ bool TaskManager::HandleReportGeneratorItemReturns(
     RAY_LOG(WARNING).WithField(object_id)
         << "Failed to handle streaming dynamic return: " << put_res.status();
   }
-  // }
 
   // Handle backpressure if needed.
   auto total_generated = stream_it->second.TotalNumObjectWritten();

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -90,7 +90,6 @@ rpc::ReportGeneratorItemReturnsRequest GetIntermediateTaskReturn(
   request.set_item_index(idx);
   request.set_generator_id(generator_id.Binary());
   rpc::ReturnObject *returned_object = request.mutable_returned_object();
-  // auto dynamic_return_object = request.add_dynamic_return_objects();
   returned_object->set_object_id(dynamic_return_id.Binary());
   returned_object->set_data(data->Data(), data->Size());
   returned_object->set_in_plasma(set_in_plasma);

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -89,10 +89,11 @@ rpc::ReportGeneratorItemReturnsRequest GetIntermediateTaskReturn(
   request.mutable_worker_addr()->CopyFrom(addr);
   request.set_item_index(idx);
   request.set_generator_id(generator_id.Binary());
-  auto dynamic_return_object = request.add_dynamic_return_objects();
-  dynamic_return_object->set_object_id(dynamic_return_id.Binary());
-  dynamic_return_object->set_data(data->Data(), data->Size());
-  dynamic_return_object->set_in_plasma(set_in_plasma);
+  rpc::ReturnObject *returned_object = request.mutable_returned_object();
+  // auto dynamic_return_object = request.add_dynamic_return_objects();
+  returned_object->set_object_id(dynamic_return_id.Binary());
+  returned_object->set_data(data->Data(), data->Size());
+  returned_object->set_in_plasma(set_in_plasma);
   return request;
 }
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -423,9 +423,8 @@ message NumPendingTasksReply {
 }
 
 message ReportGeneratorItemReturnsRequest {
-  // The intermediate return object that's dynamically
-  // generated from the executor side.
-  repeated ReturnObject dynamic_return_objects = 1;
+  // Object returned from the executor (can be inlined or in plasma).
+  ReturnObject returned_object = 1;
   // The address of the executor.
   Address worker_addr = 2;
   // The index of the task return. It is used to


### PR DESCRIPTION
The streaming generator sends a "report" from the executor to the submitter for each output that is yielded. In practice, the code only supports a single value per report. 

In this PR I am 
1. Cleaning up the protobuf/grpc code to use a single returned value per report
2. Removing "dynamic" from the code path to minimize confusion between the streaming generator and dynamic returns. 