### PR TITLE
[bazel] removes hermetic_python alias

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,12 +20,6 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-alias(
-    name = "hermetic_python",
-    actual = "//bazel:py310",
-    visibility = ["//visibility:public"],
-)
-
 # C/C++ toolchain constraint configs.
 
 config_setting(


### PR DESCRIPTION
people can reference `//bazel:py3` instead. it is kind of inaccurate to emphasis "hermetic"; it the constraint does not really enforces hermeticity 