### PR TITLE
[serve] Promoted DeploymentID from private to public API

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -88,6 +88,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
    serve.config.AutoscalingContext
    serve.config.AggregationFunction
    serve.config.RequestRouterConfig
+   serve.config.DeploymentID
 ```
 
 ### Schemas

--- a/doc/source/serve/doc_code/autoscaling_policy.py
+++ b/doc/source/serve/doc_code/autoscaling_policy.py
@@ -92,8 +92,7 @@ def coordinated_scaling_policy(
 
 # __begin_stateful_application_level_policy__
 from typing import Dict, Tuple, Any
-from ray.serve.config import AutoscalingContext
-from ray.serve.config import DeploymentID
+from ray.serve.config import AutoscalingContext, DeploymentID
 
 def stateful_application_level_policy(
     contexts: Dict[DeploymentID, AutoscalingContext]

--- a/doc/source/serve/doc_code/autoscaling_policy.py
+++ b/doc/source/serve/doc_code/autoscaling_policy.py
@@ -51,10 +51,7 @@ def custom_metrics_autoscaling_policy(
 
 # __begin_application_level_autoscaling_policy__
 from typing import Dict, Tuple
-from ray.serve.config import AutoscalingContext
-
-from ray.serve._private.common import DeploymentID
-from ray.serve.config import AutoscalingContext
+from ray.serve.config import AutoscalingContext, DeploymentID
 
 
 def coordinated_scaling_policy(
@@ -96,7 +93,7 @@ def coordinated_scaling_policy(
 # __begin_stateful_application_level_policy__
 from typing import Dict, Tuple, Any
 from ray.serve.config import AutoscalingContext
-from ray.serve._private.common import DeploymentID
+from ray.serve.config import DeploymentID
 
 def stateful_application_level_policy(
     contexts: Dict[DeploymentID, AutoscalingContext]

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -20,6 +20,7 @@ from ray.util.annotations import PublicAPI
 REPLICA_ID_FULL_ID_STR_PREFIX = "SERVE_REPLICA::"
 
 
+@PublicAPI(stability="alpha")
 @dataclass(frozen=True)
 class DeploymentID:
     name: str

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -7,8 +7,9 @@ from starlette.types import Scope
 
 import ray
 from ray.actor import ActorHandle
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
+from ray.serve._private.constants import SERVE_NAMESPACE
 from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
+from ray.serve.common import DeploymentID
 from ray.serve.generated.serve_pb2 import (
     DeploymentStatus as DeploymentStatusProto,
     DeploymentStatusInfo as DeploymentStatusInfoProto,
@@ -18,22 +19,6 @@ from ray.serve.grpc_util import RayServegRPCContext
 from ray.util.annotations import PublicAPI
 
 REPLICA_ID_FULL_ID_STR_PREFIX = "SERVE_REPLICA::"
-
-
-@PublicAPI(stability="alpha")
-@dataclass(frozen=True)
-class DeploymentID:
-    name: str
-    app_name: str = SERVE_DEFAULT_APP_NAME
-
-    def to_replica_actor_class_name(self):
-        return f"ServeReplica:{self.app_name}:{self.name}"
-
-    def __str__(self):
-        return f"Deployment(name='{self.name}', app='{self.app_name}')"
-
-    def __repr__(self):
-        return str(self)
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/serve/_private/deploy_utils.py
+++ b/python/ray/serve/_private/deploy_utils.py
@@ -6,10 +6,10 @@ from typing import Any, Dict, Optional, Union
 
 import ray
 import ray.util.serialization_addons
-from ray.serve._private.common import DeploymentID
 from ray.serve._private.config import DeploymentConfig, ReplicaConfig
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.deployment_info import DeploymentInfo
+from ray.serve.common import DeploymentID
 from ray.serve.schema import ServeApplicationSchema
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)

--- a/python/ray/serve/_private/endpoint_state.py
+++ b/python/ray/serve/_private/endpoint_state.py
@@ -2,10 +2,11 @@ import logging
 from typing import Any, Dict, Optional
 
 from ray import cloudpickle
-from ray.serve._private.common import DeploymentID, EndpointInfo
+from ray.serve._private.common import EndpointInfo
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.long_poll import LongPollHost, LongPollNamespace
 from ray.serve._private.storage.kv_store import KVStoreBase
+from ray.serve.common import DeploymentID
 
 CHECKPOINT_KEY = "serve-endpoint-state-checkpoint"
 

--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Coroutine, Dict, Optional, Tuple, Union
 
 import ray
 from ray import cloudpickle
-from ray.serve._private.common import DeploymentID, RequestMetadata
+from ray.serve._private.common import RequestMetadata
 from ray.serve._private.constants import (
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
     SERVE_LOGGER_NAME,
@@ -18,6 +18,7 @@ from ray.serve._private.replica import UserCallableWrapper
 from ray.serve._private.replica_result import ReplicaResult
 from ray.serve._private.router import Router
 from ray.serve._private.utils import GENERATOR_COMPOSITION_NOT_SUPPORTED_ERROR
+from ray.serve.common import DeploymentID
 from ray.serve.deployment import Deployment
 from ray.serve.exceptions import RequestCancelledError
 from ray.serve.handle import (

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -6,12 +6,13 @@ from starlette.requests import Request
 from starlette.routing import Route
 from starlette.types import Scope
 
-from ray.serve._private.common import ApplicationName, DeploymentID, EndpointInfo
+from ray.serve._private.common import ApplicationName, EndpointInfo
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.thirdparty.get_asgi_route_name import (
     RoutePattern,
     get_asgi_route_name,
 )
+from ray.serve.common import DeploymentID
 from ray.serve.handle import DeploymentHandle
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)

--- a/python/ray/serve/common.py
+++ b/python/ray/serve/common.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="alpha")
+@dataclass(frozen=True)
+class DeploymentID:
+    name: str
+    app_name: str = "default"
+
+    def to_replica_actor_class_name(self):
+        return f"ServeReplica:{self.app_name}:{self.name}"
+
+    def __str__(self):
+        return f"Deployment(name='{self.name}', app='{self.app_name}')"
+
+    def __repr__(self):
+        return str(self)

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -19,7 +19,7 @@ from ray._common.pydantic_compat import (
 from ray._common.utils import import_attr, import_module_and_attr
 
 # Import types needed for AutoscalingContext
-from ray.serve._private.common import DeploymentID, ReplicaID, TimeSeries
+from ray.serve._private.common import ReplicaID, TimeSeries
 from ray.serve._private.constants import (
     DEFAULT_AUTOSCALING_POLICY_NAME,
     DEFAULT_GRPC_PORT,
@@ -33,6 +33,7 @@ from ray.serve._private.constants import (
     SERVE_LOGGER_NAME,
 )
 from ray.serve._private.utils import validate_ssl_config
+from ray.serve.common import DeploymentID
 from ray.util.annotations import Deprecated, PublicAPI
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -13,7 +13,7 @@ from typing import Callable, Dict, List, Optional
 import ray
 from ray.exceptions import RayActorError
 from ray.serve._private.client import ServeControllerClient
-from ray.serve._private.common import DeploymentID, ReplicaID
+from ray.serve._private.common import ReplicaID
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     SERVE_CONTROLLER_NAME,
@@ -21,6 +21,7 @@ from ray.serve._private.constants import (
     SERVE_NAMESPACE,
 )
 from ray.serve._private.replica_result import ReplicaResult
+from ray.serve.common import DeploymentID
 from ray.serve.exceptions import RayServeException
 from ray.serve.grpc_util import RayServegRPCContext
 from ray.serve.schema import ReplicaRank

--- a/python/ray/serve/exceptions.py
+++ b/python/ray/serve/exceptions.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from ray.exceptions import TaskCancelledError
-from ray.serve._private.common import DeploymentID
+from ray.serve.common import DeploymentID
 from ray.util.annotations import PublicAPI
 
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -11,7 +11,6 @@ from ray._raylet import ObjectRefGenerator
 from ray.serve._private.common import (
     OBJ_REF_NOT_SUPPORTED_ERROR,
     DeploymentHandleSource,
-    DeploymentID,
     RequestMetadata,
 )
 from ray.serve._private.constants import SERVE_LOGGER_NAME
@@ -35,6 +34,7 @@ from ray.serve._private.utils import (
     inside_ray_client_context,
     is_running_in_asyncio_loop,
 )
+from ray.serve.common import DeploymentID
 from ray.serve.exceptions import RayServeException, RequestCancelledError
 from ray.util import metrics
 from ray.util.annotations import DeveloperAPI, PublicAPI


### PR DESCRIPTION
## Description
Created a new file `ray/serve/common.py` and moved the definition for `DeploymentID`.
Promotes DeploymentID to public API type for Ray Serve by marking it `@PublicAPI(stability="alpha")`, exposing it via `ray.serve.config`, and wiring it into the Serve API docs.
## Related issues
Fixes #58624

