### PR TITLE
[core] Temporarily skip `test_tensor_zero_copy_serialization.py`

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -640,6 +640,8 @@ py_test_module_list(
     files = [
         "gpu_objects/test_gpu_objects_nccl.py",
         "gpu_objects/test_gpu_objects_nixl.py",
+        # TODO: re-enable. Temporarily skipped due to postmerge failures.
+        # "test_tensor_zero_copy_serialization.py",
     ],
     tags = [
         "custom_setup",

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -640,7 +640,6 @@ py_test_module_list(
     files = [
         "gpu_objects/test_gpu_objects_nccl.py",
         "gpu_objects/test_gpu_objects_nixl.py",
-        "test_tensor_zero_copy_serialization.py",
     ],
     tags = [
         "custom_setup",

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -640,8 +640,7 @@ py_test_module_list(
     files = [
         "gpu_objects/test_gpu_objects_nccl.py",
         "gpu_objects/test_gpu_objects_nixl.py",
-        # TODO: re-enable. Temporarily skipped due to postmerge failures.
-        # "test_tensor_zero_copy_serialization.py",
+        "test_tensor_zero_copy_serialization.py",
     ],
     tags = [
         "custom_setup",

--- a/python/ray/tests/test_tensor_zero_copy_serialization.py
+++ b/python/ray/tests/test_tensor_zero_copy_serialization.py
@@ -167,7 +167,7 @@ def test_cpu_tensor_serialization(ray_start_cluster_with_zero_copy_tensors):
         assert_tensors_equivalent(obj, restored2)
 
 
-@pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
+@pytest.mark.skip(reason="GPU test is currently failing.")
 def test_gpu_tensor_serialization(ray_start_cluster_with_zero_copy_tensors):
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")


### PR DESCRIPTION
Skip this test for now because it's failing on postmerge.

We should have a CPU-only version that runs on premerge and a GPU version on postmerge.