### PR TITLE
[llm][release test] Specify STRICT_PACK for release test

### DIFF
--- a/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_tp2.yaml
+++ b/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_tp2.yaml
@@ -3,6 +3,12 @@ model_loading_config:
 
 accelerator_type: A10G
 
+placement_group_config:
+  bundles:
+    - GPU: 1
+    - GPU: 1
+  strategy: STRICT_PACK
+
 engine_kwargs:
   max_model_len: 8192
   tensor_parallel_size: 2


### PR DESCRIPTION
## Description
- Since [#56980](https://github.com/ray-project/ray/pull/56980/files#diff-d064d97eb6c08546afa5a4eee56dc442cdaafae55cfac33af327d3bcfd346444R232). we default to placement strategy "PACK".
- This means the Anyscale auto-select worker feature is allowed to select single accelerator nodes for TP deployments, which causes inconsistent probe measurements

## Fix
Set STRICT_PACK directly for this config
