### PR TITLE
[Data] - Fix Spacing on Glossary DocTest

### DIFF
--- a/doc/source/ray-references/glossary.rst
+++ b/doc/source/ray-references/glossary.rst
@@ -96,7 +96,7 @@ documentation, sorted alphabetically.
             pyarrow.Table
             id: int64
             ----
-            id: [[0],[1],...,[3],[4]]                                                                                                         
+            id: [[0],[1],...,[3],[4]]
 
         To learn more about batch formats, read
         :ref:`Configuring batch formats <configure_batch_format>`.


### PR DESCRIPTION
## Description
As title suggests.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
