### PR TITLE
[Data][LLM] Bump max latency threshold to 140s for single_node_baseline_benchmark

### DIFF
--- a/release/llm_tests/batch/test_batch_single_node_vllm.py
+++ b/release/llm_tests/batch/test_batch_single_node_vllm.py
@@ -112,7 +112,7 @@ def test_single_node_baseline_benchmark():
 
     # Optional thresholds to fail on regressions
     min_throughput = _get_float_env("RAY_DATA_LLM_BENCHMARK_MIN_THROUGHPUT", 5)
-    max_latency_s = _get_float_env("RAY_DATA_LLM_BENCHMARK_MAX_LATENCY_S", 120)
+    max_latency_s = _get_float_env("RAY_DATA_LLM_BENCHMARK_MAX_LATENCY_S", 140)
     if min_throughput is not None:
         assert (
             result.throughput >= min_throughput

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4247,7 +4247,7 @@
   python: "3.11"
   group: llm-batch
   working_dir: llm_tests/batch
-  frequency: weekly
+  frequency: nightly
   team: llm
 
   cluster:


### PR DESCRIPTION
Bump threshold for release test `test_batch_single_node_vllm.py::test_single_node_baseline_benchmark` to avoid flakiness + make it nightly (for now).

## Related Issues
- Fixes https://github.com/anyscale/ray/issues/688