### PR TITLE
[Data] minor clean-up about Write concurrency

### DIFF
--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional, Union
 
+from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.logical.operators.map_operator import AbstractMap
 from ray.data.datasource.datasink import Datasink
@@ -14,7 +15,7 @@ class Write(AbstractMap):
         input_op: LogicalOperator,
         datasink_or_legacy_datasource: Union[Datasink, Datasource],
         ray_remote_args: Optional[Dict[str, Any]] = None,
-        concurrency: Optional[int] = None,
+        compute: Optional[ComputeStrategy] = None,
         **write_args,
     ):
         if isinstance(datasink_or_legacy_datasource, Datasink):
@@ -29,7 +30,7 @@ class Write(AbstractMap):
             input_op,
             min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
+            compute=compute,
         )
         self._datasink_or_legacy_datasource = datasink_or_legacy_datasource
         self._write_args = write_args
-        self._concurrency = concurrency

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -2,7 +2,6 @@ import itertools
 import uuid
 from typing import Callable, Iterator, List, Union
 
-from ray.data._internal.compute import TaskPoolStrategy
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_operator import MapOperator
@@ -124,7 +123,7 @@ def _plan_write_op_internal(
         map_task_kwargs={WRITE_UUID_KWARG_NAME: uuid.uuid4().hex},
         ray_remote_args=op._ray_remote_args,
         min_rows_per_bundle=op._min_rows_per_bundled_input,
-        compute_strategy=TaskPoolStrategy(op._concurrency),
+        compute_strategy=op._compute,
         on_start=on_start,
     )
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -28,7 +28,7 @@ import ray
 import ray.cloudpickle as pickle
 from ray._common.usage import usage_lib
 from ray._private.thirdparty.tabulate.tabulate import tabulate
-from ray.data._internal.compute import ComputeStrategy
+from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.datasource.bigquery_datasink import BigQueryDatasink
 from ray.data._internal.datasource.clickhouse_datasink import (
     ClickHouseDatasink,
@@ -1116,9 +1116,6 @@ class Dataset:
             raise TypeError(
                 "select_columns requires 'cols' to be a string or a list of strings."
             )
-        # Don't feel like we really need this
-        from ray.data._internal.compute import TaskPoolStrategy
-
         compute = TaskPoolStrategy(size=concurrency)
 
         plan = self._plan.copy()
@@ -1243,7 +1240,6 @@ class Dataset:
             )
 
         # Construct the plan and project operation
-        from ray.data._internal.compute import TaskPoolStrategy
 
         compute = TaskPoolStrategy(size=concurrency)
 
@@ -1529,7 +1525,6 @@ class Dataset:
 
         if expr is not None:
             _check_fn_params_incompatible("expr")
-            from ray.data._internal.compute import TaskPoolStrategy
 
             # Check if expr is a string (deprecated) or Expr object
             if isinstance(expr, str):
@@ -5322,7 +5317,7 @@ class Dataset:
             self._logical_plan.dag,
             datasink,
             ray_remote_args=ray_remote_args,
-            concurrency=concurrency,
+            compute=TaskPoolStrategy(concurrency),
         )
         logical_plan = LogicalPlan(write_op, self.context)
 

--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -7,6 +7,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data._internal.compute import TaskPoolStrategy
 from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
 from ray.data._internal.execution.interfaces.op_runtime_metrics import OpRuntimeMetrics
 from ray.data._internal.execution.operators.base_physical_operator import (
@@ -156,7 +157,7 @@ def test_write_operator(ray_start_regular_shared_2_cpus, tmp_path):
     op = Write(
         read_op,
         datasink,
-        concurrency=concurrency,
+        compute=TaskPoolStrategy(concurrency),
     )
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag


### PR DESCRIPTION
## Description

Similar to #59422, the `Write` op already has a `_compute` attribute for specifying compute strategy. So we do not need to store `concurrency` separately..

This will also make it easier to implement actor-based data sink (with `ActorPoolStrategy`) in the future.

## Additional information
* No change to public APIs
* Cleaned up some imports in `dataset.py`
