### PR TITLE
[ci] add ray-cpp-wheel-build, ray-wheel-build to build+upload

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -35,15 +35,77 @@ steps:
       HOSTTYPE: "x86_64"
       MANYLINUX_VERSION: "251216.3835fc5"
 
-  - label: ":tapioca: build: wheel {{matrix}} (x86_64)"
+  - name: ray-wheel-build
+    label: "wanda: wheel py{{matrix}} (x86_64)"
+    wanda: ci/docker/ray-wheel.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: ""
+      HOSTTYPE: "x86_64"
+      MANYLINUX_VERSION: "251216.3835fc5"
+    tags:
+      - release_wheels
+      - linux_wheels
+      - oss
+    depends_on:
+      - ray-core-build
+      - ray-dashboard-build
+      - ray-java-build
+
+  - name: ray-cpp-core-build
+    label: "wanda: cpp core py{{matrix}} (x86_64)"
+    wanda: ci/docker/ray-cpp-core.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: ""
+      HOSTTYPE: "x86_64"
+      MANYLINUX_VERSION: "251216.3835fc5"
+    tags:
+      - release_wheels
+      - oss
+    depends_on:
+      - ray-core-build
+
+  - name: ray-cpp-wheel-build
+    label: "wanda: cpp wheel py{{matrix}} (x86_64)"
+    wanda: ci/docker/ray-cpp-wheel.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: ""
+      HOSTTYPE: "x86_64"
+      MANYLINUX_VERSION: "251216.3835fc5"
+    tags:
+      - release_wheels
+      - oss
+    depends_on:
+      - ray-wheel-build
+      - ray-cpp-core-build
+
+  - label: ":tapioca: upload: wheel py{{matrix}} (x86_64)"
     key: linux_wheels
     tags:
       - release_wheels
       - linux_wheels
       - oss
-    instance_type: large
+    instance_type: small
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture x86_64 --upload
+      - bazel run //ci/ray_ci/automation:extract_wanda_wheel -- --python-version {{matrix}} --arch x86_64
+      - ./ci/build/copy_build_artifacts.sh wheel
     matrix:
       - "3.10"
       - "3.11"
@@ -52,6 +114,8 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
+      - ray-wheel-build
+      - ray-cpp-wheel-build
 
   - label: ":tapioca: build: jar"
     key: java_wheels

--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -305,3 +305,29 @@ py_binary(
         ci_require("click"),
     ],
 )
+
+py_binary(
+    name = "extract_wanda_wheel",
+    srcs = ["extract_wanda_wheel.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    deps = [
+        "//ci/ray_ci:ray_ci_lib",
+        ci_require("click"),
+    ],
+)
+
+py_test(
+    name = "test_extract_wanda_wheel",
+    size = "small",
+    srcs = ["test_extract_wanda_wheel.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ci_require("click"),
+        ci_require("pytest"),
+        ":automation",
+    ],
+)

--- a/ci/ray_ci/automation/extract_wanda_wheel.py
+++ b/ci/ray_ci/automation/extract_wanda_wheel.py
@@ -96,7 +96,7 @@ def _extract_wheel(image_tag: str, image_name: str, output_dir: Path) -> None:
                 wheel_count += 1
 
             if wheel_count == 0:
-                logger.warning(f"  No wheel files found in {image_name}")
+                raise WheelExtractionError(f"No wheel files found in {image_name}")
             else:
                 logger.info(f"Extracted {wheel_count} wheel(s) from {image_name}")
 
@@ -105,6 +105,7 @@ def _extract_wheel(image_tag: str, image_name: str, output_dir: Path) -> None:
         subprocess.run(
             ["docker", "rm", container_id],
             capture_output=True,
+            check=True,
         )
 
 

