### PR TITLE
[release] upgrading last data release tests to py3.10

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -657,7 +657,6 @@
 #################################################
 
 - name: "cross_az_map_batches_autoscaling"
-  python: "3.10"
   frequency: manual
   env: gce
   cluster:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -562,6 +562,7 @@
 
 
 - name: image_embedding_from_jsonl_{{case}}
+  python: "3.10"
   frequency: "{{frequency}}"
   group: data-batch-inference
 
@@ -638,7 +639,7 @@
 ##############
 
 - name: "tpch_q1_{{scaling}}"
-
+  python: "3.10"
   matrix:
     setup:
       scaling: [fixed_size, autoscaling]
@@ -656,6 +657,7 @@
 #################################################
 
 - name: "cross_az_map_batches_autoscaling"
+  python: "3.10"
   frequency: manual
   env: gce
   cluster:


### PR DESCRIPTION
upgrading data releasee tests to py3.10
image_embedding_from_jsonl_{{case}}
tpch_q1_{{scaling}}

successful release test run: https://buildkite.com/ray-project/release/builds/70541#

skipping cross_az_map_batches_autoscaling & image_embedding_from_jsonl_fixed_size_chaos which are manually run tests