### PR TITLE
[core] Fail fast for ray.remote(num_returns='streaming|dynamic') if the task isa non-generator function

### DIFF
--- a/python/ray/_common/ray_option_utils.py
+++ b/python/ray/_common/ray_option_utils.py
@@ -130,9 +130,9 @@ def _validate_resources(resources: Optional[Dict[str, float]]) -> Optional[str]:
 
 
 def _validate_num_returns(num_returns: str | int, func: Any) -> Optional[str]:
-    """The number of returned values from a task can only be "streaming" or an int > 0."""
+    """The number of returned values from a task can only be "streaming", "dynamic" or an int > 0."""
 
-    error_msg: str = "The keyword 'num_returns' only accepts a non-negative integer or 'streaming' (for generators)."
+    error_msg: str = "The keyword 'num_returns' only accepts a non-negative integer, 'streaming', or 'dynamic' (for generators)."
     is_generator_function: bool = inspect.isgeneratorfunction(func)
 
     if isinstance(num_returns, int) and num_returns >= 0:
@@ -140,7 +140,7 @@ def _validate_num_returns(num_returns: str | int, func: Any) -> Optional[str]:
 
     if (
         isinstance(num_returns, str)
-        and num_returns == "streaming"
+        and (num_returns == "streaming" or num_returns == "dynamic")
         and is_generator_function
     ):
         return

--- a/python/ray/_common/ray_option_utils.py
+++ b/python/ray/_common/ray_option_utils.py
@@ -129,7 +129,7 @@ def _validate_resources(resources: Optional[Dict[str, float]]) -> Optional[str]:
     return None
 
 
-def _validate_num_returns(num_returns: str | int, func: Any) -> Optional[str]:
+def _validate_num_returns(num_returns: Union[str, int], func: Any) -> Optional[str]:
     """The number of returned values from a task can only be "streaming", "dynamic" or an int > 0."""
 
     error_msg: str = "The keyword 'num_returns' only accepts a non-negative integer, 'streaming', or 'dynamic' (for generators)."

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -3389,7 +3389,9 @@ def _make_remote(function_or_class, options):
         function_or_class.__module__ = "global"
 
     if inspect.isfunction(function_or_class) or is_cython(function_or_class):
