### PR TITLE
[core][ci] remove the availability_zone which causes an ssh timeout issue in the aws cluster launcher yaml

### DIFF
--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -97,12 +97,12 @@ def get_docker_image(docker_override):
         applicable.
     """
     if docker_override == "latest":
-        return "rayproject/ray:latest-py39"
+        return "rayproject/ray:latest-py310"
     elif docker_override == "nightly":
-        return "rayproject/ray:nightly-py39"
+        return "rayproject/ray:nightly-py310"
     elif docker_override == "commit":
         if re.match("^[0-9]+.[0-9]+.[0-9]+$", ray.__version__):
-            return f"rayproject/ray:{ray.__version__}.{ray.__commit__[:6]}-py39"
+            return f"rayproject/ray:{ray.__version__}.{ray.__commit__[:6]}-py310"
         else:
             print(
                 "Error: docker image is only available for "
@@ -494,6 +494,7 @@ if __name__ == "__main__":
         ensure_ssh_keys_azure()
     elif provider_type == "aws":
         download_ssh_key_aws()
+        config_yaml["provider"].pop("availability_zone", None)
     elif provider_type == "gcp":
         download_ssh_key_gcp()
         # Get the active account email


### PR DESCRIPTION
## Description

The `availability_zone` restrictions cause aws_cluster_launcher_full tests to fail with SSH timeouts when the cluster launcher tries to set up the cluster it launched via SSH, because some subnets in our CI environment are private:
<img width="781" height="485" alt="image" src="https://github.com/user-attachments/assets/19fdd02a-e2eb-466f-b872-077471882696" />


After commenting `availability_zone` out, the tests now pass https://buildkite.com/ray-project/release/builds/71069.
<img width="1676" height="68" alt="image" src="https://github.com/user-attachments/assets/5a3c6a96-7955-448d-82ee-4696cc4d02d7" />



## Related issues

Fixes https://github.com/anyscale/ray/issues/552

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
