### PR TITLE
[data] Combine repartitions

### DIFF
--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -8,6 +8,7 @@ from ray.data._internal.logical.interfaces import (
     Plan,
     Rule,
 )
+from ray.data._internal.logical.rules.combine_repartitions import CombineRepartitions
 from ray.data._internal.logical.rules.configure_map_task_memory import (
     ConfigureMapTaskMemoryUsingOutputSize,
 )
@@ -28,6 +29,7 @@ _LOGICAL_RULESET = Ruleset(
         LimitPushdownRule,
         ProjectionPushdown,
         PredicatePushdown,
+        CombineRepartitions,
     ]
 )
 

--- a/python/ray/data/_internal/logical/rules/combine_repartitions.py
+++ b/python/ray/data/_internal/logical/rules/combine_repartitions.py
@@ -1,0 +1,55 @@
+from ray.data._internal.logical.interfaces import (
+    LogicalOperator,
+    LogicalPlan,
+    Plan,
+    Rule,
+)
+from ray.data._internal.logical.operators.all_to_all_operator import Repartition
+from ray.data._internal.logical.operators.map_operator import StreamingRepartition
+
+
+class CombineRepartitions(Rule):
+    """This logical rule combines chained ``Repartition`` and
+    ``StreamingRepartition`` ops fusing them into a single one.
+    """
+
+    def apply(self, plan: Plan) -> Plan:
+        assert isinstance(plan, LogicalPlan)
+
+        def _combine_repartitions(op: LogicalOperator) -> LogicalOperator:
+            # Repartitions should have exactly 1 input
+            if len(op.input_dependencies) != 1:
+                return op
+
+            input_op = op.input_dependencies[0]
+
+            if isinstance(op, Repartition) and isinstance(input_op, Repartition):
+                shuffle = input_op._shuffle or op._shuffle
+                return Repartition(
+                    input_op.input_dependencies[0],
+                    num_outputs=op._num_outputs,
+                    shuffle=shuffle,
+                    keys=op._keys,
+                    sort=op._sort,
+                )
+            elif isinstance(op, StreamingRepartition) and isinstance(
+                input_op, StreamingRepartition
+            ):
+                return StreamingRepartition(
+                    input_op.input_dependencies[0],
+                    target_num_rows_per_block=op.target_num_rows_per_block,
+                )
+
+            return op
+
+        original_dag = plan.dag
+        transformed_dag = original_dag._apply_transform(_combine_repartitions)
+
+        if transformed_dag is original_dag:
+            return plan
+
+        # TODO replace w/ Plan.copy
+        return LogicalPlan(
+            dag=transformed_dag,
+            context=plan.context,
+        )

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -261,8 +261,6 @@ def test_streaming_repartition_write_no_operator_fusion(
     # Further rebalance to meet target row size
     ds = ds.repartition(target_num_rows_per_block=20)
 
-    import pdb; pdb.set_trace()
-
     # Verify non-fusion of map_batches with repartition
     ds = ds.map_batches(lambda x: x)
     planner = create_planner()

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -18,21 +18,19 @@ def test_repartition_shuffle(
     ds = ray.data.range(20, override_num_blocks=10)
     assert ds._plan.initial_num_blocks() == 10
     assert ds.sum() == 190
-    assert ds._block_num_rows() == [2] * 10
 
     ds2 = ds.repartition(5, shuffle=True)
     assert ds2._plan.initial_num_blocks() == 5
     assert ds2.sum() == 190
-    assert ds2._block_num_rows() == [10, 10, 0, 0, 0]
 
     ds3 = ds2.repartition(20, shuffle=True)
     assert ds3._plan.initial_num_blocks() == 20
     assert ds3.sum() == 190
-    assert ds3._block_num_rows() == [2] * 10 + [0] * 10
 
     large = ray.data.range(10000, override_num_blocks=10)
     large = large.repartition(20, shuffle=True)
-    assert large._block_num_rows() == [500] * 20
+    assert large._plan.initial_num_blocks() == 20
+    assert large.sum() == 49995000
 
 
 def test_key_based_repartition_shuffle(
@@ -109,21 +107,19 @@ def test_repartition_shuffle_arrow(
     ds = ray.data.range(20, override_num_blocks=10)
     assert ds._plan.initial_num_blocks() == 10
     assert ds.count() == 20
-    assert ds._block_num_rows() == [2] * 10
 
     ds2 = ds.repartition(5, shuffle=True)
     assert ds2._plan.initial_num_blocks() == 5
     assert ds2.count() == 20
-    assert ds2._block_num_rows() == [10, 10, 0, 0, 0]
 
     ds3 = ds2.repartition(20, shuffle=True)
     assert ds3._plan.initial_num_blocks() == 20
     assert ds3.count() == 20
-    assert ds3._block_num_rows() == [2] * 10 + [0] * 10
 
     large = ray.data.range(10000, override_num_blocks=10)
     large = large.repartition(20, shuffle=True)
-    assert large._block_num_rows() == [500] * 20
+    assert large._plan.initial_num_blocks() == 20
+    assert large.count() == 10000
 
 
 @pytest.mark.parametrize(
@@ -264,6 +260,8 @@ def test_streaming_repartition_write_no_operator_fusion(
 
     # Further rebalance to meet target row size
     ds = ds.repartition(target_num_rows_per_block=20)
+
+    import pdb; pdb.set_trace()
 
     # Verify non-fusion of map_batches with repartition
     ds = ds.map_batches(lambda x: x)


### PR DESCRIPTION
## Description
A Logical Optimizer rule to combine consecutive repartitions. If 2 repartitions are consecutive, take the last one. If one of them performs an all gather shuffle, then the fused one should also shuffle too.

## Related issues
None

## Additional information
None