### PR TITLE
fix permissions bug when building wheel

### DIFF
--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -16,8 +16,8 @@ if [ "$EUID" -eq 0 ]; then
   useradd -m -u "$HOST_UID" -g "$HOST_GID" -d /ray builduser
 
   # Grant the builduser permissions to access $HOME.
-  sudo chown builduser $HOME
-  sudo chmod -R u+rwx $HOME
+  chown builduser $HOME
+  chmod -R u+rwx $HOME
 
   # Give sudo access
   echo "builduser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -15,6 +15,10 @@ if [ "$EUID" -eq 0 ]; then
   groupadd -g "$HOST_GID" builduser
   useradd -m -u "$HOST_UID" -g "$HOST_GID" -d /ray builduser
 
+  # Grant the builduser permissions to access $HOME.
+  sudo chown builduser $HOME
+  sudo chmod -R u+rwx $HOME
+
   # Give sudo access
   echo "builduser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 


### PR DESCRIPTION
I am compiling Ray's wheel following [building-wheel.md](https://github.com/ray-project/ray/blob/master/python/README-building-wheels.md), but get the following error:
<img width="2944" height="872" alt="image" src="https://github.com/user-attachments/assets/74ff03d7-a3c0-415a-9b5e-42590686def6" />

This issue is caused by the newly created user "builduser" not having permissions for the $HOME directory. This PR resolves the issue.

