### PR TITLE
[WIP]Add inc and dec method to prometheus Gauge class

### DIFF
--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -359,6 +359,38 @@ class Gauge(Metric):
 
         self._record(value, tags)
 
+    def inc(self, value: Union[int, float] = 1.0, tags: Dict[str, str] = None):
+        """Increment the gauge by `value` (defaults to 1).
+
+        Tags passed in will take precedence over the metric's default tags.
+
+        Args:
+            value: Value to increment the gauge by (default=1).
+            tags: Tags to set or override for this gauge.
+        """
+        if not isinstance(value, (int, float)):
+            raise TypeError(f"value must be int or float, got {type(value)}.")
+        if value <= 0:
+            raise ValueError(f"value must be >0, got {value}")
+
+        self._record(value, tags)
+
+    def dec(self, value: Union[int, float] = 1.0, tags: Dict[str, str] = None):
+        """Decrement the gauge by `value` (defaults to 1).
+
+        Tags passed in will take precedence over the metric's default tags.
+
+        Args:
+            value: Value to decrement the gauge by (default=1).
+            tags: Tags to set or override for this gauge.
+        """
+        if not isinstance(value, (int, float)):
+            raise TypeError(f"value must be int or float, got {type(value)}.")
+        if value <= 0:
+            raise ValueError(f"value must be >0, got {value}")
+
+        self._record(-value, tags)
+
     def __reduce__(self):
         deserializer = Gauge
         serialized_data = (self._name, self._description, self._tag_keys)


### PR DESCRIPTION
## Description
We should add `inc` and `dec` to `Gauge` class to update prometheus metrics value

## Related issues
Closes [#39754](https://github.com/ray-project/ray/issues/39754)

## Additional information
I used the test script to test:
```
from ray.util.metrics import Counter, Gauge

g = Gauge("my_metric", "doc")
g.inc()
g.dec()
```

As expected, there is no attribute error
