### PR TITLE
[Serve][1/n] Improve type annotations for DeploymentHandle, DeploymentResponse, and DeploymentResponseGenerator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,7 +120,9 @@ repos:
             python/ray/autoscaler/sdk/sdk.py|
             python/ray/autoscaler/_private/commands.py|
             python/ray/autoscaler/_private/autoscaler.py|
-            python/ray/_private/gcs_utils.py
+            python/ray/_private/gcs_utils.py|
+            python/ray/serve/handle.py|
+            python/ray/serve/tests/typing_files/check_handle_typing.py
           )
         additional_dependencies:
           [

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -3,11 +3,23 @@ import concurrent.futures
 import logging
 import time
 import warnings
-from typing import Any, AsyncIterator, Dict, Iterator, Optional, Tuple, Union
+from typing import (
+    Any,
+    AsyncIterator,
+    Dict,
+    Generator,
+    Generic,
+    Iterator,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import ray
 from ray import serve
-from ray._raylet import ObjectRefGenerator
+from ray._raylet import ObjectRefGenerator  # type: ignore[attr-defined]
 from ray.serve._private.common import (
     OBJ_REF_NOT_SUPPORTED_ERROR,
     DeploymentHandleSource,
@@ -41,8 +53,13 @@ from ray.util.annotations import DeveloperAPI, PublicAPI
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
+# TypeVar for the deployment class type in DeploymentHandle[T]
+T = TypeVar("T")
+# TypeVar for the response/result type in DeploymentResponse[R]
+R = TypeVar("R")
 
-class _DeploymentHandleBase:
+
+class _DeploymentHandleBase(Generic[T]):
     def __init__(
         self,
         deployment_name: str,
@@ -159,9 +176,13 @@ class _DeploymentHandleBase:
             ServeUsageTag.DEPLOYMENT_HANDLE_API_USED.record("1")
 
     def _is_router_running_in_separate_loop(self) -> bool:
+        if self.init_options is None:
+            return False
         return self.init_options._run_router_in_separate_loop
 
-    def _options(self, _prefer_local_routing=DEFAULT.VALUE, **kwargs):
+    def _options(
+        self, _prefer_local_routing=DEFAULT.VALUE, **kwargs
+    ) -> "DeploymentHandle[T]":
         if kwargs.get("stream") is True and inside_ray_client_context():
             raise RuntimeError(
                 "Streaming DeploymentHandles are not currently supported when "
@@ -206,10 +227,23 @@ class _DeploymentHandleBase:
                 "application": metadata.app_name,
             }
         )
+        if self._router is None:
+            raise RuntimeError("Router is not initialized")
 
         return self._router.assign_request(metadata, *args, **kwargs), metadata
 
-    def __getattr__(self, name):
+    def options(
+        self,
+        *,
+        method_name: Union[str, DEFAULT] = DEFAULT.VALUE,
+        multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
+        stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
+        use_new_handle_api: Union[bool, DEFAULT] = DEFAULT.VALUE,
+        _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
+    ) -> "DeploymentHandle[T]":
+        raise NotImplementedError
+
+    def __getattr__(self, name: str) -> "DeploymentHandle[T]":
         return self.options(method_name=name)
 
     def shutdown(self):
@@ -234,11 +268,11 @@ class _DeploymentHandleBase:
             else:
                 await shutdown_future
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}" f"(deployment='{self.deployment_name}')"
 
     @classmethod
-    def _deserialize(cls, kwargs):
+    def _deserialize(cls, kwargs: Dict[str, Any]) -> "_DeploymentHandleBase[T]":
         """Required for this class's __reduce__ method to be picklable."""
         return cls(**kwargs)
 
@@ -251,7 +285,7 @@ class _DeploymentHandleBase:
         return self.__class__._deserialize, (serialized_constructor_args,)
 
 
-class _DeploymentResponseBase:
+class _DeploymentResponseBase(Generic[R]):
     def __init__(
         self,
         replica_result_future: Union[
@@ -289,9 +323,13 @@ class _DeploymentResponseBase:
                     "loop. Use `await response` instead."
                 )
             try:
-                self._replica_result = self._replica_result_future.result(
-                    timeout=_timeout_s
+                # When _is_router_running_in_separate_loop is True, the future
+                # is a concurrent.futures.Future (not asyncio.Future)
+                sync_future = cast(
+                    concurrent.futures.Future[ReplicaResult],
+                    self._replica_result_future,
                 )
+                self._replica_result = sync_future.result(timeout=_timeout_s)
 
             except concurrent.futures.TimeoutError:
                 raise TimeoutError("Timed out resolving to ObjectRef.") from None
@@ -316,7 +354,10 @@ class _DeploymentResponseBase:
                 )
             else:
                 # self._replica_result_future is a object of type asyncio.Future
-                self._replica_result = await self._replica_result_future
+                async_future = cast(
+                    asyncio.Future[ReplicaResult], self._replica_result_future
+                )
+                self._replica_result = await async_future
 
         return self._replica_result
 
@@ -372,7 +413,7 @@ class _DeploymentResponseBase:
 
 
 @PublicAPI(stability="stable")
-class DeploymentResponse(_DeploymentResponseBase):
+class DeploymentResponse(_DeploymentResponseBase[R]):
     """A future-like object wrapping the result of a unary deployment handle call.
 
     From inside a deployment, a `DeploymentResponse` can be awaited to retrieve the
@@ -441,7 +482,7 @@ class DeploymentResponse(_DeploymentResponseBase):
         assert handle.remote(0).result() == 2
     """
 
-    def __await__(self):
+    def __await__(self) -> Generator[Any, None, R]:
         """Yields the final result of the deployment handle call."""
         try:
             replica_result = yield from self._fetch_future_result_async().__await__()
@@ -466,7 +507,7 @@ class DeploymentResponse(_DeploymentResponseBase):
         *,
         timeout_s: Optional[float] = None,
         _skip_asyncio_check: bool = False,
-    ) -> Any:
+    ) -> R:
         """Fetch the result of the handle call synchronously.
 
         This should *not* be used from within a deployment as it runs in an asyncio
@@ -554,7 +595,7 @@ class DeploymentResponse(_DeploymentResponseBase):
 
 
 @PublicAPI(stability="stable")
-class DeploymentResponseGenerator(_DeploymentResponseBase):
+class DeploymentResponseGenerator(_DeploymentResponseBase[R]):
     """A future-like object wrapping the result of a streaming deployment handle call.
 
     This is returned when using `handle.options(stream=True)` and calling a generator
@@ -614,10 +655,10 @@ class DeploymentResponseGenerator(_DeploymentResponseBase):
             "or `await response.__anext__() instead`."
         )
 
