### PR TITLE
[data] Fix memory accounting pillow arrays in pandas

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -663,7 +663,6 @@ def _map_task(
             meta_with_schema = BlockMetadataWithSchema(metadata=m_out, schema=s_out)
             yield b_out
             yield meta_with_schema
-            print(f"type={type(b_out)} block size is {meta_with_schema.size_bytes}")
             stats = BlockExecStats.builder()
             profiler.reset()
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -663,6 +663,7 @@ def _map_task(
             meta_with_schema = BlockMetadataWithSchema(metadata=m_out, schema=s_out)
             yield b_out
             yield meta_with_schema
+            print(f"type={type(b_out)} block size is {meta_with_schema.size_bytes}")
             stats = BlockExecStats.builder()
             profiler.reset()
 

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -41,7 +41,7 @@ try:
     from PIL.Image import Image
 
     PIL_Image = Image
-except Exception:
+except ImportError:
     pass
 
 if TYPE_CHECKING:

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from PIL import Image
 
 import ray
 import ray.data
@@ -457,14 +458,12 @@ class TestSizeBytes:
 
     def test_pil_image(ray_start_regular_shared):
         """Test that size_bytes correctly handles PIL Image objects."""
-        pytest.importorskip("PIL")
-        from PIL import Image
 
         # Create a 200x200 RGB image (~120KB uncompressed)
         # RGB = 3 bytes per pixel, 200x200 = 40,000 pixels = 120,000 bytes
         width, height = 200, 200
         img = Image.new("RGB", (width, height), color="red")
-        
+
         # Put the PIL Image in a DataFrame
         block = pd.DataFrame({"image": [img]})
         block_accessor = PandasBlockAccessor.for_block(block)
@@ -473,7 +472,7 @@ class TestSizeBytes:
         # The true size is the image data size
         # For PIL Images, this is width * height * num_channels
         true_size = len(img.tobytes())
-        
+
         # The size_bytes should be within 1% of the actual image size
         # Note: There's some overhead from the DataFrame structure and PIL object wrapper
         assert bytes_size == pytest.approx(true_size, rel=0.01), (

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -455,6 +455,32 @@ class TestSizeBytes:
         )
         assert bytes_size == pytest.approx(true_size, rel=0.1), (bytes_size, true_size)
 
+    def test_pil_image(ray_start_regular_shared):
+        """Test that size_bytes correctly handles PIL Image objects."""
+        pytest.importorskip("PIL")
+        from PIL import Image
+
+        # Create a 200x200 RGB image (~120KB uncompressed)
+        # RGB = 3 bytes per pixel, 200x200 = 40,000 pixels = 120,000 bytes
+        width, height = 200, 200
+        img = Image.new("RGB", (width, height), color="red")
+        
+        # Put the PIL Image in a DataFrame
+        block = pd.DataFrame({"image": [img]})
+        block_accessor = PandasBlockAccessor.for_block(block)
+        bytes_size = block_accessor.size_bytes()
+
+        # The true size is the image data size
+        # For PIL Images, this is width * height * num_channels
+        true_size = len(img.tobytes())
+        
+        # The size_bytes should be within 1% of the actual image size
+        # Note: There's some overhead from the DataFrame structure and PIL object wrapper
+        assert bytes_size == pytest.approx(true_size, rel=0.01), (
+            bytes_size,
+            true_size,
+        )
+
 
 def test_iter_rows_with_na(ray_start_regular_shared):
     block = pd.DataFrame({"col": [pd.NA]})


### PR DESCRIPTION
## Description
Summary of what doesn't work and what does work before this PR:
```python
import pandas as pd
import sys
import numpy as np
from ray.data.block import BlockAccessor 
df = pd.DataFrame({'img': [img]})
df.info()
acc = BlockAccessor.for_block(df)
block = acc.to_numpy()
print(f"getsizeof: {sys.getsizeof(img)}") # 48
print(f"length of bytes: {len(img.tobytes())}") # 750000
print(f"pandas: {acc.size_bytes()}") # 750136
print(f"to_numpy: {block['img'].nbytes}") # 8
print(f"pandas -> numpy: {df['img'].to_numpy().nbytes}") # 8
print(f"pandas -> numpy: {np.array(df['img']).nbytes}") # 8
```

The results above show that when a user
- specifies `batch_format=pandas`
- doesn't convert their pil image into a numpy array, ie, they are returning `Image.open(...)`, not `np.array(Image.open(...))`

memory usage is severely undercounted. This PR addresses this by adding another case for pillow images. I don't think this is greatest solution long-term, but since pil images are heavily used, I think we should handle the common case. Other alternatives include

- Providing hooks for users to provide their own memory usage accounting
- use ray core APIs, like 
```python
locations = ray.experimental.get_object_locations([obj_ref])
size_bytes = locations[obj_ref]["object_size"]
```

## Related issues

## Additional information
Note: have tried https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.memory_usage.html and  https://github.com/pympler/pympler, these are inaccurate