### PR TITLE
[serve][llm] Fix llm_batch_sglang_llama

### DIFF
--- a/python/ray/llm/_internal/batch/utils.py
+++ b/python/ray/llm/_internal/batch/utils.py
@@ -32,8 +32,14 @@ def get_cached_tokenizer(tokenizer: AnyTokenizer) -> AnyTokenizer:
             chat_template = getattr(tokenizer, "chat_template", None)
 
     tokenizer_all_special_ids = set(tokenizer.all_special_ids)
-    tokenizer_all_special_tokens_extended = tokenizer.all_special_tokens_extended
     tokenizer_all_special_tokens = set(tokenizer.all_special_tokens)
+    # all_special_tokens_extended is removed in transformers v5, used in latest
+    # SGLang version. We require this SGLang version bc it's ABI compatible with
+    # PyTorch 2.9, which is installed by vLLM.
+    # TODO(seiji) remove the attribute completely once vLLM moves to transformers v5.
+    tokenizer_all_special_tokens_extended = getattr(
+        tokenizer, "all_special_tokens_extended", None
+    )
     tokenizer_len = len(tokenizer)
 
     class CachedTokenizer(tokenizer.__class__):  # type: ignore

--- a/release/ray_release/byod/byod_llm_sglang_test.sh
+++ b/release/ray_release/byod/byod_llm_sglang_test.sh
@@ -4,4 +4,4 @@
 
 set -exo pipefail
 
-pip3 install "sglang[all]==0.5.1.post2"
+pip3 install "sglang[all]==0.5.6.post1"


### PR DESCRIPTION
## Description
- Since vLLM updated to PyTorch 2.9, trying to install an old SGLang version that relies on 2.8 will create ABI incompatibilities that look like this:
```
asctime":"2025-12-09 13:19:47,629","levelname":"E","message":"Unhandled exception: St9bad_alloc. what(): std::bad_alloc /home/ray/anaconda3/lib/python3.11/site-packages/ray/_raylet.so(+0x16ad45a) [0x73b808df145a
```
- Fix: update the SGLang byod version. And update the Ray Data LLM utils for compatibility with transformers v5, which is required by that updated SGLang version. This is the earliest SGLang version that uses PyTorch 2.9

## Related Issues
- Closes https://github.com/anyscale/ray/issues/674
