### PR TITLE
[ci] [docs] Restore formatting checks for doc/source/ after format.sh removal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,9 @@ repos:
       - id: check-ast
         exclude: |
           (?x)(
-            python/ray/serve/tests/test_config_files/syntax_error\.py|
+            python/ray/serve/tests/test_config_files/syntax_error\.py$|
             ^doc/source/
-          )$
+          )
       - id: check-json
         exclude: |
           (?x)^(
@@ -128,9 +128,7 @@ repos:
             python/ray/autoscaler/sdk/sdk.py|
             python/ray/autoscaler/_private/commands.py|
             python/ray/autoscaler/_private/autoscaler.py|
-            python/ray/_private/gcs_utils.py|
-            python/ray/serve/handle.py|
-            python/ray/serve/tests/typing_files/check_handle_typing.py
+            python/ray/_private/gcs_utils.py
           )
         additional_dependencies:
           [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,36 +11,43 @@ exclude: |
     rllib/offline/tests/data|
     thirdparty/patches/|
     src/ray/thirdparty/|
-    doc/external/|
-    doc/source/
+    doc/external/
   )
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: trailing-whitespace
+        exclude: ^doc/source/
       - id: end-of-file-fixer
+        exclude: ^doc/source/
       - id: check-added-large-files
+        exclude: ^doc/source/
       - id: check-ast
         exclude: |
           (?x)(
-            python/ray/serve/tests/test_config_files/syntax_error\.py
+            python/ray/serve/tests/test_config_files/syntax_error\.py|
+            ^doc/source/
           )$
       - id: check-json
         exclude: |
           (?x)^(
             # Intentionally bad json schema
-            python/ray/tests/unit/test_runtime_env_validation_bad_schema.json
+            python/ray/tests/unit/test_runtime_env_validation_bad_schema.json|
+            doc/source/
           )
       - id: check-toml
+        exclude: ^doc/source/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.4
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
+        exclude: ^doc/source/
       - id: ruff
         args: [ --select, "I", --fix, --exit-non-zero-on-fix ]
+        exclude: ^doc/source/
 
   - repo: https://github.com/jsh9/pydoclint
     rev: "0.8.3"
@@ -106,6 +113,7 @@ repos:
     hooks:
       - id: prettier
         files: 'doc/'
+        exclude: ^doc/source/
         types_or: [javascript, ts, tsx, html, css]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -120,7 +128,9 @@ repos:
             python/ray/autoscaler/sdk/sdk.py|
             python/ray/autoscaler/_private/commands.py|
             python/ray/autoscaler/_private/autoscaler.py|
-            python/ray/_private/gcs_utils.py
+            python/ray/_private/gcs_utils.py|
+            python/ray/serve/handle.py|
+            python/ray/serve/tests/typing_files/check_handle_typing.py
           )
         additional_dependencies:
           [
@@ -131,9 +141,13 @@ repos:
     rev: v1.10.0
     hooks:
       - id: rst-directive-colons
+        exclude: ^doc/source/
       - id: rst-inline-touching-normal
+        exclude: ^doc/source/
       - id: python-no-log-warn
+        exclude: ^doc/source/
       - id: python-check-mock-methods
+        exclude: ^doc/source/
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.1
@@ -149,6 +163,7 @@ repos:
     rev: v12.0.1
     hooks:
       - id: clang-format
+        exclude: ^doc/source/
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.11.0
@@ -160,7 +175,8 @@ repos:
             java/api/src/main/java/io/ray/api/ActorCall.java|
             java/api/src/main/java/io/ray/api/CppActorCall.java|
             java/api/src/main/java/io/ray/api/PyActorCall.java|
-            java/api/src/main/java/io/ray/api/RayCall.java
+            java/api/src/main/java/io/ray/api/RayCall.java|
+            doc/source/
           )
 
   - repo: local
@@ -176,6 +192,7 @@ repos:
     hooks:
       - id: semgrep
         args: [--config=semgrep.yml, --error]
+        exclude: ^doc/source/
 
   - repo: https://github.com/errata-ai/vale
     rev: v3.4.1
@@ -188,6 +205,7 @@ repos:
     hooks:
       - id: cython-lint
         args: [--no-pycodestyle]
+        exclude: ^doc/source/
 
   - repo: local
     hooks:

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -52,11 +52,6 @@ pre_commit_pydoclint() {
   pre-commit run pydoclint --all-files --show-diff-on-failure
 }
 
-code_format() {
-  pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
-  FORMAT_SH_PRINT_DIFF=1 ./ci/lint/format.sh --all-scripts
-}
-
 semgrep_lint() {
   pip install -c python/requirements_compiled.txt semgrep pre-commit
   pre-commit run semgrep --all-files --show-diff-on-failure


### PR DESCRIPTION
## Context

PR #57799 removed `format.sh` and the `code_format` job in favor of pre-commit, but `.pre-commit-config.yaml` excluded `doc/source/`, so Python/shell/yaml files in docs were no longer formatted or linted. This includes CI tests (e.g microcheck)

For context, here is the previous `format.sh` 
https://github.com/ray-project/ray/blob/4ec817b18c8e06518837217fea43f6868b6aab81/ci/lint/format.sh

## Solution

* Re-enabled formatting/linting for `doc/source/` by:
  * Removing `doc/source/` from the global exclude of `pre-commit`
  * Adding `exclude: ^doc/source/` only to hooks that were **not** part of the old `format.sh`, just for consistent behavior with the previous way of using `format.sh`. But we can argue some of them might be relevant (ruff ?)
  * Keeping `black`, `shellcheck`, `docstyle`, and `check-import-order` active for `doc/source/`, as before
* Removed the unused `code_format()` function in `ci/lint/lint.sh` (leftover from previous format.sh usage)

## Files Changed

* `.pre-commit-config.yaml`: Restore formatting/linting coverage for `doc/source/`
* `ci/lint/lint.sh`: Remove dead `code_format()` function


Two other points to mention ?
- Because it's been ~2 months, ~15 files in doc/source weren't checked and can be automatically fixed (i think it's just black issues)
- I notice vale is only used on ray data docs: https://github.com/ray-project/ray/pull/53564 . Should we switch to all of doc/source ? If yes, should we refactor everything in this PR ( i see ~300 issues but they all seem to be low-effort to fix, just rewriting sentences)
- Some pre-commit hooks are checking things that were not checked by `format.sh`, should we include them for doc/source files too ? For example ruff, trailing-space etc