### PR TITLE
[Core] Clarify compat target location

### DIFF
--- a/src/ray/common/BUILD.bazel
+++ b/src/ray/common/BUILD.bazel
@@ -1,11 +1,6 @@
 load("//bazel:ray.bzl", "ray_cc_library")
 
 ray_cc_library(
-    name = "compat",
-    hdrs = ["compat.h"],
-)
-
-ray_cc_library(
     name = "constants",
     hdrs = ["constants.h"],
 )


### PR DESCRIPTION
## Description
While Sync Ray project on Bazel plugin in Clion on MacOS, there are some following error for example:

```
could not find label: //src/ray/common:compat.h
```
this appears to be caused by an incorrect or stale entry in
`src/ray/common/BUILD.bazel.`

### What actually happens
- The real compat.h file exists only under:
```
src/ray/util/compat.h
```
- All C++ source files include it via:
```
#include "ray/util/compat.h"
```
- However, `src/ray/common/BUILD.bazel` incorrectly contains:
```
hdrs = ["compat.h"]
```
- Bazel therefore expects a file named `compat.h` inside `src/ray/common/`, corresponding to the label:
```
 //src/ray/common:compat.h
```
- Since no such file exists in that package, Bazel cannot bind the label and the build fails during the loading phase.

### Evidence
```
src/ray/util/BUILD.bazel:254: hdrs = ["compat.h"]
src/ray/common/BUILD.bazel:5: hdrs = ["compat.h"]   <-- incorrect
```
So `src/ray/common/BUILD.bazel` is declaring a header that does not exist in that package.
This appears to be a leftover / stale BUILD rule.


### Expected fix
Remove the incorrect `hdrs = ["compat.h"]` entry from `src/ray/common/BUILD.bazel`
