### PR TITLE
[core] Improve error handling for num_returns in @ray.remote and @ray.method

### DIFF
--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -101,6 +101,18 @@ class RemoteFunction:
                 "async function with `asyncio.run(f())`. See more at:"
                 "https://docs.ray.io/en/latest/ray-core/actors/async_api.html "
             )
+
+        # Validate num_returns for non-generator functions
+        num_returns = task_options.get("num_returns")
+        is_generator = inspect.isgeneratorfunction(function)
+        if num_returns in ("streaming", "dynamic") and not is_generator:
+            raise ValueError(
+                f"num_returns='{num_returns}' is only valid for generator functions "
+                f"(functions that use 'yield'). The function '{function.__name__}' "
+                "is not a generator function. Either change the function to use "
+                "'yield' or remove/change the num_returns parameter."
+            )
+
         self._default_options = task_options
 
         # When gpu is used, set the task non-recyclable by default.


### PR DESCRIPTION
## Summary
- Add fail-fast validation for `num_returns` parameter in `@ray.remote` and `@ray.method`
- Provides clear error messages at decoration time instead of confusing runtime behavior

## Changes
- `@ray.remote`: Raise ValueError when `num_returns='streaming'` or `'dynamic'` is used with non-generator functions
- `@ray.method`: Validate `num_returns` is non-negative (raise ValueError for negative values)
- `@ray.method`: Raise ValueError when `num_returns='streaming'` or `'dynamic'` is used with non-generator methods
- Add unit tests for all validation cases

## Test plan
- Added `test_num_returns_streaming_requires_generator` - verifies @ray.remote validation
- Added `test_ray_method_num_returns_validation` - verifies @ray.method validation

Fixes #59274