### PR TITLE
[ci] get_docker_image allows setting docker_repo

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -50,7 +50,6 @@ steps:
       - "3.12"
       - "3.13"
     depends_on:
-      - manylinux-x86_64
       - forge
 
   - label: ":tapioca: build: jar"
@@ -83,7 +82,6 @@ steps:
         --platform cpu
         --image-type ray --upload
     depends_on:
-      - manylinux-x86_64
       - forge
       - raycudabase
       - raycpubase
@@ -109,7 +107,6 @@ steps:
         --platform cpu
         --image-type ray-extra --upload
     depends_on:
-      - manylinux-x86_64
       - forge
       - raycpubaseextra
       - raycudabaseextra
@@ -128,7 +125,6 @@ steps:
       - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
         --platform cu12.8.1-cudnn --image-type ray-llm --upload
     depends_on:
-      - manylinux-x86_64
       - forge
       - ray-llmbase
     matrix:
@@ -144,7 +140,6 @@ steps:
       - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
         --platform cu12.8.1-cudnn --image-type ray-llm-extra --upload
     depends_on:
-      - manylinux-x86_64
       - forge
       - ray-llmbaseextra
     matrix:

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -252,7 +252,6 @@ steps:
         --only-tags post_wheel_build
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
     depends_on:
-      - manylinux-x86_64
       - corebuild-multipy
       - forge
 
@@ -452,7 +451,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core --only-tags ha_integration
         --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
-      - manylinux-x86_64
       - forge
       - raycpubase
       - corebuild-multipy
@@ -474,7 +472,6 @@ steps:
         --install-mask all-ray-libraries
         --only-tags runtime_env_container
     depends_on:
-      - manylinux-x86_64
       - forge
       - raycpubase
       - corebuild-multipy

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -16,7 +16,6 @@ steps:
     docker_network: "host"
     depends_on:
       - k8sbuild
-      - manylinux-x86_64
       - forge
       - raycpubase
       - ray-core-build
@@ -44,7 +43,6 @@ steps:
           - "test_streaming_llm"
           - "test_many_job_submissions"
     depends_on:
-      - manylinux-x86_64
       - forge
       - raycpubase
       - ray-core-build

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -9,13 +9,6 @@ steps:
     wanda: ci/docker/forge.aarch64.wanda.yaml
     instance_type: builder-arm64
 
-  - name: manylinux-aarch64
-    wanda: ci/docker/manylinux.wanda.yaml
-    env:
-      HOSTTYPE: "aarch64"
-      MANYLINUX_VERSION: "251216.3835fc5"
-    instance_type: builder-arm64
-
   - name: ray-java-build-aarch64
     label: "wanda: java build (aarch64)"
     wanda: ci/docker/ray-java.wanda.yaml

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -147,7 +147,6 @@ steps:
       - "3.12"
       - "3.13"
     depends_on:
-      - manylinux-aarch64
       - forge-aarch64
     job_env: forge-aarch64
 
@@ -168,7 +167,6 @@ steps:
         --platform cpu
         --image-type ray-extra --architecture aarch64 --upload
     depends_on:
-      - manylinux-aarch64
       - forge-aarch64
       - raycudabaseextra-aarch64
       - raycpubaseextra-aarch64
@@ -195,7 +193,6 @@ steps:
         --platform cpu
         --image-type ray --architecture aarch64 --upload
     depends_on:
-      - manylinux-aarch64
       - forge-aarch64
       - raycudabase-aarch64
       - raycpubase-aarch64
@@ -217,7 +214,6 @@ steps:
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
         --python-version 3.10
     depends_on:
-      - manylinux-aarch64
       - oss-ci-base_build-aarch64
       - forge-aarch64
     job_env: forge-aarch64
@@ -234,7 +230,6 @@ steps:
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
         --python-version 3.10
     depends_on:
-      - manylinux-aarch64
       - oss-ci-base_build-aarch64
       - forge-aarch64
     job_env: forge-aarch64

--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -78,7 +78,6 @@ steps:
         --python-version {{matrix.python}} --platform {{matrix.platform}}
         --image-type ray --upload
     depends_on:
-      - manylinux-x86_64
       - forge
       - raycpubaseextra-testdeps
       - raycudabaseextra-testdeps
@@ -104,7 +103,6 @@ steps:
       - bazel run //ci/ray_ci:build_in_docker -- anyscale --python-version {{matrix}}
         --platform cu12.8.1-cudnn --image-type ray-llm --upload
     depends_on:
-      - manylinux-x86_64
       - forge
       - ray-llmbaseextra-testdeps
     matrix:
@@ -120,7 +118,6 @@ steps:
       - bazel run //ci/ray_ci:build_in_docker -- anyscale --python-version {{matrix}}
         --platform cu12.1.1-cudnn8 --image-type ray-ml --upload
     depends_on:
-      - manylinux-x86_64
       - forge
       - ray-mlcudabaseextra-testdeps
     matrix:

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -126,7 +126,6 @@ steps:
         --build-name servebuild-py3.10
         --python-version 3.10
     depends_on:
-      - manylinux-x86_64
       - servebuild-multipy
       - forge
 
@@ -201,7 +200,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests/... serve
         --only-tags ha_integration --python-version 3.10 --build-name servebuild-py3.10
     depends_on:
-      - manylinux-x86_64
       - forge
       - raycpubase
       - servebuild-multipy

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -4,6 +4,9 @@ from ci.ray_ci.configs import BUILD_TYPES, PYTHON_VERSIONS
 from ci.ray_ci.linux_container import LinuxContainer
 
 
