### PR TITLE
[Data] Compute Expressions-Expr Logarithmic

### DIFF
--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -438,19 +438,25 @@ class Expr(ABC):
     # logarithmic helpers
     def ln(self) -> "UDFExpr":
         """Compute the natural logarithm of the expression."""
-        return _create_pyarrow_compute_udf(pc.ln)(self)
+        return _create_pyarrow_compute_udf(pc.ln, return_dtype=DataType.float64())(self)
 
     def log10(self) -> "UDFExpr":
         """Compute the base-10 logarithm of the expression."""
-        return _create_pyarrow_compute_udf(pc.log10)(self)
+        return _create_pyarrow_compute_udf(pc.log10, return_dtype=DataType.float64())(
+            self
+        )
 
     def log2(self) -> "UDFExpr":
         """Compute the base-2 logarithm of the expression."""
-        return _create_pyarrow_compute_udf(pc.log2)(self)
+        return _create_pyarrow_compute_udf(pc.log2, return_dtype=DataType.float64())(
+            self
+        )
 
     def exp(self) -> "UDFExpr":
         """Compute the natural exponential of the expression."""
-        return _create_pyarrow_compute_udf(pc.exp)(self)
+        return _create_pyarrow_compute_udf(pc.exp, return_dtype=DataType.float64())(
+            self
+        )
 
     @property
     def list(self) -> "_ListNamespace":

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -435,6 +435,23 @@ class Expr(ABC):
         """Truncate fractional values toward zero."""
         return _create_pyarrow_compute_udf(pc.trunc)(self)
 
+    # logarithmic helpers
+    def ln(self) -> "UDFExpr":
+        """Compute the natural logarithm of the expression."""
+        return _create_pyarrow_compute_udf(pc.ln)(self)
+
+    def log10(self) -> "UDFExpr":
+        """Compute the base-10 logarithm of the expression."""
+        return _create_pyarrow_compute_udf(pc.log10)(self)
+
+    def log2(self) -> "UDFExpr":
+        """Compute the base-2 logarithm of the expression."""
+        return _create_pyarrow_compute_udf(pc.log2)(self)
+
+    def exp(self) -> "UDFExpr":
+        """Compute the natural exponential of the expression."""
+        return _create_pyarrow_compute_udf(pc.exp)(self)
+
     @property
     def list(self) -> "_ListNamespace":
         """Access list operations for this expression.

--- a/python/ray/data/tests/test_with_column.py
+++ b/python/ray/data/tests/test_with_column.py
@@ -643,13 +643,21 @@ def test_with_column_rounding_operations(
         pytest.param(lambda: col("value").exp(), math.exp, id="exp"),
     ],
 )
+@pytest.mark.parametrize(
+    "input_values",
+    [
+        pytest.param([1.0, math.e, 10.0, 4.0], id="float_inputs"),
+        pytest.param([1, 10, 4, 2], id="int_inputs"),
+    ],
+)
 def test_with_column_logarithmic_operations(
     ray_start_regular_shared,
     expr_factory,
     expected_fn,
+    input_values,
 ):
     """Test logarithmic and exponential expressions."""
-    values = [1.0, math.e, 10.0, 4.0]
+    values = input_values
     ds = ray.data.from_items([{"value": v} for v in values])
     expr = expr_factory()
     expected_values = [expected_fn(v) for v in values]


### PR DESCRIPTION
### Description
Completing the Expr (direct) Logarithmic operations (ln, log10, log2, exp)

#### test for example:
```
import ray
from ray.data import from_items
from ray.data.expressions import col

ray.init(include_dashboard=False, ignore_reinit_error=True)

ds = from_items([
    {"x": 1.1},
    {"x": 2.5},
    {"x": 3.7},
])

for row in ds.iter_rows():
    print(row)

x_expr = col("x")

hasattr(x_expr, "ln")
ds = ds.with_column("x_ln", x_expr.ln())

hasattr(x_expr, "log10")
ds = ds.with_column("x_log10", x_expr.log10())

hasattr(x_expr, "log2")
ds = ds.with_column("x_log2", x_expr.log2())

hasattr(x_expr, "exp")
ds = ds.with_column("x_exp", x_expr.exp())

for row in ds.iter_rows():
    print(row)
```


### Related issues
Related to https://github.com/ray-project/ray/issues/58674

Related PR: https://github.com/ray-project/ray/pull/59295

### Additional information