### PR TITLE
[train] TrainController reraises AsyncioActorExit

### DIFF
--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 import ray
 import ray._private.ray_constants as ray_constants
+from ray.exceptions import AsyncioActorExit
 from ray.train.v2._internal.constants import (
     DEFAULT_ENABLE_CONTROLLER_LOGGING,
     DEFAULT_HEALTH_CHECK_INTERVAL_S,
@@ -432,6 +433,8 @@ class TrainController:
             try:
                 worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
             except Exception as e:
+                if isinstance(e, AsyncioActorExit):
+                    raise e
                 training_failed_error = ControllerError(e)
                 failure_decision = self._failure_policy.make_decision(
                     training_failed_error=training_failed_error,

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -432,9 +432,9 @@ class TrainController:
         elif isinstance(controller_state, RunningState):
             try:
                 worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
+            except AsyncioActorExit:
+                raise
             except Exception as e:
-                if isinstance(e, AsyncioActorExit):
-                    raise e
                 training_failed_error = ControllerError(e)
                 failure_decision = self._failure_policy.make_decision(
                     training_failed_error=training_failed_error,


### PR DESCRIPTION
# Summary

@justinvyu noticed the following logs 

```
(TrainController pid=95437) [State Transition] RUNNING -> ABORTED.
(TrainController pid=95437) [FailurePolicy] RAISE
(TrainController pid=95437)   Source: controller
(TrainController pid=95437)   Error count: 1 (max allowed: 0)
(TrainController pid=95437) 
(TrainController pid=95437) Traceback (most recent call last):
(TrainController pid=95437)   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/train/v2/_internal/execution/controller/controller.py", line 433, in _step
(TrainController pid=95437)     worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
(TrainController pid=95437)   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/util/tracing/tracing_helper.py", line 493, in _resume_span
(TrainController pid=95437)     return await method(self, *_args, **_kwargs)
(TrainController pid=95437)   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/train/v2/_internal/execution/controller/controller.py", line 283, in _poll_workers
(TrainController pid=95437)     ray.actor.exit_actor()
(TrainController pid=95437)   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/actor.py", line 2492, in exit_actor
(TrainController pid=95437)     raise AsyncioActorExit()
(TrainController pid=95437) ray.train.ControllerError: Training failed due to controller error:
(TrainController pid=95437) 
(TrainController pid=95437) [State Transition] ABORTED -> SHUTTING_DOWN.
```

The problem is that the fallback I implemented in https://github.com/ray-project/ray/pull/58287 didn't work because the `TrainController` caught the `AsyncioActorExit` raised by `ray.actor.exit_actor` and handled it as a `ControllerError`. However, what we actually want is to finish the abort asap by reraising the exception.

# Testing

Unit tests. I didn't add a new unit test for this specifically because the situation it covers happens flakily and would require a lot of contrived mocking to reproduce.