### PR TITLE
[data][llm] Add pooling parameter

### DIFF
--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -575,8 +575,8 @@ def build_processor(
         preprocess: An optional lambda function that takes a row (dict) as input
             and returns a preprocessed row (dict). The output row must contain the
             required fields for the following processing stages. Each row
-            can contain a `sampling_params` field which will be used by the
-            engine for row-specific sampling parameters.
+            can contain a `sampling_params` or `pooling_params` field which will be used
+            by the engine for row-specific sampling or pooling parameters respectively.
             Note that all columns will be carried over until the postprocess stage.
         postprocess: An optional lambda function that takes a row (dict) as input
             and returns a postprocessed row (dict). To keep all the original columns,

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -484,6 +484,10 @@ class vLLMEngineWrapper:
                 request_id=str(request.request_id),
                 prompt=llm_prompt,
                 pooling_params=request.params,
+                # vLLM 0.12.0 ignores truncate_prompt_tokens in the pooling_params.
+                # TODO (jeffreywang): Remove the following line once
+                # https://github.com/vllm-project/vllm/issues/31012 is fixed.
+                truncate_prompt_tokens=request.params.truncate_prompt_tokens,
             )
         else:
             stream = self.engine.generate(

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -862,11 +862,13 @@ class vLLMEngineStage(StatefulStage):
         map_batches_kwargs.update(ray_remote_args)
         return values
 
+    def _get_task_type(self) -> vLLMTaskType:
+        return self.fn_constructor_kwargs.get("task_type", vLLMTaskType.GENERATE)
+
     def get_required_input_keys(self) -> Dict[str, str]:
         """The required input keys of the stage and their descriptions."""
         ret = {"prompt": "The text prompt (str)."}
-        task_type = self.fn_constructor_kwargs.get("task_type", vLLMTaskType.GENERATE)
-        if task_type == vLLMTaskType.GENERATE:
+        if self._get_task_type() == vLLMTaskType.GENERATE:
             ret["sampling_params"] = (
                 "The sampling parameters. See "
                 "https://docs.vllm.ai/en/latest/api/vllm/#vllm.SamplingParams "
@@ -885,8 +887,7 @@ class vLLMEngineStage(StatefulStage):
             "mm_processor_kwargs": "The kwargs for the engine's multimodal processor.",
             "multimodal_uuids": "User-specified UUIDs for multimodal items, mapped by modality.",
         }
-        task_type = self.fn_constructor_kwargs.get("task_type", vLLMTaskType.GENERATE)
-        if task_type == vLLMTaskType.EMBED:
+        if self._get_task_type() == vLLMTaskType.EMBED:
             ret["pooling_params"] = (
                 "The pooling parameters. See "
                 "https://docs.vllm.ai/en/latest/api/vllm/#vllm.PoolingParams "

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -338,13 +338,17 @@ async def test_vllm_wrapper_embed(model_opt_125m):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "pooling_params",
+    "pooling_params,expect_same_output",
     [
-        {"truncate_prompt_tokens": -1},
-        {"truncate_prompt_tokens": 3, "normalize": True},
+        ({}, True),
+        ({"truncate_prompt_tokens": 3}, False),
+        ({"normalize": True}, False),
     ],
 )
-async def test_vllm_wrapper_embed_with_pooling_params(model_opt_125m, pooling_params):
+async def test_vllm_wrapper_embed_pooling_params(
+    model_opt_125m, pooling_params, expect_same_output
+):
+    prompt = "Hello! How's the weather?"
     wrapper = vLLMEngineWrapper(
         model=model_opt_125m,
         model_source=model_opt_125m,
@@ -361,20 +365,76 @@ async def test_vllm_wrapper_embed_with_pooling_params(model_opt_125m, pooling_pa
     batch = [
         {
             "__idx_in_batch": 0,
-            "prompt": "Hello! How's the weather?",
+            "prompt": prompt,
             "pooling_params": pooling_params,
+        },
+        {
+            "__idx_in_batch": 1,
+            "prompt": prompt,
+            # By default, no pooling params are applied.
         },
     ]
 
     tasks = [asyncio.create_task(wrapper.generate_async(row)) for row in batch]
 
+    outputs = {}
     for resp in asyncio.as_completed(tasks):
         request, output, time_taken_llm = await resp
+        idx = request.idx_in_batch
+        outputs[idx] = output
 
-        for key, expected_value in pooling_params.items():
-            assert hasattr(request.params, key)
-            actual_value = getattr(request.params, key)
-            assert actual_value == expected_value
+        # Validate pooling params for idx=0
+        if idx == 0 and pooling_params:
+            for key, expected_value in pooling_params.items():
+                assert hasattr(request.params, key)
+                actual_value = getattr(request.params, key)
+                assert actual_value == expected_value
+
+        assert output["embeddings"].shape == (768,)
+        assert time_taken_llm > 0
+
+    assert (
+        outputs[0]["embeddings"] == outputs[1]["embeddings"]
+    ).all() == expect_same_output
+
+    # Clean up GPU memory
+    wrapper.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_vllm_wrapper_embed_long_prompt(model_opt_125m):
+    # Sufficiently long prompt to trigger truncation to max_model_len
+    prompt = "Hello! How's the weather?" * 10_000
+    wrapper = vLLMEngineWrapper(
+        model=model_opt_125m,
+        model_source=model_opt_125m,
+        idx_in_batch_column="__idx_in_batch",
+        disable_log_stats=True,
+        max_pending_requests=10,
+        # Skip CUDA graph capturing to reduce the start time.
+        enforce_eager=True,
+        gpu_memory_utilization=0.8,
+        max_model_len=2048,
+        task=vLLMTaskType.EMBED,
+    )
+
+    batch = [
+        {
+            "__idx_in_batch": 0,
+            "prompt": prompt,
+            # Long prompts shouldn't induce vLLM errors as prommpt length is truncated
+            # to max_model_len when truncate_prompt_tokens is set to -1
+            "pooling_params": {"truncate_prompt_tokens": -1},
+        },
+    ]
+
+    tasks = [asyncio.create_task(wrapper.generate_async(row)) for row in batch]
+
+    outputs = {}
+    for resp in asyncio.as_completed(tasks):
+        request, output, time_taken_llm = await resp
+        idx = request.idx_in_batch
+        outputs[idx] = output
 
         assert output["embeddings"].shape == (768,)
         assert time_taken_llm > 0


### PR DESCRIPTION
## Description
The preprocessor forwards only `sampling_params` to the engine today. For `task_type="embed"`, however, we should also allow forwarding `pooling_params`, enabling features such as truncating the input prompt to a fixed token budget via `truncate_prompt_tokens` or normalizing the output embedding via `normalize`. See https://docs.vllm.ai/en/latest/api/vllm/#vllm.PoolingParams for a comprehensive list of supported attributes.

## Related issues
Resolves #57805

## Additional information
- Similar to sampling parameters, we allow users to specify pooling parameter under the "pooling_params" column for embedding tasks.
- Add tests in `test_vllm_engine_stage` to validate that the pooling parameters are received by the engine.
