### PR TITLE
[Core] Add authentication token to c++ opentelemetry_metrics_recorder grpc calls

### DIFF
--- a/python/ray/tests/test_token_auth_integration.py
+++ b/python/ray/tests/test_token_auth_integration.py
@@ -9,7 +9,13 @@ from typing import Optional
 import pytest
 
 import ray
-from ray._private.test_utils import client_test_enabled, wait_for_condition
+from ray._common.network_utils import build_address
+from ray._private.test_utils import (
+    PrometheusTimeseries,
+    client_test_enabled,
+    fetch_prometheus_timeseries,
+    wait_for_condition,
+)
 
 try:
     from ray._raylet import AuthenticationTokenLoader
@@ -631,6 +637,59 @@ def test_no_token_with_auth_enabled_returns_false():
         # has_token(ignore_auth_mode=True) should return False, not raise an exception
         result = token_loader.has_token(ignore_auth_mode=True)
         assert result is False
+
+
+@pytest.mark.skipif(
+    client_test_enabled(),
+    reason="no benefit testing this in client mode",
+)
+def test_opentelemetry_metrics_with_token_auth(setup_cluster_with_token_auth):
+    """Test that OpenTelemetry metrics are exported with token authentication.
+
+    This test verifies that the C++ OpenTelemetryMetricRecorder correctly includes
+    the authentication token in its gRPC metadata when exporting metrics to the
+    metrics agent. If the auth headers are missing or incorrect, the metrics agent
+    would reject the requests and metrics wouldn't be collected.
+    """
+
+    cluster_info = setup_cluster_with_token_auth
+    cluster = cluster_info["cluster"]
+
+    # Get the metrics export address from the head node
+    head_node = cluster.head_node
+    prom_addresses = [
+        build_address(head_node.node_ip_address, head_node.metrics_export_port)
+    ]
+
+    timeseries = PrometheusTimeseries()
+
+    def verify_metrics_collected():
+        """Verify that metrics are being exported successfully."""
+        fetch_prometheus_timeseries(prom_addresses, timeseries)
+        metric_names = list(timeseries.metric_descriptors.keys())
+
+        # Check for core Ray metrics that are always exported
+        # These metrics are exported via the C++ OpenTelemetry recorder
+        expected_metrics = [
+            "ray_node_cpu_utilization",
+            "ray_node_mem_used",
+            "ray_node_disk_usage",
+        ]
+
+        # At least some metrics should be present
+        return len(metric_names) > 0 and any(
+            any(expected in name for name in metric_names)
+            for expected in expected_metrics
+        )
+
+    # Wait for metrics to be collected
+    # If auth wasn't working, the metrics agent would reject the exports
+    # and we wouldn't see any metrics
+    wait_for_condition(verify_metrics_collected, retry_interval_ms=1000)
+
+    # Verify we have actual metric data
+    metric_names = list(timeseries.metric_descriptors.keys())
+    assert len(metric_names) > 0, "Expected metrics to be collected with token auth"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_token_auth_integration.py
+++ b/python/ray/tests/test_token_auth_integration.py
@@ -687,10 +687,6 @@ def test_opentelemetry_metrics_with_token_auth(setup_cluster_with_token_auth):
     # and we wouldn't see any metrics
     wait_for_condition(verify_metrics_collected, retry_interval_ms=1000)
 
-    # Verify we have actual metric data
-    metric_names = list(timeseries.metric_descriptors.keys())
-    assert len(metric_names) > 0, "Expected metrics to be collected with token auth"
-
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-vv", __file__]))

--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -9,7 +9,10 @@ ray_cc_library(
         "open_telemetry_metric_recorder.h",
     ],
     deps = [
+        "//src/ray/common:constants",
         "//src/ray/common:ray_config",
+        "//src/ray/rpc/authentication:authentication_mode",
+        "//src/ray/rpc/authentication:authentication_token_loader",
         "//src/ray/util:logging",
         "@com_google_absl//absl/container:flat_hash_map",
         "@io_opentelemetry_cpp//api",

--- a/src/ray/observability/open_telemetry_metric_recorder.cc
+++ b/src/ray/observability/open_telemetry_metric_recorder.cc
@@ -29,6 +29,9 @@
 #include <cassert>
 #include <utility>
 
+#include "ray/common/constants.h"
+#include "ray/rpc/authentication/authentication_mode.h"
+#include "ray/rpc/authentication/authentication_token_loader.h"
 #include "ray/util/logging.h"
 
 // Anonymous namespace that contains the private callback functions for the
@@ -93,6 +96,14 @@ void OpenTelemetryMetricRecorder::Start(const std::string &endpoint,
   // counting.
   exporter_options.aggregation_temporality =
       opentelemetry::exporter::otlp::PreferredAggregationTemporality::kDelta;
+  // Add authentication token to metadata if auth is enabled
+  if (rpc::RequiresTokenAuthentication()) {
+    auto token = rpc::AuthenticationTokenLoader::instance().GetToken();
+    if (token.has_value() && !token->empty()) {
+      exporter_options.metadata.insert(
+          {std::string(kAuthTokenKey), token->ToAuthorizationHeaderValue()});
+    }
+  }
   auto exporter = std::make_unique<OpenTelemetryMetricExporter>(exporter_options);
 
   // Initialize the OpenTelemetry SDK and create a Meter


### PR DESCRIPTION
## Description
Adds token authentication to OpenTelemetry metric exports. The open telemetry grpc client is created internally within the Opentelemetry sdk and hence does not add the common interceptor automatically hence requiring us to manually include and pass the token header.


fixes https://github.com/ray-project/ray/issues/59361