### PR TITLE
refactor(ci-automation): move crane into crane_lib

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -100,17 +100,64 @@ py_binary(
 )
 
 py_library(
-    name = "docker_tags_lib",
-    srcs = ["docker_tags_lib.py"],
+    name = "crane_lib",
+    srcs = ["crane_lib.py"],
     data = [
         "@crane_linux_x86_64//:file",
     ],
+    visibility = [
+        "//ci/ray_ci/automation:__subpackages__",
+        "//ci/ray_ci/base_images:__subpackages__",
+    ],
+    deps = [
+        "//ci/ray_ci:ray_ci_lib",
+    ],
+)
+
+py_library(
+    name = "test_utils",
+    srcs = ["test_utils.py"],
+    data = [
+        "@registry_x86_64//:file",
+    ],
+    visibility = ["//ci/ray_ci/automation:__subpackages__"],
+    deps = [
+        ci_require("pytest"),
+        ci_require("requests"),
+        ci_require("bazel-runfiles"),
+    ],
+)
+
+py_test(
+    name = "test_crane_lib",
+    size = "small",
+    srcs = ["test_crane_lib.py"],
+    data = [
+        "@crane_linux_x86_64//:file",
+        "@registry_x86_64//:file",
+    ],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ci_require("pytest"),
+        ci_require("requests"),
+        ":crane_lib",
+        ":test_utils",
+    ],
+)
+
+py_library(
+    name = "docker_tags_lib",
+    srcs = ["docker_tags_lib.py"],
     visibility = ["//ci/ray_ci/automation:__subpackages__"],
     deps = [
         "//ci/ray_ci:ray_ci_lib",
+        ":crane_lib",
         ci_require("docker"),
         ci_require("requests"),
-        ci_require("bazel-runfiles"),
     ],
 )
 
@@ -129,6 +176,7 @@ py_test(
     deps = [
         ci_require("pytest"),
         ":docker_tags_lib",
+        ":test_utils",
     ],
 )
 

--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -154,8 +154,8 @@ py_library(
     srcs = ["docker_tags_lib.py"],
     visibility = ["//ci/ray_ci/automation:__subpackages__"],
     deps = [
-        "//ci/ray_ci:ray_ci_lib",
         ":crane_lib",
+        "//ci/ray_ci:ray_ci_lib",
         ci_require("docker"),
         ci_require("requests"),
     ],

--- a/ci/ray_ci/automation/crane_lib.py
+++ b/ci/ray_ci/automation/crane_lib.py
@@ -1,9 +1,12 @@
 """
-Wrapper library for the crane Docker registry tool.
+Wrapper library for using the crane tool for managing container images.
+https://github.com/google/go-containerregistry/blob/v0.19.0/cmd/crane/doc/crane.md
 
 All functions return (return_code, output) tuples. On success, return_code is 0.
 On failure, return_code is non-zero and output may be None (stderr is not captured).
-Callers should check return_code to detect failures rather than relying on exceptions.
+
+Callers are responsible for checking return_code to detect failures rather than
+relying on exceptions.
 """
 
 import platform
@@ -34,10 +37,10 @@ def _crane_binary() -> str:
 
 def call_crane_copy(source: str, destination: str) -> Tuple[int, str]:
     """
-    Copy a Docker image from source to destination using crane.
+    Copy a container image from source to destination.
 
     Args:
-        source: Source image reference (e.g., "registry/repo:tag").
+        source: Source image reference (e.g., "registry.example.com/repo:tag").
         destination: Destination image reference.
 
     Returns:
@@ -67,14 +70,14 @@ def call_crane_copy(source: str, destination: str) -> Tuple[int, str]:
         return e.returncode, e.output
 
 
-def call_crane_cp(tag: str, source: str, aws_ecr_repo: str) -> Tuple[int, str]:
+def call_crane_cp(tag: str, source: str, dest_repo: str) -> Tuple[int, str]:
     """
-    Copy a Docker image to AWS ECR using crane cp.
+    Copy a container image to a destination repository with a specified tag.
 
     Args:
         tag: Tag to apply to the destination image.
         source: Source image reference.
-        aws_ecr_repo: AWS ECR repository URL (tag will be appended as ":tag").
+        dest_repo: Destination repository URL (tag will be appended as ":tag").
 
     Returns:
         Tuple of (return_code, output). return_code is 0 on success, non-zero on
@@ -86,7 +89,7 @@ def call_crane_cp(tag: str, source: str, aws_ecr_repo: str) -> Tuple[int, str]:
                 _crane_binary(),
                 "cp",
                 source,
-                f"{aws_ecr_repo}:{tag}",
+                f"{dest_repo}:{tag}",
             ],
             stdout=subprocess.PIPE,
             text=True,
