### PR TITLE
[Data] Compute Expressions-Expr Rounding

### DIFF
--- a/python/ray/data/namespace_expressions/string_namespace.py
+++ b/python/ray/data/namespace_expressions/string_namespace.py
@@ -9,7 +9,7 @@ import pyarrow
 import pyarrow.compute as pc
 
 from ray.data.datatype import DataType
-from ray.data.expressions import pyarrow_udf
+from ray.data.expressions import _create_pyarrow_compute_udf, pyarrow_udf
 
 if TYPE_CHECKING:
     from ray.data.expressions import Expr, UDFExpr
@@ -33,14 +33,7 @@ def _create_str_udf(
         A callable that creates UDFExpr instances
     """
 
-    def wrapper(expr: Expr, *positional: Any, **kwargs: Any) -> "UDFExpr":
-        @pyarrow_udf(return_dtype=return_dtype)
-        def udf(arr: pyarrow.Array) -> pyarrow.Array:
-            return pc_func(arr, *positional, **kwargs)
-
-        return udf(expr)
-
-    return wrapper
+    return _create_pyarrow_compute_udf(pc_func, return_dtype=return_dtype)
 
 
 @dataclass

--- a/python/ray/data/tests/test_with_column.py
+++ b/python/ray/data/tests/test_with_column.py
@@ -605,6 +605,33 @@ def test_with_column_floor_division_and_logical_operations(
     reason="with_column requires PyArrow >= 20.0.0",
 )
 @pytest.mark.parametrize(
+    "expr_factory, expected_values",
+    [
+        pytest.param(lambda: col("value").ceil(), [-1, 0, 0, 1, 2], id="ceil"),
+        pytest.param(lambda: col("value").floor(), [-2, -1, 0, 0, 1], id="floor"),
+        pytest.param(lambda: col("value").round(), [-2, 0, 0, 0, 2], id="round"),
+        pytest.param(lambda: col("value").trunc(), [-1, 0, 0, 0, 1], id="trunc"),
+    ],
+)
+def test_with_column_rounding_operations(
+    ray_start_regular_shared,
+    expr_factory,
+    expected_values,
+):
+    """Test ceil, floor, round, and trunc expressions."""
+    values = [-1.75, -0.25, 0.0, 0.25, 1.75]
+    ds = ray.data.from_items([{"value": v} for v in values])
+    expr = expr_factory()
+    result_df = ds.with_column("result", expr).to_pandas()
+    expected_df = pd.DataFrame({"value": values, "result": expected_values})
+    pd.testing.assert_frame_equal(result_df, expected_df, check_dtype=False)
+
+
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("20.0.0"),
+    reason="with_column requires PyArrow >= 20.0.0",
+)
+@pytest.mark.parametrize(
     "test_data, expression, expected_results, test_description",
     [
         # Test with null values

--- a/python/ray/data/tests/test_with_column.py
+++ b/python/ray/data/tests/test_with_column.py
@@ -6,6 +6,7 @@ from pkg_resources import parse_version
 
 import ray
 from ray._private.arrow_utils import get_pyarrow_version
+from ray.data._internal.util import rows_same
 from ray.data.datatype import DataType
 from ray.data.exceptions import UserCodeException
 from ray.data.expressions import col, lit, udf
@@ -624,7 +625,7 @@ def test_with_column_rounding_operations(
     expr = expr_factory()
     result_df = ds.with_column("result", expr).to_pandas()
     expected_df = pd.DataFrame({"value": values, "result": expected_values})
-    pd.testing.assert_frame_equal(result_df, expected_df, check_dtype=False)
+    assert rows_same(result_df, expected_df)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
### Description
Completing the Expr (direct) Rounding operations (ceil, floor, round, trunc)

for example:
```
import ray
from ray.data import from_items
from ray.data.expressions import col

ray.init(include_dashboard=False, ignore_reinit_error=True)
ds = from_items([{"x": 1.1}, {"x": 2.5}, {"x": -3.7}])
for row in ds.iter_rows():
    print(row)

x_expr = col("x")
hasattr(x_expr, "ceil")
ds = ds.with_column("x_ceil", x_expr.ceil())
hasattr(x_expr, "floor")
ds = ds.with_column("x_floor", x_expr.floor())
hasattr(x_expr, "round")
ds = ds.with_column("x_round", x_expr.round())
hasattr(x_expr, "trunc")
ds = ds.with_column("x_trunc", x_expr.trunc())
for row in ds.iter_rows():
    print(row)
```


### Related issues
Related to https://github.com/ray-project/ray/issues/58674

### Additional information