### PR TITLE
Add perf metrics for 2.53.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 109.3632,
+    "_dashboard_memory_usage_mb": 97.763328,
     "_dashboard_test_success": true,
     "_peak_memory": 4.6,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3285\t2.23GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5814\t0.82GiB\tpython distributed/test_many_actors.py\n2864\t0.41GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3502\t0.2GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3985\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2823\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1140\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3987\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3415\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5610\t0.07GiB\tray::JobSupervisor",
-    "actors_per_second": 403.10794652127487,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3288\t2.22GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5688\t0.83GiB\tpython distributed/test_many_actors.py\n2638\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3508\t0.18GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3992\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2769\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1137\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3994\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3417\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5502\t0.07GiB\tray::JobSupervisor",
+    "actors_per_second": 403.97078934630366,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 403.10794652127487
+            "perf_metric_value": 403.97078934630366
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 20.494
+            "perf_metric_value": 30.152
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3843.186
+            "perf_metric_value": 3504.953
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7078.797
+            "perf_metric_value": 3993.037
         }
     ],
-    "time": 24.8072509765625
+    "time": 24.754265069961548
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 93.167616,
+    "_dashboard_memory_usage_mb": 93.601792,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.41,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3099\t0.69GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2648\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4521\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3312\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3795\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2691\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1086\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3229\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3797\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n4762\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 2.34,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3115\t0.61GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2638\t0.31GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5058\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3328\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3810\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2789\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1088\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3244\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3812\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3326\t0.08GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 390.190063861316
+            "perf_metric_value": 379.30168512953065
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.037
+            "perf_metric_value": 7.417
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.15
+            "perf_metric_value": 25.72
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 49.411
+            "perf_metric_value": 55.245
         }
     ],
-    "tasks_per_second": 390.190063861316,
-    "time": 302.5628535747528,
+    "tasks_per_second": 379.30168512953065,
+    "time": 302.63642382621765,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 89.985024,
+    "_dashboard_memory_usage_mb": 80.26112,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.85,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3274\t1.08GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n4694\t0.36GiB\tpython distributed/test_many_pgs.py\n2853\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n579\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3980\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2807\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3494\t0.09GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n1152\t0.08GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3982\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n2605\t0.08GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l",
+    "_peak_memory": 2.87,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3290\t1.04GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2748\t0.53GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4875\t0.38GiB\tpython distributed/test_many_pgs.py\n585\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3507\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3991\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2882\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1141\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2609\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n3993\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 17.630807526575012
+            "perf_metric_value": 18.933742626442143
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.91
+            "perf_metric_value": 3.729
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.033
+            "perf_metric_value": 35.467
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 382.069
+            "perf_metric_value": 983.739
         }
     ],
-    "pgs_per_second": 17.630807526575012,
-    "time": 56.7188994884491
+    "pgs_per_second": 18.933742626442143,
+    "time": 52.81575965881348
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 90.853376,
+    "_dashboard_memory_usage_mb": 99.9424,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.63,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3270\t2.24GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3490\t1.06GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4675\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2831\t0.3GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3493\t0.16GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n3970\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2790\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3400\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n1114\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3972\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
+    "_peak_memory": 5.61,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3286\t2.21GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3509\t1.06GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4691\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2777\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3512\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n3991\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2711\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1117\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3415\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3993\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 552.9028002075252
+            "perf_metric_value": 582.6440311743918
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.264
+            "perf_metric_value": 5.21
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 915.177
+            "perf_metric_value": 891.025
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2840.518
+            "perf_metric_value": 2650.58
         }
     ],
