### PR TITLE
fix: fix multiple deployment same name resolve

### DIFF
--- a/python/ray/serve/_private/build_app.py
+++ b/python/ray/serve/_private/build_app.py
@@ -108,7 +108,7 @@ def build_app(
         name=name,
         route_prefix=route_prefix,
         logging_config=logging_config,
-        ingress_deployment_name=app._bound_deployment.name,
+        ingress_deployment_name=deployment_names[app],
         deployments=deployments,
         deployment_handles={
             deployment_names[app]: handle for app, handle in handles.items()

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -526,6 +526,7 @@ def test_ingress_name_got_modified():
     collisions.
     """
 
+    @serve.deployment
     class D:
         pass
 

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -521,5 +521,26 @@ def test_external_scaler_enabled():
     assert built_app_default.name == "app-default"
 
 
+def test_ingress_name_got_modified():
+    """Test that the ingress deployment name is modified when there are name
+    collisions.
+    """
+
+    @serve.deployment
+    class D:
+        pass
+
+    app = D.bind(D.bind(D.bind()))
+    built_app: BuiltApplication = build_app(
+        app,
+        name="default",
+        make_deployment_handle=FakeDeploymentHandle.from_deployment,
+    )
+
+    # The ingress deployment name should be modified to avoid collision.
+    assert built_app.ingress_deployment_name == "D_2"
+    assert len(built_app.deployments) == 3
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -526,7 +526,6 @@ def test_ingress_name_got_modified():
     collisions.
     """
 
-    @serve.deployment
     class D:
         pass
 
@@ -539,7 +538,10 @@ def test_ingress_name_got_modified():
 
     # The ingress deployment name should be modified to avoid collision.
     assert built_app.ingress_deployment_name == "D_2"
+
+    # The ingress deployment should be the last one.
     assert len(built_app.deployments) == 3
+    assert built_app.deployments[-1].name == "D_2"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Fix ingress deployment name could be modified if child deployment has the same name

## Related issues
Fixes https://github.com/ray-project/ray/issues/53295

## Additional information
Because there is a child app with the same name as the ingress deployment app, the ingress deployment app name was modified during _build_app_recursive function. Therefore we should use the modified name instead.

Another solution is changing the child_app name instead of the ingress deployment app name
