### PR TITLE
[Core] Avoid GCS query for is_head in dashboard agent startup

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1806,6 +1806,9 @@ def start_raylet(
         # that requires additional dependencies to be downloaded.
         dashboard_agent_command.append("--minimal")
 
+    if is_head_node:
+        dashboard_agent_command.append("--head")
+
     runtime_env_agent_command = [
         *_build_python_executable_command_memory_profileable(
             ray_constants.PROCESS_TYPE_RUNTIME_ENV_AGENT, session_dir


### PR DESCRIPTION
## Description

Ray processes don’t strictly wait for each other to start. In practice, GCS, raylet, and the dashboard agent all start around the same time, and they rely on retries and timeouts to eventually connect to each other.
However, we should avoid unnecessary dependencies during startup when we can.


Before this PR:
- raylet starts the dashboard agent but does not wait for it.
- raylet then registers itself and its metadata to GCS.
- Meanwhile, the dashboard agent queries GCS to check whether this node is the head node. It keeps retrying until raylet has finished registering to GCS.


This is unnecessary and a bit odd: since the raylet is the one launching the dashboard agent, raylet can simply tell the agent whether it is the head node via command-line arguments instead of forcing the agent to poll GCS.

This PR avoids that unnecessary dependency and makes the startup sequence more straightforward and robust.

## Additional information

I’m also working on https://github.com/ray-project/ray/pull/59065, where the dashboard agent must report its bound port back to the raylet so that the raylet can then register itself (with the correct port info)  to GCS. If the dashboard agent still depended on the raylet registering to GCS first, this would create a deadlock.

