### PR TITLE
[core] Deflake many actors iptable variant

### DIFF
--- a/release/nightly_tests/chaos_test/actor_workload.py
+++ b/release/nightly_tests/chaos_test/actor_workload.py
@@ -14,7 +14,7 @@ def run_actor_workload(total_num_cpus, smoke):
     shouldn't fail.
     """
 
-    @ray.remote(num_cpus=0)
+    @ray.remote(num_cpus=0, max_task_retries=-1)
     class DBActor:
         def __init__(self):
             self.letter_dict = set()


### PR DESCRIPTION
## Description
> Briefly describe what this PR accomplishes and why it's needed.

From https://buildkite.com/ray-project/release/builds/69591#019abf06-cf8c-4b43-9d8d-59df344112a7 the DB Actor task failed with an ActorUnavailableError. This is because max_task_retries was not set for the DB actor and defaulted to 0. In the prior version before ip tables was introduced the DB actor was created specifically on the head node, so RPCs to it should never fail since the head node was never killed. However the IP table script will blackout all connections, including those to and from the head node which contains the DB Actor. Hence we should also set max_task_retries=-1 for the DB actor.