### PR TITLE
[docs/data] Add `download` to key user journeys in documentation

### DIFF
--- a/doc/source/data/benchmark.md
+++ b/doc/source/data/benchmark.md
@@ -60,7 +60,7 @@ All benchmark results are taken from an average/std across 4 runs. A warmup was 
     - Code
 -   - **Image Classification**
     - 800k images from ImageNet
-    - s3://ray-example-data/imagenet/metadata_file
+    - s3://ray-example-data/imagenet/metadata_file.parquet
     - 1 head / 8 workers of varying instance types
     - [Link](https://github.com/ray-project/ray/tree/master/release/nightly_tests/multimodal_inference_benchmarks/image_classification)
 -   - **Document Embedding**

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -354,7 +354,7 @@ The following example shows how to download a batch of images from URLs listed i
     from ray.data.expressions import col, download
 
     # Read a Parquet file containing a column of image URLs
-    ds = ray.data.read_parquet("s3://anonymous@ray-example-data/imagenet/metadata_file")
+    ds = ray.data.read_parquet("s3://anonymous@ray-example-data/imagenet/metadata_file.parquet")
 
     # Use `with_column` and `download` to download the images in parallel.
     # This creates a new column 'bytes' with the downloaded file contents.

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -351,7 +351,7 @@ The following example shows how to download a batch of images from URLs listed i
 .. testcode::
 
     import ray
-    from ray.data.expressions import col, download
+    from ray.data.expressions import download
 
     # Read a Parquet file containing a column of image URLs
     ds = ray.data.read_parquet("s3://anonymous@ray-example-data/imagenet/metadata_file.parquet")

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -344,7 +344,7 @@ Downloading files from URIs
 
 Sometimes you may have a metadata table with a column of URIs and you want to download the files referenced by the URIs.
 
-You can download data in bulk by leveraging the :func:`~ray.data.with_column` method together with the :func:`~ray.data.expressions.download` expression. This approach lets the system handle the parallel downloading of files referenced by URLs in your dataset, without needing to manage async code within your own transformations.
+You can download data in bulk by leveraging the :func:`~ray.data.Dataset.with_column` method together with the :func:`~ray.data.expressions.download` expression. This approach lets the system handle the parallel downloading of files referenced by URLs in your dataset, without needing to manage async code within your own transformations.
 
 The following example shows how to download a batch of images from URLs listed in a Parquet file:
 

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -338,6 +338,33 @@ You can use any `codec supported by Arrow <https://arrow.apache.org/docs/python/
         arrow_open_stream_args={"compression": "gzip"},
     )
 
+
+Downloading files from URIs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you may have a metadata table with a column of URIs and you want to download the files referenced by the URIs.
+
+You can download data in bulk by leveraging the :func:`~ray.data.with_column` method together with the :func:`~ray.data.expressions.download` expression. This approach lets the system handle the parallel downloading of files referenced by URLs in your dataset, without needing to manage async code within your own transformations.
+
+The following example shows how to download a batch of images from URLs listed in a Parquet file:
+
+.. testcode::
+
+    import ray
+    from ray.data.expressions import col, download
+
+    # Read a Parquet file containing a column of image URLs
+    ds = ray.data.read_parquet("s3://anonymous@ray-example-data/imagenet/metadata_file")
+
+    # Use `with_column` and `download` to download the images in parallel.
+    # This creates a new column 'bytes' with the downloaded file contents.
+    ds = ds.with_column(
+        "bytes",
+        download("image_url"),
+    )
+
+    ds.take(1)
+
 Loading data from other libraries
 =================================
 

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -58,7 +58,7 @@ To view the full list of supported file formats, see the
             import ray
             from ray.data.expressions import col, download
 
-            ds = ray.data.read_parquet("s3://anonymous@ray-example-data/imagenet/metadata_file")
+            ds = ray.data.read_parquet("s3://anonymous@ray-example-data/imagenet/metadata_file.parquet")
             ds = ds.with_column("bytes", download("image_url"))
 
             print(ds.schema())

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -49,6 +49,27 @@ To view the full list of supported file formats, see the
             ------  ----
             image   ArrowTensorTypeV2(shape=(32, 32, 3), dtype=uint8)
 
+    .. tab-item:: Images from Dataset of URIs
+
+        To load images from a dataset of URIs, use the :func:`~ray.data.with_column` method together with the :func:`~ray.data.expressions.download` expression.
+
+        .. testcode::
+
+            import ray
+            from ray.data.expressions import col, download
+
+            ds = ray.data.read_parquet("s3://anonymous@ray-example-data/imagenet/metadata_file")
+            ds = ds.with_column("bytes", download("image_url"))
+
+            print(ds.schema())
+
+        .. testoutput::
+
+            Column  Type
+            ------  ----
+            bytes   binary
+            image_url string
+
     .. tab-item:: NumPy
 
         To load images stored in NumPy format, call :func:`~ray.data.read_numpy`.

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -51,7 +51,7 @@ To view the full list of supported file formats, see the
 
     .. tab-item:: Images from Dataset of URIs
 
-        To load images from a dataset of URIs, use the :func:`~ray.data.with_column` method together with the :func:`~ray.data.expressions.download` expression.
+        To load images from a dataset of URIs, use the :func:`~ray.data.Dataset.with_column` method together with the :func:`~ray.data.expressions.download` expression.
 
         .. testcode::
 
@@ -67,8 +67,8 @@ To view the full list of supported file formats, see the
 
             Column  Type
             ------  ----
-            bytes   binary
             image_url string
+            bytes   null
 
     .. tab-item:: NumPy
 

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -65,10 +65,10 @@ To view the full list of supported file formats, see the
 
         .. testoutput::
 
-            Column  Type
-            ------  ----
+            Column    Type
+            ------    ----
             image_url string
-            bytes   null
+            bytes     null
 
     .. tab-item:: NumPy
 

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -56,7 +56,7 @@ To view the full list of supported file formats, see the
         .. testcode::
 
             import ray
-            from ray.data.expressions import col, download
+            from ray.data.expressions import download
 
             ds = ray.data.read_parquet("s3://anonymous@ray-example-data/imagenet/metadata_file.parquet")
             ds = ds.with_column("bytes", download("image_url"))

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -65,10 +65,10 @@ To view the full list of supported file formats, see the
 
         .. testoutput::
 
-            Column    Type
-            ------    ----
-            image_url string
-            bytes     null
+            Column     Type
+            ------     ----
+            image_url  string
+            bytes      null
 
     .. tab-item:: NumPy
 

--- a/release/nightly_tests/multimodal_inference_benchmarks/image_classification/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/image_classification/ray_data_main.py
@@ -14,7 +14,7 @@ import ray
 
 
 NUM_GPU_NODES = 8
-INPUT_PATH = "s3://anonymous@ray-example-data/imagenet/metadata_file"
+INPUT_PATH = "s3://anonymous@ray-example-data/imagenet/metadata_file.parquet"
 OUTPUT_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
 BATCH_SIZE = 100
 


### PR DESCRIPTION
Shows users how to use `download` to download from URI tables.