### PR TITLE
[core] Non-null func proposal

### DIFF
--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -317,6 +317,7 @@ ray_cc_library(
         "//src/ray/stats:stats_metric",
         "//src/ray/util:counter_map",
         "//src/ray/util:exponential_backoff",
+        "//src/ray/util:non_null_func",
         "//src/ray/util:time",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -35,6 +35,7 @@
 #include "ray/gcs_rpc_client/gcs_client.h"
 #include "ray/observability/metric_interface.h"
 #include "ray/util/counter_map.h"
+#include "ray/util/non_null_func.h"
 #include "src/ray/protobuf/common.pb.h"
 #include "src/ray/protobuf/core_worker.pb.h"
 #include "src/ray/protobuf/gcs.pb.h"
@@ -47,8 +48,7 @@ class ActorManager;
 using TaskStatusCounter = CounterMap<std::tuple<std::string, rpc::TaskStatus, bool>>;
 using PutInLocalPlasmaCallback =
     std::function<Status(const RayObject &object, const ObjectID &object_id)>;
-using AsyncRetryTaskCallback =
-    std::function<void(TaskSpecification &spec, uint32_t delay_ms)>;
+using AsyncRetryTaskCallback = NonNullFunc<void, TaskSpecification &, uint32_t>;
 using ReconstructObjectCallback = std::function<void(const ObjectID &object_id)>;
 using PushErrorCallback = std::function<Status(const JobID &job_id,
                                                const std::string &type,

--- a/src/ray/util/BUILD.bazel
+++ b/src/ray/util/BUILD.bazel
@@ -362,3 +362,8 @@ ray_cc_library(
         "@com_google_absl//absl/strings:str_format",
     ],
 )
+
+ray_cc_library(
+    name = "non_null_func",
+    hdrs = ["non_null_func.h"],
+)

--- a/src/ray/util/non_null_func.h
+++ b/src/ray/util/non_null_func.h
@@ -1,4 +1,4 @@
-// Copyright 2017 The Ray Authors.
+// Copyright 2025 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/util/non_null_func.h
+++ b/src/ray/util/non_null_func.h
@@ -1,0 +1,34 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+
+template <typename ReturnType, typename... Args>
+class NonNullFunc {
+ private:
+  std::function<ReturnType(Args...)> func_;
+
+ public:
+  template <typename F,
+            typename = std::enable_if_t<std::is_invocable_r_v<ReturnType, F, Args...>>>
+  // NOLINTNEXTLINE - for non-explicit single arg constructor
+  NonNullFunc(F &&func) : func_(std::forward<F>(func)) {}
+
+  ReturnType operator()(Args... args) const { return func_(std::forward<Args>(args)...); }
+};


### PR DESCRIPTION
## Description
@israbbani dared to ask why we have to do
```
RAY_CHECK(func_ != nullptr)
```
everywhere.

This offers a way to create a function object that is compile-time enforced to not be null. NonNullFunc has no default constructor and its constructor doesn't allow nullptr being passed into it thanks to the is_invokable type trait.

I have no idea why this isn't part of any standard library like boost / absl / folly. Open to thoughts, not totally convinced of actually merging / using this.