### PR TITLE
[Data] Fix redundant `create_dir` calls in ParquetDatasink

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -152,7 +152,7 @@ class ParquetDatasink(_FileDatasink):
         super().__init__(
             path,
             filesystem=filesystem,
-            try_create_dir=try_create_dir,
+            try_create_dir=False,
             open_stream_args=open_stream_args,
             filename_provider=filename_provider,
             dataset_uuid=dataset_uuid,
@@ -288,7 +288,6 @@ class ParquetDatasink(_FileDatasink):
             max_rows_per_group=max_rows_per_group,
             max_rows_per_file=max_rows_per_file,
             file_options=ds.ParquetFileFormat().make_write_options(**write_kwargs),
-            create_dir=False,  # Directory is already created by _FileDatasink.on_write_start()
         )
 
     @property

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -288,6 +288,7 @@ class ParquetDatasink(_FileDatasink):
             max_rows_per_group=max_rows_per_group,
             max_rows_per_file=max_rows_per_file,
             file_options=ds.ParquetFileFormat().make_write_options(**write_kwargs),
+            create_dir=False,  # Directory is already created by _FileDatasink.on_write_start()
         )
 
     @property


### PR DESCRIPTION
## Description
In `ParquetDatasink` both `FileDatasink` and `write_dataset` is trying to create directory.

This PR address the problem and only let `FileDatasink` handle the creation. 

## Related issues
Closes #59082

