### PR TITLE
[core] Remove extra copy through proxy on every worker server request

### DIFF
--- a/src/ray/core_worker/core_worker_rpc_proxy.h
+++ b/src/ray/core_worker/core_worker_rpc_proxy.h
@@ -16,6 +16,7 @@
 
 #include <functional>
 #include <memory>
+#include <utility>
 
 #include "absl/synchronization/mutex.h"
 #include "absl/synchronization/notification.h"
@@ -30,7 +31,8 @@ namespace core {
   void Handle##METHOD(rpc::METHOD##Request request,                          \
                       rpc::METHOD##Reply *reply,                             \
                       rpc::SendReplyCallback send_reply_callback) override { \
-    core_worker_->Handle##METHOD(request, reply, send_reply_callback);       \
+    core_worker_->Handle##METHOD(                                            \
+        std::move(request), reply, std::move(send_reply_callback));          \
   }
 
 // This class was introduced as a result of changes in


### PR DESCRIPTION
## Description
Found that there's an extra unnecessary copy on every worker request through the CoreWorkerServiceHandlerProxy. This ends up dominating io context time in cases where you're streaming back lots of large objects (tested through config var to bump up max inline size).

<img width="1197" height="389" alt="Screenshot 2025-12-07 at 2 05 03 PM" src="https://github.com/user-attachments/assets/ebc6ade7-7e59-4030-8e42-ccf4873e9cff" />


