### PR TITLE
[serve][llm] Fix LLM target_ongoing_requests default

### DIFF
--- a/python/ray/llm/_internal/common/dict_utils.py
+++ b/python/ray/llm/_internal/common/dict_utils.py
@@ -1,4 +1,28 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+
+def maybe_apply_llm_deployment_config_defaults(
+    defaults: Dict[str, Any],
+    user_deployment_config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Apply defaults based on user-provided deployment config.
+
+    If the user has explicitly set 'num_replicas' in their deployment config,
+    we need to remove 'autoscaling_config' from the defaults since Ray Serve
+    does not allow both to be set simultaneously.
+
+    Args:
+        defaults: The default deployment options dictionary.
+        user_deployment_config: The user-provided deployment configuration.
+
+    Returns:
+        A copy of defaults with 'autoscaling_config' removed if 'num_replicas'
+        is present in user_deployment_config.
+    """
+    if user_deployment_config and "num_replicas" in user_deployment_config:
+        defaults = defaults.copy()
+        defaults.pop("autoscaling_config", None)
+    return defaults
 
 
 def deep_merge_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/ray/llm/_internal/common/dict_utils.py
+++ b/python/ray/llm/_internal/common/dict_utils.py
@@ -5,24 +5,24 @@ def maybe_apply_llm_deployment_config_defaults(
     defaults: Dict[str, Any],
     user_deployment_config: Optional[Dict[str, Any]],
 ) -> Dict[str, Any]:
-    """Apply defaults based on user-provided deployment config.
+    """Apply defaults and merge with user-provided deployment config.
 
     If the user has explicitly set 'num_replicas' in their deployment config,
-    we need to remove 'autoscaling_config' from the defaults since Ray Serve
-    does not allow both to be set simultaneously.
+    we remove 'autoscaling_config' from the defaults since Ray Serve
+    does not allow both to be set simultaneously. Then merges the defaults
+    with the user config.
 
     Args:
         defaults: The default deployment options dictionary.
         user_deployment_config: The user-provided deployment configuration.
 
     Returns:
-        A copy of defaults with 'autoscaling_config' removed if 'num_replicas'
-        is present in user_deployment_config.
+        The merged deployment options with conflicts resolved.
     """
     if user_deployment_config and "num_replicas" in user_deployment_config:
         defaults = defaults.copy()
         defaults.pop("autoscaling_config", None)
-    return defaults
+    return deep_merge_dicts(defaults, user_deployment_config or {})
 
 
 def deep_merge_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -119,16 +119,22 @@ def build_openai_app(builder_config: dict) -> Application:
     llm_deployments = [build_llm_deployment(c) for c in llm_configs]
 
     ingress_cls_config = builder_config.ingress_cls_config
-    ingress_options = ingress_cls_config.ingress_cls.get_deployment_options(llm_configs)
+    default_ingress_options = ingress_cls_config.ingress_cls.get_deployment_options(
+        llm_configs
+    )
 
-    if builder_config.ingress_deployment_config:
-        ingress_options = deep_merge_dicts(
-            ingress_options, builder_config.ingress_deployment_config
-        )
-        # When num_replicas is explicitly set, we should not include autoscaling_config
-        # in the defaults since Ray Serve does not allow both.
-        if "num_replicas" in builder_config.ingress_deployment_config:
-            ingress_options.pop("autoscaling_config", None)
+    # When num_replicas is explicitly set, we should not include autoscaling_config
+    # in the defaults since Ray Serve does not allow both.
+    if (
+        builder_config.ingress_deployment_config
+        and "num_replicas" in builder_config.ingress_deployment_config
+    ):
+        default_ingress_options = default_ingress_options.copy()
+        default_ingress_options.pop("autoscaling_config", None)
+
+    ingress_options = deep_merge_dicts(
+        default_ingress_options, builder_config.ingress_deployment_config or {}
+    )
 
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
 

--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -7,7 +7,6 @@ from pydantic import Field, field_validator, model_validator
 from ray import serve
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.dict_utils import (
-    deep_merge_dicts,
     maybe_apply_llm_deployment_config_defaults,
 )
 from ray.llm._internal.common.utils.import_utils import load_class
@@ -126,12 +125,8 @@ def build_openai_app(builder_config: dict) -> Application:
         llm_configs
     )
 
-    default_ingress_options = maybe_apply_llm_deployment_config_defaults(
+    ingress_options = maybe_apply_llm_deployment_config_defaults(
         default_ingress_options, builder_config.ingress_deployment_config
-    )
-
-    ingress_options = deep_merge_dicts(
-        default_ingress_options, builder_config.ingress_deployment_config or {}
     )
 
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)

