### PR TITLE
[release] upgrading torch and huggingface release test python versions

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1928,7 +1928,6 @@
     script: python torch_local_mode_launcher.py
 
 - name: torch_lightning
-  python: "3.10"
   group: Train tests
   working_dir: train_tests/pytorch_lightning
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1911,6 +1911,7 @@
 
 
 - name: torch_local_mode
+  python: "3.10"
   group: Train tests
   working_dir: train_tests/local_mode
 
@@ -1927,6 +1928,7 @@
     script: python torch_local_mode_launcher.py
 
 - name: torch_lightning
+  python: "3.10"
   group: Train tests
   working_dir: train_tests/pytorch_lightning
 
@@ -1944,6 +1946,7 @@
     script: RAY_TRAIN_V2_ENABLED=1 python test_lightning.py
 
 - name: huggingface_transformers
+  python: "3.10"
   group: Train tests
   working_dir: train_tests/huggingface_transformers
 
@@ -1961,6 +1964,7 @@
     script: RAY_TRAIN_V2_ENABLED=1 python test_huggingface_transformers.py
 
 - name: huggingface_accelerate
+  python: "3.10"
   group: Train tests
   working_dir: train_tests/huggingface_accelerate
 


### PR DESCRIPTION
upgrading torch and hugging face release tests


Successful release tests: https://buildkite.com/ray-project/release/builds/70543#
Leaving torch lightning as py 3.9 test (will fix in another PR)