### PR TITLE
[deps] raydepsets relax operation: dependency graph (2/3)

### DIFF
--- a/ci/raydepsets/BUILD.bazel
+++ b/ci/raydepsets/BUILD.bazel
@@ -10,12 +10,18 @@ py_library(
 )
 
 py_library(
+    name = "dependency_graph",
+    srcs = ["dependency_graph.py"],
+)
+
+py_library(
     name = "raydepsets_lib",
     srcs = [
         "cli.py",
     ],
     data = ["//:uv_file"],
     deps = [
+        ":dependency_graph",
         ":workspace",
         ci_require("bazel-runfiles"),
         ci_require("click"),
@@ -81,5 +87,21 @@ py_test(
         ci_require("pytest"),
         ":utils",
         ":workspace",
+    ],
+)
+
+py_test(
+    name = "test_dependency_graph",
+    srcs = ["tests/test_dependency_graph.py"],
+    data = [
+    ],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ci_require("pytest"),
+        ":raydepsets_lib",
+        ":utils",
     ],
 )

--- a/ci/raydepsets/dependency_graph.py
+++ b/ci/raydepsets/dependency_graph.py
@@ -13,6 +13,8 @@ class Dep:
 
 
 class DependencyGraph:
+    """Manages a dependency graph of Python packages."""
+
     def __init__(self):
         self.graph = DiGraph()
 
@@ -28,7 +30,6 @@ class DependencyGraph:
             for dependent in dep.required_by:
                 if not self.graph.has_node(dependent):
                     raise ValueError(f"Dependency {dependent} not found in deps")
-                # Edge: dependent -> dep (the package that requires points to what it requires)
                 self.graph.add_edge(dependent, dep.name)
 
     def build_dependency_graph(self, deps: List[Dep]):
@@ -36,13 +37,14 @@ class DependencyGraph:
         self.add_edges(deps)
 
     def remove_dropped_dependencies(self, dropped_dependencies: List[str]):
+        """Remove dependencies and their children from the graph"""
         for dep in dropped_dependencies:
             if not self.graph.has_node(dep):
                 raise ValueError(f"Dependency {dep} not found in deps")
 
         to_remove = set(dropped_dependencies)
 
-        # Cascade: find nodes that should be removed because nothing else requires them
+        # Find nodes that should be removed because nothing else requires them
         # A node should be removed if ALL its predecessors (dependents) are being removed
         changed = True
         while changed:
@@ -50,7 +52,7 @@ class DependencyGraph:
             for node in list(self.graph.nodes()):
                 if node in to_remove:
                     continue
-                # Get all packages that require this node (predecessors point TO this node)
+                # Get all packages that require this node
                 dependents = set(self.graph.predecessors(node))
                 # If this node has dependents and ALL of them are being removed,
                 # then this node is no longer needed

--- a/ci/raydepsets/dependency_graph.py
+++ b/ci/raydepsets/dependency_graph.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from typing import List
+
+from networkx import DiGraph
+
+
+@dataclass
+class Dep:
+    name: str
+    version: str
+    required_by: List[str]
+
+
+class DependencyGraph:
+    def __init__(self):
+        self.graph = DiGraph()
+
+    def add_nodes(self, deps: List[Dep]):
+        for dep in deps:
+            if not self.graph.has_node(dep.name):
+                self.graph.add_node(dep.name, version=dep.version)
+
+    def add_edges(self, deps: List[Dep]):
+        for dep in deps:
+            if len(dep.required_by) == 0:
+                continue
+            for dependent in dep.required_by:
+                if not self.graph.has_node(dependent):
+                    raise ValueError(f"Dependency {dependent} not found in deps")
+                # Edge: dependent -> dep (the package that requires points to what it requires)
+                self.graph.add_edge(dependent, dep.name)
+
+    def build_dependency_graph(self, deps: List[Dep]):
+        self.add_nodes(deps)
+        self.add_edges(deps)
+
+    def remove_dropped_dependencies(self, dropped_dependencies: List[str]):
+        for dep in dropped_dependencies:
+            if not self.graph.has_node(dep):
+                raise ValueError(f"Dependency {dep} not found in deps")
+
+        to_remove = set(dropped_dependencies)
+
+        # Cascade: find nodes that should be removed because nothing else requires them
+        # A node should be removed if ALL its predecessors (dependents) are being removed
+        changed = True
+        while changed:
+            changed = False
+            for node in list(self.graph.nodes()):
+                if node in to_remove:
+                    continue
+                # Get all packages that require this node (predecessors point TO this node)
+                dependents = set(self.graph.predecessors(node))
+                # If this node has dependents and ALL of them are being removed,
+                # then this node is no longer needed
+                if dependents and dependents.issubset(to_remove):
+                    to_remove.add(node)
+                    changed = True
+
+        self.graph.remove_nodes_from(to_remove)

