### PR TITLE
[WIP] Clean up `ActorHandle` reference

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -328,11 +328,6 @@ python/ray/actor.py
     DOC201: Method `ActorClass.options` does not have a return section in docstring
     DOC106: Method `ActorClass._remote`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Method `ActorClass._remote`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC107: Method `ActorHandle.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC107: Method `ActorHandle._deserialization_helper`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC104: Method `ActorHandle._deserialization_helper`: Arguments are the same in the docstring and the function signature, but are in a different order.
-    DOC105: Method `ActorHandle._deserialization_helper`: Argument names match, but type hints in these args do not match: weak_ref
-    DOC201: Method `ActorHandle._deserialization_helper` does not have a return section in docstring
 --------------------
 python/ray/air/_internal/mlflow.py
     DOC104: Method `_MLflowLoggerUtil.setup_mlflow`: Arguments are the same in the docstring and the function signature, but are in a different order.

--- a/doc/source/ray-core/api/core.rst
+++ b/doc/source/ray-core/api/core.rst
@@ -34,7 +34,6 @@ Actors
     ray.actor.ActorClass.options
     ray.actor.ActorMethod
     ray.actor.ActorHandle
-    ray.actor.ActorClassInheritanceException
     ray.actor.exit_actor
     ray.method
     ray.get_actor

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1894,13 +1894,13 @@ class _ActorHandle(Generic[T]):
 
     def __init__(
         self,
-        language,
-        actor_id,
+        language: Language,
+        actor_id: str,
         max_task_retries: Optional[int],
         enable_task_events: bool,
         method_is_generator: Dict[str, bool],
-        method_decorators,
-        method_signatures,
+        method_decorators: Dict,
+        method_signatures Dict,
         method_num_returns: Dict[str, Union[int, Literal["streaming"]]],
         method_max_task_retries: Dict[str, int],
         method_retry_exceptions: Dict[str, Union[bool, list, tuple]],
@@ -1909,9 +1909,9 @@ class _ActorHandle(Generic[T]):
         enable_tensor_transport: bool,
         method_name_to_tensor_transport: Dict[str, str],
         actor_method_cpus: int,
-        actor_creation_function_descriptor,
-        cluster_and_job,
-        original_handle=False,
+        actor_creation_function_descriptor: PythonFunctionDescriptor,
+        cluster_and_job: Any,
+        original_handle: bool =False,
         weak_ref: bool = False,
         allow_out_of_order_execution: Optional[bool] = None,
     ):
@@ -2298,7 +2298,7 @@ class _ActorHandle(Generic[T]):
         return (*state, self._ray_weak_ref)
 
     @classmethod
-    def _deserialization_helper(cls, state, weak_ref: bool, outer_object_ref: Optional["ray.ObjectRef"] = None):
+    def _deserialization_helper(cls, state: Dict, weak_ref: bool, outer_object_ref: Optional["ray.ObjectRef"] = None):
         """This is defined in order to make pickling work.
 
         Args:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1911,7 +1911,7 @@ class _ActorHandle(Generic[T]):
         actor_method_cpus: int,
         actor_creation_function_descriptor: PythonFunctionDescriptor,
         cluster_and_job: Any,
-        original_handle: bool =False,
+        original_handle: bool = False,
         weak_ref: bool = False,
         allow_out_of_order_execution: Optional[bool] = None,
     ):
@@ -2298,7 +2298,12 @@ class _ActorHandle(Generic[T]):
         return (*state, self._ray_weak_ref)
 
     @classmethod
-    def _deserialization_helper(cls, state: Dict, weak_ref: bool, outer_object_ref: Optional["ray.ObjectRef"] = None):
+    def _deserialization_helper(
+        cls,
+        state: Dict,
+        weak_ref: bool,
+        outer_object_ref: Optional["ray.ObjectRef"] = None,
+    ):
         """This is defined in order to make pickling work.
 
         Args:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1900,7 +1900,7 @@ class _ActorHandle(Generic[T]):
         enable_task_events: bool,
         method_is_generator: Dict[str, bool],
         method_decorators: Dict,
-        method_signatures Dict,
+        method_signatures: Dict,
         method_num_returns: Dict[str, Union[int, Literal["streaming"]]],
         method_max_task_retries: Dict[str, int],
         method_retry_exceptions: Dict[str, Union[bool, list, tuple]],

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1882,8 +1882,7 @@ class ActorClass(Generic[T]):
         )
 
 
-@PublicAPI
-class ActorHandle(Generic[T]):
+class _ActorHandle(Generic[T]):
     """A handle to an actor.
 
     An ActorHandle is created by calling `.remote()` on an `ActorClass` and can be

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2298,7 +2298,7 @@ class _ActorHandle(Generic[T]):
         return (*state, self._ray_weak_ref)
 
     @classmethod
-    def _deserialization_helper(cls, state, weak_ref: bool, outer_object_ref=None):
+    def _deserialization_helper(cls, state, weak_ref: bool, outer_object_ref=None) -> "_ActorHandle":
         """This is defined in order to make pickling work.
 
         Args:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2302,12 +2302,13 @@ class _ActorHandle(Generic[T]):
         """This is defined in order to make pickling work.
 
         Args:
+            cls: The class definition.
             state: The serialized state of the actor handle.
+            weak_ref: Whether this was serialized from an actor handle with a
+                weak ref to the actor.
             outer_object_ref: The ObjectRef that the serialized actor handle
                 was contained in, if any. This is used for counting references
                 to the actor handle.
-            weak_ref: Whether this was serialized from an actor handle with a
-                weak ref to the actor.
 
         """
         worker = ray._private.worker.global_worker

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2302,7 +2302,6 @@ class _ActorHandle(Generic[T]):
         """This is defined in order to make pickling work.
 
         Args:
-            cls: The class definition.
             state: The serialized state of the actor handle.
             weak_ref: Whether this was serialized from an actor handle with a
                 weak ref to the actor.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2298,7 +2298,7 @@ class _ActorHandle(Generic[T]):
         return (*state, self._ray_weak_ref)
 
     @classmethod
-    def _deserialization_helper(cls, state, weak_ref: bool, outer_object_ref=None) -> "_ActorHandle":
+    def _deserialization_helper(cls, state, weak_ref: bool, outer_object_ref=None):
         """This is defined in order to make pickling work.
 
         Args:
@@ -2309,6 +2309,8 @@ class _ActorHandle(Generic[T]):
                 was contained in, if any. This is used for counting references
                 to the actor handle.
 
+        Returns:
+            A deserialized _ActorHandle.
         """
         worker = ray._private.worker.global_worker
         worker.check_connected()

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2298,7 +2298,7 @@ class _ActorHandle(Generic[T]):
         return (*state, self._ray_weak_ref)
 
     @classmethod
-    def _deserialization_helper(cls, state, weak_ref: bool, outer_object_ref=None):
+    def _deserialization_helper(cls, state, weak_ref: bool, outer_object_ref: Optional["ray.ObjectRef"] = None):
         """This is defined in order to make pickling work.
 
         Args:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1881,6 +1881,7 @@ class ActorClass(Generic[T]):
             self.__ray_metadata__.modified_class, args, kwargs, self._default_options
         )
 
+
 @PublicAPI
 class ActorHandle(Generic[T]):
     """A handle to an actor.
@@ -2352,6 +2353,7 @@ class ActorHandle(Generic[T]):
         # deserialized out-of-band using pickle.
         return self.__class__._deserialization_helper, (serialized, weak_ref, None)
 
+
 @PublicAPI
 class ActorHandle(_ActorHandle, Generic[T]):
     """A handle to an actor.
@@ -2368,10 +2370,6 @@ class ActorHandle(_ActorHandle, Generic[T]):
         """ActorHandles should *not* be initialized directly.
 
         Instead, call `.remote()` on an `ActorClass`.
-
-        Args:
-            args: internal arguments to create an actor handle.
-            kwargs: internal arguments to create an actor handle.
         """
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Subclassing `ActorHandle` to hide implementation details from the docstrings. See: https://docs.ray.io/en/latest/ray-core/api/doc/ray.actor.ActorHandle.html#ray.actor.ActorHandle

Closes https://github.com/ray-project/ray/issues/32638