### PR TITLE
[Data] - Reapply iceberg overwrite + upsert changes + schema updates on driver

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1018,10 +1018,6 @@ python/ray/data/_internal/block_batching/util.py
     DOC402: Function `finalize_batches` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `finalize_batches` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
 --------------------
-python/ray/data/_internal/datasource/iceberg_datasink.py
-    DOC102: Method `IcebergDatasink.__init__`: Docstring contains more arguments than in function signature.
-    DOC103: Method `IcebergDatasink.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [to an iceberg table, e.g. {"commit_time": ].
---------------------
 python/ray/data/_internal/datasource/lance_datasink.py
     DOC101: Method `LanceDatasink.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `LanceDatasink.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: , max_rows_per_file: int, min_rows_per_file: int, mode: Literal['create', 'append', 'overwrite'], schema: Optional[pa.Schema], storage_options: Optional[Dict[str, Any]], uri: str]. Arguments in the docstring but not in the function signature: [max_rows_per_file : , min_rows_per_file : , mode : , schema : , storage_options : , uri : ].

--- a/python/ray/data/_internal/datasource/iceberg_datasink.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasink.py
@@ -3,30 +3,56 @@ Module to write a Ray Dataset into an iceberg table, by using the Ray Datasink A
 """
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
-
-from packaging import version
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
 from ray.data._internal.execution.interfaces import TaskContext
+from ray.data._internal.savemode import SaveMode
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.datasink import Datasink, WriteResult
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
+    import pyarrow as pa
     from pyiceberg.catalog import Catalog
     from pyiceberg.manifest import DataFile
+    from pyiceberg.table import Table, Transaction
+
+    from ray.data.expressions import Expr
 
 
 logger = logging.getLogger(__name__)
 
+_JOIN_COLS_KEY = "join_cols"
+
+
+def _append_and_commit(
+    txn: "Transaction",
+    data_files: List["DataFile"],
+    snapshot_properties: Dict[str, str],
+) -> None:
+    """Helper to append data files to a transaction and commit.
+
+    Args:
+        txn: PyIceberg transaction object
+        data_files: List of DataFile objects to append
+        snapshot_properties: Custom properties to write to snapshot summary
+    """
+    with txn._append_snapshot_producer(snapshot_properties) as append_files:
+        for data_file in data_files:
+            append_files.append_data_file(data_file)
+    txn.commit_transaction()
+
 
 @DeveloperAPI
-class IcebergDatasink(Datasink[List["DataFile"]]):
+class IcebergDatasink(
+    Datasink[Union[List["DataFile"], tuple[List["DataFile"], Dict[str, List[Any]]]]]
+):
     """
-    Iceberg datasink to write a Ray Dataset into an existing Iceberg table. This module
-    heavily uses PyIceberg to write to iceberg table. All the routines in this class override
-    `ray.data.Datasink`.
-
+    Iceberg datasink to write a Ray Dataset into an existing Iceberg table.
+    This datasink handles concurrent writes by:
+    - Each worker writes Parquet files to storage and returns DataFile metadata
+    - The driver collects all DataFile objects and performs a single commit
     """
 
     def __init__(
@@ -34,137 +60,450 @@ class IcebergDatasink(Datasink[List["DataFile"]]):
         table_identifier: str,
         catalog_kwargs: Optional[Dict[str, Any]] = None,
         snapshot_properties: Optional[Dict[str, str]] = None,
+        mode: SaveMode = SaveMode.APPEND,
+        overwrite_filter: Optional["Expr"] = None,
+        upsert_kwargs: Optional[Dict[str, Any]] = None,
+        overwrite_kwargs: Optional[Dict[str, Any]] = None,
+        upsert_commit_memory: Optional[int] = None,
+        incoming_schema: Optional["pa.Schema"] = None,
     ):
         """
         Initialize the IcebergDatasink
 
         Args:
-            table_identifier: The identifier of the table to read e.g. `default.taxi_dataset`
-            catalog_kwargs: Optional arguments to use when setting up the Iceberg
-                catalog
-            snapshot_properties: custom properties write to snapshot when committing
-            to an iceberg table, e.g. {"commit_time": "2021-01-01T00:00:00Z"}
+            table_identifier: The identifier of the table such as `default.taxi_dataset`
+            catalog_kwargs: Optional arguments to use when setting up the Iceberg catalog
+            snapshot_properties: Custom properties to write to snapshot summary
+            mode: Write mode - APPEND, UPSERT, or OVERWRITE. Defaults to APPEND.
+                - APPEND: Add new data without checking for duplicates
+                - UPSERT: Update existing rows or insert new ones based on a join condition
+                - OVERWRITE: Replace table data (all data or filtered subset)
+            overwrite_filter: Optional filter for OVERWRITE mode to perform partial overwrites.
+                Must be a Ray Data expression from `ray.data.expressions`. Only rows matching
+                this filter are replaced. If None with OVERWRITE mode, replaces all table data.
+            upsert_kwargs: Optional arguments for upsert operations.
+                Supported parameters: join_cols (List[str]), case_sensitive (bool),
+                branch (str). Note: This implementation uses a copy-on-write strategy
+                that always updates all columns for matched keys and inserts all new keys.
+            overwrite_kwargs: Optional arguments to pass through to PyIceberg's table.overwrite()
+                method. Supported parameters include case_sensitive (bool) and branch (str).
+                See PyIceberg documentation for details.
+            upsert_commit_memory: [For UPSERT mode only] The heap memory in bytes
+                to reserve for the upsert commit operation. If None,
+                uses Ray's default memory allocation.
+            incoming_schema: Optional PyArrow schema of the incoming data. Used to evolve
+                table schema before writing to avoid name mapping errors.
+
+        Note:
+            Schema evolution is automatically enabled. New columns in the incoming data
+            are automatically added to the table schema.
         """
-
-        from pyiceberg.io import FileIO
-        from pyiceberg.table import Transaction
-        from pyiceberg.table.metadata import TableMetadata
-
         self.table_identifier = table_identifier
-        self._catalog_kwargs = catalog_kwargs if catalog_kwargs is not None else {}
-        self._snapshot_properties = (
-            snapshot_properties if snapshot_properties is not None else {}
-        )
+        self._catalog_kwargs = (catalog_kwargs or {}).copy()
+        self._snapshot_properties = snapshot_properties or {}
+        self._mode = mode
+        self._overwrite_filter = overwrite_filter
+        self._upsert_kwargs = (upsert_kwargs or {}).copy()
+        self._overwrite_kwargs = (overwrite_kwargs or {}).copy()
+        self._upsert_commit_memory = upsert_commit_memory
+        self._incoming_schema = incoming_schema
+
+        # Validate kwargs are only set for relevant modes
+        if self._upsert_kwargs and self._mode != SaveMode.UPSERT:
+            raise ValueError(
+                f"upsert_kwargs can only be specified when mode is SaveMode.UPSERT, but mode is {self._mode}"
+            )
+        if self._overwrite_kwargs and self._mode != SaveMode.OVERWRITE:
+            raise ValueError(
+                f"overwrite_kwargs can only be specified when mode is SaveMode.OVERWRITE, but mode is {self._mode}"
+            )
+
+        # Remove invalid parameters from overwrite_kwargs if present
+        for invalid_param, reason in [
+            (
+                "overwrite_filter",
+                "should be passed as a separate parameter to write_iceberg()",
+            ),
+            (
+                "delete_filter",
+                "is an internal PyIceberg parameter; use 'overwrite_filter' instead",
+            ),
+        ]:
+            if self._overwrite_kwargs.pop(invalid_param, None) is not None:
+                logger.warning(
+                    f"Removed '{invalid_param}' from overwrite_kwargs: {reason}"
+                )
 
         if "name" in self._catalog_kwargs:
             self._catalog_name = self._catalog_kwargs.pop("name")
         else:
             self._catalog_name = "default"
 
-        self._uuid: str = None
-        self._io: FileIO = None
-        self._txn: Transaction = None
-        self._table_metadata: TableMetadata = None
+        self._table: "Table" = None
+        self._write_uuid: uuid.UUID = None
 
-    # Since iceberg transaction is not pickle-able, because of the table and catalog properties
-    # we need to exclude the transaction object during serialization and deserialization during pickle
     def __getstate__(self) -> dict:
-        """Exclude `_txn` during pickling."""
+        """Exclude `_table` during pickling."""
         state = self.__dict__.copy()
-        del state["_txn"]
+        state.pop("_table", None)
         return state
 
     def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
-        self._txn = None
+        self._table = None
 
     def _get_catalog(self) -> "Catalog":
         from pyiceberg import catalog
 
         return catalog.load_catalog(self._catalog_name, **self._catalog_kwargs)
 
-    def on_write_start(self) -> None:
-        """Prepare for the transaction"""
-        import pyiceberg
-        from pyiceberg.table import TableProperties
-
-        if version.parse(pyiceberg.__version__) >= version.parse("0.9.0"):
-            from pyiceberg.utils.properties import property_as_bool
-        else:
-            from pyiceberg.table import PropertyUtil
-
-            property_as_bool = PropertyUtil.property_as_bool
+    def _reload_table(self) -> None:
+        """Reload the Iceberg table from the catalog."""
+        from pyiceberg.exceptions import NoSuchTableError
 
         catalog = self._get_catalog()
-        table = catalog.load_table(self.table_identifier)
-        self._txn = table.transaction()
-        self._io = self._txn._table.io
-        self._table_metadata = self._txn.table_metadata
-        self._uuid = uuid.uuid4()
+        try:
+            self._table = catalog.load_table(self.table_identifier)
+        except NoSuchTableError:
+            # Table will be created in write() when we have the first block's schema
+            self._table = None
 
-        if unsupported_partitions := [
-            field
-            for field in self._table_metadata.spec().fields
-            if not field.transform.supports_pyarrow_transform
-        ]:
-            raise ValueError(
-                f"Not all partition types are supported for writes. Following partitions cannot be written using pyarrow: {unsupported_partitions}."
-            )
+    def _get_join_cols(self) -> List[str]:
+        """Get join columns for upsert, using table identifier fields as fallback."""
+        join_cols = self._upsert_kwargs.get(_JOIN_COLS_KEY, [])
+        if not join_cols:
+            # Use table's identifier fields as fallback
+            for field_id in self._table.metadata.schema().identifier_field_ids:
+                col_name = self._table.metadata.schema().find_column_name(field_id)
+                if col_name:
+                    join_cols.append(col_name)
+        return join_cols
 
-        self._manifest_merge_enabled = property_as_bool(
-            self._table_metadata.properties,
-            TableProperties.MANIFEST_MERGE_ENABLED,
-            TableProperties.MANIFEST_MERGE_ENABLED_DEFAULT,
-        )
+    def _update_schema(self, incoming_schema: "pa.Schema") -> None:
+        """
+        Update the table schema to accommodate incoming data using union-by-name semantics.
+
+        This is now only called from the driver after reconciling all schemas.
+
+        Args:
+            incoming_schema: The PyArrow schema to merge with the table schema
+        """
+        from pyiceberg.exceptions import CommitFailedException
+
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                with self._table.update_schema() as update:
+                    update.union_by_name(incoming_schema)
+                # Succeeded, reload to get latest table version and exit.
+                self._reload_table()
+                return
+            except CommitFailedException:
+                if attempt < max_retries - 1:
+                    logger.debug(
+                        f"Schema update conflict - reloading and retrying "
+                        f"(attempt {attempt + 1}/{max_retries})"
+                    )
+                    self._reload_table()
+                else:
+                    logger.error(
+                        "Failed to update schema after %d retries due to conflicts.",
+                        max_retries,
+                    )
+                    raise
+
+    def _evolve_schema_if_needed(self, incoming_schema: "pa.Schema") -> None:
+        """
+        Evolve table schema if incoming data has new columns.
+
+        This must be called before files are written to avoid PyIceberg
+        name mapping errors when the incoming data has columns not in
+        the table schema.
+
+        Args:
+            incoming_schema: The PyArrow schema of the incoming data
+        """
+        from pyiceberg.io import pyarrow as pyi_pa_io
+
+        table_schema: "pa.Schema" = pyi_pa_io.schema_to_pyarrow(self._table.schema())
+        table_field_names = set(table_schema.names)
+        incoming_field_names = set(incoming_schema.names)
+
+        # Only evolve schema if there are new columns.
+        # Don't trigger evolution for type mismatches on existing columns
+        # (e.g., empty datasets with inferred types like double instead of string).
+        new_columns = incoming_field_names - table_field_names
+        if new_columns:
+            self._update_schema(incoming_schema)
+
+    def on_write_start(self) -> None:
+        """Initialize table for writing and create a shared write UUID."""
+        self._reload_table()
+
+        self._write_uuid = uuid.uuid4()
+
+        # Evolve schema BEFORE any files are written
+        # This prevents PyIceberg name mapping errors when incoming data has new columns
+        if self._table is not None and self._incoming_schema is not None:
+            self._evolve_schema_if_needed(self._incoming_schema)
+
+        # Validate join_cols for UPSERT mode before writing any files
+        if self._mode == SaveMode.UPSERT:
+            join_cols = self._upsert_kwargs.get(_JOIN_COLS_KEY, [])
+            if not join_cols:
+                # Check if table has identifier fields as fallback
+                identifier_field_ids = (
+                    self._table.metadata.schema().identifier_field_ids
+                )
+                if not identifier_field_ids:
+                    raise ValueError(
+                        "join_cols must be specified in upsert_kwargs for UPSERT mode "
+                        "when table has no identifier fields"
+                    )
 
     def write(
         self, blocks: Iterable[Block], ctx: TaskContext
-    ) -> WriteResult[List["DataFile"]]:
-        from pyiceberg.io.pyarrow import (
-            _check_pyarrow_schema_compatible,
-            _dataframe_to_data_files,
-        )
-        from pyiceberg.table import DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE
-        from pyiceberg.utils.config import Config
+    ) -> Union[
+        tuple[List["DataFile"], "pa.Schema"],
+        tuple[List["DataFile"], Dict[str, List[Any]], "pa.Schema"],
+    ]:
+        """
+        Write blocks to Parquet files in storage and return DataFile metadata with schema.
 
-        data_files_list: WriteResult[List["DataFile"]] = []
+        This runs on each worker in parallel. Files are written directly to storage
+        (S3, HDFS, etc.) and only metadata is returned to the driver.
+        Schema updates are NOT performed here - they happen on the driver.
+
+        Args:
+            blocks: Iterable of Ray Data blocks to write
+            ctx: TaskContext object containing task-specific information
+
+        Returns:
+            For APPEND/OVERWRITE: Tuple of (List of DataFile objects, PyArrow schema).
+            For UPSERT: Tuple of (List of DataFile objects, Dict mapping col names to key values, PyArrow schema).
+        """
+        from pyiceberg.io.pyarrow import _dataframe_to_data_files
+
+        if self._table is None:
+            self._reload_table()
+
+        all_data_files = []
+        join_keys_dict = defaultdict(list)
+        first_schema = None
+
+        # Extract join keys for copy-on-write upsert
+        extract_join_keys = self._mode == SaveMode.UPSERT
+
         for block in blocks:
             pa_table = BlockAccessor.for_block(block).to_arrow()
+            if pa_table.num_rows > 0:
+                # Track schema for reconciliation on driver
+                # We allow different schemas between blocks (nullability, missing columns, type promotion)
+                # Schema reconciliation happens on driver using unify_schemas
+                if first_schema is None:
+                    first_schema = pa_table.schema
 
-            downcast_ns_timestamp_to_us = (
-                Config().get_bool(DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE) or False
-            )
-            _check_pyarrow_schema_compatible(
-                self._table_metadata.schema(),
-                provided_schema=pa_table.schema,
-                downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us,
-            )
+                # Extract join key values for copy-on-write upsert
+                if extract_join_keys:
+                    join_cols = self._get_join_cols()
+                    for col in join_cols:
+                        join_keys_dict[col].extend(pa_table[col].to_pylist())
 
-            if pa_table.shape[0] <= 0:
+                # Write data files to storage
+                # Note: We need table metadata to write files. If table doesn't exist,
+                # we'll create it in on_write_complete after schema reconciliation.
+                # For now, create a temporary table if needed - it will be updated
+                # with the reconciled schema in on_write_complete.
+                if self._table is None:
+                    # Create table with first schema - will be updated with reconciled schema later
+                    catalog = self._get_catalog()
+                    self._table = catalog.create_table(
+                        self.table_identifier, schema=first_schema
+                    )
+
+                data_files = list(
+                    _dataframe_to_data_files(
+                        table_metadata=self._table.metadata,
+                        write_uuid=self._write_uuid,
+                        df=pa_table,
+                        io=self._table.io,
+                    )
+                )
+                all_data_files.extend(data_files)
+
+        # Return schema along with data files
+        # Use first_schema (may be None if no blocks had rows)
+        if first_schema is None:
+            import pyarrow as pa
+
+            first_schema = pa.schema([])
+
+        if extract_join_keys:
+            return (all_data_files, join_keys_dict, first_schema)
+        return (all_data_files, first_schema)
+
+    def _commit_upsert(
+        self, data_files: List["DataFile"], join_keys_dicts: List[Dict[str, List[Any]]]
+    ) -> None:
+        """
+        Commit upsert transaction with copy-on-write strategy.
+
+        Args:
+            data_files: List of DataFile objects to commit
+            join_keys_dicts: List of dictionaries mapping column names to lists of key values
+        """
+        import functools
+        from collections import defaultdict
+
+        import pyarrow as pa
+        from pyiceberg.table.upsert_util import create_match_filter
+
+        # Merge all join keys dictionaries
+        merged_keys_dict = defaultdict(list)
+        for join_keys_dict in join_keys_dicts:
+            for col, values in join_keys_dict.items():
+                merged_keys_dict[col].extend(values)
+
+        # Start transaction
+        txn = self._table.transaction()
+
+        # Create delete filter if we have join keys
+        if merged_keys_dict:
+            # Create PyArrow table from join keys
+            keys_table = pa.table(dict(merged_keys_dict))
+
+            # Filter out rows with any NULL values in join columns
+            # (NULL != NULL in SQL semantics)
+            join_cols = self._get_join_cols()
+            masks = (pa.compute.is_valid(keys_table[col]) for col in join_cols)
+            mask = functools.reduce(pa.compute.and_, masks)
+            keys_table = keys_table.filter(mask)
+
+            # Only delete if we have non-NULL keys
+            if len(keys_table) > 0:
+                # Use PyIceberg's helper to build delete filter
+                delete_filter = create_match_filter(keys_table, join_cols)
+                txn.delete(
+                    delete_filter=delete_filter,
+                    snapshot_properties=self._snapshot_properties,
+                )
+
+        # Append new data files (includes updates and inserts) and commit
+        _append_and_commit(txn, data_files, self._snapshot_properties)
+
+    def on_write_complete(self, write_result: WriteResult) -> None:
+        """
+        Complete the write by reconciling schemas and committing all data files.
+
+        This runs on the driver after all workers finish writing files.
+        Collects all DataFile objects and schemas from all workers, reconciles schemas
+        (allowing type promotion), updates table schema if needed, then performs a single
+        atomic commit.
+        """
+        # Reload table to get latest metadata
+        self._reload_table()
+
+        # Collect all data files, schemas, and join keys (if applicable) from all workers
+        all_data_files = []
+        all_schemas = []
+        join_keys_dicts = []
+
+        # Check if we're in upsert mode (returns tuple with join keys)
+        use_copy_on_write_upsert = self._mode == SaveMode.UPSERT
+
+        for write_return in write_result.write_returns:
+            if not write_return:
                 continue
 
-            task_uuid = uuid.uuid4()
-            data_files = _dataframe_to_data_files(
-                self._table_metadata, pa_table, self._io, task_uuid
+            if use_copy_on_write_upsert:
+                # For copy-on-write upsert, write() returns (data_files, join_keys_dict, schema)
+                data_files, join_keys_dict, schema = write_return
+                if data_files:  # Only add schema if we have data files
+                    all_data_files.extend(data_files)
+                    all_schemas.append(schema)
+                    join_keys_dicts.append(join_keys_dict)
+            else:
+                # For other modes, write() returns (data_files, schema)
+                data_files, schema = write_return
+                if data_files:  # Only add schema if we have data files
+                    all_data_files.extend(data_files)
+                    all_schemas.append(schema)
+
+        if not all_data_files:
+            return
+
+        # Reconcile all schemas from workers using unify_schemas with type promotion enabled
+        # This handles nullability differences, missing columns, and type promotion
+        from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
+
+        reconciled_schema = unify_schemas(all_schemas, promote_types=True)
+
+        # Create table if it doesn't exist, or update schema if it does
+        if self._table is None:
+            catalog = self._get_catalog()
+            self._table = catalog.create_table(
+                self.table_identifier, schema=reconciled_schema
             )
-            data_files_list.extend(data_files)
+        else:
+            # Get table schema and union with reconciled schema
+            from pyiceberg.io import pyarrow as pyi_pa_io
 
-        return data_files_list
+            table_schema = pyi_pa_io.schema_to_pyarrow(self._table.schema())
+            # Union table schema with reconciled schema using unify_schemas with promotion
+            all_schemas_with_table = [table_schema, reconciled_schema]
+            final_reconciled_schema = unify_schemas(
+                all_schemas_with_table, promote_types=True
+            )
 
-    def on_write_complete(self, write_result: WriteResult[List["DataFile"]]):
-        update_snapshot = self._txn.update_snapshot(
-            snapshot_properties=self._snapshot_properties
-        )
-        append_method = (
-            update_snapshot.merge_append
-            if self._manifest_merge_enabled
-            else update_snapshot.fast_append
-        )
+            # Update table schema if it differs
+            if not final_reconciled_schema.equals(table_schema):
+                self._update_schema(final_reconciled_schema)
 
-        with append_method() as append_files:
-            append_files.commit_uuid = self._uuid
-            for data_files in write_result.write_returns:
-                for data_file in data_files:
-                    append_files.append_data_file(data_file)
+        # Reload table to get latest metadata after schema update
+        self._reload_table()
 
-        self._txn.commit_transaction()
+        # Create transaction and commit based on mode
+        if self._mode == SaveMode.APPEND:
+            self._commit_append(all_data_files)
+        elif self._mode == SaveMode.OVERWRITE:
+            self._commit_overwrite(all_data_files)
+        elif self._mode == SaveMode.UPSERT:
+            self._commit_upsert(all_data_files, join_keys_dicts)
+        else:
+            raise ValueError(f"Unsupported mode: {self._mode}")
+
+    def _commit_append(self, data_files: List["DataFile"]) -> None:
+        """Commit data files using APPEND mode."""
+        txn = self._table.transaction()
+        _append_and_commit(txn, data_files, self._snapshot_properties)
+
+    def _commit_overwrite(self, data_files: List["DataFile"]) -> None:
+        """Commit data files using OVERWRITE mode."""
+        txn = self._table.transaction()
+        # Delete matching data if filter provided
+        if self._overwrite_filter is not None:
+            from ray.data._internal.datasource.iceberg_datasource import (
+                _IcebergExpressionVisitor,
+            )
+
+            visitor = _IcebergExpressionVisitor()
+            pyi_filter = visitor.visit(self._overwrite_filter)
+
+            txn.delete(
+                delete_filter=pyi_filter,
+                snapshot_properties=self._snapshot_properties,
+                **self._overwrite_kwargs,
+            )
+        else:
+            # Full overwrite - delete all
+            from pyiceberg.expressions import AlwaysTrue
+
+            txn.delete(
+                delete_filter=AlwaysTrue(),
+                snapshot_properties=self._snapshot_properties,
+                **self._overwrite_kwargs,
+            )
+
+        # Append new data files and commit
+        _append_and_commit(txn, data_files, self._snapshot_properties)

--- a/python/ray/data/_internal/savemode.py
+++ b/python/ray/data/_internal/savemode.py
@@ -5,7 +5,21 @@ from ray.util.annotations import PublicAPI
 
 @PublicAPI(stability="alpha")
 class SaveMode(str, Enum):
+    """Enum of possible modes for saving/writing data."""
+
+    """Add new data without modifying existing data."""
     APPEND = "append"
+
+    """Replace all existing data with new data."""
     OVERWRITE = "overwrite"
+
+    """Don't write if data already exists."""
     IGNORE = "ignore"
+
+    """Raise an error if data already exists."""
     ERROR = "error"
+
+    """Update existing rows that match on key fields, or insert new rows.
+    Requires identifier/key fields to be specified.
+    """
+    UPSERT = "upsert"

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4213,7 +4213,6 @@ class Dataset:
 
                 # Basic append (current behavior)
                 docs = [{"id": i, "title": f"Doc {i}"} for i in range(4)]
-                docs = [{"title": "Iceberg data sink test"} for key in range(4)]
                 ds = ray.data.from_pandas(pd.DataFrame(docs))
                 ds.write_iceberg(
                     table_identifier="db_name.table_name",

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4189,6 +4189,10 @@ class Dataset:
         table_identifier: str,
         catalog_kwargs: Optional[Dict[str, Any]] = None,
         snapshot_properties: Optional[Dict[str, str]] = None,
+        mode: "SaveMode" = SaveMode.APPEND,
+        overwrite_filter: Optional["Expr"] = None,
+        upsert_kwargs: Optional[Dict[str, Any]] = None,
+        overwrite_kwargs: Optional[Dict[str, Any]] = None,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,
     ) -> None:
@@ -4204,31 +4208,119 @@ class Dataset:
 
                 import ray
                 import pandas as pd
+                from ray.data import SaveMode
+                from ray.data.expressions import col
+
+                # Basic append (current behavior)
+                docs = [{"id": i, "title": f"Doc {i}"} for i in range(4)]
                 docs = [{"title": "Iceberg data sink test"} for key in range(4)]
                 ds = ray.data.from_pandas(pd.DataFrame(docs))
                 ds.write_iceberg(
                     table_identifier="db_name.table_name",
                     catalog_kwargs={"name": "default", "type": "sql"}
                 )
+                # Upsert mode - update existing rows or insert new ones
+                updated_docs = [{"id": 2, "title": "Updated Doc 2"}, {"id": 5, "title": "New Doc 5"}]
+                ds_updates = ray.data.from_pandas(pd.DataFrame(updated_docs))
+                ds_updates.write_iceberg(
+                    table_identifier="db_name.table_name",
+                    catalog_kwargs={"name": "default", "type": "sql"},
+                    mode=SaveMode.UPSERT,
+                    upsert_kwargs={"join_cols": ["id"]},
+                )
+
+                # Schema evolution is automatic - new columns are added automatically
+                enriched_docs = [{"id": i, "title": f"Doc {i}", "category": "new"} for i in range(3)]
+                ds_enriched = ray.data.from_pandas(pd.DataFrame(enriched_docs))
+                ds_enriched.write_iceberg(
+                    table_identifier="db_name.table_name",
+                    catalog_kwargs={"name": "default", "type": "sql"}
+                )
+
+                # Partial overwrite with Ray Data expressions
+                ds.write_iceberg(
+                    table_identifier="events.user_activity",
+                    catalog_kwargs={"name": "default", "type": "rest"},
+                    mode=SaveMode.OVERWRITE,
+                    overwrite_filter=col("date") >= "2024-10-28"
+                )
 
         Args:
             table_identifier: Fully qualified table identifier (``db_name.table_name``)
             catalog_kwargs: Optional arguments to pass to PyIceberg's catalog.load_catalog()
-                function (e.g., name, type, etc.). For the function definition, see
+                function (such as name, type, etc.). For the function definition, see
                 `pyiceberg catalog
                 <https://py.iceberg.apache.org/reference/pyiceberg/catalog/\
                 #pyiceberg.catalog.load_catalog>`_.
