### PR TITLE
[core][autoscaler] fix: Invalid status transition from QUEUED to RAY_STOP_REQUESTED in autoscaler v2

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/common.py
+++ b/python/ray/autoscaler/v2/instance_manager/common.py
@@ -200,6 +200,10 @@ class InstanceUtil:
                 # Cloud provider requested to launch a node for the instance.
                 # This happens when the a launch request is made to the node provider.
                 Instance.REQUESTED,
+                # Allocation request canceled before being requested.
+                # This happens when max_workers config is reduced or other termination
+                # triggers occur while the instance is still queued.
+                Instance.TERMINATED,
             },
             # When in this status, a launch request to the node provider is made.
             Instance.REQUESTED: {
@@ -333,10 +337,12 @@ class InstanceUtil:
                 # Retry the termination, become terminating again.
                 Instance.TERMINATING,
             },
-            # Whenever a cloud instance disappears from the list of running cloud
-            # instances from the node provider, the instance is marked as stopped. Since
-            # we guarantee 1:1 mapping of a Instance to a cloud instance, this is a
-            # terminal state.
+            # An instance is marked as terminated when:
+            # 1. A cloud instance disappears from the list of running cloud instances
+            #    from the node provider (follows from TERMINATING or other running states).
+            # 2. An allocation request is canceled before cloud resources are allocated
+            #    (follows from QUEUED).
+            # This is a terminal state.
             Instance.TERMINATED: set(),  # Terminal state.
             # When in this status, the cloud instance failed to be allocated by the
             # node provider.

--- a/python/ray/autoscaler/v2/tests/test_instance_util.py
+++ b/python/ray/autoscaler/v2/tests/test_instance_util.py
@@ -34,7 +34,7 @@ class InstanceUtilTest(unittest.TestCase):
 
         g = InstanceUtil.get_valid_transitions()
 
-        assert g[Instance.QUEUED] == {Instance.REQUESTED}
+        assert g[Instance.QUEUED] == {Instance.REQUESTED, Instance.TERMINATED}
         all_status.remove(Instance.QUEUED)
 
         assert g[Instance.REQUESTED] == {

--- a/src/ray/protobuf/instance_manager.proto
+++ b/src/ray/protobuf/instance_manager.proto
@@ -74,8 +74,9 @@ message Instance {
     // The instance is terminating - follows from the RAY_STOPPED state or ALLOCATED
     // state.
     TERMINATING = 9;
-    // The instance is terminated - follows from TERMINATING state or any other running
-    // states when instance was preempted.
+    // The instance is terminated - follows from TERMINATING state, QUEUED state when
+    // allocation request is canceled, or any other running states when instance was
+    // preempted.
     TERMINATED = 10;
     // Error states.
     // The instance allocation failed - follows from the REQUESTED state.


### PR DESCRIPTION
## Description

 When the autoscaler attempts to terminate QUEUED instances to enforce the `max_num_nodes_per_type` limit, the reconciler crashes with an assertion error. This happens because QUEUED instances are selected for termination, but the state machine doesn't allow transitioning them to a terminated state.

The reconciler assumes all non-ALLOCATED instances have Ray running and attempts to transition QUEUED → RAY_STOP_REQUESTED, which is invalid.

https://github.com/ray-project/ray/blob/ba727da47a1a4af1f58c1642839deb0defd82d7a/python/ray/autoscaler/v2/instance_manager/reconciler.py#L1178-L1197

This occurs when `max_workers` configuration is dynamically reduced or when instances exceed the limit.

```
2025-12-04 06:21:55,298	INFO event_logger.py:77 -- Removing 167 nodes of type elser-v2-ingest (max number of worker nodes per type reached).
2025-12-04 06:21:55,307 - INFO - Update instance QUEUED->RAY_STOP_REQUESTED (id=e13a1528-ffd9-403b-9fd1-b54e9c2698a0, type=elser-v2-ingest, cloud_instance_id=, ray_id=): draining ray: Terminating node due to MAX_NUM_NODE_PER_TYPE: max_num_nodes=None, max_num_nodes_per_type=220
2025-12-04 06:21:55,307	INFO instance_manager.py:263 -- Update instance QUEUED->RAY_STOP_REQUESTED (id=e13a1528-ffd9-403b-9fd1-b54e9c2698a0, type=elser-v2-ingest, cloud_instance_id=, ray_id=): draining ray: Terminating node due to MAX_NUM_NODE_PER_TYPE: max_num_nodes=None, max_num_nodes_per_type=220
2025-12-04 06:21:55,307 - ERROR - Invalid status transition from QUEUED to RAY_STOP_REQUESTED
```

This PR add a valid transition `QUEUED -> TERMINATED` to allow canceling queued instances.

## Related issues
Closes #59219

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
