### PR TITLE
Fix broken tuned_examples links in RLlib docs

### DIFF
--- a/doc/source/rllib/index.rst
+++ b/doc/source/rllib/index.rst
@@ -299,7 +299,7 @@ Why chose RLlib?
     **Ray.Data** has been integrated into RLlib, enabling **large-scale data ingestion** for offline RL and behavior
     cloning (BC) workloads.
 
-    See here for a basic `tuned example for the behavior cloning algo <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/bc/cartpole_bc.py>`__
+    See here for a basic `tuned example for the behavior cloning algo <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/bc/cartpole_bc.py>`__
     and here for how to `pre-train a policy with BC, then finetuning it with online PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/offline_rl/train_w_bc_finetune_w_ppo.py>`__.
 
 .. dropdown:: **Support for External Env Clients**

--- a/doc/source/rllib/index.rst
+++ b/doc/source/rllib/index.rst
@@ -300,7 +300,7 @@ Why chose RLlib?
     cloning (BC) workloads.
 
     See here for a basic `tuned example for the behavior cloning algo <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/bc/cartpole_bc.py>`__
-    and here for how to `pre-train a policy with BC, then finetuning it with online PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/offline_rl/train_w_bc_finetune_w_ppo.py>`__.
+    and here for how to `pre-train a policy with BC, then finetuning it with online PPO <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/examples/offline_rl/train_w_bc_finetune_w_ppo.py>`__.
 
 .. dropdown:: **Support for External Env Clients**
     :animate: fade-in-slide-down

