### PR TITLE
[Data] Fix bug where `AutoscalingCoordinator` crashes if you request 0 GPUs on CPU-only cluster

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -352,7 +352,8 @@ class _AutoscalingCoordinatorActor:
         if any(res1.get(key, 0) < res2[key] for key in res2):
             return False
         for key in res2:
-            res1[key] -= res2[key]
+            if key in res1:
+                res1[key] -= res2[key]
         return True
 
     def _update_cluster_node_resources(self) -> bool:

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -396,6 +396,20 @@ def test_request_resources_handles_timeout_error(teardown_autoscaling_coordinato
     )
 
 
+def test_coordinator_accepts_zero_resource_for_missing_resource_type(
+    teardown_autoscaling_coordinator,
+):
+    # This is a regression test for a bug where the coordinator crashes when you request
+    # a resource type (e.g., GPU: 0) that doesn't exist on the cluster.
+    coordinator = DefaultAutoscalingCoordinator()
+
+    coordinator.request_resources(
+        requester_id="spam", resources=[{"CPU": 1, "GPU": 0}], expire_after_s=1
+    )
+
+    assert coordinator.get_allocated_resources("spam") == [{"CPU": 1, "GPU": 0}]
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
If you request zero GPUs from the autoscaling coordinator but GPUs don't exist on the cluster, the autoscaling coordinator crashes.

This PR fixes that bug.
