### PR TITLE
Update Lance read/write API

### DIFF
--- a/doc/source/data/api/input_output.rst
+++ b/doc/source/data/api/input_output.rst
@@ -244,6 +244,35 @@ Delta Lake
 Lance
 -----
 
+.. note::
+
+   Lance support in Ray is provided by the external ``lance-ray`` connector,
+   which is maintained by the Lance project and provides a richer feature
+   set (catalog integration, data evolution, etc.). The built-in
+   :func:`ray.data.read_lance` and :meth:`ray.data.Dataset.write_lance`
+   keep the same Ray Data API, but now delegate to
+   ``lance_ray.read_lance``/``lance_ray.write_lance``. Install the
+   connector before using them:
+
+   .. code-block:: bash
+
+      pip install lance-ray
+
+   .. code-block:: python
+
+      import ray
+
+      ray.init()
+      data = ray.data.range(1000).map(
+          lambda row: {"id": row["id"], "value": row["id"] * 2}
+      )
+
+      data.write_lance("my_dataset.lance")
+      ds = ray.data.read_lance("my_dataset.lance")
+
+   See the `Lance-Ray documentation <https://lance.org/integrations/ray/>`_
+   for full API details.
+
 .. autosummary::
    :nosignatures:
    :toctree: doc/

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -43,7 +43,6 @@ from ray.data._internal.datasource.csv_datasink import CSVDatasink
 from ray.data._internal.datasource.iceberg_datasink import IcebergDatasink
 from ray.data._internal.datasource.image_datasink import ImageDatasink
 from ray.data._internal.datasource.json_datasink import JSONDatasink
-from ray.data._internal.datasource.lance_datasink import LanceDatasink
 from ray.data._internal.datasource.mongo_datasink import MongoDatasink
 from ray.data._internal.datasource.numpy_datasink import NumpyDatasink
 from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
@@ -5117,7 +5116,16 @@ class Dataset:
                 for more details.
             storage_options: The storage options for the writer. Default is None.
         """
-        datasink = LanceDatasink(
+        try:
+            import lance_ray
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "lance-ray is required for `Dataset.write_lance`. "
+                "Install it with: pip install lance-ray"
+            ) from exc
+
+        return lance_ray.write_lance(
+            self,
             path,
             schema=schema,
             mode=mode,
@@ -5125,10 +5133,6 @@ class Dataset:
             max_rows_per_file=max_rows_per_file,
             data_storage_version=data_storage_version,
             storage_options=storage_options,
-        )
-
-        self.write_datasink(
-            datasink,
             ray_remote_args=ray_remote_args,
             concurrency=concurrency,
         )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -4003,8 +4003,13 @@ def read_lance(
     cleaned_scanner_options = scanner_options.copy() if scanner_options else None
     fragment_ids = None
     if cleaned_scanner_options and "fragments" in cleaned_scanner_options:
-        fragments = cleaned_scanner_options.pop("fragments") or []
-        fragment_ids = [fragment.metadata.id for fragment in fragments]
+        fragments = cleaned_scanner_options.pop("fragments")
+        if fragments is None:
+            fragment_ids = None
+        elif len(fragments) == 0:
+            fragment_ids = []
+        else:
+            fragment_ids = [fragment.metadata.id for fragment in fragments]
 
     ray_remote_args = merge_resources_to_ray_remote_args(
         num_cpus,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3937,9 +3937,9 @@ def read_lance(
     storage_options: Optional[Dict[str, str]] = None,
     scanner_options: Optional[Dict[str, Any]] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
-    num_cpus: Optional[int] = None,
-    num_gpus: Optional[int] = None,
-    memory: Optional[int] = None,
+    num_cpus: Optional[float] = None,
+    num_gpus: Optional[float] = None,
+    memory: Optional[float] = None,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
 ) -> Dataset:


### PR DESCRIPTION
## Description

This PR updates the usage instructions for working with Lance datasets in Ray.

The existing documentation and example for `ray.data.read_lance` and `ray.data.datasets.write_lance` are out of date. 

> [!NOTE]
 > Lance support in Ray is provided by the external ``lance-ray`` connector, which is maintained by the Lance project and provides a richer feature set (catalog integration, data evolution, etc.). The public methods `ray.data.read_lance` and `ray.data.Dataset.write_lance` keep the same Ray Data API, but now delegate to ``lance_ray.read_lance`` ``lance_ray.write_lance``. We now ask users to install the  connector before using them.
 
 cc @jackye1995

## Related issues

Merging this should close [#49211](https://github.com/ray-project/ray/issues/49211), as the tests are passing and the example provided in the [lance_ray](https://lance.org/integrations/ray/#simple-example) docs work without issue.

## Additional information

More information and usage scenarios can be found at the [lance](https://lance.org/integrations/ray/) format documentation site, where further support will be provided.
