### PR TITLE
[train] rename ScalingConfig.bundle_label_selector to label_selector

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/tpu_reservation_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/tpu_reservation_callback.py
@@ -22,10 +22,10 @@ class TPUReservationCallback(ControllerCallback):
             num_workers: The number of workers to be started.
 
         Returns:
-            A dictionary defining a `bundle_label_selector` to gang schedule
+            A dictionary defining a `label_selector` to gang schedule
             the worker group on the reserved TPU slice.
         """
-        bundle_label_selector = None
+        label_selector = None
 
         if scaling_config.use_tpu and num_workers > 1:
             assert scaling_config.accelerator_type is not None
@@ -38,8 +38,6 @@ class TPUReservationCallback(ControllerCallback):
             if not slice_name:
                 raise RuntimeError("Failed to reserve TPU slice.")
 
-            bundle_label_selector = {
-                ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY: slice_name
-            }
+            label_selector = {ray._raylet.RAY_NODE_TPU_SLICE_NAME_KEY: slice_name}
 
-        return bundle_label_selector
+        return label_selector

--- a/python/ray/train/v2/_internal/execution/callback.py
+++ b/python/ray/train/v2/_internal/execution/callback.py
@@ -88,7 +88,7 @@ class ControllerCallback(RayTrainCallback):
         pass
 
     # TODO(matthewdeng): Revisit this callback interface for better extensibility.
-    # This hook was added for the specific use case of setting a `bundle_label_selector`
+    # This hook was added for the specific use case of setting a `label_selector`
     # for new worker groups (e.g., for TPU reservations). The current interface is
     # tightly coupled to this purpose and limits its reuse for other use-cases.
     def on_controller_start_worker_group(
@@ -104,7 +104,7 @@ class ControllerCallback(RayTrainCallback):
             num_workers: The number of workers to be started.
 
         Returns:
-            An optional dictionary defining a `bundle_label_selector`
+            An optional dictionary defining a `label_selector`
             to gang schedule the worker group on the reserved TPU slice.
         """
         return None

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -302,13 +302,13 @@ class TrainController:
         placement_strategy = self._scaling_policy.scaling_config.placement_strategy
         scaling_config = self._train_run_context.scaling_config
 
-        # Check for `bundle_label_selector` to influence WorkerGroup scheduling.
-        bundle_label_selector = None
-        if isinstance(scaling_config.bundle_label_selector, list):
-            bundle_label_selector = scaling_config.bundle_label_selector[:num_workers]
-        elif isinstance(scaling_config.bundle_label_selector, dict):
-            bundle_label_selector = [
-                scaling_config.bundle_label_selector.copy() for _ in range(num_workers)
+        # Check for `label_selector` to influence WorkerGroup scheduling.
+        label_selector = None
+        if isinstance(scaling_config.label_selector, list):
+            label_selector = scaling_config.label_selector[:num_workers]
+        elif isinstance(scaling_config.label_selector, dict):
+            label_selector = [
+                scaling_config.label_selector.copy() for _ in range(num_workers)
             ]
         try:
             for callback in self._controller_callbacks:
@@ -316,14 +316,12 @@ class TrainController:
                     scaling_config=scaling_config, num_workers=num_workers
                 )
                 if selector:
-                    if bundle_label_selector:
+                    if label_selector:
                         logger.warning(
-                            f"Overriding `ScalingConfig.bundle_label_selector` {bundle_label_selector} "
-                            f"with bundle_label_selector returned by user-specified callback {selector}"
+                            f"Overriding `ScalingConfig.label_selector` {label_selector} "
+                            f"with label_selector returned by user-specified callback {selector}"
                         )
-                    bundle_label_selector = [
-                        selector.copy() for _ in range(num_workers)
-                    ]
+                    label_selector = [selector.copy() for _ in range(num_workers)]
                     break
         except Exception as e:
             return ControllerError(e)
@@ -334,7 +332,7 @@ class TrainController:
             num_workers=num_workers,
             resources_per_worker=resources_per_worker,
             placement_strategy=placement_strategy,
