### PR TITLE
[Data] Remove duplicate `PhysicalOperator` method to get max operator concurrency

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -489,7 +489,7 @@ class PhysicalOperator(Operator):
         """
         return ExecutionResources.zero()
 
-    def max_task_concurrency(self: "PhysicalOperator") -> Optional[int]:
+    def get_max_concurrency_limit(self: "PhysicalOperator") -> Optional[int]:
         """The maximum number of tasks that can be run concurrently.
 
         Some operators manually configure a maximum concurrency. For example, if you
@@ -815,11 +815,6 @@ class PhysicalOperator(Operator):
             op.num_outputs_total() or 0 for op in self.input_dependencies
         )
         return upstream_op_num_outputs
-
-    def get_max_concurrency_limit(self) -> Optional[int]:
-        """Max value of how many tasks this operator could run
-        concurrently (if limited)"""
-        return None
 
 
 class ReportsExtraResourceUsage(abc.ABC):


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/57788 renamed the `max_task_concurrency()` as `get_max_concurrency_limit()`. However, the PR didn't remove the original ``max_task_concurrency()` method on the `PhysicalOperator` base class (probably an oversight?).

This PR fixes the issue by removing the dead method.