### PR TITLE
[serve] Added validation for `lookback_period_s` > metrics interval and updated docs

### DIFF
--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -162,12 +162,10 @@ downscaling.
 * **[`metrics_interval_s`](../api/doc/ray.serve.config.AutoscalingConfig.metrics_interval_s.rst) [default_value=10]**: In future this deployment level
 config will be removed in favor of cross-application level global config.
   
-This controls how often each replica and handle sends reports on current ongoing
-requests to the autoscaler. Note that the autoscaler can't make new decisions if
-it doesn't receive updated metrics, so you most likely want to set these values to
-be less than or equal to the upscale and downscale delay values. For instance, if
-you set `upscale_delay_s = 3`, but keep the push interval at 10s, the autoscaler
-only upscales roughly every 10 seconds.
+This controls how often each replica and handle sends reports on current ongoing requests to the autoscaler.
+::{note}
+If metrics are reported infrequently, Ray Serve can take longer to notice a change in autoscaling metrics, so scaling can start later even if your delays are short. For example, if you set `upscale_delay_s = 3` but metrics are pushed every 10 seconds, Ray Serve might not see a change until the next push, so scaling up can be limited to about once every 10 seconds.
+::
 
 * **[`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.look_back_period_s.rst) [default_value=30]**: This is the window over which the
 average number of ongoing requests per replica is calculated.
@@ -279,10 +277,10 @@ The timing parameters interact in important ways:
 - New scaling decisions only happen when fresh metrics arrive
 
 **Push interval vs upscale/downscale delays:**
-- Delays (30s/600s) should be ≥ push interval (10s)
-- Generally the delay should be set to some multiples of push interval, so the autoscaler only reacts after 
-  multiple consecutive metric breaches—this filters out short-lived spikes and prevents noisy, oscillating scale-ups.
-- Example: `upscale_delay_s = 5` but push interval = 10s means actual delay ≈ 10s
+- Delays control when Ray Serve applies a scale up or scale down.
+- The metrics push interval controls how quickly Ray Serve sees traffic changes.
+- If the push interval < delay, Ray Serve can use multiple metric updates before it scales.
+- Example: push every 10s with `upscale_delay_s = 20` means up to 2 new metric updates before scaling
 
 **Recommendation:** Keep default values unless you have specific needs. If you
 need faster autoscaling, decrease push intervals first, then adjust delays.

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -278,7 +278,7 @@ The timing parameters interact in important ways:
 
 **Push interval vs upscale/downscale delays:**
 - Delays control when Ray Serve applies a scale up or scale down.
-- The metrics push interval controls how quickly Ray Serve sees traffic changes.
+- The metrics push interval controls how quickly Ray Serve receives fresh metrics.
 - If the push interval < delay, Ray Serve can use multiple metric updates before it scales.
 - Example: push every 10s with `upscale_delay_s = 20` means up to 2 new metric updates before scaling
 

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -267,7 +267,7 @@ The timing parameters interact in important ways:
 - With default values: Each push contains 1 data points (10s ÷ 10s)
 
 **Push interval vs look-back period:**
-- [`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.look_back_period_s.rst) (30s) should be ≥ push interval (10s)
+- [`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.look_back_period_s.rst) (30s) should be > push interval (10s)
 - If look-back is too short, you won't have enough data for stable decisions
 - If look-back is too long, autoscaling becomes less responsive
 

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -520,6 +520,19 @@ class AutoscalingConfig(BaseModel):
             )
         return v
 
+    @validator("look_back_period_s", always=True)
+    def look_back_period_s_valid(cls, v: PositiveFloat, values):
+        # Get metrics_interval_s from values, or use default if not set
+        metrics_interval_s = values.get(
+            "metrics_interval_s", DEFAULT_METRICS_INTERVAL_S
+        )
+        if v <= metrics_interval_s:
+            raise ValueError(
+                f"look_back_period_s ({v}) must be greater than "
+                f"metrics_interval_s ({metrics_interval_s})!"
+            )
+        return v
+
     @validator("aggregation_function", always=True)
     def aggregation_function_valid(cls, v: Union[str, AggregationFunction]):
         if isinstance(v, AggregationFunction):

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -527,9 +527,12 @@ class AutoscalingConfig(BaseModel):
             "metrics_interval_s", DEFAULT_METRICS_INTERVAL_S
         )
         if v <= metrics_interval_s:
-            raise ValueError(
-                f"look_back_period_s ({v}) must be greater than "
-                f"metrics_interval_s ({metrics_interval_s})!"
+            # Warns currently, will raise an exception in a future release
+            warnings.warn(
+                f"`look_back_period_s` ({v}) must be greater than `metrics_interval_s` "
+                f"({metrics_interval_s}). This will raise an exception in a future "
+                f"release. Please set `look_back_period_s` > `metrics_interval_s`.",
+                FutureWarning,
             )
         return v
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -548,6 +548,7 @@ def test_cold_start_time(serve_instance):
         autoscaling_config={
             "min_replicas": 0,
             "max_replicas": 1,
+            "metrics_interval_s": 0.1,
             "look_back_period_s": 0.2,
         },
     )
@@ -965,7 +966,7 @@ def test_e2e_preserve_prev_replicas(serve_instance_with_signal):
             downscale_delay_s=600,
             upscale_delay_s=0,
             metrics_interval_s=1,
-            look_back_period_s=1,
+            look_back_period_s=2,
         ),
     )
     def scaler():
@@ -1029,7 +1030,7 @@ def test_e2e_preserve_prev_replicas(serve_instance_with_signal):
             downscale_delay_s=600,
             upscale_delay_s=600,
             metrics_interval_s=1,
-            look_back_period_s=1,
+            look_back_period_s=2,
         )
     )
     handle = serve.run(scaler.bind())
@@ -1080,7 +1081,7 @@ app = g.bind()
                     "downscale_delay_s": 600,
                     "upscale_delay_s": 0,
                     "metrics_interval_s": 1,
-                    "look_back_period_s": 1,
+                    "look_back_period_s": 2,
                 },
             }
         ],

--- a/python/ray/serve/tests/test_custom_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_custom_autoscaling_metrics.py
@@ -101,7 +101,7 @@ class TestCustomServeMetrics:
                 "upscale_delay_s": 2,
                 "downscale_delay_s": 10,
                 "metrics_interval_s": 1,
-                "look_back_period_s": 1,
+                "look_back_period_s": 2,
             }
         )
         class DummyMetricTimeout:
@@ -133,7 +133,7 @@ class TestCustomServeMetrics:
                 "upscale_delay_s": 2,
                 "downscale_delay_s": 10,
                 "metrics_interval_s": 1,
-                "look_back_period_s": 1,
+                "look_back_period_s": 2,
             }
         )
         class DummyInvalidMetric:

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -355,7 +355,7 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
             autoscaling_config={
                 "metrics_interval_s": 1,
                 "upscale_delay_s": 1,
-                "look_back_period_s": 1,
+                "look_back_period_s": 2,
             },
             graceful_shutdown_timeout_s=1,
         )
@@ -365,7 +365,7 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
             autoscaling_config={
                 "metrics_interval_s": 1,
                 "upscale_delay_s": 1,
-                "look_back_period_s": 1,
+                "look_back_period_s": 2,
             },
             graceful_shutdown_timeout_s=1,
         )(A)
@@ -389,7 +389,7 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
         "metrics_interval_s": 1.0,
         "upscale_delay_s": 1.0,
         # Untouched defaults
-        "look_back_period_s": 1.0,
+        "look_back_period_s": 2.0,
         "downscale_delay_s": 600.0,
         "downscale_to_zero_delay_s": None,
         "upscale_smoothing_factor": None,

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -291,9 +291,9 @@ def test_controller_recover_target_capacity(
         "downscaling_factor": 4,
         "metrics_interval_s": 1,
         # The default look_back_period_s is 30, which means the test assertions will be
-        # slow to respond to changes in metrics. Setting it to 1 makes the test assertions
+        # slow to respond to changes in metrics. Setting it to 2 makes the test assertions
         # more responsive to changes in metrics, hence reducing flakiness.
-        "look_back_period_s": 1,
+        "look_back_period_s": 2,
     },
     max_ongoing_requests=2,
     graceful_shutdown_timeout_s=0,

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -98,9 +98,9 @@ def test_autoscaling_config_validation():
     assert non_default_autoscaling_config.policy.is_default_policy_function() is False
 
     # look_back_period_s must be greater than metrics_interval_s
-    with pytest.raises(ValueError):
+    with pytest.warns(FutureWarning):
         AutoscalingConfig(look_back_period_s=5.0, metrics_interval_s=10.0)
-    with pytest.raises(ValueError):
+    with pytest.warns(FutureWarning):
         AutoscalingConfig(look_back_period_s=10.0, metrics_interval_s=10.0)
     AutoscalingConfig(look_back_period_s=30.0, metrics_interval_s=10.0)
     AutoscalingConfig(look_back_period_s=10.0, metrics_interval_s=5.0)

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -97,6 +97,14 @@ def test_autoscaling_config_validation():
     )
     assert non_default_autoscaling_config.policy.is_default_policy_function() is False
 
+    # look_back_period_s must be greater than metrics_interval_s
+    with pytest.raises(ValueError):
+        AutoscalingConfig(look_back_period_s=5.0, metrics_interval_s=10.0)
+    with pytest.raises(ValueError):
+        AutoscalingConfig(look_back_period_s=10.0, metrics_interval_s=10.0)
+    AutoscalingConfig(look_back_period_s=30.0, metrics_interval_s=10.0)
+    AutoscalingConfig(look_back_period_s=10.0, metrics_interval_s=5.0)
+
 
 def test_autoscaling_config_metrics_interval_s_deprecation_warning() -> None:
     """Test that the metrics_interval_s deprecation warning is raised."""

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -103,7 +103,7 @@ def test_autoscaling_config_validation():
     with pytest.warns(FutureWarning):
         AutoscalingConfig(look_back_period_s=10.0, metrics_interval_s=10.0)
     AutoscalingConfig(look_back_period_s=30.0, metrics_interval_s=10.0)
-    AutoscalingConfig(look_back_period_s=10.0, metrics_interval_s=5.0)
+    AutoscalingConfig(look_back_period_s=20.0, metrics_interval_s=10.0)
 
 
 def test_autoscaling_config_metrics_interval_s_deprecation_warning() -> None:

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -2848,6 +2848,7 @@ class TestAutoscaling:
                 "upscale_delay_s": 0,
                 "downscale_delay_s": 0,
                 "metrics_interval_s": 100,
+                "look_back_period_s": 200,
             }
         )
         dsm.deploy(TEST_DEPLOYMENT_ID, info)
@@ -3038,6 +3039,7 @@ class TestAutoscaling:
                 "upscale_delay_s": 0,
                 "downscale_delay_s": 0,
                 "metrics_interval_s": 100,
+                "look_back_period_s": 200,
             }
         )
 
@@ -3393,6 +3395,7 @@ class TestAutoscaling:
                 "upscale_delay_s": 0,
                 "downscale_delay_s": 0,
                 "metrics_interval_s": 100,
+                "look_back_period_s": 200,
             }
         )
         dsm.deploy(TEST_DEPLOYMENT_ID, info)
@@ -3484,6 +3487,7 @@ class TestAutoscaling:
                 "upscale_delay_s": 0,
                 "downscale_delay_s": 0,
                 "metrics_interval_s": 100,
+                "look_back_period_s": 200,
             }
         )
         dsm.deploy(TEST_DEPLOYMENT_ID, info)
@@ -3809,6 +3813,7 @@ class TestAutoscaling:
                 "upscale_delay_s": 0,
                 "downscale_delay_s": 0,
                 "metrics_interval_s": 100,
+                "look_back_period_s": 200,
             }
         )
         dsm.deploy(TEST_DEPLOYMENT_ID, info)

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -1043,7 +1043,9 @@ class TestRouterMetricsManager:
         )
         metrics_manager.update_deployment_config(
             deployment_config=DeploymentConfig(
-                autoscaling_config=AutoscalingConfig(look_back_period_s=0.01)
+                autoscaling_config=AutoscalingConfig(
+                    metrics_interval_s=0.005, look_back_period_s=0.01
+                )
             ),
             curr_num_replicas=0,
         )


### PR DESCRIPTION
## Description
- Added config validation to ensure `look_back_period_s` is greater than `metrics_interval_s` in `AutoscalingConfig`. 
- Updated autoscaling docs to clarify the relationship between delays and metric push intervals.

## Related issues
Fixes #57714

## Additional information
- Updated documentation around the interaction between metrics push interval and autoscaling delays: Delays are enforced purely via the control loop interval and delay parameters, while the push interval bounds how quickly the autoscaler can see metric changes.