-    "tasks_per_second": 552.9028002075252,
-    "time": 318.0863616466522,
+    "tasks_per_second": 582.6440311743918,
+    "time": 317.1631381511688,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.52.0"}
+{"release_version": "2.53.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8479.131512159902,
-        449.64091460972287
+        8591.539773771437,
+        327.6473689212415
     ],
     "1_1_actor_calls_concurrent": [
-        5629.888924437268,
-        234.90676364325793
+        4965.99522007048,
+        110.57050182691287
     ],
     "1_1_actor_calls_sync": [
-        1894.334713622146,
-        24.612801215171302
+        1989.7334090798931,
+        25.505826231728204
     ],
     "1_1_async_actor_calls_async": [
-        4314.570035703319,
-        304.5453646146402
+        3853.261228971964,
+        99.83936195976952
     ],
     "1_1_async_actor_calls_sync": [
-        1425.2460291392301,
-        10.972434631632895
+        1433.5390152119278,
+        17.93284593948981
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2762.9385297368535,
-        126.75534928061596
+        2490.991223668351,
+        63.57171243588424
     ],
     "1_n_actor_calls_async": [
-        7818.847120700663,
-        64.99608921713438
+        6838.2845805526595,
+        314.82799922635735
     ],
     "1_n_async_actor_calls_async": [
-        6913.550938819563,
-        98.3567118445223
+        6280.583274671035,
+        151.9212740998498
     ],
     "client__1_1_actor_calls_async": [
-        1152.0966726586987,
-        5.949648400768134
+        814.5335887693782,
+        4.838251093544874
     ],
     "client__1_1_actor_calls_concurrent": [
-        1146.7134222243185,
-        6.42547694106721
+        828.6299560282166,
+        29.552952884738705
     ],
     "client__1_1_actor_calls_sync": [
-        576.2018967799997,
-        10.50153867932314
+        453.8059915017394,
+        8.187850810536593
     ],
     "client__get_calls": [
-        1033.7763022350296,
-        5.34524244588223
+        925.594265020844,
+        38.537498340367016
     ],
     "client__put_calls": [
-        821.8214713340072,
-        6.060117412244701
+        733.6703843739219,
+        27.03154164960252
     ],
     "client__put_gigabytes": [
-        0.10220457395600176,
-        0.0007220930561878849
+        0.10217222369611438,
+        0.0009032714197567093
     ],
     "client__tasks_and_get_batch": [
-        1.0755792867557323,
-        0.013832969422864473
+        0.8011125804259877,
+        0.02763619914898006
     ],
     "client__tasks_and_put_batch": [
-        11657.102874288967,
-        208.2074750539261
+        9220.111790372692,
+        113.82433420954683
     ],
     "multi_client_put_calls_Plasma_Store": [
-        13260.224066162647,
-        116.63110628919485
+        9658.981678535481,
+        86.1679973849462
     ],
     "multi_client_put_gigabytes": [
-        47.62336463265461,
-        4.1367625605785605
+        35.29689743165927,
+        1.8641014249003314
     ],
     "multi_client_tasks_async": [
-        20569.559125979922,
-        1553.3544021601588
+        20114.199533908533,
+        2167.6533639918985
     ],
     "n_n_actor_calls_async": [
-        24531.521409406632,
-        1132.8337423991986
+        22593.67022851302,
+        1130.0768199962295
     ],
     "n_n_actor_calls_with_arg_async": [
-        3353.6340010226468,
-        26.1884248878178
+        3263.220674257469,
+        15.530961554792869
     ],
     "n_n_async_actor_calls_async": [
-        21866.061040938854,
-        575.3937912232543
+        19945.253372184772,
+        1200.2869336158885
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9541.420239681218
+            "perf_metric_value": 9361.068161075398
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4686.60144219099
+            "perf_metric_value": 4116.404938052882
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13260.224066162647
+            "perf_metric_value": 9658.981678535481
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10.83745250237838
+            "perf_metric_value": 18.177676237873847
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6.5168926025589275
+            "perf_metric_value": 5.683136512909751
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 47.62336463265461
+            "perf_metric_value": 35.29689743165927
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.697911312818526
+            "perf_metric_value": 12.521640061929554
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.803898199921876
+            "perf_metric_value": 4.716418799247922
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 872.2036137608502
+            "perf_metric_value": 844.7209532677355
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6961.354217387221
+            "perf_metric_value": 6769.634231009387
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20569.559125979922
+            "perf_metric_value": 20114.199533908533
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1894.334713622146
+            "perf_metric_value": 1989.7334090798931
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8479.131512159902
+            "perf_metric_value": 8591.539773771437
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5629.888924437268
+            "perf_metric_value": 4965.99522007048
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7818.847120700663
+            "perf_metric_value": 6838.2845805526595
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 24531.521409406632
+            "perf_metric_value": 22593.67022851302
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3353.6340010226468
+            "perf_metric_value": 3263.220674257469
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1425.2460291392301
+            "perf_metric_value": 1433.5390152119278
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4314.570035703319
+            "perf_metric_value": 3853.261228971964
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2762.9385297368535
+            "perf_metric_value": 2490.991223668351
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6913.550938819563
+            "perf_metric_value": 6280.583274671035
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21866.061040938854
+            "perf_metric_value": 19945.253372184772
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 685.9076055741489
+            "perf_metric_value": 678.9244842339416
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1033.7763022350296
+            "perf_metric_value": 925.594265020844
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 821.8214713340072
+            "perf_metric_value": 733.6703843739219
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.10220457395600176
+            "perf_metric_value": 0.10217222369611438
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11657.102874288967
+            "perf_metric_value": 9220.111790372692
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 576.2018967799997
+            "perf_metric_value": 453.8059915017394
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1152.0966726586987
+            "perf_metric_value": 814.5335887693782
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1146.7134222243185
+            "perf_metric_value": 828.6299560282166
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1.0755792867557323
+            "perf_metric_value": 0.8011125804259877
         }
     ],
     "placement_group_create/removal": [
-        685.9076055741489,
-        10.053761287925537
+        678.9244842339416,
+        6.1808624839892765
     ],
     "single_client_get_calls_Plasma_Store": [
-        9541.420239681218,
-        526.7310377593739
+        9361.068161075398,
+        133.98238819244128
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.697911312818526,
-        0.6476957042464793
+        12.521640061929554,
+        0.7656933312890627
     ],
     "single_client_put_calls_Plasma_Store": [
-        4686.60144219099,
-        37.15917359963806
+        4116.404938052882,
+        47.31031901113499
     ],
     "single_client_put_gigabytes": [
-        10.83745250237838,
-        11.421048565096807
+        18.177676237873847,
+        5.672608875733518
     ],
     "single_client_tasks_and_get_batch": [
-        6.5168926025589275,
-        0.5072828248370477
+        5.683136512909751,
+        0.37988932464883635
     ],
     "single_client_tasks_async": [
-        6961.354217387221,
-        386.1156802835829
+        6769.634231009387,
+        328.5600631566425
     ],
     "single_client_tasks_sync": [
-        872.2036137608502,
-        14.19648045767642
+        844.7209532677355,
+        10.758093678954005
     ],
     "single_client_wait_1k_refs": [
-        4.803898199921876,
-        0.048573156597531704
+        4.716418799247922,
+        0.039491139734240316
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.110535204000001,
+    "broadcast_time": 16.937953781000004,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.110535204000001
+            "perf_metric_value": 16.937953781000004
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.502108547999995,
-    "get_time": 23.5936516,
+    "args_time": 17.71234498399999,
+    "get_time": 23.304285948,
     "large_object_size": 107374182400,
-    "large_object_time": 29.36838078400001,
+    "large_object_time": 28.68260234600001,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.502108547999995
+            "perf_metric_value": 17.71234498399999
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.539246789999993
+            "perf_metric_value": 5.576066161
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.5936516
+            "perf_metric_value": 23.304285948
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 177.25064926800002
+            "perf_metric_value": 220.095988608
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.36838078400001
+            "perf_metric_value": 28.68260234600001
         }
     ],
