### PR TITLE
[Core]Fix: `ClusterSizeBasedLeaseRequestRateLimiter` incorrectly calculates the number of alive nodes.

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1549,3 +1549,13 @@ def setup_cluster_without_token_auth(cleanup_auth_token_env):
     finally:
         ray.shutdown()
         cluster.shutdown()
+
+
+@pytest.fixture
+def set_debug_info():
+    old_env = os.environ.copy()
+    os.environ["RAY_BACKEND_LOG_LEVEL"] = "debug"
+    yield
+    os.environ.pop("RAY_BACKEND_LOG_LEVEL", None)
+    os.environ.update(old_env)
+    

--- a/src/ray/core_worker/task_submission/normal_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.cc
@@ -821,7 +821,8 @@ void ClusterSizeBasedLeaseRequestRateLimiter::OnNodeChanges(
   } else {
     num_alive_nodes_++;
   }
-  RAY_LOG_EVERY_MS(INFO, 60000) << "Number of alive nodes:" << num_alive_nodes_.load();
+  RAY_LOG_EVERY_MS_OR(INFO, 60000, DEBUG)
+      << "Number of alive nodes:" << num_alive_nodes_.load();
 }
 
 }  // namespace core


### PR DESCRIPTION

## Description
`ClusterSizeBasedLeaseRequestRateLimiter` calculates the `num_alive_nodes_`  by subscribing to NodeInfo.
In short, it  +1 for every node that becomes Alive and -1 when a becomes Dead.
However, the subscription starts with a RPC GetAllNodes and then watches subsequent NodeInfo changes.
Nodes that are already Dead in that initial snapshot must not be subtracted, because `ClusterSizeBasedLeaseRequestRateLimiter` never saw them while they were Alive and therefore never included them in the `num_alive_nodes_` counter in the first place.

The fix is to replace the simple counter with a flat_hash_set.

## Related issues
Fixes #59131
## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
