### PR TITLE
[vm launcher] disable azure tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3626,7 +3626,9 @@
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
-  frequency: nightly
+  # TODO: the test seems to be leaking resources, and will
+  # start failing over time; needs more investigation.
+  frequency: manual
   team: clusters
   cluster:
     byod:


### PR DESCRIPTION
the azure vm launcher seems to be leaking resources in the resource group, and will start failing after several nights.

so marking it to manual for now.
