### PR TITLE
[core] skip wheel test on premerge

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -238,7 +238,10 @@ steps:
         --except-tags kubernetes,manual
 
   - label: ":ray: core: wheel tests"
-    tags: linux_wheels
+    tags:
+      - linux_wheels
+      # TODO(aslonnie): fix this test
+      - skip-on-premerge
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //doc/... core


### PR DESCRIPTION
it got broken after python version upgrade