### PR TITLE
[Core] Correctly interpret RAY_PYTEST_USE_GPU for enabling/disabling tests

### DIFF
--- a/python/ray/dag/tests/experimental/test_execution_schedule_gpu.py
+++ b/python/ray/dag/tests/experimental/test_execution_schedule_gpu.py
@@ -16,7 +16,7 @@ from ray.tests.conftest import *  # noqa
 if sys.platform != "linux" and sys.platform != "darwin":
     pytest.skip("Skipping, requires Linux or Mac.", allow_module_level=True)
 
-USE_GPU = bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))
+USE_GPU = os.environ.get("RAY_PYTEST_USE_GPU") == "1"
 
 if not USE_GPU:
     pytest.skip("Skipping, these tests require GPUs.", allow_module_level=True)

--- a/python/ray/dag/tests/experimental/test_multi_args_gpu.py
+++ b/python/ray/dag/tests/experimental/test_multi_args_gpu.py
@@ -13,7 +13,7 @@ from ray.tests.conftest import *  # noqa
 if sys.platform != "linux" and sys.platform != "darwin":
     pytest.skip("Skipping, requires Linux or Mac.", allow_module_level=True)
 
-USE_GPU = bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))
+USE_GPU = os.environ.get("RAY_PYTEST_USE_GPU") == "1"
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 if sys.platform != "linux" and sys.platform != "darwin":
     pytest.skip("Skipping, requires Linux or Mac.", allow_module_level=True)
 
-USE_GPU = bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))
+USE_GPU = os.environ.get("RAY_PYTEST_USE_GPU") == "1"
 
 
 @ray.remote

--- a/python/ray/dag/tests/experimental/test_torch_tensor_transport.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_transport.py
@@ -13,7 +13,7 @@ from ray.tests.conftest import *  # noqa
 if sys.platform != "linux" and sys.platform != "darwin":
     pytest.skip("Skipping, requires Linux or Mac.", allow_module_level=True)
 
-USE_GPU = bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))
+USE_GPU = os.environ.get("RAY_PYTEST_USE_GPU") == "1"
 
 
 @ray.remote


### PR DESCRIPTION
## Description
The expression `bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))` incorrectly evaluates to `True` when the environment variable is explicitly set to "0". This happens because `os.environ.get()` returns a string when the variable is set, and bool("0") is True (non-empty string). The common pattern used elsewhere in this codebase is `os.environ.get("VAR") == "1"`, which correctly handles all cases. If someone sets `RAY_PYTEST_USE_GPU=0` to disable GPU tests, the tests would still run unexpectedly.

@tianyi-ge 

## Related issues
Closes #59213


