### PR TITLE
[Data] Add compute parameter and allow ActorPoolStrategy for read_datasource()

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1958,3 +1958,17 @@ py_test(
         "//:ray_lib",
     ],
 )
+
+py_test(
+    name = "test_read_datasource",
+    size = "small",
+    srcs = ["tests/test_read_datasource.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     import pyarrow
     from pyarrow.dataset import ParquetFileFragment
 
+    from ray.data.datasource.file_based_datasource import FileShuffleConfig
 
 logger = logging.getLogger(__name__)
 
@@ -304,9 +305,9 @@ class ParquetDatasource(Datasource):
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None,
         meta_provider: Optional[FileMetadataProvider] = None,
-        partition_filter: PathPartitionFilter = None,
+        partition_filter: Optional[PathPartitionFilter] = None,
         partitioning: Optional[Partitioning] = Partitioning("hive"),
-        shuffle: Union[Literal["files"], None] = None,
+        shuffle: Union["FileShuffleConfig", Literal["files"], None] = None,
         include_paths: bool = False,
         file_extensions: Optional[List[str]] = None,
     ):

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -648,6 +648,52 @@ def get_compute_strategy(
             return TaskPoolStrategy()
 
 
+def get_compute_strategy_for_read_api(
+    compute: Optional["ComputeStrategy"] = None,
+    concurrency: Optional[int] = None,
+) -> "ComputeStrategy":
+    """Get `ComputeStrategy` for read APIs.
+
+    This function is used to support both TaskPoolStrategy and ActorPoolStrategy for read APIs.
+    The default behavior is to use TaskPoolStrategy, with size set to ``concurrency`` (integer).
+    To use ActorPoolStrategy, pass an ActorPoolStrategy instance to the ``compute`` parameter. The
+    ``concurrency`` parameter takes precedence over the ``compute`` parameter.
+
+    Args:
+        compute: The compute strategy to use for reading. Pass an
+            :class:`~ray.data.ActorPoolStrategy` instance to use an actor pool,
+            or a :class:`~ray.data.TaskPoolStrategy` instance (default) to use Ray tasks.
+            If not specified, defaults to ``TaskPoolStrategy(concurrency)``.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This parameter takes precedence
+            over the ``compute`` parameter. If both are specified, the ``concurrency`` parameter
+            is used.
+
+    Returns:
+        The `ComputeStrategy` for reading.
+    """
+    from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
+
+    # ``concurrency`` parameter takes precedence over the ``compute`` parameter.
+    if concurrency is not None:
+        if compute is not None:
+            logger.warning(
+                "Both ``compute`` and ``concurrency`` are specified. The ``compute`` parameter will be ignored."
+            )
+        return TaskPoolStrategy(concurrency)
+
+    # When ``concurrency`` is not specified:
+    if compute is None:
+        return TaskPoolStrategy()
+    elif isinstance(compute, ComputeStrategy):
+        return compute
+    else:
+        raise ValueError(
+            f"compute must be a ComputeStrategy instance (e.g. ActorPoolStrategy or TaskPoolStrategy), but "
+            f"got {compute}"
+        )
+
+
 def capfirst(s: str):
     """Capitalize the first letter of a string
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -22,7 +22,7 @@ from packaging.version import parse as parse_version
 import ray
 from ray._private.arrow_utils import get_pyarrow_version
 from ray._private.auto_init_hook import wrap_auto_init
-from ray.data._internal.compute import TaskPoolStrategy
+from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.datasource.audio_datasource import AudioDatasource
 from ray.data._internal.datasource.avro_datasource import AvroDatasource
 from ray.data._internal.datasource.bigquery_datasource import BigQueryDatasource
@@ -75,6 +75,7 @@ from ray.data._internal.stats import DatasetStats
 from ray.data._internal.tensor_extensions.utils import _create_possibly_ragged_ndarray
 from ray.data._internal.util import (
     _autodetect_parallelism,
+    get_compute_strategy_for_read_api,
     get_table_block_metadata_schema,
     merge_resources_to_ray_remote_args,
     ndarray_to_block,
@@ -366,8 +367,9 @@ def read_datasource(
     num_cpus: Optional[float] = None,
     num_gpus: Optional[float] = None,
     memory: Optional[float] = None,
-    ray_remote_args: Dict[str, Any] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
     concurrency: Optional[int] = None,
+    compute: Optional[ComputeStrategy] = None,
     override_num_blocks: Optional[int] = None,
     **read_args,
 ) -> Dataset:
@@ -386,6 +388,11 @@ def read_datasource(
             to control number of tasks to run concurrently. This doesn't change the
             total number of tasks run or the total number of output blocks. By default,
             concurrency is dynamically decided based on the available resources.
+        compute: The compute strategy to use for reading. Pass an
+            :class:`~ray.data.ActorPoolStrategy` instance to use an actor pool,
+            or a :class:`~ray.data.TaskPoolStrategy` instance (default) to use Ray tasks.
+            If not specified, defaults to ``TaskPoolStrategy(concurrency)``. If both
+            ``compute`` and ``concurrency`` are specified, ``concurrency`` takes precedence.
         override_num_blocks: Override the number of output blocks from all read tasks.
             By default, the number of output blocks is dynamically decided based on
             input data size and available resources. You shouldn't manually set this
@@ -395,6 +402,22 @@ def read_datasource(
 
     Returns:
         :class:`~ray.data.Dataset` that reads data from the :class:`~ray.data.Datasource`.
+
+    Examples:
+        Read using default task-based execution:
+
+        >>> import ray
+        >>> from ray.data._internal.datasource.range_datasource import RangeDatasource
+        >>> datasource = RangeDatasource(n=1000, block_format="arrow")
+        >>> ds = ray.data.read_datasource(datasource) # doctest: +SKIP
+
+        Read using actors for stateful operations:
+
+        >>> from ray.data import ActorPoolStrategy
+        >>> ds = ray.data.read_datasource( # doctest: +SKIP
+        ...     datasource,
+        ...     compute=ActorPoolStrategy(size=4)  # Use 4 actors
+        ... )
     """  # noqa: E501
     parallelism = _get_num_output_blocks(parallelism, override_num_blocks)
 
@@ -442,13 +465,16 @@ def read_datasource(
         metadata={"Read": [read_task.metadata for read_task in read_tasks]},
         parent=None,
     )
+
+    compute_strategy = get_compute_strategy_for_read_api(compute, concurrency)
+
     read_op = Read(
         datasource,
         datasource_or_legacy_reader,
         parallelism=parallelism,
         num_outputs=len(read_tasks) if read_tasks else 0,
         ray_remote_args=ray_remote_args,
-        compute=TaskPoolStrategy(concurrency),
+        compute=compute_strategy,
     )
     execution_plan = ExecutionPlan(
         stats,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -418,6 +418,11 @@ def read_datasource(
         ...     datasource,
         ...     compute=ActorPoolStrategy(size=4)  # Use 4 actors
         ... )
+
+    .. note::
+        The use of `ActorPoolStrategy` is currently experimental and comes with caveats, such
+        as additional overhead due to limited operator fusion opportunities.
+
     """  # noqa: E501
     parallelism = _get_num_output_blocks(parallelism, override_num_blocks)
 

--- a/python/ray/data/tests/test_read_datasource.py
+++ b/python/ray/data/tests/test_read_datasource.py
@@ -1,0 +1,252 @@
+import time
+from typing import TYPE_CHECKING, List, Optional
+
+import pandas as pd
+import pytest
+
+import ray
+from ray.data import ActorPoolStrategy, TaskPoolStrategy
+from ray.data._internal.datasource.range_datasource import RangeDatasource
+from ray.data._internal.logical.operators.read_operator import Read
+from ray.data._internal.util import rows_same
+from ray.data.block import Block, BlockMetadata
+from ray.data.context import DataContext
+from ray.data.datasource import Datasource, ReadTask
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+if TYPE_CHECKING:
+    from ray.actor import ActorHandle
+    from ray.data._internal.logical.interfaces import LogicalOperator
+
+
+def find_read_op(op: "LogicalOperator") -> Optional[Read]:
+    """Find the Read operator in the logical plan."""
+    if isinstance(op, Read):
+        return op
+    if hasattr(op, "input_dependencies"):
+        for input_op in op.input_dependencies:
+            result = find_read_op(input_op)
+            if result:
+                return result
+    return None
+
+
+class TestDatasource(Datasource):
+    """Unified datasource that captures actor_id and optionally tracks concurrency."""
+
+    def __init__(self, n: int, concurrency_counter: Optional["ActorHandle"] = None):
+        super().__init__()
+        self._n = int(n)
+        self._concurrency_counter = concurrency_counter
+
+    def get_name(self) -> str:
+        return "TestDatasource"
+
+    def estimate_inmemory_data_size(self) -> Optional[int]:
+        """Return an estimate of the in-memory data size."""
+        # 2 columns (value, actor_id), 8 bytes per value
+        return 8 * self._n * 2
+
+    def get_read_tasks(
+        self,
+        parallelism: int,
+        per_task_row_limit: Optional[int] = None,
+        data_context: Optional["DataContext"] = None,
+    ) -> List[ReadTask]:
+        if self._n == 0:
+            return []
+
+        read_tasks: List[ReadTask] = []
+        n = self._n
+        block_size = max(1, n // parallelism)
+        counter_ref = self._concurrency_counter
+
+        def make_block(start: int, count: int, counter) -> Block:
+            import pyarrow as pa
+
+            # Track concurrency if counter is provided
+            if counter is not None:
+                ray.get(counter.inc.remote())  # type: ignore
+            try:
+                # Simulate some work when tracking concurrency
+                if counter is not None:
+                    time.sleep(0.1)
+
+                # Capture actor_id during execution
+                runtime_context = ray.get_runtime_context()
+                actor_id = runtime_context.get_actor_id()
+
+                return pa.Table.from_arrays(
+                    [
+                        pa.array(range(start, start + count)),
+                        pa.array([actor_id] * count),
+                    ],
+                    names=["value", "actor_id"],
+                )
+            finally:
+                # Decrement concurrency counter if provided
+                if counter is not None:
+                    ray.get(counter.decr.remote())  # type: ignore
+
+        i = 0
+        while i < n:
+            count = min(block_size, n - i)
+            meta = BlockMetadata(
+                num_rows=count,
+                size_bytes=8 * count * 2,  # Rough estimate: 2 columns
+                input_files=None,
+                exec_stats=None,
+            )
+
+            def read_fn(start=i, count=count, counter=counter_ref):
+                yield make_block(start, count, counter)
+
+            read_tasks.append(
+                ReadTask(
+                    read_fn,
+                    meta,
+                    schema=None,
+                    per_task_row_limit=per_task_row_limit,
+                )
+            )
+            i += block_size
+
+        return read_tasks
+
+
+@pytest.mark.parametrize(
+    "concurrency,compute,expected_strategy_type",
+    [
+        (None, None, TaskPoolStrategy),
+        (1, None, TaskPoolStrategy),
+        (2, None, TaskPoolStrategy),
+        (None, TaskPoolStrategy(), TaskPoolStrategy),
+        (None, TaskPoolStrategy(size=4), TaskPoolStrategy),
+        (None, ActorPoolStrategy(size=2), ActorPoolStrategy),
+        (
+            1,
+            ActorPoolStrategy(size=4),
+            TaskPoolStrategy,
+        ),  # concurrency takes precedence
+    ],
+)
+def test_read_datasource_compute_strategy(
+    ray_start_regular_shared_2_cpus,
+    concurrency,
+    compute,
+    expected_strategy_type,
+    target_max_block_size_infinite_or_default,
+):
+    """Test that compute strategy is correctly set based on concurrency and compute parameters."""
+    datasource = RangeDatasource(n=100)
+
+    ds = ray.data.read_datasource(
+        datasource,
+        concurrency=concurrency,
+        compute=compute,
+        override_num_blocks=4,
+    )
+
+    # Get the logical plan to inspect the compute strategy on the logical operator
+    logical_plan = ds._plan._logical_plan
+    read_op = find_read_op(logical_plan.dag)
+
+    # Verify the compute strategy type on the logical operator
+    assert read_op is not None, "Could not find Read operator in logical plan"
+    assert isinstance(
+        read_op._compute, expected_strategy_type
+    ), f"Expected {expected_strategy_type}, got {type(read_op._compute)}"
+
+    # If concurrency was specified, verify it takes precedence
+    if concurrency is not None:
+        assert isinstance(read_op._compute, TaskPoolStrategy)
+        assert read_op._compute.size == concurrency
+
+
+@pytest.mark.parametrize(
+    "compute,expect_actor_execution",
+    [
+        (TaskPoolStrategy(), False),
+        (ActorPoolStrategy(size=2), True),
+        (ActorPoolStrategy(min_size=1, max_size=4), True),
+    ],
+)
+def test_read_datasource_actor_execution(
+    ray_start_regular_shared_2_cpus,
+    compute,
+    expect_actor_execution,
+    target_max_block_size_infinite_or_default,
+):
+    """Test that ReadTasks execute in actors when using ActorPoolStrategy."""
+    datasource = TestDatasource(n=100)
+
+    ds = ray.data.read_datasource(
+        datasource,
+        compute=compute,
+        override_num_blocks=4,
+    )
+
+    # Materialize to trigger execution
+    result = ds.take_all()
+
+    # Extract actor_ids from the data (they're included in each row)
+    actor_ids_in_data = {row.get("actor_id") for row in result}
+
+    if expect_actor_execution:
+        # Should have actor_ids in the data (not None)
+        assert len(actor_ids_in_data) > 0, "Expected actor_ids in data"
+        # All actor_ids should be non-None
+        assert (
+            None not in actor_ids_in_data
+        ), "Expected all actor_ids to be non-None for ActorPoolStrategy"
+        # With ActorPoolStrategy(size=2), we should have at most 2 unique actor_ids
+        # When size is specified, min_size == max_size == size
+        if (
+            isinstance(compute, ActorPoolStrategy)
+            and compute.min_size == compute.max_size
+        ):
+            assert (
+                len(actor_ids_in_data) <= compute.min_size
+            ), f"Expected at most {compute.min_size} unique actor_ids, got {len(actor_ids_in_data)}"
+    else:
+        # Should not have actor_ids (all None)
+        assert (
+            actor_ids_in_data == {None} or len(actor_ids_in_data) == 0
+        ), f"Expected all actor_ids to be None for TaskPoolStrategy, got {actor_ids_in_data}"
+
+
+@pytest.mark.parametrize(
+    "compute_strategy",
+    [
+        TaskPoolStrategy(),
+        TaskPoolStrategy(size=2),
+        ActorPoolStrategy(size=2),
+        ActorPoolStrategy(min_size=1, max_size=4),
+    ],
+)
+def test_read_datasource_basic_functionality(
+    ray_start_regular_shared_2_cpus,
+    compute_strategy,
+):
+    """Test that read_datasource works correctly with different compute strategies."""
+    datasource = RangeDatasource(n=100)
+
+    ds = ray.data.read_datasource(
+        datasource,
+        compute=compute_strategy,
+        override_num_blocks=4,
+    )
+
+    df = ds.to_pandas()
+
+    expected_df = pd.DataFrame({"value": list(range(100))})
+    assert rows_same(df, expected_df)
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description
This PR adds an option to use `ActorPoolStrategy` as `compute` for `read_datasource`. This is a simple extension to expose the option to set `Read` op's compute strategy (see #59422 ).

For the time being, there is no change to the `concurrency` parameter. When both `concurrency` and `compute` are set, a warning is given and we will simply use `TaskPoolStrategy(concurrency)`.

## Additional information
Unlike `map_batches`, there is no "class-based" implementation of a `ReadTask` yet. So there is no change to how user should implement a `Datasource`, i.e., they should still provide a list of `ReadTask` that calls some read _functions_ (`get_read_tasks`).

Ideally, in the future, we can allow user to define their "class-based" datasource where they can handle how each ReadTask should run on a pool of actors.

### Changes in this PR
* added a new parameter `compute` to `read_datasource`
* no change to other read_* APIs
* added a bunch of tests on the concurrency/compute options, fusion rules, etc.
* [minor] fixed some type hints in parquet datasource

