### PR TITLE
[Data] Compute Expression-str Padding

### DIFF
--- a/python/ray/data/namespace_expressions/string_namespace.py
+++ b/python/ray/data/namespace_expressions/string_namespace.py
@@ -258,6 +258,22 @@ class _StringNamespace:
             self._expr, width, padding, *args, **kwargs
         )
 
+    def lpad(
+        self, width: int, padding: str = " ", *args: Any, **kwargs: Any
+    ) -> "UDFExpr":
+        """Left-pad strings up to ``width`` using ``padding``."""
+        return _create_str_udf(pc.utf8_lpad, DataType.string())(
+            self._expr, width, padding, *args, **kwargs
+        )
+
+    def rpad(
+        self, width: int, padding: str = " ", *args: Any, **kwargs: Any
+    ) -> "UDFExpr":
+        """Right-pad strings up to ``width`` using ``padding``."""
+        return _create_str_udf(pc.utf8_rpad, DataType.string())(
+            self._expr, width, padding, *args, **kwargs
+        )
+
     # Custom methods that need special logic beyond simple PyArrow function calls
     def strip(self, characters: str | None = None) -> "UDFExpr":
         """Remove leading and trailing whitespace or specified characters.

--- a/python/ray/data/namespace_expressions/string_namespace.py
+++ b/python/ray/data/namespace_expressions/string_namespace.py
@@ -261,7 +261,10 @@ class _StringNamespace:
     def lpad(
         self, width: int, padding: str = " ", *args: Any, **kwargs: Any
     ) -> "UDFExpr":
-        """Left-pad strings up to ``width`` using ``padding``."""
+        """Left-pad strings to a fixed ``width``.
+
+        If a string is longer than ``width``, it is truncated from the right.
+        """
         return _create_str_udf(pc.utf8_lpad, DataType.string())(
             self._expr, width, padding, *args, **kwargs
         )
@@ -269,7 +272,10 @@ class _StringNamespace:
     def rpad(
         self, width: int, padding: str = " ", *args: Any, **kwargs: Any
     ) -> "UDFExpr":
-        """Right-pad strings up to ``width`` using ``padding``."""
+        """Right-pad strings to a fixed ``width``.
+
+        If a string is longer than ``width``, it is truncated from the right.
+        """
         return _create_str_udf(pc.utf8_rpad, DataType.string())(
             self._expr, width, padding, *args, **kwargs
         )

--- a/python/ray/data/namespace_expressions/string_namespace.py
+++ b/python/ray/data/namespace_expressions/string_namespace.py
@@ -261,9 +261,9 @@ class _StringNamespace:
     def lpad(
         self, width: int, padding: str = " ", *args: Any, **kwargs: Any
     ) -> "UDFExpr":
-        """Left-pad strings to a fixed ``width``.
+        """Right-align strings by padding with a given character while respecting ``width``.
 
-        If a string is longer than ``width``, it is truncated from the right.
+        If the string is longer than the specified width, it remains intact (no truncation occurs).
         """
         return _create_str_udf(pc.utf8_lpad, DataType.string())(
             self._expr, width, padding, *args, **kwargs
@@ -272,9 +272,9 @@ class _StringNamespace:
     def rpad(
         self, width: int, padding: str = " ", *args: Any, **kwargs: Any
     ) -> "UDFExpr":
-        """Right-pad strings to a fixed ``width``.
+        """Left-align strings by padding with a given character while respecting ``width``.
 
-        If a string is longer than ``width``, it is truncated from the right.
+        If the string is longer than the specified width, it remains intact (no truncation occurs).
         """
         return _create_str_udf(pc.utf8_rpad, DataType.string())(
             self._expr, width, padding, *args, **kwargs

--- a/python/ray/data/tests/test_namespace_expressions.py
+++ b/python/ray/data/tests/test_namespace_expressions.py
@@ -234,6 +234,8 @@ class TestStringTrimming:
         ("pad", {"width": 5, "fillchar": "*", "side": "right"}, "hi***"),
         ("pad", {"width": 5, "fillchar": "*", "side": "left"}, "***hi"),
         ("pad", {"width": 6, "fillchar": "*", "side": "both"}, "**hi**"),
+        ("lpad", {"width": 5, "padding": "*"}, "***hi"),
+        ("rpad", {"width": 5, "padding": "*"}, "hi***"),
         ("center", {"width": 6, "padding": "*"}, "**hi**"),
     ],
 )


### PR DESCRIPTION
### Description
Completing the str Padding operations (lpad, rpad)

#### test for example:
```
import ray
from ray.data import from_items
from ray.data.expressions import col

ray.init(include_dashboard=False, ignore_reinit_error=True)

ds = from_items([
    {"x": "ray"},
    {"x": "data"},
    {"x": "expr"},
])

for row in ds.iter_rows():
    print(row)

x_expr = col("x")

# lpad
hasattr(x_expr.str, "lpad")
ds = ds.with_column("x_lpad", x_expr.str.lpad(6, "_"))

# rpad
hasattr(x_expr.str, "rpad")
ds = ds.with_column("x_rpad", x_expr.str.rpad(6, "_"))

for row in ds.iter_rows():
    print(row)
```


### Related issues
Related to https://github.com/ray-project/ray/issues/58674

Related PR: [Data] Add namespaced expressions that expose pyarrow functions (#58465)

### Additional information