### PR TITLE
[ci] move arm64 linux tests to python 3.10

### DIFF
--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -39,6 +39,8 @@ steps:
   - name: oss-ci-base_build-aarch64
     wanda: ci/docker/base.build.aarch64.wanda.yaml
     depends_on: oss-ci-base_test-aarch64
+    env:
+      PYTHON: "3.10"
     instance_type: builder-arm64
 
   - name: oss-ci-base_ml

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -211,6 +211,7 @@ steps:
         --parallelism-per-worker 3
         --only-tags post_wheel_build
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
+        --python-version 3.10
     depends_on:
       - manylinux-aarch64
       - oss-ci-base_build-aarch64
@@ -227,6 +228,7 @@ steps:
         --parallelism-per-worker 3
         --only-tags post_wheel_build
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
+        --python-version 3.10
     depends_on:
       - manylinux-aarch64
       - oss-ci-base_build-aarch64

--- a/ci/docker/base.test.aarch64.wanda.yaml
+++ b/ci/docker/base.test.aarch64.wanda.yaml
@@ -8,5 +8,6 @@ srcs:
   - .bazelversion
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
+  - PYTHON=3.10
 tags:
   - cr.ray.io/rayproject/oss-ci-base_test-aarch64


### PR DESCRIPTION
stop using python 3.9