### PR TITLE
[release] upgrading data release tests (sort_* and random_*)

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -413,7 +413,7 @@
 ########################
 
 - name: "random_shuffle_{{scaling}}"
-
+  python: "3.10"
   matrix:
     setup:
       # This release test consistently fails on autoscaling clusters. So, we only run
@@ -433,6 +433,7 @@
 
 
 - name: random_shuffle_chaos
+  python: "3.10"
   working_dir: nightly_tests
   stable: False
 
@@ -453,7 +454,7 @@
 
 
 - name: "sort_{{scaling}}"
-
+  python: "3.10"
   matrix:
     setup:
       scaling: [fixed_size, autoscaling]
@@ -470,6 +471,7 @@
 
 
 - name: sort_chaos
+  python: "3.10"
   working_dir: nightly_tests
   stable: False
 


### PR DESCRIPTION
upgrading sort and random data release tests:


Successful release test run:https://buildkite.com/ray-project/release/builds/70537#
