### PR TITLE
[bazel] nit: add comment for '-Wconversion-null' info log

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -13,6 +13,8 @@ COPTS_TESTS = select({
     ],
     "//conditions:default": [
         "-Wunused-result",
+        # TODO(andrew): -Wconversion-null can be moved to cxxopts for related rules_cc targets once rules_cc upgraded.
+        # This will fix info warning when building src/ray/thirdparty/aligned_alloc.c
         "-Wconversion-null",
         "-Wno-misleading-indentation",
         "-Wimplicit-fallthrough",


### PR DESCRIPTION
Bumped into this while running a 'bazel build //:gen_ray_pkg'. Added a note in case others run into the same and try to update to cxxopts

```
$ bazel build //:gen_ray_pkg
...
INFO: From Compiling src/ray/thirdparty/aligned_alloc.c:
cc1: warning: command line option '-Wconversion-null' is valid for C++/ObjC++ but not for C
```