### PR TITLE
[Data] Increase `test_preserve_hash_shuffle_blocks` timeout

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1834,7 +1834,7 @@ py_test(
 
 py_test(
     name = "test_preserve_hash_shuffle_blocks",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_preserve_hash_shuffle_blocks.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
## Description

`test_preserve_hash_shuffle_blocks` has been flaking consistently. To mitigate the flakiness, this PR bumps the test size from "small" to "medium".

This is a follow-up to https://github.com/ray-project/ray/pull/59256, which accidentally bumped the wrong test.

```
[2025-12-06T07:06:32Z] //python/ray/data:test_preserve_hash_shuffle_blocks                     TIMEOUT in 3 out of 3 in 63.4s
--
[2025-12-06T07:06:32Z]   Stats over 3 runs: max = 63.4s, min = 60.1s, avg = 62.3s, dev = 1.6s
[2025-12-06T07:06:32Z]   /root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/testlogs/python/ray/data/test_preserve_hash_shuffle_blocks/test.log
[2025-12-06T07:06:32Z]   /root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/testlogs/python/ray/data/test_preserve_hash_shuffle_blocks/test_attempts/attempt_1.log
[2025-12-06T07:06:32Z]   /root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/testlogs/python/ray/data/test_preserve_hash_shuffle_blocks/test_attempts/attempt_2.log
[2025-12-06T07:06:32Z]
```

See also https://github.com/ray-project/ray/pull/58988
