### PR TITLE
[Core] Fix flaky test_autoscaler_init: poll cluster status instead of using stale snapshot

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -136,11 +136,7 @@ def test_autoscaler_init(
     cluster.head_node.start_gcs_server()
 
     # Fetch the cluster status from the autoscaler and check that it works.
-    def check_cluster_status():
-        status = get_cluster_status(cluster.address)
-        return len(status.idle_nodes) == 2
-
-    wait_for_condition(check_cluster_status)
+    wait_for_condition(lambda: len(get_cluster_status(cluster.address).idle_nodes) == 2)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -136,8 +136,11 @@ def test_autoscaler_init(
     cluster.head_node.start_gcs_server()
 
     # Fetch the cluster status from the autoscaler and check that it works.
-    status = get_cluster_status(cluster.address)
-    wait_for_condition(lambda: len(status.idle_nodes) == 2)
+    def check_cluster_status():
+        status = get_cluster_status(cluster.address)
+        return len(status.idle_nodes) == 2
+
+    wait_for_condition(check_cluster_status)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
1. Start a new Ray cluster with two nodes with FT
2. Kill GCS and then restart
3. Fetch the cluster status from the autoscaler and check it still knows the two nodes

The flaky issue is because the `status` gotten from `get_cluster_status(cluster.address)` is static. The autoscaler might still be working and getting correct info from the restarted GCS, but `wait_for_condition` was previously checking a static value. This PR fixes this by making `wait_for_condition` properly check by getting a fresh `cluster_status` on every check.


I noticed this because it reproduces consistently in my local dev environment.


## Test
```shell
(venv) (base) ubuntu@devbox:~/ray$ for i in {1..4}; do echo "=== Run $i ===" && python -m pytest python/ray/tests/test_gcs_fault_tolerance.py::test_autoscaler_init -v --tb=short 2>&1 | tail -5; done
=== Run 1 ===
collecting ... collected 1 item

python/ray/tests/test_gcs_fault_tolerance.py::test_autoscaler_init[ray_start_cluster_head_with_external_redis0] PASSED [100%]

============================== 1 passed in 15.01s ==============================
=== Run 2 ===
collecting ... collected 1 item

python/ray/tests/test_gcs_fault_tolerance.py::test_autoscaler_init[ray_start_cluster_head_with_external_redis0] PASSED [100%]

============================== 1 passed in 16.55s ==============================
=== Run 3 ===
collecting ... collected 1 item

python/ray/tests/test_gcs_fault_tolerance.py::test_autoscaler_init[ray_start_cluster_head_with_external_redis0] PASSED [100%]

============================== 1 passed in 17.49s ==============================
=== Run 4 ===
collecting ... collected 1 item

python/ray/tests/test_gcs_fault_tolerance.py::test_autoscaler_init[ray_start_cluster_head_with_external_redis0] PASSED [100%]

============================== 1 passed in 15.57s ==============================
```