-    "queued_time": 177.25064926800002,
-    "returns_time": 5.539246789999993,
+    "queued_time": 220.095988608,
+    "returns_time": 5.576066161,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 1.0091288590431213,
-    "max_iteration_time": 4.532180547714233,
-    "min_iteration_time": 0.08194804191589355,
+    "avg_iteration_time": 0.8959456539154053,
+    "max_iteration_time": 2.6714906692504883,
+    "min_iteration_time": 0.39049792289733887,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0091288590431213
+            "perf_metric_value": 0.8959456539154053
         }
     ],
-    "total_time": 100.91300749778748
+    "total_time": 89.5946934223175
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.6011176109313965
+            "perf_metric_value": 5.5611889362335205
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.045441269874573
+            "perf_metric_value": 14.662270617485046
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 36.306496143341064
+            "perf_metric_value": 41.472771883010864
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.8323874473571777
+            "perf_metric_value": 1.3985865116119385
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1911.0371930599213
+            "perf_metric_value": 2849.039920568466
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.26078188348514014
+            "perf_metric_value": 0.4400494907723027
         }
     ],
-    "stage_0_time": 5.6011176109313965,
-    "stage_1_avg_iteration_time": 14.045441269874573,
-    "stage_1_max_iteration_time": 14.364872932434082,
-    "stage_1_min_iteration_time": 12.86737847328186,
-    "stage_1_time": 140.45464706420898,
-    "stage_2_avg_iteration_time": 36.306496143341064,
-    "stage_2_max_iteration_time": 36.481056928634644,
-    "stage_2_min_iteration_time": 35.84029817581177,
-    "stage_2_time": 181.53298115730286,
-    "stage_3_creation_time": 1.8323874473571777,
-    "stage_3_time": 1911.0371930599213,
-    "stage_4_spread": 0.26078188348514014
+    "stage_0_time": 5.5611889362335205,
+    "stage_1_avg_iteration_time": 14.662270617485046,
+    "stage_1_max_iteration_time": 16.892216205596924,
+    "stage_1_min_iteration_time": 13.176414012908936,
+    "stage_1_time": 146.62276768684387,
+    "stage_2_avg_iteration_time": 41.472771883010864,
+    "stage_2_max_iteration_time": 64.94682741165161,
+    "stage_2_min_iteration_time": 35.315046548843384,
+    "stage_2_time": 207.3643946647644,
+    "stage_3_creation_time": 1.3985865116119385,
+    "stage_3_time": 2849.039920568466,
+    "stage_4_spread": 0.4400494907723027
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.6386530375375787,
-    "avg_pg_remove_time_ms": 1.4351014099100747,
+    "avg_pg_create_time_ms": 1.573554048048569,
+    "avg_pg_remove_time_ms": 1.452357480480116,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.6386530375375787
+            "perf_metric_value": 1.573554048048569
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4351014099100747
+            "perf_metric_value": 1.452357480480116
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 29.30%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1152.0966726586987 to 814.5335887693782 in microbenchmark.json
REGRESSION 27.74%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1146.7134222243185 to 828.6299560282166 in microbenchmark.json
REGRESSION 27.16%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 13260.224066162647 to 9658.981678535481 in microbenchmark.json
REGRESSION 25.88%: multi_client_put_gigabytes (THROUGHPUT) regresses from 47.62336463265461 to 35.29689743165927 in microbenchmark.json
REGRESSION 25.52%: client__tasks_and_get_batch (THROUGHPUT) regresses from 1.0755792867557323 to 0.8011125804259877 in microbenchmark.json
REGRESSION 21.24%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 576.2018967799997 to 453.8059915017394 in microbenchmark.json
REGRESSION 20.91%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11657.102874288967 to 9220.111790372692 in microbenchmark.json
REGRESSION 12.79%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 6.5168926025589275 to 5.683136512909751 in microbenchmark.json
REGRESSION 12.54%: 1_n_actor_calls_async (THROUGHPUT) regresses from 7818.847120700663 to 6838.2845805526595 in microbenchmark.json
REGRESSION 12.17%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 4686.60144219099 to 4116.404938052882 in microbenchmark.json
REGRESSION 11.79%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5629.888924437268 to 4965.99522007048 in microbenchmark.json
REGRESSION 10.73%: client__put_calls (THROUGHPUT) regresses from 821.8214713340072 to 733.6703843739219 in microbenchmark.json
REGRESSION 10.69%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4314.570035703319 to 3853.261228971964 in microbenchmark.json
REGRESSION 10.46%: client__get_calls (THROUGHPUT) regresses from 1033.7763022350296 to 925.594265020844 in microbenchmark.json
REGRESSION 9.84%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2762.9385297368535 to 2490.991223668351 in microbenchmark.json
REGRESSION 9.16%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 6913.550938819563 to 6280.583274671035 in microbenchmark.json
REGRESSION 8.78%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 21866.061040938854 to 19945.253372184772 in microbenchmark.json
REGRESSION 7.90%: n_n_actor_calls_async (THROUGHPUT) regresses from 24531.521409406632 to 22593.67022851302 in microbenchmark.json
REGRESSION 3.15%: single_client_tasks_sync (THROUGHPUT) regresses from 872.2036137608502 to 844.7209532677355 in microbenchmark.json
REGRESSION 2.79%: tasks_per_second (THROUGHPUT) regresses from 390.190063861316 to 379.30168512953065 in benchmarks/many_nodes.json
REGRESSION 2.75%: single_client_tasks_async (THROUGHPUT) regresses from 6961.354217387221 to 6769.634231009387 in microbenchmark.json
REGRESSION 2.70%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 3353.6340010226468 to 3263.220674257469 in microbenchmark.json
REGRESSION 2.21%: multi_client_tasks_async (THROUGHPUT) regresses from 20569.559125979922 to 20114.199533908533 in microbenchmark.json
REGRESSION 1.89%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 9541.420239681218 to 9361.068161075398 in microbenchmark.json
REGRESSION 1.82%: single_client_wait_1k_refs (THROUGHPUT) regresses from 4.803898199921876 to 4.716418799247922 in microbenchmark.json
REGRESSION 1.39%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.697911312818526 to 12.521640061929554 in microbenchmark.json
REGRESSION 1.02%: placement_group_create/removal (THROUGHPUT) regresses from 685.9076055741489 to 678.9244842339416 in microbenchmark.json
REGRESSION 0.03%: client__put_gigabytes (THROUGHPUT) regresses from 0.10220457395600176 to 0.10217222369611438 in microbenchmark.json
REGRESSION 157.48%: dashboard_p99_latency_ms (LATENCY) regresses from 382.069 to 983.739 in benchmarks/many_pgs.json
REGRESSION 108.23%: dashboard_p95_latency_ms (LATENCY) regresses from 17.033 to 35.467 in benchmarks/many_pgs.json
REGRESSION 68.74%: stage_4_spread (LATENCY) regresses from 0.26078188348514014 to 0.4400494907723027 in stress_tests/stress_test_many_tasks.json
REGRESSION 49.97%: dashboard_p95_latency_ms (LATENCY) regresses from 17.15 to 25.72 in benchmarks/many_nodes.json
REGRESSION 49.08%: stage_3_time (LATENCY) regresses from 1911.0371930599213 to 2849.039920568466 in stress_tests/stress_test_many_tasks.json
REGRESSION 47.13%: dashboard_p50_latency_ms (LATENCY) regresses from 20.494 to 30.152 in benchmarks/many_actors.json
REGRESSION 39.86%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 12.110535204000001 to 16.937953781000004 in scalability/object_store.json
REGRESSION 24.17%: 1000000_queued_time (LATENCY) regresses from 177.25064926800002 to 220.095988608 in scalability/single_node.json
REGRESSION 22.86%: dashboard_p50_latency_ms (LATENCY) regresses from 6.037 to 7.417 in benchmarks/many_nodes.json
REGRESSION 14.23%: stage_2_avg_iteration_time (LATENCY) regresses from 36.306496143341064 to 41.472771883010864 in stress_tests/stress_test_many_tasks.json
REGRESSION 11.81%: dashboard_p99_latency_ms (LATENCY) regresses from 49.411 to 55.245 in benchmarks/many_nodes.json
REGRESSION 4.39%: stage_1_avg_iteration_time (LATENCY) regresses from 14.045441269874573 to 14.662270617485046 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.20%: avg_pg_remove_time_ms (LATENCY) regresses from 1.4351014099100747 to 1.452357480480116 in stress_tests/stress_test_placement_group.json
REGRESSION 1.20%: 10000_args_time (LATENCY) regresses from 17.502108547999995 to 17.71234498399999 in scalability/single_node.json
REGRESSION 0.66%: 3000_returns_time (LATENCY) regresses from 5.539246789999993 to 5.576066161 in scalability/single_node.json
```