### PR TITLE
[RLlib] Fix rollout fragment length calculation in AlgorithmConfig

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -4263,10 +4263,10 @@ class AlgorithmConfig(_Config):
                     rollout_fragment_length
                 ) * self.num_envs_per_env_runner * (self.num_env_runners or 1)
                 if ((worker_index - 1) * self.num_envs_per_env_runner) >= diff:
-                    return int(rollout_fragment_length)
+                    return int(rollout_fragment_length) or 1
                 else:
                     return int(rollout_fragment_length) + 1
-            return int(rollout_fragment_length)
+            return int(rollout_fragment_length) or 1
         else:
             return self.rollout_fragment_length
 

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -4239,6 +4239,7 @@ class AlgorithmConfig(_Config):
         If result is a fraction AND `worker_index` is provided, makes
         those workers add additional timesteps, such that the overall batch size (across
         the workers) adds up to exactly the `total_train_batch_size`.
+        Fractions < 1 calculated this way are rounded up to a rollout_fragment_length of 1.
 
         Returns:
             The user-provided `rollout_fragment_length` or a computed one (if user

--- a/rllib/algorithms/tests/test_algorithm_config.py
+++ b/rllib/algorithms/tests/test_algorithm_config.py
@@ -431,6 +431,30 @@ class TestAlgorithmConfig(unittest.TestCase):
             lambda: config.rl_module_spec,
         )
 
+    def test_rollout_fragment_length_with_small_batch_and_multiple_learners(self):
+        """Test that get_rollout_fragment_length doesn't return 0 when train_batch_size=1 and num_learners > 1."""
+        for num_env_runners in [1, 2, 3, 4]:
+            config = (
+                AlgorithmConfig()
+                .env_runners(
+                    rollout_fragment_length="auto",
+                    num_env_runners=num_env_runners,
+                )
+                .learners(
+                    num_learners=2
+                )  # Multiple learners with train_batch_size=1 causes the issue
+                .training(
+                    train_batch_size=1
+                )  # Small batch size with multiple learners causes integer division to 0
+            )
+
+            # This should not return 0
+            rollout_fragment_length = config.get_rollout_fragment_length(0)
+            self.assertEqual(
+                rollout_fragment_length,
+                1,
+            )
+
 
 if __name__ == "__main__":
     import sys

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
     error=False,
 )
 def add_rllib_example_script_args(*args, **kwargs):
-    from ray.rllib.utils.test_utils import add_rllib_example_script_args
+    from ray.rllib.examples.utils import add_rllib_example_script_args
 
     return add_rllib_example_script_args(*args, **kwargs)
 

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -69,7 +69,7 @@ def add_rllib_example_script_args(*args, **kwargs):
     error=False,
 )
 def should_stop(*args, **kwargs):
-    from ray.rllib.utils.test_utils import should_stop
+    from ray.rllib.examples.utils import should_stop
 
     return should_stop(*args, **kwargs)
 
@@ -80,7 +80,7 @@ def should_stop(*args, **kwargs):
     error=False,
 )
 def run_rllib_example_script_experiment(*args, **kwargs):
-    from ray.rllib.utils.test_utils import run_rllib_example_script_experiment
+    from ray.rllib.examples.utils import run_rllib_example_script_experiment
 
     return run_rllib_example_script_experiment(*args, **kwargs)
 


### PR DESCRIPTION
## Description

Rollout fragment length in AlgorithmConfig can be calculated to be zero if num_learners are high enough.
This PR guarantees that rollout fragments are at least of size 1