### PR TITLE
[serve][llm] Parity with vLLM: model should be optional in Ray Serve LLM

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -420,6 +420,29 @@ class OpenAiIngress(DeploymentProtocol):
 
         return self._configured_serve_handles[model_id]
 
+    async def _get_model_id(self, model: Optional[str]) -> str:
+        # Default to the only configured model if no model specified
+        if model is None:
+            if len(self._llm_configs) == 1:
+                model = next(iter(self._llm_configs.keys()))
+            else:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    "Model parameter is required when multiple models are configured. "
+                    f"Available models: {list(self._llm_configs.keys())}",
+                )
+
+        base_model_id = get_base_model_id(model)
+        if base_model_id not in self._llm_configs:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND,
+                f'Got request for model "{model}". '
+                f'Could not find base model with ID "{base_model_id}".',
+            )
+
+        # Return original model ID so multiplexed routing works correctly.
+        return model
+
     async def _get_response(
         self,
         *,
@@ -442,26 +465,8 @@ class OpenAiIngress(DeploymentProtocol):
         None,
     ]:
         """Calls the model deployment and returns the stream."""
-        model: Optional[str] = body.model
-        # Default to the only configured model if no model specified
-        if model is None:
-            if len(self._llm_configs) == 1:
-                model = next(iter(self._llm_configs.keys()))
-            else:
-                raise HTTPException(
-                    status.HTTP_400_BAD_REQUEST,
-                    "Model parameter is required when multiple models are configured. "
-                    f"Available models: {list(self._llm_configs.keys())}",
-                )
-        base_model_id = get_base_model_id(model)
-        if base_model_id not in self._llm_configs:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                f'Got request for model "{model}". '
-                f'Could not find base model with ID "{base_model_id}".',
-            )
-
-        model_handle = self._get_configured_serve_handle(model)
+        model_id = await self._get_model_id(body.model)
+        model_handle = self._get_configured_serve_handle(model_id)
 
         # TODO(seiji): Remove when we update to Pydantic v2.11+ with the fix
         # for tool calling ValidatorIterator serialization issue.

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -442,7 +442,17 @@ class OpenAiIngress(DeploymentProtocol):
         None,
     ]:
         """Calls the model deployment and returns the stream."""