--- a/ci/ray_ci/automation/extract_wanda_wheel.py
+++ b/ci/ray_ci/automation/extract_wanda_wheel.py
@@ -1,0 +1,224 @@
+"""
+Extract Ray wheels from Wanda-cached Docker images.
+
+This script pulls wheel scratch images from the Wanda cache and extracts
+the .whl files to the .whl/ directory for upload.
+
+Example:
+    bazel run //ci/ray_ci/automation:extract_wanda_wheel -- \\
+        --python-version 3.10 \\
+        --arch x86_64
+
+Run with --help to see all options.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from ci.ray_ci.utils import docker_pull, ecr_docker_login
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+
+class WheelExtractionError(Exception):
+    """Error raised when wheel extraction fails."""
+
+
+def _get_arch_suffix(arch: str) -> str:
+    """Get the architecture suffix for Wanda image names."""
+    if arch == "x86_64":
+        return ""
+    elif arch == "aarch64":
+        return "-aarch64"
+    else:
+        raise WheelExtractionError(f"Unknown architecture: {arch}")
+
+
+def _extract_wheel(image_tag: str, image_name: str, output_dir: Path) -> None:
+    """Extract wheel files from a scratch Docker image."""
+    logger.info(f"--- Extracting from {image_name} ---")
+
+    # Pull the image
+    try:
+        docker_pull(image_tag)
+    except subprocess.CalledProcessError as e:
+        raise WheelExtractionError(f"Failed to pull image {image_tag}: {e}") from e
+
+    # Create a container from the image
+    logger.info(f"Creating container from {image_tag}...")
+    result = subprocess.run(
+        ["docker", "create", image_tag, "true"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise WheelExtractionError(f"Failed to create container: {result.stderr}")
+
+    container_id = result.stdout.strip()
+    logger.info(f"Extracting wheels from container {container_id}...")
+
+    try:
+        # Extract files to a temp directory first
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Copy root filesystem from container
+            result = subprocess.run(
+                ["docker", "cp", f"{container_id}:/", str(temp_path)],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise WheelExtractionError(
+                    f"Failed to copy from container: {result.stderr}"
+                )
+
+            # Find and copy .whl files to output directory
+            wheel_count = 0
+            for whl_file in temp_path.rglob("*.whl"):
+                dest = output_dir / whl_file.name
+                shutil.copy2(whl_file, dest)
+                logger.info(f"  Extracted: {whl_file.name}")
+                wheel_count += 1
+
+            if wheel_count == 0:
+                logger.warning(f"  No wheel files found in {image_name}")
+            else:
+                logger.info(f"Extracted {wheel_count} wheel(s) from {image_name}")
+
+    finally:
+        # Clean up container
+        subprocess.run(
+            ["docker", "rm", container_id],
+            capture_output=True,
+        )
+
+
+@click.command()
+@click.option(
+    "--python-version",
+    type=str,
+    required=True,
+    help="Python version (e.g., '3.10', '3.11', '3.12').",
+)
+@click.option(
+    "--arch",
+    type=str,
+    required=True,
+    help="Architecture (e.g., 'x86_64', 'aarch64').",
+)
+@click.option(
+    "--rayci-work-repo",
+    type=str,
+    default=None,
+    help="RAYCI work repository URL. Defaults to RAYCI_WORK_REPO env var.",
+)
+@click.option(
+    "--rayci-build-id",
+    type=str,
+    default=None,
+    help="RAYCI build ID. Defaults to RAYCI_BUILD_ID env var.",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=Path(".whl"),
+    help="Output directory for extracted wheels. Defaults to '.whl'.",
+)
+@click.option(
+    "--skip-ray",
+    is_flag=True,
+    default=False,
+    help="Skip extracting the ray wheel.",
+)
+@click.option(
+    "--skip-ray-cpp",
+    is_flag=True,
+    default=False,
+    help="Skip extracting the ray-cpp wheel.",
+)
+def main(
+    python_version: str,
+    arch: str,
+    rayci_work_repo: Optional[str],
+    rayci_build_id: Optional[str],
+    output_dir: Path,
+    skip_ray: bool,
+    skip_ray_cpp: bool,
+) -> None:
+    """
+    Extract Ray wheels from Wanda-cached Docker images.
+
+    Pulls the wheel scratch images from the Wanda cache and extracts
+    the .whl files to the output directory.
+    """
+    # Get configuration from env vars if not provided
+    rayci_work_repo = rayci_work_repo or os.environ.get(
+        "RAYCI_WORK_REPO",
+        "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp",
+    )
+    rayci_build_id = rayci_build_id or os.environ.get("RAYCI_BUILD_ID")
+
+    if not rayci_build_id:
+        raise WheelExtractionError("RAYCI_BUILD_ID environment variable required")
+
+    # Determine architecture suffix
+    arch_suffix = _get_arch_suffix(arch)
+
+    # Build image names
+    ray_wheel_image = f"ray-wheel-py{python_version}{arch_suffix}"
+    ray_cpp_wheel_image = f"ray-cpp-wheel-py{python_version}{arch_suffix}"
+
+    # Full image tags in Wanda cache
+    ray_wheel_tag = f"{rayci_work_repo}:{rayci_build_id}-{ray_wheel_image}"
+    ray_cpp_wheel_tag = f"{rayci_work_repo}:{rayci_build_id}-{ray_cpp_wheel_image}"
+
+    logger.info("=== Extracting Ray wheels from Wanda cache ===")
+    logger.info(f"Python version: {python_version}")
+    logger.info(f"Architecture: {arch} (suffix: '{arch_suffix}')")
+    logger.info(f"Ray wheel image: {ray_wheel_tag}")
+    logger.info(f"Ray C++ wheel image: {ray_cpp_wheel_tag}")
+    logger.info(f"Output directory: {output_dir}")
+
+    # Create output directory
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Authenticate with ECR
+    ecr_registry = rayci_work_repo.split("/")[0]
+    ecr_docker_login(ecr_registry)
+
+    # Extract wheels
+    if not skip_ray:
+        _extract_wheel(ray_wheel_tag, ray_wheel_image, output_dir)
+
+    if not skip_ray_cpp:
+        _extract_wheel(ray_cpp_wheel_tag, ray_cpp_wheel_image, output_dir)
+
+    # List extracted wheels
+    logger.info("=== Extraction complete ===")
+    logger.info("Wheels in output directory:")
+    wheels = list(output_dir.glob("*.whl"))
+    if wheels:
+        for whl in sorted(wheels):
+            size_mb = whl.stat().st_size / (1024 * 1024)
+            logger.info(f"  {whl.name} ({size_mb:.1f} MB)")
+    else:
+        logger.warning("  (no wheel files found)")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/automation/test_extract_wanda_wheel.py
+++ b/ci/ray_ci/automation/test_extract_wanda_wheel.py
@@ -1,0 +1,263 @@
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from ci.ray_ci.automation.extract_wanda_wheel import (
+    WheelExtractionError,
+    _get_arch_suffix,
+    _extract_wheel,
+    main,
+)
+
+
+class TestGetArchSuffix:
+    """Tests for _get_arch_suffix function."""
+
+    def test_x86_64_returns_empty_string(self):
+        assert _get_arch_suffix("x86_64") == ""
+
+    def test_aarch64_returns_suffix(self):
+        assert _get_arch_suffix("aarch64") == "-aarch64"
+
+    def test_unknown_arch_raises_error(self):
+        with pytest.raises(WheelExtractionError, match="Unknown architecture"):
+            _get_arch_suffix("arm64")
+
+    def test_empty_arch_raises_error(self):
+        with pytest.raises(WheelExtractionError, match="Unknown architecture"):
+            _get_arch_suffix("")
+
+
+class TestExtractWheel:
+    """Tests for _extract_wheel function."""
+
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.docker_pull")
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.subprocess.run")
+    def test_extract_wheel_success(self, mock_run, mock_docker_pull):
+        """Test successful wheel extraction."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            output_dir.mkdir()
+
+            # Create a fake wheel file that docker cp will "extract"
+            docker_temp = Path(temp_dir) / "docker_fs"
+            docker_temp.mkdir()
+            fake_wheel = docker_temp / "ray-3.0.0-cp310-cp310-linux_x86_64.whl"
+            fake_wheel.write_text("fake wheel content")
+
+            # Mock docker create (returns container ID)
+            # Mock docker cp (copies files)
+            # Mock docker rm (cleanup)
+            def mock_subprocess(args, **kwargs):
+                result = mock.MagicMock()
+                if args[0:2] == ["docker", "create"]:
+                    result.returncode = 0
+                    result.stdout = "abc123container"
+                    result.stderr = ""
+                elif args[0:2] == ["docker", "cp"]:
+                    # Simulate copying by actually copying the fake wheel
+                    import shutil
+
+                    for whl in docker_temp.glob("*.whl"):
+                        shutil.copy2(whl, output_dir / whl.name)
+                    result.returncode = 0
+                    result.stdout = ""
+                    result.stderr = ""
+                elif args[0:2] == ["docker", "rm"]:
+                    result.returncode = 0
+                    result.stdout = ""
+                    result.stderr = ""
+                else:
+                    result.returncode = 1
+                    result.stderr = f"Unknown command: {args}"
+                return result
+
+            mock_run.side_effect = mock_subprocess
+
+            _extract_wheel(
+                "test-repo:test-tag", "test-image", output_dir
+            )
+
+            # Verify docker_pull was called
+            mock_docker_pull.assert_called_once_with("test-repo:test-tag")
+
+            # Verify wheel was "extracted"
+            extracted_wheels = list(output_dir.glob("*.whl"))
+            assert len(extracted_wheels) == 1
+            assert extracted_wheels[0].name == "ray-3.0.0-cp310-cp310-linux_x86_64.whl"
+
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.docker_pull")
+    def test_extract_wheel_pull_failure(self, mock_docker_pull):
+        """Test that pull failure raises error."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+
+            mock_docker_pull.side_effect = subprocess.CalledProcessError(
+                1, "docker pull", stderr="Error: image not found"
+            )
+
+            with pytest.raises(WheelExtractionError, match="Failed to pull image"):
+                _extract_wheel("nonexistent:tag", "test-image", output_dir)
+
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.docker_pull")
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.subprocess.run")
+    def test_extract_wheel_create_failure(self, mock_run, mock_docker_pull):
+        """Test that container create failure raises error."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+
+            # docker create fails
+            mock_run.return_value = mock.MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="Error: cannot create container",
+            )
+
+            with pytest.raises(WheelExtractionError, match="Failed to create container"):
+                _extract_wheel("test:tag", "test-image", output_dir)
+
+
+class TestMainCLI:
+    """Tests for the main CLI function."""
+
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel._extract_wheel")
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.ecr_docker_login")
+    def test_main_extracts_both_wheels(self, mock_ecr_login, mock_extract):
+        """Test that main extracts both ray and ray-cpp wheels by default."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "--python-version", "3.10",
+                    "--arch", "x86_64",
+                    "--rayci-build-id", "test-build-123",
+                    "--output-dir", temp_dir,
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert mock_extract.call_count == 2
+
+            # Verify both wheel types were extracted
+            call_args = [call[0] for call in mock_extract.call_args_list]
+            image_tags = [args[0] for args in call_args]
+            assert any("ray-wheel-py3.10" in tag for tag in image_tags)
+            assert any("ray-cpp-wheel-py3.10" in tag for tag in image_tags)
+
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel._extract_wheel")
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.ecr_docker_login")
+    def test_main_skip_ray(self, mock_ecr_login, mock_extract):
+        """Test --skip-ray flag."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "--python-version", "3.10",
+                    "--arch", "x86_64",
+                    "--rayci-build-id", "test-build-123",
+                    "--output-dir", temp_dir,
+                    "--skip-ray",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert mock_extract.call_count == 1
+
+            # Only ray-cpp should be extracted
+            call_args = mock_extract.call_args_list[0][0]
+            assert "ray-cpp-wheel" in call_args[0]
+
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel._extract_wheel")
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.ecr_docker_login")
+    def test_main_skip_ray_cpp(self, mock_ecr_login, mock_extract):
+        """Test --skip-ray-cpp flag."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "--python-version", "3.10",
+                    "--arch", "x86_64",
+                    "--rayci-build-id", "test-build-123",
+                    "--output-dir", temp_dir,
+                    "--skip-ray-cpp",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert mock_extract.call_count == 1
+
+            # Only ray should be extracted
+            call_args = mock_extract.call_args_list[0][0]
+            assert "ray-wheel-py3.10" in call_args[0]
+            assert "ray-cpp" not in call_args[0]
+
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel._extract_wheel")
+    @mock.patch("ci.ray_ci.automation.extract_wanda_wheel.ecr_docker_login")
+    def test_main_aarch64_arch_suffix(self, mock_ecr_login, mock_extract):
+        """Test that aarch64 architecture adds correct suffix."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "--python-version", "3.11",
+                    "--arch", "aarch64",
+                    "--rayci-build-id", "test-build-123",
+                    "--output-dir", temp_dir,
+                ],
+            )
+
+            assert result.exit_code == 0
+
+            # Verify aarch64 suffix in image tags
+            call_args = [call[0] for call in mock_extract.call_args_list]
+            image_tags = [args[0] for args in call_args]
+            assert any("ray-wheel-py3.11-aarch64" in tag for tag in image_tags)
+            assert any("ray-cpp-wheel-py3.11-aarch64" in tag for tag in image_tags)
+
+    def test_main_missing_build_id(self):
+        """Test that missing RAYCI_BUILD_ID raises error."""
+        runner = CliRunner()
+
+        # Ensure env var is not set
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = runner.invoke(
+                main,
+                [
+                    "--python-version", "3.10",
+                    "--arch", "x86_64",
+                ],
+            )
+
+            assert result.exit_code != 0
+            assert isinstance(result.exception, WheelExtractionError)
+            assert "RAYCI_BUILD_ID" in str(result.exception)
+
+    def test_main_invalid_arch(self):
+        """Test that invalid architecture raises error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--python-version", "3.10",
+                "--arch", "invalid_arch",
+                "--rayci-build-id", "test-build-123",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert isinstance(result.exception, WheelExtractionError)
+        assert "Unknown architecture" in str(result.exception)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/ci/ray_ci/automation/test_extract_wanda_wheel.py
+++ b/ci/ray_ci/automation/test_extract_wanda_wheel.py
@@ -10,8 +10,8 @@ from click.testing import CliRunner
 
 from ci.ray_ci.automation.extract_wanda_wheel import (
     WheelExtractionError,
-    _get_arch_suffix,
     _extract_wheel,
+    _get_arch_suffix,
     main,
 )
 
@@ -62,10 +62,12 @@ class TestExtractWheel:
                     result.stderr = ""
                 elif args[0:2] == ["docker", "cp"]:
                     # Simulate copying by actually copying the fake wheel
+                    # to the destination path provided in the command.
                     import shutil
 
+                    dest_path = Path(args[3])
                     for whl in docker_temp.glob("*.whl"):
-                        shutil.copy2(whl, output_dir / whl.name)
+                        shutil.copy2(whl, dest_path / whl.name)
                     result.returncode = 0
                     result.stdout = ""
                     result.stderr = ""
@@ -80,9 +82,7 @@ class TestExtractWheel:
 
             mock_run.side_effect = mock_subprocess
 
-            _extract_wheel(
-                "test-repo:test-tag", "test-image", output_dir
-            )
+            _extract_wheel("test-repo:test-tag", "test-image", output_dir)
 
             # Verify docker_pull was called
             mock_docker_pull.assert_called_once_with("test-repo:test-tag")
@@ -119,7 +119,9 @@ class TestExtractWheel:
                 stderr="Error: cannot create container",
             )
 
-            with pytest.raises(WheelExtractionError, match="Failed to create container"):
+            with pytest.raises(
+                WheelExtractionError, match="Failed to create container"
+            ):
                 _extract_wheel("test:tag", "test-image", output_dir)
 
 
@@ -135,10 +137,14 @@ class TestMainCLI:
             result = runner.invoke(
                 main,
                 [
-                    "--python-version", "3.10",
-                    "--arch", "x86_64",
-                    "--rayci-build-id", "test-build-123",
-                    "--output-dir", temp_dir,
+                    "--python-version",
+                    "3.10",
+                    "--arch",
+                    "x86_64",
+                    "--rayci-build-id",
+                    "test-build-123",
+                    "--output-dir",
+                    temp_dir,
                 ],
             )
 
@@ -160,10 +166,14 @@ class TestMainCLI:
             result = runner.invoke(
                 main,
                 [
-                    "--python-version", "3.10",
-                    "--arch", "x86_64",
-                    "--rayci-build-id", "test-build-123",
-                    "--output-dir", temp_dir,
+                    "--python-version",
+                    "3.10",
+                    "--arch",
+                    "x86_64",
+                    "--rayci-build-id",
+                    "test-build-123",
+                    "--output-dir",
+                    temp_dir,
                     "--skip-ray",
                 ],
             )
@@ -184,10 +194,14 @@ class TestMainCLI:
             result = runner.invoke(
                 main,
                 [
-                    "--python-version", "3.10",
-                    "--arch", "x86_64",
-                    "--rayci-build-id", "test-build-123",
-                    "--output-dir", temp_dir,
+                    "--python-version",
+                    "3.10",
+                    "--arch",
+                    "x86_64",
+                    "--rayci-build-id",
+                    "test-build-123",
+                    "--output-dir",
+                    temp_dir,
                     "--skip-ray-cpp",
                 ],
             )
@@ -209,10 +223,14 @@ class TestMainCLI:
             result = runner.invoke(
                 main,
                 [
-                    "--python-version", "3.11",
-                    "--arch", "aarch64",
-                    "--rayci-build-id", "test-build-123",
-                    "--output-dir", temp_dir,
+                    "--python-version",
+                    "3.11",
+                    "--arch",
+                    "aarch64",
+                    "--rayci-build-id",
+                    "test-build-123",
+                    "--output-dir",
+                    temp_dir,
                 ],
             )
 
@@ -233,8 +251,10 @@ class TestMainCLI:
             result = runner.invoke(
                 main,
                 [
-                    "--python-version", "3.10",
-                    "--arch", "x86_64",
+                    "--python-version",
+                    "3.10",
+                    "--arch",
+                    "x86_64",
                 ],
             )
 
@@ -248,9 +268,12 @@ class TestMainCLI:
         result = runner.invoke(
             main,
             [
-                "--python-version", "3.10",
-                "--arch", "invalid_arch",
-                "--rayci-build-id", "test-build-123",
+                "--python-version",
+                "3.10",
+                "--arch",
+                "invalid_arch",
+                "--rayci-build-id",
+                "test-build-123",
             ],
         )
 


### PR DESCRIPTION
* Adds script to take prebuilt wheel image, and extract
* Ports current wheel build+upload to use prebuilt wheel image

Topic: ci-ray-wheel-wanda
Relative: ray-wheel-wanda

Signed-off-by: andrew <andrew@anyscale.com>