### PR TITLE
[Docs] Update KubeRay & Volcano integration document

### DIFF
--- a/doc/source/cluster/kubernetes/k8s-ecosystem/volcano.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/volcano.md
@@ -1,7 +1,9 @@
 (kuberay-volcano)=
 # KubeRay integration with Volcano
 
-[Volcano](https://github.com/volcano-sh/volcano) is a batch scheduling system built on Kubernetes. It provides a suite of mechanisms (gang scheduling, job queues, fair scheduling policies) currently missing from Kubernetes that are commonly required by many classes of batch and elastic workloads. KubeRay's Volcano integration enables more efficient scheduling of Ray pods in multi-tenant Kubernetes environments.
+[Volcano](https://github.com/volcano-sh/volcano) is a batch scheduling system built on Kubernetes, providing gang scheduling, job queues, fair scheduling policies, and network topology-aware scheduling. KubeRay integrates natively with Volcano for RayCluster, RayJob, and RayService, enabling more efficient scheduling of Ray pods in multi-tenant Kubernetes environments.
+
+This guide covers [setup instructions](#setup), [configuration options](#step-4-install-a-raycluster-with-the-volcano-scheduler), and [examples](#example) demonstrating gang scheduling for both RayCluster and RayJob.
 
 ## Setup
 
@@ -39,12 +41,8 @@ helm install kuberay-operator kuberay/kuberay-operator --version 1.5.1 --set bat
 ```
 
 ### Step 4: Install a RayCluster with the Volcano scheduler
-
-The RayCluster custom resource must include the `ray.io/scheduler-name: volcano` label to submit the cluster Pods to Volcano for scheduling.
-
 ```shell
 # Path: kuberay/ray-operator/config/samples
-# Includes label `ray.io/scheduler-name: volcano` in the metadata.labels
 curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.5.1/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
 kubectl apply -f ray-cluster.volcano-scheduler.yaml
 
@@ -54,24 +52,36 @@ kubectl get pod -l ray.io/cluster=test-cluster-0
 # test-cluster-0-head-jj9bg            1/1     Running   0          36s
 ```
 
-You can also be provide the following labels in the RayCluster metadata:
+You can also provide the following labels in the RayCluster, RayJob and RayService metadata:
 
 - `ray.io/priority-class-name`: The cluster priority class as defined by [Kubernetes](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass)
   - This label only works after you create a `PriorityClass` resource
   - ```shell
     labels:
-      ray.io/scheduler-name: volcano
       ray.io/priority-class-name: <replace with correct PriorityClass resource name>
     ```
 - `volcano.sh/queue-name`: The Volcano [queue](https://volcano.sh/en/docs/queue/) name the cluster submits to.
   - This label only works after you create a `Queue` resource
   - ```shell
     labels:
-      ray.io/scheduler-name: volcano
       volcano.sh/queue-name: <replace with correct Queue resource name>
     ```
+- `volcano.sh/network-topology-mode`: Enables [network topology-aware scheduling](https://volcano.sh/en/docs/network_topology_aware_scheduling/) to optimize pod placement based on network proximity, reducing inter-node communication latency for distributed workloads. Valid values are `soft` (best-effort) or `hard` (strict enforcement).
+  - This label only works after you create a `HyperNode` resource
+  - ```shell
+    labels:
+      volcano.sh/network-topology-mode: "soft"  # or "hard"
+    ```
+- `volcano.sh/network-topology-highest-tier-allowed`: Specifies the highest network topology tier for pod placement, restricting pods to be scheduled within the specified tier boundary. The value must match a tier defined in your `HyperNode` resource. Must be used together with `volcano.sh/network-topology-mode`.
+  - This label only works after you create a `HyperNode` resource
+  - ```shell
+    labels:
+      volcano.sh/network-topology-highest-tier-allowed: <tier>
+    ```
 
-If autoscaling is enabled, `minReplicas` is used for gang scheduling, otherwise the desired `replicas` is used.
+**Note**:
+- Starting from KubeRay v1.3.0, you **no** longer need to add the `ray.io/scheduler-name: volcano` label to your RayCluster/RayJob. The batch scheduler is now configured at the operator level using the `--batch-scheduler=volcano` flag.
+- When autoscaling is enabled, KubeRay uses `minReplicas` to calculate the minimum resources required for gang scheduling. Otherwise, it uses the `desired` replicas value.
 
 ### Step 5: Use Volcano for batch scheduling
 
@@ -112,7 +122,7 @@ Next, create a RayCluster with a head node (1 CPU + 2Gi of RAM) and two workers 
 
 ```shell
 # Path: kuberay/ray-operator/config/samples
-# Includes  the `ray.io/scheduler-name: volcano` and `volcano.sh/queue-name: kuberay-test-queue` labels in the metadata.labels
+# Includes the `volcano.sh/queue-name: kuberay-test-queue` label in the metadata.labels
 curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.5.1/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
 kubectl apply -f ray-cluster.volcano-scheduler-queue.yaml
 ```
@@ -186,7 +196,7 @@ Next, add an additional RayCluster with the same configuration of head and worke
 
 ```shell
 # Path: kuberay/ray-operator/config/samples
-# Includes the `ray.io/scheduler-name: volcano` and `volcano.sh/queue-name: kuberay-test-queue` labels in the metadata.labels
+# Includes the `volcano.sh/queue-name: kuberay-test-queue` label in the metadata.labels
 # Replaces the name to test-cluster-1
 sed 's/test-cluster-0/test-cluster-1/' ray-cluster.volcano-scheduler-queue.yaml | kubectl apply -f-
 ```


### PR DESCRIPTION
## Description
Previously, the `ray.io/scheduler-name` label was used to [determine the scheduler](https://github.com/ray-project/kuberay/blob/release-0.6/ray-operator/controllers/ray/batchscheduler/schedulermanager.go#L57-L64) for KubeRay CRDs. However, with the adoption of the new scheduler framework, the scheduler name is now configured via the controller configuration, `--batch-scheduler`, and the label is no longer needed.
Therefore, we can remove the information related to `ray.io/scheduler-name` to avoid ambiguity.

## Related issues
Related to https://github.com/ray-project/kuberay/pull/4305

## Additional information
