### PR TITLE
[Data] Remove `scikit-image` from `requirements.txt`

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -45,7 +45,6 @@ opencensus
 aiohttp_cors
 dm_tree
 uvicorn
-scikit-image>=0.21.0
 prometheus_client>=0.7.1
 pandas
 tensorboardX


### PR DESCRIPTION
We don't import `skimage` anywhere in our codebase, and `scikit-image` isn't a required dependency in `setup.py`. I think RLlib depended it at some point, but the dependency has since been removed.

To avoid unnecessarily installing it in our images (and slowing down our CI), this PR removes it from `requirements.txt`.
