### PR TITLE
[deps] unify cryptography version constraint

### DIFF
--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -125,9 +125,7 @@ attrs>=22.2.0
 openapi-schema-validator>=0.6.3
 wheel>=0.45.1
 aiohttp>=3.11.16
-cryptography>=44.0.3 ; sys_platform != "darwin"
-cryptography>=43.0.3 ; sys_platform == "darwin" and platform_machine != "arm64"
-cryptography>=44.0.3 ; sys_platform == "darwin" and platform_machine == "arm64"
+cryptography>=44.0.3
 pyopenssl>=25.0.0
 starlette>=0.40.0
 requests>=2.32.3

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -389,7 +389,7 @@ crc32c==2.3
     # via -r python/requirements/ml/data-requirements.txt
 crcmod==1.7
     # via gsutil
-cryptography==44.0.3 ; sys_platform != "darwin"
+cryptography==44.0.3
     # via
     #   -r python/requirements/test-requirements.txt
     #   adal


### PR DESCRIPTION
as amd64 macos is no longer being built or shipped
