### PR TITLE
[CI][Doc] Update the example output of the dataset iterator.

### DIFF
--- a/doc/source/ray-references/glossary.rst
+++ b/doc/source/ray-references/glossary.rst
@@ -93,8 +93,9 @@ documentation, sorted alphabetically.
             3   3
             4   4
             >>> next(iter(dataset.iter_batches(batch_format="pyarrow", batch_size=5)))
-            id: int64                                                                                                                          
-            ----                                                                                                                               
+            pyarrow.Table
+            id: int64
+            ----
             id: [[0],[1],...,[3],[4]]                                                                                                         
 
         To learn more about batch formats, read


### PR DESCRIPTION
## Description
There are the following error in the CI; fix it.
```shell
[2025-12-04T05:13:38Z] doc/source/ray-references/glossary.rst::glossary.rst FAILED              [ 90%]2025-12-04 05:11:44,723	INFO util.py:257 -- Exiting prefetcher's background thread
[2025-12-04T05:13:38Z]
[2025-12-04T05:13:38Z]
[2025-12-04T05:13:38Z] =================================== FAILURES ===================================
[2025-12-04T05:13:38Z] ____________________________ [doctest] glossary.rst ____________________________
[2025-12-04T05:13:38Z] 086             >>> next(iter(dataset.iter_batches(batch_format="numpy", batch_size=5)))
[2025-12-04T05:13:38Z] 087             {'id': array([0, 1, 2, 3, 4])}
[2025-12-04T05:13:38Z] 088             >>> next(iter(dataset.iter_batches(batch_format="pandas", batch_size=5)))
[2025-12-04T05:13:38Z] 089                id
[2025-12-04T05:13:38Z] 090             0   0
[2025-12-04T05:13:38Z] 091             1   1
[2025-12-04T05:13:38Z] 092             2   2
[2025-12-04T05:13:38Z] 093             3   3
[2025-12-04T05:13:38Z] 094             4   4
[2025-12-04T05:13:38Z] 095             >>> next(iter(dataset.iter_batches(batch_format="pyarrow", batch_size=5)))
[2025-12-04T05:13:38Z] Differences (unified diff with -expected +actual):
[2025-12-04T05:13:38Z]     @@ -1,3 +1,4 @@
[2025-12-04T05:13:38Z]     -id: int64
[2025-12-04T05:13:38Z]     -----
[2025-12-04T05:13:38Z]     -id: [[0],[1],...,[3],[4]]
[2025-12-04T05:13:38Z]     +pyarrow.Table
[2025-12-04T05:13:38Z]     +id: int64
[2025-12-04T05:13:38Z]     +----
[2025-12-04T05:13:38Z]     +id: [[0],[1],...,[3],[4]]
```
https://buildkite.com/ray-project/premerge/builds/54980/steps/canvas?sid=019ae7af-ae4b-422e-a14e-7ff2ea22a920
## Related issues
PR #58971