### PR TITLE
[ci][macos] Fix FileNotFoundError in cpp tests by adding missing bazel_export_options

### DIFF
--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -91,15 +91,18 @@ run_ray_cpp() {
   bazel run --config=ci //cpp:gen_ray_cpp_pkg
 
   echo "--- Test //cpp:all"
-  bazel test --config=ci --test_strategy=exclusive --build_tests_only \
+  # shellcheck disable=SC2046
+  bazel test --config=ci $(./ci/run/bazel_export_options) --test_strategy=exclusive --build_tests_only \
     --test_tag_filters=-no_macos //cpp:all
 
   echo "--- Test //cpp:cluster_mode_test"
-  bazel test --config=ci //cpp:cluster_mode_test --test_arg=--external_cluster=true \
+  # shellcheck disable=SC2046
+  bazel test --config=ci $(./ci/run/bazel_export_options) //cpp:cluster_mode_test --test_arg=--external_cluster=true \
     --test_arg=--ray_redis_password="1234" --test_arg=--ray_redis_username="default"
 
   echo "--- Test //cpp:test_python_call_cpp"
-  bazel test --config=ci --test_output=all //cpp:test_python_call_cpp
+  # shellcheck disable=SC2046
+  bazel test --config=ci $(./ci/run/bazel_export_options) --test_output=all //cpp:test_python_call_cpp
 }
 
 bisect() {


### PR DESCRIPTION
## Description

So, the error I encountered was:
https://buildkite.com/ray-project/premerge/builds/55984/steps/canvas?sid=019b29ab-6751-4e17-8f94-5a268cefd3c3#019b2b1b-6bfa-475c-a939-b8cdd44f0495/L3617
```shell
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/bazel_event_logs' when running bazel run //ci/ray_ci/automation:test_db_bot -- core /tmp/bazel_event_logs in run_ray_cpp.
```
This occurred when running:
```shell
bazel run //ci/ray_ci/automation:test_db_bot -- core /tmp/bazel_event_logs
```
inside `run_ray_cpp`.

All other tests under `ci/ray_ci/macos/macos_ci.sh` include `./ci/run/bazel_export_options`, which creates the `/tmp/bazel_event_logs` directory.

Earlier tests did include this, but a later PR accidentally removed it:
https://github.com/ray-project/ray/pull/56222/files#diff-1893645dd6c67d6f2c2b80525fa062fd18f441a4773d90a73d8a64ad9f22f3a6L94
(In test_cpp, it will call `./ci/run/bazel_export_options`.)

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