--- a/doc/source/rllib/learner-connector.rst
+++ b/doc/source/rllib/learner-connector.rst
@@ -243,7 +243,7 @@ you have to apply the stacking logic twice (in the :ref:`env-to-module pipeline 
 The following is an example for implementing such a frame-stacking mechanism using
 the :py:class:`~ray.rllib.connectors.connector_v2.ConnectorV2` APIs with an RL environment, in which observations are plain 1D tensors.
 
-See here for a `more complex end-to-end Atari example for PPO <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/atari_ppo.py>`__.
+See here for a `more complex end-to-end Atari example for PPO <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/ppo/atari_ppo.py>`__.
 
 You can write a single :py:class:`~ray.rllib.connectors.connector_v2.ConnectorV2` class to cover both the env-to-module as well as
 the Learner custom connector part:

--- a/doc/source/rllib/new-api-stack-migration-guide.rst
+++ b/doc/source/rllib/new-api-stack-migration-guide.rst
@@ -277,7 +277,8 @@ AlgorithmConfig.env_runners()
 
     If you want to IDE-debug what's going on inside your `EnvRunners`, set `num_env_runners=0`
     and make sure you are running your experiment locally and not through Ray Tune.
-    In order to do this with any of RLlib's `example <https://github.com/ray-project/ray/tree/master/rllib/examples>`__
+    In order to do this with any of RLlib's
+    `example <https://github.com/ray-project/ray/tree/ray-2.52.1/rllib/examples>`__
     or `tuned_example <https://github.com/ray-project/ray/tree/ray-2.52.1/rllib/tuned_examples>`__ scripts,
     simply set the command line args: `--no-tune --num-env-runners=0`.
 

--- a/doc/source/rllib/new-api-stack-migration-guide.rst
+++ b/doc/source/rllib/new-api-stack-migration-guide.rst
@@ -278,7 +278,7 @@ AlgorithmConfig.env_runners()
     If you want to IDE-debug what's going on inside your `EnvRunners`, set `num_env_runners=0`
     and make sure you are running your experiment locally and not through Ray Tune.
     In order to do this with any of RLlib's
-    `example <https://github.com/ray-project/ray/tree/ray-2.52.1/rllib/examples>`__
+    `example <https://github.com/ray-project/ray/tree/master/rllib/examples>`__
     or `tuned_example <https://github.com/ray-project/ray/tree/ray-2.52.1/rllib/tuned_examples>`__ scripts,
     simply set the command line args: `--no-tune --num-env-runners=0`.
 

--- a/doc/source/rllib/new-api-stack-migration-guide.rst
+++ b/doc/source/rllib/new-api-stack-migration-guide.rst
@@ -278,7 +278,7 @@ AlgorithmConfig.env_runners()
     If you want to IDE-debug what's going on inside your `EnvRunners`, set `num_env_runners=0`
     and make sure you are running your experiment locally and not through Ray Tune.
     In order to do this with any of RLlib's `example <https://github.com/ray-project/ray/tree/master/rllib/examples>`__
-    or `tuned_example <https://github.com/ray-project/ray/tree/master/rllib/tuned_examples>`__ scripts,
+    or `tuned_example <https://github.com/ray-project/ray/tree/ray-2.52.1/rllib/tuned_examples>`__ scripts,
     simply set the command line args: `--no-tune --num-env-runners=0`.
 
 In case you were using the `observation_filter` setting, perform the following translations:

--- a/doc/source/rllib/rl-modules.rst
+++ b/doc/source/rllib/rl-modules.rst
@@ -213,7 +213,7 @@ see :py:class:`~ray.rllib.core.rl_module.default_model_config.DefaultModelConfig
     ``DefaultModelConfig.use_lstm`` setting in combination with the
     ``DefaultModelConfig.lstm_cell_size`` and ``DefaultModelConfig.max_seq_len`` settings.
     See here for a tuned
-    `example that uses a default RLModule with an LSTM layer <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/stateless_cartpole_ppo.py>`__.
+    `example that uses a default RLModule with an LSTM layer <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/ppo/stateless_cartpole_ppo.py>`__.
 
 .. TODO: mention attention example once done
 

--- a/doc/source/rllib/rllib-algorithms.rst
+++ b/doc/source/rllib/rllib-algorithms.rst
@@ -74,9 +74,9 @@ Proximal Policy Optimization (PPO)
 
 
 **Tuned examples:**
-`Pong-v5 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/atari_ppo.py>`__,
-`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/cartpole_ppo.py>`__.
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/pendulum_ppo.py>`__.
+`Pong-v5 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/ppo/atari_ppo.py>`__,
+`CartPole-v1 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/ppo/cartpole_ppo.py>`__.
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/ppo/pendulum_ppo.py>`__.
 
 
 **PPO-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
@@ -111,11 +111,11 @@ All of the DQN improvements evaluated in `Rainbow <https://arxiv.org/abs/1710.02
 See also how to use `parametric-actions in DQN <rllib-models.html#variable-length-parametric-action-spaces>`__.
 
 **Tuned examples:**
-`PongDeterministic-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/pong-dqn.yaml>`__,
-`Rainbow configuration <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/pong-rainbow.yaml>`__,
-`{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/atari-dqn.yaml>`__,
-`with Dueling and Double-Q <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/atari-duel-ddqn.yaml>`__,
-`with Distributional DQN <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/atari-dist-dqn.yaml>`__.
+`PongDeterministic-v4 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/dqn/pong-dqn.yaml>`__,
+`Rainbow configuration <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/dqn/pong-rainbow.yaml>`__,
+`{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/dqn/atari-dqn.yaml>`__,
+`with Dueling and Double-Q <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/dqn/atari-duel-ddqn.yaml>`__,
+`with Distributional DQN <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/dqn/atari-dist-dqn.yaml>`__.
 
 .. hint::
     For a complete `rainbow <https://arxiv.org/pdf/1710.02298.pdf>`__ setup,
@@ -154,8 +154,8 @@ Soft Actor Critic (SAC)
 
 
 **Tuned examples:**
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/sac/pendulum-sac.yaml>`__,
-`HalfCheetah-v3 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/sac/halfcheetah_sac.py>`__,
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/sac/pendulum-sac.yaml>`__,
+`HalfCheetah-v3 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/sac/halfcheetah_sac.py>`__,
 
 **SAC-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -195,8 +195,8 @@ Asynchronous Proximal Policy Optimization (APPO)
 
 
 **Tuned examples:**
-`Pong-v5 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/appo/pong_appo.py>`__
-`HalfCheetah-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/appo/halfcheetah_appo.py>`__
+`Pong-v5 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/appo/pong_appo.py>`__
+`HalfCheetah-v4 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/appo/halfcheetah_appo.py>`__
 
 **APPO-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -226,10 +226,10 @@ Importance Weighted Actor-Learner Architecture (IMPALA)
 
 
 Tuned examples:
-`PongNoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/impala/pong-impala.yaml>`__,
-`vectorized configuration <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/impala/pong-impala-vectorized.yaml>`__,
-`multi-gpu configuration <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/impala/pong-impala-fast.yaml>`__,
-`{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/impala/atari-impala.yaml>`__.
+`PongNoFrameskip-v4 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/impala/pong-impala.yaml>`__,
+`vectorized configuration <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/impala/pong-impala-vectorized.yaml>`__,
+`multi-gpu configuration <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/impala/pong-impala-fast.yaml>`__,
+`{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/impala/atari-impala.yaml>`__.
 
 .. figure:: images/impala.png
     :width: 650
@@ -274,9 +274,9 @@ Also see `this README here for more details on how to run experiments <https://g
 
 
 **Tuned examples:**
-`Atari 100k <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dreamerv3/atari_100k_dreamerv3.py>`__,
-`Atari 200M <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dreamerv3/atari_200M_dreamerv3.py>`__,
-`DeepMind Control Suite <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dreamerv3/dm_control_suite_vision_dreamerv3.py>`__
+`Atari 100k <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/dreamerv3/atari_100k_dreamerv3.py>`__,
+`Atari 200M <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/dreamerv3/atari_200M_dreamerv3.py>`__,
+`DeepMind Control Suite <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/dreamerv3/dm_control_suite_vision_dreamerv3.py>`__
 
 
 **Pong-v5 results (1, 2, and 4 GPUs)**:
@@ -332,8 +332,8 @@ Behavior Cloning (BC)
     BC try to match the behavior policy, which generated the offline data, disregarding any resulting rewards.
 
 **Tuned examples:**
-`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/bc/cartpole_bc.py>`__
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/bc/pendulum_bc.py>`__
+`CartPole-v1 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/bc/cartpole_bc.py>`__
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/bc/pendulum_bc.py>`__
 
 **BC-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -359,7 +359,7 @@ Conservative Q-Learning (CQL)
 
 
 **Tuned examples:**
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/cql/pendulum_cql.py>`__
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/cql/pendulum_cql.py>`__
 
 **CQL-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -384,7 +384,7 @@ Implicit Q-Learning (IQL)
     high-advantage actions—enabling substantial performance gains over the behavior policy using only in-dataset actions.
 
 **Tuned examples:**
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/iql/pendulum_iql.py>`__
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/iql/pendulum_iql.py>`__
 
 **IQL-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -411,7 +411,7 @@ Monotonic Advantage Re-Weighted Imitation Learning (MARWIL)
 
 
 **Tuned examples:**
-`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/marwil/cartpole_marwil.py>`__
+`CartPole-v1 <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/marwil/cartpole_marwil.py>`__
 
 **MARWIL-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 

--- a/doc/source/rllib/rllib-dev.rst
+++ b/doc/source/rllib/rllib-dev.rst
@@ -56,7 +56,7 @@ or as a fully-integrated RLlib Algorithm in `rllib/algorithms <https://github.co
     - must offer substantial new functionality not possible to add to other algorithms
     - should support custom RLModules
     - should use RLlib abstractions and support distributed execution
-    - should include at least one `tuned hyperparameter example <https://github.com/ray-project/ray/tree/master/rllib/tuned_examples>`__, testing of which is part of the CI
+    - should include at least one `tuned hyperparameter example <https://github.com/ray-project/ray/tree/ray-2.52.1/rllib/tuned_examples>`__, testing of which is part of the CI
 
 Both integrated and contributed algorithms ship with the ``ray`` PyPI package, and are tested as part of Ray's automated tests.
 
@@ -92,7 +92,7 @@ Benchmarks
 ==========
 
 A number of training run results are available in the `rl-experiments repo <https://github.com/ray-project/rl-experiments>`__,
-and there is also a list of working hyperparameter configurations in `tuned_examples <https://github.com/ray-project/ray/tree/master/rllib/tuned_examples>`__, sorted by algorithm.
+and there is also a list of working hyperparameter configurations in `tuned_examples <https://github.com/ray-project/ray/tree/ray-2.52.1/rllib/tuned_examples>`__, sorted by algorithm.
 Benchmark results are extremely valuable to the community, so if you happen to have results that may be of interest, consider making a pull request to either repo.
 
 

--- a/doc/source/rllib/rllib-examples.rst
+++ b/doc/source/rllib/rllib-examples.rst
@@ -363,7 +363,7 @@ Multi-agent RL
    Uses OpenSpiel to demonstrate league-based self-play, where agents play against various
    versions of themselves, frozen or in-training, to improve through competitive interaction.
 
-- `Self-play with Footsies and PPO algorithm <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/multi_agent_footsies_ppo.py>`__:
+- `Self-play with Footsies and PPO algorithm <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/ppo/multi_agent_footsies_ppo.py>`__:
     Implements self-play with the Footsies environment (two player zero-sum game).
     This example highlights RLlib's capabilities in connecting to the external binaries running the game engine, as well as
     setting up a multi-agent self-play training scenario.
@@ -442,21 +442,26 @@ RLModules
 Tuned examples
 --------------
 
-The `tuned examples <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples>`__ folder
+The `tuned examples <https://github.com/ray-project/ray/tree/ray-2.52.1/rllib/tuned_examples>`__ folder
 contains python config files that you can execute analogously to all other example scripts described
 here to run tuned learning experiments for the different algorithms and environment types.
 
-For example, see this `tuned Atari example for PPO <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/atari_ppo.py>`__,
+.. note::
+    The ``rllib/tuned_examples`` directory is not present on the ``master`` branch.
+    These tuned examples are available in release tags such as ``ray-2.52.1``.
+
+For example, see this
+`tuned Atari example for PPO <https://github.com/ray-project/ray/blob/ray-2.52.1/rllib/tuned_examples/ppo/atari_ppo.py>`__,
 which learns to solve the Pong environment in roughly 5 minutes. You can run it as follows on a single
 g5.24xlarge or g6.24xlarge machine with 4 GPUs and 96 CPUs:
 
 .. code-block:: bash
 
-    $ cd ray/rllib/tuned_examples/ppo
-    $ python atari_ppo.py --env=ale_py:ALE/Pong-v5 --num-learners=4 --num-env-runners=95
+    git checkout ray-2.52.1
+    cd rllib/tuned_examples/ppo
+    python atari_ppo.py --env=ale_py:ALE/Pong-v5 --num-learners=4 --num-env-runners=95
 
 Note that RLlib's daily or weekly release tests use some of the files in this folder as well.
-
 
 Community examples
 ------------------


### PR DESCRIPTION
Fixes #59400

The rllib/tuned_examples directory no longer exists on the master branch, causing multiple RLlib documentation links to return 404 errors.

**What this PR does**

- Updates all tuned_examples links to point to the ray-2.52.1 release tag, where the directory exists

- Keeps rllib/examples links on master, since that directory is present and actively evolving

- Adds a short note in the docs clarifying that tuned_examples live in release tags (not master)

- Clarifies the required checkout steps when running tuned examples

**Why this is correct**

- rllib/tuned_examples is used by CI and reference configs but is not part of master

- Pinning to a release tag prevents link rot while preserving reproducibility

- rllib/examples should continue to track master
