### PR TITLE
[train] Configure async validation retries 

### DIFF
--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -147,6 +147,7 @@ Ray Train Utilities
     ~train.CheckpointUploadMode
     ~train.CheckpointConsistencyMode
     ~train.TrainContext
+    ~train.ValidateTaskConfig
 
 **Functions**
 

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -51,6 +51,7 @@ if is_v2_enabled():
     from ray.train.v2.api.report_config import (  # noqa: F811
         CheckpointConsistencyMode,
         CheckpointUploadMode,
+        ValidateTaskConfig,
     )
     from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint  # noqa: F811
     from ray.train.v2.api.result import Result  # noqa: F811
@@ -107,6 +108,7 @@ if is_v2_enabled():
             "ControllerError",
             "ReportedCheckpoint",
             "UserCallback",
+            "ValidateTaskConfig",
             "WorkerGroupError",
             "get_all_reported_checkpoints",
         ]
@@ -117,6 +119,7 @@ if is_v2_enabled():
     ControllerError.__module__ = "ray.train"
     ReportedCheckpoint.__module__ = "ray.train"
     UserCallback.__module__ = "ray.train"
+    ValidateTaskConfig.__module__ = "ray.train"
     WorkerGroupError.__module__ = "ray.train"
     get_all_reported_checkpoints.__module__ = "ray.train"
 

--- a/python/ray/train/v2/_internal/execution/context.py
+++ b/python/ray/train/v2/_internal/execution/context.py
@@ -26,6 +26,7 @@ from ray.train.v2.api.config import RunConfig, ScalingConfig
 from ray.train.v2.api.report_config import (
     CheckpointConsistencyMode,
     CheckpointUploadMode,
+    ValidateTaskConfig,
 )
 
 if TYPE_CHECKING:
@@ -330,6 +331,7 @@ class TrainContext:
         ] = None,
         validate_fn: Optional[Callable[["Checkpoint", Optional[Dict]], Dict]] = None,
         validate_config: Optional[Dict] = None,
+        validate_task_config: Optional[ValidateTaskConfig] = None,
     ) -> None:
         """
         Upload checkpoint to remote storage and put a training
@@ -362,6 +364,7 @@ class TrainContext:
                 validation_spec = _ValidationSpec(
                     validate_fn=validate_fn,
                     validate_config=validate_config,
+                    validate_task_config=validate_task_config or ValidateTaskConfig(),
                 )
             else:
                 validation_spec = None

--- a/python/ray/train/v2/_internal/execution/train_fn_utils.py
+++ b/python/ray/train/v2/_internal/execution/train_fn_utils.py
@@ -17,6 +17,7 @@ from ray.train.v2.api.context import (
 from ray.train.v2.api.report_config import (
     CheckpointConsistencyMode,
     CheckpointUploadMode,
+    ValidateTaskConfig,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,7 @@ class TrainFnUtils(ABC):
         ] = None,
         validate_fn: Optional[Callable[["Checkpoint", Optional[Dict]], Dict]] = None,
         validate_config: Optional[Dict] = None,
+        validate_task_config: Optional[ValidateTaskConfig] = None,
     ) -> None:
         """Upload checkpoint to remote storage and put a training result on the result queue.
 
@@ -68,6 +70,7 @@ class TrainFnUtils(ABC):
                 this function.
             validate_config: Configuration passed to the validate_fn. Can contain info
                 like the validation dataset.
