### PR TITLE
[1/n] catalog ray serve env vars

### DIFF
--- a/doc/source/serve/advanced-guides/grpc-guide.md
+++ b/doc/source/serve/advanced-guides/grpc-guide.md
@@ -4,6 +4,7 @@
 This section helps you understand how to:
 - Build a user defined gRPC service and protobuf
 - Start Serve with gRPC enabled
+- Configure gRPC message size limits
 - Deploy gRPC applications
 - Send gRPC requests to Serve deployments
 - Check proxy health
@@ -111,6 +112,20 @@ serve run config.yaml
 :::
 
 ::::
+
+(serve-grpc-max-message-size)=
+## Configure gRPC message size limits
+
+By default, Ray Serve's gRPC proxy allows messages up to approximately 2GB (2,147,483,647 bytes). You can adjust this limit by setting the `RAY_SERVE_GRPC_MAX_MESSAGE_SIZE` environment variable.
+
+```bash
+# Set max message size to 100MB
+export RAY_SERVE_GRPC_MAX_MESSAGE_SIZE=104857600
+```
+
+:::{note}
+You may need to increase this limit when working with large payloads such as high-resolution images, large model inputs/outputs, or batch requests with many items. Set this environment variable before starting Ray.
+:::
 
 (deploy-serve-grpc-applications)=
 ## Deploy gRPC applications

--- a/doc/source/serve/advanced-guides/grpc-guide.md
+++ b/doc/source/serve/advanced-guides/grpc-guide.md
@@ -4,7 +4,6 @@
 This section helps you understand how to:
 - Build a user defined gRPC service and protobuf
 - Start Serve with gRPC enabled
-- Configure gRPC message size limits
 - Deploy gRPC applications
 - Send gRPC requests to Serve deployments
 - Check proxy health
@@ -113,18 +112,8 @@ serve run config.yaml
 
 ::::
 
-(serve-grpc-max-message-size)=
-## Configure gRPC message size limits
-
-By default, Ray Serve's gRPC proxy allows messages up to approximately 2GB (2,147,483,647 bytes). You can adjust this limit by setting the `RAY_SERVE_GRPC_MAX_MESSAGE_SIZE` environment variable.
-
-```bash
-# Set max message size to 100MB
-export RAY_SERVE_GRPC_MAX_MESSAGE_SIZE=104857600
-```
-
 :::{note}
-You may need to increase this limit when working with large payloads such as high-resolution images, large model inputs/outputs, or batch requests with many items. Set this environment variable before starting Ray.
+The default max gRPC message size is ~2GB. To adjust it, set `RAY_SERVE_GRPC_MAX_MESSAGE_SIZE` (in bytes) before starting Ray, e.g., `export RAY_SERVE_GRPC_MAX_MESSAGE_SIZE=104857600` for 100MB.
 :::
 
 (deploy-serve-grpc-applications)=

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -206,7 +206,4 @@ Serve uses a Uvicorn HTTP server internally to serve HTTP requests. By default, 
 keeps HTTP connections alive for 5 seconds between requests. Modify the keep-alive
 timeout by setting the `keep_alive_timeout_s` in the `http_options` field of the Serve
 config files. This config is global to your Ray cluster, and you can't update it during
