### PR TITLE
[Data] Increase `test_download_expression` timeout

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1651,7 +1651,7 @@ py_test(
 
 py_test(
     name = "test_download_expression",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_download_expression.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
`test_download_expression` has been occasionally timing out recently. To mtiigate this flakiness, this PR bumps the test size from "small" to "medium".
