### PR TITLE
[Runtime Env] Add support for custom transport parameters in smart_open

### DIFF
--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -305,7 +305,11 @@ class ProtocolsProvider:
         merged = default_params.copy()
 
         for key, value in custom_params.items():
-            if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            if (
+                key in merged
+                and isinstance(merged[key], dict)
+                and isinstance(value, dict)
+            ):
                 merged[key] = cls._merge_transport_params(merged[key], value)
             else:
                 merged[key] = value

--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -261,7 +261,7 @@ class ProtocolsProvider:
 
             def open_file(uri, mode, *, transport_params=None):
                 return open(uri, mode)
-        
+
             tp = transport_params
 
         elif protocol == "https":

--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -205,9 +205,16 @@ class PyModulesPlugin(RuntimeEnvPlugin):
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ) -> int:
+        # Extract transport_params from runtime_env config if available
+        config = runtime_env.get("config")
+        transport_params = config.get("transport_params") if config else None
 
         module_dir = await download_and_unpack_package(
-            uri, self._resources_dir, self._gcs_client, logger=logger
+            uri,
+            self._resources_dir,
+            self._gcs_client,
+            logger=logger,
+            transport_params=transport_params,
         )
 
         if is_whl_uri(uri):

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -192,12 +192,17 @@ class WorkingDirPlugin(RuntimeEnvPlugin):
         context: RuntimeEnvContext,
         logger: logging.Logger = default_logger,
     ) -> int:
+        # Extract transport_params from runtime_env config if available
+        config = runtime_env.get("config")
+        transport_params = config.get("transport_params") if config else None
+
         local_dir = await download_and_unpack_package(
             uri,
             self._resources_dir,
             self._gcs_client,
             logger=logger,
             overwrite=True,
+            transport_params=transport_params,
         )
         return get_directory_size_bytes(local_dir)
 

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -48,7 +48,12 @@ class RuntimeEnvConfig(dict):
             downloading remote URIs.
     """
 
-    known_fields: Set[str] = {"setup_timeout_seconds", "eager_install", "log_files", "transport_params"}
+    known_fields: Set[str] = {
+        "setup_timeout_seconds",
+        "eager_install",
+        "log_files",
+        "transport_params",
+    }
 
     _default_config: Dict = {
         "setup_timeout_seconds": DEFAULT_RUNTIME_ENV_TIMEOUT_SECONDS,
@@ -154,7 +159,7 @@ class RuntimeEnvConfig(dict):
         # assign the default value to setup_timeout_seconds.
         if setup_timeout_seconds == 0:
             setup_timeout_seconds = cls._default_config["setup_timeout_seconds"]
-        
+
         return cls(
             setup_timeout_seconds=setup_timeout_seconds,
             eager_install=runtime_env_config.eager_install,


### PR DESCRIPTION
## Description

This PR adds support for custom transport parameters in smart_open when downloading packages from remote storage systems in Ray's runtime environment. This enables users to customize how packages are downloaded, including authentication methods, SSL settings, and protocol-specific client configurations.

The implementation allows users to specify transport_params in their runtime_env configuration, which are then passed to smart_open during package downloads. For protocols with default configurations (S3, Azure, GCS, ABFSS), custom parameters are merged with defaults, with custom parameters taking precedence.

## Related issues

Fixes [#46833](https://github.com/ray-project/ray/issues/46833)

## Additional information

### Implementation Details

1. Modified `download_and_unpack_package()` in `python/ray/_private/runtime_env/packaging.py` to accept transport_params
2. Updated PyModulesPlugin and WorkingDirPlugin to extract transport_params from runtime_env
3. Enhanced protocol handlers in `python/ray/_private/runtime_env/protocol.py` to merge custom parameters with defaults
4. Added `_merge_transport_params()` helper method to properly combine default and custom parameters

### Usage Examples

#### GitLab Integration (resolves #46833)
```python
ray.init(
    runtime_env={
        "working_dir": "https://gitlab.example.com/group/project/-/archive/main.zip",
        "config": {
            "transport_params": {
                "headers": {
                    "PRIVATE-TOKEN": "TOKEN",
                },
            },
        },
    }
)