-            snapshot_properties: custom properties write to snapshot when committing
+            snapshot_properties: Custom properties to write to snapshot when committing
                 to an iceberg table.
+            mode: Write mode using SaveMode enum. Options:
+
+                * SaveMode.APPEND (default): Add new data to the table without checking for duplicates.
+                * SaveMode.UPSERT: Update existing rows that match on the join condition (``join_cols`` in ``upsert_kwargs``),
+                  or insert new rows if they don't exist in the table.
+                * SaveMode.OVERWRITE: Replace all existing data in the table with new data, or replace
+                  data matching overwrite_filter if specified.
+
+            overwrite_filter: Optional filter for OVERWRITE mode to perform partial overwrites.
+                Must be a Ray Data expression from `ray.data.expressions`. Only rows matching
+                this filter are replaced. If None with OVERWRITE mode, replaces all table data.
+                Example: `col("date") >= "2024-01-01"` or `(col("region") == "US") & (col("status") == "active")`
+            upsert_kwargs: Optional arguments for upsert operations.
+                Supported parameters: join_cols (List[str]), case_sensitive (bool), branch (str).
+                Note: Ray Data uses a copy-on-write strategy that always updates all columns
+                for matched keys and inserts all new keys for optimal parallelism.
+            overwrite_kwargs: Optional arguments to pass through to PyIceberg's table.overwrite() method.
+                Supported parameters: case_sensitive (bool), branch (str). See PyIceberg documentation
+                for details.
             ray_remote_args: kwargs passed to :func:`ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the
                 total number of tasks run. By default, concurrency is dynamically
                 decided based on the available resources.
+
+        Note:
+            Schema evolution is automatically enabled. New columns in the incoming data
+            are automatically added to the table schema.
+
+        Raises:
+            ValueError: If `mode` is `SaveMode.UPSERT`, `join_cols` is not provided in `upsert_kwargs`, and the table has no identifier fields.
         """
+        # Get the dataset's schema to pass to datasink for early schema evolution
+        # This allows evolving the table schema before files are written,
+        # avoiding PyIceberg name mapping errors when incoming data has new columns
+        incoming_schema = None
+        ds_schema = self.schema(fetch_if_missing=True)
+        if ds_schema is not None:
+            import pyarrow as pa
+
+            base_schema = ds_schema.base_schema
+            if isinstance(base_schema, pa.Schema):
+                # Already a PyArrow schema, use directly
+                incoming_schema = base_schema
+            else:
+                # For Pandas schemas, Schema.types converts to Arrow types but may
+                # return Python's `object` for unsupported types (e.g., strings).
+                # Convert `object` types to pa.large_string() for Iceberg compatibility.
+                fields = []
+                for name, dtype in zip(ds_schema.names, ds_schema.types):
+                    if isinstance(dtype, pa.DataType):
+                        fields.append((name, dtype))
+                    elif dtype is object:
+                        # Python object type typically means string in Pandas
+                        fields.append((name, pa.large_string()))
+                if fields:
+                    incoming_schema = pa.schema(fields)
 
         datasink = IcebergDatasink(
-            table_identifier, catalog_kwargs, snapshot_properties
+            table_identifier=table_identifier,
+            catalog_kwargs=catalog_kwargs,
+            snapshot_properties=snapshot_properties,
+            mode=mode,
+            overwrite_filter=overwrite_filter,
+            upsert_kwargs=upsert_kwargs,
+            overwrite_kwargs=overwrite_kwargs,
+            incoming_schema=incoming_schema,
         )
 
         self.write_datasink(

--- a/python/ray/data/tests/test_iceberg.py
+++ b/python/ray/data/tests/test_iceberg.py
@@ -1,5 +1,6 @@
 import os
 import random
+from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -12,8 +13,10 @@ from pyiceberg import (
     schema as pyi_schema,
     types as pyi_types,
 )
+from pyiceberg.catalog import Catalog
 from pyiceberg.catalog.sql import SqlCatalog
 from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.table import Table
 from pyiceberg.transforms import IdentityTransform
 
 import ray
@@ -22,6 +25,7 @@ from ray.data import read_iceberg
 from ray.data._internal.datasource.iceberg_datasource import IcebergDatasource
 from ray.data._internal.logical.operators.map_operator import Filter, Project
 from ray.data._internal.logical.optimizers import LogicalOptimizer
+from ray.data._internal.savemode import SaveMode
 from ray.data._internal.util import rows_same
 from ray.data.expressions import col
 from ray.data.tests.test_util import (
@@ -213,9 +217,8 @@ def test_read_basic():
     )
     table: pa.Table = pa.concat_tables((ray.get(ref) for ref in ray_ds.to_arrow_refs()))
 
-    # string -> large_string because pyiceberg by default chooses large_string
     expected_schema = pa.schema(
-        [pa.field("col_a", pa.int32()), pa.field("col_b", pa.large_string())]
+        [pa.field("col_a", pa.int32()), pa.field("col_b", pa.string())]
     )
     assert table.schema.equals(expected_schema)
 
@@ -737,6 +740,994 @@ def test_predicate_pushdown_complex_expression():
     )
 
     assert rows_same(result, expected_table)
+
+
+# Helper functions and fixtures for write mode tests
+@pytest.fixture
+def clean_table() -> Generator[Tuple[Catalog, Table], None, None]:
+    """Pytest fixture to get a clean Iceberg table by deleting all data."""
+    sql_catalog = pyi_catalog.load_catalog(**_CATALOG_KWARGS)
+    table = sql_catalog.load_table(f"{_DB_NAME}.{_TABLE_NAME}")
+    table.delete()
+    yield sql_catalog, table
+
+
+def _create_typed_dataframe(data_dict: Dict[str, List[Any]]) -> pd.DataFrame:
+    """Create a pandas DataFrame with proper int32 dtypes for col_a and col_c."""
+    df = pd.DataFrame(data_dict)
+    if "col_a" in df.columns:
+        # Use nullable Int32 to support NaN values
+        df["col_a"] = df["col_a"].astype("Int32")
+    if "col_c" in df.columns:
+        # Use nullable Int32 to support NaN values
+        df["col_c"] = df["col_c"].astype("Int32")
+    return df
+
+
+def _write_to_iceberg(
+    df: pd.DataFrame, mode: Optional[SaveMode] = None, **kwargs: Any
+) -> None:
+    """Write a DataFrame to the test Iceberg table."""
+    ds = ray.data.from_pandas(df)
+    write_kwargs: Dict[str, Any] = {
+        "table_identifier": f"{_DB_NAME}.{_TABLE_NAME}",
+        "catalog_kwargs": _CATALOG_KWARGS.copy(),
+    }
+    if mode is not None:
+        write_kwargs["mode"] = mode
+    write_kwargs.update(kwargs)
+    ds.write_iceberg(**write_kwargs)
+
+
+def _read_from_iceberg(sort_by: Optional[Union[str, List[str]]] = None) -> pd.DataFrame:
+    """Read data from the test Iceberg table and optionally sort."""
+    ds = ray.data.read_iceberg(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+    result_df = ds.to_pandas()
+    if sort_by:
+        result_df = result_df.sort_values(sort_by).reset_index(drop=True)
+    return result_df
+
+
+def _verify_schema(expected_fields: Dict[str, Type[pyi_types.IcebergType]]) -> None:
+    """
+    Verify the Iceberg table schema matches expected fields.
+
+    Args:
+        expected_fields: Dict mapping field names to PyIceberg type classes
+                        e.g., {"col_a": pyi_types.IntegerType, "col_b": pyi_types.StringType}
+    """
+    sql_catalog = pyi_catalog.load_catalog(**_CATALOG_KWARGS)
+    table = sql_catalog.load_table(f"{_DB_NAME}.{_TABLE_NAME}")
+    schema = {field.name: field.field_type for field in table.schema().fields}
+
+    assert len(schema) == len(
+        expected_fields
+    ), f"Expected {len(expected_fields)} fields, got {len(schema)}"
+
+    for field_name, expected_type in expected_fields.items():
+        assert field_name in schema, f"Field {field_name} not found in schema"
+        assert isinstance(schema[field_name], expected_type), (
+            f"Field {field_name} expected type {expected_type}, "
+            f"got {type(schema[field_name])}"
+        )
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+class TestBasicWriteModes:
+    """Test basic write operations for APPEND, UPSERT, and OVERWRITE modes."""
+
+    def test_append_basic(self, clean_table):
+        """Test basic APPEND mode - add new rows without schema changes."""
+        initial_data = _create_typed_dataframe(
+            {"col_a": [1, 2], "col_b": ["row_1", "row_2"], "col_c": [1, 2]}
+        )
+        _write_to_iceberg(initial_data)
+
+        append_data = _create_typed_dataframe(
+            {"col_a": [3, 4], "col_b": ["row_3", "row_4"], "col_c": [3, 4]}
+        )
+        _write_to_iceberg(append_data, mode=SaveMode.APPEND)
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3, 4],
+                "col_b": ["row_1", "row_2", "row_3", "row_4"],
+                "col_c": [1, 2, 3, 4],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+    def test_upsert_basic(self, clean_table):
+        """Test basic upsert - update existing rows and insert new ones."""
+        initial_data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["initial_1", "initial_2", "initial_3"],
+                "col_c": [1, 2, 3],
+            }
+        )
+        _write_to_iceberg(initial_data)
+
+        upsert_data = _create_typed_dataframe(
+            {
+                "col_a": [2, 3, 4],
+                "col_b": ["updated_2", "updated_3", "new_4"],
+                "col_c": [2, 3, 4],
+            }
+        )
+        _write_to_iceberg(
+            upsert_data, mode=SaveMode.UPSERT, upsert_kwargs={"join_cols": ["col_a"]}
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3, 4],
+                "col_b": ["initial_1", "updated_2", "updated_3", "new_4"],
+                "col_c": [1, 2, 3, 4],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+    def test_upsert_composite_key(self, clean_table):
+        """Test upsert with composite key (multiple identifier fields)."""
+        initial_data = _create_typed_dataframe(
+            {
+                "col_a": [1, 1, 2, 2],
+                "col_b": ["A", "B", "A", "B"],
+                "col_c": [10, 20, 30, 40],
+            }
+        )
+        _write_to_iceberg(initial_data)
+
+        # Update (1, "B") and (2, "A"), insert (3, "A")
+        upsert_data = _create_typed_dataframe(
+            {"col_a": [1, 2, 3], "col_b": ["B", "A", "A"], "col_c": [999, 888, 777]}
+        )
+        _write_to_iceberg(
+            upsert_data,
+            mode=SaveMode.UPSERT,
+            upsert_kwargs={"join_cols": ["col_a", "col_b"]},
+        )
+
+        result_df = _read_from_iceberg(sort_by=["col_a", "col_b"])
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [1, 1, 2, 2, 3],
+                "col_b": ["A", "B", "A", "B", "A"],
+                "col_c": [10, 999, 888, 40, 777],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+    def test_overwrite_full_table(self, clean_table):
+        """Test full table overwrite - replace all data."""
+        initial_data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3, 4, 5],
+                "col_b": ["old_1", "old_2", "old_3", "old_4", "old_5"],
+                "col_c": [1, 2, 3, 4, 5],
+            }
+        )
+        _write_to_iceberg(initial_data)
+
+        new_data = _create_typed_dataframe(
+            {
+                "col_a": [10, 20, 30],
+                "col_b": ["new_10", "new_20", "new_30"],
+                "col_c": [100, 200, 300],
+            }
+        )
+        _write_to_iceberg(new_data, mode=SaveMode.OVERWRITE)
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [10, 20, 30],
+                "col_b": ["new_10", "new_20", "new_30"],
+                "col_c": [100, 200, 300],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+    def test_overwrite_with_filter(self, clean_table):
+        """Test partial overwrite using filter expression."""
+        initial_data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3, 4, 5],
+                "col_b": ["data_1", "data_2", "data_3", "data_4", "data_5"],
+                "col_c": [1, 1, 2, 2, 3],
+            }
+        )
+        _write_to_iceberg(initial_data)
+
+        # Replace only rows where col_c == 2
+        overwrite_data = _create_typed_dataframe(
+            {
+                "col_a": [10, 20],
+                "col_b": ["replaced_10", "replaced_20"],
+                "col_c": [2, 2],
+            }
+        )
+        _write_to_iceberg(
+            overwrite_data, mode=SaveMode.OVERWRITE, overwrite_filter=col("col_c") == 2
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 5, 10, 20],
+                "col_b": ["data_1", "data_2", "data_5", "replaced_10", "replaced_20"],
+                "col_c": [1, 1, 3, 2, 2],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+    def test_overwrite_full_table_missing_columns(self, clean_table):
+        """Test full table overwrite when new data is missing columns - they become NULL."""
+        # Initial data with 3 columns
+        initial_data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["alice", "bob", "charlie"],
+                "col_c": [10, 20, 30],
+            }
+        )
+        _write_to_iceberg(initial_data)
+
+        # Overwrite with data that's missing col_b (non-partition column)
+        # Note: col_c must be present since table is partitioned by col_c
+        new_data = _create_typed_dataframe(
+            {
+                "col_a": [10, 20],
+                # col_b is intentionally missing (non-partition column)
+                "col_c": [100, 200],
+            }
+        )
+        _write_to_iceberg(new_data, mode=SaveMode.OVERWRITE)
+
+        # Read back and verify
+        result_df = _read_from_iceberg(sort_by="col_a")
+
+        # All old data should be gone
+        assert len(result_df) == 2
+        assert result_df["col_a"].tolist() == [10, 20]
+        assert result_df["col_c"].tolist() == [100, 200]
+
+        # col_b should still exist in schema but be NULL for new rows
+        assert "col_b" in result_df.columns
+        assert pd.isna(result_df["col_b"].iloc[0])
+        assert pd.isna(result_df["col_b"].iloc[1])
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+class TestSchemaEvolution:
+    """Test schema evolution across different write modes."""
+
+    @pytest.mark.parametrize("mode", [SaveMode.APPEND, SaveMode.OVERWRITE])
+    def test_schema_evolution_by_mode(self, clean_table, mode):
+        """Test adding new columns works for APPEND and OVERWRITE."""
+        initial_data = _create_typed_dataframe(
+            {"col_a": [1, 2], "col_b": ["row_1", "row_2"], "col_c": [1, 2]}
+        )
+        _write_to_iceberg(initial_data)
+
+        new_data = _create_typed_dataframe(
+            {
+                "col_a": [3, 4],
+                "col_b": ["row_3", "row_4"],
+                "col_c": [3, 4],
+                "col_d": ["extra_3", "extra_4"],
+            }
+        )
+        _write_to_iceberg(new_data, mode=mode)
+
+        _verify_schema(
+            {
+                "col_a": pyi_types.IntegerType,
+                "col_b": pyi_types.StringType,
+                "col_c": pyi_types.IntegerType,
+                "col_d": pyi_types.StringType,
+            }
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        if mode == SaveMode.APPEND:
+            expected = _create_typed_dataframe(
+                {
+                    "col_a": [1, 2, 3, 4],
+                    "col_b": ["row_1", "row_2", "row_3", "row_4"],
+                    "col_c": [1, 2, 3, 4],
+                    "col_d": [None, None, "extra_3", "extra_4"],
+                }
+            )
+        else:  # OVERWRITE
+            expected = _create_typed_dataframe(
+                {
+                    "col_a": [3, 4],
+                    "col_b": ["row_3", "row_4"],
+                    "col_c": [3, 4],
+                    "col_d": ["extra_3", "extra_4"],
+                }
+            )
+        assert rows_same(result_df, expected)
+
+    def test_multiple_schema_evolutions(self, clean_table):
+        """Test multiple sequential schema evolutions."""
+        initial_data = _create_typed_dataframe(
+            {"col_a": [1], "col_b": ["row_1"], "col_c": [10]}
+        )
+        _write_to_iceberg(initial_data)
+
+        # First evolution: add col_d
+        data_with_d = _create_typed_dataframe(
+            {"col_a": [2], "col_b": ["row_2"], "col_c": [20], "col_d": ["extra_2"]}
+        )
+        _write_to_iceberg(data_with_d, mode=SaveMode.APPEND)
+
+        _verify_schema(
+            {
+                "col_a": pyi_types.IntegerType,
+                "col_b": pyi_types.StringType,
+                "col_c": pyi_types.IntegerType,
+                "col_d": pyi_types.StringType,
+            }
+        )
+
+        # Second evolution: add col_e
+        data_with_e = _create_typed_dataframe(
+            {
+                "col_a": [3],
+                "col_b": ["row_3"],
+                "col_c": [30],
+                "col_d": ["extra_3"],
+                "col_e": ["bonus_3"],
+            }
+        )
+        _write_to_iceberg(data_with_e, mode=SaveMode.APPEND)
+
+        _verify_schema(
+            {
+                "col_a": pyi_types.IntegerType,
+                "col_b": pyi_types.StringType,
+                "col_c": pyi_types.IntegerType,
+                "col_d": pyi_types.StringType,
+                "col_e": pyi_types.StringType,
+            }
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["row_1", "row_2", "row_3"],
+                "col_c": [10, 20, 30],
+                "col_d": [None, "extra_2", "extra_3"],
+                "col_e": [None, None, "bonus_3"],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+    def test_column_order_independence(self, clean_table):
+        """Test writing data with columns in different order works."""
+        initial_data = _create_typed_dataframe(
+            {"col_a": [1, 2], "col_b": ["row_1", "row_2"], "col_c": [1, 2]}
+        )
+        _write_to_iceberg(initial_data)
+
+        # Append data with columns in different order
+        reordered_data = _create_typed_dataframe(
+            {"col_c": [3, 4], "col_a": [3, 4], "col_b": ["row_3", "row_4"]}
+        )
+        _write_to_iceberg(reordered_data, mode=SaveMode.APPEND)
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3, 4],
+                "col_b": ["row_1", "row_2", "row_3", "row_4"],
+                "col_c": [1, 2, 3, 4],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+    def test_multi_block_schema_reconciliation(self, clean_table):
+        """Test schema reconciliation across blocks with different numeric types."""
+        initial_data = _create_typed_dataframe(
+            {"col_a": [1, 2], "col_b": ["row_1", "row_2"], "col_c": [1, 2]}
+        )
+        _write_to_iceberg(initial_data)
+
+        # Create two blocks with different numeric types for col_d:
+        # Block 1: int32, Block 2: int64 - requires type promotion during reconciliation
+        block1 = pa.table(
+            {
+                "col_a": pa.array([3], type=pa.int32()),
+                "col_b": ["row_3"],
+                "col_c": pa.array([3], type=pa.int32()),
+                "col_d": pa.array([100], type=pa.int32()),
+            }
+        )
+        block2 = pa.table(
+            {
+                "col_a": pa.array([4], type=pa.int32()),
+                "col_b": ["row_4"],
+                "col_c": pa.array([4], type=pa.int32()),
+                "col_d": pa.array([200], type=pa.int64()),
+            }
+        )
+
+        # Create dataset from multiple blocks with different schemas
+        ds = ray.data.from_arrow([block1, block2])
+        ds.write_iceberg(
+            table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+            catalog_kwargs=_CATALOG_KWARGS.copy(),
+            mode=SaveMode.APPEND,
+        )
+
+        # Verify schema has col_d with promoted type (int64)
+        _verify_schema(
+            {
+                "col_a": pyi_types.IntegerType,
+                "col_b": pyi_types.StringType,
+                "col_c": pyi_types.IntegerType,
+                "col_d": pyi_types.LongType,
+            }
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = pd.DataFrame(
+            {
+                "col_a": pd.array([1, 2, 3, 4], dtype="Int32"),
+                "col_b": ["row_1", "row_2", "row_3", "row_4"],
+                "col_c": pd.array([1, 2, 3, 4], dtype="Int32"),
+                "col_d": pd.array([None, None, 100, 200], dtype="Int64"),
+            }
+        )
+        assert rows_same(result_df, expected)
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+class TestUpsertScenarios:
+    """Test various upsert matching scenarios."""
+
+    @pytest.mark.parametrize(
+        "upsert_keys,upsert_col_b,upsert_col_c,expected_data",
+        [
+            # No matching rows (behaves like append)
+            (
+                [4, 5, 6],
+                ["new_4", "new_5", "new_6"],
+                [40, 50, 60],
+                {
+                    "col_a": [1, 2, 3, 4, 5, 6],
+                    "col_b": ["row_1", "row_2", "row_3", "new_4", "new_5", "new_6"],
+                    "col_c": [10, 20, 30, 40, 50, 60],
+                },
+            ),
+            # All rows match (behaves like update)
+            (
+                [1, 2, 3],
+                ["updated_1", "updated_2", "updated_3"],
+                [100, 200, 300],
+                {
+                    "col_a": [1, 2, 3],
+                    "col_b": ["updated_1", "updated_2", "updated_3"],
+                    "col_c": [100, 200, 300],
+                },
+            ),
+            # Partial match (mixed update and insert)
+            (
+                [2, 3, 4],
+                ["updated_2", "updated_3", "new_4"],
+                [200, 300, 40],
+                {
+                    "col_a": [1, 2, 3, 4],
+                    "col_b": ["row_1", "updated_2", "updated_3", "new_4"],
+                    "col_c": [10, 200, 300, 40],
+                },
+            ),
+        ],
+    )
+    def test_upsert_matching_scenarios(
+        self, clean_table, upsert_keys, upsert_col_b, upsert_col_c, expected_data
+    ):
+        """Test upsert with different row matching patterns."""
+        initial_data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["row_1", "row_2", "row_3"],
+                "col_c": [10, 20, 30],
+            }
+        )
+        _write_to_iceberg(initial_data)
+
+        upsert_data = _create_typed_dataframe(
+            {"col_a": upsert_keys, "col_b": upsert_col_b, "col_c": upsert_col_c}
+        )
+        _write_to_iceberg(
+            upsert_data, mode=SaveMode.UPSERT, upsert_kwargs={"join_cols": ["col_a"]}
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(expected_data)
+        assert rows_same(result_df, expected)
+
+    @pytest.mark.parametrize(
+        "join_cols,initial_data_dict,upsert_data_dict,sort_by",
+        [
+            # Single column join key
+            (
+                ["col_a"],
+                {
+                    "col_a": [1, 2, 3, 4, 5],
+                    "col_b": ["A", "B", "C", "D", "E"],
+                    "col_c": [10, 20, 30, 40, 50],
+                },
+                {
+                    "col_a": [2, 3, 4, 6],
+                    "col_b": ["B_updated", "C_updated", "D_updated", "F_new"],
+                    "col_c": [200, 300, 400, 600],
+                },
+                "col_a",
+            ),
+            # Composite join key
+            (
+                ["col_a", "col_b"],
+                {
+                    "col_a": [1, 1, 2, 2, 3],
+                    "col_b": ["X", "Y", "X", "Y", "X"],
+                    "col_c": [10, 20, 30, 40, 50],
+                },
+                {
+                    "col_a": [1, 2, 3, 4],
+                    "col_b": ["Y", "X", "Y", "X"],
+                    "col_c": [999, 888, 777, 666],
+                },
+                ["col_a", "col_b"],
+            ),
+        ],
+    )
+    def test_upsert_matches_pyiceberg_native(
+        self, clean_table, join_cols, initial_data_dict, upsert_data_dict, sort_by
+    ):
+        """Test that Ray Data's upsert produces identical results to PyIceberg's native upsert."""
+        catalog, table = clean_table
+
+        initial_data = _create_typed_dataframe(initial_data_dict)
+        upsert_data = _create_typed_dataframe(upsert_data_dict)
+
+        # Apply upsert with Ray Data
+        _write_to_iceberg(initial_data)
+        _write_to_iceberg(
+            upsert_data, mode=SaveMode.UPSERT, upsert_kwargs={"join_cols": join_cols}
+        )
+        ray_result = _read_from_iceberg(sort_by=sort_by)
+
+        # Reset table and apply same operations with PyIceberg native
+        catalog.drop_table(f"{_DB_NAME}.{_TABLE_NAME}")
+        table = catalog.create_table(
+            f"{_DB_NAME}.{_TABLE_NAME}",
+            schema=pyi_schema.Schema(
+                pyi_types.NestedField(
+                    field_id=1,
+                    name="col_a",
+                    field_type=pyi_types.IntegerType(),
+                    required=False,
+                ),
+                pyi_types.NestedField(
+                    field_id=2,
+                    name="col_b",
+                    field_type=pyi_types.StringType(),
+                    required=False,
+                ),
+                pyi_types.NestedField(
+                    field_id=3,
+                    name="col_c",
+                    field_type=pyi_types.IntegerType(),
+                    required=False,
+                ),
+            ),
+        )
+        table.append(pa.Table.from_pandas(initial_data))
+        table.upsert(df=pa.Table.from_pandas(upsert_data), join_cols=join_cols)
+
+        # Read with PyIceberg native
+        pyiceberg_result = table.scan().to_pandas()
+        if isinstance(sort_by, list):
+            pyiceberg_result = pyiceberg_result.sort_values(by=sort_by).reset_index(
+                drop=True
+            )
+        else:
+            pyiceberg_result = pyiceberg_result.sort_values(by=sort_by).reset_index(
+                drop=True
+            )
+
+        # Results should be identical
+        assert rows_same(ray_result, pyiceberg_result)
+
+    def test_upsert_schema_evolution(self, clean_table):
+        """Test that upsert supports automatic schema evolution (adding new columns)."""
+        # Initial data with 3 columns
+        initial_data = _create_typed_dataframe(
+            {"col_a": [1, 2], "col_b": ["row_1", "row_2"], "col_c": [10, 20]}
+        )
+        _write_to_iceberg(initial_data)
+
+        # Upsert with new column col_d
+        upsert_data = _create_typed_dataframe(
+            {
+                "col_a": [2, 3],
+                "col_b": ["updated_2", "new_3"],
+                "col_c": [200, 30],
+                "col_d": ["extra_2", "extra_3"],
+            }
+        )
+        _write_to_iceberg(
+            upsert_data, mode=SaveMode.UPSERT, upsert_kwargs={"join_cols": ["col_a"]}
+        )
+
+        # Verify schema has col_d
+        _verify_schema(
+            {
+                "col_a": pyi_types.IntegerType,
+                "col_b": pyi_types.StringType,
+                "col_c": pyi_types.IntegerType,
+                "col_d": pyi_types.StringType,
+            }
+        )
+
+        # Verify data
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["row_1", "updated_2", "new_3"],
+                "col_c": [10, 200, 30],
+                "col_d": [None, "extra_2", "extra_3"],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+    @pytest.mark.parametrize(
+        "join_cols,initial_data_dict,upsert_data_dict,expected_data_dict",
+        [
+            # NULL in initial data - row with NULL key isn't updated
+            (
+                ["col_a"],
+                {
+                    "col_a": [1, 2, None],
+                    "col_b": ["A", "B", "C"],
+                    "col_c": [10, 20, 30],
+                },  # Initial data
+                {
+                    "col_a": [2, 3],
+                    "col_b": ["B_updated", "new_3"],
+                    "col_c": [200, 300],
+                },  # Upsert data
+                {
+                    "col_a": [1, 2, 3, None],
+                    "col_b": ["A", "B_updated", "new_3", "C"],
+                    "col_c": [10, 200, 300, 30],
+                },  # Expected data
+            ),
+            # NULL in upsert data - row with NULL key is inserted
+            (
+                ["col_a"],
+                {
+                    "col_a": [1, 2, 3],
+                    "col_b": ["A", "B", "C"],
+                    "col_c": [10, 20, 30],
+                },  # Initial data
+                {
+                    "col_a": [2, None],
+                    "col_b": ["B_updated", "null_row"],
+                    "col_c": [200, 300],
+                },  # Upsert data
+                {
+                    "col_a": [1, 2, 3, None],
+                    "col_b": ["A", "B_updated", "C", "null_row"],
+                    "col_c": [10, 200, 30, 300],
+                },  # Expected data
+            ),
+            # Composite key with NULL in initial - row not updated
+            (
+                ["col_a", "col_b"],
+                {
+                    "col_a": [1, 2, None],
+                    "col_b": ["X", "Y", None],
+                    "col_c": [10, 20, 30],
+                },  # Initial data
+                {
+                    "col_a": [2, 3],
+                    "col_b": ["Y", "Z"],
+                    "col_c": [200, 300],
+                },  # Upsert data
+                {
+                    "col_a": [1, 2, 3, None],
+                    "col_b": ["X", "Y", "Z", None],
+                    "col_c": [10, 200, 300, 30],
+                },  # Expected data
+            ),
+        ],
+    )
+    def test_upsert_null_in_join_keys(
+        self,
+        clean_table,
+        join_cols,
+        initial_data_dict,
+        upsert_data_dict,
+        expected_data_dict,
+    ):
+        """Test upsert behavior with NULL values in join key columns (NULL != NULL in SQL)."""
+        initial_data = _create_typed_dataframe(initial_data_dict)
+        upsert_data = _create_typed_dataframe(upsert_data_dict)
+        expected = _create_typed_dataframe(expected_data_dict)
+
+        _write_to_iceberg(initial_data)
+        _write_to_iceberg(
+            upsert_data, mode=SaveMode.UPSERT, upsert_kwargs={"join_cols": join_cols}
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        assert rows_same(result_df, expected)
+
+    def test_upsert_empty_table(self, clean_table):
+        """Test upserting into a completely empty table (behaves like insert)."""
+        upsert_data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["new_1", "new_2", "new_3"],
+                "col_c": [10, 20, 30],
+            }
+        )
+        _write_to_iceberg(
+            upsert_data, mode=SaveMode.UPSERT, upsert_kwargs={"join_cols": ["col_a"]}
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["new_1", "new_2", "new_3"],
+                "col_c": [10, 20, 30],
+            }
+        )
+        assert rows_same(result_df, expected)
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+class TestOverwriteScenarios:
+    """Test various overwrite filter scenarios."""
+
+    @pytest.mark.parametrize(
+        "filter_expr,overwrite_col_c,expected_data",
+        [
+            # Filter matches nothing (behaves like append)
+            (
+                col("col_c") == 999,
+                [999, 999],
+                {
+                    "col_a": [1, 2, 3, 4, 5],
+                    "col_b": ["row_1", "row_2", "row_3", "row_4", "row_5"],
+                    "col_c": [10, 20, 30, 999, 999],
+                },
+            ),
+            # Filter matches some rows
+            (
+                col("col_c") >= 20,
+                [200, 300],
+                {
+                    "col_a": [1, 4, 5],
+                    "col_b": ["row_1", "row_4", "row_5"],
+                    "col_c": [10, 200, 300],
+                },
+            ),
+            # Filter matches all rows (full overwrite)
+            (
+                col("col_c") < 100,
+                [40, 50],
+                {
+                    "col_a": [4, 5],
+                    "col_b": ["row_4", "row_5"],
+                    "col_c": [40, 50],
+                },
+            ),
+        ],
+    )
+    def test_overwrite_filter_scenarios(
+        self, clean_table, filter_expr, overwrite_col_c, expected_data
+    ):
+        """Test partial overwrite with different filter matching patterns."""
+        initial_data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["row_1", "row_2", "row_3"],
+                "col_c": [10, 20, 30],
+            }
+        )
+        _write_to_iceberg(initial_data)
+
+        overwrite_data = _create_typed_dataframe(
+            {"col_a": [4, 5], "col_b": ["row_4", "row_5"], "col_c": overwrite_col_c}
+        )
+        _write_to_iceberg(
+            overwrite_data, mode=SaveMode.OVERWRITE, overwrite_filter=filter_expr
+        )
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(expected_data)
+        assert rows_same(result_df, expected)
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_write_creates_table_if_not_exists():
+    """Test writing to a non-existent table creates it with correct schema."""
+    new_table_name = "ray_test_auto_create"
+    table_identifier = f"{_DB_NAME}.{new_table_name}"
+
+    sql_catalog = pyi_catalog.load_catalog(**_CATALOG_KWARGS)
+
+    # Ensure table doesn't exist
+    if (_DB_NAME, new_table_name) in sql_catalog.list_tables(_DB_NAME):
+        sql_catalog.drop_table(table_identifier)
+
+    try:
+        # Write data to non-existent table
+        data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["row_1", "row_2", "row_3"],
+                "col_c": [10, 20, 30],
+            }
+        )
+        ds = ray.data.from_pandas(data)
+        ds.write_iceberg(
+            table_identifier=table_identifier,
+            catalog_kwargs=_CATALOG_KWARGS.copy(),
+        )
+
+        # Verify table was created
+        assert (
+            _DB_NAME,
+            new_table_name,
+        ) in sql_catalog.list_tables(_DB_NAME), "Table should have been created"
+
+        # Verify schema
+        table = sql_catalog.load_table(table_identifier)
+
+        # Verify data
+        result_df = table.scan().to_pandas().sort_values("col_a").reset_index(drop=True)
+        assert rows_same(result_df, data)
+    finally:
+        # Cleanup
+        if (_DB_NAME, new_table_name) in sql_catalog.list_tables(_DB_NAME):
+            sql_catalog.drop_table(table_identifier)
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+class TestEdgeCases:
+    """Test edge cases and special scenarios."""
+
+    @pytest.mark.parametrize(
+        "mode", [SaveMode.APPEND, SaveMode.UPSERT, SaveMode.OVERWRITE]
+    )
+    def test_write_empty_dataset(self, clean_table, mode):
+        """Test writing empty dataset doesn't fail or modify table."""
+        initial_data = _create_typed_dataframe(
+            {"col_a": [1, 2], "col_b": ["row_1", "row_2"], "col_c": [1, 2]}
+        )
+        _write_to_iceberg(initial_data)
+
+        empty_data = _create_typed_dataframe({"col_a": [], "col_b": [], "col_c": []})
+
+        write_kwargs = {}
+        if mode == SaveMode.UPSERT:
+            write_kwargs["upsert_kwargs"] = {"join_cols": ["col_a"]}
+        elif mode == SaveMode.OVERWRITE:
+            write_kwargs["overwrite_filter"] = col("col_c") == 999
+
+        _write_to_iceberg(empty_data, mode=mode, **write_kwargs)
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        assert rows_same(result_df, initial_data)
+
+    def test_overwrite_empty_table(self, clean_table):
+        """Test overwriting an empty table."""
+        data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["row_1", "row_2", "row_3"],
+                "col_c": [10, 20, 30],
+            }
+        )
+        _write_to_iceberg(data, mode=SaveMode.OVERWRITE)
+
+        result_df = _read_from_iceberg(sort_by="col_a")
+        assert rows_same(result_df, data)
+
+    @pytest.mark.parametrize("mode", [SaveMode.APPEND, SaveMode.OVERWRITE])
+    def test_snapshot_properties(self, clean_table, mode):
+        """Test snapshot_properties are passed through for APPEND and OVERWRITE."""
+        # Note: UPSERT doesn't support snapshot_properties in PyIceberg
+        data = _create_typed_dataframe(
+            {
+                "col_a": [1, 2, 3],
+                "col_b": ["row_1", "row_2", "row_3"],
+                "col_c": [10, 20, 30],
+            }
+        )
+
+        snapshot_props = {"test_property": "test_value", "author": "ray_data_test"}
+
+        ds = ray.data.from_pandas(data)
+        ds.write_iceberg(
+            table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+            catalog_kwargs=_CATALOG_KWARGS.copy(),
+            mode=mode,
+            snapshot_properties=snapshot_props,
+        )
+
+        sql_catalog = pyi_catalog.load_catalog(**_CATALOG_KWARGS)
+        table = sql_catalog.load_table(f"{_DB_NAME}.{_TABLE_NAME}")
+        latest_snapshot = table.current_snapshot()
+
+        assert latest_snapshot is not None
+        assert latest_snapshot.summary.get("test_property") == "test_value"
+        assert latest_snapshot.summary.get("author") == "ray_data_test"
+
+    def test_mixed_mode_operations(self, clean_table):
+        """Test mixing different write modes in sequence."""
+        # Start with APPEND
+        data1 = _create_typed_dataframe(
+            {"col_a": [1, 2], "col_b": ["a", "b"], "col_c": [10, 20]}
+        )
+        _write_to_iceberg(data1, mode=SaveMode.APPEND)
+
+        # Then UPSERT (update row 2, add row 3)
+        data2 = _create_typed_dataframe(
+            {"col_a": [2, 3], "col_b": ["updated_b", "c"], "col_c": [200, 30]}
+        )
+        _write_to_iceberg(
+            data2, mode=SaveMode.UPSERT, upsert_kwargs={"join_cols": ["col_a"]}
+        )
+
+        # Then OVERWRITE with filter (deletes rows 2 and 3, adds rows 4 and 5)
+        data3 = _create_typed_dataframe(
+            {"col_a": [4, 5], "col_b": ["d", "e"], "col_c": [40, 50]}
+        )
+        _write_to_iceberg(
+            data3, mode=SaveMode.OVERWRITE, overwrite_filter=col("col_c") >= 30
+        )
+
+        # Verify final state: rows 2 and 3 deleted, rows 4 and 5 added
+        result_df = _read_from_iceberg(sort_by="col_a")
+        expected = _create_typed_dataframe(
+            {"col_a": [1, 4, 5], "col_b": ["a", "d", "e"], "col_c": [10, 40, 50]}
+        )
+        assert rows_same(result_df, expected)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_iceberg.py
+++ b/python/ray/data/tests/test_iceberg.py
@@ -970,6 +970,25 @@ class TestBasicWriteModes:
         )
         assert rows_same(result_df, expected)
 
+    def test_overwrite_filter_incompatible_mode(self, clean_table):
+        """Test that passing overwrite_filter with non-OVERWRITE mode raises ValueError."""
+        data = _create_typed_dataframe({"col_a": [1], "col_b": ["row_1"], "col_c": [1]})
+
+        # With APPEND
+        with pytest.raises(ValueError, match="overwrite_filter can only be specified"):
+            _write_to_iceberg(
+                data, mode=SaveMode.APPEND, overwrite_filter=col("col_c") > 0
+            )
+
+        # With UPSERT
+        with pytest.raises(ValueError, match="overwrite_filter can only be specified"):
+            _write_to_iceberg(
+                data,
+                mode=SaveMode.UPSERT,
+                overwrite_filter=col("col_c") > 0,
+                upsert_kwargs={"join_cols": ["col_a"]},
+            )
+
     def test_overwrite_full_table_missing_columns(self, clean_table):
         """Test full table overwrite when new data is missing columns - they become NULL."""
         # Initial data with 3 columns

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -19,7 +19,7 @@ deltalake==0.9.0
 pytest-mock
 decord
 snowflake-connector-python>=3.15.0
-pyiceberg[sql-sqlite]==0.9.0
+pyiceberg[sql-sqlite]==0.10.0
 clickhouse-connect
 kafka-python
 pybase64

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1702,7 +1702,7 @@ pygments==2.18.0
     #   nbconvert
     #   rich
     #   sphinx
-pyiceberg==0.9.0
+pyiceberg==0.10.0
     # via -r python/requirements/ml/data-test-requirements.txt
 pyjwt==2.8.0
     # via
@@ -1754,6 +1754,8 @@ pyro-ppl==1.9.1
     # via botorch
 pyro4==4.82
     # via hpbandster
+pyroaring==1.0.3
+    # via pyiceberg
 pysocks==1.7.1
     # via requests
 pyspark==3.4.1


### PR DESCRIPTION
## Description
Prior to this change, schema evolution occurred on the workers which involved handling concurrent edits.
Now there's one schema update prior to writing out the underlying tables and one at the end, to account for any type promotions etc. All of these operations will take place on the driver. 

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