-        model: str = body.model
+        model: Optional[str] = body.model
+        # Default to the only configured model if no model specified
+        if model is None:
+            if len(self._llm_configs) == 1:
+                model = next(iter(self._llm_configs.keys()))
+            else:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    "Model parameter is required when multiple models are configured. "
+                    f"Available models: {list(self._llm_configs.keys())}",
+                )
         base_model_id = get_base_model_id(model)
         if base_model_id not in self._llm_configs:
             raise HTTPException(

--- a/python/ray/llm/tests/serve/gpu/integration/test_openai_compatibility.py
+++ b/python/ray/llm/tests/serve/gpu/integration/test_openai_compatibility.py
@@ -143,6 +143,28 @@ class TestOpenAICompatibility:
         assert data["model"] == expected_model
         assert data["choices"][0]["message"]["content"]
 
+    def test_chat_without_model_parameter_multiple_models(
+        self, testing_multiple_models
+    ):  # noqa: F811
+        """Test that chat completions return 400 when model not specified with multiple models.
+
+        When multiple models are configured and the model parameter is not specified,
+        an HTTP 400 Bad Request should be returned.
+        """
+        client, model_ids = testing_multiple_models
+        assert len(model_ids) > 1, "This test requires multiple models"
+        # Use requests directly since OpenAI client requires model parameter
+        response = requests.post(
+            f"{client.base_url}chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hello world"}],
+            },
+            headers={"Authorization": f"Bearer {client.api_key}"},
+        )
+        assert (
+            response.status_code == 400
+        ), f"Expected 400, got {response.status_code}: {response.text}"
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/gpu/integration/test_openai_compatibility.py
+++ b/python/ray/llm/tests/serve/gpu/integration/test_openai_compatibility.py
@@ -130,7 +130,7 @@ class TestOpenAICompatibility:
         client, expected_model = testing_model
         # Use requests directly since OpenAI client requires model parameter
         response = requests.post(
-            f"{client.base_url}/chat/completions",
+            f"{client.base_url}chat/completions",
             json={
                 "messages": [{"role": "user", "content": "Hello world"}],
             },

--- a/python/ray/llm/tests/serve/mock_vllm_model_2.yaml
+++ b/python/ray/llm/tests/serve/mock_vllm_model_2.yaml
@@ -1,0 +1,27 @@
+model_loading_config:
+  model_id: FAKE_MODEL_2_UNDER_TEST
+
+# Overriding the engine class to only focus on testing the components around the engine
+runtime_env:
+  env_vars:
+    RAYLLM_VLLM_ENGINE_CLS: "ray.llm.tests.serve.mocks.mock_vllm_engine.MockVLLMEngine"
+
+llm_engine: vLLM
+
+engine_kwargs:
+  max_model_len: 4096
+
+accelerator_type: A10G
+
+deployment_config:
+  autoscaling_config:
+    min_replicas: 4
+    initial_replicas: 4
+    max_replicas: 10
+    target_ongoing_requests: 20
+    metrics_interval_s: 10.0
+    look_back_period_s: 30.0
+    smoothing_factor: 0.6
+    downscale_delay_s: 300.0
+    upscale_delay_s: 15.0
+  max_ongoing_requests: 48

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -131,7 +131,7 @@ class MockVLLMEngine(LLMEngine):
         response = EmbeddingResponse(
             object="list",
             data=embedding_data,
-            model=getattr(request, "model", "mock-model"),
+            model=request.model or self.llm_config.model_id,
             usage={
                 "prompt_tokens": len(str(request.input).split()),
                 "total_tokens": len(str(request.input).split()),
@@ -183,7 +183,7 @@ class MockVLLMEngine(LLMEngine):
         response = ScoreResponse(
             object="list",
             data=score_data,
-            model=getattr(request, "model", "mock-model"),
+            model=request.model or self.llm_config.model_id,
             usage={
                 "prompt_tokens": len(str(text_1).split()) + len(str(text_2).split()),
                 "total_tokens": len(str(text_1).split()) + len(str(text_2).split()),
@@ -197,6 +197,8 @@ class MockVLLMEngine(LLMEngine):
         """Generate mock chat completion response."""
 
         request_id = request.request_id or f"chatcmpl-{random.randint(1000, 9999)}"
+        # # Use request.model if provided, otherwise fall back to llm_config.model_id
+        model_name = request.model or self.llm_config.model_id
         lora_prefix = (
             ""
             if request.model not in self._current_lora_model
@@ -205,7 +207,6 @@ class MockVLLMEngine(LLMEngine):
         if request.stream:
             # Streaming response - return SSE formatted strings
             created_time = int(asyncio.get_event_loop().time())
-            model_name = getattr(request, "model", "mock-model")
 
             for i in range(max_tokens):
                 if i == 0:
@@ -255,7 +256,7 @@ class MockVLLMEngine(LLMEngine):
                 id=request_id,
                 object="chat.completion",
                 created=int(asyncio.get_event_loop().time()),
-                model=getattr(request, "model", "mock-model"),
+                model=model_name,
                 choices=[choice],
                 usage={
                     "prompt_tokens": len(prompt_text.split()),
@@ -272,6 +273,7 @@ class MockVLLMEngine(LLMEngine):
         """Generate mock completion response."""
 
         request_id = request.request_id or f"cmpl-{random.randint(1000, 9999)}"
+        model_name = request.model or self.llm_config.model_id
         lora_prefix = (
             ""
             if request.model not in self._current_lora_model
@@ -280,7 +282,6 @@ class MockVLLMEngine(LLMEngine):
         if request.stream:
             # Streaming response - return SSE formatted strings
             created_time = int(asyncio.get_event_loop().time())
-            model_name = getattr(request, "model", "mock-model")
 
             for i in range(max_tokens):
                 if i == 0:
@@ -322,7 +323,7 @@ class MockVLLMEngine(LLMEngine):
                 id=request_id,
                 object="text_completion",
                 created=int(asyncio.get_event_loop().time()),
-                model=getattr(request, "model", "mock-model"),
+                model=model_name,
                 choices=[choice],
                 usage={
                     "prompt_tokens": len(prompt_text.split()),
@@ -355,10 +356,11 @@ class MockVLLMEngine(LLMEngine):
         if lora_prefix:
             mock_transcription_text = f"{lora_prefix}{mock_transcription_text}"
 
+        model_name = request.model or self.llm_config.model_id
+
         if request.stream:
             # Streaming response - return SSE formatted strings
             created_time = int(asyncio.get_event_loop().time())
-            model_name = getattr(request, "model", "mock-model")
 
             # Split transcription into words for streaming
             words = mock_transcription_text.split()


### PR DESCRIPTION

## Description
- Logic: select sole model if there is one, otherwise raise an exception
- Parity: with vLLM https://github.com/vllm-project/vllm/pull/13568

Serve:
```
from ray import serve
from ray.serve.llm import LLMConfig, build_openai_app

llm_config = LLMConfig(
    model_loading_config={
        "model_id": "qwen-0.5b",
        "model_source": "Qwen/Qwen2.5-0.5B-Instruct",
    },
    deployment_config={
        "autoscaling_config": {
            "min_replicas": 1,
            "max_replicas": 2,
        }
    },
    engine_kwargs={
        "enforce_eager": True,
    },
    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
)

app = build_openai_app({"llm_configs": [llm_config]})
serve.run(app, blocking=True)
```

Result
```
(base) ray@ip-10-1-153-10:~/default/test$ curl -X POST http://localhost:8000/v1/chat/completions      -H "Content-Type: application/json"      -H "Authorization: Bearer fake-key"      -d '{
           "messages": [{"role": "user", "content": "Hello!"}]
         }'
{"id":"chatcmpl-57d330d9-ccf8-4b35-9b66-28e99271f677","object":"chat.completion","created":1764801840,"model":"qwen-0.5b","choices":[{"index":0,"message":{"role":"assistant","content":"Hello! How can I assist you today?","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":31,"total_tokens":41,"completion_tokens":10,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}(base) ray@ip-10-1-153-10:~/default/test$ 
```
## Related issues
- Closes https://github.com/ray-project/ray/issues/56638
