### PR TITLE
[core] Fix GCS crash from race condition in MetricsAgentClient exporter initialization

### DIFF
--- a/src/ray/rpc/metrics_agent_client.cc
+++ b/src/ray/rpc/metrics_agent_client.cc
@@ -51,11 +51,11 @@ void MetricsAgentClientImpl::WaitForServerReadyWithRetry(
                max_retry,
                retry_interval_ms](auto &status, auto &&reply) {
                 if (status.ok()) {
-                  if (exporter_initialized_) {
+                  bool expected = false;
+                  if (!exporter_initialized_.compare_exchange_strong(expected, true)) {
                     return;
                   }
                   init_exporter_fn(status);
-                  exporter_initialized_ = true;
                   RAY_LOG(INFO) << "Exporter initialized.";
                   return;
                 }

--- a/src/ray/rpc/metrics_agent_client.h
+++ b/src/ray/rpc/metrics_agent_client.h
@@ -16,6 +16,7 @@
 
 #include <grpcpp/grpcpp.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <thread>
@@ -102,7 +103,7 @@ class MetricsAgentClientImpl : public MetricsAgentClient {
   /// The io context to run the retry loop.
   instrumented_io_context &io_service_;
   /// Whether the exporter is initialized.
-  bool exporter_initialized_ = false;
+  std::atomic<bool> exporter_initialized_{false};
   /// Wait for the server to be ready with a retry count. Invokes the callback
   /// with the status of the server. This is a helper function for WaitForServerReady.
   void WaitForServerReadyWithRetry(std::function<void(const Status &)> init_exporter_fn,
@@ -113,6 +114,7 @@ class MetricsAgentClientImpl : public MetricsAgentClient {
   friend class MetricsAgentClientTest;
   FRIEND_TEST(MetricsAgentClientTest, WaitForServerReadyWithRetrySuccess);
   FRIEND_TEST(MetricsAgentClientTest, WaitForServerReadyWithRetryFailure);
+  FRIEND_TEST(MetricsAgentClientTest, ConcurrentCallbacksCallInitExporterFnOnlyOnce);
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/tests/metrics_agent_client_test.cc
+++ b/src/ray/rpc/tests/metrics_agent_client_test.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -36,11 +37,6 @@ class TestableMetricsAgentClientImpl : public MetricsAgentClientImpl {
       : MetricsAgentClientImpl(address, port, io_service, client_call_manager),
         count_to_return_ok_(count_to_return_ok) {}
 
-  // HealthCheck is a macro+template method that supposes to invoke the callback upon
-  // the completion of an RPC call. We override it to invoke the callback directly
-  // without the RPC call. Ideally we would create a GrpcClientMock that overrides
-  // the RPC call. However, currently the RPC call is a template method, which cannot
-  // be overridden.
   void HealthCheck(const HealthCheckRequest &request,
                    const ClientCallback<HealthCheckReply> &callback) override {
     health_check_count_++;
@@ -55,6 +51,25 @@ class TestableMetricsAgentClientImpl : public MetricsAgentClientImpl {
  private:
   int count_to_return_ok_;
   int health_check_count_ = 1;
+};
+
+class DeferredCallbackMetricsAgentClientImpl : public MetricsAgentClientImpl {
+ public:
+  using MetricsAgentClientImpl::MetricsAgentClientImpl;
+
+  void HealthCheck(const HealthCheckRequest &request,
+                   const ClientCallback<HealthCheckReply> &callback) override {
+    pending_callbacks_.push_back(callback);
+  }
+
+  void InvokeAllPendingCallbacksWithOk() {
+    for (auto &callback : pending_callbacks_) {
+      callback(Status::OK(), HealthCheckReply());
+    }
+    pending_callbacks_.clear();
+  }
+
+  std::vector<ClientCallback<HealthCheckReply>> pending_callbacks_;
 };
 
 class MetricsAgentClientTest : public ::testing::Test {
@@ -78,7 +93,7 @@ TEST_F(MetricsAgentClientTest, WaitForServerReadyWithRetrySuccess) {
       kCountToReturnOk,
       kRetryIntervalMs);
   io_service_.run_for(std::chrono::milliseconds(kCountToReturnOk * kRetryIntervalMs));
-  ASSERT_TRUE(client_->exporter_initialized_);
+  ASSERT_TRUE(client_->exporter_initialized_.load());
 }
 
 TEST_F(MetricsAgentClientTest, WaitForServerReadyWithRetryFailure) {
@@ -88,7 +103,23 @@ TEST_F(MetricsAgentClientTest, WaitForServerReadyWithRetryFailure) {
       kCountToReturnOk - 2,
       kRetryIntervalMs);
   io_service_.run_for(std::chrono::milliseconds(kCountToReturnOk * kRetryIntervalMs));
-  ASSERT_FALSE(client_->exporter_initialized_);
+  ASSERT_FALSE(client_->exporter_initialized_.load());
+}
+
+TEST_F(MetricsAgentClientTest, ConcurrentCallbacksCallInitExporterFnOnlyOnce) {
+  auto deferred_client = std::make_unique<DeferredCallbackMetricsAgentClientImpl>(
+      "127.0.0.1", 8000, io_service_, *client_call_manager_);
+
+  int init_call_count = 0;
+  auto init_fn = [&init_call_count](const Status &status) { init_call_count++; };
+
+  deferred_client->WaitForServerReadyWithRetry(init_fn, 0, 10, kRetryIntervalMs);
+  deferred_client->WaitForServerReadyWithRetry(init_fn, 0, 10, kRetryIntervalMs);
+
+  deferred_client->InvokeAllPendingCallbacksWithOk();
+
+  ASSERT_EQ(init_call_count, 1);
+  ASSERT_TRUE(deferred_client->exporter_initialized_.load());
 }
 
 }  // namespace rpc


### PR DESCRIPTION
## Description
Fixes a race condition in `MetricsAgentClientImpl::WaitForServerReadyWithRetry` where concurrent HealthCheck callbacks could both attempt to initialize the exporter, causing GCS to crash with:
```
Check failed: !exporting_started_ RayEventRecorder::StartExportingEvents() should be called only once.
```
The `exporter_initialized_` flag was a non-atomic bool. When multiple HealthCheck RPCs completed simultaneously, their callbacks could both read false before either set it to true, leading to `init_exporter_fn` being called twice. Changed the flag to `std::atomic<bool>` to ensure only one callback wins the race.
