### PR TITLE
[Core] Introduce local port service discovery 

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -194,6 +194,7 @@ pyx_library(
         "//src/ray/raylet_rpc_client:raylet_client_with_io_context_lib",
         "//src/ray/thirdparty/setproctitle",
         "//src/ray/util:memory",
+        "//src/ray/util:port_persistence",
         "//src/ray/util:raii",
         "//src/ray/util:stream_redirection",
         "//src/ray/util:stream_redirection_options",

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -362,7 +362,7 @@ class Node:
             # We retry in a loop in case it takes longer than expected.
             time.sleep(0.1)
             start_time = time.monotonic()
-            raylet_start_wait_time_s = 60
+            raylet_start_wait_time_s = 30
             while True:
                 try:
                     # Will raise a RuntimeError if the node info is not available.

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -403,12 +403,12 @@ class RayParams:
                     "between 1024 and 65535."
                 )
         if self.runtime_env_agent_port is not None:
-            if (
+            if self.runtime_env_agent_port != 0 and (
                 self.runtime_env_agent_port < 1024
                 or self.runtime_env_agent_port > 65535
             ):
                 raise ValueError(
-                    "runtime_env_agent_port must be an integer "
+                    "runtime_env_agent_port must be 0 (auto-assign) or an integer "
                     "between 1024 and 65535."
                 )
 

--- a/python/ray/_private/prometheus_exporter.py
+++ b/python/ray/_private/prometheus_exporter.py
@@ -5,10 +5,12 @@
 
 import logging
 import re
+import threading
+from wsgiref.simple_server import make_server
 
 from opencensus.common.transports import sync
 from opencensus.stats import aggregation_data as aggregation_data_module, base_exporter
-from prometheus_client import start_http_server
+from prometheus_client import make_wsgi_app
 from prometheus_client.core import (
     REGISTRY,
     CounterMetricFamily,
@@ -264,7 +266,7 @@ class PrometheusStatsExporter(base_exporter.StatsExporter):
         self._gatherer = gatherer
         self._collector = collector
         self._transport = transport(self)
-        self.serve_http()
+        self._port = self.serve_http()
         REGISTRY.register(self._collector)
 
     @property
@@ -290,6 +292,11 @@ class PrometheusStatsExporter(base_exporter.StatsExporter):
     def options(self):
         """Options to be used to configure the exporter"""
         return self._options
+
+    @property
+    def port(self):
+        """The port the HTTP server is listening on."""
+        return self._port
 
     def export(self, view_data):
         """export send the data to the transport class
@@ -317,9 +324,13 @@ class PrometheusStatsExporter(base_exporter.StatsExporter):
 
     def serve_http(self):
         """serve_http serves the Prometheus endpoint."""
-        address = str(self.options.address)
-        kwargs = {"addr": address} if address else {}
-        start_http_server(port=self.options.port, **kwargs)
+        address = self.options.address or ""
+        httpd = make_server(address, self.options.port, make_wsgi_app())
+        t = threading.Thread(target=httpd.serve_forever)
+        t.daemon = True
+        t.start()
+        # Return the actual port (in case port=0 was specified)
+        return httpd.server_address[1]
 
 
 def new_stats_exporter(option):

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -506,16 +506,6 @@ SESSION_LATEST = "session_latest"
 NUM_PORT_RETRIES = 40
 NUM_REDIS_GET_RETRIES = int(os.environ.get("RAY_NUM_REDIS_GET_RETRIES", "20"))
 
-# The allowed cached ports in Ray. Refer to Port configuration for more details:
-# https://docs.ray.io/en/latest/ray-core/configure.html#ports-configurations
-RAY_ALLOWED_CACHED_PORTS = {
-    "metrics_agent_port",
-    "metrics_export_port",
-    "dashboard_agent_listen_port",
-    "runtime_env_agent_port",
-    "gcs_server_port",  # the `port` option for gcs port.
-}
-
 # Turn this on if actor task log's offsets are expected to be recorded.
 # With this enabled, actor tasks' log could be queried with task id.
 RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING = env_bool(

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import socket
 import sys
 
 import ray._private.ray_constants as ray_constants
@@ -12,7 +13,7 @@ from ray._private.authentication.http_token_authentication import (
     get_token_auth_middleware,
 )
 from ray._private.process_watcher import create_check_raylet_task
-from ray._raylet import GcsClient
+from ray._raylet import RUNTIME_ENV_AGENT_PORT_NAME, GcsClient, persist_port
 from ray.core.generated import (
     runtime_env_agent_pb2,
 )
@@ -34,6 +35,12 @@ from runtime_env_agent import RuntimeEnvAgent  # noqa: E402
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Runtime env agent.")
     parser.add_argument(
+        "--node-id",
+        required=True,
+        type=str,
+        help="the unique ID of this node.",
+    )
+    parser.add_argument(
         "--node-ip-address",
         required=True,
         type=str,
@@ -45,6 +52,13 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help="The port on which the runtime env agent will receive HTTP requests.",
+    )
+    parser.add_argument(
+        "--session-dir",
+        required=True,
+        type=str,
+        default=None,
+        help="The path of this ray session directory.",
     )
 
     parser.add_argument(
@@ -222,13 +236,24 @@ if __name__ == "__main__":
         check_raylet_task = create_check_raylet_task(
             args.log_dir, gcs_client, parent_dead_callback, loop
         )
+
+    port = args.runtime_env_agent_port or 0
+    infos = socket.getaddrinfo(args.node_ip_address, port, type=socket.SOCK_STREAM)
+    family, socktype, proto, _, sockaddr = infos[0]
+    sock = socket.socket(family, socktype, proto)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(sockaddr)
+
+    bound_port = sock.getsockname()[1]
+    persist_port(
+        args.session_dir,
+        args.node_id,
+        RUNTIME_ENV_AGENT_PORT_NAME,
+        bound_port,
+    )
+
     try:
-        web.run_app(
-            app,
-            host=args.node_ip_address,
-            port=args.runtime_env_agent_port,
-            loop=loop,
-        )
+        web.run_app(app, sock=sock, loop=loop)
     except SystemExit as e:
         agent._logger.info(f"SystemExit! {e}")
         # We have to poke the task exception, or there's an error message

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -588,7 +588,8 @@ def get_node_with_retry(
             node_info = get_node(gcs_address, node_id)
             if node_info is not None:
                 return node_info
-        except Exception:
+        except RuntimeError:
+            # This is expected if the node hasn't registered with GCS yet.
             pass
 
         if time.time() >= end_time:

--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -355,6 +355,7 @@ class FakeMultiNodeProvider(NodeProvider):
                 min_worker_port=0,
                 max_worker_port=0,
                 dashboard_port=None,
+                dashboard_agent_listen_port=0,
                 num_cpus=resources.pop("CPU", 0),
                 num_gpus=resources.pop("GPU", 0),
                 object_store_memory=resources.pop("object_store_memory", None),

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -15,7 +15,13 @@ from ray._private import logging_utils
 from ray._private.process_watcher import create_check_raylet_task
 from ray._private.ray_constants import AGENT_GRPC_MAX_MESSAGE_LENGTH
 from ray._private.ray_logging import setup_component_logger
-from ray._raylet import GcsClient
+from ray._raylet import (
+    DASHBOARD_AGENT_LISTEN_PORT_NAME,
+    METRICS_AGENT_PORT_NAME,
+    METRICS_EXPORT_PORT_NAME,
+    GcsClient,
+    persist_port,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +87,22 @@ class DashboardAgent:
 
         if not self.minimal:
             self._init_non_minimal()
+        else:
+            # Write -1 to indicate the service is not in use.
+            persist_port(
+                self.session_dir,
+                self.node_id,
+                METRICS_AGENT_PORT_NAME,
+                -1,
+            )
+            # This metric export port is run by reporter module
+            # which is not included in minimal mode.
+            persist_port(
+                self.session_dir,
+                self.node_id,
+                METRICS_EXPORT_PORT_NAME,
+                -1,
+            )
 
     def _init_non_minimal(self):
         from grpc import aio as aiogrpc
@@ -126,25 +148,24 @@ class DashboardAgent:
                 ),
             ),  # noqa
         )
-        try:
-            add_port_to_grpc_server(self.server, build_address(self.ip, self.grpc_port))
-            if not is_localhost(self.ip):
-                add_port_to_grpc_server(self.server, f"127.0.0.1:{self.grpc_port}")
-        except Exception:
-            # TODO(SongGuyang): Catch the exception here because there is
-            # port conflict issue which brought from static port. We should
-            # remove this after we find better port resolution.
-            logger.exception(
-                "Failed to add port to grpc server. Agent will stay alive but "
-                "disable the grpc service."
-            )
-            self.server = None
-            self.grpc_port = None
-        else:
-            logger.info(
-                "Dashboard agent grpc address: %s",
-                build_address(self.ip, self.grpc_port),
-            )
+
+        # grpc_port can be 0 for dynamic port assignment. get the actual bound port.
+        self.grpc_port = add_port_to_grpc_server(
+            self.server, build_address(self.ip, self.grpc_port)
+        )
+        if not is_localhost(self.ip):
+            add_port_to_grpc_server(self.server, f"127.0.0.1:{self.grpc_port}")
+
+        persist_port(
+            self.session_dir,
+            self.node_id,
+            METRICS_AGENT_PORT_NAME,
+            self.grpc_port,
+        )
+        logger.info(
+            "Dashboard agent grpc address: %s",
+            build_address(self.ip, self.grpc_port),
+        )
 
         # If the agent is not minimal it should start the http server
         # to communicate with the dashboard in a head node.
@@ -189,6 +210,8 @@ class DashboardAgent:
         if self.http_server:
             try:
                 await self.http_server.start(modules)
+                # listen_port can be 0 for dynamic port assignment. get the actual bound port.
+                self.listen_port = self.http_server.http_port
             except Exception as e:
                 # TODO(kevin85421): We should fail the agent if the HTTP server
                 # fails to start to avoid hiding the root cause. However,
@@ -200,6 +223,15 @@ class DashboardAgent:
                     "The agent will stay alive but the HTTP service will be disabled.",
                 )
                 launch_http_server = False
+
+        # If the HTTP server fails to start or is not launched, we should
+        # persist -1 to indicate that the service is not available.
+        persist_port(
+            self.session_dir,
+            self.node_id,
+            DASHBOARD_AGENT_LISTEN_PORT_NAME,
+            self.listen_port if self.http_server and launch_http_server else -1,
+        )
 
         if launch_http_server:
             # Writes agent address to kv.
@@ -255,6 +287,12 @@ class DashboardAgent:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Dashboard agent.")
+    parser.add_argument(
+        "--node-id",
+        required=True,
+        type=str,
+        help="the unique ID of this node.",
+    )
     parser.add_argument(
         "--node-ip-address",
         required=True,

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -40,7 +40,13 @@ from ray._private.telemetry.open_telemetry_metric_recorder import (
     OpenTelemetryMetricRecorder,
 )
 from ray._private.utils import get_system_memory
-from ray._raylet import GCS_PID_KEY, RayletClient, WorkerID
+from ray._raylet import (
+    GCS_PID_KEY,
+    METRICS_EXPORT_PORT_NAME,
+    RayletClient,
+    WorkerID,
+    persist_port,
+)
 from ray.core.generated import reporter_pb2, reporter_pb2_grpc
 from ray.dashboard import k8s_utils
 from ray.dashboard.consts import (
@@ -443,23 +449,14 @@ class ReporterAgent(
         self._open_telemetry_metric_recorder = None
         self._session_name = dashboard_agent.session_name
         if not self._metrics_collection_disabled:
-            try:
-                stats_exporter = prometheus_exporter.new_stats_exporter(
-                    prometheus_exporter.Options(
-                        namespace="ray",
-                        port=dashboard_agent.metrics_export_port,
-                        address="127.0.0.1" if self._ip == "127.0.0.1" else "",
-                    )
+            stats_exporter = prometheus_exporter.new_stats_exporter(
+                prometheus_exporter.Options(
+                    namespace="ray",
+                    port=dashboard_agent.metrics_export_port,
+                    address="127.0.0.1" if self._ip == "127.0.0.1" else "",
                 )
-            except Exception:
-                # TODO(SongGuyang): Catch the exception here because there is
-                # port conflict issue which brought from static port. We should
-                # remove this after we find better port resolution.
-                logger.exception(
-                    "Failed to start prometheus stats exporter. Agent will stay "
-                    "alive but disable the stats."
-                )
-                stats_exporter = None
+            )
+            dashboard_agent.metrics_export_port = stats_exporter.port
 
             self._metrics_agent = MetricsAgent(
                 stats_module.stats.view_manager,
@@ -471,6 +468,16 @@ class ReporterAgent(
                 # proxy_exporter_collector is None
                 # if Prometheus server is not started.
                 REGISTRY.register(self._metrics_agent.proxy_exporter_collector)
+
+        # Metrics collection is disabled, write -1 to indicate the port is not in use.
+        persist_port(
+            dashboard_agent.session_dir,
+            self._dashboard_agent.node_id,
+            METRICS_EXPORT_PORT_NAME,
+            dashboard_agent.metrics_export_port
+            if not self._metrics_collection_disabled
+            else -1,
+        )
         self._key = (
             f"{reporter_consts.REPORTER_PREFIX}" f"{self._dashboard_agent.node_id}"
         )

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -297,9 +297,11 @@ def test_prometheus_export_worker_and_memory_stats(enable_test_module, shutdown_
     wait_for_condition(test_worker_stats, retry_interval_ms=1000)
 
 
-def test_report_stats():
+def test_report_stats(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
     raylet_client = MagicMock()
     agent = ReporterAgent(dashboard_agent, raylet_client)
     # Assume it is a head node.
@@ -373,9 +375,11 @@ def test_report_stats():
     assert isinstance(stats_payload, str)
 
 
-def test_report_stats_gpu():
+def test_report_stats_gpu(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
     raylet_client = MagicMock()
     agent = ReporterAgent(dashboard_agent, raylet_client)
     # Assume it is a head node.
@@ -484,9 +488,11 @@ def test_report_stats_gpu():
     assert isinstance(stats_payload, str)
 
 
-def test_get_tpu_usage():
+def test_get_tpu_usage(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
     raylet_client = MagicMock()
     agent = ReporterAgent(dashboard_agent, raylet_client)
 
@@ -542,9 +548,11 @@ def test_get_tpu_usage():
             assert tpu_utilizations == expected_utilizations
 
 
-def test_report_stats_tpu():
+def test_report_stats_tpu(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
     raylet_client = MagicMock()
     agent = ReporterAgent(dashboard_agent, raylet_client)
 
@@ -622,9 +630,11 @@ def test_report_stats_tpu():
     assert isinstance(stats_payload, str)
 
 
-def test_report_per_component_stats():
+def test_report_per_component_stats(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
     raylet_client = MagicMock()
     agent = ReporterAgent(dashboard_agent, raylet_client)
     # Assume it is a head node.
@@ -1190,6 +1200,10 @@ async def test_reporter_raylet_agent(ray_start_with_dashboard):
     dashboard_agent.node_manager_port = (
         ray._private.worker.global_worker.node.node_manager_port
     )
+    dashboard_agent.session_dir = (
+        ray._private.worker.global_worker.node.get_session_dir_path()
+    )
+    dashboard_agent.node_id = ray._private.worker.global_worker.node.unique_id
     agent = ReporterAgent(dashboard_agent)
     pids = await agent._async_get_worker_pids_from_raylet()
     assert len(pids) == 2

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -28,6 +28,11 @@ from ray.includes.common cimport (
     kLabelKeyTpuWorkerId,
     kLabelKeyTpuPodType,
     kRayInternalNamespacePrefix,
+    kRuntimeEnvAgentPortName,
+    kMetricsAgentPortName,
+    kMetricsExportPortName,
+    kDashboardAgentListenPortName,
+    kGcsServerPortName,
 )
 
 from ray.exceptions import (
@@ -168,6 +173,13 @@ RAY_NODE_TPU_POD_TYPE_KEY = kLabelKeyTpuPodType.decode()
 RAY_INTERNAL_NAMESPACE_PREFIX = kRayInternalNamespacePrefix.decode()
 # Prefix for namespaces which are used internally by ray.
 # Jobs within these namespaces should be hidden from users
+
+# Port names for local port discovery
+RUNTIME_ENV_AGENT_PORT_NAME = kRuntimeEnvAgentPortName.decode()
+METRICS_AGENT_PORT_NAME = kMetricsAgentPortName.decode()
+METRICS_EXPORT_PORT_NAME = kMetricsExportPortName.decode()
+DASHBOARD_AGENT_LISTEN_PORT_NAME = kDashboardAgentListenPortName.decode()
+GCS_SERVER_PORT_NAME = kGcsServerPortName.decode()
 # and should not be considered user activity.
 RAY_INTERNAL_DASHBOARD_NAMESPACE = f"{RAY_INTERNAL_NAMESPACE_PREFIX}dashboard"
 

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -84,6 +84,8 @@ cdef class GlobalStateAccessor:
                     c_node_info.object_store_socket_name().decode(),
                 "RayletSocketName": c_node_info.raylet_socket_name().decode(),
                 "MetricsExportPort": c_node_info.metrics_export_port(),
+                "MetricsAgentPort": c_node_info.metrics_agent_port(),
+                "DashboardAgentListenPort": c_node_info.dashboard_agent_listen_port(),
                 "NodeName": c_node_info.node_name().decode(),
                 "RuntimeEnvAgentPort": c_node_info.runtime_env_agent_port(),
                 "DeathReason": c_node_info.death_info().reason(),
@@ -279,5 +281,9 @@ cdef class GlobalStateAccessor:
             "raylet_socket_name": c_node_info.raylet_socket_name().decode(),
             "node_manager_port": c_node_info.node_manager_port(),
             "node_id": c_node_info.node_id().hex(),
+            "runtime_env_agent_port": c_node_info.runtime_env_agent_port(),
+            "metrics_agent_port": c_node_info.metrics_agent_port(),
+            "metrics_export_port": c_node_info.metrics_export_port(),
+            "dashboard_agent_listen_port": c_node_info.dashboard_agent_listen_port(),
             "labels": {key.decode(): value.decode() for key, value in c_labels},
         }

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -132,7 +132,6 @@ py_test_module_list(
         "test_request_timeout.py",
         "test_streaming_response.py",
         "test_task_processor.py",
-        "test_telemetry.py",
     ],
     tags = [
         "exclusive",
@@ -171,7 +170,7 @@ py_test_module_list(
 
 # Large tests.
 py_test_module_list(
-    size = "large",
+    size = "enormous",
     files = [
         "test_autoscaling_policy.py",
         "test_deploy.py",
@@ -180,6 +179,7 @@ py_test_module_list(
         "test_standalone.py",
         "test_standalone_3.py",
         "test_target_capacity.py",
+        "test_telemetry.py",
         "test_telemetry_1.py",
         "test_telemetry_2.py",
     ],
@@ -470,7 +470,7 @@ py_test_module_list(
 
 # Large tests with pack scheduling
 py_test_module_list(
-    size = "large",
+    size = "enormous",
     env = {"RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY": "1"},
     files = [
         "test_standalone.py",

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -55,7 +55,6 @@ py_test_module_list(
         "test_failure_3.py",
         "test_gcs_utils.py",
         "test_get_locations.py",
-        "test_global_state.py",
         "test_healthcheck.py",
         "test_metric_cardinality.py",
         "test_metrics_agent.py",
@@ -540,6 +539,7 @@ py_test_module_list(
         "test_list_actors_2.py",
         "test_list_actors_3.py",
         "test_list_actors_4.py",
+        "test_local_port_service_discovery.py",
         "test_log_dedup.py",
         "test_memory_scheduling.py",
         "test_metrics_agent_2.py",
@@ -562,7 +562,6 @@ py_test_module_list(
         "test_runtime_env_py_executable.py",
         "test_state_api_summary.py",
         "test_streaming_generator_regression.py",
-        "test_submission_client_auth.py",
         "test_system_metrics.py",
         "test_task_events_3.py",
         "test_task_metrics_reconstruction.py",
@@ -732,6 +731,7 @@ py_test_module_list(
     files = [
         "test_autoscaler_e2e.py",
         "test_autoscaler_fake_multinode.py",  # Temporarily owned by core.
+        "test_submission_client_auth.py",
     ],
     tags = [
         "exclusive",
@@ -899,6 +899,7 @@ py_test_module_list(
         "test_failure.py",
         "test_failure_2.py",
         "test_generators.py",
+        "test_global_state.py",
         "test_multi_node.py",
         "test_object_manager_fault_tolerance.py",
         "test_placement_group_3.py",
@@ -980,6 +981,7 @@ py_test_module_list(
     size = "large",
     files = [
         "test_failure_4.py",
+        "test_implicit_resource.py",
         "test_object_spilling.py",
         "test_object_spilling_3.py",
         "test_placement_group_mini_integration.py",
@@ -999,7 +1001,6 @@ py_test_module_list(
 py_test_module_list(
     size = "medium",
     files = [
-        "test_implicit_resource.py",
         "test_plasma_unlimited.py",
         "test_threaded_actor.py",
     ],

--- a/python/ray/tests/test_actor_cancel.py
+++ b/python/ray/tests/test_actor_cancel.py
@@ -310,7 +310,8 @@ def test_cancel_recursive_tree(shutdown_only):
     run_ref = a.run.remote(child_actor, sig)
     task_id = run_ref.task_id().hex()
     wait_for_condition(
-        lambda: list_tasks(filters=[("task_id", "=", task_id)])[0].state == "RUNNING"
+        lambda: list_tasks(filters=[("task_id", "=", task_id)])[0].state == "RUNNING",
+        timeout=20,
     )
     ray.cancel(run_ref, recursive=True)
     ray.get(sig.send.remote())
@@ -327,7 +328,8 @@ def test_cancel_recursive_tree(shutdown_only):
     run_ref = a.run.remote(child_actor, sig)
     task_id = run_ref.task_id().hex()
     wait_for_condition(
-        lambda: list_tasks(filters=[("task_id", "=", task_id)])[0].state == "RUNNING"
+        lambda: list_tasks(filters=[("task_id", "=", task_id)])[0].state == "RUNNING",
+        timeout=20,
     )
     ray.cancel(run_ref, recursive=False)
     ray.get(sig.send.remote())
@@ -353,7 +355,8 @@ def test_cancel_recursive_tree(shutdown_only):
             lambda task_id=task_id: list_tasks(filters=[("task_id", "=", task_id)])[
                 0
             ].state
-            == "RUNNING"
+            == "RUNNING",
+            timeout=20,
         )
         children_refs = ray.get(a.get_children_refs.remote(task_id))
         for child_ref in children_refs:
@@ -362,7 +365,8 @@ def test_cancel_recursive_tree(shutdown_only):
                 lambda task_id=task_id: list_tasks(filters=[("task_id", "=", task_id)])[
                     0
                 ].state
-                == "RUNNING"
+                == "RUNNING",
+                timeout=20,
             )
         recursive = i % 2 == 0
         ray.cancel(run_ref, recursive=recursive)

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -23,14 +23,14 @@ from ray.job_config import JobConfig
 
 def start_ray_and_proxy_manager(n_ports=2):
     ray_instance = ray.init(_redis_password=REDIS_DEFAULT_PASSWORD)
-    runtime_env_agent_address = (
-        ray._private.worker.global_worker.node.runtime_env_agent_address
-    )
+    node = ray._private.worker.global_worker.node
+    runtime_env_agent_address = node.runtime_env_agent_address
     pm = proxier.ProxyManager(
         ray_instance["address"],
         session_dir=ray_instance["session_dir"],
         redis_password=REDIS_DEFAULT_PASSWORD,
         runtime_env_agent_address=runtime_env_agent_address,
+        node_id=node.node_id,
     )
     free_ports = random.choices(pm._free_ports, k=n_ports)
     assert len(free_ports) == n_ports

--- a/python/ray/tests/test_local_port_service_discovery.py
+++ b/python/ray/tests/test_local_port_service_discovery.py
@@ -1,0 +1,48 @@
+import sys
+
+import pytest
+
+from ray._private.services import get_node
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head",
+    [
+        {
+            "gcs_server_port": 0,
+            "metrics_export_port": 0,
+            "metrics_agent_port": 0,
+            "runtime_env_agent_port": 0,
+            "dashboard_agent_listen_port": 0,
+        }
+    ],
+    indirect=True,
+)
+def test_local_port_service_discovery(ray_start_cluster_head):
+    """
+    Test that when all ports are set to 0 (auto-assign), all components
+    self-bind to available ports and the port information is correctly
+    reported to GCS.
+
+    """
+    cluster = ray_start_cluster_head
+    gcs_address = cluster.gcs_address
+    node_id = cluster.head_node.node_id
+
+    # We won't be able to get node info if GCS port didn't report correctly
+    # So, get_node implicitly validate GCS port reporting.
+    node_info = get_node(gcs_address, node_id)
+
+    port_fields = [
+        "metrics_export_port",
+        "metrics_agent_port",
+        "runtime_env_agent_port",
+        "dashboard_agent_listen_port",
+    ]
+    for field in port_fields:
+        port = node_info.get(field)
+        assert port and port > 0, f"{field} should be > 0, got {port}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -261,6 +261,19 @@ def _setup_cluster_for_test(request, ray_start_cluster):
     prom_addresses = []
     for node_info in node_info_list:
         metrics_export_port = node_info["MetricsExportPort"]
+        if enable_metrics_collection:
+            # When metrics are enabled, all nodes should have valid ports
+            assert metrics_export_port > 0, (
+                f"Expected MetricsExportPort > 0 when metrics enabled, "
+                f"but got {metrics_export_port} for node {node_info['NodeID']}"
+            )
+        else:
+            # When metrics are disabled, all nodes should have port == -1
+            assert metrics_export_port == -1, (
+                f"Expected MetricsExportPort == -1 when metrics disabled, "
+                f"but got {metrics_export_port} for node {node_info['NodeID']}"
+            )
+            continue
         addr = node_info["NodeManagerAddress"]
         prom_addresses.append(build_address(addr, metrics_export_port))
     autoscaler_export_addr = build_address(
@@ -1152,38 +1165,12 @@ def test_custom_metrics_validation(shutdown_only):
 @pytest.mark.parametrize("_setup_cluster_for_test", [False], indirect=True)
 def test_metrics_disablement(_setup_cluster_for_test):
     """Make sure the metrics are not exported when it is disabled."""
-    prom_addresses, autoscaler_export_addr, _ = _setup_cluster_for_test
-    timeseries = PrometheusTimeseries()
-
-    def verify_metrics_not_collected():
-        fetch_prometheus_timeseries(prom_addresses, timeseries)
-        components_dict = timeseries.components_dict
-        metric_descriptors = timeseries.metric_descriptors
-        metric_names = metric_descriptors.keys()
-        # Make sure no component is reported.
-        for _, comp in components_dict.items():
-            if len(comp) > 0:
-                print(f"metrics from a component {comp} exists although it should not.")
-                return False
-
-        # Make sure metrics are not there.
-        for metric in (
-            _METRICS
-            + _AUTOSCALER_METRICS
-            + _DASHBOARD_METRICS
-            + _EVENT_AGGREGATOR_METRICS
-        ):
-            if metric in metric_names:
-                print("f{metric} exists although it should not.")
-                return False
-        return True
-
-    # Make sure metrics are not collected for more than 10 seconds.
-    for _ in range(10):
-        assert verify_metrics_not_collected()
-        import time
-
-        time.sleep(1)
+    prom_addresses, _, _ = _setup_cluster_for_test
+    # When metrics are disabled, prom_addresses should be empty
+    assert len(prom_addresses) == 0, (
+        f"Expected no prometheus addresses when metrics disabled, "
+        f"but got {prom_addresses}"
+    )
 
 
 _FAULTY_METRIC_REGEX = re.compile(".*Invalid metric name.*")

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from itertools import chain
 from threading import Event, Lock, RLock, Thread
 from typing import Callable, Dict, List, Optional, Tuple
+from urllib.parse import urlparse, urlunparse
 
 import grpc
 
@@ -18,7 +19,11 @@ import ray
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 import ray.core.generated.ray_client_pb2_grpc as ray_client_pb2_grpc
 import ray.core.generated.runtime_env_agent_pb2 as runtime_env_agent_pb2
-from ray._common.network_utils import build_address, is_ipv6, is_localhost
+from ray._common.network_utils import (
+    build_address,
+    is_ipv6,
+    is_localhost,
+)
 from ray._private.authentication.http_token_authentication import (
     format_authentication_http_error,
     get_auth_headers_if_auth_enabled,
@@ -27,7 +32,11 @@ from ray._private.client_mode_hook import disable_client_hook
 from ray._private.grpc_utils import init_grpc_channel
 from ray._private.parameter import RayParams
 from ray._private.runtime_env.context import RuntimeEnvContext
-from ray._private.services import ProcessInfo, start_ray_client_server
+from ray._private.services import (
+    ProcessInfo,
+    get_node_with_retry,
+    start_ray_client_server,
+)
 from ray._private.tls_utils import add_port_to_grpc_server
 from ray._private.utils import detect_fate_sharing_support
 from ray._raylet import GcsClient
@@ -122,7 +131,7 @@ class ProxyManager:
         session_dir: Optional[str] = None,
         redis_username: Optional[str] = None,
         redis_password: Optional[str] = None,
-        runtime_env_agent_port: int = 0,
+        node_id: Optional[str] = None,
     ):
         self.servers: Dict[str, SpecificServer] = dict()
         self.server_lock = RLock()
@@ -132,6 +141,22 @@ class ProxyManager:
         self._free_ports: List[int] = list(
             range(MIN_SPECIFIC_SERVER_PORT, MAX_SPECIFIC_SERVER_PORT)
         )
+
+        if runtime_env_agent_address:
+            parsed = urlparse(runtime_env_agent_address)
+            # runtime env agent self-assigns a free port, fetch it from GCS
+            if parsed.port is None or parsed.port == 0:
+                if node_id is None:
+                    raise ValueError(
+                        "node_id is required when runtime_env_agent_address "
+                        "has no port specified"
+                    )
+                node_info = get_node_with_retry(address, node_id)
+                runtime_env_agent_address = urlunparse(
+                    parsed._replace(
+                        netloc=f"{parsed.hostname}:{node_info['runtime_env_agent_port']}"
+                    )
+                )
 
         self._runtime_env_agent_address = runtime_env_agent_address
 
@@ -867,6 +892,7 @@ def serve_proxier(
     redis_password: Optional[str] = None,
     session_dir: Optional[str] = None,
     runtime_env_agent_address: Optional[str] = None,
+    node_id: Optional[str] = None,
 ):
     # Initialize internal KV to be used to upload and download working_dir
     # before calling ray.init within the RayletServicers.
@@ -890,6 +916,7 @@ def serve_proxier(
         redis_username=redis_username,
         redis_password=redis_password,
         runtime_env_agent_address=runtime_env_agent_address,
+        node_id=node_id,
     )
     task_servicer = RayletServicerProxy(None, proxy_manager)
     data_servicer = DataServicerProxy(proxy_manager)

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -886,6 +886,13 @@ def main():
         default=None,
         help="The port to use for connecting to the runtime_env_agent.",
     )
+    parser.add_argument(
+        "--node-id",
+        required=False,
+        type=str,
+        default=None,
+        help="The hex ID of this node.",
+    )
     args, _ = parser.parse_known_args()
     setup_logger(ray_constants.LOGGER_LEVEL, ray_constants.LOGGER_FORMAT)
 
@@ -906,6 +913,7 @@ def main():
             redis_username=args.redis_username,
             redis_password=args.redis_password,
             runtime_env_agent_address=args.runtime_env_agent_address,
+            node_id=args.node_id,
         )
     else:
         server = serve(args.host, args.port, ray_connect_handler)

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -66,6 +66,13 @@ constexpr int kMessagePackOffset = 9;
 /// Should be kept in sync with SETUP_WORKER_FILENAME in ray_constants.py
 constexpr char kSetupWorkerFilename[] = "setup_worker.py";
 
+// Should be kept in sync with port names in ray_constants.py
+constexpr char kRuntimeEnvAgentPortName[] = "runtime_env_agent_port";
+constexpr char kMetricsAgentPortName[] = "metrics_agent_port";
+constexpr char kMetricsExportPortName[] = "metrics_export_port";
+constexpr char kDashboardAgentListenPortName[] = "dashboard_agent_listen_port";
+constexpr char kGcsServerPortName[] = "gcs_server_port";
+
 /// The version of Ray
 constexpr char kRayVersion[] = "3.0.0.dev0";
 

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -795,7 +795,7 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
   // for java worker or in constructor of CoreWorker for python worker.
 
   // We need init stats before using it/spawning threads.
-  stats::Init(global_tags, options_.metrics_agent_port, worker_id_);
+  stats::Init(global_tags, worker_id_);
   task_by_state_gauge_ = std::unique_ptr<ray::stats::Gauge>(
       new ray::stats::Gauge(GetTaskByStateGaugeMetric()));
   actor_by_state_gauge_ = std::unique_ptr<ray::stats::Gauge>(
@@ -835,6 +835,7 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
         "127.0.0.1", options_.metrics_agent_port, io_service_, *client_call_manager_);
     metrics_agent_client_->WaitForServerReady([this](const Status &server_status) {
       if (server_status.ok()) {
+        stats::ConnectOpenCensusExporter(options_.metrics_agent_port);
         stats::InitOpenTelemetryExporter(options_.metrics_agent_port);
       } else {
         RAY_LOG(ERROR) << "Failed to establish connection to the metrics exporter agent. "

--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -561,6 +561,7 @@ ray_cc_binary(
         "//src/ray/raylet:metrics",
         "//src/ray/stats:stats_lib",
         "//src/ray/util:event",
+        "//src/ray/util:port_persistence",
         "//src/ray/util:raii",
         "//src/ray/util:stream_redirection",
         "//src/ray/util:stream_redirection_options",

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -111,6 +112,11 @@ class GcsServer {
   /// Get the port of this gcs server.
   int GetPort() const { return rpc_server_.GetPort(); }
 
+  /// Set a callback invoked once the RPC server has bound to a port.
+  void SetPortReadyCallback(std::function<void(int)> cb) {
+    port_ready_callback_ = std::move(cb);
+  }
+
   /// Check if gcs server is started.
   bool IsStarted() const { return is_started_; }
 
@@ -203,11 +209,14 @@ class GcsServer {
   /// Initialize function manager.
   void InitFunctionManager();
 
-  /// Initializes PubSub handler.
+  /// Initialize PubSub handler.
   void InitPubSubHandler();
 
   // Init RuntimeENv manager
   void InitRuntimeEnvManager();
+
+  /// Initialize metrics exporter with the given port.
+  void InitMetricsExporter(int metrics_agent_port);
 
   /// Install event listeners.
   void InstallEventListeners();
@@ -314,7 +323,11 @@ class GcsServer {
   /// Gcs service state flag, which is used for ut.
   std::atomic<bool> is_started_;
   std::atomic<bool> is_stopped_;
+  /// Flag to ensure InitMetricsExporter is only called once.
+  bool metrics_exporter_initialized_ = false;
   int task_pending_schedule_detected_ = 0;
+  // Invoked when the RPC server has bound to a port.
+  std::function<void(int)> port_ready_callback_;
   /// Throttler for global gc
   std::unique_ptr<Throttler> global_gc_throttler_;
   /// Client to call a metrics agent gRPC server.

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -318,6 +318,12 @@ message GcsNodeInfo {
   // The port at which the runtime env agent listens as HTTP.
   int32 runtime_env_agent_port = 27;
 
+  // The port at which the metrics agent (dashboard agent grpc) listens.
+  int32 metrics_agent_port = 30;
+
+  // The port at which the dashboard agent listens for HTTP requests.
+  int32 dashboard_agent_listen_port = 31;
+
   // The total resources of this node.
   map<string, double> resources_total = 11;
 

--- a/src/ray/raylet/BUILD.bazel
+++ b/src/ray/raylet/BUILD.bazel
@@ -270,6 +270,7 @@ ray_cc_library(
         "//src/ray/util:cmd_line_utils",
         "//src/ray/util:container_util",
         "//src/ray/util:network_util",
+        "//src/ray/util:port_persistence",
         "//src/ray/util:throttler",
         "//src/ray/util:time",
         "@boost//:system",

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -78,6 +79,12 @@ struct NodeManagerConfig {
   /// The port to connect the runtime env agent. Note the address is equal to the
   /// node manager address.
   int runtime_env_agent_port;
+  /// The port to connect the metrics agent (dashboard agent grpc port).
+  int metrics_agent_port;
+  /// The port at which metrics are exposed.
+  int metrics_export_port;
+  /// The port for the dashboard agent to listen on.
+  int dashboard_agent_listen_port;
   /// The lowest port number that workers started will bind on.
   /// If this is set to 0, workers will bind on random ports.
   int min_worker_port;
@@ -188,6 +195,18 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
 
   /// Get initial node manager configuration.
   const NodeManagerConfig &GetInitialConfig() const;
+
+  /// Return the runtime env agent port.
+  int GetRuntimeEnvAgentPort() const { return runtime_env_agent_port_; }
+
+  /// Return the metrics agent port.
+  int GetMetricsAgentPort() const { return metrics_agent_port_; }
+
+  /// Return the metrics export port.
+  int GetMetricsExportPort() const { return metrics_export_port_; }
+
+  /// Return the dashboard agent listen port.
+  int GetDashboardAgentListenPort() const { return dashboard_agent_listen_port_; }
 
   /// Returns debug string for class.
   ///
@@ -761,9 +780,15 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   std::unique_ptr<AgentManager> CreateDashboardAgentManager(
       const NodeID &self_node_id, const NodeManagerConfig &config);
 
+  std::tuple<int, int, int> WaitForDashboardAgentPorts(const NodeID &self_node_id,
+                                                       const NodeManagerConfig &config);
+
   /// Creates a AgentManager that creates and manages a runtime env agent.
   std::unique_ptr<AgentManager> CreateRuntimeEnvAgentManager(
       const NodeID &self_node_id, const NodeManagerConfig &config);
+
+  int WaitForRuntimeEnvAgentPort(const NodeID &self_node_id,
+                                 const NodeManagerConfig &config);
 
   /// ID of this node.
   NodeID self_node_id_;
@@ -825,6 +850,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// A manager for the runtime env agent.
   /// Ditto for the pointer argument.
   std::unique_ptr<AgentManager> runtime_env_agent_manager_;
+  int runtime_env_agent_port_{0};
+  int metrics_agent_port_{0};
+  int metrics_export_port_{0};
+  int dashboard_agent_listen_port_{0};
 
   /// The RPC server.
   rpc::GrpcServer node_manager_server_;

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -318,6 +318,12 @@ class NodeManagerTest : public ::testing::Test {
     node_manager_config.store_socket_name = "test_store_socket";
     node_manager_config.resource_config = ResourceSet(
         absl::flat_hash_map<std::string, double>{{"CPU", kTestTotalCpuResource}});
+    // Set non-zero ports to skip waiting for agents reporting ports back.
+    // we don't actually start the agents in this test.
+    node_manager_config.metrics_agent_port = 44386;
+    node_manager_config.metrics_export_port = 63802;
+    node_manager_config.dashboard_agent_listen_port = 52365;
+    node_manager_config.runtime_env_agent_port = 37429;
 
     core_worker_subscriber_ = std::make_unique<pubsub::FakeSubscriber>();
     mock_object_directory_ = std::make_unique<MockObjectDirectory>();

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -31,28 +31,54 @@ namespace stats {
 /// exporter after a main thread launched.
 class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::Handler {
  public:
-  OpenCensusProtoExporter(const int port,
-                          instrumented_io_context &io_service,
+  /// Constructs an exporter with an already-connected metrics agent client.
+  ///
+  /// Use this constructor when the metrics agent port is known at initialization time.
+  /// The exporter is immediately ready to send metrics.
+  ///
+  /// @param agent_client A connected MetricsAgentClient instance.
+  /// @param worker_id The worker ID to include in metric reports.
+  /// @param report_batch_size Maximum number of time-series per gRPC request.
+  /// @param max_grpc_payload_size Maximum gRPC payload size in bytes.
+  OpenCensusProtoExporter(std::shared_ptr<rpc::MetricsAgentClient> agent_client,
                           const WorkerID &worker_id,
                           size_t report_batch_size,
                           size_t max_grpc_payload_size);
 
-  // This constructor is only used for testing
-  OpenCensusProtoExporter(std::shared_ptr<rpc::MetricsAgentClient> agent_client,
+  /// Constructs an exporter without connecting to the metrics agent.
+  ///
+  /// Use this constructor when the metrics agent port is not yet known (e.g., when
+  /// using dynamic port allocation). The exporter will be registered with OpenCensus
+  /// but will drop metrics until Connect() is called with the actual port.
+  ///
+  /// @param io_service The IO service for async gRPC operations. Must outlive this
+  ///                   exporter.
+  /// @param worker_id The worker ID to include in metric reports.
+  /// @param report_batch_size Maximum number of time-series per gRPC request.
+  /// @param max_grpc_payload_size Maximum gRPC payload size in bytes.
+  ///
+  /// @see Connect() to establish the connection once the port is known.
+  OpenCensusProtoExporter(instrumented_io_context &io_service,
                           const WorkerID &worker_id,
                           size_t report_batch_size,
                           size_t max_grpc_payload_size);
 
   ~OpenCensusProtoExporter() override = default;
 
-  static void Register(const int port,
-                       instrumented_io_context &io_service,
-                       const WorkerID &worker_id,
-                       size_t report_batch_size,
-                       size_t max_grpc_payload_size) {
-    opencensus::stats::StatsExporter::RegisterPushHandler(
-        absl::make_unique<OpenCensusProtoExporter>(
-            port, io_service, worker_id, report_batch_size, max_grpc_payload_size));
+  /// Connects to the metrics agent at the specified port.
+  ///
+  /// @param port The port number where the metrics agent is listening.
+  void Connect(int port);
+
+  static OpenCensusProtoExporter *Register(instrumented_io_context &io_service,
+                                           const WorkerID &worker_id,
+                                           size_t report_batch_size,
+                                           size_t max_grpc_payload_size) {
+    auto exporter = absl::make_unique<OpenCensusProtoExporter>(
+        io_service, worker_id, report_batch_size, max_grpc_payload_size);
+    auto *exporter_ptr = exporter.get();
+    opencensus::stats::StatsExporter::RegisterPushHandler(std::move(exporter));
+    return exporter_ptr;
   }
 
   void ExportViewData(
@@ -96,6 +122,8 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
  private:
   /// Lock to protect the client
   mutable absl::Mutex mu_;
+  /// IO service for async operations
+  instrumented_io_context *io_service_ = nullptr;
   /// Client to call a metrics agent gRPC server.
   std::unique_ptr<rpc::ClientCallManager> client_call_manager_;
   std::shared_ptr<rpc::MetricsAgentClient> client_ ABSL_GUARDED_BY(&mu_);

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -46,6 +46,11 @@ using OpenTelemetryMetricRecorder = ray::observability::OpenTelemetryMetricRecor
 static std::shared_ptr<IOServicePool> metrics_io_service_pool;
 static absl::Mutex stats_mutex;
 
+inline OpenCensusProtoExporter *&GetOpenCensusExporter() {
+  static OpenCensusProtoExporter *exporter = nullptr;
+  return exporter;
+}
+
 // Returns true if OpenCensus should be enabled.
 static inline bool should_enable_open_census() {
   return !RayConfig::instance().enable_open_telemetry() ||
@@ -61,12 +66,10 @@ static inline bool should_enable_open_census() {
 /// We recommend you to use this only once inside a main script and add Shutdown() method
 /// to any signal handler.
 /// \param global_tags[in] Tags that will be appended to all metrics in this process.
-/// \param metrics_agent_port[in] The port to export metrics at each node.
 /// \param worker_id[in] The worker ID of the current component.
 static inline void Init(
     const TagsType &global_tags,
-    const int metrics_agent_port,
-    const WorkerID &worker_id,
+    const WorkerID &worker_id = WorkerID::Nil(),
     int64_t metrics_report_batch_size = RayConfig::instance().metrics_report_batch_size(),
     int64_t max_grpc_payload_size = RayConfig::instance().agent_max_grpc_message_size()) {
   absl::MutexLock lock(&stats_mutex);
@@ -99,11 +102,9 @@ static inline void Init(
         StatsConfig::instance().GetReportInterval());
     opencensus::stats::DeltaProducer::Get()->SetHarvestInterval(
         StatsConfig::instance().GetHarvestInterval());
-    OpenCensusProtoExporter::Register(metrics_agent_port,
-                                      (*metrics_io_service),
-                                      worker_id,
-                                      metrics_report_batch_size,
-                                      max_grpc_payload_size);
+
+    GetOpenCensusExporter() = OpenCensusProtoExporter::Register(
+        *metrics_io_service, worker_id, metrics_report_batch_size, max_grpc_payload_size);
   }
 
   StatsConfig::instance().SetGlobalTags(global_tags);
@@ -128,6 +129,13 @@ static inline void InitOpenTelemetryExporter(const int metrics_agent_port) {
           absl::ToInt64Milliseconds(0.5 * StatsConfig::instance().GetReportInterval())));
 }
 
+static inline void ConnectOpenCensusExporter(const int metrics_agent_port) {
+  absl::MutexLock lock(&stats_mutex);
+  if (GetOpenCensusExporter() != nullptr) {
+    GetOpenCensusExporter()->Connect(metrics_agent_port);
+  }
+}
+
 /// Shutdown the initialized stats library.
 /// This cleans up various threads and metadata for stats library.
 static inline void Shutdown() {
@@ -144,6 +152,7 @@ static inline void Shutdown() {
     opencensus::stats::DeltaProducer::Get()->Shutdown();
     opencensus::stats::StatsExporter::Shutdown();
     metrics_io_service_pool = nullptr;
+    GetOpenCensusExporter() = nullptr;
   }
   StatsConfig::instance().SetIsInitialized(false);
   RAY_LOG(INFO) << "Stats module has shutdown.";

--- a/src/ray/util/BUILD.bazel
+++ b/src/ray/util/BUILD.bazel
@@ -66,6 +66,30 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "file_persistence",
+    srcs = ["file_persistence.cc"],
+    hdrs = ["file_persistence.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/ray/common:status",
+        "//src/ray/common:status_or",
+    ],
+)
+
+ray_cc_library(
+    name = "port_persistence",
+    srcs = ["port_persistence.cc"],
+    hdrs = ["port_persistence.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":file_persistence",
+        "//src/ray/common:id",
+        "//src/ray/common:status",
+        "//src/ray/common:status_or",
+    ],
+)
+
+ray_cc_library(
     name = "container_util",
     hdrs = ["container_util.h"],
     deps = [

--- a/src/ray/util/file_persistence.cc
+++ b/src/ray/util/file_persistence.cc
@@ -1,0 +1,74 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/util/file_persistence.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+
+namespace ray {
+
+Status WriteFile(const std::string &file_path, const std::string &value) {
+  std::string tmp_path = file_path + ".tmp";
+  std::ofstream file(tmp_path);
+  if (!file.is_open()) {
+    return Status::IOError("Failed to open temp file for writing: " + tmp_path);
+  }
+  file << value;
+  file.close();
+  if (file.fail()) {
+    return Status::IOError("Failed to write to temp file: " + tmp_path);
+  }
+
+  std::error_code ec;
+  // On Windows, rename doesn't overwrite existing files, so remove first.
+  std::filesystem::remove(file_path, ec);
+  std::filesystem::rename(tmp_path, file_path, ec);
+  if (ec) {
+    return Status::IOError("Failed to rename " + tmp_path + " to " + file_path + ": " +
+                           ec.message());
+  }
+  return Status::OK();
+}
+
+StatusSetOr<std::string, StatusT::IOError, StatusT::TimedOut> WaitForFile(
+    const std::string &file_path, int timeout_ms, int poll_interval_ms) {
+  auto start = std::chrono::steady_clock::now();
+  while (true) {
+    if (std::filesystem::exists(file_path)) {
+      std::ifstream file(file_path);
+      if (file.is_open()) {
+        std::string content((std::istreambuf_iterator<char>(file)),
+                            std::istreambuf_iterator<char>());
+        file.close();
+        if (!file.fail()) {
+          return content;
+        }
+        return StatusT::IOError("Failed to read file: " + file_path);
+      }
+    }
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - start)
+                       .count();
+    if (elapsed >= timeout_ms) {
+      return StatusT::TimedOut("Timed out waiting for file " + file_path);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(poll_interval_ms));
+  }
+}
+
+}  // namespace ray

--- a/src/ray/util/file_persistence.h
+++ b/src/ray/util/file_persistence.h
@@ -1,0 +1,56 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "ray/common/status.h"
+#include "ray/common/status_or.h"
+
+namespace ray {
+
+/**
+ * @brief Write a string value to a file atomically. Overwrites if the file exists.
+ *
+ * Uses temp file + rename pattern for cross-platform (Linux/Windows) and
+ * cross-language (C++/Python) safe file sharing. This guarantees readers
+ * will not read partial content.
+ *
+ * @param file_path The absolute path to the target file.
+ * @param value The string value to write.
+ * @return Status::OK if the file was written successfully.
+ * @return Status::IOError if the temp file could not be opened, written to,
+ *         or renamed to the target path.
+ */
+Status WriteFile(const std::string &file_path, const std::string &value);
+
+/**
+ * @brief Wait for a file to appear and return its content as a string.
+ *
+ * Best suited for write-once, read-many scenarios. No protection against
+ * concurrent writes or content changes during/after read.
+ *
+ * @param file_path The absolute path to the file to wait for.
+ * @param timeout_ms Maximum time to wait in milliseconds. Defaults to 15000.
+ * @param poll_interval_ms Interval between filesystem checks in milliseconds.
+ *        Defaults to 50.
+ * @return The file content if successful.
+ * @return StatusT::IOError if the file exists but cannot be read.
+ * @return StatusT::TimedOut if the file does not appear within the timeout period.
+ */
+StatusSetOr<std::string, StatusT::IOError, StatusT::TimedOut> WaitForFile(
+    const std::string &file_path, int timeout_ms = 15000, int poll_interval_ms = 50);
+
+}  // namespace ray

--- a/src/ray/util/port_persistence.cc
+++ b/src/ray/util/port_persistence.cc
@@ -1,0 +1,65 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/util/port_persistence.h"
+
+#include <filesystem>
+#include <string>
+
+#include "ray/util/file_persistence.h"
+
+namespace ray {
+
+std::string GetPortFileName(const NodeID &node_id, const std::string &port_name) {
+  return port_name + "_" + node_id.Hex();
+}
+
+Status PersistPort(const std::string &dir,
+                   const NodeID &node_id,
+                   const std::string &port_name,
+                   int port) {
+  std::string file_name = GetPortFileName(node_id, port_name);
+  std::string file_path = (std::filesystem::path(dir) / file_name).string();
+  return WriteFile(file_path, std::to_string(port));
+}
+
+StatusSetOr<int, StatusT::IOError, StatusT::TimedOut, StatusT::Invalid>
+WaitForPersistedPort(const std::string &dir,
+                     const NodeID &node_id,
+                     const std::string &port_name,
+                     int timeout_ms,
+                     int poll_interval_ms) {
+  using RetType = StatusSetOr<int, StatusT::IOError, StatusT::TimedOut, StatusT::Invalid>;
+  std::string file_name = GetPortFileName(node_id, port_name);
+  std::string file_path = (std::filesystem::path(dir) / file_name).string();
+  auto result = WaitForFile(file_path, timeout_ms, poll_interval_ms);
+  if (result.has_error()) {
+    return std::visit(overloaded{[](const StatusT::IOError &e) -> RetType {
+                                   return StatusT::IOError(e.message());
+                                 },
+                                 [](const StatusT::TimedOut &e) -> RetType {
+                                   return StatusT::TimedOut(e.message());
+                                 }},
+                      result.error());
+  }
+
+  try {
+    return std::stoi(result.value());
+  } catch (const std::exception &e) {
+    return StatusT::Invalid("Invalid port value in file " + file_path + ": " +
+                            result.value());
+  }
+}
+
+}  // namespace ray

--- a/src/ray/util/port_persistence.h
+++ b/src/ray/util/port_persistence.h
@@ -1,0 +1,82 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+/**
+ * @file port_persistence.h
+ * @brief Local port discovery utilities for inter-component communication.
+ *
+ * These functions enable components to discover each other's dynamically
+ * bound ports via the local filesystem. Typical usage pattern:
+ *   - A component (e.g., dashboard agent) binds to port 0 and calls
+ *     PersistPort() to write its actual port to a file.
+ *   - Other components (e.g., raylet) call WaitForPersistedPort() to
+ *     read the port.
+ */
+
+#include <string>
+
+#include "ray/common/id.h"
+#include "ray/common/status.h"
+#include "ray/common/status_or.h"
+
+namespace ray {
+
+/**
+ * @brief Generate the standard filename for a port file.
+ *
+ * @param node_id The node ID of this node.
+ * @param port_name The name of the port.
+ * @return The filename in format "{port_name}_{node_id_hex}".
+ */
+std::string GetPortFileName(const NodeID &node_id, const std::string &port_name);
+
+/**
+ * @brief Persist a port number to a file.
+ *
+ * @param dir The directory where the port file will be created.
+ * @param node_id The node ID of this node.
+ * @param port_name The name of the port.
+ * @param port The port number to persist.
+ * @return Status::OK if the port was persisted successfully.
+ * @return Status::IOError if the file could not be written.
+ */
+Status PersistPort(const std::string &dir,
+                   const NodeID &node_id,
+                   const std::string &port_name,
+                   int port);
+
+/**
+ * @brief Wait for a persisted port file and return the port number.
+ *
+ * @param dir The directory where the port file is expected.
+ * @param node_id The node ID to identify this port file.
+ * @param port_name The name of the port (e.g., "dashboard_agent").
+ * @param timeout_ms Maximum time to wait in milliseconds. Defaults to 15000.
+ * @param poll_interval_ms Interval between filesystem checks in milliseconds.
+ *        Defaults to 50.
+ * @return The port number if successful.
+ * @return StatusT::IOError if the file exists but cannot be read.
+ * @return StatusT::TimedOut if the file does not appear within the timeout period.
+ * @return StatusT::Invalid if the file content is not a valid port number.
+ */
+StatusSetOr<int, StatusT::IOError, StatusT::TimedOut, StatusT::Invalid>
+WaitForPersistedPort(const std::string &dir,
+                     const NodeID &node_id,
+                     const std::string &port_name,
+                     int timeout_ms = 15000,
+                     int poll_interval_ms = 50);
+
+}  // namespace ray

--- a/src/ray/util/tests/BUILD.bazel
+++ b/src/ray/util/tests/BUILD.bazel
@@ -1,6 +1,18 @@
 load("//bazel:ray.bzl", "ray_cc_test")
 
 ray_cc_test(
+    name = "file_persistence_test",
+    size = "small",
+    srcs = ["file_persistence_test.cc"],
+    tags = ["team:core"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/ray/util:file_persistence",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+ray_cc_test(
     name = "array_test",
     srcs = ["array_test.cc"],
     tags = ["team:core"],

--- a/src/ray/util/tests/file_persistence_test.cc
+++ b/src/ray/util/tests/file_persistence_test.cc
@@ -1,0 +1,67 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/util/file_persistence.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace ray {
+
+TEST(FilePersistenceTest, ConcurrentRead) {
+  auto test_dir = std::filesystem::temp_directory_path() / "file_persistence_concurrent";
+  std::filesystem::create_directories(test_dir);
+  std::string file_path = (test_dir / "concurrent.txt").string();
+  const std::string expected_content = "hello world";
+
+  // Start multiple readers first (they will wait for the file)
+  std::vector<std::thread> readers;
+  for (int i = 0; i < 5; i++) {
+    readers.emplace_back([&]() {
+      auto result = WaitForFile(file_path, /*timeout_ms=*/5000, /*poll_interval_ms=*/10);
+      EXPECT_TRUE(result.has_value());
+      EXPECT_EQ(result.value(), expected_content);
+    });
+  }
+
+  // Give readers time to start waiting
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  // Write file once
+  ASSERT_TRUE(WriteFile(file_path, expected_content).ok());
+
+  for (auto &t : readers) {
+    t.join();
+  }
+
+  std::filesystem::remove_all(test_dir);
+}
+
+TEST(FilePersistenceTest, TimeoutOnMissingFile) {
+  std::string file_path = "/tmp/file_persistence_nonexistent/missing.txt";
+
+  auto result = WaitForFile(file_path,
+                            /*timeout_ms=*/10,
+                            /*poll_interval_ms=*/5);
+
+  EXPECT_TRUE(result.has_error());
+  EXPECT_TRUE(std::holds_alternative<StatusT::TimedOut>(result.error()));
+}
+
+}  // namespace ray


### PR DESCRIPTION
## Description

Previously, if the user did not specify them, Ray preassigned the GCS port, dashboard agent port, runtime environment port, etc., and passed them to each component at startup. This created a race condition: Ray might believe a port is free, but by the time the port information is propagated to each component, another process may have already bound to that port. 

This can cause user-facing issues, for example when Raylet heartbeat messages are missed frequently enough that the GCS considers the node unhealthy and removes it.

We originally did this because there was no standard local service discovery, so components had no way to know each other’s serving ports unless they were preassigned.

The final port discovery design is here:
<img width="2106" height="1492" alt="image" src="https://github.com/user-attachments/assets/eaac8190-99d8-404b-8a8d-283a4f2f0f33" />



This PR addresses port discovery for:
- GCS reporting back to the startup script (driver)✅
- The runtime env agent reporting back to the raylet✅
- The dashboard agent reporting back to the raylet ✅
- The raylet blocking registration with the GCS until it has collected port information from all agents ✅
- GCS adding InitMetricsExporter to node_added_listeners_ so it starts the MetricsExporter as soon as the raylet registers with the GCS with complete port information ✅
- The Ray client server obtaining the runtime env agent port from GCS✅
- Ensuring that both a connected-only driver (e.g., `ray.init()`) and a startup driver still receive all port information from the GCS✅
- Ensure GCS FT Works：Using the same GCS port as before✅
- Ensure no metric loss✅
- Clean up the old cache port code✅

(Note that this PR is a clean-up version of https://github.com/ray-project/ray/pull/59065)

## Consideration
**GCS Fault tolerance:**
GCS fault tolerance requires GCS to restart using exactly the same port, even if it initially starts with a dynamically assigned port (0). Before this PR, GCS cached the port in a file, and this PR preserves the same behavior (although ideally, the port should only be read from the file by the Raylet and its agent).

This can be further improved by storing the GCS port in Redis, but that should be addressed in a separate PR.

**GCS start sequence related:**
OpenCensus Exporter and the Event Aggregator Client are now constructed without connecting to the agent port; instead, they defer the actual connection until the head Raylet registers via a callback. At that point, the actual metrics_agent_port is known from the node information.

The OpenTelemetry Exporter is now also initialized at head Raylet registration time.

**Ray nodes that share the same file system:**
There are cases where people run multiple Ray nodes from the same or different Ray clusters, so the port file name is based on a fixed prefix plus the node ID.

## Related issues
Closes https://github.com/ray-project/ray/issues/54321

## Test

For GCS-related work, here is a detailed test I wrote that covers seven starting/connecting cases: 
- https://github.com/Yicheng-Lu-llll/ray/blob/port-self-discovery-test-file/python/ray/tests/test_gcs_port_reporting.py
  - ray.init starts a head node and exposes a dynamic GCS port.
  - Connect a driver via address="auto" using the address file
  - Connect a driver via an explicit address
  - CLI starts head with dynamic GCS port
  - CLI starts worker connecting to the head via GCS address
  - CLI starts head with an explicit GCS port
  - CLI starts head with default GCS port

For runtime env agent:
- https://github.com/Yicheng-Lu-llll/ray/blob/port-self-discovery-test-file/test_agent_port.py
  - ray start --head (auto port discovery)
  - ray start --head with fixed runtime-env-agent-port
  - ray.init() local cluster (auto port discovery)
  - (we don't have ray.init() with fixed _runtime_env_agent_port)

Test that ray_client_server works correctly with dynamic runtime env agent port:
- https://github.com/Yicheng-Lu-llll/ray/blob/port-self-discovery-test-file/test_ray_client_with_runtime_env.py

For dashboard agent ports, the existing tests already cover this quite well.


## Follow up
- The dashboard agent reporting back to the raylet
- The dashboard agent now also writes to GCS, but we should allow only the raylet to write to GCS

## performance

before this PR:

```shell
[0.000s] Starting ray.init()...
[0.000s] Session dir created
[0.070s] Process: gcs_server
[6.885s] Process: runtime_env_agent
[6.955s] Process: raylet
[6.955s] Process: dashboard_agent
2025-12-12 04:47:34,391 INFO worker.py:2014 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265 
/home/ubuntu/ray/python/ray/_private/worker.py:2062: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
[9.061s] ray.init() completed
```

After This PR:
```shell
[0.000s] Starting ray.init()...
[0.075s] Process: gcs_server
[0.075s] Session dir created
[0.075s] File: gcs_server_port.json = 39451
[6.976s] Process: raylet
[6.976s] Process: dashboard_agent
[6.976s] Process: runtime_env_agent
[7.576s] File: runtime_env_agent_port.json = 38747
[7.640s] File: metrics_agent_port.json = 40005
[8.083s] File: metrics_export_port.json = 44515
[8.083s] File: dashboard_agent_listen_port.json = 52365
2025-12-12 02:02:54,925 INFO worker.py:1998 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265 
/home/ubuntu/ray/python/ray/_private/worker.py:2046: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
[10.035s] ray.init() completed
```
We can see that the dominant time is actually at the start of GCS. We wait for GCS to be ready and write the cluster info.
The port reporting speed is quite fast (file appearance time − raylet start time).
https://github.com/ray-project/ray/blob/863ae9fd573b13a05dcae63b483e9b1eb0175571/python/ray/_private/node.py#L1365-L367

