### PR TITLE
[ci][data] tensorflow-datasets tests: move tfds tests (1/2)

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1074,6 +1074,21 @@ py_test(
 )
 
 py_test(
+    name = "test_tensorflow_datasets",
+    size = "small",
+    srcs = ["tests/test_tensorflow_datasets.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+        "tensorflow_datasets",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_execution_optimizer_limit_pushdown",
     size = "medium",
     srcs = ["tests/test_execution_optimizer_limit_pushdown.py"],

--- a/python/ray/data/tests/test_execution_optimizer_integrations.py
+++ b/python/ray/data/tests/test_execution_optimizer_integrations.py
@@ -205,35 +205,6 @@ def test_from_huggingface_e2e(ray_start_regular_shared_2_cpus):
     _check_usage_record(["FromArrow"])
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12),
-    reason="Skip due to incompatibility tensorflow with Python 3.12+",
-)
-def test_from_tf_e2e(ray_start_regular_shared_2_cpus):
-    import tensorflow as tf
-    import tensorflow_datasets as tfds
-
-    tf_dataset = tfds.load("mnist", split=["train"], as_supervised=True)[0]
-    tf_dataset = tf_dataset.take(8)  # Use subset to make test run faster.
-
-    ray_dataset = ray.data.from_tf(tf_dataset)
-
-    actual_data = extract_values("item", ray_dataset.take_all())
-    expected_data = list(tf_dataset)
-    assert len(actual_data) == len(expected_data)
-    for (expected_features, expected_label), (actual_features, actual_label) in zip(
-        expected_data, actual_data
-    ):
-        tf.debugging.assert_equal(expected_features, actual_features)
-        tf.debugging.assert_equal(expected_label, actual_label)
-
-    # Check that metadata fetch is included in stats.
-    assert "FromItems" in ray_dataset.stats()
-    # Underlying implementation uses `FromItems` operator
-    assert ray_dataset._plan._logical_plan.dag.name == "FromItems"
-    _check_usage_record(["FromItems"])
-
-
 def test_from_torch_e2e(ray_start_regular_shared_2_cpus, tmp_path):
     import torchvision
 

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -225,29 +225,6 @@ def test_read_example_data(ray_start_regular_shared, tmp_path):
     ]
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12),
-    reason="Skip due to incompatibility tensorflow with Python 3.12+",
-)
-def test_from_tf(ray_start_regular_shared):
-    import tensorflow as tf
-    import tensorflow_datasets as tfds
-
-    tf_dataset = tfds.load("mnist", split=["train"], as_supervised=True)[0]
-    tf_dataset = tf_dataset.take(8)  # Use subset to make test run faster.
-
-    ray_dataset = ray.data.from_tf(tf_dataset)
-
-    actual_data = extract_values("item", ray_dataset.take_all())
-    expected_data = list(tf_dataset)
-    assert len(actual_data) == len(expected_data)
-    for (expected_features, expected_label), (actual_features, actual_label) in zip(
-        expected_data, actual_data
-    ):
-        tf.debugging.assert_equal(expected_features, actual_features)
-        tf.debugging.assert_equal(expected_label, actual_label)
-
-
 def test_read_s3_file_error(shutdown_only, s3_path):
     dummy_path = s3_path + "_dummy"
     error_message = "Please check that file exists and has properly configured access."

--- a/python/ray/data/tests/test_tensorflow_datasets.py
+++ b/python/ray/data/tests/test_tensorflow_datasets.py
@@ -9,6 +9,10 @@ from ray.data.tests.util import extract_values
 from ray.tests.conftest import *  # noqa
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Skip due to incompatibility tensorflow with Python 3.12+",
+)
 def test_from_tf(ray_start_regular_shared_2_cpus):
     import tensorflow as tf
     import tensorflow_datasets as tfds
@@ -28,6 +32,10 @@ def test_from_tf(ray_start_regular_shared_2_cpus):
         tf.debugging.assert_equal(expected_label, actual_label)
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Skip due to incompatibility tensorflow with Python 3.12+",
+)
 def test_from_tf_e2e(ray_start_regular_shared_2_cpus):
     import tensorflow as tf
     import tensorflow_datasets as tfds

--- a/python/ray/data/tests/test_tensorflow_datasets.py
+++ b/python/ray/data/tests/test_tensorflow_datasets.py
@@ -1,0 +1,57 @@
+import sys
+
+import pytest
+
+import ray
+from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.test_util import _check_usage_record
+from ray.data.tests.util import extract_values
+from ray.tests.conftest import *  # noqa
+
+
+def test_from_tf(ray_start_regular_shared_2_cpus):
+    import tensorflow as tf
+    import tensorflow_datasets as tfds
+
+    tf_dataset = tfds.load("mnist", split=["train"], as_supervised=True)[0]
+    tf_dataset = tf_dataset.take(8)  # Use subset to make test run faster.
+
+    ray_dataset = ray.data.from_tf(tf_dataset)
+
+    actual_data = extract_values("item", ray_dataset.take_all())
+    expected_data = list(tf_dataset)
+    assert len(actual_data) == len(expected_data)
+    for (expected_features, expected_label), (actual_features, actual_label) in zip(
+        expected_data, actual_data
+    ):
+        tf.debugging.assert_equal(expected_features, actual_features)
+        tf.debugging.assert_equal(expected_label, actual_label)
+
+
+def test_from_tf_e2e(ray_start_regular_shared_2_cpus):
+    import tensorflow as tf
+    import tensorflow_datasets as tfds
+
+    tf_dataset = tfds.load("mnist", split=["train"], as_supervised=True)[0]
+    tf_dataset = tf_dataset.take(8)  # Use subset to make test run faster.
+
+    ray_dataset = ray.data.from_tf(tf_dataset)
+
+    actual_data = extract_values("item", ray_dataset.take_all())
+    expected_data = list(tf_dataset)
+    assert len(actual_data) == len(expected_data)
+    for (expected_features, expected_label), (actual_features, actual_label) in zip(
+        expected_data, actual_data
+    ):
+        tf.debugging.assert_equal(expected_features, actual_features)
+        tf.debugging.assert_equal(expected_label, actual_label)
+
+    # Check that metadata fetch is included in stats.
+    assert "FromItems" in ray_dataset.stats()
+    # Underlying implementation uses `FromItems` operator
+    assert ray_dataset._plan._logical_plan.dag.name == "FromItems"
+    _check_usage_record(["FromItems"])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
moving tensorflow-metadata tests in preparation to remove it as a declared test dependency