### PR TITLE
feat(util.multiprocessing): add cluster resources wait timeout in Pool initialization

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -64,6 +64,7 @@ py_test_module_list(
         "test_multiprocessing_standalone.py",
         "test_node_label_scheduling_strategy.py",
         "test_object_spilling_2.py",
+        "test_pool_resources_timeout.py",
         "test_ray_event_export_task_events.py",
         "test_reference_counting_2.py",
         "test_reference_counting_standalone.py",

--- a/python/ray/tests/test_pool_resources_timeout.py
+++ b/python/ray/tests/test_pool_resources_timeout.py
@@ -1,0 +1,84 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+from ray.util.multiprocessing import Pool
+
+
+def test_pool_timeout_success():
+    """Test that Pool waits for resources when cluster_resources_timeout is set."""
+    with patch("ray.init"), \
+         patch("ray.is_initialized", return_value=True), \
+         patch("ray._private.state.cluster_resources") as mock_resources, \
+         patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
+
+        # Simulate resources becoming available after a few calls
+        # 1st call: empty
+        # 2nd call: empty
+        # 3rd call: has CPU
+        mock_resources.side_effect = [{}, {}, {"CPU": 4}]
+
+        start = time.time()
+        # Should succeed within timeout
+        Pool(processes=2, cluster_resources_timeout=2.0)
+        duration = time.time() - start
+
+        # Verify it waited (called more than once)
+        assert mock_resources.call_count == 3
+        # Should be fast enough
+        assert duration < 2.0
+
+def test_pool_timeout_wait_for_sufficient_cpus():
+    """Test that Pool waits until ENOUGH resources are available."""
+    with patch("ray.init"), \
+         patch("ray.is_initialized", return_value=True), \
+         patch("ray._private.state.cluster_resources") as mock_resources, \
+         patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
+
+        # 1st call: 2 CPUs (insufficient for 4 processes)
+        # 2nd call: 4 CPUs (sufficient)
+        mock_resources.side_effect = [{"CPU": 2}, {"CPU": 4}]
+
+        start = time.time()
+        # Should succeed within timeout
+        Pool(processes=4, cluster_resources_timeout=2.0)
+        duration = time.time() - start
+
+        # Verify it waited
+        assert mock_resources.call_count == 2
+        assert duration < 2.0
+
+
+def test_pool_timeout_failure():
+    """Test that Pool raises ValueError when timeout expires."""
+    with patch("ray.init"), \
+         patch("ray.is_initialized", return_value=True), \
+         patch("ray._private.state.cluster_resources") as mock_resources, \
+         patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
+
+        # Always return empty resources
+        mock_resources.return_value = {}
+
+        with pytest.raises(ValueError, match="Insufficient CPU resources found"):
+            Pool(processes=2, cluster_resources_timeout=0.5)
+
+def test_pool_default_backward_compatibility():
+    """Test that default behavior (timeout=0) raises error immediately if no resources."""
+    with patch("ray.init"), \
+         patch("ray.is_initialized", return_value=True), \
+         patch("ray._private.state.cluster_resources") as mock_resources, \
+         patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
+
+        mock_resources.return_value = {}
+
+        # Default is timeout=0
+        with pytest.raises(ValueError, match="No CPU resources found"):
+            Pool(processes=2)
+
+        # Verify it was called only once for immediate check
+        assert mock_resources.call_count == 1
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_pool_resources_timeout.py
+++ b/python/ray/tests/test_pool_resources_timeout.py
@@ -8,10 +8,9 @@ from ray.util.multiprocessing import Pool
 
 def test_pool_timeout_success():
     """Test that Pool waits for resources when cluster_resources_timeout is set."""
-    with patch("ray.init"), \
-         patch("ray.is_initialized", return_value=True), \
-         patch("ray._private.state.cluster_resources") as mock_resources, \
-         patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
+    with patch("ray.init"), patch("ray.is_initialized", return_value=True), patch(
+        "ray._private.state.cluster_resources"
+    ) as mock_resources, patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
 
         # Simulate resources becoming available after a few calls
         # 1st call: empty
@@ -29,12 +28,12 @@ def test_pool_timeout_success():
         # Should be fast enough
         assert duration < 2.0
 
+
 def test_pool_timeout_wait_for_sufficient_cpus():
     """Test that Pool waits until ENOUGH resources are available."""
-    with patch("ray.init"), \
-         patch("ray.is_initialized", return_value=True), \
-         patch("ray._private.state.cluster_resources") as mock_resources, \
-         patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
+    with patch("ray.init"), patch("ray.is_initialized", return_value=True), patch(
+        "ray._private.state.cluster_resources"
+    ) as mock_resources, patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
 
         # 1st call: 2 CPUs (insufficient for 4 processes)
         # 2nd call: 4 CPUs (sufficient)
@@ -52,10 +51,9 @@ def test_pool_timeout_wait_for_sufficient_cpus():
 
 def test_pool_timeout_failure():
     """Test that Pool raises ValueError when timeout expires."""
-    with patch("ray.init"), \
-         patch("ray.is_initialized", return_value=True), \
-         patch("ray._private.state.cluster_resources") as mock_resources, \
-         patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
+    with patch("ray.init"), patch("ray.is_initialized", return_value=True), patch(
+        "ray._private.state.cluster_resources"
+    ) as mock_resources, patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
 
         # Always return empty resources
         mock_resources.return_value = {}
@@ -63,12 +61,12 @@ def test_pool_timeout_failure():
         with pytest.raises(ValueError, match="Insufficient CPU resources found"):
             Pool(processes=2, cluster_resources_timeout=0.5)
 
+
 def test_pool_default_backward_compatibility():
     """Test that default behavior (timeout=0) raises error immediately if no resources."""
-    with patch("ray.init"), \
-         patch("ray.is_initialized", return_value=True), \
-         patch("ray._private.state.cluster_resources") as mock_resources, \
-         patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
+    with patch("ray.init"), patch("ray.is_initialized", return_value=True), patch(
+        "ray._private.state.cluster_resources"
+    ) as mock_resources, patch("ray.util.multiprocessing.pool.Pool._start_actor_pool"):
 
         mock_resources.return_value = {}
 
@@ -79,6 +77,8 @@ def test_pool_default_backward_compatibility():
         # Verify it was called only once for immediate check
         assert mock_resources.call_count == 1
 
+
 if __name__ == "__main__":
     import sys
+
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

Introduce an optional resource readiness timeout parameter to ray.util.multiprocessing.Pool (name bikesheddable; e.g. cluster_ready_timeout, resource_ready_timeout, etc.):

- New parameter (proposal):
    - resource_ready_timeout: float = 0.0 (seconds, default 0 for backward compatibility)
    - Optionally, a resource_check_interval: float = 0.5 (seconds) for polling frequency.

- Behavior:
    - When initializing Pool, before validating resources with cluster_resources():
        - Repeatedly call ray._private.state.cluster_resources() until:
                 - The CPU count is at least the requested pool size (if processes is set), or
                 - At least some minimal expected resources are present (e.g., ≥ 1 CPU if processes is not explicitly set).
        -  Stop when either:
                 - The condition is satisfied → proceed with pool initialization.
                 - The elapsed time exceeds resource_ready_timeout → raise a clear TimeoutError (or a Ray-specific exception) indicating that cluster resources never became ready in time, including the last seen cluster_resources() snapshot in the error message.

- This approach:
   - Keeps current behavior when resource_ready_timeout=0 (no waiting, fail fast).
   - Allows users to opt-in to a more robust behavior in environments where the application may connect as soon as the head node is up but before worker resources are fully registered.
   - Avoids hacky user-side workarounds like hardcoded sleep calls or custom polling loops around Pool.

## Related issues
https://github.com/ray-project/ray/issues/59503


