### PR TITLE
[Serve] Fix `make_fastapi_class_based_view` for inherited methods

### DIFF
--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_make_fastapi_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_make_fastapi_ingress.py
@@ -25,11 +25,19 @@ class TestMakeFastapiIngress:
 
             pass
 
+        app = FastAPI()
         # Create the ingress class - should not raise
-        ingress_cls = make_fastapi_ingress(MyCustomIngress)
+        ingress_cls = make_fastapi_ingress(MyCustomIngress, app=app)
 
-        # Check that the class qualname matches the input class qualname
-        assert ingress_cls.__qualname__ == MyCustomIngress.__qualname__
+        # Verify the ingress class was created successfully
+        assert ingress_cls is not None
+
+        # Verify routes are registered (inherited from OpenAiIngress)
+        route_paths = [
+            route.path for route in app.routes if isinstance(route, APIRoute)
+        ]
+        assert "/v1/models" in route_paths
+        assert "/v1/completions" in route_paths
 
     def test_subclass_with_custom_method(self):
         """Test that custom methods added by subclass are also properly handled."""

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_make_fastapi_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_make_fastapi_ingress.py
@@ -46,13 +46,17 @@ class TestMakeFastapiIngress:
             **DEFAULT_ENDPOINTS,
         }
 
-        # Should not raise
+        app = FastAPI()
         ingress_cls = make_fastapi_ingress(
-            MyCustomIngress, endpoint_map=custom_endpoints
+            MyCustomIngress, endpoint_map=custom_endpoints, app=app
         )
 
-        # Verify the class was created
+        # Verify the class was created and the custom route is registered
         assert ingress_cls is not None
+        route_paths = [
+            route.path for route in app.routes if isinstance(route, APIRoute)
+        ]
+        assert "/custom" in route_paths
 
     def test_routes_registered_correctly(self):
         """Test that routes are registered with the FastAPI app."""

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_make_fastapi_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_make_fastapi_ingress.py
@@ -1,0 +1,170 @@
+import inspect
+import sys
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.routing import APIRoute
+
+from ray.llm._internal.serve.core.ingress.ingress import (
+    DEFAULT_ENDPOINTS,
+    OpenAiIngress,
+    make_fastapi_ingress,
+)
+
+
+class TestMakeFastapiIngressInheritance:
+    """Test suite for make_fastapi_ingress with inherited classes.
+
+    These tests verify that when subclassing OpenAiIngress, inherited methods
+    are properly transformed so that `self` is treated as a dependency
+    (instance binding) rather than a query parameter.
+    """
+
+    def test_subclass_methods_have_correct_qualname(self):
+        """Test that inherited methods get their __qualname__ updated to the subclass.
+
+        If inherited methods keep their parent's __qualname__, they won't be
+        recognized as belonging to the subclass and won't be transformed.
+        """
+
+        class MyCustomIngress(OpenAiIngress):
+            """Custom ingress that inherits all OpenAI endpoints."""
+
+            pass
+
+        # Create the ingress class
+        ingress_cls = make_fastapi_ingress(MyCustomIngress)
+
+        # Check that the class qualname matches the input class qualname
+        # (classes defined inside methods have full path in qualname)
+        assert ingress_cls.__qualname__ == MyCustomIngress.__qualname__
+
+        # Check that inherited methods have updated __qualname__
+        for method_name in DEFAULT_ENDPOINTS.keys():
+            method = getattr(ingress_cls, method_name)
+            assert "MyCustomIngress" in method.__qualname__, (
+                f"Method {method_name} should have MyCustomIngress in __qualname__, "
+                f"but got {method.__qualname__}"
+            )
+
+    def test_subclass_with_custom_method(self):
+        """Test that custom methods added by subclass are also properly handled."""
+
+        class MyCustomIngress(OpenAiIngress):
+            """Custom ingress with an additional endpoint."""
+
+            async def custom_endpoint(self, request: Request):
+                """A custom endpoint added by the subclass."""
+                return {"status": "ok"}
+
+        custom_endpoints = {
+            "custom_endpoint": lambda app: app.post("/custom"),
+            **DEFAULT_ENDPOINTS,
+        }
+
+        ingress_cls = make_fastapi_ingress(
+            MyCustomIngress, endpoint_map=custom_endpoints
+        )
+
+        # Check custom method has correct qualname
+        custom_method = ingress_cls.custom_endpoint
+        assert "MyCustomIngress" in custom_method.__qualname__
+
+        # Check inherited methods also have correct qualname
+        completions_method = ingress_cls.completions
+        assert "MyCustomIngress" in completions_method.__qualname__
+
+    def test_routes_registered_correctly(self):
+        """Test that routes are registered with the FastAPI app."""
+
+        class MyCustomIngress(OpenAiIngress):
+            pass
+
+        app = FastAPI()
+        make_fastapi_ingress(MyCustomIngress, app=app)
+
+        # Get all registered routes
+        route_paths = [
+            route.path for route in app.routes if isinstance(route, APIRoute)
+        ]
+
+        # Check that default endpoints are registered
+        assert "/v1/models" in route_paths
+        assert "/v1/completions" in route_paths
+        assert "/v1/chat/completions" in route_paths
+
+    def test_custom_endpoint_map_overrides_defaults(self):
+        """Test that custom endpoint_map can override default endpoints."""
+
+        class MyCustomIngress(OpenAiIngress):
+            async def models(self):
+                """Override the models endpoint."""
+                return {"custom": True}
+
+        # Only register models endpoint with a custom path
+        custom_endpoints = {
+            "models": lambda app: app.get("/custom/models"),
+        }
+
+        app = FastAPI()
+        make_fastapi_ingress(MyCustomIngress, endpoint_map=custom_endpoints, app=app)
+
+        route_paths = [
+            route.path for route in app.routes if isinstance(route, APIRoute)
+        ]
+
+        # Should have custom path, not default
+        assert "/custom/models" in route_paths
+        assert "/v1/models" not in route_paths
+
+    def test_deeply_nested_inheritance(self):
+        """Test that deeply nested inheritance also works correctly."""
+
+        class IntermediateIngress(OpenAiIngress):
+            """Intermediate class in inheritance chain."""
+
+            async def intermediate_method(self, request: Request):
+                return {"level": "intermediate"}
+
+        class FinalIngress(IntermediateIngress):
+            """Final class in inheritance chain."""
+
+            async def final_method(self, request: Request):
+                return {"level": "final"}
+
+        custom_endpoints = {
+            "intermediate_method": lambda app: app.post("/intermediate"),
+            "final_method": lambda app: app.post("/final"),
+            **DEFAULT_ENDPOINTS,
+        }
+
+        ingress_cls = make_fastapi_ingress(FinalIngress, endpoint_map=custom_endpoints)
+
+        # All methods should have FinalIngress in their qualname
+        for method_name in custom_endpoints.keys():
+            method = getattr(ingress_cls, method_name)
+            assert "FinalIngress" in method.__qualname__, (
+                f"Method {method_name} should have FinalIngress in __qualname__, "
+                f"but got {method.__qualname__}"
+            )
+
+    def test_method_signature_preserved(self):
+        """Test that method signatures are preserved after decoration."""
+
+        class MyCustomIngress(OpenAiIngress):
+            pass
+
+        ingress_cls = make_fastapi_ingress(MyCustomIngress)
+
+        # Get the completions method and check its signature
+        completions_method = ingress_cls.completions
+        sig = inspect.signature(completions_method)
+        param_names = list(sig.parameters.keys())
+
+        # Should have 'self' and 'body' parameters
+        assert "self" in param_names
+        assert "body" in param_names
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -452,8 +452,10 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
         # NOTE: We check against all classes in the MRO to handle inherited
         # methods. When a method is inherited, its __qualname__ still references
         # the parent class (e.g., "ParentClass.method" not "ChildClass.method").
