### PR TITLE
[release] upgrading train release tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1382,6 +1382,7 @@
 # Runtime env tests
 ########################
 - name: runtime_env_rte_many_tasks_actors
+  python: "3.10"
   group: Runtime env tests
   working_dir: runtime_env_tests
 
@@ -1814,6 +1815,7 @@
         script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=recsys --dataloader_type=ray_data --num_workers=8 --train_batch_size=8192 --validation_batch_size=16384 --num_epochs=1
 
 - name: training_ingest_benchmark-soak_test
+  python: "3.10"
   group: Train tests
   working_dir: train_tests/benchmark
 
@@ -1871,6 +1873,7 @@
   alert: default
 
 - name: train_async_checkpointing_validation_benchmark
+  python: "3.10"
   group: Train tests
   working_dir: train_tests/async_checkpointing_validation_benchmark
   frequency: nightly

--- a/release/runtime_env_tests/workloads/rte_many_tasks_actors.py
+++ b/release/runtime_env_tests/workloads/rte_many_tasks_actors.py
@@ -21,10 +21,10 @@ def update_progress(result):
 
 
 if __name__ == "__main__":
-    ray.init(address="auto", runtime_env={"pip": ["requests==2.18.0"]})
+    ray.init(address="auto", runtime_env={"pip": ["requests==2.31.0"]})
     versions = ["2.28.0", "2.29.0", "2.31.0"]
     envs = [{"pip": [f"requests=={versions[i]}"]} for i in range(len(versions) - 1)]
-    # If a task's env is {}, we should have requests==2.18.0 from the job's env
+    # If a task's env is {}, we should have requests==2.31.0 from the job's env
     envs.append({})
 
     NUM_TASK_ITERATIONS = 10

--- a/release/runtime_env_tests/workloads/rte_many_tasks_actors.py
+++ b/release/runtime_env_tests/workloads/rte_many_tasks_actors.py
@@ -22,7 +22,7 @@ def update_progress(result):
 
 if __name__ == "__main__":
     ray.init(address="auto", runtime_env={"pip": ["requests==2.18.0"]})
-    versions = ["2.16.0", "2.17.0", "2.18.0"]
+    versions = ["2.28.0", "2.29.0", "2.31.0"]
     envs = [{"pip": [f"requests=={versions[i]}"]} for i in range(len(versions) - 1)]
     # If a task's env is {}, we should have requests==2.18.0 from the job's env
     envs.append({})


### PR DESCRIPTION
upgrading train and runtime env release tests to run on py310

train release tests run: https://buildkite.com/ray-project/release/builds/70548#
training_ingest_benchmark-task=recsys.full_training.ray_data (failing test) is disabled: 

Runtime release tests run: https://buildkite.com/ray-project/release/builds/70612
