### PR TITLE
[core] aggregation function for high cardinality metric

### DIFF
--- a/python/ray/_private/telemetry/metric_cardinality.py
+++ b/python/ray/_private/telemetry/metric_cardinality.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Set
+from typing import Callable, Dict, List
 
 from ray._private.ray_constants import RAY_METRIC_CARDINALITY_LEVEL
 
@@ -7,7 +7,10 @@ from ray._private.ray_constants import RAY_METRIC_CARDINALITY_LEVEL
 WORKER_ID_TAG_KEY = "WorkerId"
 # Keep in sync with the NameKey in src/ray/stats/metric_defs.cc
 TASK_OR_ACTOR_NAME_TAG_KEY = "Name"
-HIGH_CARDINALITY_METRICS: Set[str] = {"tasks", "actors"}
+HIGH_CARDINALITY_METRICS_TO_AGGREGATION: Dict[str, Callable[[List[float]], float]] = {
+    "tasks": lambda values: sum(values),
+    "actors": lambda values: sum(values),
+}
 
 _CARDINALITY_LEVEL = None
 _HIGH_CARDINALITY_LABELS: Dict[str, List[str]] = {}
@@ -42,6 +45,16 @@ class MetricCardinality(str, Enum):
         return _CARDINALITY_LEVEL
 
     @staticmethod
+    def get_aggregation_function(metric_name: str) -> Callable[[List[float]], float]:
+        if metric_name in HIGH_CARDINALITY_METRICS_TO_AGGREGATION:
+            return HIGH_CARDINALITY_METRICS_TO_AGGREGATION[metric_name]
+        return lambda values: values[0]
+
+    @staticmethod
+    def get_high_cardinality_metrics() -> List[str]:
+        return list(HIGH_CARDINALITY_METRICS_TO_AGGREGATION.keys())
+
+    @staticmethod
     def get_high_cardinality_labels_to_drop(metric_name: str) -> List[str]:
         """
         Get the high cardinality labels of the metric.
@@ -52,12 +65,15 @@ class MetricCardinality(str, Enum):
         cardinality_level = MetricCardinality.get_cardinality_level()
         if (
             cardinality_level == MetricCardinality.LEGACY
-            or metric_name not in HIGH_CARDINALITY_METRICS
+            or metric_name not in MetricCardinality.get_high_cardinality_metrics()
         ):
             _HIGH_CARDINALITY_LABELS[metric_name] = []
             return []
 
         _HIGH_CARDINALITY_LABELS[metric_name] = [WORKER_ID_TAG_KEY]
-        if cardinality_level == MetricCardinality.LOW:
+        if cardinality_level == MetricCardinality.LOW and metric_name in [
+            "tasks",
+            "actors",
+        ]:
             _HIGH_CARDINALITY_LABELS[metric_name].append(TASK_OR_ACTOR_NAME_TAG_KEY)
         return _HIGH_CARDINALITY_LABELS[metric_name]

--- a/python/ray/_private/telemetry/metric_cardinality.py
+++ b/python/ray/_private/telemetry/metric_cardinality.py
@@ -58,9 +58,6 @@ class MetricCardinality(str, Enum):
             return []
 
         _HIGH_CARDINALITY_LABELS[metric_name] = [WORKER_ID_TAG_KEY]
-        if cardinality_level == MetricCardinality.LOW and metric_name in [
-            "tasks",
-            "actors",
-        ]:
+        if cardinality_level == MetricCardinality.LOW:
             _HIGH_CARDINALITY_LABELS[metric_name].append(TASK_OR_ACTOR_NAME_TAG_KEY)
         return _HIGH_CARDINALITY_LABELS[metric_name]

--- a/python/ray/tests/test_metric_cardinality.py
+++ b/python/ray/tests/test_metric_cardinality.py
@@ -16,7 +16,7 @@ from ray._common.network_utils import build_address
 from ray._private.telemetry.metric_cardinality import (
     WORKER_ID_TAG_KEY,
     TASK_OR_ACTOR_NAME_TAG_KEY,
-    HIGH_CARDINALITY_METRICS,
+    MetricCardinality,
 )
 
 
@@ -90,7 +90,10 @@ def _cardinality_level_test(_setup_cluster_for_test, cardinality_level, metric):
         samples = metric_samples.get(f"ray_{metric}")
         assert samples, f"Metric {metric} not found in samples"
         for sample in samples:
-            if cardinality_level == "legacy" or metric not in HIGH_CARDINALITY_METRICS:
+            if (
+                cardinality_level == "legacy"
+                or metric not in MetricCardinality.get_high_cardinality_metrics()
+            ):
                 # If the cardinality level is legacy, the WorkerId tag should be
                 # present
                 assert (


### PR DESCRIPTION
`RAY_metric_cardinality_level` is a setting a user can set to reduce high cardinality label in Ray metrics. By default, `WorkerId` label will be dropped and the values will be aggregated using a sum function. This only supports `ray_tasks` and `ray_actors` metric.

This PR supports configurable aggregation function. For example, for a gauge latency metric, one might want to use `median` etc. rather than `sum` as an aggregation.

Test:
- CI