### PR TITLE
fix nil actor id error when calling job id

### DIFF
--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -319,6 +319,8 @@ cdef class ActorID(BaseID):
 
     @property
     def job_id(self):
+        if self.data.IsNil():
+            raise ValueError("ActorID is nil")
         return JobID(self.data.JobId().Binary())
 
     def binary(self):

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -37,6 +37,11 @@ def check_id(b, size=kUniqueIDSize):
                          str(size) + ", got " + str(len(b)))
 
 
+def check_nil(id_obj):
+    if id_obj.is_nil():
+        raise ValueError(f"{id_obj.__class__.__name__} is nil")
+
+
 cdef extern from "ray/common/constants.h" nogil:
     cdef int64_t kUniqueIDSize
 
@@ -165,6 +170,7 @@ cdef class TaskID(BaseID):
         return ActorID(self.data.ActorId().Binary())
 
     def job_id(self):
+        check_nil(self)
         return JobID(self.data.JobId().Binary())
 
     cdef size_t hash(self):
@@ -319,8 +325,7 @@ cdef class ActorID(BaseID):
 
     @property
     def job_id(self):
-        if self.data.IsNil():
-            raise ValueError("ActorID is nil")
+        check_nil(self)
         return JobID(self.data.JobId().Binary())
 
     def binary(self):


### PR DESCRIPTION
## Description
When running bellow code:
```
from ray import ActorID
ActorID.nil().job_id
```
or
```
from ray import TaskID
TaskID.nil().job_id()
```

Bellow error shows:
<img width="1912" height="331" alt="截圖 2025-12-18 下午6 49 18" src="https://github.com/user-attachments/assets/b4200ef8-10df-4c91-83ff-f96f7874b0ce" />

The program should throw an error instead of crash, and this PR fixed it by adding a helper function to do nil check.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".
Closes [#53872](https://github.com/ray-project/ray/issues/53872)

## Additional information
After the fix, now it will throw an `ValueError`
<img width="334" height="52" alt="截圖 2025-12-20 上午8 47 30" src="https://github.com/user-attachments/assets/00228923-2d26-4cb4-bf53-615945d2ce6c" />

<img width="668" height="103" alt="截圖 2025-12-20 上午8 47 49" src="https://github.com/user-attachments/assets/ee68213a-681a-4499-bef2-2e13533e3ffd" />
