### PR TITLE
[data] handle azure UC user delegation SAS

### DIFF
--- a/python/ray/data/_internal/datasource/uc_datasource.py
+++ b/python/ray/data/_internal/datasource/uc_datasource.py
@@ -95,11 +95,16 @@ class UnityCatalogConnector:
                 sas_token = sas_token[1:]
             if sas_token:
                 env_vars["AZURE_STORAGE_SAS_TOKEN"] = sas_token
-            if azure.get("storage_account"):
-                env_vars.setdefault("AZURE_STORAGE_ACCOUNT", azure["storage_account"])
-                env_vars.setdefault(
-                    "AZURE_STORAGE_ACCOUNT_NAME", azure["storage_account"]
+            else:
+                known_keys = ", ".join(azure.keys())
+                raise ValueError(
+                    "Azure UC credentials missing SAS token in azure_user_delegation_sas. "
+                    f"Available keys: {known_keys}"
                 )
+            storage_account = azure.get("storage_account")
+            if storage_account:
+                env_vars["AZURE_STORAGE_ACCOUNT"] = storage_account
+                env_vars["AZURE_STORAGE_ACCOUNT_NAME"] = storage_account
         elif "gcp_service_account" in creds:
             gcp_json = creds["gcp_service_account"]
             temp_file = tempfile.NamedTemporaryFile(

--- a/python/ray/data/_internal/datasource/uc_datasource.py
+++ b/python/ray/data/_internal/datasource/uc_datasource.py
@@ -81,6 +81,25 @@ class UnityCatalogConnector:
                 env_vars["AWS_DEFAULT_REGION"] = self.region
         elif "azuresasuri" in creds:
             env_vars["AZURE_STORAGE_SAS_TOKEN"] = creds["azuresasuri"]
+        # Azure UC returns a user delegation SAS; see
+        # https://docs.databricks.com/en/data-governance/unity-catalog/credential-vending.html
+        elif "azure_user_delegation_sas" in creds:
+            azure = creds["azure_user_delegation_sas"] or {}
+            sas_token = (
+                azure.get("sas_token")
+                or azure.get("sas")
+                or azure.get("token")
+                or azure.get("sasToken")
+            )
+            if sas_token and sas_token.startswith("?"):
+                sas_token = sas_token[1:]
+            if sas_token:
+                env_vars["AZURE_STORAGE_SAS_TOKEN"] = sas_token
+            if azure.get("storage_account"):
+                env_vars.setdefault("AZURE_STORAGE_ACCOUNT", azure["storage_account"])
+                env_vars.setdefault(
+                    "AZURE_STORAGE_ACCOUNT_NAME", azure["storage_account"]
+                )
         elif "gcp_service_account" in creds:
             gcp_json = creds["gcp_service_account"]
             temp_file = tempfile.NamedTemporaryFile(
@@ -95,8 +114,10 @@ class UnityCatalogConnector:
             self._gcp_temp_file = temp_file.name
             atexit.register(self._cleanup_gcp_temp_file, temp_file.name)
         else:
+            known_keys = ", ".join(creds.keys())
             raise ValueError(
-                "No known credential type found in Databricks UC response."
+                "No known credential type found in Databricks UC response. "
+                f"Available keys: {known_keys}"
             )
 
         for k, v in env_vars.items():


### PR DESCRIPTION
## Description
Add support for Databricks UC Azure responses that return `azure_user_delegation_sas`, extracting the SAS token and storage account for Ray Data reads.

Improve the credential error message to list available keys, aiding troubleshooting when UC returns unexpected fields.

## Related issues
Related to Azure Databricks Unity Catalog credential vending; no tracked GitHub issue provided.

## Additional information

Uses Databricks UC credential vending docs for Azure: https://docs.databricks.com/en/data-governance/unity-catalog/credential-vending.html

No API changes; behavior now matches AWS/Azure parity for `ray.data.read_unity_catalog`.