### PR TITLE
[llm][docs] Add VLLM_DISABLE_COMPILE_CACHE to doc tests

### DIFF
--- a/doc/source/llm/doc_code/serve/qwen/llm_config_example.yaml
+++ b/doc/source/llm/doc_code/serve/qwen/llm_config_example.yaml
@@ -10,9 +10,6 @@ applications:
             autoscaling_config:
                 min_replicas: 1
                 max_replicas: 2
-          runtime_env:
-            env_vars:
-                VLLM_USE_V1: "1"
         - model_loading_config:
             model_id: qwen-1.5b
             model_source: Qwen/Qwen2.5-1.5B-Instruct
@@ -21,9 +18,6 @@ applications:
             autoscaling_config:
                 min_replicas: 1
                 max_replicas: 2
-          runtime_env:
-            env_vars:
-                VLLM_USE_V1: "1"
   import_path: ray.serve.llm:build_openai_app
   name: llm_app
   route_prefix: "/" 

--- a/doc/source/llm/doc_code/serve/qwen/llm_yaml_config_example.py
+++ b/doc/source/llm/doc_code/serve/qwen/llm_yaml_config_example.py
@@ -23,6 +23,12 @@ with open(config_path, "r") as f:
 llm_configs = config_dict["applications"][0]["args"]["llm_configs"]
 for config in llm_configs:
     config.pop("accelerator_type", None)
+    # Disable compile cache to avoid cache corruption in CI
+    if "runtime_env" not in config:
+        config["runtime_env"] = {}
+    if "env_vars" not in config["runtime_env"]:
+        config["runtime_env"]["env_vars"] = {}
+    config["runtime_env"]["env_vars"]["VLLM_DISABLE_COMPILE_CACHE"] = "1"
 
 app = llm.build_openai_app({"llm_configs": llm_configs})
 serve.run(app, blocking=False)

--- a/doc/source/llm/doc_code/serve/qwen/qwen_example.py
+++ b/doc/source/llm/doc_code/serve/qwen/qwen_example.py
@@ -27,6 +27,12 @@ def _testing_build_openai_app(llm_serving_args):
     """Removes accelerator requirements for testing"""
     for config in llm_serving_args["llm_configs"]:
         config.accelerator_type = None
+        # Disable compile cache to avoid cache corruption in CI
+        if not config.runtime_env:
+            config.runtime_env = {}
+        if "env_vars" not in config.runtime_env:
+            config.runtime_env["env_vars"] = {}
+        config.runtime_env["env_vars"]["VLLM_DISABLE_COMPILE_CACHE"] = "1"
 
     return _original_build_openai_app(llm_serving_args)
 
@@ -55,7 +61,6 @@ llm_config = LLMConfig(
     engine_kwargs={
         "tensor_parallel_size": 2,
     },
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
 )
 
 app = build_openai_app({"llm_configs": [llm_config]})


### PR DESCRIPTION
## Description
- Broken postmerge CI: https://buildkite.com/ray-project/postmerge/builds/14837#019b0465-76c5-42d5-aef6-a5f31425bdf4
```
torch._dynamo.exc.BackendCompilerFailed: backend='<vllm.compilation.backends.VllmBackend object at 0x7ff36c0b5250>' raised: [repeated 2x across cluster]
RuntimeError: Bytes object is corrupted, checksum does not match. Expected: b'\xf4\xd5\nx', Got: b'p\xd2\x80\x8e' [repeated 2x across cluster]
```
- All tests try to access `~/.cache/vllm/torch_compile_cache`, which is 

Fix: disable compile cache
## Related issues
- https://github.com/ray-project/ray/issues/55929

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
