### PR TITLE
[Core] Fix incorrect task reference in test_cancel_recursive_tree verification loop

### DIFF
--- a/python/ray/tests/test_actor_cancel.py
+++ b/python/ray/tests/test_actor_cancel.py
@@ -381,7 +381,7 @@ def test_cancel_recursive_tree(shutdown_only):
                 assert ray.get(ref)
 
         with pytest.raises(ray.exceptions.TaskCancelledError):
-            ray.get(run_ref)
+            ray.get(run_refs[i])
 
 
 @pytest.mark.parametrize("recursive", [True, False])


### PR DESCRIPTION

## Description

In test_cancel_recursive_tree, the concurrent test case:
1. Creates 10 ChildActor instances
2. Submits 10 Actor.run tasks, each spawning child tasks on a ChildActor
3. Cancels 5 tasks with recursive=True and 5 with recursive=False
4. Expects that for recursive=True, both the parent task and child tasks are cancelled; for recursive=False, only the parent task is cancelled

The issue is in the verification loop: when checking if the parent tasks are cancelled, the test uses `run_ref` (a stale loop variable from the previous loop) instead of run_refs[i]. This causes the test to verify the same task (`run_refs[9]`) ten times, rather than verifying all 10 tasks.

This PR fixes the issue by using `run_refs[i]` to correctly verify each task.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