--- a/ci/raydepsets/dependency_graph.py
+++ b/ci/raydepsets/dependency_graph.py
@@ -6,6 +6,7 @@ from networkx import DiGraph
 
 @dataclass
 class Dep:
+    """Represents a dependency with its name, version, and dependents."""
     name: str
     version: str
     required_by: List[str]

--- a/ci/raydepsets/dependency_graph.py
+++ b/ci/raydepsets/dependency_graph.py
@@ -7,6 +7,7 @@ from networkx import DiGraph
 @dataclass
 class Dep:
     """Represents a dependency with its name, version, and dependents."""
+
     name: str
     version: str
     required_by: List[str]
@@ -25,8 +26,6 @@ class DependencyGraph:
 
     def add_edges(self, deps: List[Dep]):
         for dep in deps:
-            if len(dep.required_by) == 0:
-                continue
             for dependent in dep.required_by:
                 if not self.graph.has_node(dependent):
                     raise ValueError(f"Dependency {dependent} not found in deps")

--- a/ci/raydepsets/tests/test_dependency_graph.py
+++ b/ci/raydepsets/tests/test_dependency_graph.py
@@ -1,0 +1,42 @@
+import sys
+
+import pytest
+
+from ci.raydepsets.dependency_graph import Dep, DependencyGraph
+
+
+def test_dependency_graph():
+    deps = [
+        Dep(name="aiohappyeyeballs", version="2.6.1", required_by=["aiohttp"]),
+        Dep(name="aiohttp", version="3.11.16", required_by=[]),
+        Dep(name="attrs", version="25.4.0", required_by=["aiohttp"]),
+        Dep(name="multidict", version="6.7.0", required_by=["aiohttp", "yarl"]),
+        Dep(name="yarl", version="1.22.0", required_by=["aiohttp"]),
+    ]
+    dependency_graph = DependencyGraph()
+    dependency_graph.build_dependency_graph(deps)
+    assert len(dependency_graph.graph.nodes()) == 5
+    assert len(dependency_graph.graph.edges()) == 5
+
+
+def test_dependency_graph_remove_dropped_dependencies():
+    deps = [
+        Dep(name="aiohappyeyeballs", version="2.6.1", required_by=["aiohttp"]),
+        Dep(name="aiohttp", version="3.11.16", required_by=[]),
+        Dep(name="attrs", version="25.4.0", required_by=["aiohttp"]),
+        Dep(name="multidict", version="6.7.0", required_by=["aiohttp", "yarl"]),
+        Dep(name="yarl", version="1.22.0", required_by=["aiohttp"]),
+        Dep(name="anyio", version="3.8.1", required_by=[]),
+        Dep(name="sniffio", version="1.3.1", required_by=["anyio"]),
+    ]
+    dependency_graph = DependencyGraph()
+    dependency_graph.build_dependency_graph(deps)
+    assert len(dependency_graph.graph.nodes()) == 7
+    assert len(dependency_graph.graph.edges()) == 6
+    dependency_graph.remove_dropped_dependencies(["anyio"])
+    assert len(dependency_graph.graph.nodes()) == 5
+    assert len(dependency_graph.graph.edges()) == 5
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Pre requisite for the relax operation. The dependency graph takes a list of dependency objects (name, version, required_by) and constructs a dependency graph of all the depenedencies.

The dependency graph also allows users to easily drop specified dependencies and their children from the graph