+            validate_task_config: Configuration for the validation task itself e.g. retries.
         """
         pass
 
@@ -156,6 +159,7 @@ class DistributedTrainFnUtils(TrainFnUtils):
         ] = None,
         validate_fn: Optional[Callable[["Checkpoint", Optional[Dict]], Dict]] = None,
         validate_config: Optional[Dict] = None,
+        validate_task_config: Optional[ValidateTaskConfig] = None,
     ) -> None:
         return get_internal_train_context().report(
             metrics,
@@ -166,6 +170,7 @@ class DistributedTrainFnUtils(TrainFnUtils):
             checkpoint_upload_fn,
             validate_fn,
             validate_config,
+            validate_task_config,
         )
 
     def get_checkpoint(self):
@@ -230,6 +235,7 @@ class LocalTrainFnUtils(TrainFnUtils):
         ] = None,
         validate_fn: Optional[Callable[["Checkpoint", Optional[Dict]], Dict]] = None,
         validate_config: Optional[Dict] = None,
+        validate_task_config: Optional[ValidateTaskConfig] = None,
     ) -> None:
         self._last_metrics = metrics
         self._last_checkpoint = checkpoint

--- a/python/ray/train/v2/_internal/execution/training_report.py
+++ b/python/ray/train/v2/_internal/execution/training_report.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 if TYPE_CHECKING:
     from ray.train import Checkpoint
+    from ray.train.v2.api.report_config import ValidateTaskConfig
 
 
 class _ValidationSpec:
@@ -11,12 +12,14 @@ class _ValidationSpec:
         self,
         validate_fn: Callable[["Checkpoint", Optional[Dict]], Dict],
         validate_config: Dict,
+        validate_task_config: "ValidateTaskConfig",
     ):
         self.validate_fn = validate_fn
         self.validate_config = validate_config
+        self.validate_task_config = validate_task_config
 
     def __repr__(self) -> str:
-        return f"ValidationSpec(validate_fn={self.validate_fn}, validate_config={self.validate_config})"
+        return f"ValidationSpec(validate_fn={self.validate_fn}, validate_config={self.validate_config}, validate_task_config={self.validate_task_config})"
 
 
 class _TrainingReport:

--- a/python/ray/train/v2/api/report_config.py
+++ b/python/ray/train/v2/api/report_config.py
@@ -55,4 +55,4 @@ class ValidateTaskConfig:
     """
 
     max_retries: int = 3
-    retry_exceptions: Optional[List[Exception]] = None
+    retry_exceptions: Optional[List[Type[Exception]]] = None

--- a/python/ray/train/v2/api/report_config.py
+++ b/python/ray/train/v2/api/report_config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Type
 
 from ray.util.annotations import PublicAPI
 

--- a/python/ray/train/v2/api/report_config.py
+++ b/python/ray/train/v2/api/report_config.py
@@ -1,4 +1,6 @@
+from dataclasses import dataclass
 from enum import Enum
+from typing import List, Optional
 
 from ray.util.annotations import PublicAPI
 
@@ -34,3 +36,23 @@ class CheckpointConsistencyMode(Enum):
 
     COMMITTED = "COMMITTED"
     VALIDATED = "VALIDATED"
+
+
+@dataclass
+@PublicAPI(stability="alpha")
+class ValidateTaskConfig:
+    """Configuration for the validation task.
+
+    This configuration is used when running validation functions asynchronously
+    via :meth:`ray.train.report` with a ``validate_fn``.
+
+    Args:
+        max_retries: The maximum number of times to retry validation if it fails.
+            Defaults to 3.
+        retry_exceptions: A list of exception types to retry validation on.
+            By default, only Ray errors are retried, not user exceptions.
+            If you want to retry on specific user exceptions, provide them here.
+    """
+
+    max_retries: int = 3
+    retry_exceptions: Optional[List[Exception]] = None

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -7,6 +7,7 @@ from ray.train.v2.api.context import TrainContext
 from ray.train.v2.api.report_config import (
     CheckpointConsistencyMode,
     CheckpointUploadMode,
+    ValidateTaskConfig,
 )
 from ray.util.annotations import PublicAPI
 
