### PR TITLE
[core][rdt] Let torch create pinned receiving buffers if possible

### DIFF
--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -98,7 +98,11 @@ def __ray_recv__(
         tensors = []
         for meta in tensor_meta:
             shape, dtype = meta
-            tensor = torch.empty(shape, dtype=dtype, device=device)
+            tensor = None
+            if torch.cuda.is_available() and device.type == "cpu":
+                tensor = torch.empty(shape, dtype=dtype, device=device, pin_memory=True)
+            else:
+                tensor = torch.empty(shape, dtype=dtype, device=device)
             tensors.append(tensor)
 
         tensor_transport_manager = get_tensor_transport_manager(backend)

--- a/python/ray/experimental/gpu_object_manager/gpu_object_store.py
+++ b/python/ray/experimental/gpu_object_manager/gpu_object_store.py
@@ -99,6 +99,9 @@ def __ray_recv__(
         for meta in tensor_meta:
             shape, dtype = meta
             tensor = None
+            # Torch won't allow us to pin memory if cuda isn't available because it actually uses cudaHostAlloc
+            # Doing this through torch here is beneficial because it has a caching allocator that will keep
+            # and reuse old pinned memory.
             if torch.cuda.is_available() and device.type == "cpu":
                 tensor = torch.empty(shape, dtype=dtype, device=device, pin_memory=True)
             else:


### PR DESCRIPTION
## Description
Torch has its own memory caching allocator for pinned (page-locked / not swappable) memory. Currently we create the receiving buffers on cpu memory without pinning them and rely on the rdma memory registration to actually pin the memory (e.g. nixl's memory registration function will actually call mlock). Torch keeps the pinned memory around though and on repeated transfers, it's less likely that we'll pay the cost of allocating, faulting in, and locking pages on the recv. Two of the more expensive parts of rdma memory registration right now are faulting in the pages and locking them. Basically torch provides us with this kind of half-registered memory pool that seems like a decent alternative to building a registered memory pool ourselves.

On the latency tests on 1GB tensors in `rdt_single_node_microbenchmark.py`, we can get 30% faster overall transfers using nixl on cpu. Note that these are just single node ipc's so the actual transfer time isn't reality but basically eliminating receving buffer creation + registration a lot of the time should still help a lot in other cases and are usually always a big part of the recv.

The gotcha with this is that torch actually uses cuda's cudaHostAlloc to allocate the memory on the cpu, so a user can't actually use this on a no gpu machine. To make this even worse, torch doesn't just check for the existence of the library if you set pin memory, it actually checks for the existence of a gpu so if you're running this on a ray actor with num_gpus=0, you won't be able to pin the memory even if the node does actually have gpus and cuda libraries because Ray will set cuda_visible_devices in the process's env...