### PR TITLE
[ci] remove oss-ci-base_build-py39

### DIFF
--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -7,7 +7,6 @@ steps:
     label: "wanda: oss-ci-base_test-py{{matrix}}"
     wanda: ci/docker/base.test.wanda.yaml
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -23,7 +22,6 @@ steps:
     label: "wanda: oss-ci-base_build-py{{matrix}}"
     wanda: ci/docker/base.build.wanda.yaml
     matrix:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"


### PR DESCRIPTION
not used anywhere anymore
