### PR TITLE
[data][llm] Add video/audio examples for vLLMEngineProcessor

### DIFF
--- a/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
+++ b/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
@@ -53,46 +53,6 @@ from ray.data.llm import (
     TokenizerStageConfig,
     DetokenizeStageConfig,
 )
-from datasets import load_dataset
-from huggingface_hub import hf_hub_download
-
-
-# Download and extract WAV files from MRSAudio dataset
-def download_and_extract_audio_files():
-    """Download MRSAudio dataset and extract WAV files."""
-    dataset_name = "MRSAudio/MRSAudio"
-    dataset = load_dataset(dataset_name, split="train")
-
-    audio_items = []
-
-    # Limit to first 10 samples for the example
-    num_samples = min(10, len(dataset))
-    for i in range(num_samples):
-        item = dataset[i]
-
-        audio_path = hf_hub_download(
-            repo_id=dataset_name, filename=item["path"], repo_type="dataset"
-        )
-
-        with open(audio_path, "rb") as f:
-            audio_bytes = f.read()
-
-        audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
-        audio_items.append(
-            {
-                "audio_data": audio_base64,
-                "text": "Describe this audio.",
-            }
-        )
-
-    return audio_items
-
-
-audio_items = download_and_extract_audio_files()
-
-audio_dataset = (
-    ray.data.from_items(audio_items) if audio_items else ray.data.from_items([])
-)
 
 # __omni_audio_config_example_start__
 audio_processor_config = vLLMEngineProcessorConfig(

--- a/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
+++ b/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
@@ -48,10 +48,6 @@ import ray
 from ray.data.llm import (
     vLLMEngineProcessorConfig,
     build_processor,
-    PrepareMultimodalStageConfig,
-    ChatTemplateStageConfig,
-    TokenizerStageConfig,
-    DetokenizeStageConfig,
 )
 
 # __omni_audio_config_example_start__
@@ -64,13 +60,13 @@ audio_processor_config = vLLMEngineProcessorConfig(
     batch_size=16,
     accelerator_type="L4",
     concurrency=1,
-    prepare_multimodal_stage=PrepareMultimodalStageConfig(
-        enabled=True,
-        chat_template_content_format="openai",
-    ),
-    chat_template_stage=ChatTemplateStageConfig(enabled=True),
-    tokenize_stage=TokenizerStageConfig(enabled=True),
-    detokenize_stage=DetokenizeStageConfig(enabled=True),
+    prepare_multimodal_stage={
+        "enabled": True,
+        "chat_template_content_format": "openai",
+    },
+    chat_template_stage={"enabled": True},
+    tokenize_stage={"enabled": True},
+    detokenize_stage={"enabled": True},
 )
 # __omni_audio_config_example_end__
 
@@ -180,13 +176,13 @@ def create_omni_audio_config():
         batch_size=16,
         accelerator_type="L4",
         concurrency=1,
-        prepare_multimodal_stage=PrepareMultimodalStageConfig(
-            enabled=True,
-            chat_template_content_format="openai",
-        ),
-        chat_template_stage=ChatTemplateStageConfig(enabled=True),
-        tokenize_stage=TokenizerStageConfig(enabled=True),
-        detokenize_stage=DetokenizeStageConfig(enabled=True),
+        prepare_multimodal_stage={
+            "enabled": True,
+            "chat_template_content_format": "openai",
+        },
+        chat_template_stage={"enabled": True},
+        tokenize_stage={"enabled": True},
+        detokenize_stage={"enabled": True},
     )
 
 
@@ -203,8 +199,9 @@ def run_omni_audio_example():
 
         print("Omni audio processor configured successfully")
         print(f"Model: {config.model_source}")
-        print(f"Has multimodal support: {config.prepare_multimodal_stage.enabled}")
+        print(f"Has multimodal support: {config.prepare_multimodal_stage.get('enabled', False)}")
         result = processor(audio_dataset).take_all()
+        print(result)
         return config, processor, result
     # __omni_audio_run_example_end__
     return None, None, None

--- a/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
+++ b/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
@@ -1,0 +1,271 @@
+"""
+This file serves as a documentation example and CI test for VLM batch inference with audio.
+
+Structure:
+1. Infrastructure setup: Dataset compatibility patches, dependency handling
+2. Docs example (between __vlm_audio_example_start/end__): Embedded in Sphinx docs via literalinclude
+3. Test validation and cleanup
+"""
+
+import subprocess
+import sys
+import base64
+
+# Dependency setup
+subprocess.check_call(
+    [sys.executable, "-m", "pip", "install", "--upgrade", "transformers", "datasets"]
+)
+subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "ray[llm]"])
+subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
+
+
+'''
+# __audio_message_format_example_start__
+"""Supported audio input formats: audio URL, audio binary data"""
+{
+    "messages": [
+        {
+            "role": "system",
+            "content": "Provide a detailed description of the audio."
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe what happens in this audio."},
+                # Option 1: Provide audio URL
+                {"type": "audio_url", "audio_url": {"url": "https://example.com/audio.wav"}},
+                # Option 2: Provide audio binary data
+                {"type": "input_audio", "input_audio": {"data": audio_base64, "format": "wav"}},
+            ]
+        },
+    ]
+}
+# __audio_message_format_example_end__
+'''
+
+# __omni_audio_example_start__
+import ray
+from ray.data.llm import (
+    vLLMEngineProcessorConfig,
+    build_processor,
+    PrepareMultimodalStageConfig,
+    ChatTemplateStageConfig,
+    TokenizerStageConfig,
+    DetokenizeStageConfig,
+)
+from datasets import load_dataset
+from huggingface_hub import hf_hub_download
+
+
+# Download and extract WAV files from MRSAudio dataset
+def download_and_extract_audio_files():
+    """Download MRSAudio dataset and extract WAV files."""
+    dataset_name = "MRSAudio/MRSAudio"
+    dataset = load_dataset(dataset_name, split="train")
+
+    audio_items = []
+
+    # Limit to first 10 samples for the example
+    num_samples = min(10, len(dataset))
+    for i in range(num_samples):
+        item = dataset[i]
+
+        audio_path = hf_hub_download(
+            repo_id=dataset_name, filename=item["path"], repo_type="dataset"
+        )
+
+        with open(audio_path, "rb") as f:
+            audio_bytes = f.read()
+
+        audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
+        audio_items.append(
+            {
+                "audio_data": audio_base64,
+                "text": "Describe this audio.",
+            }
+        )
+
+    return audio_items
+
+
+audio_items = download_and_extract_audio_files()
+
+audio_dataset = (
+    ray.data.from_items(audio_items) if audio_items else ray.data.from_items([])
+)
+
+# __omni_audio_config_example_start__
+audio_processor_config = vLLMEngineProcessorConfig(
+    model_source="Qwen/Qwen2.5-Omni-3B",
+    task_type="generate",
+    engine_kwargs=dict(
+        limit_mm_per_prompt={"audio": 1},
+    ),
+    batch_size=16,
+    accelerator_type="L4",
+    concurrency=1,
+    prepare_multimodal_stage=PrepareMultimodalStageConfig(
+        enabled=True,
+        chat_template_content_format="openai",
+    ),
+    chat_template_stage=ChatTemplateStageConfig(enabled=True),
+    tokenize_stage=TokenizerStageConfig(enabled=True),
+    detokenize_stage=DetokenizeStageConfig(enabled=True),
+)
+# __omni_audio_config_example_end__
+
+
+# __omni_audio_preprocess_example_start__
+def audio_preprocess(row: dict) -> dict:
+    """
+    Preprocessing function for audio-language model inputs.
+
+    Converts dataset rows into the format expected by the Omni model:
+    - System prompt for analysis instructions
+    - User message with text and audio content
+    - Sampling parameters
+    """
+    return {
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant that analyzes audio. "
+                "Listen to the audio carefully and provide detailed descriptions.",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": row["text"],
+                    },
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": row["audio_data"],
+                            "format": "wav",
+                        },
+                    },
+                ],
+            },
+        ],
+        "sampling_params": {
+            "temperature": 0.3,
+            "max_tokens": 150,
+            "detokenize": False,
+        },
+    }
+
+
+def audio_postprocess(row: dict) -> dict:
+    return {
+        "resp": row["generated_text"],
+    }
+
+
+# __omni_audio_preprocess_example_end__
+
+audio_processor = build_processor(
+    audio_processor_config,
+    preprocess=audio_preprocess,
+    postprocess=audio_postprocess,
+)
+
+
+def load_audio_dataset():
+    """
+    Load audio dataset from MRSAudio Hugging Face dataset.
+    """
+    try:
+        from datasets import load_dataset
+        from huggingface_hub import hf_hub_download
+        import base64
+
+        dataset_name = "MRSAudio/MRSAudio"
+
+        dataset = load_dataset(dataset_name, split="train")
+
+        audio_items = []
+
+        # Limit to first 10 samples for the example
+        num_samples = min(10, len(dataset))
+        for i in range(num_samples):
+            item = dataset[i]
+
+            audio_path = hf_hub_download(
+                repo_id=dataset_name, filename=item["path"], repo_type="dataset"
+            )
+
+            with open(audio_path, "rb") as f:
+                audio_bytes = f.read()
+
+            audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
+            audio_items.append(
+                {
+                    "audio_data": audio_base64,
+                    "text": item.get("text", "Describe this audio."),
+                }
+            )
+
+        audio_dataset = ray.data.from_items(audio_items)
+        return audio_dataset
+    except Exception as e:
+        print(f"Error loading dataset: {e}")
+        return None
+
+
+def create_omni_audio_config():
+    """Create Omni audio configuration."""
+    return vLLMEngineProcessorConfig(
+        model_source="Qwen/Qwen2.5-Omni-3B",
+        task_type="generate",
+        engine_kwargs=dict(
+            enforce_eager=True,
+            limit_mm_per_prompt={"audio": 1},
+        ),
+        batch_size=16,
+        accelerator_type="L4",
+        concurrency=1,
+        prepare_multimodal_stage=PrepareMultimodalStageConfig(
+            enabled=True,
+            chat_template_content_format="openai",
+        ),
+        chat_template_stage=ChatTemplateStageConfig(enabled=True),
+        tokenize_stage=TokenizerStageConfig(enabled=True),
+        detokenize_stage=DetokenizeStageConfig(enabled=True),
+    )
+
+
+def run_omni_audio_example():
+    """Run the complete Omni audio example workflow."""
+    config = create_omni_audio_config()
+    audio_dataset = load_audio_dataset()
+
+    if audio_dataset:
+        # Build processor with preprocessing and postprocessing
+        processor = build_processor(
+            config, preprocess=audio_preprocess, postprocess=audio_postprocess
+        )
+
+        print("Omni audio processor configured successfully")
+        print(f"Model: {config.model_source}")
+        print(f"Has multimodal support: {config.prepare_multimodal_stage.enabled}")
+        result = processor(audio_dataset).take_all()
+        return config, processor, result
+    # __omni_audio_run_example_end__
+    return None, None, None
+
+
+# __omni_audio_example_end__
+
+if __name__ == "__main__":
+    # Run the example Omni audio workflow only if GPU is available
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            run_omni_audio_example()
+        else:
+            print("Skipping Omni audio example run (no GPU available)")
+    except Exception as e:
+        print(f"Skipping Omni audio example run due to environment error: {e}")

--- a/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
+++ b/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
@@ -7,17 +7,6 @@ Structure:
 3. Test validation and cleanup
 """
 
-import subprocess
-import sys
-import base64
-
-# Dependency setup
-subprocess.check_call(
-    [sys.executable, "-m", "pip", "install", "--upgrade", "transformers", "datasets"]
-)
-subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "ray[llm]"])
-subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
-
 
 '''
 # __audio_message_format_example_start__
@@ -201,7 +190,6 @@ def run_omni_audio_example():
         print(f"Model: {config.model_source}")
         print(f"Has multimodal support: {config.prepare_multimodal_stage.get('enabled', False)}")
         result = processor(audio_dataset).take_all()
-        print(result)
         return config, processor, result
     # __omni_audio_run_example_end__
     return None, None, None

--- a/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
+++ b/doc/source/data/doc_code/working-with-llms/omni_audio_example.py
@@ -165,12 +165,6 @@ def audio_postprocess(row: dict) -> dict:
 
 # __omni_audio_preprocess_example_end__
 
-audio_processor = build_processor(
-    audio_processor_config,
-    preprocess=audio_preprocess,
-    postprocess=audio_postprocess,
-)
-
 
 def load_audio_dataset():
     """

