### PR TITLE
[Data] Fix `TensorArray` to Arrow tensor conversion

### DIFF
--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -231,7 +231,8 @@ def convert_to_pyarrow_array(
             # Convert to Numpy before creating instance of `ArrowTensorArray` to
             # align tensor shapes falling back to ragged ndarray only if necessary
             return ArrowTensorArray.from_numpy(
-                convert_to_numpy(column_values), column_name
+                convert_to_numpy(column_values),
+                column_name=column_name
             )
         else:
             return _convert_to_pyarrow_native_array(column_values, column_name)
@@ -717,6 +718,7 @@ class ArrowTensorArray(pa.ExtensionArray):
     def from_numpy(
         cls,
         arr: Union[np.ndarray, Iterable[np.ndarray]],
+        *,
         column_name: Optional[str] = None,
     ) -> Union["ArrowTensorArray", "ArrowVariableShapedTensorArray"]:
         """
@@ -761,7 +763,6 @@ class ArrowTensorArray(pa.ExtensionArray):
 
         try:
             timestamp_dtype = _try_infer_pa_timestamp_type(arr)
-
             if timestamp_dtype:
                 # NOTE: Quirky Arrow behavior will coerce unsupported Numpy `datetime64`
                 #       precisions that are nested inside a list type, but won't do it,
@@ -1162,7 +1163,8 @@ class ArrowVariableShapedTensorArray(pa.ExtensionArray):
 
     @classmethod
     def from_numpy(
-        cls, arr: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]]
+        cls,
+        arr: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]],
     ) -> "ArrowVariableShapedTensorArray":
         """
         Convert an ndarray or an iterable of heterogeneous-shaped ndarrays to an array

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1318,7 +1318,7 @@ def _ravel_tensors(
     raveled = np.empty(len(arr), dtype=np.object_)
 
     shapes = np.empty(len(arr), dtype=np.object_)
-    sizes = np.arange(len(arr), dtype=np.int64)
+    sizes = np.empty(len(arr), dtype=np.int64)
 
     ndim = None
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -798,9 +798,7 @@ class ArrowTensorArray(pa.ExtensionArray):
             #       arrays. Convert the entire array to scalar dtype through PyArrow,
             #       which handles None -> null -> nan conversion.
             original_shape = arr.shape
-            arr = (
-                _ensure_scalar_ndarray(arr).reshape(original_shape)
-            )
+            arr = _ensure_scalar_ndarray(arr).reshape(original_shape)
 
         if not arr.flags.c_contiguous:
             # We only natively support C-contiguous ndarrays.
@@ -1356,11 +1354,7 @@ def _ensure_scalar_ndarray(a: np.ndarray) -> np.ndarray:
     #       to appropriately handle type conversions
     if a.dtype == np.object_:
         shape = a.shape
-        a = (
-            pa.array(np.ravel(a))
-                .to_numpy(zero_copy_only=False)
-                .reshape(shape)
-        )
+        a = pa.array(np.ravel(a)).to_numpy(zero_copy_only=False).reshape(shape)
 
     return a
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1360,7 +1360,12 @@ def _ensure_scalar_ndarray(a: np.ndarray) -> np.ndarray:
     #       would have to be copied. We cycle these t/h Pyarrow
     #       to appropriately handle type conversions
     if a.dtype == np.object_:
-        a = pa.array(a).to_numpy(zero_copy_only=False)
+        shape = a.shape
+        a = (
+            pa.array(np.ravel(a))
+                .to_numpy(zero_copy_only=False)
+                .reshape(shape)
+        )
 
     return a
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -803,7 +803,7 @@ class ArrowTensorArray(pa.ExtensionArray):
 
                 assert len({tuple(s) for s in shapes}) == 1, (
                     f"Provided tensors must be homogeneously shaped "
-                    f"(got: {set(tuple(s) for s in shapes)=})"
+                    f"(got: {set(tuple(s) for s in shapes)=})"  # noqa: C401
                 )
 
                 num_tensors = len(arr)

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -231,8 +231,7 @@ def convert_to_pyarrow_array(
             # Convert to Numpy before creating instance of `ArrowTensorArray` to
             # align tensor shapes falling back to ragged ndarray only if necessary
             return ArrowTensorArray.from_numpy(
-                convert_to_numpy(column_values),
-                column_name=column_name
+                convert_to_numpy(column_values), column_name=column_name
             )
         else:
             return _convert_to_pyarrow_native_array(column_values, column_name)
@@ -797,7 +796,9 @@ class ArrowTensorArray(pa.ExtensionArray):
             # NOTE: In case of conversion from a Pandas extension types supporting
             #       nullable numeric values (like `pd.Int64Dtype`) we have to explicitly
             #       ravel tensors
-            _, raveled, shapes, sizes = ArrowVariableShapedTensorArray._ravel_tensors(arr)
+            _, raveled, shapes, sizes = ArrowVariableShapedTensorArray._ravel_tensors(
+                arr
+            )
 
             # TODO assert shapes, sizes
 
@@ -1254,12 +1255,9 @@ class ArrowVariableShapedTensorArray(pa.ExtensionArray):
         return type_.wrap_array(storage)
 
     @classmethod
-    def _ravel_tensors(cls, arr: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]]) -> Tuple[
-        int,
-        np.ndarray,
-        np.ndarray,
-        np.ndarray,
-    ]:
+    def _ravel_tensors(
+        cls, arr: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]]
+    ) -> Tuple[int, np.ndarray, np.ndarray, np.ndarray,]:
         raveled = np.empty(len(arr), dtype=np.object_)
         shapes = np.empty(len(arr), dtype=np.object_)
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1349,7 +1349,7 @@ def _ravel_tensors(
 
 def _ensure_scalar_ndarray(a: np.ndarray) -> np.ndarray:
     # NOTE: In cases of nullable types being passed from Pandas
-    #       we might get ndarrays(type='0') that unfortunately
+    #       we might get ndarrays(dtype='O') that unfortunately
     #       would have to be copied. We cycle these t/h Pyarrow
     #       to appropriately handle type conversions
     if a.dtype == np.object_:

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -114,7 +114,9 @@ def _is_ndarray_variable_shaped_tensor(arr: np.ndarray) -> bool:
             return False
         if a.shape != shape:
             return True
-    return True
+
+    # All shapes are identical
+    return False
 
 
 def _create_possibly_ragged_ndarray(

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -1,3 +1,4 @@
+import traceback
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -16,6 +17,18 @@ from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     from pandas.core.dtypes.generic import ABCSeries
+
+
+_pandas = None
+
+
+def lazy_import_pandas():
+    global _pandas
+    if _pandas is None:
+        import pandas
+
+        _pandas = pandas
+    return _pandas
 
 
 @DeveloperAPI(stability="beta")
@@ -46,6 +59,11 @@ def _is_arrow_array(value: ArrayLike) -> bool:
     return isinstance(value, (pa.Array, pa.ChunkedArray))
 
 
+def _is_pd_series(value: ArrayLike) -> bool:
+    pd = lazy_import_pandas()
+    return pd is not None and isinstance(value, pd.Series)
+
+
 def _should_convert_to_tensor(
     column_values: Union[List[Any], np.ndarray, ArrayLike], column_name: str
 ) -> bool:
@@ -53,7 +71,7 @@ def _should_convert_to_tensor(
 
     # We convert passed in column values into a tensor representation (involving
     # Arrow/Pandas extension types) in either of the following cases:
-    return (
+    res = (
         # - Column name is `TENSOR_COLUMN_NAME` (for compatibility)
         column_name == TENSOR_COLUMN_NAME
         # - Provided column values are already represented by a Numpy tensor (ie
@@ -62,18 +80,31 @@ def _should_convert_to_tensor(
         # - Provided collection is already implementing Ndarray protocol like
         #   `torch.Tensor`, `pd.Series`, etc (but *excluding* `pyarrow.Array`,
         #   `pyarrow.ChunkedArray`)
-        or _is_ndarray_like_not_pyarrow_array(column_values)
+        or _is_ndarray_like_not_pyarrow_array_or_pd_series(column_values)
         # - Provided column values is a list of a) ndarrays or b) ndarray-like objects
         #   (excluding Pyarrow arrays). This is done for compatibility with previous
         #   existing behavior where all column values were blindly converted to Numpy
         #   leading to list of ndarrays being converted a tensor):
         or isinstance(column_values[0], np.ndarray)
-        or _is_ndarray_like_not_pyarrow_array(column_values[0])
+        or _is_ndarray_like_not_pyarrow_array_or_pd_series(column_values[0])
     )
 
+    if res:
+        print(
+            f">>> [DBG] _should_convert_to_tensor(column_values): {column_values=}, {type(column_values[0])=}, {_is_ndarray_tensor(column_values)=}, {_is_ndarray_like_not_pyarrow_array_or_pd_series(column_values)=}, {_is_ndarray_like_not_pyarrow_array_or_pd_series(column_values[0])=} {res=}"
+        )
 
-def _is_ndarray_like_not_pyarrow_array(column_values):
-    return is_ndarray_like(column_values) and not _is_arrow_array(column_values)
+        traceback.print_stack()
+
+    return res
+
+
+def _is_ndarray_like_not_pyarrow_array_or_pd_series(column_values):
+    return (
+        is_ndarray_like(column_values)
+        and not _is_arrow_array(column_values)
+        # and not _is_pd_series(column_values)
+    )
 
 
 def _is_ndarray_tensor(t: Any) -> bool:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -4407,7 +4407,7 @@ def _resolve_parquet_args(
                 block = block.set_column(
                     block._ensure_integer_index(tensor_col_name),
                     tensor_col_name,
-                    ArrowTensorArray.from_numpy(np_col, tensor_col_name),
+                    ArrowTensorArray.from_numpy(np_col, column_name=tensor_col_name),
                 )
             if existing_block_udf is not None:
                 # Apply UDF after casting the tensor columns.

--- a/python/ray/data/tests/test_tensor_extension.py
+++ b/python/ray/data/tests/test_tensor_extension.py
@@ -59,6 +59,21 @@ def test_tensor_array_validation():
         TensorArray([object(), object()])
 
 
+@pytest.mark.parametrize("tensor_type", ["fixed_shape", "var_shape"])
+def test_pandas_to_arrow_tensor_conversion(tensor_type):
+    array = pd.Series([1, 2, 3, None], dtype=pd.Int64Dtype).to_numpy()
+    tensor = np.stack([array, array])
+
+    if tensor_type == "fixed_shape":
+        fixed_shape = ArrowTensorArray.from_numpy(tensor)
+        print(fixed_shape)
+    elif tensor_type == "var_shape":
+        var_shape = ArrowVariableShapedTensorArray.from_numpy(tensor)
+        print(var_shape)
+    else:
+        pytest.fail(f"Invalid tensor type: {tensor_type}")
+
+
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_arrow_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
     DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"

--- a/python/ray/data/tests/test_tensor_extension.py
+++ b/python/ray/data/tests/test_tensor_extension.py
@@ -104,7 +104,7 @@ def test_pandas_to_arrow_var_shape_tensor_conversion():
 def test_arrow_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
     DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
-    arr = np.arange(10)
+    arr = np.arange(1000).reshape((10, 1, 100))
     ata = ArrowTensorArray.from_numpy(arr)
     assert isinstance(ata.type, pa.DataType)
     assert len(ata) == len(arr)
@@ -132,7 +132,7 @@ def test_arrow_scalar_tensor_array_roundtrip_boolean(
 def test_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
     DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
-    arr = np.arange(10)
+    arr = np.arange(1000).reshape(10, 1, 100)
     ta = TensorArray(arr)
     assert isinstance(ta.dtype, TensorDtype)
     assert len(ta) == len(arr)
@@ -197,33 +197,30 @@ def test_arrow_variable_shaped_tensor_array_validation(
         )
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_arrow_variable_shaped_tensor_array_roundtrip(
-    restore_data_context, tensor_format
+    restore_data_context
 ):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [
         np.arange(offset, offset + np.prod(shape)).reshape(shape)
         for offset, shape in zip(cumsum_sizes, shapes)
     ]
-    arr = np.array(arrs, dtype=object)
+
+    arr = create_ragged_ndarray(arrs)
     ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+
     assert isinstance(ata.type, ArrowVariableShapedTensorType)
     assert len(ata) == len(arr)
+
     out = ata.to_numpy()
     for o, a in zip(out, arr):
         np.testing.assert_array_equal(o, a)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
-    restore_data_context, tensor_format
+    restore_data_context
 ):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
     arr = np.array(
         [[True, False], [False, False, True], [False], [True, True, False, True]],
         dtype=object,
@@ -236,12 +233,9 @@ def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
         np.testing.assert_array_equal(o, a)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(
-    restore_data_context, tensor_format
+    restore_data_context
 ):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
     # Test that a roundtrip on slices of an already-contiguous 1D base array does not
     # create any unnecessary copies.
     base = np.arange(6)
@@ -257,10 +251,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(
         np.testing.assert_array_equal(o, a)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_slice(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_tensor_array_slice(restore_data_context):
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [
@@ -294,12 +285,9 @@ def test_arrow_variable_shaped_tensor_array_slice(restore_data_context, tensor_f
             np.testing.assert_array_equal(o, e)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_arrow_variable_shaped_bool_tensor_array_slice(
-    restore_data_context, tensor_format
+    restore_data_context
 ):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
     arr = np.array(
         [
             [True],
@@ -335,12 +323,9 @@ def test_arrow_variable_shaped_bool_tensor_array_slice(
             np.testing.assert_array_equal(o, e)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_arrow_variable_shaped_string_tensor_array_slice(
-    restore_data_context, tensor_format
+    restore_data_context
 ):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
     arr = np.array(
         [
             ["Philip", "J", "Fry"],
@@ -380,10 +365,7 @@ def test_arrow_variable_shaped_string_tensor_array_slice(
             np.testing.assert_array_equal(o, e)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_variable_shaped_tensor_array_roundtrip(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_variable_shaped_tensor_array_roundtrip(restore_data_context):
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [
@@ -407,10 +389,7 @@ def test_variable_shaped_tensor_array_roundtrip(restore_data_context, tensor_for
         np.testing.assert_array_equal(o, a)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_variable_shaped_tensor_array_slice(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_variable_shaped_tensor_array_slice(restore_data_context):
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [

--- a/python/ray/data/tests/test_tensor_extension.py
+++ b/python/ray/data/tests/test_tensor_extension.py
@@ -60,7 +60,13 @@ def test_tensor_array_validation():
 
 
 def test_pandas_to_arrow_fixed_shape_tensor_conversion():
-    array = pd.Series([1, 2, 3, None], dtype=pd.Int64Dtype).to_numpy()
+    # First, convert Pandas serise w/ nulls to numpy
+    array = (
+        pd.Series([1, 2, 3, None], dtype=pd.Int64Dtype)
+            .to_numpy()
+            .reshape((2, 2))
+    )
+
     input_tensor = np.stack([array, array])
 
     pa_tensor = ArrowTensorArray.from_numpy(input_tensor)
@@ -73,9 +79,13 @@ def test_pandas_to_arrow_fixed_shape_tensor_conversion():
 
 
 def test_pandas_to_arrow_var_shape_tensor_conversion():
+    # First, convert Pandas serise w/ nulls to numpy
     array = pd.Series([1, 2, 3, None], dtype=pd.Int64Dtype).to_numpy()
 
-    input_tensor = create_ragged_ndarray([array.reshape(1, 4), array.reshape((2, 2))])
+    input_tensor = create_ragged_ndarray([
+        array.reshape(1, 4),
+        array.reshape((2, 2))
+    ])
 
     # For ragged arrays, we need to convert each element individually
     expeted_np_tensor = create_ragged_ndarray(

--- a/python/ray/data/tests/test_tensor_extension.py
+++ b/python/ray/data/tests/test_tensor_extension.py
@@ -72,13 +72,13 @@ def test_pandas_to_arrow_fixed_shape_tensor_conversion():
 
 
 def test_pandas_to_arrow_var_shape_tensor_conversion():
-    # First, convert Pandas serise w/ nulls to numpy
+    # First, convert Pandas series w/ nulls to numpy
     array = pd.Series([1, 2, 3, None], dtype=pd.Int64Dtype).to_numpy()
 
     input_tensor = create_ragged_ndarray([array.reshape(1, 4), array.reshape((2, 2))])
 
     # For ragged arrays, we need to convert each element individually
-    expeted_np_tensor = create_ragged_ndarray(
+    expected_np_tensor = create_ragged_ndarray(
         [t.astype(np.float64) for t in input_tensor]
     )
 

--- a/python/ray/data/tests/test_tensor_extension.py
+++ b/python/ray/data/tests/test_tensor_extension.py
@@ -61,31 +61,21 @@ def test_tensor_array_validation():
 
 def test_pandas_to_arrow_fixed_shape_tensor_conversion():
     # First, convert Pandas serise w/ nulls to numpy
-    array = (
-        pd.Series([1, 2, 3, None], dtype=pd.Int64Dtype)
-            .to_numpy()
-            .reshape((2, 2))
-    )
+    array = pd.Series([1, 2, 3, None], dtype=pd.Int64Dtype).to_numpy().reshape((2, 2))
 
     input_tensor = np.stack([array, array])
 
     pa_tensor = ArrowTensorArray.from_numpy(input_tensor)
     res_tensor = pa_tensor.to_numpy()
 
-    np.testing.assert_array_equal(
-        res_tensor,
-        np.stack([array.astype(np.float64)] * 2)
-    )
+    np.testing.assert_array_equal(res_tensor, np.stack([array.astype(np.float64)] * 2))
 
 
 def test_pandas_to_arrow_var_shape_tensor_conversion():
     # First, convert Pandas serise w/ nulls to numpy
     array = pd.Series([1, 2, 3, None], dtype=pd.Int64Dtype).to_numpy()
 
-    input_tensor = create_ragged_ndarray([
-        array.reshape(1, 4),
-        array.reshape((2, 2))
-    ])
+    input_tensor = create_ragged_ndarray([array.reshape(1, 4), array.reshape((2, 2))])
 
     # For ragged arrays, we need to convert each element individually
     expeted_np_tensor = create_ragged_ndarray(
@@ -197,9 +187,7 @@ def test_arrow_variable_shaped_tensor_array_validation(
         )
 
 
-def test_arrow_variable_shaped_tensor_array_roundtrip(
-    restore_data_context
-):
+def test_arrow_variable_shaped_tensor_array_roundtrip(restore_data_context):
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [
@@ -218,9 +206,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip(
         np.testing.assert_array_equal(o, a)
 
 
-def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
-    restore_data_context
-):
+def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(restore_data_context):
     arr = np.array(
         [[True, False], [False, False, True], [False], [True, True, False, True]],
         dtype=object,
@@ -234,7 +220,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
 
 
 def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(
-    restore_data_context
+    restore_data_context,
 ):
     # Test that a roundtrip on slices of an already-contiguous 1D base array does not
     # create any unnecessary copies.
@@ -285,9 +271,7 @@ def test_arrow_variable_shaped_tensor_array_slice(restore_data_context):
             np.testing.assert_array_equal(o, e)
 
 
-def test_arrow_variable_shaped_bool_tensor_array_slice(
-    restore_data_context
-):
+def test_arrow_variable_shaped_bool_tensor_array_slice(restore_data_context):
     arr = np.array(
         [
             [True],
@@ -323,9 +307,7 @@ def test_arrow_variable_shaped_bool_tensor_array_slice(
             np.testing.assert_array_equal(o, e)
 
 
-def test_arrow_variable_shaped_string_tensor_array_slice(
-    restore_data_context
-):
+def test_arrow_variable_shaped_string_tensor_array_slice(restore_data_context):
     arr = np.array(
         [
             ["Philip", "J", "Fry"],


### PR DESCRIPTION
## Description

This change addresses a long-standing problem when Pandas tensors holding null values couldn't be converted into Arrow ones.

More details are captured in https://github.com/ray-project/ray/issues/59445.

Following changes are made to address that:

 - Fixed `_is_ndarray_variable_shaped_tensor`
 - Numpy tensors with `dtype='o'` are cycled t/h Pyarrow to be converted into proper ndarrays
 - Path raveling and formatting are unified b/w fixed-shape and var-shaped tensors

## Related issues

Addresses https://github.com/ray-project/ray/issues/59445

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