+        # We use "ClassName." prefix matching (not substring) to avoid false
+        # positives where class "A" would incorrectly match routes from "AA".
         and any(
-            base.__qualname__ in route.endpoint.__qualname__
+            route.endpoint.__qualname__.startswith(base.__qualname__ + ".")
             for base in cls.__mro__
             if base is not object
         )


### PR DESCRIPTION
## Summary

Fixed a bug in Ray Serve where inheriting from a class with FastAPI-decorated methods would cause FastAPI to treat `self` as a required query parameter, resulting in `400 Bad Request` errors:

```
{"error":{"message":"Invalid request format: Field required at ('query', 'self')"}}
```

This affected any Serve user who inherits decorated methods, including Ray LLM's `OpenAiIngress`.

## Root Cause

When a class inherits from another class with FastAPI-decorated methods, inherited methods retain their parent class's `__qualname__`:

```python
class Parent:
    @app.get("/endpoint")
    def my_method(self): ...

class Child(Parent):
    pass  # my_method.__qualname__ is still "Parent.my_method"
```

In `make_fastapi_class_based_view`, the check to identify class methods was:

```python
cls.__qualname__ in route.endpoint.__qualname__
```

This fails for inherited methods because `"Child"` is not in `"Parent.my_method"`. As a result, these routes are not transformed, and FastAPI treats `self` as a required query parameter.

## Fix

Updated `make_fastapi_class_based_view` in `ray/serve/_private/http_util.py` to check the entire MRO (Method Resolution Order) instead of just the immediate class:

```python
# Before (broken for inheritance):
cls.__qualname__ in route.endpoint.__qualname__

# After (handles inheritance correctly):
any(
    base.__qualname__ in route.endpoint.__qualname__
    for base in cls.__mro__
    if base is not object
)
```

This ensures inherited methods from any ancestor class are properly recognized and transformed.

## Testing

Added `test_ingress_inheritance` to `ray/serve/tests/test_fastapi.py` that verifies:

1. **Multi-level inheritance**: Grandparent → Parent → Child → ServedIngress
2. **Direct inheritance**: BaseIngress → DirectServedIngress

Both cases test that inherited endpoints work correctly via actual HTTP requests (not mock/unit tests).
