### PR TITLE
[core] fix wheel test

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -239,10 +239,8 @@ steps:
         --except-tags kubernetes,manual
 
   - label: ":ray: core: wheel tests"
-    tags:
-      - linux_wheels
-      # TODO(aslonnie): fix this test
-      - skip-on-premerge
+    key: core-wheel-tests
+    tags: linux_wheels
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //doc/... core

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -234,7 +234,8 @@ def main(
     if build_type == "wheel" or build_type == "wheel-aarch64":
         # for wheel testing, we first build the wheel and then use it for running tests
         architecture = DEFAULT_ARCHITECTURE if build_type == "wheel" else "aarch64"
-        BuilderContainer(DEFAULT_PYTHON_VERSION, DEFAULT_BUILD_TYPE, architecture).run()
+        wheel_python_version = python_version or DEFAULT_PYTHON_VERSION
+        BuilderContainer(wheel_python_version, DEFAULT_BUILD_TYPE, architecture).run()
     bisect_run_test_target = bisect_run_test_target or os.environ.get(
         "RAYCI_BISECT_TEST_TARGET"
     )

--- a/python/ray/tests/test_runtime_env_conda_and_pip_5.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_5.py
@@ -63,8 +63,8 @@ def test_runtime_env_with_conflict_pip_version(start_cluster):
 )
 def test_runtime_env_cache_with_pip_check(start_cluster):
 
-    # moto require requests>=2.5
-    conflict_packages = ["moto==3.0.5", "requests==2.4.0"]
+    # requests 2.32.3 depends on idna>=2.5, so it's a conflict.
+    conflict_packages = ["idna==2.4", "requests==2.32.3"]
     runtime_env = {
         "pip": {
             "packages": conflict_packages,
@@ -86,8 +86,8 @@ def test_runtime_env_cache_with_pip_check(start_cluster):
         ray.get(f.options(runtime_env=runtime_env).remote())
 
     assert "The conflict is caused by:" in str(error.value)
-    assert "The user requested requests==2.4.0" in str(error.value)
-    assert "moto 3.0.5 depends on requests>=2.5" in str(error.value)
+    assert "The user requested idna==2.4" in str(error.value)
+    assert "requests 2.32.3 depends on idna<4 and >=2.5" in str(error.value)
 
     runtime_env["pip"]["pip_check"] = True
     runtime_env["pip"]["pip_version"] = "==20.2.3"


### PR DESCRIPTION
failing on python 3.10 due to old package version used in tests
