### PR TITLE
[core] Add global option to disable worker logs

### DIFF
--- a/doc/source/ray-observability/user-guides/configure-logging.md
+++ b/doc/source/ray-observability/user-guides/configure-logging.md
@@ -63,6 +63,11 @@ printed from the autoscaler respectively. They're usually empty except when the 
 - ``runtime_env_setup-ray_client_server_[port].log``: Logs from installing {ref}`Runtime Environments <runtime-environments>` for a job when connecting with {ref}`Ray Client <ray-client-ref>`.
 - ``runtime_env_setup-[job_id].log``: Logs from installing {ref}`runtime environments <runtime-environments>` for a Task, Actor, or Job. This file is only present if you install a runtime environment.
 
+Disable worker logs globally
+----------------------------
+
+Set the environment variable ``RAY_DISABLE_WORKER_LOGS=1`` on every node before running ``ray start`` (head and workers) to disable worker log files. When this flag is set, Ray does not create worker stdout/stderr files (``worker-*.out|err``) or core worker logs (``python-core-worker-*.log``). Driver and system logs are not affected.
+
 
 (log-redirection-to-driver)=
 ## Redirecting Worker logs to the Driver

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -62,6 +62,11 @@ RAY_DISABLE_FAILURE_SIGNAL_HANDLER = env_bool(
     "RAY_DISABLE_FAILURE_SIGNAL_HANDLER", False
 )
 
+# Whether to disable worker log files (worker-*.out/err and python-core-worker-*.log).
+# When enabled, prevents creation of worker log files to reduce disk usage and I/O overhead
+# in large-scale deployments. Driver and system component logs remain unaffected.
+RAY_DISABLE_WORKER_LOGS = env_bool("RAY_DISABLE_WORKER_LOGS", False)
+
 RAY_LOG_TO_DRIVER = env_bool("RAY_LOG_TO_DRIVER", True)
 
 # Filter level under which events will be filtered out, i.e. not printing to driver

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2664,8 +2664,9 @@ def connect(
             job_config._py_driver_sys_path.extend(code_paths)
 
     serialized_job_config = job_config._serialize()
-    if not node.should_redirect_logs():
-        # Logging to stderr, so give core worker empty logs directory.
+    # When worker logs are disabled or not redirecting to files,
+    # give core worker empty logs directory.
+    if ray_constants.RAY_DISABLE_WORKER_LOGS or not node.should_redirect_logs():
         logs_dir = ""
     else:
         logs_dir = node.get_logs_dir_path()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2662,11 +2662,17 @@ cdef class CoreWorker:
         options.raylet_socket = raylet_socket.encode("ascii")
         options.job_id = job_id.native()
         options.gcs_options = gcs_options.native()[0]
-        options.enable_logging = True
+
+        if ray_constants.RAY_DISABLE_WORKER_LOGS:
+            options.enable_logging = False
+            log_dir = ""
+            options.install_failure_signal_handler = False
+        else:
+            options.enable_logging = True
+            options.install_failure_signal_handler = (
+                not ray_constants.RAY_DISABLE_FAILURE_SIGNAL_HANDLER
+            )
         options.log_dir = log_dir.encode("utf-8")
-        options.install_failure_signal_handler = (
-            not ray_constants.RAY_DISABLE_FAILURE_SIGNAL_HANDLER
-        )
         # https://stackoverflow.com/questions/2356399/tell-if-python-is-in-interactive-mode
         options.interactive = hasattr(sys, "ps1")
         options.node_ip_address = node_ip_address.encode("utf-8")


### PR DESCRIPTION
## Background

In large-scale Ray deployments with many tasks and workers, the system can generate millions of worker log files (worker-.out/err and python-core-worker-.log), causing disk space exhaustion, severe I/O performance degradation, and operational burden. These worker-level logs provide little value for most production use cases. This is a well-documented pain point in the Ray community, with multiple users reporting the issue (https://discuss.ray.io/t/how-to-disable-the-info-log/11619/3 and https://discuss.ray.io/t/ray-is-creating-hundreds-of-logs-files-under-tmp-ray-session-latest-logs-causing-disk-space-issue-and-i-o-spikes/12058/11). This PR addresses these concerns by introducing a global mechanism to disable worker log file generation while preserving driver and system component logs that are essential for cluster monitoring and debugging.

## Description
This PR adds a global mechanism to disable worker logs via the RAY_DISABLE_WORKER_LOGS environment variable. When set to "1", this prevents the creation of worker stdout/stderr files (worker-*.out/err) and C++ core worker log files (python-core-worker-*.log) for all workers in the cluster. Driver logs and system component logs remain unaffected.

This feature is useful for large-scale deployments where worker log files can accumulate rapidly and consume significant disk space.

- Added RAY_DISABLE_WORKER_LOGS environment variable support in:
  - `python/ray/_private/worker.py`: Sets empty logs_dir when disabled
  - `python/ray/_private/workers/default_worker.py`: Skips log file creation and sets out/err files to None when disabled
  - `python/ray/_raylet.pyx`: Sets enable_logging=False, empty log_dir, and disables failure signal handler when disabled
- Updated documentation in `configure-logging.md` to describe the new feature

Verified that when RAY_DISABLE_WORKER_LOGS=1 is set:
- No worker-*.out/err files are created
- No python-core-worker-*.log files are created
- Driver logs continue to work normally
- System component logs (raylet, gcs_server, etc.) are unaffected

## Related issues

https://discuss.ray.io/t/how-to-disable-the-info-log/11619/3

https://discuss.ray.io/t/ray-is-creating-hundreds-of-logs-files-under-tmp-ray-session-latest-logs-causing-disk-space-issue-and-i-o-spikes/12058/11

## Additional information
The environment variable should be set before starting Ray nodes (both head and worker nodes) using `ray start`. This is a global setting that applies to all workers in the cluster.
