### PR TITLE
[data] fix resource allocator not respecting max resource requirement

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -933,7 +933,10 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         if eligible_ops and not remaining_shared.is_zero():
             for op in reversed(eligible_ops):
                 _, max_resource_usage = op.min_max_resource_requirements()
-                if max_resource_usage is None or max_resource_usage == ExecutionResources.inf():
+                if (
+                    max_resource_usage is None
+                    or max_resource_usage == ExecutionResources.inf()
+                ):
                     self._op_budgets[op] = self._op_budgets[op].add(
                         remaining_shared.copy(gpu=0)
                     )

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -792,6 +792,60 @@ class TestReservationOpResourceAllocator:
             cpu=14, object_store_memory=110
         )
 
+    def test_budget_capped_by_max_resource_usage_all_capped(self, restore_data_context):
+        """Test when all operators are capped, remaining shared resources are not given."""
+        DataContext.get_current().op_resource_reservation_enabled = True
+        DataContext.get_current().op_resource_reservation_ratio = 0.5
+
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(o1, incremental_resource_usage=ExecutionResources(1, 0, 10))
+        o3 = mock_map_op(o2, incremental_resource_usage=ExecutionResources(1, 0, 10))
+
+        # Both operators are capped.
+        o2.min_max_resource_requirements = MagicMock(
+            return_value=(
+                ExecutionResources.zero(),
+                ExecutionResources(cpu=4, object_store_memory=float("inf")),
+            )
+        )
+        o3.min_max_resource_requirements = MagicMock(
+            return_value=(
+                ExecutionResources.zero(),
+                ExecutionResources(cpu=4, object_store_memory=float("inf")),
+            )
+        )
+
+        topo = build_streaming_topology(o3, ExecutionOptions())
+
+        global_limits = ExecutionResources(cpu=20, object_store_memory=400)
+
+        op_usages = {
+            o1: ExecutionResources.zero(),
+            o2: ExecutionResources(cpu=2, object_store_memory=40),
+            o3: ExecutionResources(cpu=2, object_store_memory=40),
+        }
+
+        resource_manager = ResourceManager(
+            topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
+        )
+        resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
+        resource_manager._mem_op_internal = {o1: 0, o2: 40, o3: 40}
+        resource_manager._mem_op_outputs = {o1: 0, o2: 0, o3: 0}
+        resource_manager.get_global_limits = MagicMock(return_value=global_limits)
+
+        allocator = resource_manager._op_resource_allocator
+        allocator.update_budgets(limits=global_limits)
+
+        # Both ops are capped (max cpu=4), so remaining CPU is not given to any op.
+        # o2: reserved_remaining (2, 10) + capped op_shared (0, 100) = (2, 110)
+        # o3: reserved_remaining (2, 10) + capped op_shared (0, 100) = (2, 110)
+        assert allocator._op_budgets[o2] == ExecutionResources(
+            cpu=2, object_store_memory=110
+        )
+        assert allocator._op_budgets[o3] == ExecutionResources(
+            cpu=2, object_store_memory=110
+        )
+
     def test_only_handle_eligible_ops(self, restore_data_context):
         """Test that we only handle non-completed map ops."""
         DataContext.get_current().op_resource_reservation_enabled = True


### PR DESCRIPTION
This PR adds a cap on the total budget allocation by max_resource_usage in ReservationOpResourceAllocator.

Previously, the reservation was capped by max_resource_usage, but the total budget (reservation + shared resources) could exceed the max. This could lead to operators being allocated more resources than they can use, while other operators are starved.
 
Changes

  Cap total allocation by max_resource_usage:
  - Total allocation = max(total_reserved, op_usage) + op_shared
  - We now cap op_shared so that total allocation ≤ max_resource_usage
  - Excess shared resources remain in remaining_shared for other operators

  Redistribute remaining shared resources:
  - After the allocation loop, any remaining shared resources (from caps) are given to the most downstream uncapped operator
  - An operator is "uncapped" if its max_resource_usage == ExecutionResources.inf()
  - If all operators are capped, remaining resources are not redistributed

  Tests

  - test_budget_capped_by_max_resource_usage: Tests that capped operators don't receive excess shared resources, and remaining goes to uncapped downstream op
  - test_budget_capped_by_max_resource_usage_all_capped: Tests that when all operators are capped, remaining shared resources are not redistributed
