### PR TITLE
[Data] Remove `test_hash_shuffle` from excluded `missing-pytest-main` lint

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -32,9 +32,6 @@ rules:
     paths:
       include:
         - "python/ray/data/tests/**/test_*.py"
-      exclude:
-        # FIXME: These tests weren't run in CI, and now they're failing.
-        - "python/ray/data/tests/test_hash_shuffle.py"
     languages:
       - python
     message: |


### PR DESCRIPTION
Our CI uses Bazel to run Python tests (not pytest). If we don't call `pytest.main` in a test module, the tests aren't actually run. 

https://github.com/ray-project/ray/pull/58816 fixed this issue for `test_hash_shuffle`. As a follow up, this PR removes the `test_hash_shuffle` from the list of files excluded from the `pytest.main` lint.