### PR TITLE
[Data] Make `test_map_batches_e2e` not assume output ordering

### DIFF
--- a/python/ray/data/tests/test_execution_optimizer_basic.py
+++ b/python/ray/data/tests/test_execution_optimizer_basic.py
@@ -217,7 +217,7 @@ def test_map_batches_operator(ray_start_regular_shared_2_cpus):
 def test_map_batches_e2e(ray_start_regular_shared_2_cpus):
     ds = ray.data.range(5)
     ds = ds.map_batches(column_udf("id", lambda x: x))
-    assert extract_values("id", ds.take_all()) == list(range(5)), ds
+    assert sorted(extract_values("id", ds.take_all())) == list(range(5)), ds
     _check_usage_record(["ReadRange", "MapBatches"])
 
 


### PR DESCRIPTION
`test_map_batches_e2e` occasionally flakes because it assumes that the Dataset outputs data in a specific order, but that order can vary if tasks finish out of order.

```
[2025-12-04T21:34:13Z]     def test_map_batches_e2e(ray_start_regular_shared_2_cpus):
--
[2025-12-04T21:34:13Z]         ds = ray.data.range(5)
[2025-12-04T21:34:13Z]         ds = ds.map_batches(column_udf("id", lambda x: x))
[2025-12-04T21:34:13Z] >       assert extract_values("id", ds.take_all()) == list(range(5)), ds
[2025-12-04T21:34:13Z] E       AssertionError: MapBatches(<lambda>)
[2025-12-04T21:34:13Z] E         +- Dataset(num_rows=5, schema={id: int64})
[2025-12-04T21:34:13Z] E       assert [0, 1, 2, 4, 3] == [0, 1, 2, 3, 4]
[2025-12-04T21:34:13Z] E         At index 3 diff: 4 != 3
[2025-12-04T21:34:13Z] E         Full diff:
[2025-12-04T21:34:13Z] E         - [0, 1, 2, 3, 4]
[2025-12-04T21:34:13Z] E         ?            ---
[2025-12-04T21:34:13Z] E         + [0, 1, 2, 4, 3]
[2025-12-04T21:34:13Z] E         ?           +++
[2025-12-04T21:34:13Z]
```

To mitigate this issue, this PR sorts the output values.