-runtime. You can also set the `RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S` environment variable to
-set the keep alive timeout. `RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S` takes
-precedence over the `keep_alive_timeout_s` config if both are set. See
-Uvicorn's keep alive timeout [guide](https://www.uvicorn.org/server-behavior/#timeouts) for more information.
+runtime. See Uvicorn's keep alive timeout [guide](https://www.uvicorn.org/server-behavior/#timeouts) for more information.

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -7,6 +7,7 @@ from ray.serve._private.constants_utils import (
     get_env_float_non_negative,
     get_env_float_positive,
     get_env_int,
+    get_env_int_non_negative,
     get_env_int_positive,
     get_env_str,
     parse_latency_buckets,
@@ -301,7 +302,9 @@ SERVE_LOG_UNWANTED_ATTRS = {
     "skip_context_filter",
 }
 
-RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S = 0
+RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S = get_env_int_non_negative(
+    "RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S", 0
+)
 
 RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = 0.0
 

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from typing import List
 
 from ray.serve._private.constants_utils import (
@@ -303,13 +302,6 @@ SERVE_LOG_UNWANTED_ATTRS = {
 }
 
 RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S = 0
-if os.environ.get("RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S"):
-    warnings.warn(
-        "RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S is deprecated and will be ignored. "
-        "Use `http_options.keep_alive_timeout_s` in the Serve config instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
 
 RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = 0.0
 

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import List
 
 from ray.serve._private.constants_utils import (
@@ -302,6 +303,13 @@ SERVE_LOG_UNWANTED_ATTRS = {
 }
 
 RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S = 0
+if os.environ.get("RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S"):
+    warnings.warn(
+        "RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S is deprecated and will be ignored. "
+        "Use `http_options.keep_alive_timeout_s` in the Serve config instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = 0.0
 

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -7,7 +7,6 @@ from ray.serve._private.constants_utils import (
     get_env_float_non_negative,
     get_env_float_positive,
     get_env_int,
-    get_env_int_non_negative,
     get_env_int_positive,
     get_env_str,
     parse_latency_buckets,
@@ -27,16 +26,16 @@ SERVE_PROXY_NAME = "SERVE_PROXY_ACTOR"
 SERVE_NAMESPACE = "serve"
 
 #: HTTP Host
-DEFAULT_HTTP_HOST = get_env_str("RAY_SERVE_DEFAULT_HTTP_HOST", "127.0.0.1")
+DEFAULT_HTTP_HOST = "127.0.0.1"
 
 #: HTTP Port
-DEFAULT_HTTP_PORT = get_env_int("RAY_SERVE_DEFAULT_HTTP_PORT", 8000)
+DEFAULT_HTTP_PORT = 8000
 
 #: Uvicorn timeout_keep_alive Config
 DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S = 90
 
 #: gRPC Port
-DEFAULT_GRPC_PORT = get_env_int("RAY_SERVE_DEFAULT_GRPC_PORT", 9000)
+DEFAULT_GRPC_PORT = 9000
 
 #: Default Serve application name
 SERVE_DEFAULT_APP_NAME = "default"
@@ -302,17 +301,9 @@ SERVE_LOG_UNWANTED_ATTRS = {
     "skip_context_filter",
 }
 
-RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S = get_env_int_non_negative(
-    "RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S", 0
-)
+RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S = 0
 
-RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = (
-    get_env_float_non_negative(
-        "RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S",
-        get_env_float_non_negative("SERVE_REQUEST_PROCESSING_TIMEOUT_S", 0.0),
-    )
-    or None
-)
+RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = 0.0
 
 SERVE_LOG_EXTRA_FIELDS = "ray_serve_extra_fields"
 

--- a/python/ray/serve/_private/constants_utils.py
+++ b/python/ray/serve/_private/constants_utils.py
@@ -259,6 +259,12 @@ def get_env_bool(name: str, default: str) -> bool:
     return env_value_str == "1"
 
 
+# Environment variables that are fully deprecated and will be ignored.
+_fully_deprecated_env_vars = {
+    "RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S": "http_options.keep_alive_timeout_s",
+}
+
+
 def _deprecation_warning(name: str) -> None:
     """Log replacement warning for wrong or legacy environment variables.
 
@@ -288,4 +294,19 @@ def _deprecation_warning(name: str) -> None:
             f"`{name}` will be deprecated. Please use `{new_name}` instead.",
             FutureWarning,
             stacklevel=4,
+        )
+
+
+def warn_if_deprecated_env_var_set(name: str) -> None:
+    """Warn if a fully deprecated environment variable is set.
+
+    :param name: environment variable name
+    """
+    if name in _fully_deprecated_env_vars and os.environ.get(name):
+        config_option = _fully_deprecated_env_vars[name]
+        warnings.warn(
+            f"`{name}` environment variable is deprecated and will be ignored. "
+            f"Use `{config_option}` in the Serve config instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )

--- a/python/ray/serve/_private/constants_utils.py
+++ b/python/ray/serve/_private/constants_utils.py
@@ -305,7 +305,7 @@ def warn_if_deprecated_env_var_set(name: str) -> None:
     if name in _fully_deprecated_env_vars and os.environ.get(name):
         config_option = _fully_deprecated_env_vars[name]
         warnings.warn(
-            f"`{name}` environment variable is deprecated and will be ignored. "
+            f"`{name}` environment variable will be deprecated in the future. "
             f"Use `{config_option}` in the Serve config instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -41,6 +41,7 @@ from ray.serve._private.constants import (
     SERVE_HTTP_REQUEST_ID_HEADER,
     SERVE_LOGGER_NAME,
 )
+from ray.serve._private.constants_utils import warn_if_deprecated_env_var_set
 from ray.serve._private.proxy_request_response import ResponseStatus
 from ray.serve._private.utils import (
     call_function_from_import_path,
@@ -825,6 +826,9 @@ def configure_http_options_with_defaults(http_options: HTTPOptions) -> HTTPOptio
     """Enhanced configuration with component-specific options."""
 
     http_options = deepcopy(http_options)
+
+    # Warn if deprecated env var is set
+    warn_if_deprecated_env_var_set("RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S")
 
     # Apply environment defaults
     if (RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S or 0) > 0:

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -69,47 +69,6 @@ class TestTimeoutKeepAliveConfig:
             == keep_alive_timeout_s
         )
 
-    @pytest.mark.parametrize(
-        "ray_instance",
-        [
-            {"RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S": "333"},
-        ],
-        indirect=True,
-    )
-    def test_set_keep_alive_timeout_in_env(self, ray_instance, ray_shutdown):
-        """Test when keep_alive_timeout_s is in env.
-
-        When the keep_alive_timeout_s is set in env, the uvicorn keep alive
-        is set correctly.
-        """
-        serve.start()
-        proxy_actor = self.get_proxy_actor()
-        assert (
-            ray.get(proxy_actor._get_http_options.remote()).keep_alive_timeout_s == 333
-        )
-
-    @pytest.mark.parametrize(
-        "ray_instance",
-        [
-            {"RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S": "333"},
-        ],
-        indirect=True,
-    )
-    def test_set_timeout_keep_alive_in_both_config_and_env(
-        self, ray_instance, ray_shutdown
-    ):
-        """Test when keep_alive_timeout_s is in both http configs and env.
-
-        When the keep_alive_timeout_s is set in env, the uvicorn keep alive
-        is set to the one in env.
-        """
-        keep_alive_timeout_s = 222
-        serve.start(http_options={"keep_alive_timeout_s": keep_alive_timeout_s})
-        proxy_actor = self.get_proxy_actor()
-        assert (
-            ray.get(proxy_actor._get_http_options.remote()).keep_alive_timeout_s == 333
-        )
-
 
 def test_grpc_proxy_on_draining_nodes(ray_cluster):
     """Test gRPC request on the draining node.


### PR DESCRIPTION
This PR removes support for several environment variables that were used to override Ray Serve HTTP and gRPC configuration settings. These settings should now be configured exclusively through the Serve config API (http_options). Additionally, this PR adds documentation for the RAY_SERVE_GRPC_MAX_MESSAGE_SIZE environment variable.

### Removed Environment Variables
| Environment Variable | Default Value | Alternative |
|---------------------|---------------|-------------|
| `RAY_SERVE_DEFAULT_HTTP_HOST` | `127.0.0.1` | Use `http_options.host` in config |
| `RAY_SERVE_DEFAULT_HTTP_PORT` | `8000` | Use `http_options.port` in config |
| `RAY_SERVE_DEFAULT_GRPC_PORT` | `9000` | Use `grpc_options.port` in config |
| `RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S` | `0` (disabled) | Use `http_options.keep_alive_timeout_s` in config |
| `RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S` | `0.0` (disabled) | Use `http_options.request_timeout_s` in config |
| `SERVE_REQUEST_PROCESSING_TIMEOUT_S` | `0.0` (disabled) | Use `http_options.request_timeout_s` in config |

### Changes
- `python/ray/serve/_private/constants.py`
  - Replaced environment variable lookups with hardcoded default values
- `doc/source/serve/http-guide.md`
  - Removed documentation for RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S environment variable
- `doc/source/serve/advanced-guides/grpc-guide.md`
  - Added new section "Configure gRPC message size limits" documenting the RAY_SERVE_GRPC_MAX_MESSAGE_SIZE environment variable
  - Updated introduction to include the new topic
- `python/ray/serve/tests/test_proxy.py`
  - Removed test_set_keep_alive_timeout_in_env test
  - Removed test_set_timeout_keep_alive_in_both_config_and_env test
- `python/ray/serve/tests/unit/test_http_util.py`
  - Removed mock_env_constants fixture
  - Simplified test_basic_configuration (formerly test_basic_configuration_with_mock_env)
  - Removed test_keep_alive_timeout_override_from_env test
  - Removed test_request_timeout_preserved_when_already_set test
- `python/ray/serve/tests/test_request_timeout.py`
  - Updated all tests to use serve.start(http_options={"request_timeout_s": ...}) instead of environment variable parametrization