### PR TITLE
[llm][docs] Restore literalinclude to code example

### DIFF
--- a/doc/source/serve/llm/user-guides/prefix-aware-routing.md
+++ b/doc/source/serve/llm/user-guides/prefix-aware-routing.md
@@ -50,42 +50,10 @@ The router maintains a distributed prefix tree actor that:
 
 The following example shows how to deploy an LLM with prefix-aware routing:
 
-```python
-from ray import serve
-from ray.serve.llm import LLMConfig, build_openai_app
-from ray.serve.llm.request_router import (
-    PrefixCacheAffinityRouter
-)
-
-llm_config = LLMConfig(
-    model_loading_config=dict(
-        model_id="qwen-7b",
-        model_source="Qwen/Qwen2.5-7B-Instruct",
-    ),
-    # Enable APC in vLLM
-    engine_kwargs=dict(
-        enable_prefix_caching=True,
-    ),
-    deployment_config=dict(
-        autoscaling_config=dict(
-            min_replicas=2,
-            max_replicas=4,
-        )
-    ),
-    accelerator_type="A10G",
-)
-
-# Configure prefix-aware router
-app = build_openai_app({
-    "llm_configs": [llm_config],
-    "router_cls": PrefixCacheAffinityRouter,
-    "router_config": {
-        "imbalanced_threshold": 10,
-        "match_rate_threshold": 0.1,
-    }
-})
-
-serve.run(app)
+```{literalinclude} ../../../../llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
+:start-after: __prefix_aware_example_start__
+:end-before: __prefix_aware_example_end__
+:language: python
 ```
 
 ## Configuration parameters


### PR DESCRIPTION
## Description

Fix documentation regression introduced in #57787 where the prefix-aware routing example used incorrect kwargs.
This PR restores the `literalinclude` directive that references the tested example file, ensuring the documentation stays in sync with the actual API and CI validates the example.

## Related issues

Fixes regression from #57787

## Additional information

**Before (incorrect):**
```python
app = build_openai_app({
    "llm_configs": [llm_config],
    "router_cls": PrefixCacheAffinityRouter,  # Does not exist
    "router_config": {...}  # Does not exist
})
```

**After (correct, via literalinclude):**
```python
llm_config = LLMConfig(
    ...
    deployment_config={
        ...
        "request_router_config": {
            "request_router_class": PrefixCacheAffinityRouter,
            "request_router_kwargs": {...},
        },
    },
)
app = build_openai_app({"llm_configs": [llm_config]})
```
