### PR TITLE
[Serve] Resolve deadlock when replica result is accessed from two eve…

### DIFF
--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -75,7 +75,6 @@ class ActorReplicaResult(ReplicaResult):
         self._is_streaming: bool = metadata.is_streaming
         self._request_id: str = metadata.request_id
         self._object_ref_or_gen_sync_lock = threading.Lock()
-        self._lazy_object_ref_or_gen_asyncio_lock = None
         self._with_rejection = with_rejection
         self._rejection_response = None
 
@@ -101,14 +100,6 @@ class ActorReplicaResult(ReplicaResult):
                     request_context._internal_request_id, self._response_id
                 )
             )
-
-    @property
-    def _object_ref_or_gen_asyncio_lock(self) -> asyncio.Lock:
-        """Lazy `asyncio.Lock` object."""
-        if self._lazy_object_ref_or_gen_asyncio_lock is None:
-            self._lazy_object_ref_or_gen_asyncio_lock = asyncio.Lock()
-
-        return self._lazy_object_ref_or_gen_asyncio_lock
 
     def _process_response(f: Union[Callable, Coroutine]):
         @wraps(f)

--- a/python/ray/serve/tests/test_handle_2.py
+++ b/python/ray/serve/tests/test_handle_2.py
@@ -217,7 +217,10 @@ def test_compose_args_and_kwargs(serve_instance):
 
 
 @pytest.mark.parametrize("await_order", ["b_first", "c_first"])
-def test_chained_deployment_response_await_order(serve_instance, await_order: str):
+@pytest.mark.asyncio
+async def test_chained_deployment_response_await_order(
+    serve_instance, await_order: str
+):
     @serve.deployment
     class DeploymentA:
         async def __call__(self, number: int) -> int:
@@ -265,7 +268,7 @@ def test_chained_deployment_response_await_order(serve_instance, await_order: st
     )
 
     # Use a timeout to detect hangs
-    result = handle.remote(5, await_order).result(timeout_s=30)
+    result = await handle.remote(5, await_order)
 
     # Verify the result is correct:
     # a = 5 * 2 = 10

--- a/python/ray/serve/tests/test_handle_2.py
+++ b/python/ray/serve/tests/test_handle_2.py
@@ -216,6 +216,65 @@ def test_compose_args_and_kwargs(serve_instance):
     }
 
 
+@pytest.mark.parametrize("await_order", ["b_first", "c_first"])
+def test_chained_deployment_response_await_order(serve_instance, await_order: str):
+    @serve.deployment
+    class DeploymentA:
+        async def __call__(self, number: int) -> int:
+            await asyncio.sleep(0.01)
+            return number * 2
+
+    @serve.deployment
+    class DeploymentB:
+        async def __call__(self, number: int) -> int:
+            await asyncio.sleep(0.01)
+            return number * 3
+
+    @serve.deployment
+    class DeploymentC:
+        async def __call__(self, number: int) -> int:
+            await asyncio.sleep(0.01)
+            return number * 4
+
+    @serve.deployment
+    class ComposedDeployment:
+        def __init__(self, deployment_a, deployment_b, deployment_c):
+            self.deployment_a = deployment_a
+            self.deployment_b = deployment_b
+            self.deployment_c = deployment_c
+
+        async def __call__(self, number: int, await_order: str) -> int:
+            a = self.deployment_a.remote(number)
+            b = self.deployment_b.remote(a)
+            c = self.deployment_c.remote(b)
+
+            # Test different await orders - both should work without hanging
+            if await_order == "b_first":
+                true_b = await b
+                true_c = await c
+            else:
+                true_c = await c
+                true_b = await b
+
+            return true_b * true_c
+
+    handle = serve.run(
+        ComposedDeployment.bind(
+            DeploymentA.bind(), DeploymentB.bind(), DeploymentC.bind()
+        ),
+    )
+
+    # Use a timeout to detect hangs
+    result = handle.remote(5, await_order).result(timeout_s=30)
+
+    # Verify the result is correct:
+    # a = 5 * 2 = 10
+    # b = 10 * 3 = 30 (true_b)
+    # c = 30 * 4 = 120 (true_c)
+    # result = 30 * 120 = 3600
+    assert result == 3600, f"Expected 3600, got {result}"
+
+
 def test_nested_deployment_response_error(serve_instance):
     """Test that passing a deployment response in a nested object to a downstream
     handle call errors, and with an informative error message."""


### PR DESCRIPTION
### Summary
Fixes a deadlock that occurs when awaiting intermediate `DeploymentResponse` objects in a chain of deployment calls.

### Problem
The following code would hang indefinitely:
```python
a = self.deployment_a.remote(number)
b = self.deployment_b.remote(a)
c = self.deployment_c.remote(b)

true_b = await b  # HANGS
true_c = await c
```

Interestingly, reversing the await order (`await c` then `await b`) worked fine.

### Root Cause
When chained `DeploymentResponse` objects are used, the same `ReplicaResult` can be accessed from two different event loops concurrently:

1. **User's event loop (replica)**: When user code calls `await b`
2. **Router's event loop (singleton thread)**: When resolving `b` as an argument to `c`

Both code paths call `ReplicaResult.to_object_ref_async()`, which used an `asyncio.Lock` for synchronization. However, `asyncio.Lock` is **not thread-safe** and **not designed for cross-event-loop usage**, causing a deadlock.

### Fix
Replace the `asyncio.Lock` with a non-blocking acquire pattern using the existing thread-safe `threading.Lock`:

### Testing
Added `test_chained_deployment_response_await_order` which tests both await orders (`b_first` and `c_first`) to ensure they complete without hanging. Ran this test with all combinations of `RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD` and `RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP` env vars

Tested against the repro in https://github.com/ray-project/ray/issues/54201

### Performance

Use the same repro script as given in the GH issue except i switch the order, i'e `await c` then `await b` so that i can run it on master.

`locust --headless -u 100 -r 10 --host http://localhost:8000`

Metric | Branch | Master | Notes
-- | -- | -- | --
Requests (#reqs) | 4030 | 4465 | Master handled 10.8% more requests in same test window
Requests/sec | 80.39 | 80.83 | Nearly identical throughput
Avg latency (ms) | 1109 | 1118 | Essentially the same
Median (p50) latency | 650 ms | 700 ms | Branch slightly faster at p50
p90 latency | 2200 ms | 2200 ms | Identical
p95 latency | 2200 ms | 2300 ms | Master slightly slower
p99 latency | 2400 ms | 2500 ms | Master slightly slower
Max latency | 2519 ms | 2760 ms | Master has higher tail
Failures | 0 | 0 | Both perfect
