### PR TITLE
[rllib] Fix `as-release-test` silently failing results upload

### DIFF
--- a/rllib/examples/utils.py
+++ b/rllib/examples/utils.py
@@ -707,8 +707,8 @@ def run_rllib_example_script_experiment(
             f"Running the example script resulted in one or more errors! {errors}"
         )
 
-    print(f'{args.as_test=}, {args.as_release_test=}')
-    print(f'{os.environ=}')
+    print(f"{args.as_test=}, {args.as_release_test=}")
+    print(f"{os.environ=}")
     print("TEST_OUTPUT_JSON:", os.environ.get("TEST_OUTPUT_JSON", "MISSING!!!"))
     print("METRICS_OUTPUT_JSON:", os.environ.get("METRICS_OUTPUT_JSON", "MISSING!!!"))
 
@@ -752,14 +752,15 @@ def run_rllib_example_script_experiment(
                 "not_passed": [not test_passed],
                 "failures": {str(trial): 1} if not test_passed else {},
             }
-            with open(
-                os.environ.get("TEST_OUTPUT_JSON", "/tmp/learning_test.json"),
-                "wt",
-            ) as f:
+            print(f"writing these {json_summary=}")
+            filename = os.environ.get("TEST_OUTPUT_JSON", "/tmp/learning_test.json")
+            print(f"{filename=}")
+            with open(filename, "wt") as f:
                 try:
                     json.dump(json_summary, f)
                 # Something went wrong writing json. Try again w/ simplified stats.
-                except Exception:
+                except Exception as e:
+                    print(f"Exception occurred trying to dump data: {e}")
                     from ray.rllib.algorithms.algorithm import Algorithm
 
                     simplified_stats = {

--- a/rllib/examples/utils.py
+++ b/rllib/examples/utils.py
@@ -707,6 +707,11 @@ def run_rllib_example_script_experiment(
             f"Running the example script resulted in one or more errors! {errors}"
         )
 
+    print(f'{args.as_test=}, {args.as_release_test=}')
+    print(f'{os.environ=}')
+    print("TEST_OUTPUT_JSON:", os.environ.get("TEST_OUTPUT_JSON", "MISSING!!!"))
+    print("METRICS_OUTPUT_JSON:", os.environ.get("METRICS_OUTPUT_JSON", "MISSING!!!"))
+
     # If run as a test, check whether we reached the specified success criteria.
     test_passed = False
     if args.as_test:

--- a/rllib/utils/serialization.py
+++ b/rllib/utils/serialization.py
@@ -27,7 +27,15 @@ def convert_numpy_to_python_primitives(obj: Any):
     Args:
         obj: The object to convert.
     """
-    if isinstance(obj, np.integer):
+    if isinstance(obj, dict):
+        return {
+            key: convert_numpy_to_python_primitives(val) for key, val in obj.items()
+        }
+    elif isinstance(obj, tuple):
+        return tuple(convert_numpy_to_python_primitives(val) for val in obj)
+    elif isinstance(obj, list):
+        return [convert_numpy_to_python_primitives(val) for val in obj]
+    elif isinstance(obj, np.integer):
         return int(obj)
     elif isinstance(obj, np.floating):
         return float(obj)

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
     error=False,
 )
 def add_rllib_example_script_args(*args, **kwargs):
-    from ray.rllib.utils.test_utils import add_rllib_example_script_args
+    from ray.rllib.examples.utils import add_rllib_example_script_args
 
     return add_rllib_example_script_args(*args, **kwargs)
 
@@ -69,7 +69,7 @@ def add_rllib_example_script_args(*args, **kwargs):
     error=False,
 )
 def should_stop(*args, **kwargs):
-    from ray.rllib.utils.test_utils import should_stop
+    from ray.rllib.examples.utils import should_stop
 
     return should_stop(*args, **kwargs)
 
@@ -80,7 +80,7 @@ def should_stop(*args, **kwargs):
     error=False,
 )
 def run_rllib_example_script_experiment(*args, **kwargs):
-    from ray.rllib.utils.test_utils import run_rllib_example_script_experiment
+    from ray.rllib.examples.utils import run_rllib_example_script_experiment
 
     return run_rllib_example_script_experiment(*args, **kwargs)
 


### PR DESCRIPTION
## Description
RLlib has nightly tests running currently however an exception was silently being ignored (`Object of type int64 is not JSON serializable`). 
This PR adds a numpy to json compatible function conversion for the results being serialized and remove the try / except to prevent an error occurring the future and not being alerted