@@ -145,12 +148,12 @@ def call_crane_index(index_name: str, tags: List[str]) -> Tuple[int, str]:
 
 def call_crane_manifest(tag: str) -> Tuple[int, str]:
     """
-    Fetch the manifest for a Docker image.
+    Fetch the manifest for a container image.
 
     Can be used to check if an image exists (return_code 0 means it exists).
 
     Args:
-        tag: Image reference to fetch manifest for (e.g., "registry/repo:tag").
+        tag: Image reference to fetch manifest for (e.g., "registry.example.com/repo:tag").
 
     Returns:
         Tuple of (return_code, output). return_code is 0 if image exists, non-zero

--- a/ci/ray_ci/automation/crane_lib.py
+++ b/ci/ray_ci/automation/crane_lib.py
@@ -58,7 +58,9 @@ def _run_crane_command(args: List[str]) -> Tuple[int, str]:
                 logger.error(
                     f"Crane command `{' '.join(command)}` failed with stderr:\n{stderr}"
                 )
-                raise subprocess.CalledProcessError(return_code, command, output, stderr)
+                raise subprocess.CalledProcessError(
+                    return_code, command, output, stderr
+                )
             return return_code, output
     except subprocess.CalledProcessError as e:
         return e.returncode, e.output
@@ -133,4 +135,3 @@ def call_crane_manifest(tag: str) -> Tuple[int, str]:
         since stderr is not captured.
     """
     return _run_crane_command(["manifest", tag])
-