--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -125,6 +125,10 @@ def build_openai_app(builder_config: dict) -> Application:
         ingress_options = deep_merge_dicts(
             ingress_options, builder_config.ingress_deployment_config
         )
+        # When num_replicas is explicitly set, we should not include autoscaling_config
+        # in the defaults since Ray Serve does not allow both.
+        if "num_replicas" in builder_config.ingress_deployment_config:
+            ingress_options.pop("autoscaling_config", None)
 
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
 

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -30,8 +30,8 @@ from ray.llm._internal.common.utils.lora_utils import (
 )
 from ray.llm._internal.serve.constants import (
     DEFAULT_LLM_ROUTER_HTTP_TIMEOUT,
-    DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS,
     DEFAULT_MAX_ONGOING_REQUESTS,
+    DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
 )
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 from ray.llm._internal.serve.core.configs.openai_api_models import (
@@ -89,7 +89,7 @@ T = TypeVar("T")
 DEFAULT_INGRESS_OPTIONS = {
     "max_ongoing_requests": DEFAULT_MAX_ONGOING_REQUESTS,
     "autoscaling_config": {
-        "target_ongoing_requests": DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS,
+        "target_ongoing_requests": DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
     },
 }
 

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -30,6 +30,7 @@ from ray.llm._internal.common.utils.lora_utils import (
 )
 from ray.llm._internal.serve.constants import (
     DEFAULT_LLM_ROUTER_HTTP_TIMEOUT,
+    DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS,
     DEFAULT_MAX_ONGOING_REQUESTS,
 )
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
@@ -87,6 +88,9 @@ T = TypeVar("T")
 
 DEFAULT_INGRESS_OPTIONS = {
     "max_ongoing_requests": DEFAULT_MAX_ONGOING_REQUESTS,
+    "autoscaling_config": {
+        "target_ongoing_requests": DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS,
+    },
 }
 
 # These methods correspond to functions defined in the LLMEngine class in python/ray/llm/_internal/serve/deployments/llm/llm_engine.py

--- a/python/ray/llm/_internal/serve/core/server/builder.py
+++ b/python/ray/llm/_internal/serve/core/server/builder.py
@@ -70,9 +70,13 @@ def build_llm_deployment(
     if override_serve_options:
         deployment_options.update(override_serve_options)
 
-    deployment_options = deep_merge_dicts(
-        DEFAULT_DEPLOYMENT_OPTIONS, deployment_options
-    )
+    # When num_replicas is explicitly set, we should not include autoscaling_config
+    # in the defaults since Ray Serve does not allow both.
+    defaults = DEFAULT_DEPLOYMENT_OPTIONS.copy()
+    if "num_replicas" in deployment_options:
+        defaults.pop("autoscaling_config", None)
+
+    deployment_options = deep_merge_dicts(defaults, deployment_options)
 
     logger.info("============== Deployment Options ==============")
     logger.info(pprint.pformat(deployment_options))

--- a/python/ray/llm/_internal/serve/core/server/builder.py
+++ b/python/ray/llm/_internal/serve/core/server/builder.py
@@ -2,7 +2,10 @@ import pprint
 from typing import Optional, Type
 
 from ray import serve
-from ray.llm._internal.common.dict_utils import deep_merge_dicts
+from ray.llm._internal.common.dict_utils import (
+    deep_merge_dicts,
+    maybe_apply_llm_deployment_config_defaults,
+)
 from ray.llm._internal.serve.constants import (
     DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_HEALTH_CHECK_TIMEOUT_S,
@@ -70,12 +73,9 @@ def build_llm_deployment(
     if override_serve_options:
         deployment_options.update(override_serve_options)
 
-    # When num_replicas is explicitly set, we should not include autoscaling_config
-    # in the defaults since Ray Serve does not allow both.
-    defaults = DEFAULT_DEPLOYMENT_OPTIONS.copy()
-    if "num_replicas" in deployment_options:
-        defaults.pop("autoscaling_config", None)
-
+    defaults = maybe_apply_llm_deployment_config_defaults(
+        DEFAULT_DEPLOYMENT_OPTIONS, deployment_options
+    )
     deployment_options = deep_merge_dicts(defaults, deployment_options)
 
     logger.info("============== Deployment Options ==============")

--- a/python/ray/llm/_internal/serve/core/server/builder.py
+++ b/python/ray/llm/_internal/serve/core/server/builder.py
@@ -7,6 +7,7 @@ from ray.llm._internal.serve.constants import (
     DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_HEALTH_CHECK_TIMEOUT_S,
     DEFAULT_MAX_ONGOING_REQUESTS,
+    DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
 )
 from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
@@ -22,6 +23,9 @@ DEFAULT_DEPLOYMENT_OPTIONS = {
     "max_ongoing_requests": DEFAULT_MAX_ONGOING_REQUESTS,
     "health_check_period_s": DEFAULT_HEALTH_CHECK_PERIOD_S,
     "health_check_timeout_s": DEFAULT_HEALTH_CHECK_TIMEOUT_S,
+    "autoscaling_config": {
+        "target_ongoing_requests": DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
+    },
 }
 
 

--- a/python/ray/llm/_internal/serve/core/server/builder.py
+++ b/python/ray/llm/_internal/serve/core/server/builder.py
@@ -3,7 +3,6 @@ from typing import Optional, Type
 
 from ray import serve
 from ray.llm._internal.common.dict_utils import (
-    deep_merge_dicts,
     maybe_apply_llm_deployment_config_defaults,
 )
 from ray.llm._internal.serve.constants import (
@@ -73,10 +72,9 @@ def build_llm_deployment(
     if override_serve_options:
         deployment_options.update(override_serve_options)
 
-    defaults = maybe_apply_llm_deployment_config_defaults(
+    deployment_options = maybe_apply_llm_deployment_config_defaults(
         DEFAULT_DEPLOYMENT_OPTIONS, deployment_options
     )
-    deployment_options = deep_merge_dicts(defaults, deployment_options)
 
     logger.info("============== Deployment Options ==============")
     logger.info(pprint.pformat(deployment_options))

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
@@ -168,6 +168,10 @@ def build_pd_openai_app(pd_serving_args: dict) -> Application:
         ingress_options = deep_merge_dicts(
             ingress_options, pd_config.ingress_deployment_config
         )
+        # When num_replicas is explicitly set, we should not include autoscaling_config
+        # in the defaults since Ray Serve does not allow both.
+        if "num_replicas" in pd_config.ingress_deployment_config:
+            ingress_options.pop("autoscaling_config", None)
 
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
     return serve.deployment(ingress_cls, **ingress_options).bind(

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
@@ -167,12 +167,8 @@ def build_pd_openai_app(pd_serving_args: dict) -> Application:
         [pd_config.prefill_config, pd_config.decode_config]
     )
 
-    default_ingress_options = maybe_apply_llm_deployment_config_defaults(
+    ingress_options = maybe_apply_llm_deployment_config_defaults(
         default_ingress_options, pd_config.ingress_deployment_config
-    )
-
-    ingress_options = deep_merge_dicts(
-        default_ingress_options, pd_config.ingress_deployment_config or {}
     )
 
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_builder_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_builder_llm_server.py
@@ -3,8 +3,10 @@ import sys
 import pytest
 
 from ray import serve
+from ray.llm._internal.serve.constants import DEFAULT_MAX_TARGET_ONGOING_REQUESTS
 from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
+    ModelLoadingConfig,
 )
 from ray.llm._internal.serve.core.server.builder import (
     build_llm_deployment,
@@ -57,6 +59,64 @@ class TestBuildVllmDeployment:
         assert isinstance(app, serve.Application)
         handle = serve.run(app)
         assert handle.deployment_name == _name_prefix_for_test + _deployment_name
+
+    def test_default_autoscaling_config_included_without_num_replicas(
+        self, disable_placement_bundles
+    ):
+        """Test that default autoscaling_config with target_ongoing_requests is included
+        when num_replicas is not specified.
+        """
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model"),
+        )
+        app = build_llm_deployment(llm_config)
+
+        deployment = app._bound_deployment
+        autoscaling_config = deployment._deployment_config.autoscaling_config
+        assert autoscaling_config is not None
+        assert (
+            autoscaling_config.target_ongoing_requests
+            == DEFAULT_MAX_TARGET_ONGOING_REQUESTS
+        )
+
+    def test_autoscaling_config_removed_from_defaults_when_num_replicas_specified(
+        self, disable_placement_bundles
+    ):
+        """Test that autoscaling_config from defaults is removed when user specifies
+        num_replicas, since Ray Serve does not allow both.
+        """
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model"),
+            deployment_config={
+                "num_replicas": 2,
+            },
+        )
+        app = build_llm_deployment(llm_config)
+
+        deployment = app._bound_deployment
+        assert deployment._deployment_config.num_replicas == 2
+        # autoscaling_config should be None since num_replicas is set
+        assert deployment._deployment_config.autoscaling_config is None
+
+    def test_user_target_ongoing_requests_respected(self, disable_placement_bundles):
+        """Test that user-specified target_ongoing_requests is respected and not
+        overridden by defaults.
+        """
+        user_target = 50
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-model"),
+            deployment_config={
+                "autoscaling_config": {
+                    "target_ongoing_requests": user_target,
+                },
+            },
+        )
+        app = build_llm_deployment(llm_config)
+
+        deployment = app._bound_deployment
+        autoscaling_config = deployment._deployment_config.autoscaling_config
+        assert autoscaling_config is not None
+        assert autoscaling_config.target_ongoing_requests == user_target
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
@@ -10,6 +10,7 @@ import yaml
 
 from ray import serve
 from ray._common.test_utils import wait_for_condition
+from ray.llm._internal.serve.constants import DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS
 from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
     ModelLoadingConfig,
@@ -306,6 +307,69 @@ class TestBuildOpenaiApp:
         assert deployment.ray_actor_options["num_cpus"] == 4
         assert deployment.ray_actor_options["memory"] == 1024
         assert deployment._deployment_config.max_ongoing_requests == 200
+
+    def test_default_autoscaling_config_included_without_num_replicas(
+        self, llm_config, disable_placement_bundles
+    ):
+        """Test that default autoscaling_config with target_ongoing_requests is included
+        when num_replicas is not specified.
+        """
+        app = build_openai_app(
+            dict(
+                llm_configs=[llm_config],
+            )
+        )
+
+        deployment = app._bound_deployment
+        autoscaling_config = deployment._deployment_config.autoscaling_config
+        assert autoscaling_config is not None
+        assert (
+            autoscaling_config.target_ongoing_requests
+            == DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS
+        )
+
+    def test_autoscaling_config_removed_from_defaults_when_num_replicas_specified(
+        self, llm_config, disable_placement_bundles
+    ):
+        """Test that autoscaling_config from defaults is removed when user specifies
+        num_replicas, since Ray Serve does not allow both.
+        """
+        app = build_openai_app(
+            dict(
+                llm_configs=[llm_config],
+                ingress_deployment_config={
+                    "num_replicas": 2,
+                },
+            )
+        )
+
+        deployment = app._bound_deployment
+        assert deployment._deployment_config.num_replicas == 2
+        # autoscaling_config should be None since num_replicas is set
+        assert deployment._deployment_config.autoscaling_config is None
+
+    def test_user_target_ongoing_requests_respected(
+        self, llm_config, disable_placement_bundles
+    ):
+        """Test that user-specified target_ongoing_requests is respected and not
+        overridden by defaults.
+        """
+        user_target = 50
+        app = build_openai_app(
+            dict(
+                llm_configs=[llm_config],
+                ingress_deployment_config={
+                    "autoscaling_config": {
+                        "target_ongoing_requests": user_target,
+                    },
+                },
+            )
+        )
+
+        deployment = app._bound_deployment
+        autoscaling_config = deployment._deployment_config.autoscaling_config
+        assert autoscaling_config is not None
+        assert autoscaling_config.target_ongoing_requests == user_target
 
 
 def extract_applications_from_output(output: bytes) -> dict:

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
@@ -10,7 +10,7 @@ import yaml
 
 from ray import serve
 from ray._common.test_utils import wait_for_condition
-from ray.llm._internal.serve.constants import DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS
+from ray.llm._internal.serve.constants import DEFAULT_MAX_TARGET_ONGOING_REQUESTS
 from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
     ModelLoadingConfig,
@@ -325,7 +325,7 @@ class TestBuildOpenaiApp:
         assert autoscaling_config is not None
         assert (
             autoscaling_config.target_ongoing_requests
-            == DEFAULT_LLM_ROUTER_TARGET_ONGOING_REQUESTS
+            == DEFAULT_MAX_TARGET_ONGOING_REQUESTS
         )
 
     def test_autoscaling_config_removed_from_defaults_when_num_replicas_specified(


### PR DESCRIPTION
## Description
- In https://github.com/ray-project/ray/pull/57181, `DEFAULT_MAX_TARGET_ONGOING_REQUESTS` was no longer passed to the default `LLMServer` deployment config
- Fix: add it back