### PR TITLE
[Core] Add get_session_name() to RuntimeContext

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -150,12 +150,12 @@ class RuntimeContext(object):
             "session_2025-01-01_00-00-00_000000_1234").
 
         Raises:
-            AssertionError: If not called in a driver or worker. Generally,
-                this means that ray.init() was not called.
+            RuntimeError: If Ray has not been initialized.
         """
-        assert (
-            ray.is_initialized()
-        ), "Session name is not available because Ray has not been initialized."
+        if not ray.is_initialized():
+            raise RuntimeError(
+                "Session name is not available because Ray has not been initialized."
+            )
         return self.worker.node.session_name
 
     def get_worker_id(self) -> str:

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -70,12 +70,12 @@ class RuntimeContext(object):
             job ID will be hex format.
 
         Raises:
-            AssertionError: If not called in a driver or worker. Generally,
-                this means that ray.init() was not called.
+            RuntimeError: If Ray has not been initialized.
         """
-        assert (
-            ray.is_initialized()
-        ), "Job ID is not available because Ray has not been initialized."
+        if not ray.is_initialized():
+            raise RuntimeError(
+                "Job ID is not available because Ray has not been initialized."
+            )
         job_id = self.worker.current_job_id
         return job_id.hex()
 
@@ -106,12 +106,12 @@ class RuntimeContext(object):
             A node id in hex format for this worker or driver.
 
         Raises:
-            AssertionError: If not called in a driver or worker. Generally,
-                this means that ray.init() was not called.
+            RuntimeError: If Ray has not been initialized.
         """
-        assert (
-            ray.is_initialized()
-        ), "Node ID is not available because Ray has not been initialized."
+        if not ray.is_initialized():
+            raise RuntimeError(
+                "Node ID is not available because Ray has not been initialized."
+            )
         node_id = self.worker.current_node_id
         return node_id.hex()
 
@@ -163,10 +163,14 @@ class RuntimeContext(object):
 
         Returns:
             A worker id in hex format for this worker or driver process.
+
+        Raises:
+            RuntimeError: If Ray has not been initialized.
         """
-        assert (
-            ray.is_initialized()
-        ), "Worker ID is not available because Ray has not been initialized."
+        if not ray.is_initialized():
+            raise RuntimeError(
+                "Worker ID is not available because Ray has not been initialized."
+            )
         return self.worker.worker_id.hex()
 
     @property

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -119,7 +119,7 @@ class RuntimeContext(object):
         """Get the session name for the Ray cluster this process is connected to.
 
         The session name uniquely identifies a Ray cluster instance. This is the
-        same value that appears as the ``SessionName`` label in Prometheus metrics,
+        same value that appears as the ``SessionName`` label in Ray metrics,
         making it useful for filtering metrics when multiple clusters run the same
         application name.
 
@@ -142,9 +142,8 @@ class RuntimeContext(object):
                 # Session name is the same across all processes in the cluster
                 assert ray.get(get_session_name.remote()) == session_name
 
-                # Use in Prometheus query to filter metrics by cluster
-                # promql: ray_serve_http_request_latency_ms_bucket{SessionName="%s"}
-                # % session_name
+                # Use SessionName label to filter metrics by cluster, e.g.:
+                # ray_serve_http_request_latency_ms_bucket{SessionName="<session_name>"}
 
         Returns:
             A session name string for the Ray cluster (e.g.,
@@ -614,7 +613,7 @@ def get_runtime_context() -> RuntimeContext:
             import ray
             # Get the job id.
             ray.get_runtime_context().get_job_id()
-            # Get the session name (used in Prometheus SessionName label).
+            # Get the session name (used as SessionName label in Ray metrics).
             ray.get_runtime_context().get_session_name()
             # Get the actor id.
             ray.get_runtime_context().get_actor_id()

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -953,6 +953,27 @@ def test_get_runtime_context_gcs_client(call_ray_start_shared):
         assert context.gcs_address, "gcs_address not set"
 
 
+def test_get_runtime_context_session_name_client(call_ray_start_shared):
+    """
+    Tests get_runtime_context get_session_name in client mode
+    """
+    with ray_start_client_server_for_address(call_ray_start_shared) as ray:
+        context = ray.get_runtime_context()
+        session_name = context.get_session_name()
+        assert isinstance(session_name, str), "session_name should be a string"
+        assert len(session_name) > 0, "session_name should not be empty"
+
+        @ray.remote
+        def verify_session_name(expected_session_name):
+            rtc = ray.get_runtime_context()
+            assert isinstance(rtc.get_session_name(), str)
+            assert rtc.get_session_name() == expected_session_name
+            return True
+
+        # Verify session name is consistent across driver and remote tasks
+        ray.get(verify_session_name.remote(session_name))
+
+
 def test_internal_kv_in_proxy_mode(call_ray_start_shared):
     import ray
 

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -160,6 +160,20 @@ def test_ids(ray_start_regular):
         assert rtc.get_node_id() == rtc.node_id.hex()
         assert any("Use get_node_id() instead" in str(warning.message) for warning in w)
 
+    # session name
+    assert isinstance(rtc.get_session_name(), str)
+    session_name = rtc.get_session_name()
+    assert len(session_name) > 0
+
+    @ray.remote
+    def verify_session_name(expected_session_name):
+        rtc = ray.get_runtime_context()
+        assert isinstance(rtc.get_session_name(), str)
+        assert rtc.get_session_name() == expected_session_name
+        return True
+
+    ray.get(verify_session_name.remote(session_name))
+
     # job id
     assert isinstance(rtc.get_job_id(), str)
     with warnings.catch_warnings(record=True) as w:

--- a/python/ray/util/client/runtime_context.py
+++ b/python/ray/util/client/runtime_context.py
@@ -63,3 +63,8 @@ class _ClientWorkerPropertyAPI:
     @property
     def gcs_client(self) -> str:
         return SimpleNamespace(address=self._fetch_runtime_context().gcs_address)
+
+    @property
+    def node(self):
+        """Emulates the worker.node property for client mode"""
+        return SimpleNamespace(session_name=self._fetch_runtime_context().session_name)

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -270,6 +270,7 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
                 )
                 ctx.gcs_address = rtc.gcs_address
                 ctx.runtime_env = rtc.get_runtime_env_string()
+                ctx.session_name = rtc.get_session_name()
             resp.runtime_context.CopyFrom(ctx)
         else:
             with disable_client_hook():

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -205,6 +205,7 @@ message ClusterInfoResponse {
     string runtime_env = 4;
     bool capture_client_tasks = 5;
     string gcs_address = 6;
+    string session_name = 7;
   }
 
   ClusterInfoType.TypeEnum type = 1;


### PR DESCRIPTION
## Description

Currently, there's no public API to retrieve the Ray session name. Users need to use private APIs like `ray._private.worker.global_worker.node.session_name` or query the dashboard REST API. This makes it difficult to filter Prometheus metrics by cluster when multiple clusters run the same application name, since Ray metrics use the `SessionName` label (which contains the session_name value).

## Checks

- [x] I've run `scripts/format.sh` to lint the code
- [x] I've included any doc changes needed
- [x] I've added tests for my changes
- [x] I've updated the changelog (if needed)