-        ray_option_utils.validate_task_options(options, in_options=False)
+        ray_option_utils.validate_task_options(
+            options, in_options=False, func=function_or_class
+        )
         return ray.remote_function.RemoteFunction(
             Language.PYTHON,
             function_or_class,
@@ -3694,12 +3696,12 @@ def remote(
 
     Args:
         num_returns: This is only for *remote functions*. It specifies
-            the number of object refs returned by the remote function
-            invocation. The default value is 1.
-            Pass "dynamic" to allow the task to decide how many
-            return values to return during execution, and the caller will
-            receive an ObjectRef[DynamicObjectRefGenerator].
-            See :ref:`dynamic generators <dynamic-generators>` for more details.
+            the number of object refs returned by the remote function invocation.
+            For non-generator functions, the default value is 1.
+            For generator functions, the default value is "streaming" and an ObjectRefGenerator
+            will be returned. See "ref" `ray generator <ray-generator>` for more details.
+            Raises ValueError if num_returns < 0 or num_returns="streaming" with a non-generator
+            function.
         num_cpus: The quantity of CPU resources to reserve
             for this task or for the lifetime of the actor.
             By default, tasks use 1 CPU resource and actors use 1 CPU

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -871,6 +871,7 @@ py_test_module_list(
         "test_iter.py",
         "test_placement_group.py",
         "test_ray_get.py",
+        "test_ray_remote_decorator.py",
         "test_state_api_2.py",
         "test_task_events.py",
         "test_unavailable_actors.py",

--- a/python/ray/tests/test_ray_remote_decorator.py
+++ b/python/ray/tests/test_ray_remote_decorator.py
@@ -35,6 +35,20 @@ def test_num_returns_streaming_with_generator_task_returns_remote_function():
         yield 1
 
 
+def test_num_returns_dynamic_with_non_generator_task_raises_value_error():
+    with pytest.raises(ValueError):
+
+        @ray.remote(num_returns="dynamic")
+        def f():
+            pass
+
+
+def test_num_returns_dynamic_with_generator_task_returns_remote_function():
+    @ray.remote(num_returns="dynamic")
+    def f():
+        yield 1
+
+
 def test_num_returns_gte_0_with_generator_task_returns_remote_function():
     # TODO(irabbani): Allowing num_returns=0 for backwards compatability. I don't
     # think it makes any sense so we should probably remove it.

--- a/python/ray/tests/test_ray_remote_decorator.py
+++ b/python/ray/tests/test_ray_remote_decorator.py
@@ -1,0 +1,51 @@
+import sys
+
+import pytest
+
+import ray
+
+
+def test_num_returns_lt_0_with_non_generator_task_raises_value_error():
+    with pytest.raises(ValueError):
+
+        @ray.remote(num_returns=-1)
+        def f():
+            pass
+
+
+def test_num_returns_lt_0_with_generator_task_raises_value_error():
+    with pytest.raises(ValueError):
+
+        @ray.remote(num_returns=-1)
+        def f():
+            yield 1
+
+
+def test_num_returns_streaming_with_non_generator_task_raises_value_error():
+    with pytest.raises(ValueError):
+
+        @ray.remote(num_returns="streaming")
+        def f():
+            pass
+
+
+def test_num_returns_streaming_with_generator_task_returns_remote_function():
+    @ray.remote(num_returns="streaming")
+    def f():
+        yield 1
+
+
+def test_num_returns_gte_0_with_generator_task_returns_remote_function():
+    # TODO(irabbani): Allowing num_returns=0 for backwards compatability. I don't
+    # think it makes any sense so we should probably remove it.
+    @ray.remote(num_returns=0)
+    def f():
+        yield 1
+
+    @ray.remote(num_returns=1)
+    def g():
+        yield 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
There are two fundamental modes of task execution in Ray (generator and non-generator). In python, a function is a generator function if it uses the `yield` keyword. We use `inspect.isgeneratorfunction(f)` to determine if a function is a generator. 

If a function is a generator, then we return either an `ObjectRef` or an `ObjectRefGenerator` from it. 

The behavior today is that if you have a non-generator function and you specify `num_returns=dynamic|streaming`, the function can be submitted, and it will return an `ObjectRef` or and `ObjectRefGenerator`.

### Dynamic Generator
```python
import ray

ray.init()

@ray.remote(num_returns="dynamic")
def f():
     return 1, 2, 3

obj_ref = f.remote()

ray.get(obj_ref)
```
The type of obj_ref is `ObjectRef` and it resolve to `RayTaskError(ValueError): ray::f() (pid=1946777, ip=172.31.4.214)
ValueError: Functions with @ray.remote(num_returns="dynamic" must return a generator`

### Streaming Generator
```python
@ray.remote(num_returns="streaming")
def f():
    return 1, 2, 3

gen = f.remote()
for obj_ref in gen:
    print(ray.get(obj_ref)) 
```
The type of `gen` is `ObjectRefGenerator`. It contains 1 `ObjectRef` (!) which resolves to the `RayTaskError(ValueError): ray::f() (pid=2051701, ip=172.31.12.251)
ValueError: Functions with @ray.remote(num_returns="streaming" must return a generator`

In this PR
1. The @ray.remote decorator will inspect the function and fail fast with a ValueError
2. I've added started adding tests for the @ray.remote decorator. I couldn't find an existing suite (happy to merge if I missed it). If it doesn't exist, we should do a lot more of this kind of work.

### Rough Edges
Actor tasks use a different decorator `@ray.method` which goes through a different code path. It's inconsistent with `num_returns` validation with normal tasks. Will fix this next. 