-            bundle_label_selector=bundle_label_selector,
+            label_selector=label_selector,
         )
         try:
             self._worker_group = self.worker_group_cls.create(

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -90,7 +90,7 @@ class WorkerGroupContext:
         num_workers: The number of workers in the worker group.
         resources_per_worker: The resources per worker.
         placement_strategy: Strategy for placing workers.
-        bundle_label_selector: Optional label selectors to apply per-bundle for workers.
+        label_selector: Optional label selectors to apply per-bundle for workers.
     """
 
     run_attempt_id: str
@@ -98,7 +98,7 @@ class WorkerGroupContext:
     num_workers: int
     resources_per_worker: Dict[str, float]
     placement_strategy: str = "PACK"
-    bundle_label_selector: Optional[List[Dict[str, str]]] = None
+    label_selector: Optional[List[Dict[str, str]]] = None
 
 
 class WorkerGroup(BaseWorkerGroup):
@@ -271,7 +271,7 @@ class WorkerGroup(BaseWorkerGroup):
                 bundles=[worker_group_context.resources_per_worker]
                 * worker_group_context.num_workers,
                 strategy=worker_group_context.placement_strategy,
-                bundle_label_selector=worker_group_context.bundle_label_selector,
+                bundle_label_selector=worker_group_context.label_selector,
             )
             logger.info(
                 f"Attempting to start training worker group of size {worker_group_context.num_workers} with "

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -48,7 +48,7 @@ class ScalingConfig(ScalingConfigV1):
         placement_strategy: The placement strategy to use for the
             placement group of the Ray actors. See :ref:`Placement Group
             Strategies <pgroup-strategy>` for the possible options.
-        bundle_label_selector: A list of label selectors for Ray Train worker placement.
+        label_selector: A list of label selectors for Ray Train worker placement.
             If a single label selector is provided, it will be applied to all Ray Train workers.
             If a list is provided, it must be the same length as the max number of Ray Train workers.
         accelerator_type: [Experimental] If specified, Ray Train will launch the
@@ -72,7 +72,7 @@ class ScalingConfig(ScalingConfigV1):
     trainer_resources: Optional[dict] = None
     use_tpu: Union[bool] = False
     topology: Optional[str] = None
-    bundle_label_selector: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None
+    label_selector: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None
 
     def __post_init__(self):
         if self.trainer_resources is not None:
@@ -107,19 +107,19 @@ class ScalingConfig(ScalingConfigV1):
                     "`accelerator_type` must be specified in ScalingConfig when "
                     "`use_tpu=True` and `num_workers` > 1."
                 )
-            if self.bundle_label_selector:
+            if self.label_selector:
                 raise ValueError(
-                    "Cannot set `bundle_label_selector` when `use_tpu=True` because "
+                    "Cannot set `label_selector` when `use_tpu=True` because "
                     "Ray Train automatically reserves a TPU slice with a predefined label."
                 )
 
         if (
-            isinstance(self.bundle_label_selector, list)
+            isinstance(self.label_selector, list)
             and isinstance(self.num_workers, int)
-            and len(self.bundle_label_selector) != self.num_workers
+            and len(self.label_selector) != self.num_workers
         ):
             raise ValueError(
-                "If `bundle_label_selector` is a list, it must be the same length as `num_workers`."
+                "If `label_selector` is a list, it must be the same length as `num_workers`."
             )
 
         if self.num_workers == 0:

--- a/python/ray/train/v2/tests/test_config.py
+++ b/python/ray/train/v2/tests/test_config.py
@@ -17,11 +17,9 @@ def test_scaling_config_validation():
 
     with pytest.raises(
         ValueError,
-        match="If `bundle_label_selector` is a list, it must be the same length as `num_workers`",
+        match="If `label_selector` is a list, it must be the same length as `num_workers`",
     ):
-        ScalingConfig(
-            num_workers=2, bundle_label_selector=[{"subcluster": "my_subcluster"}]
-        )
+        ScalingConfig(num_workers=2, label_selector=[{"subcluster": "my_subcluster"}])
 
 
 def test_scaling_config_accelerator_type():

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -146,14 +146,14 @@ def test_minimal_multihost(ray_tpu_multi_host, tmp_path):
 
 def test_scaling_config_validation():
     with pytest.raises(
-        ValueError, match="Cannot set `bundle_label_selector` when `use_tpu=True`"
+        ValueError, match="Cannot set `label_selector` when `use_tpu=True`"
     ):
         ScalingConfig(
             num_workers=2,
             use_tpu=True,
             topology="2x2x2",
             accelerator_type="TPU-V4",
-            bundle_label_selector={"subcluster": "my_subcluster"},
+            label_selector={"subcluster": "my_subcluster"},
         )
 
 

--- a/python/ray/train/v2/tests/test_scheduling.py
+++ b/python/ray/train/v2/tests/test_scheduling.py
@@ -90,7 +90,7 @@ def test_infeasible_placement_strategy(
 
 
 @pytest.mark.parametrize(
-    "bundle_label_selector, expected_subcluster_counts",
+    "label_selector, expected_subcluster_counts",
     [
         ({"subcluster": "my_subcluster"}, {"my_subcluster": 2}),
         (
@@ -103,8 +103,8 @@ def test_infeasible_placement_strategy(
         ),
     ],
 )
-def test_bundle_label_selector(
-    multi_cpu_node_labeled_cluster, bundle_label_selector, expected_subcluster_counts
+def test_label_selector(
+    multi_cpu_node_labeled_cluster, label_selector, expected_subcluster_counts
 ):
     @ray.remote
     class Counter:
@@ -120,7 +120,7 @@ def test_bundle_label_selector(
     counter = Counter.remote()
     scaling_config = ScalingConfig(
         num_workers=2,
-        bundle_label_selector=bundle_label_selector,
+        label_selector=label_selector,
     )
 
     def train_fn():


### PR DESCRIPTION
## Description
Rename `ScalingConfig.bundle_label_selector` to `ScalingConfig.label_selector` for a cleaner API.

This matches the `@ray.remote` API, as opposed to the `PlacementGroup` API which uses `bundle_label_selector`.

## Related issues

API was introduced in https://github.com/ray-project/ray/pull/58845.

## Additional information

This change is technically backwards incompatible, but `bundle_label_selector` was just introduced and not part of any minor version releases yet.

Also made the same changes to `WorkerGroupContext`, and renamed local variables in `TrainController` and `TPUReservationCallback`