### PR TITLE
[core] Handle exception types with read-only args in RayTaskError

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -178,10 +178,17 @@ class RayTaskError(RayError):
         class cls(RayTaskError, cause_cls):
             def __init__(self, cause):
                 self.cause = cause
-                self.args = (cause,)
+                # Some exception types don't allow `args` to be set
+                # (e.g., their `args` property has no setter).
+                # In such cases, we skip setting `args` and rely on
+                # `__reduce__` returning `self.cause` for pickling.
+                try:
+                    self.args = (cause,)
+                except AttributeError:
+                    pass
 
             def __reduce__(self):
-                return (cls, self.args)
+                return (cls, (self.cause,))
 
             def __getattr__(self, name):
                 return getattr(self.cause, name)


### PR DESCRIPTION
## Summary
- Fix RayTaskError deserialization crash when the cause exception has a read-only `args` property
- Some exception types (e.g., `rasterio._err.CPLE_AppDefinedError`) don't allow `args` to be set, causing AttributeError

## Changes
- Wrap `self.args = (cause,)` in try-except to catch AttributeError
- Update `__reduce__` to use `self.cause` directly instead of relying on `self.args`
- Add unit tests for the fix

## Test plan
- Added `test_dual_exception_with_readonly_args` - verifies exception wrapping works
- Added `test_dual_exception_pickling_with_readonly_args` - verifies pickling works

Fixes #59437