--- a/ci/ray_ci/automation/crane_lib.py
+++ b/ci/ray_ci/automation/crane_lib.py
@@ -1,0 +1,180 @@
+"""
+Wrapper library for the crane Docker registry tool.
+
+All functions return (return_code, output) tuples. On success, return_code is 0.
+On failure, return_code is non-zero and output may be None (stderr is not captured).
+Callers should check return_code to detect failures rather than relying on exceptions.
+"""
+
+import platform
+import subprocess
+from typing import List, Tuple
+
+import runfiles
+
+from ci.ray_ci.utils import logger
+
+
+def _crane_binary() -> str:
+    """
+    Get the path to the crane binary from bazel runfiles.
+
+    Returns:
+        Path to the crane binary.
+
+    Raises:
+        ValueError: If running on unsupported platform (non-Linux or non-x86_64).
+    """
+    r = runfiles.Create()
+    system = platform.system()
+    if system != "Linux" or platform.processor() != "x86_64":
+        raise ValueError(f"Unsupported platform: {system}")
+    return r.Rlocation("crane_linux_x86_64/crane")
+
+
+def call_crane_copy(source: str, destination: str) -> Tuple[int, str]:
+    """
+    Copy a Docker image from source to destination using crane.
+
+    Args:
+        source: Source image reference (e.g., "registry/repo:tag").
+        destination: Destination image reference.
+
+    Returns:
+        Tuple of (return_code, output). return_code is 0 on success, non-zero on
+        failure. On failure, output may be None since stderr is not captured.
+    """
+    try:
+        with subprocess.Popen(
+            [
+                _crane_binary(),
+                "copy",
+                source,
+                destination,
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+        ) as proc:
+            output = ""
+            for line in proc.stdout:
+                logger.info(line + "\n")
+                output += line
+            return_code = proc.wait()
+            if return_code:
+                raise subprocess.CalledProcessError(return_code, proc.args)
+            return return_code, output
+    except subprocess.CalledProcessError as e:
+        return e.returncode, e.output
+
+
+def call_crane_cp(tag: str, source: str, aws_ecr_repo: str) -> Tuple[int, str]:
+    """
+    Copy a Docker image to AWS ECR using crane cp.
+
+    Args:
+        tag: Tag to apply to the destination image.
+        source: Source image reference.
+        aws_ecr_repo: AWS ECR repository URL (tag will be appended as ":tag").
+
+    Returns:
+        Tuple of (return_code, output). return_code is 0 on success, non-zero on
+        failure. On failure, output may be None since stderr is not captured.
+    """
+    try:
+        with subprocess.Popen(
+            [
+                _crane_binary(),
+                "cp",
+                source,
+                f"{aws_ecr_repo}:{tag}",
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+        ) as proc:
+            output = ""
+            for line in proc.stdout:
+                logger.info(line + "\n")
+                output += line
+            return_code = proc.wait()
+            if return_code:
+                raise subprocess.CalledProcessError(return_code, proc.args)
+            return return_code, output
+    except subprocess.CalledProcessError as e:
+        return e.returncode, e.output
+
+
+def call_crane_index(index_name: str, tags: List[str]) -> Tuple[int, str]:
+    """
+    Create a multi-architecture image index from platform-specific images.
+
+    Args:
+        index_name: Name for the resulting multi-arch index.
+        tags: List of exactly 2 platform-specific image tags to combine.
+
+    Returns:
+        Tuple of (return_code, output). return_code is 0 on success, non-zero on
+        failure. On failure, output may be None since stderr is not captured.
+    """
+    try:
+        with subprocess.Popen(
+            [
+                _crane_binary(),
+                "index",
+                "append",
+                "-m",
+                tags[0],
+                "-m",
+                tags[1],
+                "-t",
+                index_name,
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+        ) as proc:
+            output = ""
+            for line in proc.stdout:
+                logger.info(line + "\n")
+                output += line
+            return_code = proc.wait()
+            if return_code:
+                raise subprocess.CalledProcessError(return_code, proc.args)
+            return return_code, output
+    except subprocess.CalledProcessError as e:
+        return e.returncode, e.output
+
+
+def call_crane_manifest(tag: str) -> Tuple[int, str]:
+    """
+    Fetch the manifest for a Docker image.
+
+    Can be used to check if an image exists (return_code 0 means it exists).
+
+    Args:
+        tag: Image reference to fetch manifest for (e.g., "registry/repo:tag").
+
+    Returns:
+        Tuple of (return_code, output). return_code is 0 if image exists, non-zero
+        if image doesn't exist or fetch fails. On failure, output may be None
+        since stderr is not captured.
+    """
+    try:
+        with subprocess.Popen(
+            [
+                _crane_binary(),
+                "manifest",
+                tag,
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+        ) as proc:
+            output = ""
+            for line in proc.stdout:
+                logger.info(line + "\n")
+                output += line
+            return_code = proc.wait()
+            if return_code:
+                raise subprocess.CalledProcessError(return_code, proc.args)
+            return return_code, output
+    except subprocess.CalledProcessError as e:
+        return e.returncode, e.output
+

--- a/ci/ray_ci/automation/docker_tags_lib.py
+++ b/ci/ray_ci/automation/docker_tags_lib.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import re
 import subprocess
 import sys
@@ -7,10 +6,14 @@ from datetime import datetime
 from typing import Callable, List, Optional, Tuple
 
 import requests
-import runfiles
 from dateutil import parser
 
 import docker
+from ci.ray_ci.automation.crane_lib import (
+    call_crane_copy,
+    call_crane_index,
+    call_crane_manifest,
+)
 from ci.ray_ci.configs import DEFAULT_ARCHITECTURE, DEFAULT_PYTHON_TAG_VERSION
 from ci.ray_ci.docker_container import (
     ARCHITECTURES_RAY,
@@ -461,114 +464,6 @@ def _is_release_tag(
     return True
 
 
-def _crane_binary():
-    r = runfiles.Create()
-    system = platform.system()
-    if system != "Linux" or platform.processor() != "x86_64":
-        raise ValueError(f"Unsupported platform: {system}")
-    return r.Rlocation("crane_linux_x86_64/crane")
-
-
-def call_crane_copy(source: str, destination: str) -> Tuple[int, str]:
-    try:
-        with subprocess.Popen(
-            [
-                _crane_binary(),
-                "copy",
-                source,
-                destination,
-            ],
-            stdout=subprocess.PIPE,
-            text=True,
-        ) as proc:
-            output = ""
-            for line in proc.stdout:
-                logger.info(line + "\n")
-                output += line
-            return_code = proc.wait()
-            if return_code:
-                raise subprocess.CalledProcessError(return_code, proc.args)
-            return return_code, output
-    except subprocess.CalledProcessError as e:
-        return e.returncode, e.output
-
-
-def _call_crane_cp(tag: str, source: str, aws_ecr_repo: str) -> Tuple[int, str]:
-    try:
-        with subprocess.Popen(
-            [
-                _crane_binary(),
-                "cp",
-                source,
-                f"{aws_ecr_repo}:{tag}",
-            ],
-            stdout=subprocess.PIPE,
-            text=True,
-        ) as proc:
-            output = ""
-            for line in proc.stdout:
-                logger.info(line + "\n")
-                output += line
-            return_code = proc.wait()
-            if return_code:
-                raise subprocess.CalledProcessError(return_code, proc.args)
-            return return_code, output
-    except subprocess.CalledProcessError as e:
-        return e.returncode, e.output
-
-
-def _call_crane_index(index_name: str, tags: List[str]) -> Tuple[int, str]:
-    try:
-        with subprocess.Popen(
-            [
-                _crane_binary(),
-                "index",
-                "append",
-                "-m",
-                tags[0],
-                "-m",
-                tags[1],
-                "-t",
-                index_name,
-            ],
-            stdout=subprocess.PIPE,
-            text=True,
-        ) as proc:
-            output = ""
-            for line in proc.stdout:
-                logger.info(line + "\n")
-                output += line
-            return_code = proc.wait()
-            if return_code:
-                raise subprocess.CalledProcessError(return_code, proc.args)
-            return return_code, output
-    except subprocess.CalledProcessError as e:
-        return e.returncode, e.output
-
-
-def _call_crane_manifest(tag: str) -> Tuple[int, str]:
-    try:
-        with subprocess.Popen(
-            [
-                _crane_binary(),
-                "manifest",
-                tag,
-            ],
-            stdout=subprocess.PIPE,
-            text=True,
-        ) as proc:
-            output = ""
-            for line in proc.stdout:
-                logger.info(line + "\n")
-                output += line
-            return_code = proc.wait()
-            if return_code:
-                raise subprocess.CalledProcessError(return_code, proc.args)
-            return return_code, output
-    except subprocess.CalledProcessError as e:
-        return e.returncode, e.output
-
-
 def copy_tag_to_aws_ecr(tag: str, aws_ecr_repo: str) -> bool:
     """
     Copy tag from Docker Hub to AWS ECR.
@@ -629,7 +524,7 @@ def generate_index(index_name: str, tags: List[str]) -> bool:
     print(f"Generating index {index_name} with tags {tags}")
     # Make sure tag is an image and not an index
     for tag in tags:
-        return_code, output = _call_crane_manifest(tag)
+        return_code, output = call_crane_manifest(tag)
         if return_code:
             logger.info(f"Failed to get manifest for {tag}")
             logger.info(f"Error: {output}")
@@ -638,7 +533,7 @@ def generate_index(index_name: str, tags: List[str]) -> bool:
             logger.info(f"Tag {tag} is an index, not an image")
             return False
 
-    return_code, output = _call_crane_index(index_name=index_name, tags=tags)
+    return_code, output = call_crane_index(index_name=index_name, tags=tags)
     if return_code:
         logger.info(f"Failed to generate index {index_name}......")
         logger.info(f"Error: {output}")

--- a/ci/ray_ci/automation/docker_tags_lib.py
+++ b/ci/ray_ci/automation/docker_tags_lib.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import sys
 from datetime import datetime
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional
 
 import requests
 from dateutil import parser

--- a/ci/ray_ci/automation/test_crane_lib.py
+++ b/ci/ray_ci/automation/test_crane_lib.py
@@ -1,0 +1,133 @@
+import platform
+import sys
+from unittest import mock
+
+import pytest
+import requests
+
+from ci.ray_ci.automation.crane_lib import (
+    _crane_binary,
+    call_crane_copy,
+    call_crane_index,
+    call_crane_manifest,
+)
+from ci.ray_ci.automation.test_utils import local_registry  # noqa: F401
+
+
+class TestCraneBinary:
+    """Tests for _crane_binary function."""
+
+    def test_crane_binary_returns_valid_path(self):
+        """Test that crane binary path exists and is executable."""
+        if platform.system() != "Linux" or platform.processor() != "x86_64":
+            pytest.skip("Only supported on Linux x86_64")
+
+        binary_path = _crane_binary()
+        assert binary_path is not None
+        assert binary_path.endswith("crane")
+
+    @mock.patch("platform.system")
+    @mock.patch("platform.processor")
+    def test_crane_binary_unsupported_platform(self, mock_processor, mock_system):
+        """Test crane binary raises error on unsupported platform."""
+        mock_system.return_value = "Darwin"
+        mock_processor.return_value = "arm64"
+
+        with pytest.raises(ValueError, match="Unsupported platform"):
+            _crane_binary()
+
+
+class TestCraneCopyIntegration:
+    """Integration tests for crane copy operations using a local registry."""
+
+    def test_copy_public_image_to_local_registry(self, local_registry):
+        """Test copying a public image to local registry."""
+        port = local_registry
+        # Use a small, well-known public image digest for reproducibility
+        source = "alpine:3.16@sha256:0db9d004361b106932f8c7632ae54d56e92c18281e2dd203127d77405020abf6"
+        destination = f"localhost:{port}/test-alpine:copied"
+
+        return_code, output = call_crane_copy(source=source, destination=destination)
+
+        assert return_code == 0
+
+        # Verify image exists in local registry
+        response = requests.get(
+            f"http://localhost:{port}/v2/test-alpine/manifests/copied"
+        )
+        assert response.status_code == 200
+
+    def test_copy_nonexistent_image_fails(self, local_registry):
+        """Test that copying a non-existent image returns error."""
+        port = local_registry
+        source = "localhost:9999/nonexistent/image:tag"
+        destination = f"localhost:{port}/should-not-exist:tag"
+
+        return_code, output = call_crane_copy(source=source, destination=destination)
+
+        assert return_code != 0
+
+
+class TestCraneManifestIntegration:
+    """Integration tests for crane manifest operations."""
+
+    def test_get_manifest_from_local_registry(self, local_registry):
+        """Test getting manifest from local registry."""
+        port = local_registry
+        # First copy an image to the registry
+        source = "alpine:3.16@sha256:0db9d004361b106932f8c7632ae54d56e92c18281e2dd203127d77405020abf6"
+        destination = f"localhost:{port}/manifest-test:v1"
+        call_crane_copy(source=source, destination=destination)
+
+        return_code, output = call_crane_manifest(tag=destination)
+
+        assert return_code == 0
+        assert "schemaVersion" in output or "config" in output
+
+    def test_get_manifest_nonexistent_tag_fails(self, local_registry):
+        """Test that getting manifest for non-existent tag fails."""
+        port = local_registry
+        tag = f"localhost:{port}/does-not-exist:missing"
+
+        return_code, output = call_crane_manifest(tag=tag)
+
+        assert return_code != 0
+
+
+class TestCraneIndexIntegration:
+    """Integration tests for crane index operations."""
+
+    def test_create_multiarch_index(self, local_registry):
+        """Test creating a multi-architecture index."""
+        port = local_registry
+
+        # Copy two different architecture images
+        amd64_digest = "sha256:0db9d004361b106932f8c7632ae54d56e92c18281e2dd203127d77405020abf6"
+        arm64_digest = "sha256:4bdb4ac63839546daabfe0a267a363b3effa17ce02ac5f42d222174484c5686c"
+
+        amd64_dest = f"localhost:{port}/index-test:amd64"
+        arm64_dest = f"localhost:{port}/index-test:arm64"
+
+        call_crane_copy(source=f"alpine:3.16@{amd64_digest}", destination=amd64_dest)
+        call_crane_copy(source=f"alpine:3.16@{arm64_digest}", destination=arm64_dest)
+
+        # Create index
+        index_name = f"localhost:{port}/index-test:multiarch"
+        return_code, output = call_crane_index(
+            index_name=index_name, tags=[amd64_dest, arm64_dest]
+        )
+
+        assert return_code == 0
+
+        # Verify index was created
+        response = requests.get(
+            f"http://localhost:{port}/v2/index-test/manifests/multiarch"
+        )
+        assert response.status_code == 200
+        manifest = response.json()
+        assert "manifests" in manifest
+        assert len(manifest["manifests"]) == 2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-vv", __file__]))

--- a/ci/ray_ci/automation/test_crane_lib.py
+++ b/ci/ray_ci/automation/test_crane_lib.py
@@ -11,7 +11,7 @@ from ci.ray_ci.automation.crane_lib import (
     call_crane_index,
     call_crane_manifest,
 )
-from ci.ray_ci.automation.test_utils import local_registry  # noqa: F401
+from ci.ray_ci.automation.test_utils import local_registry  # noqa: F401, F811
 
 
 class TestCraneBinary:
@@ -40,7 +40,7 @@ class TestCraneBinary:
 class TestCraneCopyIntegration:
     """Integration tests for crane copy operations using a local registry."""
 
-    def test_copy_public_image_to_local_registry(self, local_registry):
+    def test_copy_public_image_to_local_registry(self, local_registry):  # noqa: F811
         """Test copying a public image to local registry."""
         port = local_registry
         # Use a small, well-known public image digest for reproducibility
@@ -57,7 +57,7 @@ class TestCraneCopyIntegration:
         )
         assert response.status_code == 200
 
-    def test_copy_nonexistent_image_fails(self, local_registry):
+    def test_copy_nonexistent_image_fails(self, local_registry):  # noqa: F811
         """Test that copying a non-existent image returns error."""
         port = local_registry
         source = "localhost:9999/nonexistent/image:tag"
@@ -71,7 +71,7 @@ class TestCraneCopyIntegration:
 class TestCraneManifestIntegration:
     """Integration tests for crane manifest operations."""
 
-    def test_get_manifest_from_local_registry(self, local_registry):
+    def test_get_manifest_from_local_registry(self, local_registry):  # noqa: F811
         """Test getting manifest from local registry."""
         port = local_registry
         # First copy an image to the registry
@@ -84,7 +84,7 @@ class TestCraneManifestIntegration:
         assert return_code == 0
         assert "schemaVersion" in output or "config" in output
 
-    def test_get_manifest_nonexistent_tag_fails(self, local_registry):
+    def test_get_manifest_nonexistent_tag_fails(self, local_registry):  # noqa: F811
         """Test that getting manifest for non-existent tag fails."""
         port = local_registry
         tag = f"localhost:{port}/does-not-exist:missing"
@@ -97,13 +97,17 @@ class TestCraneManifestIntegration:
 class TestCraneIndexIntegration:
     """Integration tests for crane index operations."""
 
-    def test_create_multiarch_index(self, local_registry):
+    def test_create_multiarch_index(self, local_registry):  # noqa: F811
         """Test creating a multi-architecture index."""
         port = local_registry
 
         # Copy two different architecture images
-        amd64_digest = "sha256:0db9d004361b106932f8c7632ae54d56e92c18281e2dd203127d77405020abf6"
-        arm64_digest = "sha256:4bdb4ac63839546daabfe0a267a363b3effa17ce02ac5f42d222174484c5686c"
+        amd64_digest = (
+            "sha256:0db9d004361b106932f8c7632ae54d56e92c18281e2dd203127d77405020abf6"
+        )
+        arm64_digest = (
+            "sha256:4bdb4ac63839546daabfe0a267a363b3effa17ce02ac5f42d222174484c5686c"
+        )
 
         amd64_dest = f"localhost:{port}/index-test:amd64"
         arm64_dest = f"localhost:{port}/index-test:arm64"

--- a/ci/ray_ci/automation/test_docker_tags_lib.py
+++ b/ci/ray_ci/automation/test_docker_tags_lib.py
@@ -1,18 +1,12 @@
-import platform
-import random
-import shutil
-import subprocess
 import sys
-import tempfile
-import threading
-import time
 from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
 import requests
-import runfiles
 
+from ci.ray_ci.automation.crane_lib import call_crane_copy
+from ci.ray_ci.automation.test_utils import local_registry  # noqa: F401
 from ci.ray_ci.automation.docker_tags_lib import (
     AuthTokenException,
     DockerHubRateLimitException,
@@ -23,7 +17,6 @@ from ci.ray_ci.automation.docker_tags_lib import (
     _is_release_tag,
     _list_recent_commit_short_shas,
     backup_release_tags,
-    call_crane_copy,
     check_image_ray_commit,
     copy_tag_to_aws_ecr,
     delete_tag,
@@ -643,96 +636,42 @@ def test_check_image_ray_commit_failure(
         )
 
 
-def _registry_binary():
-    r = runfiles.Create()
-    system = platform.system()
-    if system != "Linux" or platform.processor() != "x86_64":
-        raise ValueError(f"Unsupported platform: {system}")
-    return r.Rlocation("registry_x86_64/registry")
+def test_generate_index(local_registry):
+    port = local_registry
+    test_image1 = f"localhost:{port}/test-image:test-tag-amd64"
+    test_image2 = f"localhost:{port}/test-image:test-tag-arm64"
 
-
-def _start_local_registry():
-    """Start local registry for testing."""
-    port = random.randint(2000, 20000)
-    temp_dir = tempfile.mkdtemp()
-    config_content = "\n".join(
-        [
-            "version: 0.1",
-            "storage:",
-            "    filesystem:",
-            f"        rootdirectory: {temp_dir}",
-            "http:",
-            f"    addr: :{port}",
-        ]
+    alpine3_16_amd64_digest = (
+        "sha256:0db9d004361b106932f8c7632ae54d56e92c18281e2dd203127d77405020abf6"
+    )
+    alpine3_16_arm64_digest = (
+        "sha256:4bdb4ac63839546daabfe0a267a363b3effa17ce02ac5f42d222174484c5686c"
+    )
+    call_crane_copy(
+        source=f"alpine:3.16@{alpine3_16_amd64_digest}", destination=test_image1
+    )
+    call_crane_copy(
+        source=f"alpine:3.16@{alpine3_16_arm64_digest}", destination=test_image2
     )
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml") as config_file:
-        config_file.write(config_content)
-        config_file.flush()
+    # Generate index
+    index_repo = "test-index"
+    index_name = f"localhost:{port}/{index_repo}:test-multiarch-tag"
+    generate_index(index_name=index_name, tags=[test_image1, test_image2])
 
-        registry_proc = subprocess.Popen(
-            [_registry_binary(), "serve", config_file.name],
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        )
-        registry_thread = threading.Thread(
-            target=lambda: registry_proc.wait(), daemon=True
-        )
-        registry_thread.start()
-
-        for _ in range(10):  # Wait for 10 seconds for registry to start
-            try:
-                response = requests.get(f"http://localhost:{port}/v2/")
-                if response.status_code == 200:
-                    return registry_proc, registry_thread, temp_dir, port
-            except requests.exceptions.ConnectionError:
-                pass
-            time.sleep(1)
-
-        raise TimeoutError("Registry failed to start within 10 seconds")
-
-
-def test_generate_index():
-    registry_proc, registry_thread, temp_dir, port = _start_local_registry()
-    try:
-        test_image1 = f"localhost:{port}/test-image:test-tag-amd64"
-        test_image2 = f"localhost:{port}/test-image:test-tag-arm64"
-
-        alpine3_16_amd64_digest = (
-            "sha256:0db9d004361b106932f8c7632ae54d56e92c18281e2dd203127d77405020abf6"
-        )
-        alpine3_16_arm64_digest = (
-            "sha256:4bdb4ac63839546daabfe0a267a363b3effa17ce02ac5f42d222174484c5686c"
-        )
-        call_crane_copy(
-            source=f"alpine:3.16@{alpine3_16_amd64_digest}", destination=test_image1
-        )
-        call_crane_copy(
-            source=f"alpine:3.16@{alpine3_16_arm64_digest}", destination=test_image2
-        )
-
-        # Generate index
-        index_repo = "test-index"
-        index_name = f"localhost:{port}/{index_repo}:test-multiarch-tag"
-        generate_index(index_name=index_name, tags=[test_image1, test_image2])
-
-        # Verify index was created with 2 image manifests
-        response = requests.get(
-            f"http://localhost:{port}/v2/{index_repo}/manifests/test-multiarch-tag"
-        )
-        assert response.status_code == 200
-        assert "manifests" in response.json()
-        assert len(response.json()["manifests"]) == 2
-        for manifest in response.json()["manifests"]:
-            architecture = manifest["platform"]["architecture"]
-            if architecture == "amd64":
-                assert manifest["digest"] == alpine3_16_amd64_digest
-            elif architecture == "arm64":
-                assert manifest["digest"] == alpine3_16_arm64_digest
-    finally:
-        registry_proc.kill()
-        registry_thread.join()
-        shutil.rmtree(temp_dir)
+    # Verify index was created with 2 image manifests
+    response = requests.get(
+        f"http://localhost:{port}/v2/{index_repo}/manifests/test-multiarch-tag"
+    )
+    assert response.status_code == 200
+    assert "manifests" in response.json()
+    assert len(response.json()["manifests"]) == 2
+    for manifest in response.json()["manifests"]:
+        architecture = manifest["platform"]["architecture"]
+        if architecture == "amd64":
+            assert manifest["digest"] == alpine3_16_amd64_digest
+        elif architecture == "arm64":
+            assert manifest["digest"] == alpine3_16_arm64_digest
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/automation/test_docker_tags_lib.py
+++ b/ci/ray_ci/automation/test_docker_tags_lib.py
@@ -6,7 +6,6 @@ import pytest
 import requests
 
 from ci.ray_ci.automation.crane_lib import call_crane_copy
-from ci.ray_ci.automation.test_utils import local_registry  # noqa: F401
 from ci.ray_ci.automation.docker_tags_lib import (
     AuthTokenException,
     DockerHubRateLimitException,
@@ -26,6 +25,7 @@ from ci.ray_ci.automation.docker_tags_lib import (
     query_tags_from_docker_hub,
     query_tags_from_docker_with_oci,
 )
+from ci.ray_ci.automation.test_utils import local_registry  # noqa: F401, F811
 
 
 @mock.patch("requests.get")
@@ -636,7 +636,7 @@ def test_check_image_ray_commit_failure(
         )
 
 
-def test_generate_index(local_registry):
+def test_generate_index(local_registry):  # noqa: F811
     port = local_registry
     test_image1 = f"localhost:{port}/test-image:test-tag-amd64"
     test_image2 = f"localhost:{port}/test-image:test-tag-arm64"

--- a/ci/ray_ci/automation/test_utils.py
+++ b/ci/ray_ci/automation/test_utils.py
@@ -1,5 +1,6 @@
 """Shared test utilities for ci/ray_ci/automation tests."""
 
+import os
 import platform
 import random
 import shutil
@@ -41,12 +42,10 @@ def _start_local_registry():
         ]
     )
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".yml", delete=False
-    ) as config_file:
+    config_path = os.path.join(temp_dir, "registry.yml")
+    with open(config_path, "w") as config_file:
         config_file.write(config_content)
         config_file.flush()
-        config_path = config_file.name
 
     registry_proc = subprocess.Popen(
         [_registry_binary(), "serve", config_path],

--- a/ci/ray_ci/automation/test_utils.py
+++ b/ci/ray_ci/automation/test_utils.py
@@ -53,9 +53,7 @@ def _start_local_registry():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    registry_thread = threading.Thread(
-        target=lambda: registry_proc.wait(), daemon=True
-    )
+    registry_thread = threading.Thread(target=lambda: registry_proc.wait(), daemon=True)
     registry_thread.start()
 
     for _ in range(10):

--- a/ci/ray_ci/automation/test_utils.py
+++ b/ci/ray_ci/automation/test_utils.py
@@ -1,0 +1,84 @@
+"""Shared test utilities for ci/ray_ci/automation tests."""
+
+import platform
+import random
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+
+import pytest
+import requests
+import runfiles
+
+
+def _registry_binary():
+    """Get the path to the local registry binary."""
+    r = runfiles.Create()
+    system = platform.system()
+    if system != "Linux" or platform.processor() != "x86_64":
+        raise ValueError(f"Unsupported platform: {system}")
+    return r.Rlocation("registry_x86_64/registry")
+
+
+def _start_local_registry():
+    """Start local registry for testing.
+
+    Returns:
+        Tuple of (registry_proc, registry_thread, temp_dir, port)
+    """
+    port = random.randint(2000, 20000)
+    temp_dir = tempfile.mkdtemp()
+    config_content = "\n".join(
+        [
+            "version: 0.1",
+            "storage:",
+            "    filesystem:",
+            f"        rootdirectory: {temp_dir}",
+            "http:",
+            f"    addr: :{port}",
+        ]
+    )
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yml", delete=False
+    ) as config_file:
+        config_file.write(config_content)
+        config_file.flush()
+        config_path = config_file.name
+
+    registry_proc = subprocess.Popen(
+        [_registry_binary(), "serve", config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    registry_thread = threading.Thread(
+        target=lambda: registry_proc.wait(), daemon=True
+    )
+    registry_thread.start()
+
+    for _ in range(10):
+        try:
+            response = requests.get(f"http://localhost:{port}/v2/")
+            if response.status_code == 200:
+                return registry_proc, registry_thread, temp_dir, port
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(1)
+
+    raise TimeoutError("Registry failed to start within 10 seconds")
+
+
+@pytest.fixture(scope="module")
+def local_registry():
+    """Fixture that provides a local Docker registry for testing.
+
+    Yields:
+        int: The port number of the local registry.
+    """
+    registry_proc, registry_thread, temp_dir, port = _start_local_registry()
+    yield port
+    registry_proc.kill()
+    registry_thread.join(timeout=5)
+    shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
* Crane will be used as part of other automation outside of docker_tags_lib. Refactoring to move to a separate lib for subsequent consumption
* Refactored registry-related test setup into test_utils, since it is consumed by both test_docker_tags_lib and test_crane_lib