### PR TITLE
[data] Fix: Ensure task cleanup runs when actor dies mid-task

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -597,9 +597,7 @@ def process_completed_tasks(
                             max_bytes_to_read_per_op[state] -= bytes_read
                     except Exception as e:
                         # Ensure task cleanup happens even on failure.
-                        if not task._has_finished:
-                            task._task_done_callback(e)
-                            task._has_finished = True
+                        task.finish(e)
 
                         num_errored_blocks += 1
                         should_ignore = (

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -596,6 +596,11 @@ def process_completed_tasks(
                         if state in max_bytes_to_read_per_op:
                             max_bytes_to_read_per_op[state] -= bytes_read
                     except Exception as e:
+                        # Ensure task cleanup happens even on failure.
+                        if not task._has_finished:
+                            task._task_done_callback(e)
+                            task._has_finished = True
+
                         num_errored_blocks += 1
                         should_ignore = (
                             max_errored_blocks < 0


### PR DESCRIPTION
When an actor is OOM killed or dies mid-task, DataOpTask.on_data_ready() can raise an exception (e.g., RayActorError) without executing the task-done callback chain. This leaves operator bookkeeping stuck:
- MapOperator._data_tasks is never cleaned up
- ActorPoolMapOperator's num_tasks_in_flight stays elevated
- No new tasks can be scheduled, causing a deadlock

This commit ensures that when on_data_ready() raises an exception in process_completed_tasks(), we still invoke the task's done callback to properly clean up operator state and allow scheduling to continue.

Added a regression test that:
1. Starts an actor pool map operator with a blocking transform
2. Submits one input and verifies task is in-flight
3. Kills the actor mid-task
4. Verifies that process_completed_tasks() properly cleans up:
   - num_tasks_in_flight decrements to 0
   - _data_tasks is cleared