@@ -27,6 +28,7 @@ def report(
     checkpoint_upload_fn: Optional[Callable[["Checkpoint", str], "Checkpoint"]] = None,
     validate_fn: Optional[Callable[["Checkpoint", Optional[Dict]], Dict]] = None,
     validate_config: Optional[Dict] = None,
+    validate_task_config: Optional[ValidateTaskConfig] = None,
 ):
     """Report metrics and optionally save a checkpoint.
 
@@ -105,6 +107,8 @@ def report(
             this function.
         validate_config: Configuration passed to the validate_fn. Can contain info
             like the validation dataset.
+        validate_task_config: Configuration for the validation task retries.
+            See :class:`~ray.train.ValidateTaskConfig` for more details.
     """
     if delete_local_checkpoint_after_upload is None:
         delete_local_checkpoint_after_upload = (
@@ -115,6 +119,11 @@ def report(
     if validate_config and not validate_fn:
         raise ValueError("validate_fn must be provided together with validate_config")
 
+    if validate_task_config and not validate_fn:
+        raise ValueError(
+            "validate_fn must be provided together with validate_task_config"
+        )
+
     get_train_fn_utils().report(
         metrics=metrics,
         checkpoint=checkpoint,
@@ -124,6 +133,7 @@ def report(
         checkpoint_upload_fn=checkpoint_upload_fn,
         validate_fn=validate_fn,
         validate_config=validate_config or {},
+        validate_task_config=validate_task_config or ValidateTaskConfig(),
     )
 
 

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
     from ray.train.v2.api.reported_checkpoint import ReportedCheckpoint
 
 
+_VALIDATE_CONFIG_WITHOUT_VALIDATE_FN_ERROR = (
+    "validate_fn must be provided together with validate_config"
+)
+_VALIDATE_TASK_CONFIG_WITHOUT_VALIDATE_FN_ERROR = (
+    "validate_fn must be provided together with validate_task_config"
+)
+
+
 @PublicAPI(stability="stable")
 @requires_train_worker(raise_in_tune_session=True)
 def report(
@@ -117,12 +125,10 @@ def report(
 
     # TODO: figure out how to validate validate_fn itself
     if validate_config and not validate_fn:
-        raise ValueError("validate_fn must be provided together with validate_config")
+        raise ValueError(_VALIDATE_CONFIG_WITHOUT_VALIDATE_FN_ERROR)
 
     if validate_task_config and not validate_fn:
-        raise ValueError(
-            "validate_fn must be provided together with validate_task_config"
-        )
+        raise ValueError(_VALIDATE_TASK_CONFIG_WITHOUT_VALIDATE_FN_ERROR)
 
     get_train_fn_utils().report(
         metrics=metrics,

--- a/python/ray/train/v2/tests/test_async_checkpointing_validation.py
+++ b/python/ray/train/v2/tests/test_async_checkpointing_validation.py
@@ -21,6 +21,10 @@ from ray.train.v2.api.report_config import (
     CheckpointConsistencyMode,
     CheckpointUploadMode,
 )
+from ray.train.v2.api.train_fn_utils import (
+    _VALIDATE_CONFIG_WITHOUT_VALIDATE_FN_ERROR,
+    _VALIDATE_TASK_CONFIG_WITHOUT_VALIDATE_FN_ERROR,
+)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -245,7 +249,7 @@ def test_report_validate_config_without_validate_fn():
     )
     with pytest.raises(
         WorkerGroupError,
-        match="validate_fn must be provided together with validate_config",
+        match=_VALIDATE_CONFIG_WITHOUT_VALIDATE_FN_ERROR,
     ) as exc_info:
         trainer.fit()
     assert isinstance(exc_info.value.worker_failures[0]._base_exc, ValueError)
@@ -265,7 +269,7 @@ def test_report_validate_task_config_without_validate_fn():
     )
     with pytest.raises(
         WorkerGroupError,
-        match="validate_fn must be provided together with validate_task_config",
+        match=_VALIDATE_TASK_CONFIG_WITHOUT_VALIDATE_FN_ERROR,
     ) as exc_info:
         trainer.fit()
     assert isinstance(exc_info.value.worker_failures[0]._base_exc, ValueError)

--- a/python/ray/train/v2/tests/test_validation_manager.py
+++ b/python/ray/train/v2/tests/test_validation_manager.py
@@ -38,7 +38,6 @@ def test_before_controller_shutdown(mock_wait, monkeypatch):
     task2 = create_autospec(ray.ObjectRef, instance=True)
     task3 = create_autospec(ray.ObjectRef, instance=True)
     vm = validation_manager.ValidationManager(checkpoint_manager=checkpoint_manager)
-    # modoru: many in queue too
     vm._pending_validations = {
         task1: checkpoint1,
         task2: checkpoint2,


### PR DESCRIPTION
# Summary

Based on https://github.com/ray-project/ray/pull/59128/files so please review the diff with that. 

By default, Ray retries failed tasks 3 times (https://docs.ray.io/en/latest/ray-core/fault_tolerance/tasks.html#retrying-failed-tasks). However, it doesn't retry errors thrown by application code.

This PR introduces a new `ValidateTaskConfig` object with the following fields:
* `max_retries`: The number of times to retry the task. Possible use case: set this to 0 to unblock training progress.
* `retry_exceptions`: List of exception types to retry on. Users might prefer this to writing their own retry logic within their task because this way is easier to write, provides a centralized failure cap (e.g. a task might retry user-code twice before being OOM-evicted and retrying from scratch), retries in a fresh context, etc.

Users can then call `ray.train.report` with this new `ValidateTaskConfig` object. If they don't specify this object, the behavior is the same as before this PR. 

In the future, this config can handle:
* Timeouts: could be useful if 1 hang impedes training progress. 
* Retry backoff: might be overkill though since ideally Ray Train is aware of the cluster and can schedule retries best. 

# Testing

Unit tests. Note that I modified `test_validation_manager` to test `ValidationManager` code changes and `test_async_checkpointing_validation` to test worker-side code changes. 