+_DEFAULT_MANYLINUX_VERSION = "251216.3835fc5"
+
+
 class BuilderContainer(LinuxContainer):
     def __init__(
         self,
@@ -12,6 +15,11 @@ class BuilderContainer(LinuxContainer):
         architecture: str,
         upload: bool = False,
     ) -> None:
+        manylinux_version = os.environ.get(
+            "MANYLINUX_VERSION", _DEFAULT_MANYLINUX_VERSION
+        )
+        docker_repo = "rayproject/manylinux2014"
+        docker_tag = f"{manylinux_version}-jdk-{architecture}"
         super().__init__(
             f"manylinux-{architecture}",
             volumes=[f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/rayci"],

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -3,7 +3,6 @@ import os
 from ci.ray_ci.configs import BUILD_TYPES, PYTHON_VERSIONS
 from ci.ray_ci.linux_container import LinuxContainer
 
-
 _DEFAULT_MANYLINUX_VERSION = "251216.3835fc5"
 
 

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -63,15 +63,17 @@ def get_docker_image(
             If a non-default repo is provided, the image is treated as external
             and the build_id prefix is not added.
     """
-    if docker_repo is not None and docker_repo != _DOCKER_ECR_REPO:
+    # If a docker_repo is provided and it's not the default ECR repo,
+    # treat it as an external image and don't prepend the build_id.
+    if docker_repo and docker_repo != _DOCKER_ECR_REPO:
         return f"{docker_repo}:{docker_tag}"
 
-    docker_repo = _DOCKER_ECR_REPO
-    if not build_id:
-        build_id = _RAYCI_BUILD_ID
-    if build_id:
-        return f"{docker_repo}:{build_id}-{docker_tag}"
-    return f"{docker_repo}:{docker_tag}"
+    # Otherwise, use the default ECR repo and prepend the build_id if it exists.
+    repo = _DOCKER_ECR_REPO
+    final_build_id = build_id or _RAYCI_BUILD_ID
+    if final_build_id:
+        return f"{repo}:{final_build_id}-{docker_tag}"
+    return f"{repo}:{docker_tag}"
 
 
 class Container(abc.ABC):

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -18,6 +18,7 @@ class LinuxContainer(Container):
     def __init__(
         self,
         docker_tag: str,
+        docker_repo: Optional[str] = None,
         volumes: Optional[List[str]] = None,
         envs: Optional[List[str]] = None,
         python_version: Optional[str] = None,
@@ -25,7 +26,7 @@ class LinuxContainer(Container):
         architecture: Optional[str] = None,
         privileged: bool = False,
     ) -> None:
-        super().__init__(docker_tag, volumes, envs)
+        super().__init__(docker_tag, docker_repo, volumes, envs)
 
         if tmp_filesystem is not None:
             if tmp_filesystem != "tmpfs":

--- a/ci/ray_ci/test_builder_container.py
+++ b/ci/ray_ci/test_builder_container.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from ci.ray_ci.builder_container import BuilderContainer, _DEFAULT_MANYLINUX_VERSION
+from ci.ray_ci.builder_container import _DEFAULT_MANYLINUX_VERSION, BuilderContainer
 
 
 def test_init() -> None:

--- a/ci/ray_ci/test_builder_container.py
+++ b/ci/ray_ci/test_builder_container.py
@@ -1,15 +1,18 @@
+import os
 import sys
 from typing import List
 from unittest import mock
 
 import pytest
 
-from ci.ray_ci.builder_container import BuilderContainer
+from ci.ray_ci.builder_container import BuilderContainer, _DEFAULT_MANYLINUX_VERSION
 
 
 def test_init() -> None:
     builder = BuilderContainer("3.10", "optimized", "aarch64")
-    assert builder.docker_tag == "manylinux-aarch64"
+    assert builder.docker_tag == f"{_DEFAULT_MANYLINUX_VERSION}-jdk-aarch64"
+    assert builder.docker_repo == "rayproject/manylinux2014"
+
     builder = BuilderContainer("3.10", "optimized", "x86_64")
     assert builder.docker_tag == "manylinux-x86_64"
 

--- a/ci/ray_ci/test_container.py
+++ b/ci/ray_ci/test_container.py
@@ -11,6 +11,16 @@ def test_get_docker_image() -> None:
         get_docker_image("test-image", "a1b2c3")
         == f"{_DOCKER_ECR_REPO}:a1b2c3-test-image"
     )
+    # Test external repo (no build_id prefix when docker_repo != _DOCKER_ECR_REPO)
+    assert (
+        get_docker_image("1.0.0-jdk-x86_64", docker_repo="rayproject/manylinux2014")
+        == "rayproject/manylinux2014:1.0.0-jdk-x86_64"
+    )
+    # Test that external repo ignores build_id
+    assert (
+        get_docker_image("1.0.0-jdk-x86_64", "a1b2c3", docker_repo="rayproject/manylinux2014")
+        == "rayproject/manylinux2014:1.0.0-jdk-x86_64"
+    )
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/test_container.py
+++ b/ci/ray_ci/test_container.py
@@ -18,7 +18,9 @@ def test_get_docker_image() -> None:
     )
     # Test that external repo ignores build_id
     assert (
-        get_docker_image("1.0.0-jdk-x86_64", "a1b2c3", docker_repo="rayproject/manylinux2014")
+        get_docker_image(
+            "1.0.0-jdk-x86_64", "a1b2c3", docker_repo="rayproject/manylinux2014"
+        )
         == "rayproject/manylinux2014:1.0.0-jdk-x86_64"
     )
 


### PR DESCRIPTION
Adjust `get_docker_image` to allow fetching from a docker repo that is not `_DOCKER_ECR_REPO`.

This allows us to remove the `manylinux` step as a pre-req from all but one job that uses `job_env: manylinux`