### PR TITLE
[Core]Fix: `ClusterSizeBasedLeaseRequestRateLimiter` incorrectly calculates the number of alive nodes.save

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1549,3 +1549,13 @@ def setup_cluster_without_token_auth(cleanup_auth_token_env):
     finally:
         ray.shutdown()
         cluster.shutdown()
+
+
+@pytest.fixture
+def set_debug_info():
+    old_env = os.environ.copy()
+    os.environ["RAY_BACKEND_LOG_LEVEL"] = "debug"
+    yield
+    os.environ.pop("RAY_BACKEND_LOG_LEVEL", None)
+    os.environ.update(old_env)
+    

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1556,6 +1556,5 @@ def set_debug_info():
     old_env = os.environ.copy()
     os.environ["RAY_BACKEND_LOG_LEVEL"] = "debug"
     yield
-    os.environ.pop("RAY_BACKEND_LOG_LEVEL", None)
+    os.environ.clear()
     os.environ.update(old_env)
-    

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -428,7 +428,9 @@ def test_core_worker_alive_node(ray_start_cluster, set_debug_info):
 
     driver_path = None
     for file in os.listdir(log_dir):
-        if file.startswith("python-core-driver-01000000ffffffffffffffffffffffffffffffffffffffffffffffff"):
+        if file.startswith(
+            "python-core-driver-01000000ffffffffffffffffffffffffffffffffffffffffffffffff"
+        ):
             driver_path = os.path.join(log_dir, file)
             break
     assert driver_path is not None
@@ -446,7 +448,9 @@ def test_core_worker_alive_node(ray_start_cluster, set_debug_info):
         return alive_node_number
 
     _ = cluster.add_node(node_name="worker_0", resources={"worker": 10}, num_cpus=10)
-    worker_1 = cluster.add_node(node_name="worker_1", resources={"worker": 10}, num_cpus=10)
+    worker_1 = cluster.add_node(
+        node_name="worker_1", resources={"worker": 10}, num_cpus=10
+    )
 
     wait_for_condition(lambda: get_alive_node_number(driver_path) == 3)
     cluster.remove_node(worker_1)
@@ -456,19 +460,18 @@ def test_core_worker_alive_node(ray_start_cluster, set_debug_info):
     class A:
         def getpid(self):
             return os.getpid()
+
     a = A.remote()
     a_pid = ray.get(a.getpid.remote())
 
     a_log_path = None
     for file in os.listdir(log_dir):
-        if file.startswith("python-core-worker-") and file.endswith(
-            f"_{a_pid}.log"
-        ):
+        if file.startswith("python-core-worker-") and file.endswith(f"_{a_pid}.log"):
             a_log_path = os.path.join(log_dir, file)
             break
     assert a_log_path is not None
     assert get_alive_node_number(a_log_path) == 2
-    
+
 
 if __name__ == "__main__":
     # Make subprocess happy in bazel.

--- a/src/ray/core_worker/task_submission/normal_task_submitter.h
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.h
@@ -74,7 +74,9 @@ class ClusterSizeBasedLeaseRequestRateLimiter : public LeaseRequestRateLimiter {
 
  private:
   const size_t min_concurrent_lease_cap_;
-  std::atomic<size_t> num_alive_nodes_;
+  absl::Mutex mutex_;
+  // NodeID
+  absl::flat_hash_set<std::string> alive_nodes_ ABSL_GUARDED_BY(mutex_);
 };
 
 // This class is thread-safe.


### PR DESCRIPTION
## Description
`ClusterSizeBasedLeaseRequestRateLimiter` calculates the `num_alive_nodes_`  by subscribing to NodeInfo.
In short, it  +1 for every node that becomes Alive and -1 when a becomes Dead.
However, the subscription starts with a RPC GetAllNodes and then watches subsequent NodeInfo changes.
Nodes that are already Dead in that initial snapshot must not be subtracted, because `ClusterSizeBasedLeaseRequestRateLimiter` never saw them while they were Alive and therefore never included them in the `num_alive_nodes_` counter in the first place.

The fix is to replace the simple counter with a flat_hash_set.

## Related issues
Fixes #59131
## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