--- a/doc/source/data/doc_code/working-with-llms/vlm_image_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_image_example.py
@@ -70,6 +70,8 @@ vision_processor_config = vLLMEngineProcessorConfig(
         max_model_len=4096,
         enable_chunked_prefill=True,
         max_num_batched_tokens=2048,
+        trust_remote_code=True,
+        limit_mm_per_prompt={"image": 1},
     ),
     # Override Ray's runtime env to include the Hugging Face token. Ray Data uses Ray under the hood to orchestrate the inference pipeline.
     runtime_env=dict(
@@ -156,12 +158,6 @@ def vision_postprocess(row: dict) -> dict:
 
 
 # __vlm_preprocess_example_end__
-
-vision_processor = build_processor(
-    vision_processor_config,
-    preprocess=vision_preprocess,
-    postprocess=vision_postprocess,
-)
 
 
 def load_vision_dataset():

--- a/doc/source/data/doc_code/working-with-llms/vlm_image_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_image_example.py
@@ -7,16 +7,6 @@ Structure:
 3. Test validation and cleanup
 """
 
-import subprocess
-import sys
-
-# Dependency setup
-subprocess.check_call(
-    [sys.executable, "-m", "pip", "install", "--upgrade", "transformers", "datasets"]
-)
-subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "ray[llm]"])
-subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
-
 
 '''
 # __image_message_format_example_start__

--- a/doc/source/data/doc_code/working-with-llms/vlm_image_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_image_example.py
@@ -50,7 +50,6 @@ from io import BytesIO
 from ray.data.llm import (
     vLLMEngineProcessorConfig,
     build_processor,
-    PrepareMultimodalStageConfig,
 )
 from huggingface_hub import HfFileSystem
 
@@ -83,9 +82,7 @@ vision_processor_config = vLLMEngineProcessorConfig(
     batch_size=16,
     accelerator_type="L4",
     concurrency=1,
-    prepare_multimodal_stage=PrepareMultimodalStageConfig(
-        enabled=True,
-    ),
+    prepare_multimodal_stage={"enabled": True},
 )
 # __vlm_config_example_end__
 
@@ -205,9 +202,7 @@ def create_vlm_config():
         batch_size=1,
         accelerator_type="L4",
         concurrency=1,
-        prepare_multimodal_stage=PrepareMultimodalStageConfig(
-            enabled=True,
-        ),
+        prepare_multimodal_stage={"enabled": True},
     )
 
 
@@ -224,7 +219,7 @@ def run_vlm_example():
 
         print("VLM processor configured successfully")
         print(f"Model: {config.model_source}")
-        print(f"Has multimodal support: {config.prepare_multimodal_stage.enabled}")
+        print(f"Has multimodal support: {config.prepare_multimodal_stage.get('enabled', False)}")
         result = processor(vision_dataset).take_all()
         return config, processor, result
     # __vlm_run_example_end__

--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -51,7 +51,7 @@ video_processor_config = vLLMEngineProcessorConfig(
     batch_size=1,
     accelerator_type="L4",
     concurrency=1,
-    prepare_multimodal_stage={"enabled": True,
+    prepare_multimodal_stage={
         "enabled": True,
         "model_config_kwargs": dict(
             # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig

--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -7,17 +7,7 @@ Structure:
 3. Test validation and cleanup
 """
 
-import subprocess
-import sys
 import os
-
-# Dependency setup
-subprocess.check_call(
-    [sys.executable, "-m", "pip", "install", "--upgrade", "transformers", "datasets"]
-)
-subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "ray[llm]"])
-subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
-
 
 '''
 # __video_message_format_example_start__

--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -10,8 +10,6 @@ Structure:
 import subprocess
 import sys
 import os
-import tarfile
-from pathlib import Path
 
 # Dependency setup
 subprocess.check_call(
@@ -53,44 +51,7 @@ from ray.data.llm import (
     TokenizerStageConfig,
     DetokenizeStageConfig,
 )
-from huggingface_hub import hf_hub_download
 
-
-# Download and extract video files from ShareGPTVideo dataset
-def download_and_extract_videos():
-    """Download ShareGPTVideo dataset and extract MP4 files"""
-    dataset_name = "ShareGPTVideo/train_raw_video"
-    tar_path = hf_hub_download(
-        repo_id=dataset_name, filename="activitynet/chunk_0.tar.gz", repo_type="dataset"
-    )
-
-    extract_dir = "/tmp/sharegpt_videos"
-    os.makedirs(extract_dir, exist_ok=True)
-
-    if not any(Path(extract_dir).glob("*.mp4")):
-        with tarfile.open(tar_path, "r:gz") as tar:
-            tar.extractall(extract_dir)
-
-    video_files = list(Path(extract_dir).rglob("*.mp4"))
-
-    return video_files
-
-
-video_files = download_and_extract_videos()
-
-# Limit to first 10 videos for the example
-video_files = video_files[:10]
-
-video_dataset = ray.data.from_items(
-    [
-        {
-            "video_path": str(video_file),
-            "video_url": f"file://{video_file}",
-            "text": "Describe what happens in this video.",
-        }
-        for video_file in video_files
-    ]
-)
 
 # __vlm_video_config_example_start__
 video_processor_config = vLLMEngineProcessorConfig(

--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -174,12 +174,6 @@ def video_postprocess(row: dict) -> dict:
 
 # __vlm_video_preprocess_example_end__
 
-video_processor = build_processor(
-    video_processor_config,
-    preprocess=video_preprocess,
-    postprocess=video_postprocess,
-)
-
 
 def load_video_dataset():
     """

--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -1,0 +1,288 @@
+"""
+This file serves as a documentation example and CI test for VLM batch inference with videos.
+
+Structure:
+1. Infrastructure setup: Dataset compatibility patches, dependency handling
+2. Docs example (between __vlm_video_example_start/end__): Embedded in Sphinx docs via literalinclude
+3. Test validation and cleanup
+"""
+
+import subprocess
+import sys
+import os
+import tarfile
+from pathlib import Path
+
+# Dependency setup
+subprocess.check_call(
+    [sys.executable, "-m", "pip", "install", "--upgrade", "transformers", "datasets"]
+)
+subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "ray[llm]"])
+subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
+
+
+'''
+# __video_message_format_example_start__
+"""Supported video input formats: video URL"""
+{
+    "messages": [
+        {
+            "role": "system",
+            "content": "Provide a detailed description of the video."
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe what happens in this video."},
+                # Provide video URL
+                {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}},
+            ]
+        },
+    ]
+}
+# __video_message_format_example_end__
+'''
+
+# __vlm_video_example_start__
+import ray
+from ray.data.llm import (
+    vLLMEngineProcessorConfig,
+    build_processor,
+    PrepareMultimodalStageConfig,
+    ChatTemplateStageConfig,
+    TokenizerStageConfig,
+    DetokenizeStageConfig,
+)
+from huggingface_hub import hf_hub_download
+
+
+# Download and extract video files from ShareGPTVideo dataset
+def download_and_extract_videos():
+    """Download ShareGPTVideo dataset and extract MP4 files"""
+    dataset_name = "ShareGPTVideo/train_raw_video"
+    tar_path = hf_hub_download(
+        repo_id=dataset_name, filename="activitynet/chunk_0.tar.gz", repo_type="dataset"
+    )
+
+    extract_dir = "/tmp/sharegpt_videos"
+    os.makedirs(extract_dir, exist_ok=True)
+
+    if not any(Path(extract_dir).glob("*.mp4")):
+        with tarfile.open(tar_path, "r:gz") as tar:
+            tar.extractall(extract_dir)
+
+    video_files = list(Path(extract_dir).rglob("*.mp4"))
+
+    return video_files
+
+
+video_files = download_and_extract_videos()
+
+# Limit to first 10 videos for the example
+video_files = video_files[:10]
+
+video_dataset = ray.data.from_items(
+    [
+        {
+            "video_path": str(video_file),
+            "video_url": f"file://{video_file}",
+            "text": "Describe what happens in this video.",
+        }
+        for video_file in video_files
+    ]
+)
+
+# __vlm_video_config_example_start__
+video_processor_config = vLLMEngineProcessorConfig(
+    model_source="Qwen/Qwen3-VL-4B-Instruct",
+    engine_kwargs=dict(
+        tensor_parallel_size=4,
+        pipeline_parallel_size=1,
+        trust_remote_code=True,
+        limit_mm_per_prompt={"video": 1},
+    ),
+    batch_size=1,
+    accelerator_type="L4",
+    concurrency=1,
+    prepare_multimodal_stage=PrepareMultimodalStageConfig(
+        enabled=True,
+        model_config_kwargs=dict(
+            # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
+            allowed_local_media_path="/tmp",
+        ),
+    ),
+    chat_template_stage=ChatTemplateStageConfig(enabled=True),
+    tokenize_stage=TokenizerStageConfig(enabled=True),
+    detokenize_stage=DetokenizeStageConfig(enabled=True),
+)
+# __vlm_video_config_example_end__
+
+
+# __vlm_video_preprocess_example_start__
+def video_preprocess(row: dict) -> dict:
+    """
+    Preprocessing function for video-language model inputs.
+
+    Converts dataset rows into the format expected by the VLM:
+    - System prompt for analysis instructions
+    - User message with text and video content
+    - Sampling parameters
+    - Multimodal processor kwargs for video processing
+    """
+    return {
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful assistant that analyzes videos. "
+                    "Watch the video carefully and provide detailed descriptions."
+                ),
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": row["text"],
+                    },
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": row["video_url"]},
+                    },
+                ],
+            },
+        ],
+        "sampling_params": {
+            "temperature": 0.3,
+            "max_tokens": 150,
+            "detokenize": False,
+        },
+        # Optional: Multimodal processor kwargs for video processing
+        "mm_processor_kwargs": dict(
+            min_pixels=28 * 28,
+            max_pixels=1280 * 28 * 28,
+            fps=1,
+        ),
+    }
+
+
+def video_postprocess(row: dict) -> dict:
+    return {
+        "resp": row["generated_text"],
+    }
+
+
+# __vlm_video_preprocess_example_end__
+
+video_processor = build_processor(
+    video_processor_config,
+    preprocess=video_preprocess,
+    postprocess=video_postprocess,
+)
+
+
+def load_video_dataset():
+    """
+    Load video dataset from ShareGPTVideo Hugging Face dataset.
+    """
+    try:
+        from huggingface_hub import hf_hub_download
+        import tarfile
+        from pathlib import Path
+
+        dataset_name = "ShareGPTVideo/train_raw_video"
+
+        tar_path = hf_hub_download(
+            repo_id=dataset_name,
+            filename="activitynet/chunk_0.tar.gz",
+            repo_type="dataset",
+        )
+
+        extract_dir = "/tmp/sharegpt_videos"
+        os.makedirs(extract_dir, exist_ok=True)
+
+        if not any(Path(extract_dir).glob("*.mp4")):
+            with tarfile.open(tar_path, "r:gz") as tar:
+                tar.extractall(extract_dir)
+
+        video_files = list(Path(extract_dir).rglob("*.mp4"))
+
+        # Limit to first 10 videos for the example
+        video_files = video_files[:10]
+
+        video_dataset = ray.data.from_items(
+            [
+                {
+                    "video_path": str(video_file),
+                    "video_url": f"file://{video_file}",
+                    "text": "Describe what happens in this video.",
+                }
+                for video_file in video_files
+            ]
+        )
+
+        return video_dataset
+    except Exception as e:
+        print(f"Error loading dataset: {e}")
+        return None
+
+
+def create_vlm_video_config():
+    """Create VLM video configuration."""
+    return vLLMEngineProcessorConfig(
+        model_source="Qwen/Qwen3-VL-4B-Instruct",
+        engine_kwargs=dict(
+            tensor_parallel_size=4,
+            pipeline_parallel_size=1,
+            trust_remote_code=True,
+            limit_mm_per_prompt={"video": 1},
+        ),
+        batch_size=1,
+        accelerator_type="L4",
+        concurrency=1,
+        prepare_multimodal_stage=PrepareMultimodalStageConfig(
+            enabled=True,
+            model_config_kwargs=dict(
+                # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
+                allowed_local_media_path="/tmp",
+            ),
+        ),
+        chat_template_stage=ChatTemplateStageConfig(enabled=True),
+        tokenize_stage=TokenizerStageConfig(enabled=True),
+        detokenize_stage=DetokenizeStageConfig(enabled=True),
+    )
+
+
+def run_vlm_video_example():
+    """Run the complete VLM video example workflow."""
+    config = create_vlm_video_config()
+    video_dataset = load_video_dataset()
+
+    if video_dataset:
+        # Build processor with preprocessing and postprocessing
+        processor = build_processor(
+            config, preprocess=video_preprocess, postprocess=video_postprocess
+        )
+
+        print("VLM video processor configured successfully")
+        print(f"Model: {config.model_source}")
+        print(f"Has multimodal support: {config.prepare_multimodal_stage.enabled}")
+        result = processor(video_dataset).take_all()
+        return config, processor, result
+    # __vlm_video_run_example_end__
+    return None, None, None
+
+
+# __vlm_video_example_end__
+
+if __name__ == "__main__":
+    # Run the example VLM video workflow only if GPU is available
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            run_vlm_video_example()
+        else:
+            print("Skipping VLM video example run (no GPU available)")
+    except Exception as e:
+        print(f"Skipping VLM video example run due to environment error: {e}")

--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -46,10 +46,6 @@ import ray
 from ray.data.llm import (
     vLLMEngineProcessorConfig,
     build_processor,
-    PrepareMultimodalStageConfig,
-    ChatTemplateStageConfig,
-    TokenizerStageConfig,
-    DetokenizeStageConfig,
 )
 
 
@@ -65,16 +61,16 @@ video_processor_config = vLLMEngineProcessorConfig(
     batch_size=1,
     accelerator_type="L4",
     concurrency=1,
-    prepare_multimodal_stage=PrepareMultimodalStageConfig(
-        enabled=True,
-        model_config_kwargs=dict(
+    prepare_multimodal_stage={"enabled": True,
+        "enabled": True,
+        "model_config_kwargs": dict(
             # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
             allowed_local_media_path="/tmp",
         ),
-    ),
-    chat_template_stage=ChatTemplateStageConfig(enabled=True),
-    tokenize_stage=TokenizerStageConfig(enabled=True),
-    detokenize_stage=DetokenizeStageConfig(enabled=True),
+    },
+    chat_template_stage={"enabled": True},
+    tokenize_stage={"enabled": True},
+    detokenize_stage={"enabled": True},
 )
 # __vlm_video_config_example_end__
 
@@ -195,16 +191,16 @@ def create_vlm_video_config():
         batch_size=1,
         accelerator_type="L4",
         concurrency=1,
-        prepare_multimodal_stage=PrepareMultimodalStageConfig(
-            enabled=True,
-            model_config_kwargs=dict(
+        prepare_multimodal_stage={
+            "enabled": True,
+            "model_config_kwargs": dict(
                 # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
                 allowed_local_media_path="/tmp",
             ),
-        ),
-        chat_template_stage=ChatTemplateStageConfig(enabled=True),
-        tokenize_stage=TokenizerStageConfig(enabled=True),
-        detokenize_stage=DetokenizeStageConfig(enabled=True),
+        },
+        chat_template_stage={"enabled": True},
+        tokenize_stage={"enabled": True},
+        detokenize_stage={"enabled": True},
     )
 
 
@@ -221,7 +217,7 @@ def run_vlm_video_example():
 
         print("VLM video processor configured successfully")
         print(f"Model: {config.model_source}")
-        print(f"Has multimodal support: {config.prepare_multimodal_stage.enabled}")
+        print(f"Has multimodal support: {config.prepare_multimodal_stage.get('enabled', False)}")
         result = processor(video_dataset).take_all()
         return config, processor, result
     # __vlm_video_run_example_end__

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -10,6 +10,7 @@ This guide shows you how to use :ref:`ray.data.llm <llm-ref>` to:
 * :ref:`Quickstart: vLLM batch inference <vllm_quickstart>`
 * :ref:`Perform batch inference with LLMs <batch_inference_llm>`
 * :ref:`Configure vLLM for LLM inference <vllm_llm>`
+* :ref:`Multimodal batch inference <multimodal>`
 * :ref:`Batch inference with embedding models <embedding_models>`
 * :ref:`Batch inference with classification models <classification_models>`
 * :ref:`Query deployed models with an OpenAI compatible API endpoint <openai_compatible_api_endpoint>`
@@ -131,30 +132,31 @@ To do multi-LoRA batch inference, you need to set LoRA related parameters in `en
     :start-after: __lora_config_example_start__
     :end-before: __lora_config_example_end__
 
-.. _vision_language_model:
+.. _multimodal:
 
-Batch inference with vision-language-model (VLM)
+Multimodal batch inference
 --------------------------------------------------------
 
 Ray Data LLM also supports running batch inference with vision language
-models. This example shows how to prepare a dataset with images and run
-batch inference with a vision language model.
+and Omni models on multimodal data. To enable multimodal batch inference,
+apply the following 2 adjustments on top of the previous example:
 
-This example applies 2 adjustments on top of the previous example:
+- Set `PrepareMultimodalStageConfig(enabled=True)` in the `vLLMEngineProcessorConfig`
+- Prepare multimodal data inside the preprocessor.
 
-- set `has_image=True` in `vLLMEngineProcessorConfig`
-- prepare image input inside preprocessor
-
-First, install the required dependencies:
+Prior to running the examples below, install the required dependencies:
 
 .. code-block:: bash
 
-    # Install required dependencies for vision-language models
+    # Install required dependencies for downloading datasets from Hugging Face
     pip install datasets>=4.0.0
+
+Image batch inference with vision language model (VLM)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First, load a vision dataset:
 
-.. literalinclude:: doc_code/working-with-llms/vlm_example.py
+.. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
     :language: python
     :start-after: def load_vision_dataset():
     :end-before: def create_vlm_config():
@@ -162,22 +164,29 @@ First, load a vision dataset:
 
 Next, configure the VLM processor with the essential settings:
 
-.. literalinclude:: doc_code/working-with-llms/vlm_example.py
+.. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
     :language: python
     :start-after: __vlm_config_example_start__
     :end-before: __vlm_config_example_end__
 
 Define preprocessing and postprocessing functions to convert dataset rows into
-the format expected by the VLM and extract model responses:
+the format expected by the VLM and extract model responses. Within the preprocessor,
+structure image data as part of an OpenAI-compatible message. Both image URL and PIL
+Image object are supported.
 
-.. literalinclude:: doc_code/working-with-llms/vlm_example.py
+.. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
+    :language: python
+    :start-after: __image_message_format_example_start__
+    :end-before: __image_message_format_example_end__
+
+.. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
     :language: python
     :start-after: __vlm_preprocess_example_start__
     :end-before: __vlm_preprocess_example_end__
 
 For a more comprehensive VLM configuration with advanced options:
 
-.. literalinclude:: doc_code/working-with-llms/vlm_example.py
+.. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
     :language: python
     :start-after: def create_vlm_config():
     :end-before: def run_vlm_example():
@@ -185,10 +194,94 @@ For a more comprehensive VLM configuration with advanced options:
 
 Finally, run the VLM inference:
 
-.. literalinclude:: doc_code/working-with-llms/vlm_example.py
+.. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
     :language: python
     :start-after: def run_vlm_example():
     :end-before: # __vlm_run_example_end__
+    :dedent: 0
+
+Video batch inference with vision language model (VLM)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First, load a video dataset:
+
+.. literalinclude:: doc_code/working-with-llms/vlm_video_example.py
+    :language: python
+    :start-after: def load_video_dataset():
+    :end-before: def create_vlm_video_config():
+    :dedent: 0
+
+Next, configure the VLM processor with the essential settings:
+
+.. literalinclude:: doc_code/working-with-llms/vlm_video_example.py
+    :language: python
+    :start-after: __vlm_video_config_example_start__
+    :end-before: __vlm_video_config_example_end__
+
+Define preprocessing and postprocessing functions to convert dataset rows into
+the format expected by the VLM and extract model responses. Within the preprocessor,
+structure video data as part of an OpenAI-compatible message.
+
+.. literalinclude:: doc_code/working-with-llms/vlm_video_example.py
+    :language: python
+    :start-after: __vlm_video_preprocess_example_start__
+    :end-before: __vlm_video_preprocess_example_end__
+
+Finally, run the VLM inference:
+
+.. literalinclude:: doc_code/working-with-llms/vlm_video_example.py
+    :language: python
+    :start-after: def run_vlm_video_example():
+    :end-before: # __vlm_video_run_example_end__
+    :dedent: 0
+
+Audio batch inference with Omni model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First, load an audio dataset:
+
+.. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
+    :language: python
+    :start-after: def load_audio_dataset():
+    :end-before: def create_omni_audio_config():
+    :dedent: 0
+
+Next, configure the Omni processor with the essential settings:
+
+.. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
+    :language: python
+    :start-after: __omni_audio_config_example_start__
+    :end-before: __omni_audio_config_example_end__
+
+Define preprocessing and postprocessing functions to convert dataset rows into
+the format expected by the Omni model and extract model responses. Within the preprocessor,
+structure audio data as part of an OpenAI-compatible message. Both audio URL and audio
+binary data are supported.
+
+.. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
+    :language: python
+    :start-after: __audio_message_format_example_start__
+    :end-before: __audio_message_format_example_end__
+
+.. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
+    :language: python
+    :start-after: __omni_audio_preprocess_example_start__
+    :end-before: __omni_audio_preprocess_example_end__
+
+For a more comprehensive Omni configuration with advanced options:
+
+.. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
+    :language: python
+    :start-after: def create_omni_audio_config():
+    :end-before: def run_omni_audio_example():
+    :dedent: 0
+
+Finally, run the Omni inference:
+
+.. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
+    :language: python
+    :start-after: def run_omni_audio_example():
+    :end-before: # __omni_audio_run_example_end__
     :dedent: 0
 
 .. _embedding_models:

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -141,7 +141,7 @@ Ray Data LLM also supports running batch inference with vision language
 and omni-modal models on multimodal data. To enable multimodal batch inference,
 apply the following 2 adjustments on top of the previous example:
 
-- Set `PrepareMultimodalStageConfig(enabled=True)` in the `vLLMEngineProcessorConfig`
+- Set `prepare_multimodal_stage={"enabled": True}` in the `vLLMEngineProcessorConfig`
 - Prepare multimodal data inside the preprocessor.
 
 Prior to running the examples below, install the required dependencies:

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -138,7 +138,7 @@ Multimodal batch inference
 --------------------------------------------------------
 
 Ray Data LLM also supports running batch inference with vision language
-and omnimodal models on multimodal data. To enable multimodal batch inference,
+and omni-modal models on multimodal data. To enable multimodal batch inference,
 apply the following 2 adjustments on top of the previous example:
 
 - Set `PrepareMultimodalStageConfig(enabled=True)` in the `vLLMEngineProcessorConfig`
@@ -227,7 +227,7 @@ Finally, run the VLM inference:
     :end-before: # __vlm_video_run_example_end__
     :dedent: 0
 
-Audio batch inference with omnimodal model
+Audio batch inference with omni-modal model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First, load an audio dataset:
@@ -238,7 +238,7 @@ First, load an audio dataset:
     :end-before: def create_omni_audio_config():
     :dedent: 0
 
-Next, configure the omnimodal processor with the essential settings:
+Next, configure the omni-modal processor with the essential settings:
 
 .. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
     :language: python
@@ -246,7 +246,7 @@ Next, configure the omnimodal processor with the essential settings:
     :end-before: __omni_audio_config_example_end__
 
 Define preprocessing and postprocessing functions to convert dataset rows into
-the format expected by the omnimodal model and extract model responses. Within the preprocessor,
+the format expected by the omni-modal model and extract model responses. Within the preprocessor,
 structure audio data as part of an OpenAI-compatible message. Both audio URL and audio
 binary data are supported.
 
@@ -260,7 +260,7 @@ binary data are supported.
     :start-after: __omni_audio_preprocess_example_start__
     :end-before: __omni_audio_preprocess_example_end__
 
-Finally, run the omnimodal inference:
+Finally, run the omni-modal inference:
 
 .. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
     :language: python

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -76,10 +76,10 @@ Here's a simple configuration example:
 
 The configuration includes detailed comments explaining:
 
-- **concurrency**: Number of vLLM engine replicas (typically 1 per node)
-- **batch_size**: Number of samples processed per batch (reduce if GPU memory is limited)
-- **max_num_batched_tokens**: Maximum tokens processed simultaneously (reduce if CUDA OOM occurs)
-- **accelerator_type**: Specify GPU type for optimal resource allocation
+- `concurrency`: Number of vLLM engine replicas (typically 1 per node)
+- `batch_size`: Number of samples processed per batch (reduce if GPU memory is limited)
+- `max_num_batched_tokens`: Maximum tokens processed simultaneously (reduce if CUDA OOM occurs)
+- `accelerator_type`: Specify GPU type for optimal resource allocation
 
 The vLLM processor expects input in OpenAI chat format with a 'messages' column and outputs a 'generated_text' column containing model responses.
 
@@ -138,7 +138,7 @@ Multimodal batch inference
 --------------------------------------------------------
 
 Ray Data LLM also supports running batch inference with vision language
-and Omni models on multimodal data. To enable multimodal batch inference,
+and omnimodal models on multimodal data. To enable multimodal batch inference,
 apply the following 2 adjustments on top of the previous example:
 
 - Set `PrepareMultimodalStageConfig(enabled=True)` in the `vLLMEngineProcessorConfig`
@@ -171,8 +171,8 @@ Next, configure the VLM processor with the essential settings:
 
 Define preprocessing and postprocessing functions to convert dataset rows into
 the format expected by the VLM and extract model responses. Within the preprocessor,
-structure image data as part of an OpenAI-compatible message. Both image URL and PIL
-Image object are supported.
+structure image data as part of an OpenAI-compatible message. Both image URL and
+`PIL.Image.Image` object are supported.
 
 .. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
     :language: python
@@ -227,7 +227,7 @@ Finally, run the VLM inference:
     :end-before: # __vlm_video_run_example_end__
     :dedent: 0
 
-Audio batch inference with Omni model
+Audio batch inference with omnimodal model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First, load an audio dataset:
@@ -238,7 +238,7 @@ First, load an audio dataset:
     :end-before: def create_omni_audio_config():
     :dedent: 0
 
-Next, configure the Omni processor with the essential settings:
+Next, configure the omnimodal processor with the essential settings:
 
 .. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
     :language: python
@@ -246,7 +246,7 @@ Next, configure the Omni processor with the essential settings:
     :end-before: __omni_audio_config_example_end__
 
 Define preprocessing and postprocessing functions to convert dataset rows into
-the format expected by the Omni model and extract model responses. Within the preprocessor,
+the format expected by the omnimodal model and extract model responses. Within the preprocessor,
 structure audio data as part of an OpenAI-compatible message. Both audio URL and audio
 binary data are supported.
 
@@ -260,7 +260,7 @@ binary data are supported.
     :start-after: __omni_audio_preprocess_example_start__
     :end-before: __omni_audio_preprocess_example_end__
 
-Finally, run the Omni inference:
+Finally, run the omnimodal inference:
 
 .. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
     :language: python

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -76,10 +76,10 @@ Here's a simple configuration example:
 
 The configuration includes detailed comments explaining:
 
-- **`concurrency`**: Number of vLLM engine replicas (typically 1 per node)
-- **`batch_size`**: Number of samples processed per batch (reduce if GPU memory is limited)
-- **`max_num_batched_tokens`**: Maximum tokens processed simultaneously (reduce if CUDA OOM occurs)
-- **`accelerator_type`**: Specify GPU type for optimal resource allocation
+- **concurrency**: Number of vLLM engine replicas (typically 1 per node)
+- **batch_size**: Number of samples processed per batch (reduce if GPU memory is limited)
+- **max_num_batched_tokens**: Maximum tokens processed simultaneously (reduce if CUDA OOM occurs)
+- **accelerator_type**: Specify GPU type for optimal resource allocation
 
 The vLLM processor expects input in OpenAI chat format with a 'messages' column and outputs a 'generated_text' column containing model responses.
 

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -184,14 +184,6 @@ Image object are supported.
     :start-after: __vlm_preprocess_example_start__
     :end-before: __vlm_preprocess_example_end__
 
-For a more comprehensive VLM configuration with advanced options:
-
-.. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
-    :language: python
-    :start-after: def create_vlm_config():
-    :end-before: def run_vlm_example():
-    :dedent: 0
-
 Finally, run the VLM inference:
 
 .. literalinclude:: doc_code/working-with-llms/vlm_image_example.py
@@ -267,14 +259,6 @@ binary data are supported.
     :language: python
     :start-after: __omni_audio_preprocess_example_start__
     :end-before: __omni_audio_preprocess_example_end__
-
-For a more comprehensive Omni configuration with advanced options:
-
-.. literalinclude:: doc_code/working-with-llms/omni_audio_example.py
-    :language: python
-    :start-after: def create_omni_audio_config():
-    :end-before: def run_omni_audio_example():
-    :dedent: 0
 
 Finally, run the Omni inference:
 

--- a/python/deplocks/llm/rayllm_py311_cpu.lock
+++ b/python/deplocks/llm/rayllm_py311_cpu.lock
@@ -702,9 +702,9 @@ depyf==0.20.0 \
     # via
     #   -c python/deplocks/llm/rayllm_test_py311_cpu.lock
     #   vllm
-dill==0.3.9 \
-    --hash=sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a \
-    --hash=sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c
+dill==0.3.8 \
+    --hash=sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca \
+    --hash=sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7
     # via
     #   -c python/deplocks/llm/rayllm_test_py311_cpu.lock
     #   depyf

--- a/python/deplocks/llm/rayllm_py311_cu128.lock
+++ b/python/deplocks/llm/rayllm_py311_cu128.lock
@@ -702,9 +702,9 @@ depyf==0.20.0 \
     # via
     #   -c python/deplocks/llm/rayllm_test_py311_cu128.lock
     #   vllm
-dill==0.4.0 \
-    --hash=sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0 \
-    --hash=sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049
+dill==0.3.8 \
+    --hash=sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca \
+    --hash=sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7
     # via
     #   -c python/deplocks/llm/rayllm_test_py311_cu128.lock
     #   depyf

--- a/python/deplocks/llm/rayllm_test_py311_cpu.lock
+++ b/python/deplocks/llm/rayllm_test_py311_cpu.lock
@@ -108,6 +108,7 @@ aiohttp==3.11.16 \
     #   -r python/requirements.txt
     #   adlfs
     #   aiohttp-cors
+    #   fsspec
     #   pytest-aiohttp
     #   vllm
 aiohttp-cors==0.7.0 \
@@ -852,6 +853,10 @@ cupy-cuda12x==13.4.0 ; sys_platform != 'darwin' \
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   -r python/requirements.txt
     #   ray
+datasets==4.0.0 \
+    --hash=sha256:7ef95e62025fd122882dbce6cb904c8cd3fbc829de6669a5eb939c77d50e203d \
+    --hash=sha256:9657e7140a9050db13443ba21cb5de185af8af944479b00e7ff1e00a61c8dbf1
+    # via -r python/requirements/llm/llm-test-requirements.txt
 debugpy==1.8.0 \
     --hash=sha256:125b9a637e013f9faac0a3d6a82bd17c8b5d2c875fb6b7e2772c5aba6d082332 \
     --hash=sha256:12af2c55b419521e33d5fb21bd022df0b5eb267c3e178f1d374a63a2a6bdccd0 \
@@ -891,10 +896,13 @@ depyf==0.20.0 \
     --hash=sha256:d31effad4261cebecb58955d832e448ace88f432328f95f82fd99c30fd9308d4 \
     --hash=sha256:fb7683bd72c44f67b56029df2c47721e9a02ffa4d7b19095f1c54c4ebf797a98
     # via vllm
-dill==0.3.9 \
-    --hash=sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a \
-    --hash=sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c
-    # via depyf
+dill==0.3.8 \
+    --hash=sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca \
+    --hash=sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7
+    # via
+    #   datasets
+    #   depyf
+    #   multiprocess
 diskcache==5.6.3 \
     --hash=sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc \
     --hash=sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19
@@ -1261,6 +1269,7 @@ filelock==3.17.0 \
     # via
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   -r python/requirements.txt
+    #   datasets
     #   huggingface-hub
     #   ray
     #   torch
@@ -1366,6 +1375,7 @@ fsspec==2023.12.1 \
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   -r python/requirements.txt
     #   adlfs
+    #   datasets
     #   huggingface-hub
     #   torch
 gguf==0.17.1 \
@@ -1737,6 +1747,7 @@ huggingface-hub==0.34.3 \
     --hash=sha256:5444550099e2d86e68b2898b09e85878fbd788fc2957b506c6a79ce060e39492 \
     --hash=sha256:d58130fd5aa7408480681475491c0abd7e835442082fbc3ef4d45b6c39f83853
     # via
+    #   datasets
     #   tokenizers
     #   transformers
 humanize==4.12.1 \
@@ -2722,6 +2733,20 @@ multidict==6.0.5 \
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   aiohttp
     #   yarl
+multiprocess==0.70.16 \
+    --hash=sha256:0dfd078c306e08d46d7a8d06fb120313d87aa43af60d66da43ffff40b44d2f41 \
+    --hash=sha256:161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1 \
+    --hash=sha256:37b55f71c07e2d741374998c043b9520b626a8dddc8b3129222ca4f1a06ef67a \
+    --hash=sha256:476887be10e2f59ff183c006af746cb6f1fd0eadcfd4ef49e605cbe2659920ee \
+    --hash=sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3 \
+    --hash=sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435 \
+    --hash=sha256:af4cabb0dac72abfb1e794fa7855c325fd2b55a10a44628a3c1ad3311c04127a \
+    --hash=sha256:ba8c31889abf4511c7308a8c52bb4a30b9d590e7f58523302ba00237702ca054 \
+    --hash=sha256:c4a9944c67bd49f823687463660a2d6daae94c289adff97e0f9d696ba6371d02 \
+    --hash=sha256:d951bed82c8f73929ac82c61f01a7b5ce8f3e5ef40f5b52553b4f547ce2b08ec \
+    --hash=sha256:e7b9d0f307cd9bd50851afaac0dba2cb6c44449efff697df7c7645f7d3f2be3a \
+    --hash=sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e
+    # via datasets
 nbclassic==1.0.0 \
     --hash=sha256:0ae11eb2319455d805596bf320336cda9554b41d99ab9a3c31bf8180bffa30e3 \
     --hash=sha256:f99e4769b4750076cd4235c044b61232110733322384a94a63791d2e7beacc66
@@ -2882,6 +2907,7 @@ numpy==1.26.4 \
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   -r python/requirements.txt
     #   cupy-cuda12x
+    #   datasets
     #   flashinfer-python
     #   gguf
     #   gymnasium
@@ -3076,6 +3102,7 @@ packaging==24.2 \
     #   -r python/requirements/cloud-requirements.txt
     #   -r python/requirements.txt
     #   build
+    #   datasets
     #   flashinfer-python
     #   huggingface-hub
     #   ipykernel
@@ -3126,6 +3153,7 @@ pandas==1.5.3 \
     # via
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   -r python/requirements.txt
+    #   datasets
 pandocfilters==1.5.0 \
     --hash=sha256:0b679503337d233b4339a817bfc8c50064e2eff681314376a47cb582305a7a38 \
     --hash=sha256:33aae3f25fd1a026079f5d27bdd52496f0e0803b3469282162bafdcbdf6ef14f
@@ -3525,6 +3553,7 @@ pyarrow==19.0.1 \
     # via
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   -r python/requirements.txt
+    #   datasets
 pyasn1==0.5.1 \
     --hash=sha256:4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58 \
     --hash=sha256:6d391a96e59b23130a5cfa74d6fd7f388dbbe26cc8f1edf39fdddf08d9d6676c
@@ -4057,6 +4086,7 @@ pyyaml==6.0.3 \
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   -r python/requirements/cloud-requirements.txt
     #   -r python/requirements.txt
+    #   datasets
     #   gguf
     #   huggingface-hub
     #   jupyter-events
@@ -4283,7 +4313,9 @@ requests==2.32.5 \
     #   -r python/requirements.txt
     #   azure-core
     #   azure-datalake-store
+    #   datasets
     #   flashinfer-python
+    #   fsspec
     #   google-api-core
     #   google-cloud-storage
     #   huggingface-hub
@@ -5252,6 +5284,7 @@ tqdm==4.67.1 \
     # via
     #   -c python/deplocks/llm/ray_test_py311_cpu.lock
     #   -r python/requirements/cloud-requirements.txt
+    #   datasets
     #   flashinfer-python
     #   gguf
     #   huggingface-hub
@@ -5686,6 +5719,148 @@ xgrammar==0.1.27 ; platform_machine == 'aarch64' or platform_machine == 'arm64' 
     --hash=sha256:ee2f3fdbcfeb5520c96004243413171c44cbcf9af5d424cbd533e4943ef643bf \
     --hash=sha256:fa8b7cc167737a9b4c3e1012faa7b488cc5b451ea8403c4d77ec1d53b58e9266
     # via vllm
+xxhash==3.6.0 \
+    --hash=sha256:01262da8798422d0685f7cef03b2bd3f4f46511b02830861df548d7def4402ad \
+    --hash=sha256:01362c4331775398e7bb34e3ab403bc9ee9f7c497bc7dee6272114055277dd3c \
+    --hash=sha256:016e9190af8f0a4e3741343777710e3d5717427f175adfdc3e72508f59e2a7f3 \
+    --hash=sha256:01be0c5b500c5362871fc9cfdf58c69b3e5c4f531a82229ddb9eb1eb14138004 \
+    --hash=sha256:0226aa89035b62b6a86d3c68df4d7c1f47a342b8683da2b60cedcddb46c4d95b \
+    --hash=sha256:02ea4cb627c76f48cd9fb37cf7ab22bd51e57e1b519807234b473faebe526796 \
+    --hash=sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f \
+    --hash=sha256:08d45aef063a4531b785cd72de4887766d01dc8f362a515693df349fdb825e0c \
+    --hash=sha256:0d50101e57aad86f4344ca9b32d091a2135a9d0a4396f19133426c88025b09f1 \
+    --hash=sha256:0e4edbfc7d420925b0dd5e792478ed393d6e75ff8fc219a6546fb446b6a417b1 \
+    --hash=sha256:0f7b7e2ec26c1666ad5fc9dbfa426a6a3367ceaf79db5dd76264659d509d73b0 \
+    --hash=sha256:1244460adc3a9be84731d72b8e80625788e5815b68da3da8b83f78115a40a7ec \
+    --hash=sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d \
+    --hash=sha256:18b242455eccdfcd1fa4134c431a30737d2b4f045770f8fe84356b3469d4b919 \
+    --hash=sha256:1cf9dcc4ab9cff01dfbba78544297a3a01dafd60f3bde4e2bfd016cf7e4ddc67 \
+    --hash=sha256:1fc1ed882d1e8df932a66e2999429ba6cc4d5172914c904ab193381fba825360 \
+    --hash=sha256:2577b276e060b73b73a53042ea5bd5203d3e6347ce0d09f98500f418a9fcf799 \
+    --hash=sha256:25915e6000338999236f1eb68a02a32c3275ac338628a7eaa5a269c401995679 \
+    --hash=sha256:26734cdc2d4ffe449b41d186bbeac416f704a482ed835d375a5c0cb02bc63fef \
+    --hash=sha256:2762bfff264c4e73c0e507274b40634ff465e025f0eaf050897e88ec8367575d \
+    --hash=sha256:277175a73900ad43a8caeb8b99b9604f21fe8d7c842f2f9061a364a7e220ddb7 \
+    --hash=sha256:297b7fbf86c82c550e12e8fb71968b3f033d27b874276ba3624ea868c11165a8 \
+    --hash=sha256:2aa5ee3444c25b69813663c9f8067dcfaa2e126dc55e8dddf40f4d1c25d7effa \
+    --hash=sha256:2ab89a6b80f22214b43d98693c30da66af910c04f9858dd39c8e570749593d7e \
+    --hash=sha256:2b6821e94346f96db75abaa6e255706fb06ebd530899ed76d32cd99f20dc52fa \
+    --hash=sha256:2f171a900d59d51511209f7476933c34a0c2c711078d3c80e74e0fe4f38680ec \
+    --hash=sha256:339f518c3c7a850dd033ab416ea25a692759dc7478a71131fe8869010d2b75e4 \
+    --hash=sha256:39be8e4e142550ef69629c9cd71b88c90e9a5db703fecbcf265546d9536ca4ad \
+    --hash=sha256:3cd01fa2aa00d8b017c97eb46b9a794fbdca53fc14f845f5a328c71254b0abb7 \
+    --hash=sha256:3ed0df1b11a79856df5ffcab572cbd6b9627034c1c748c5566fa79df9048a7c5 \
+    --hash=sha256:40c391dd3cd041ebc3ffe6f2c862f402e306eb571422e0aa918d8070ba31da11 \
+    --hash=sha256:418daf3db71e1413cfe211c2f9a528456936645c17f46b5204705581a45390ae \
+    --hash=sha256:42c36dd7dbad2f5238950c377fcbf6811b1cdb1c444fab447960030cea60504d \
+    --hash=sha256:44e342e8cc11b4e79dae5c57f2fb6360c3c20cc57d32049af8f567f5b4bcb5f4 \
+    --hash=sha256:457b8f85dec5825eed7b69c11ae86834a018b8e3df5e77783c999663da2f96d6 \
+    --hash=sha256:45aae0c9df92e7fa46fbb738737324a563c727990755ec1965a6a339ea10a1df \
+    --hash=sha256:48e6f2ffb07a50b52465a1032c3cf1f4a5683f944acaca8a134a2f23674c2058 \
+    --hash=sha256:4903530e866b7a9c1eadfd3fa2fbe1b97d3aed4739a80abf506eb9318561c850 \
+    --hash=sha256:49e03e6fe2cac4a1bc64952dd250cf0dbc5ef4ebb7b8d96bce82e2de163c82a2 \
+    --hash=sha256:4a082ffff8c6ac07707fb6b671caf7c6e020c75226c561830b73d862060f281d \
+    --hash=sha256:4b54219177f6c6674d5378bd862c6aedf64725f70dd29c472eaae154df1a2e89 \
+    --hash=sha256:4ccbff013972390b51a18ef1255ef5ac125c92dc9143b2d1909f59abc765540e \
+    --hash=sha256:4da8168ae52c01ac64c511d6f4a709479da8b7a4a1d7621ed51652f93747dffa \
+    --hash=sha256:4f6f72232f849eb9d0141e2ebe2677ece15adfd0fa599bc058aad83c714bb2c6 \
+    --hash=sha256:50fc255f39428a27299c20e280d6193d8b63b8ef8028995323bf834a026b4fbb \
+    --hash=sha256:51312c768403d8540487dbbfb557454cfc55589bbde6424456951f7fcd4facb3 \
+    --hash=sha256:51a73fb7cb3a3ead9f7a8b583ffd9b8038e277cdb8cb87cf890e88b3456afa0b \
+    --hash=sha256:5576b002a56207f640636056b4160a378fe36a58db73ae5c27a7ec8db35f71d4 \
+    --hash=sha256:568a6d743219e717b07b4e03b0a828ce593833e498c3b64752e0f5df6bfe84db \
+    --hash=sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119 \
+    --hash=sha256:599e64ba7f67472481ceb6ee80fa3bd828fd61ba59fb11475572cc5ee52b89ec \
+    --hash=sha256:5c1343d49ac102799905e115aee590183c3921d475356cb24b4de29a4bc56518 \
+    --hash=sha256:5dc1e14d14fa0f5789ec29a7062004b5933964bb9b02aae6622b8f530dc40296 \
+    --hash=sha256:5f059d9faeacd49c0215d66f4056e1326c80503f51a1532ca336a385edadd033 \
+    --hash=sha256:6105ef7e62b5ac73a837778efc331a591d8442f8ef5c7e102376506cb4ae2729 \
+    --hash=sha256:627f0af069b0ea56f312fd5189001c24578868643203bca1abbc2c52d3a6f3ca \
+    --hash=sha256:63275a8aba7865e44b1813d2177e0f5ea7eadad3dd063a21f7cf9afdc7054063 \
+    --hash=sha256:653a91d7c2ab54a92c19ccf43508b6a555440b9be1bc8be553376778be7f20b5 \
+    --hash=sha256:6551880383f0e6971dc23e512c9ccc986147ce7bfa1cd2e4b520b876c53e9f3d \
+    --hash=sha256:6812c25fe0d6c36a46ccb002f40f27ac903bf18af9f6dd8f9669cb4d176ab18f \
+    --hash=sha256:6965e0e90f1f0e6cb78da568c13d4a348eeb7f40acfd6d43690a666a459458b8 \
+    --hash=sha256:6f2580ffab1a8b68ef2b901cde7e55fa8da5e4be0977c68f78fc80f3c143de42 \
+    --hash=sha256:6fb5f5476bef678f69db04f2bd1efbed3030d2aba305b0fc1773645f187d6a4e \
+    --hash=sha256:757320d45d2fbcce8f30c42a6b2f47862967aea7bf458b9625b4bbe7ee390392 \
+    --hash=sha256:780b90c313348f030b811efc37b0fa1431163cb8db8064cf88a7936b6ce5f222 \
+    --hash=sha256:78e7f2f4c521c30ad5e786fdd6bae89d47a32672a80195467b5de0480aa97b1f \
+    --hash=sha256:794fe9145fe60191c6532fa95063765529770edcdd67b3d537793e8004cabbfd \
+    --hash=sha256:7a0b169aafb98f4284f73635a8e93f0735f9cbde17bd5ec332480484241aaa77 \
+    --hash=sha256:7c35c4cdc65f2a29f34425c446f2f5cdcd0e3c34158931e1cc927ece925ab802 \
+    --hash=sha256:7d14a6cfaf03b1b6f5f9790f76880601ccc7896aff7ab9cd8978a939c1eb7e0d \
+    --hash=sha256:7d8b8aaa30fca4f16f0c84a5c8d7ddee0e25250ec2796c973775373257dde8f1 \
+    --hash=sha256:7dac94fad14a3d1c92affb661021e1d5cbcf3876be5f5b4d90730775ccb7ac41 \
+    --hash=sha256:843b52f6d88071f87eba1631b684fcb4b2068cd2180a0224122fe4ef011a9374 \
+    --hash=sha256:858dc935963a33bc33490128edc1c12b0c14d9c7ebaa4e387a7869ecc4f3e263 \
+    --hash=sha256:87ff03d7e35c61435976554477a7f4cd1704c3596a89a8300d5ce7fc83874a71 \
+    --hash=sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13 \
+    --hash=sha256:89952ea539566b9fed2bbd94e589672794b4286f342254fad28b149f9615fef8 \
+    --hash=sha256:8a8f1972e75ebdd161d7896743122834fe87378160c20e97f8b09166213bf8cc \
+    --hash=sha256:8b29ee68625ab37b04c0b40c3fafdf24d2f75ccd778333cfb698f65f6c463f62 \
+    --hash=sha256:8cb2f4f679b01513b7adbb9b1b2f0f9cdc31b70007eaf9d59d0878809f385b11 \
+    --hash=sha256:9085e798c163ce310d91f8aa6b325dda3c2944c93c6ce1edb314030d4167cc65 \
+    --hash=sha256:9176dcaddf4ca963d4deb93866d739a343c01c969231dbe21680e13a5d1a5bf0 \
+    --hash=sha256:929142361a48ee07f09121fe9e96a84950e8d4df3bb298ca5d88061969f34d7b \
+    --hash=sha256:93f107c673bccf0d592cdba077dedaf52fe7f42dcd7676eba1f6d6f0c3efffd2 \
+    --hash=sha256:97460eec202017f719e839a0d3551fbc0b2fcc9c6c6ffaa5af85bbd5de432788 \
+    --hash=sha256:9b3222c686a919a0f3253cfc12bb118b8b103506612253b5baeaac10d8027cf6 \
+    --hash=sha256:9e040d3e762f84500961791fa3709ffa4784d4dcd7690afc655c095e02fff05f \
+    --hash=sha256:a034590a727b44dd8ac5914236a7b8504144447a9682586c3327e935f33ec8cc \
+    --hash=sha256:a40a3d35b204b7cc7643cbcf8c9976d818cb47befcfac8bbefec8038ac363f3e \
+    --hash=sha256:a42e633d75cdad6d625434e3468126c73f13f7584545a9cf34e883aa1710e702 \
+    --hash=sha256:a54844be970d3fc22630b32d515e79a90d0a3ddb2644d8d7402e3c4c8da61405 \
+    --hash=sha256:a756fe893389483ee8c394d06b5ab765d96e68fbbfe6fde7aa17e11f5720559f \
+    --hash=sha256:a75ffc1bd5def584129774c158e108e5d768e10b75813f2b32650bb041066ed6 \
+    --hash=sha256:a87f271a33fad0e5bf3be282be55d78df3a45ae457950deb5241998790326f87 \
+    --hash=sha256:a881851cf38b0a70e7c4d3ce81fc7afd86fbc2a024f4cfb2a97cf49ce04b75d3 \
+    --hash=sha256:aa912c62f842dfd013c5f21a642c9c10cd9f4c4e943e0af83618b4a404d9091a \
+    --hash=sha256:aed058764db109dc9052720da65fafe84873b05eb8b07e5e653597951af57c3b \
+    --hash=sha256:af1f3278bd02814d6dedc5dec397993b549d6f16c19379721e5a1d31e132c49b \
+    --hash=sha256:b0359391c3dad6de872fefb0cf5b69d55b0655c55ee78b1bb7a568979b2ce96b \
+    --hash=sha256:b1e420ef35c503869c4064f4a2f2b08ad6431ab7b229a05cce39d74268bca6b8 \
+    --hash=sha256:b45fad44d9c5c119e9c6fbf2e1c656a46dc68e280275007bbfd3d572b21426db \
+    --hash=sha256:b465afd7909db30168ab62afe40b2fcf79eedc0b89a6c0ab3123515dc0df8b99 \
+    --hash=sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a \
+    --hash=sha256:b5b848ad6c16d308c3ac7ad4ba6bede80ed5df2ba8ed382f8932df63158dd4b2 \
+    --hash=sha256:b7b2df81a23f8cb99656378e72501b2cb41b1827c0f5a86f87d6b06b69f9f204 \
+    --hash=sha256:b9c6df83594f7df8f7f708ce5ebeacfc69f72c9fbaaababf6cf4758eaada0c9b \
+    --hash=sha256:ba284920194615cb8edf73bf52236ce2e1664ccd4a38fdb543506413529cc546 \
+    --hash=sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95 \
+    --hash=sha256:bd17fede52a17a4f9a7bc4472a5867cb0b160deeb431795c0e4abe158bc784e9 \
+    --hash=sha256:bec91b562d8012dae276af8025a55811b875baace6af510412a5e58e3121bc54 \
+    --hash=sha256:bf48889c9630542d4709192578aebbd836177c9f7a4a2778a7d6340107c65f06 \
+    --hash=sha256:c0f2ab8c715630565ab8991b536ecded9416d615538be8ecddce43ccf26cbc7c \
+    --hash=sha256:c1ce4009c97a752e682b897aa99aef84191077a9433eb237774689f14f8ec152 \
+    --hash=sha256:c2f9ccd5c4be370939a2e17602fbc49995299203da72a3429db013d44d590e86 \
+    --hash=sha256:c5294f596a9017ca5a3e3f8884c00b91ab2ad2933cf288f4923c3fd4346cf3d4 \
+    --hash=sha256:c5aa639bc113e9286137cec8fadc20e9cd732b2cc385c0b7fa673b84fc1f2a93 \
+    --hash=sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd \
+    --hash=sha256:c6e193e9f56e4ca4923c61238cdaced324f0feac782544eb4c6d55ad5cc99ddd \
+    --hash=sha256:cc604dc06027dbeb8281aeac5899c35fcfe7c77b25212833709f0bff4ce74d2a \
+    --hash=sha256:cfbc5b91397c8c2972fdac13fb3e4ed2f7f8ccac85cd2c644887557780a9b6e2 \
+    --hash=sha256:d0a9751f71a1a65ce3584e9cae4467651c7e70c9d31017fa57574583a4540248 \
+    --hash=sha256:d1927a69feddc24c987b337ce81ac15c4720955b667fe9b588e02254b80446fd \
+    --hash=sha256:d597acf8506d6e7101a4a44a5e428977a51c0fadbbfd3c39650cca9253f6e5a6 \
+    --hash=sha256:d706dca2d24d834a4661619dcacf51a75c16d65985718d6a7d73c1eeeb903ddf \
+    --hash=sha256:d72f67ef8bf36e05f5b6c65e8524f265bd61071471cd4cf1d36743ebeeeb06b7 \
+    --hash=sha256:dc94790144e66b14f67b10ac8ed75b39ca47536bf8800eb7c24b50271ea0c490 \
+    --hash=sha256:dea26ae1eb293db089798d3973a5fc928a18fdd97cc8801226fae705b02b14b0 \
+    --hash=sha256:e4ff728a2894e7f436b9e94c667b0f426b9c74b71f900cf37d5468c6b5da0536 \
+    --hash=sha256:e82da5670f2d0d98950317f82a0e4a0197150ff19a6df2ba40399c2a3b9ae5fb \
+    --hash=sha256:eae5c13f3bc455a3bbb68bdc513912dc7356de7e2280363ea235f71f54064829 \
+    --hash=sha256:ec44b73a4220623235f67a996c862049f375df3b1052d9899f40a6382c32d746 \
+    --hash=sha256:ee34327b187f002a596d7b167ebc59a1b729e963ce645964bbc050d2f1b73d07 \
+    --hash=sha256:f01375c0e55395b814a679b3eea205db7919ac2af213f4a6682e01220e5fe292 \
+    --hash=sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6 \
+    --hash=sha256:f205badabde7aafd1a31e8ca2a3e5a763107a71c397c4481d6a804eb5063d8bd \
+    --hash=sha256:f22927652cba98c44639ffdc7aaf35828dccf679b10b31c4ad72a5b530a18eb7 \
+    --hash=sha256:f572dfd3d0e2eb1a57511831cf6341242f5a9f8298a45862d085f5b93394a27d \
+    --hash=sha256:f7f99123f0e1194fa59cc69ad46dbae2e07becec5df50a0509a808f90a0f03f0 \
+    --hash=sha256:fba27a198363a7ef87f8c0f6b171ec36b674fe9053742c58dd7e3201c1ab30ee \
+    --hash=sha256:ffc578717a347baf25be8397cb10d2528802d24f94cfc005c0e44fef44b5cdd6
+    # via datasets
 y-py==0.6.2 \
     --hash=sha256:015f7f6c1ce8a83d57955d1dc7ddd57cb633ae00576741a4fc9a0f72ed70007d \
     --hash=sha256:032365dfe932bfab8e80937ad6093b4c22e67d63ad880096b5fa8768f8d829ba \

--- a/python/deplocks/llm/rayllm_test_py311_cu128.lock
+++ b/python/deplocks/llm/rayllm_test_py311_cu128.lock
@@ -108,6 +108,7 @@ aiohttp==3.11.16 \
     #   -r python/requirements.txt
     #   adlfs
     #   aiohttp-cors
+    #   fsspec
     #   pytest-aiohttp
     #   vllm
 aiohttp-cors==0.7.0 \
@@ -851,6 +852,10 @@ cupy-cuda12x==13.4.0 ; sys_platform != 'darwin' \
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   -r python/requirements.txt
     #   ray
+datasets==4.0.0 \
+    --hash=sha256:7ef95e62025fd122882dbce6cb904c8cd3fbc829de6669a5eb939c77d50e203d \
+    --hash=sha256:9657e7140a9050db13443ba21cb5de185af8af944479b00e7ff1e00a61c8dbf1
+    # via -r python/requirements/llm/llm-test-requirements.txt
 debugpy==1.8.0 \
     --hash=sha256:125b9a637e013f9faac0a3d6a82bd17c8b5d2c875fb6b7e2772c5aba6d082332 \
     --hash=sha256:12af2c55b419521e33d5fb21bd022df0b5eb267c3e178f1d374a63a2a6bdccd0 \
@@ -890,10 +895,13 @@ depyf==0.20.0 \
     --hash=sha256:d31effad4261cebecb58955d832e448ace88f432328f95f82fd99c30fd9308d4 \
     --hash=sha256:fb7683bd72c44f67b56029df2c47721e9a02ffa4d7b19095f1c54c4ebf797a98
     # via vllm
-dill==0.4.0 \
-    --hash=sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0 \
-    --hash=sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049
-    # via depyf
+dill==0.3.8 \
+    --hash=sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca \
+    --hash=sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7
+    # via
+    #   datasets
+    #   depyf
+    #   multiprocess
 diskcache==5.6.3 \
     --hash=sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc \
     --hash=sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19
@@ -1260,6 +1268,7 @@ filelock==3.17.0 \
     # via
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   -r python/requirements.txt
+    #   datasets
     #   huggingface-hub
     #   ray
     #   torch
@@ -1365,6 +1374,7 @@ fsspec==2023.12.1 \
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   -r python/requirements.txt
     #   adlfs
+    #   datasets
     #   huggingface-hub
     #   torch
 gguf==0.17.0 \
@@ -1736,6 +1746,7 @@ huggingface-hub==0.34.3 \
     --hash=sha256:5444550099e2d86e68b2898b09e85878fbd788fc2957b506c6a79ce060e39492 \
     --hash=sha256:d58130fd5aa7408480681475491c0abd7e835442082fbc3ef4d45b6c39f83853
     # via
+    #   datasets
     #   tokenizers
     #   transformers
 humanize==4.12.1 \
@@ -2686,6 +2697,20 @@ multidict==6.0.5 \
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   aiohttp
     #   yarl
+multiprocess==0.70.16 \
+    --hash=sha256:0dfd078c306e08d46d7a8d06fb120313d87aa43af60d66da43ffff40b44d2f41 \
+    --hash=sha256:161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1 \
+    --hash=sha256:37b55f71c07e2d741374998c043b9520b626a8dddc8b3129222ca4f1a06ef67a \
+    --hash=sha256:476887be10e2f59ff183c006af746cb6f1fd0eadcfd4ef49e605cbe2659920ee \
+    --hash=sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3 \
+    --hash=sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435 \
+    --hash=sha256:af4cabb0dac72abfb1e794fa7855c325fd2b55a10a44628a3c1ad3311c04127a \
+    --hash=sha256:ba8c31889abf4511c7308a8c52bb4a30b9d590e7f58523302ba00237702ca054 \
+    --hash=sha256:c4a9944c67bd49f823687463660a2d6daae94c289adff97e0f9d696ba6371d02 \
+    --hash=sha256:d951bed82c8f73929ac82c61f01a7b5ce8f3e5ef40f5b52553b4f547ce2b08ec \
+    --hash=sha256:e7b9d0f307cd9bd50851afaac0dba2cb6c44449efff697df7c7645f7d3f2be3a \
+    --hash=sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e
+    # via datasets
 nbclassic==1.0.0 \
     --hash=sha256:0ae11eb2319455d805596bf320336cda9554b41d99ab9a3c31bf8180bffa30e3 \
     --hash=sha256:f99e4769b4750076cd4235c044b61232110733322384a94a63791d2e7beacc66
@@ -2845,6 +2870,7 @@ numpy==1.26.4 \
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   -r python/requirements.txt
     #   cupy-cuda12x
+    #   datasets
     #   flashinfer-python
     #   gguf
     #   gymnasium
@@ -3093,6 +3119,7 @@ packaging==24.2 \
     #   -r python/requirements/cloud-requirements.txt
     #   -r python/requirements.txt
     #   build
+    #   datasets
     #   flashinfer-python
     #   huggingface-hub
     #   ipykernel
@@ -3143,6 +3170,7 @@ pandas==1.5.3 \
     # via
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   -r python/requirements.txt
+    #   datasets
 pandocfilters==1.5.0 \
     --hash=sha256:0b679503337d233b4339a817bfc8c50064e2eff681314376a47cb582305a7a38 \
     --hash=sha256:33aae3f25fd1a026079f5d27bdd52496f0e0803b3469282162bafdcbdf6ef14f
@@ -3542,6 +3570,7 @@ pyarrow==19.0.1 \
     # via
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   -r python/requirements.txt
+    #   datasets
 pyasn1==0.5.1 \
     --hash=sha256:4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58 \
     --hash=sha256:6d391a96e59b23130a5cfa74d6fd7f388dbbe26cc8f1edf39fdddf08d9d6676c
@@ -4074,6 +4103,7 @@ pyyaml==6.0.3 \
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   -r python/requirements/cloud-requirements.txt
     #   -r python/requirements.txt
+    #   datasets
     #   gguf
     #   huggingface-hub
     #   jupyter-events
@@ -4300,7 +4330,9 @@ requests==2.32.5 \
     #   -r python/requirements.txt
     #   azure-core
     #   azure-datalake-store
+    #   datasets
     #   flashinfer-python
+    #   fsspec
     #   google-api-core
     #   google-cloud-storage
     #   huggingface-hub
@@ -5268,6 +5300,7 @@ tqdm==4.67.1 \
     # via
     #   -c python/deplocks/llm/ray_test_py311_cu128.lock
     #   -r python/requirements/cloud-requirements.txt
+    #   datasets
     #   flashinfer-python
     #   gguf
     #   huggingface-hub
@@ -5693,6 +5726,148 @@ xgrammar==0.1.27 ; platform_machine == 'aarch64' or platform_machine == 'arm64' 
     --hash=sha256:ee2f3fdbcfeb5520c96004243413171c44cbcf9af5d424cbd533e4943ef643bf \
     --hash=sha256:fa8b7cc167737a9b4c3e1012faa7b488cc5b451ea8403c4d77ec1d53b58e9266
     # via vllm
+xxhash==3.6.0 \
+    --hash=sha256:01262da8798422d0685f7cef03b2bd3f4f46511b02830861df548d7def4402ad \
+    --hash=sha256:01362c4331775398e7bb34e3ab403bc9ee9f7c497bc7dee6272114055277dd3c \
+    --hash=sha256:016e9190af8f0a4e3741343777710e3d5717427f175adfdc3e72508f59e2a7f3 \
+    --hash=sha256:01be0c5b500c5362871fc9cfdf58c69b3e5c4f531a82229ddb9eb1eb14138004 \
+    --hash=sha256:0226aa89035b62b6a86d3c68df4d7c1f47a342b8683da2b60cedcddb46c4d95b \
+    --hash=sha256:02ea4cb627c76f48cd9fb37cf7ab22bd51e57e1b519807234b473faebe526796 \
+    --hash=sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f \
+    --hash=sha256:08d45aef063a4531b785cd72de4887766d01dc8f362a515693df349fdb825e0c \
+    --hash=sha256:0d50101e57aad86f4344ca9b32d091a2135a9d0a4396f19133426c88025b09f1 \
+    --hash=sha256:0e4edbfc7d420925b0dd5e792478ed393d6e75ff8fc219a6546fb446b6a417b1 \
+    --hash=sha256:0f7b7e2ec26c1666ad5fc9dbfa426a6a3367ceaf79db5dd76264659d509d73b0 \
+    --hash=sha256:1244460adc3a9be84731d72b8e80625788e5815b68da3da8b83f78115a40a7ec \
+    --hash=sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d \
+    --hash=sha256:18b242455eccdfcd1fa4134c431a30737d2b4f045770f8fe84356b3469d4b919 \
+    --hash=sha256:1cf9dcc4ab9cff01dfbba78544297a3a01dafd60f3bde4e2bfd016cf7e4ddc67 \
+    --hash=sha256:1fc1ed882d1e8df932a66e2999429ba6cc4d5172914c904ab193381fba825360 \
+    --hash=sha256:2577b276e060b73b73a53042ea5bd5203d3e6347ce0d09f98500f418a9fcf799 \
+    --hash=sha256:25915e6000338999236f1eb68a02a32c3275ac338628a7eaa5a269c401995679 \
+    --hash=sha256:26734cdc2d4ffe449b41d186bbeac416f704a482ed835d375a5c0cb02bc63fef \
+    --hash=sha256:2762bfff264c4e73c0e507274b40634ff465e025f0eaf050897e88ec8367575d \
+    --hash=sha256:277175a73900ad43a8caeb8b99b9604f21fe8d7c842f2f9061a364a7e220ddb7 \
+    --hash=sha256:297b7fbf86c82c550e12e8fb71968b3f033d27b874276ba3624ea868c11165a8 \
+    --hash=sha256:2aa5ee3444c25b69813663c9f8067dcfaa2e126dc55e8dddf40f4d1c25d7effa \
+    --hash=sha256:2ab89a6b80f22214b43d98693c30da66af910c04f9858dd39c8e570749593d7e \
+    --hash=sha256:2b6821e94346f96db75abaa6e255706fb06ebd530899ed76d32cd99f20dc52fa \
+    --hash=sha256:2f171a900d59d51511209f7476933c34a0c2c711078d3c80e74e0fe4f38680ec \
+    --hash=sha256:339f518c3c7a850dd033ab416ea25a692759dc7478a71131fe8869010d2b75e4 \
+    --hash=sha256:39be8e4e142550ef69629c9cd71b88c90e9a5db703fecbcf265546d9536ca4ad \
+    --hash=sha256:3cd01fa2aa00d8b017c97eb46b9a794fbdca53fc14f845f5a328c71254b0abb7 \
+    --hash=sha256:3ed0df1b11a79856df5ffcab572cbd6b9627034c1c748c5566fa79df9048a7c5 \
+    --hash=sha256:40c391dd3cd041ebc3ffe6f2c862f402e306eb571422e0aa918d8070ba31da11 \
+    --hash=sha256:418daf3db71e1413cfe211c2f9a528456936645c17f46b5204705581a45390ae \
+    --hash=sha256:42c36dd7dbad2f5238950c377fcbf6811b1cdb1c444fab447960030cea60504d \
+    --hash=sha256:44e342e8cc11b4e79dae5c57f2fb6360c3c20cc57d32049af8f567f5b4bcb5f4 \
+    --hash=sha256:457b8f85dec5825eed7b69c11ae86834a018b8e3df5e77783c999663da2f96d6 \
+    --hash=sha256:45aae0c9df92e7fa46fbb738737324a563c727990755ec1965a6a339ea10a1df \
+    --hash=sha256:48e6f2ffb07a50b52465a1032c3cf1f4a5683f944acaca8a134a2f23674c2058 \
+    --hash=sha256:4903530e866b7a9c1eadfd3fa2fbe1b97d3aed4739a80abf506eb9318561c850 \
+    --hash=sha256:49e03e6fe2cac4a1bc64952dd250cf0dbc5ef4ebb7b8d96bce82e2de163c82a2 \
+    --hash=sha256:4a082ffff8c6ac07707fb6b671caf7c6e020c75226c561830b73d862060f281d \
+    --hash=sha256:4b54219177f6c6674d5378bd862c6aedf64725f70dd29c472eaae154df1a2e89 \
+    --hash=sha256:4ccbff013972390b51a18ef1255ef5ac125c92dc9143b2d1909f59abc765540e \
+    --hash=sha256:4da8168ae52c01ac64c511d6f4a709479da8b7a4a1d7621ed51652f93747dffa \
+    --hash=sha256:4f6f72232f849eb9d0141e2ebe2677ece15adfd0fa599bc058aad83c714bb2c6 \
+    --hash=sha256:50fc255f39428a27299c20e280d6193d8b63b8ef8028995323bf834a026b4fbb \
+    --hash=sha256:51312c768403d8540487dbbfb557454cfc55589bbde6424456951f7fcd4facb3 \
+    --hash=sha256:51a73fb7cb3a3ead9f7a8b583ffd9b8038e277cdb8cb87cf890e88b3456afa0b \
+    --hash=sha256:5576b002a56207f640636056b4160a378fe36a58db73ae5c27a7ec8db35f71d4 \
+    --hash=sha256:568a6d743219e717b07b4e03b0a828ce593833e498c3b64752e0f5df6bfe84db \
+    --hash=sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119 \
+    --hash=sha256:599e64ba7f67472481ceb6ee80fa3bd828fd61ba59fb11475572cc5ee52b89ec \
+    --hash=sha256:5c1343d49ac102799905e115aee590183c3921d475356cb24b4de29a4bc56518 \
+    --hash=sha256:5dc1e14d14fa0f5789ec29a7062004b5933964bb9b02aae6622b8f530dc40296 \
+    --hash=sha256:5f059d9faeacd49c0215d66f4056e1326c80503f51a1532ca336a385edadd033 \
+    --hash=sha256:6105ef7e62b5ac73a837778efc331a591d8442f8ef5c7e102376506cb4ae2729 \
+    --hash=sha256:627f0af069b0ea56f312fd5189001c24578868643203bca1abbc2c52d3a6f3ca \
+    --hash=sha256:63275a8aba7865e44b1813d2177e0f5ea7eadad3dd063a21f7cf9afdc7054063 \
+    --hash=sha256:653a91d7c2ab54a92c19ccf43508b6a555440b9be1bc8be553376778be7f20b5 \
+    --hash=sha256:6551880383f0e6971dc23e512c9ccc986147ce7bfa1cd2e4b520b876c53e9f3d \
+    --hash=sha256:6812c25fe0d6c36a46ccb002f40f27ac903bf18af9f6dd8f9669cb4d176ab18f \
+    --hash=sha256:6965e0e90f1f0e6cb78da568c13d4a348eeb7f40acfd6d43690a666a459458b8 \
+    --hash=sha256:6f2580ffab1a8b68ef2b901cde7e55fa8da5e4be0977c68f78fc80f3c143de42 \
+    --hash=sha256:6fb5f5476bef678f69db04f2bd1efbed3030d2aba305b0fc1773645f187d6a4e \
+    --hash=sha256:757320d45d2fbcce8f30c42a6b2f47862967aea7bf458b9625b4bbe7ee390392 \
+    --hash=sha256:780b90c313348f030b811efc37b0fa1431163cb8db8064cf88a7936b6ce5f222 \
+    --hash=sha256:78e7f2f4c521c30ad5e786fdd6bae89d47a32672a80195467b5de0480aa97b1f \
+    --hash=sha256:794fe9145fe60191c6532fa95063765529770edcdd67b3d537793e8004cabbfd \
+    --hash=sha256:7a0b169aafb98f4284f73635a8e93f0735f9cbde17bd5ec332480484241aaa77 \
+    --hash=sha256:7c35c4cdc65f2a29f34425c446f2f5cdcd0e3c34158931e1cc927ece925ab802 \
+    --hash=sha256:7d14a6cfaf03b1b6f5f9790f76880601ccc7896aff7ab9cd8978a939c1eb7e0d \
+    --hash=sha256:7d8b8aaa30fca4f16f0c84a5c8d7ddee0e25250ec2796c973775373257dde8f1 \
+    --hash=sha256:7dac94fad14a3d1c92affb661021e1d5cbcf3876be5f5b4d90730775ccb7ac41 \
+    --hash=sha256:843b52f6d88071f87eba1631b684fcb4b2068cd2180a0224122fe4ef011a9374 \
+    --hash=sha256:858dc935963a33bc33490128edc1c12b0c14d9c7ebaa4e387a7869ecc4f3e263 \
+    --hash=sha256:87ff03d7e35c61435976554477a7f4cd1704c3596a89a8300d5ce7fc83874a71 \
+    --hash=sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13 \
+    --hash=sha256:89952ea539566b9fed2bbd94e589672794b4286f342254fad28b149f9615fef8 \
+    --hash=sha256:8a8f1972e75ebdd161d7896743122834fe87378160c20e97f8b09166213bf8cc \
+    --hash=sha256:8b29ee68625ab37b04c0b40c3fafdf24d2f75ccd778333cfb698f65f6c463f62 \
+    --hash=sha256:8cb2f4f679b01513b7adbb9b1b2f0f9cdc31b70007eaf9d59d0878809f385b11 \
+    --hash=sha256:9085e798c163ce310d91f8aa6b325dda3c2944c93c6ce1edb314030d4167cc65 \
+    --hash=sha256:9176dcaddf4ca963d4deb93866d739a343c01c969231dbe21680e13a5d1a5bf0 \
+    --hash=sha256:929142361a48ee07f09121fe9e96a84950e8d4df3bb298ca5d88061969f34d7b \
+    --hash=sha256:93f107c673bccf0d592cdba077dedaf52fe7f42dcd7676eba1f6d6f0c3efffd2 \
+    --hash=sha256:97460eec202017f719e839a0d3551fbc0b2fcc9c6c6ffaa5af85bbd5de432788 \
+    --hash=sha256:9b3222c686a919a0f3253cfc12bb118b8b103506612253b5baeaac10d8027cf6 \
+    --hash=sha256:9e040d3e762f84500961791fa3709ffa4784d4dcd7690afc655c095e02fff05f \
+    --hash=sha256:a034590a727b44dd8ac5914236a7b8504144447a9682586c3327e935f33ec8cc \
+    --hash=sha256:a40a3d35b204b7cc7643cbcf8c9976d818cb47befcfac8bbefec8038ac363f3e \
+    --hash=sha256:a42e633d75cdad6d625434e3468126c73f13f7584545a9cf34e883aa1710e702 \
+    --hash=sha256:a54844be970d3fc22630b32d515e79a90d0a3ddb2644d8d7402e3c4c8da61405 \
+    --hash=sha256:a756fe893389483ee8c394d06b5ab765d96e68fbbfe6fde7aa17e11f5720559f \
+    --hash=sha256:a75ffc1bd5def584129774c158e108e5d768e10b75813f2b32650bb041066ed6 \
+    --hash=sha256:a87f271a33fad0e5bf3be282be55d78df3a45ae457950deb5241998790326f87 \
+    --hash=sha256:a881851cf38b0a70e7c4d3ce81fc7afd86fbc2a024f4cfb2a97cf49ce04b75d3 \
+    --hash=sha256:aa912c62f842dfd013c5f21a642c9c10cd9f4c4e943e0af83618b4a404d9091a \
+    --hash=sha256:aed058764db109dc9052720da65fafe84873b05eb8b07e5e653597951af57c3b \
+    --hash=sha256:af1f3278bd02814d6dedc5dec397993b549d6f16c19379721e5a1d31e132c49b \
+    --hash=sha256:b0359391c3dad6de872fefb0cf5b69d55b0655c55ee78b1bb7a568979b2ce96b \
+    --hash=sha256:b1e420ef35c503869c4064f4a2f2b08ad6431ab7b229a05cce39d74268bca6b8 \
+    --hash=sha256:b45fad44d9c5c119e9c6fbf2e1c656a46dc68e280275007bbfd3d572b21426db \
+    --hash=sha256:b465afd7909db30168ab62afe40b2fcf79eedc0b89a6c0ab3123515dc0df8b99 \
+    --hash=sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a \
+    --hash=sha256:b5b848ad6c16d308c3ac7ad4ba6bede80ed5df2ba8ed382f8932df63158dd4b2 \
+    --hash=sha256:b7b2df81a23f8cb99656378e72501b2cb41b1827c0f5a86f87d6b06b69f9f204 \
+    --hash=sha256:b9c6df83594f7df8f7f708ce5ebeacfc69f72c9fbaaababf6cf4758eaada0c9b \
+    --hash=sha256:ba284920194615cb8edf73bf52236ce2e1664ccd4a38fdb543506413529cc546 \
+    --hash=sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95 \
+    --hash=sha256:bd17fede52a17a4f9a7bc4472a5867cb0b160deeb431795c0e4abe158bc784e9 \
+    --hash=sha256:bec91b562d8012dae276af8025a55811b875baace6af510412a5e58e3121bc54 \
+    --hash=sha256:bf48889c9630542d4709192578aebbd836177c9f7a4a2778a7d6340107c65f06 \
+    --hash=sha256:c0f2ab8c715630565ab8991b536ecded9416d615538be8ecddce43ccf26cbc7c \
+    --hash=sha256:c1ce4009c97a752e682b897aa99aef84191077a9433eb237774689f14f8ec152 \
+    --hash=sha256:c2f9ccd5c4be370939a2e17602fbc49995299203da72a3429db013d44d590e86 \
+    --hash=sha256:c5294f596a9017ca5a3e3f8884c00b91ab2ad2933cf288f4923c3fd4346cf3d4 \
+    --hash=sha256:c5aa639bc113e9286137cec8fadc20e9cd732b2cc385c0b7fa673b84fc1f2a93 \
+    --hash=sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd \
+    --hash=sha256:c6e193e9f56e4ca4923c61238cdaced324f0feac782544eb4c6d55ad5cc99ddd \
+    --hash=sha256:cc604dc06027dbeb8281aeac5899c35fcfe7c77b25212833709f0bff4ce74d2a \
+    --hash=sha256:cfbc5b91397c8c2972fdac13fb3e4ed2f7f8ccac85cd2c644887557780a9b6e2 \
+    --hash=sha256:d0a9751f71a1a65ce3584e9cae4467651c7e70c9d31017fa57574583a4540248 \
+    --hash=sha256:d1927a69feddc24c987b337ce81ac15c4720955b667fe9b588e02254b80446fd \
+    --hash=sha256:d597acf8506d6e7101a4a44a5e428977a51c0fadbbfd3c39650cca9253f6e5a6 \
+    --hash=sha256:d706dca2d24d834a4661619dcacf51a75c16d65985718d6a7d73c1eeeb903ddf \
+    --hash=sha256:d72f67ef8bf36e05f5b6c65e8524f265bd61071471cd4cf1d36743ebeeeb06b7 \
+    --hash=sha256:dc94790144e66b14f67b10ac8ed75b39ca47536bf8800eb7c24b50271ea0c490 \
+    --hash=sha256:dea26ae1eb293db089798d3973a5fc928a18fdd97cc8801226fae705b02b14b0 \
+    --hash=sha256:e4ff728a2894e7f436b9e94c667b0f426b9c74b71f900cf37d5468c6b5da0536 \
+    --hash=sha256:e82da5670f2d0d98950317f82a0e4a0197150ff19a6df2ba40399c2a3b9ae5fb \
+    --hash=sha256:eae5c13f3bc455a3bbb68bdc513912dc7356de7e2280363ea235f71f54064829 \
+    --hash=sha256:ec44b73a4220623235f67a996c862049f375df3b1052d9899f40a6382c32d746 \
+    --hash=sha256:ee34327b187f002a596d7b167ebc59a1b729e963ce645964bbc050d2f1b73d07 \
+    --hash=sha256:f01375c0e55395b814a679b3eea205db7919ac2af213f4a6682e01220e5fe292 \
+    --hash=sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6 \
+    --hash=sha256:f205badabde7aafd1a31e8ca2a3e5a763107a71c397c4481d6a804eb5063d8bd \
+    --hash=sha256:f22927652cba98c44639ffdc7aaf35828dccf679b10b31c4ad72a5b530a18eb7 \
+    --hash=sha256:f572dfd3d0e2eb1a57511831cf6341242f5a9f8298a45862d085f5b93394a27d \
+    --hash=sha256:f7f99123f0e1194fa59cc69ad46dbae2e07becec5df50a0509a808f90a0f03f0 \
+    --hash=sha256:fba27a198363a7ef87f8c0f6b171ec36b674fe9053742c58dd7e3201c1ab30ee \
+    --hash=sha256:ffc578717a347baf25be8397cb10d2528802d24f94cfc005c0e44fef44b5cdd6
+    # via datasets
 y-py==0.6.2 \
     --hash=sha256:015f7f6c1ce8a83d57955d1dc7ddd57cb633ae00576741a4fc9a0f72ed70007d \
     --hash=sha256:032365dfe932bfab8e80937ad6093b4c22e67d63ad880096b5fa8768f8d829ba \

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -457,10 +457,9 @@ class PrepareMultimodalStageConfig(_PrepareMultimodalStageConfig):
 
     Args:
         enabled: Whether this stage is enabled. Defaults to True.
-        model_source: Name or path of the Hugging Face model to use for the
-            multimodal processor. This is required to process multimodal data
-            according to a specific model. If not specified, will use the
-            processor-level model_source.
+        model_config_kwargs: Optional kwargs to pass to the model config.
+            See available model config kwargs at
+            https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig.
         chat_template_content_format: The content format to use for the chat
             template. This is used to format the chat template content according
             to a specific model. Choices are "string" or "openai". Defaults to

--- a/python/ray/llm/_internal/batch/processor/utils.py
+++ b/python/ray/llm/_internal/batch/processor/utils.py
@@ -52,17 +52,3 @@ def build_cpu_stage_map_kwargs(
             stage_cfg.memory,
         ),
     )
-
-def update_kwargs_with_defaults(
-    kwargs: Optional[Dict[str, Any]],
-    defaults: Optional[Dict[str, Any]],
-) -> Dict[str, Any]:
-    """Update kwargs with defaults.
-    
-    If a key from defaults is present in kwargs, the value from defaults
-    will override the value in kwargs. Otherwise, keys from defaults will
-    be added to the result.
-    """
-    kwargs = kwargs or {}
-    defaults = defaults or {}
-    return {**kwargs, **defaults}

--- a/python/ray/llm/_internal/batch/processor/utils.py
+++ b/python/ray/llm/_internal/batch/processor/utils.py
@@ -52,3 +52,17 @@ def build_cpu_stage_map_kwargs(
             stage_cfg.memory,
         ),
     )
+
+def update_kwargs_with_defaults(
+    kwargs: Optional[Dict[str, Any]],
+    defaults: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Update kwargs with defaults.
+    
+    If a key from defaults is present in kwargs, the value from defaults
+    will override the value in kwargs. Otherwise, keys from defaults will
+    be added to the result.
+    """
+    kwargs = kwargs or {}
+    defaults = defaults or {}
+    return {**kwargs, **defaults}

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -21,6 +21,7 @@ from ray.llm._internal.batch.processor.base import (
 from ray.llm._internal.batch.processor.utils import (
     build_cpu_stage_map_kwargs,
     get_value_or_fallback,
+    update_kwargs_with_defaults,
 )
 from ray.llm._internal.batch.stages import (
     ChatTemplateStage,
@@ -186,7 +187,10 @@ def build_vllm_engine_processor(
         stages.append(
             PrepareMultimodalStage(
                 fn_constructor_kwargs=dict(
-                    model=prepare_multimodal_stage_cfg.model_source,
+                    model_config_kwargs=update_kwargs_with_defaults(
+                        prepare_multimodal_stage_cfg.model_config_kwargs,
+                        {"model": processor_defaults.get("model_source")},
+                    ),
                     chat_template_content_format=prepare_multimodal_stage_cfg.chat_template_content_format,
                     apply_sys_msg_formatting=prepare_multimodal_stage_cfg.apply_sys_msg_formatting,
                 ),

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -21,7 +21,6 @@ from ray.llm._internal.batch.processor.base import (
 from ray.llm._internal.batch.processor.utils import (
     build_cpu_stage_map_kwargs,
     get_value_or_fallback,
-    update_kwargs_with_defaults,
 )
 from ray.llm._internal.batch.stages import (
     ChatTemplateStage,
@@ -187,10 +186,10 @@ def build_vllm_engine_processor(
         stages.append(
             PrepareMultimodalStage(
                 fn_constructor_kwargs=dict(
-                    model_config_kwargs=update_kwargs_with_defaults(
-                        prepare_multimodal_stage_cfg.model_config_kwargs,
-                        {"model": processor_defaults.get("model_source")},
-                    ),
+                    model_config_kwargs={
+                        **(prepare_multimodal_stage_cfg.model_config_kwargs or {}),
+                        "model": processor_defaults.get("model_source"),
+                    },
                     chat_template_content_format=prepare_multimodal_stage_cfg.chat_template_content_format,
                     apply_sys_msg_formatting=prepare_multimodal_stage_cfg.apply_sys_msg_formatting,
                 ),

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -183,13 +183,18 @@ def build_vllm_engine_processor(
         )
 
     if prepare_multimodal_stage_cfg.enabled:
+        base_model_config_kwargs = (
+            prepare_multimodal_stage_cfg.model_config_kwargs or {}
+        )
+        # Respect the model source from the processor
+        model_config_kwargs = {
+            **base_model_config_kwargs,
+            "model": processor_defaults.get("model_source"),
+        }
         stages.append(
             PrepareMultimodalStage(
                 fn_constructor_kwargs=dict(
-                    model_config_kwargs={
-                        **(prepare_multimodal_stage_cfg.model_config_kwargs or {}),
-                        "model": processor_defaults.get("model_source"),
-                    },
+                    model_config_kwargs=model_config_kwargs,
                     chat_template_content_format=prepare_multimodal_stage_cfg.chat_template_content_format,
                     apply_sys_msg_formatting=prepare_multimodal_stage_cfg.apply_sys_msg_formatting,
                 ),

--- a/python/ray/llm/_internal/batch/stages/configs.py
+++ b/python/ray/llm/_internal/batch/stages/configs.py
@@ -52,10 +52,9 @@ class PrepareImageStageConfig(_StageConfigBase):
 
 
 class PrepareMultimodalStageConfig(_StageConfigBase):
-    model_source: Optional[str] = Field(
+    model_config_kwargs: Optional[Dict[str, Any]] = Field(
         default=None,
-        description="Name or path of the Hugging Face model to use for the multimodal processor. "
-        "This is required to process multimodal data according to a specific model.",
+        description="Optional kwargs to pass to the model config.",
     )
     chat_template_content_format: Optional[Literal["string", "openai"]] = Field(
         default="string",

--- a/python/ray/llm/_internal/batch/stages/configs.py
+++ b/python/ray/llm/_internal/batch/stages/configs.py
@@ -54,7 +54,8 @@ class PrepareImageStageConfig(_StageConfigBase):
 class PrepareMultimodalStageConfig(_StageConfigBase):
     model_config_kwargs: Optional[Dict[str, Any]] = Field(
         default=None,
-        description="Optional kwargs to pass to the model config.",
+        description="Optional kwargs to pass to the model config. See available model config "
+        "kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig",
     )
     chat_template_content_format: Optional[Literal["string", "openai"]] = Field(
         default="string",

--- a/python/ray/llm/_internal/batch/stages/prepare_multimodal_stage.py
+++ b/python/ray/llm/_internal/batch/stages/prepare_multimodal_stage.py
@@ -11,7 +11,7 @@ class PrepareMultimodalUDF(StatefulStageUDF):
         self,
         data_column: str,
         expected_input_keys: List[str],
-        model: str,
+        model_config_kwargs: Dict[str, Any],
         chat_template_content_format: str,
         apply_sys_msg_formatting: bool = False,
     ):
@@ -21,7 +21,7 @@ class PrepareMultimodalUDF(StatefulStageUDF):
         Args:
             data_column: The data column name.
             expected_input_keys: The expected input keys of the stage.
-            model: The model to use for the multimodal processor.
+            model_config_kwargs: The kwargs to pass to the model config.
             chat_template_content_format: The format to render message content.
             apply_sys_msg_formatting: Whether to skip formatting system messages.
         """
@@ -35,7 +35,7 @@ class PrepareMultimodalUDF(StatefulStageUDF):
                 "`pip install ray[llm]` to install required dependencies."
             ) from e
 
-        self.model_config = ModelConfig(model=model)
+        self.model_config = ModelConfig(**model_config_kwargs)
         self.chat_template_content_format = chat_template_content_format
         self.apply_sys_msg_formatting = apply_sys_msg_formatting
 

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -357,22 +357,13 @@ class vLLMEngineWrapper:
 
         # Extract image data from preprocessing output
         # Note: Field name is 'image' (singular) not 'images' (plural).
-        # When multimodal_data is present (from PrepareMultimodalStage), images are
-        # handled through multimodal_data, so we should set image to an empty list.
         if multimodal_data is not None:
-            # Images are handled through multimodal_data, so ignore the image field
+            # When multimodal_data is present, images are handled through multimodal_data,
+            # so we should set image to an empty list.
             row.pop("image", None)
             image = []
         elif "image" in row:
             image = row.pop("image")
-            # Ensure image is a list (vLLMEngineRequest expects List[Any])
-            if not isinstance(image, list):
-                # If it's a single image, wrap it in a list
-                # If it's a dict (from original dataset), ignore it
-                if isinstance(image, dict):
-                    image = []
-                else:
-                    image = [image]
         else:
             image = []
         # TODO (jeffreywang): As we decouple the multimodal processor from the vLLM engine,

--- a/python/ray/llm/tests/batch/cpu/stages/test_prepare_multimodal_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_prepare_multimodal_stage.py
@@ -13,7 +13,7 @@ async def test_prepare_multimodal_udf_image_url(image_asset):
     udf = PrepareMultimodalUDF(
         data_column="__data",
         expected_input_keys=["messages"],
-        model="Qwen/Qwen2.5-VL-3B-Instruct",
+        model_config_kwargs={"model": "Qwen/Qwen2.5-VL-3B-Instruct"},
         chat_template_content_format="string",
     )
 
@@ -65,7 +65,7 @@ async def test_prepare_multimodal_udf_pil_image(image_asset):
     udf = PrepareMultimodalUDF(
         data_column="__data",
         expected_input_keys=["messages"],
-        model="Qwen/Qwen2.5-VL-3B-Instruct",
+        model_config_kwargs={"model": "Qwen/Qwen2.5-VL-3B-Instruct"},
         chat_template_content_format="string",
     )
 
@@ -109,7 +109,7 @@ async def test_prepare_multimodal_udf_no_multimodal_content():
     udf = PrepareMultimodalUDF(
         data_column="__data",
         expected_input_keys=["messages"],
-        model="Qwen/Qwen2.5-VL-3B-Instruct",
+        model_config_kwargs={"model": "Qwen/Qwen2.5-VL-3B-Instruct"},
         chat_template_content_format="string",
     )
 
@@ -138,7 +138,7 @@ def test_prepare_multimodal_udf_expected_keys():
     udf = PrepareMultimodalUDF(
         data_column="__data",
         expected_input_keys=["messages"],
-        model="Qwen/Qwen2.5-VL-3B-Instruct",
+        model_config_kwargs={"model": "Qwen/Qwen2.5-VL-3B-Instruct"},
         chat_template_content_format="string",
     )
     assert udf.expected_input_keys == {"messages"}

--- a/python/requirements/llm/llm-test-requirements.txt
+++ b/python/requirements/llm/llm-test-requirements.txt
@@ -6,3 +6,4 @@ pynvml>=12.0.0
 jupytext>1.13.6
 sphinx==6.2.1
 backoff
+datasets


### PR DESCRIPTION
## Description
Ray Data LLM's multimodal support was introduced in https://github.com/ray-project/ray/pull/58260. This PR follows up with documentation and examples while generalizing arguments in `PrepareMultimodalUDF`.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
- Add video and audio examples
- Adapt existing image examples
- Generalize `model_config_kwargs` passed into `ModelConfig` so it can be used to instantiate the processor responsible for extracting multimodal data from input conversations in `PrepareMultimodalUDF`. Previously, only the model name could be provided; now, any attribute supported by https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig can be passed through. This is especially useful for users loading multimodal datasets from disk.
