### PR TITLE
Fix: Preserve Pydantic details when serialization fails

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -138,12 +138,14 @@ class RayTaskError(RayError):
         try:
             pickle.dumps(cause)
         except (pickle.PicklingError, TypeError) as e:
+            err_type = f"{cause.__class__.__module__}.{cause.__class__.__name__}"
+
             err_msg = (
-                "The original cause of the RayTaskError"
-                f" ({self.cause.__class__}) isn't serializable: {e}."
-                " Overwriting the cause to a RayError."
+                f"Exception {err_type} couldn't be serialized: {e}.\n"
+                f"Original exception details:\n{traceback_str}"
             )
-            logger.warning(err_msg)
+
+            logger.exception(f"The original cause of the RayTaskError ({err_type}) couldn't be serialized.")
             self.cause = RayError(err_msg)
 
         # BaseException implements a __reduce__ method that returns


### PR DESCRIPTION
Fixes #59357

## Description
The Pydantic error is not serializable, making it difficult to root cause the bug. When a Pydantic ValidationError containing ArgsKwargs objects cannot be serialized, Ray now preserves the original error details including the ValidationError message and full traceback in the error message.

## Details
Modified RayTaskError.__init__ to include the full traceback_str in the error message when serialization fails, allowing users to see the original ValidationError details even when the exception itself cannot be pickled.

## Testing
- Created test script that verifies original error details are preserved
- Confirmed wrapped error is serializable
- Verified original ValidationError information survives round-trip serialization