### PR TITLE
Support http redirection download

### DIFF
--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -223,7 +223,7 @@ class ProtocolsProvider:
 
         request = urllib.request.Request(source_uri, headers=cls._http_headers())
         try:
-            with urllib.request.urlopen(request) as response:
+            with urllib.request.urlopen(request, timeout=60) as response:
                 with open(dest_file, "wb") as fout:
                     shutil.copyfileobj(response, fout)
         except urllib.error.URLError as exc:

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -6,6 +6,7 @@ import socket
 import string
 import sys
 import tempfile
+import types
 import uuid
 import zipfile
 from filecmp import dircmp
@@ -799,6 +800,8 @@ def test_https_downloader_sets_curl_user_agent(tmp_path, monkeypatch):
         captured_headers.update(headers)
         return DummyResponse(payload)
 
+    # Force smart_open import to fail so we exercise the urllib fallback.
+    monkeypatch.setitem(sys.modules, "smart_open", None)
     monkeypatch.setattr(
         "ray._private.runtime_env.protocol.urllib.request.urlopen", fake_urlopen
     )
@@ -811,6 +814,45 @@ def test_https_downloader_sets_curl_user_agent(tmp_path, monkeypatch):
     assert dest_file.read_bytes() == payload
     assert "curl" in captured_headers["user-agent"].lower()
     assert captured_headers["accept"] == "*/*"
+
+
+def test_https_downloader_uses_smart_open_headers(tmp_path, monkeypatch):
+    payload = b"dummy-zip-content"
+    captured = {}
+
+    class DummyResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    def fake_open(uri, mode, transport_params=None):
+        captured["uri"] = uri
+        captured["mode"] = mode
+        captured["transport_params"] = transport_params
+        return DummyResponse(payload)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "smart_open",
+        types.SimpleNamespace(open=fake_open),
+    )
+
+    dest_file = tmp_path / "downloaded_via_smart_open.zip"
+    ProtocolsProvider._download_https_uri(
+        "https://example.com/test.zip", str(dest_file)
+    )
+
+    assert dest_file.read_bytes() == payload
+    assert captured["uri"] == "https://example.com/test.zip"
+    assert captured["mode"] == "rb"
+    tp = captured["transport_params"]
+    assert tp is not None
+    assert "headers" in tp
+    assert tp["headers"]["User-Agent"].startswith("ray-runtime-env-curl")
+    assert tp["headers"]["Accept"] == "*/*"
+    assert tp["timeout"] == 60
 
 
 @pytest.mark.asyncio

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -794,7 +794,7 @@ def test_https_downloader_sets_curl_user_agent(tmp_path, monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             self.close()
 
-    def fake_urlopen(request):
+    def fake_urlopen(request, timeout=None):
         headers = {k.lower(): v for k, v in request.header_items()}
         captured_headers.update(headers)
         return DummyResponse(payload)


### PR DESCRIPTION
## Description
When using `runtime_env.working_dir` with a remote zip archive URL (for example,`https://gitee.com/whaozi/kuberay/repository/archive/master.zip`), Ray downloads an HTML page instead of the actual zip file. This causes the Ray job to fail when accessing files from the working directory.

Downloading the same URL with standard tools such as `wget` works as expected and returns the correct zip archive. This PR addresses the inconsistency in how `runtime_env.working_dir` handles remote archive downloads.

#### for example
```
import ray

ray.init(include_dashboard=False, ignore_reinit_error=True)
@ray.remote(
    runtime_env={"working_dir": "https://gitee.com/whaozi/kuberay/repository/archive/master.zip"}
)
def list_repo_files():
    import pathlib
    return sorted(p.name for p in pathlib.Path(".").iterdir())

print(ray.get(list_repo_files.remote()))
ray.shutdown()
```

https_gitee_com_whaozi_kuberay_repository_archive_master is empty, 
and 
https_gitee_com_whaozi_kuberay_repository_archive_master.zip is an HTML file
<img width="1438" height="550" alt="image" src="https://github.com/user-attachments/assets/ec330c99-3bf7-431a-8f3e-6c1789e257ab" />


#### We test
```
wget https://gitee.com/whaozi/kuberay/repository/archive/master.zip
--2025-08-05 14:28:52--  https://gitee.com/whaozi/kuberay/repository/archive/master.zip
Resolving gitee.com (gitee.com)... 180.76.198.77, 180.76.199.13, 180.76.198.225
Connecting to gitee.com (gitee.com)|180.76.198.77|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://gitee.com/whaozi/kuberay/repository/blazearchive/master.zip?Expires=1754430533&Signature=8EMfEVLuEJRLPHsJPQnqkwoSfWYTon6sdYUD7VrHZcM%3D [following]
--2025-08-05 14:28:54--  https://gitee.com/whaozi/kuberay/repository/blazearchive/master.zip?Expires=1754430533&Signature=8EMfEVLuEJRLPHsJPQnqkwoSfWYTon6sdYUD7VrHZcM%3D
Reusing existing connection to gitee.com:443.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/zip]
Saving to: ‘master.zip’

master.zip                                 [                                                  <=>                        ]  10.37M  1.23MB/s    in 13s
```
I think we are not handling http redirection here. If I directly use the redirected url, it works
```
from smart_open import open as open_file

with open_file("https://gitee.com/whaozi/kuberay/repository/blazearchive/master.zip?Expires=1754430533&Signature=8EMfEVLuEJRLPHsJPQnqkwoSfWYTon6sdYUD7VrHZcM%3D", "rb") as fin:
    with open_file("/tmp/jjyao_test.zip", "wb") as fout:
        fout.write(fin.read())
```

So, 
#### Problem is:
When using runtime_env.working_dir with a remote zip URL (e.g. gitee archives), Ray’s HTTPS downloader uses the default Python-urllib user-agent, and some hosts respond with HTML rather than the archive. The working directory then contains HTML and the Ray job fails, while wget succeeds because it presents a curl-like user-agent.

#### Solution
_download_https_uri() now sets curl-like headers (ray-runtime-env-curl/1.0 UA + Accept: */*, configurable via RAY_RUNTIME_ENV_HTTP_USER_AGENT). This keeps Ray’s behavior consistent with curl/wget, allowing gitee and similar hosts to return the proper zip file. A regression test verifies the headers are set.

## Related issues
related issues: "Fixes #52233"

## Additional information
