### PR TITLE
[core] move io context to member variable

### DIFF
--- a/src/ray/raylet_rpc_client/raylet_client_with_io_context.cc
+++ b/src/ray/raylet_rpc_client/raylet_client_with_io_context.cc
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-#include "ray/common/asio/asio_util.h"
 #include "ray/common/ray_config.h"
 #include "ray/util/logging.h"
 #include "src/ray/protobuf/node_manager.grpc.pb.h"
@@ -29,10 +28,7 @@ namespace rpc {
 
 RayletClientWithIoContext::RayletClientWithIoContext(const std::string &ip_address,
                                                      int port) {
-  // Connect to the raylet on a singleton io service with a dedicated thread.
-  // This is to avoid creating multiple threads for multiple clients in python.
-  static InstrumentedIOContextWithThread io_context("raylet_client_io_service");
-  instrumented_io_context &io_service = io_context.GetIoService();
+  instrumented_io_context &io_service = io_context_.GetIoService();
   client_call_manager_ = std::make_unique<rpc::ClientCallManager>(
       io_service, /*record_stats=*/false, ip_address);
   auto raylet_unavailable_timeout_callback = []() {

--- a/src/ray/raylet_rpc_client/raylet_client_with_io_context.h
+++ b/src/ray/raylet_rpc_client/raylet_client_with_io_context.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "ray/common/asio/asio_util.h"
 #include "ray/raylet_rpc_client/raylet_client.h"
 #include "ray/rpc/grpc_client.h"
 
@@ -39,6 +40,9 @@ class RayletClientWithIoContext {
                      int64_t timeout_ms);
 
  private:
+  // Connect to the raylet on a singleton io service with a dedicated thread.
+  // This is to avoid creating multiple threads for multiple clients in python.
+  inline static InstrumentedIOContextWithThread io_context_{"raylet_client_io_service"};
   /// client call manager is created inside the raylet client, it should be kept active
   /// during the whole lifetime of client.
   std::unique_ptr<rpc::ClientCallManager> client_call_manager_;


### PR DESCRIPTION
## Description
This pr is to move io context singleton as a member of `RayletClientWithIoContext`

## Related issues
https://github.com/ray-project/ray/pull/57004#discussion_r2449226163

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