-    def __aiter__(self) -> AsyncIterator[Any]:
+    def __aiter__(self) -> AsyncIterator[R]:
         return self
 
-    async def __anext__(self) -> Any:
+    async def __anext__(self) -> R:
         try:
             replica_result = await self._fetch_future_result_async()
             return await replica_result.__anext__()
@@ -627,10 +668,10 @@ class DeploymentResponseGenerator(_DeploymentResponseBase):
             else:
                 raise asyncio.CancelledError from None
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[R]:
         return self
 
-    def __next__(self) -> Any:
+    def __next__(self) -> R:
         if is_running_in_asyncio_loop():
             raise RuntimeError(
                 "Sync methods should not be called from within an `asyncio` event "
@@ -689,7 +730,7 @@ class DeploymentResponseGenerator(_DeploymentResponseBase):
 
 
 @PublicAPI(stability="stable")
-class DeploymentHandle(_DeploymentHandleBase):
+class DeploymentHandle(_DeploymentHandleBase[T]):
     """A handle used to make requests to a deployment at runtime.
 
     This is primarily used to compose multiple deployments within a single application.
@@ -734,7 +775,7 @@ class DeploymentHandle(_DeploymentHandleBase):
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         use_new_handle_api: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
-    ) -> "DeploymentHandle":
+    ) -> "DeploymentHandle[T]":
         """Set options for this handle and return an updated copy of it.
 
         Example:
@@ -767,7 +808,7 @@ class DeploymentHandle(_DeploymentHandleBase):
 
     def remote(
         self, *args, **kwargs
-    ) -> Union[DeploymentResponse, DeploymentResponseGenerator]:
+    ) -> Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]]:
         """Issue a remote call to a method of the deployment.
 
         By default, the result is a `DeploymentResponse` that can be awaited to fetch
@@ -798,12 +839,14 @@ class DeploymentHandle(_DeploymentHandleBase):
 
         future, request_metadata = self._remote(args, kwargs)
         if self.handle_options.stream:
-            response_cls = DeploymentResponseGenerator
+            return DeploymentResponseGenerator(
+                future,
+                request_metadata,
+                _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+            )
         else:
-            response_cls = DeploymentResponse
-
-        return response_cls(
-            future,
-            request_metadata,
-            _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
-        )
+            return DeploymentResponse(
+                future,
+                request_metadata,
+                _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+            )

--- a/python/ray/serve/tests/typing_files/check_handle_typing.py
+++ b/python/ray/serve/tests/typing_files/check_handle_typing.py
@@ -1,0 +1,277 @@
+"""Type checking tests for DeploymentHandle, DeploymentResponse, and DeploymentResponseGenerator.
+
+This file is used with mypy to verify that the generic type annotations
+on handle classes work correctly. Run with:
+    mypy python/ray/serve/tests/typing_files/check_handle_typing.py python/ray/serve/handle.py  \
+        --follow-imports=skip \
+        --ignore-missing-imports
+
+mypy will fail if any assert_type() call doesn't match the expected type.
+"""
+
+from typing import Any, AsyncIterator, Iterator, Union
+
+from typing_extensions import assert_type
+
+from ray.serve.handle import (
+    DeploymentHandle,
+    DeploymentResponse,
+    DeploymentResponseGenerator,
+)
+
+
+def test_deployment_response_types() -> None:
+    """Test that DeploymentResponse[R] preserves R through methods."""
+    response: DeploymentResponse[str] = None  # type: ignore[assignment]
+
+    # result() should return R (str)
+    result = response.result()
+    assert_type(result, str)
+
+    # Properties should work
+    assert_type(response.request_id, str)
+    assert_type(response.by_reference, bool)
+
+
+async def test_deployment_response_await() -> None:
+    """Test that awaiting DeploymentResponse[R] returns R."""
+    response: DeploymentResponse[str] = None  # type: ignore[assignment]
+
+    # Awaiting should return R (str)
+    awaited_result = await response
+    assert_type(awaited_result, str)
+
+
+def test_deployment_response_generator_sync() -> None:
+    """Test that DeploymentResponseGenerator[R] iteration returns R."""
+    gen: DeploymentResponseGenerator[int] = None  # type: ignore[assignment]
+
+    # __iter__ should return Iterator[R]
+    assert_type(iter(gen), Iterator[int])
+
+    # __next__ should return R (int)
+    item = next(gen)
+    assert_type(item, int)
+
+    # For loop iteration
+    for value in gen:
+        assert_type(value, int)
+        break
+
+
+async def test_deployment_response_generator_async() -> None:
+    """Test that async iteration of DeploymentResponseGenerator[R] returns R."""
+    gen: DeploymentResponseGenerator[int] = None  # type: ignore[assignment]
+
+    # __aiter__ should return AsyncIterator[R]
+    assert_type(gen.__aiter__(), AsyncIterator[int])
+
+    # __anext__ should return R (int)
+    item = await gen.__anext__()
+    assert_type(item, int)
+
+    # Async for loop iteration
+    async for value in gen:
+        assert_type(value, int)
+        break
+
+
+def test_deployment_handle_types() -> None:
+    """Test DeploymentHandle type annotations."""
+
+    class MyDeployment:
+        def get_string(self) -> str:
+            return "hello"
+
+        def get_int(self) -> int:
+            return 42
+
+    handle: DeploymentHandle[MyDeployment] = None  # type: ignore[assignment]
+
+    # Basic properties
+    assert_type(handle.deployment_name, str)
+    assert_type(handle.app_name, str)
+    assert_type(handle.is_initialized, bool)
+
+    # options() should return DeploymentHandle[T]
+    new_handle = handle.options(method_name="get_string")
+    assert_type(new_handle, DeploymentHandle[MyDeployment])
+
+    # remote() returns Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]]
+    # (until plugin is implemented to infer the actual return type)
+    response = handle.remote()
+    assert_type(
+        response,
+        Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]],
+    )
+
+
+def test_chained_handle_access() -> None:
+    """Test that accessing methods on handle returns typed handle."""
+
+    class MyDeployment:
+        def my_method(self, x: int) -> str:
+            return str(x)
+
+    handle: DeploymentHandle[MyDeployment] = None  # type: ignore[assignment]
+
+    # Accessing a method via __getattr__ should return DeploymentHandle[T]
+    method_handle = handle.my_method
+    assert_type(method_handle, DeploymentHandle[MyDeployment])
+
+
+# =============================================================================
+# TESTS THAT REQUIRE MYPY PLUGIN
+# =============================================================================
+# The following tests verify that the mypy plugin correctly infers return types
+# based on which deployment method is being called. These tests are commented
+# out because they will fail without the plugin.
+#
+# To enable after plugin is implemented:
+# 1. Uncomment the tests below
+# 2. Run: mypy python/ray/serve/tests/typing_files/check_handle_typing.py
+# 3. All assert_type() calls should pass
+# =============================================================================
+
+
+def test_plugin_infers_method_return_type() -> None:
+    """[REQUIRES PLUGIN] Test that remote() infers return type from method."""
+    from typing import Generator
+
+    class MyDeployment:
+        def get_user(self, user_id: int) -> str:
+            return f"user_{user_id}"
+
+        def get_count(self) -> int:
+            return 42
+
+        def stream_items(self) -> Generator[bytes, None, None]:
+            yield b"chunk1"
+            yield b"chunk2"
+
+    _: DeploymentHandle[MyDeployment] = None  # type: ignore[assignment]
+
+    # # Calling a method that returns str should give DeploymentResponse[str]
+    # response_str = handle.get_user.remote(123)
+    # assert_type(response_str, DeploymentResponse[str])
+
+    # # result() should return str
+    # user = response_str.result()
+    # assert_type(user, str)
+
+    # # Calling a method that returns int should give DeploymentResponse[int]
+    # response_int = handle.get_count.remote()
+    # assert_type(response_int, DeploymentResponse[int])
+
+    # # result() should return int
+    # count = response_int.result()
+    # assert_type(count, int)
+
+
+async def test_plugin_infers_await_return_type() -> None:
+    """[REQUIRES PLUGIN] Test that await infers return type from method."""
+
+    class MyDeployment:
+        def process(self, data: str) -> dict:
+            return {"data": data}
+
+    _: DeploymentHandle[MyDeployment] = None  # type: ignore[assignment]
+
+    # response = handle.process.remote("test")
+    # assert_type(response, DeploymentResponse[dict])
+
+    # # Awaiting should return dict
+    # result = await response
+    # assert_type(result, dict)
+
+
+def test_plugin_infers_generator_yield_type() -> None:
+    """[REQUIRES PLUGIN] Test that streaming methods infer yield type."""
+    from typing import Generator
+
+    class MyDeployment:
+        def stream_strings(self) -> Generator[str, None, None]:
+            yield "a"
+            yield "b"
+
+        def stream_ints(self) -> Generator[int, None, None]:
+            yield 1
+            yield 2
+
+    _: DeploymentHandle[MyDeployment] = None  # type: ignore[assignment]
+
+    # # Streaming handle with generator method should give DeploymentResponseGenerator
+    # streaming_handle = handle.options(stream=True)
+
+    # gen_str = streaming_handle.stream_strings.remote()
+    # assert_type(gen_str, DeploymentResponseGenerator[str])
+
+    # # Iteration should yield str
+    # for item in gen_str:
+    #     assert_type(item, str)
+    #     break
+
+    # gen_int = streaming_handle.stream_ints.remote()
+    # assert_type(gen_int, DeploymentResponseGenerator[int])
+
+    # # Iteration should yield int
+    # for item in gen_int:
+    #     assert_type(item, int)
+    #     break
+
+
+async def test_plugin_async_generator_iteration() -> None:
+    """[REQUIRES PLUGIN] Test async iteration with inferred yield type."""
+    from typing import Generator
+
+    class MyDeployment:
+        def stream_bytes(self) -> Generator[bytes, None, None]:
+            yield b"chunk"
+
+    _: DeploymentHandle[MyDeployment] = None  # type: ignore[assignment]
+
+    # streaming_handle = handle.options(stream=True)
+    # gen = streaming_handle.stream_bytes.remote()
+    # assert_type(gen, DeploymentResponseGenerator[bytes])
+
+    # # Async iteration should yield bytes
+    # async for chunk in gen:
+    #     assert_type(chunk, bytes)
+    #     break
+
+
+def test_plugin_complex_return_types() -> None:
+    from typing import Dict, List, Optional, Tuple
+
+    class User:
+        name: str
+        age: int
+
+    class MyDeployment:
+        def get_users(self) -> List[User]:
+            return []
+
+        def get_user_dict(self) -> Dict[str, User]:
+            return {}
+
+        def get_optional(self) -> Optional[User]:
+            return None
+
+        def get_tuple(self) -> Tuple[str, int, User]:
+            return ("", 0, User())
+
+    _: DeploymentHandle[MyDeployment] = None  # type: ignore[assignment]
+
+    # response_list = handle.get_users.remote()
+    # assert_type(response_list, DeploymentResponse[List[User]])
+    # users = response_list.result()
+    # assert_type(users, List[User])
+
+    # response_dict = handle.get_user_dict.remote()
+    # assert_type(response_dict, DeploymentResponse[Dict[str, User]])
+
+    # response_optional = handle.get_optional.remote()
+    # assert_type(response_optional, DeploymentResponse[Optional[User]])
+
+    # response_tuple = handle.get_tuple.remote()
+    # assert_type(response_tuple, DeploymentResponse[Tuple[str, int, User]])


### PR DESCRIPTION
Fixes https://github.com/ray-project/ray/issues/52654

### Summary

This PR improves the generic type annotations on Ray Serve's handle classes to enable better IDE support and type inference. It also adds a type checking test file to verify the annotations work correctly.

### Changes

#### Type Annotation Improvements (`handle.py`)

- **Generic return types**: Updated methods to return the generic type parameter `R` instead of `Any`:
  - `DeploymentResponse.result()` → `R`
  - `DeploymentResponse.__await__()` → `Generator[Any, None, R]`
  - `DeploymentResponseGenerator.__iter__()` → `Iterator[R]`
  - `DeploymentResponseGenerator.__next__()` → `R`
  - `DeploymentResponseGenerator.__aiter__()` → `AsyncIterator[R]`
  - `DeploymentResponseGenerator.__anext__()` → `R`

- **mypy compatibility fixes**:
  - Added `cast()` for `Future` types in sync/async fetch methods to help mypy understand the conditional types
  - Aligned `_DeploymentHandleBase.options()` signature with `DeploymentHandle.options()` to fix override error
  - Refactored `remote()` to return directly from each branch instead of assigning different class types to a variable

#### Type Checking Tests (`check_handle_typing.py`)

Added a mypy test file that verifies:
- Generic type `R` is preserved through `result()`, `__await__`, iteration methods
- Generic type `T` is preserved through `options()` and method access
- Placeholder tests for future mypy plugin (commented out) that will verify method return type inference

### How to Test

```bash
    mypy python/ray/serve/tests/typing_files/check_handle_typing.py python/ray/serve/handle.py  \
        --follow-imports=skip \
        --ignore-missing-imports
```

### Future Work

A mypy plugin can be implemented to infer the return type of `.remote()` based on which deployment method is being called:

```python
handle: DeploymentHandle[MyDeployment]
response = handle.get_user.remote(123)  # Plugin would infer DeploymentResponse[str]
user = response.result()                 # Would be typed as str
```

The test file includes commented-out tests that should pass once the plugin is implemented.


## Tests

From master
```
❯ mypy python/ray/serve/tests/typing_files/check_handle_typing.py python/ray/serve/handle.py  --follow-imports=skip --ignore-missing-imports
python/ray/serve/handle.py:10: error: Module "ray._raylet" has no attribute "ObjectRefGenerator"  [attr-defined]
python/ray/serve/handle.py:162: error: Item "None" of "Optional[Any]" has no attribute "_run_router_in_separate_loop"  [union-attr]
python/ray/serve/handle.py:210: error: Item "None" of "Optional[Any]" has no attribute "assign_request"  [union-attr]
python/ray/serve/handle.py:229: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
python/ray/serve/handle.py:292: error: Unexpected keyword argument "timeout" for "result" of "Future"  [call-arg]
/home/ubuntu/.local/lib/python3.9/site-packages/mypy/typeshed/stdlib/_asyncio.pyi: note: "result" of "Future" defined here
python/ray/serve/handle.py:319: error: Incompatible types in "await" (actual type "Union[concurrent.futures._base.Future[Any], _asyncio.Future[Any]]", expected type "Awaitable[Any]")  [misc]
python/ray/serve/handle.py:803: error: Incompatible types in assignment (expression has type "type[DeploymentResponse]", variable has type "type[DeploymentResponseGenerator]")  [assignment]
python/ray/serve/tests/typing_files/check_handle_typing.py:24: error: "DeploymentResponse" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:24: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:28: error: Expression is of type "Any", not "str"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:37: error: "DeploymentResponse" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:37: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:41: error: Expression is of type "Any", not "str"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:46: error: "DeploymentResponseGenerator" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:46: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:49: error: Expression is of type "Iterator[Any]", not "Iterator[int]"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:53: error: Expression is of type "Any", not "int"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:57: error: Expression is of type "Any", not "int"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:63: error: "DeploymentResponseGenerator" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:63: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:66: error: Expression is of type "AsyncIterator[Any]", not "AsyncIterator[int]"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:70: error: Expression is of type "Any", not "int"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:74: error: Expression is of type "Any", not "int"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:88: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:88: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:97: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:104: error: "DeploymentResponse" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:104: error: "DeploymentResponseGenerator" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:115: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:115: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:119: error: Expression is of type "Any", not "DeploymentHandle"  [assert-type]
python/ray/serve/tests/typing_files/check_handle_typing.py:119: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:151: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:151: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:177: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:177: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:200: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:200: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:230: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:230: note: Error code "type-arg" not covered by "type: ignore" comment
python/ray/serve/tests/typing_files/check_handle_typing.py:262: error: "DeploymentHandle" expects no type arguments, but 1 given  [type-arg]
python/ray/serve/tests/typing_files/check_handle_typing.py:262: note: Error code "type-arg" not covered by "type: ignore" comment
Found 30 errors in 2 files (checked 2 source files)
```

Because of changes in this PR
```
❯ mypy python/ray/serve/tests/typing_files/check_handle_typing.py python/ray/serve/handle.py  --follow-imports=skip --ignore-missing-imports
python/ray/serve/handle.py:261: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Success: no issues found in 2 source files
```
