### PR TITLE
[Chore] Remove broken symlinks pointing to deleted files

### DIFF
--- a/python/ray/air/examples/lightgbm_example.ipynb
+++ b/python/ray/air/examples/lightgbm_example.ipynb
@@ -1,1 +1,0 @@
-../../../../doc/source/ray-air/examples/lightgbm_example.ipynb

--- a/python/ray/air/examples/sklearn_example.ipynb
+++ b/python/ray/air/examples/sklearn_example.ipynb
@@ -1,1 +1,0 @@
-../../../../doc/source/ray-air/examples/sklearn_example.ipynb

--- a/python/ray/air/examples/upload_to_comet_ml.ipynb
+++ b/python/ray/air/examples/upload_to_comet_ml.ipynb
@@ -1,1 +1,0 @@
-../../../../doc/source/ray-air/examples/upload_to_comet_ml.ipynb

--- a/python/ray/air/examples/upload_to_wandb.ipynb
+++ b/python/ray/air/examples/upload_to_wandb.ipynb
@@ -1,1 +1,0 @@
-../../../../doc/source/ray-air/examples/upload_to_wandb.ipynb

--- a/python/ray/air/examples/xgboost_example.ipynb
+++ b/python/ray/air/examples/xgboost_example.ipynb
@@ -1,1 +1,0 @@
-../../../../doc/source/ray-air/examples/xgboost_example.ipynb

--- a/release/air_examples/opt_deepspeed_batch_inference/opt_deepspeed_batch_inference.ipynb
+++ b/release/air_examples/opt_deepspeed_batch_inference/opt_deepspeed_batch_inference.ipynb
@@ -1,1 +1,0 @@
-../../../doc/source/ray-air/examples/opt_deepspeed_batch_inference.ipynb

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,1 +1,0 @@
-../ci/lint/format.sh


### PR DESCRIPTION
## Description
These symlinks point to deleted files and show up as unstaged changes, causing annoyance when checking out branches or stashing changes. E.g., I try to check out a branch and it fails:
```
(base) ray@ip-10-1-135-48:~/default/work/ray$ gh pr checkout 58366
remote: Enumerating objects: 246, done.
remote: Counting objects: 100% (154/154), done.
remote: Total 246 (delta 154), reused 154 (delta 154), pack-reused 92 (from 1)
Receiving objects: 100% (246/246), 38.01 KiB | 5.43 MiB/s, done.
Resolving deltas: 100% (193/193), completed with 28 local objects.
From https://github.com/ray-project/ray
 ! [rejected]              refs/pull/58366/head -> feature/serve-sglang  (non-fast-forward)
exit status 1
```

Due to these "unstaged changes":
```
(base) ray@ip-10-1-135-48:~/default/work/ray$ git status
On branch fix-prefix-router-pd-dp
Your branch is up to date with 'origin/fix-prefix-router-pd-dp'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    python/ray/air/examples/lightgbm_example.ipynb
        deleted:    python/ray/air/examples/sklearn_example.ipynb
        deleted:    python/ray/air/examples/upload_to_comet_ml.ipynb
        deleted:    python/ray/air/examples/upload_to_wandb.ipynb
        deleted:    python/ray/air/examples/xgboost_example.ipynb
        deleted:    release/air_examples/opt_deepspeed_batch_inference/opt_deepspeed_batch_inference.ipynb
        deleted:    scripts/format.sh

no changes added to commit (use "git add" and/or "git commit -a")
```

## Solution
Delete the broken symlinks

## Background (via Claude)
Here's what happened:

**The setup (June 2022, commit 4b9a89ad90)**:
When Ray AIR was created, they put symlinks in `python/ray/air/examples/` that pointed to the actual notebooks in `doc/source/ray-air/examples/`. This way the examples lived in docs but were also accessible from the package.

**The breakage (Sept 2023, commit 85186b67b4)**:
PR #39298 "[air] move doc_code and examples into respective libraries" reorganized the docs — it moved/deleted `doc/source/ray-air/examples/` contents to other places like `doc/source/train/examples/`. But it forgot to delete the symlinks that pointed to the old locations.

**For `scripts/format.sh`**:
Same story — it was a symlink to `ci/lint/format.sh` which was deleted at some point.
So yes, they're real symlinks — just orphaned ones where the targets were cleaned up but the symlinks weren't. Classic refactoring oversight.