### PR TITLE
Make PrefixCacheAwareRouter imbalance threshold less surprising

### DIFF
--- a/doc/source/serve/llm/user-guides/prefix-aware-routing.md
+++ b/doc/source/serve/llm/user-guides/prefix-aware-routing.md
@@ -94,7 +94,7 @@ The `PrefixCacheAffinityRouter` provides several configuration parameters to tun
 
 ### Core routing parameters
 
-- **`imbalanced_threshold`** (default: 10): Queue length difference threshold for considering load balanced. Lower values prioritize load balancing over cache locality.
+- **`imbalanced_threshold`** (default: infinity): Queue length difference threshold for considering load balanced. Lower values prioritize load balancing over cache locality.
 
 - **`match_rate_threshold`** (default: 0.1): Minimum prefix match rate (0.0-1.0) required to use prefix cache-aware routing. Higher values require stronger prefix matches before routing for cache locality.
 

--- a/python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py
+++ b/python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py
@@ -57,7 +57,7 @@ class PrefixCacheAffinityRouter(LocalityMixin, MultiplexMixin, RequestRouter):
 
     def initialize_state(
         self,
-        imbalanced_threshold: Optional[int] = 10,
+        imbalanced_threshold: Optional[int] = int(1e9),
         match_rate_threshold: Optional[float] = 0.1,
         do_eviction: Optional[bool] = False,
         eviction_threshold_chars: Optional[int] = 400_000,

--- a/python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py
+++ b/python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py
@@ -57,7 +57,7 @@ class PrefixCacheAffinityRouter(LocalityMixin, MultiplexMixin, RequestRouter):
 
     def initialize_state(
         self,
-        imbalanced_threshold: Optional[int] = int(1e9),
+        imbalanced_threshold: Optional[float] = float("inf"),
         match_rate_threshold: Optional[float] = 0.1,
         do_eviction: Optional[bool] = False,
         eviction_threshold_chars: Optional[int] = 400_000,

--- a/python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py
@@ -56,7 +56,7 @@ def prefix_request_router(tree_actor, request):
         construct_request_router(get_or_create_event_loop())
     )
     request_router.initialize_state(
-        imbalanced_threshold=params.get("imbalanced_threshold", 10),
+        imbalanced_threshold=params.get("imbalanced_threshold", float("inf")),
         match_rate_threshold=params.get("match_rate_threshold", 0.1),
         do_eviction=params.get("do_eviction", False),
         eviction_threshold_chars=params.get("eviction_threshold_chars"),


### PR DESCRIPTION
- During testing this was a footgun that I and @nrghosh encountered independently. The configuration is good, but I think users expect the router to be purely prefix cache-based by default.