### PR TITLE
[data][llm] Use compute instead of concurrency to specify the size of ActorPool

### DIFF
--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -58,8 +58,9 @@ class HttpRequestProcessorConfig(_HttpRequestProcessorConfig):
         url: The URL to send the HTTP request to.
         headers: The headers to send with the HTTP request.
         concurrency: The number of concurrent requests to send. Default to 1.
-            If ``concurrency`` is a ``tuple`` ``(m, n)``,
-            autoscaling strategy is used (``1 <= m <= n``).
+            If ``concurrency`` is an ``int`` ``n``, a fixed pool of ``n`` workers is used.
+            If ``concurrency`` is a ``tuple`` ``(m, n)``, autoscaling strategy
+            is used (``1 <= m <= n``).
 
     Examples:
         .. testcode::
@@ -313,6 +314,9 @@ class ServeDeploymentProcessorConfig(_ServeDeploymentProcessorConfig):
             not provided, the serve deployment is expected to accept a dict as the request.
         concurrency: The number of workers for data parallelism. Default to 1. Note that this is
             not the concurrency of the underlying serve deployment.
+            If ``concurrency`` is an ``int`` ``n``, a fixed pool of ``n`` workers is used.
+            If ``concurrency`` is a ``tuple`` ``(m, n)``, autoscaling strategy
+            is used (``1 <= m <= n``).
 
     Examples:
 

--- a/python/ray/llm/_internal/batch/processor/http_request_proc.py
+++ b/python/ray/llm/_internal/batch/processor/http_request_proc.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 
 from pydantic import Field
 
+from ray.data import ActorPoolStrategy
 from ray.data.block import UserDefinedFunction
 from ray.llm._internal.batch.observability.usage_telemetry.usage import (
     BatchModelTelemetry,
@@ -90,7 +91,9 @@ def build_http_request_processor(
                 session_factory=config.session_factory,
             ),
             map_batches_kwargs=dict(
-                concurrency=config.concurrency,
+                compute=ActorPoolStrategy(
+                    **config.get_concurrency(autoscaling_enabled=False),
+                )
             ),
         )
     ]

--- a/python/ray/llm/_internal/batch/processor/serve_deployment_proc.py
+++ b/python/ray/llm/_internal/batch/processor/serve_deployment_proc.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Type
 
 from pydantic import Field
 
+from ray.data import ActorPoolStrategy
 from ray.data.block import UserDefinedFunction
 from ray.llm._internal.batch.processor.base import (
     Processor,
@@ -64,7 +65,9 @@ def build_serve_deployment_processor(
                 dtype_mapping=config.dtype_mapping,
             ),
             map_batches_kwargs=dict(
-                concurrency=config.concurrency,
+                compute=ActorPoolStrategy(
+                    **config.get_concurrency(autoscaling_enabled=False),
+                )
             ),
         )
     ]

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -176,8 +176,7 @@ def build_sglang_engine_processor(
                 # which initiates enough many overlapping UDF calls per actor, to
                 # saturate `max_concurrency`.
                 compute=ray.data.ActorPoolStrategy(
-                    min_size=config.get_concurrency(autoscaling_enabled=False)[0],
-                    max_size=config.get_concurrency(autoscaling_enabled=False)[1],
+                    **config.get_concurrency(autoscaling_enabled=False),
                     max_tasks_in_flight_per_actor=config.experimental.get(
                         "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
                     ),

--- a/python/ray/llm/_internal/batch/processor/utils.py
+++ b/python/ray/llm/_internal/batch/processor/utils.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, Optional, Tuple, Union
 
+from ray.data import ActorPoolStrategy
 from ray.llm._internal.batch.stages.configs import _StageConfigBase
 
 
@@ -28,13 +29,16 @@ def extract_resource_kwargs(
 
 def normalize_cpu_stage_concurrency(
     concurrency: Optional[Union[int, Tuple[int, int]]]
-) -> Tuple[int, int]:
+) -> Dict[str, int]:
     """Normalize concurrency for CPU stages (int -> (1, int) for autoscaling)."""
     if concurrency is None:
-        return (1, 1)  # Default to minimal autoscaling pool
+        return {"size": 1}  # Default to minimal autoscaling pool
     if isinstance(concurrency, int):
-        return (1, concurrency)
-    return concurrency
+        return {"min_size": 1, "max_size": concurrency}
+    return {
+        "min_size": concurrency[0],
+        "max_size": concurrency[1],
+    }
 
 
 def build_cpu_stage_map_kwargs(
@@ -44,7 +48,7 @@ def build_cpu_stage_map_kwargs(
     concurrency = normalize_cpu_stage_concurrency(stage_cfg.concurrency)
     return dict(
         zero_copy_batch=True,
-        concurrency=concurrency,
+        compute=ActorPoolStrategy(**concurrency),
         batch_size=stage_cfg.batch_size,
         **extract_resource_kwargs(
             stage_cfg.runtime_env,

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -284,8 +284,7 @@ def build_vllm_engine_processor(
                 # which initiates enough many overlapping UDF calls per actor, to
                 # saturate `max_concurrency`.
                 compute=ray.data.ActorPoolStrategy(
-                    min_size=config.get_concurrency(autoscaling_enabled=False)[0],
-                    max_size=config.get_concurrency(autoscaling_enabled=False)[1],
+                    **config.get_concurrency(autoscaling_enabled=False),
                     max_tasks_in_flight_per_actor=config.experimental.get(
                         "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
                     ),

--- a/python/ray/llm/tests/batch/cpu/processor/test_http_request_proc.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_http_request_proc.py
@@ -19,7 +19,8 @@ def test_http_request_processor():
     processor = ProcessorBuilder.build(config)
     assert processor.list_stage_names() == ["HttpRequestStage"]
     stage = processor.get_stage_by_name("HttpRequestStage")
-    assert stage.map_batches_kwargs["concurrency"] == 4
+    assert stage.map_batches_kwargs["compute"].min_size == 4
+    assert stage.map_batches_kwargs["compute"].max_size == 4
     assert stage.fn_constructor_kwargs["url"] == "http://localhost:8000"
     assert stage.fn_constructor_kwargs["additional_header"] == {
         "Authorization": "Bearer 1234567890"

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -349,21 +349,41 @@ class TestProcessorConfig:
         assert msg_part in str(e.value)
 
     @pytest.mark.parametrize(
-        "n,expected", [(1, (1, 1)), (4, (1, 4)), (10, (1, 10)), ("10", (1, 10))]
+        "n,expected",
+        [
+            (1, {"min_size": 1, "max_size": 1}),
+            (4, {"min_size": 1, "max_size": 4}),
+            (10, {"min_size": 1, "max_size": 10}),
+            ("10", {"min_size": 1, "max_size": 10}),
+        ]
     )
     def test_with_int_concurrency_scaling(self, n, expected):
         conf = ProcessorConfig(concurrency=n)
         assert conf.get_concurrency() == expected
 
-    @pytest.mark.parametrize("n,expected", [(1, (1, 1)), (4, (4, 4)), (10, (10, 10))])
+    @pytest.mark.parametrize(
+        "n,expected",
+        [
+            (1, {"size": 1}),
+            (4, {"size": 4}),
+            (10, {"size": 10}),
+        ]
+    )
     def test_with_int_concurrency_fixed(self, n, expected):
         conf = ProcessorConfig(concurrency=n)
         assert conf.get_concurrency(autoscaling_enabled=False) == expected
 
-    @pytest.mark.parametrize("pair", [(1, 1), (1, 3), (2, 8)])
-    def test_with_tuple_concurrency(self, pair):
+    @pytest.mark.parametrize(
+        "pair,expected",
+        [
+            ((1, 1), {"min_size": 1, "max_size": 1}),
+            ((1, 3), {"min_size": 1, "max_size": 3}),
+            ((2, 8), {"min_size": 2, "max_size": 8}),
+        ]
+    )
+    def test_with_tuple_concurrency(self, pair, expected):
         conf = ProcessorConfig(concurrency=pair)
-        assert conf.get_concurrency() == pair
+        assert conf.get_concurrency() == expected
 
 
 class TestMapKwargs:

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -355,7 +355,7 @@ class TestProcessorConfig:
             (4, {"min_size": 1, "max_size": 4}),
             (10, {"min_size": 1, "max_size": 10}),
             ("10", {"min_size": 1, "max_size": 10}),
-        ]
+        ],
     )
     def test_with_int_concurrency_scaling(self, n, expected):
         conf = ProcessorConfig(concurrency=n)
@@ -367,7 +367,7 @@ class TestProcessorConfig:
             (1, {"size": 1}),
             (4, {"size": 4}),
             (10, {"size": 10}),
-        ]
+        ],
     )
     def test_with_int_concurrency_fixed(self, n, expected):
         conf = ProcessorConfig(concurrency=n)
@@ -379,7 +379,7 @@ class TestProcessorConfig:
             ((1, 1), {"min_size": 1, "max_size": 1}),
             ((1, 3), {"min_size": 1, "max_size": 3}),
             ((2, 8), {"min_size": 2, "max_size": 8}),
-        ]
+        ],
     )
     def test_with_tuple_concurrency(self, pair, expected):
         conf = ProcessorConfig(concurrency=pair)

--- a/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
@@ -5,6 +5,7 @@ import pytest
 
 import ray
 from ray import serve
+from ray.data import ActorPoolStrategy
 from ray.data.llm import ServeDeploymentProcessorConfig, build_processor
 from ray.llm._internal.batch.processor import ProcessorBuilder
 from ray.serve.llm.openai_api_models import ChatCompletionRequest, CompletionRequest
@@ -39,9 +40,10 @@ def test_serve_deployment_processor(dtype_mapping):
         "dtype_mapping": dtype_mapping,
     }
 
-    assert stage.map_batches_kwargs == {
-        "concurrency": 1,
-    }
+    assert "compute" in stage.map_batches_kwargs
+    assert isinstance(stage.map_batches_kwargs["compute"], ActorPoolStrategy)
+    assert stage.map_batches_kwargs["compute"].min_size == 1
+    assert stage.map_batches_kwargs["compute"].max_size == 1
 
 
 def test_simple_serve_deployment(serve_cleanup):

--- a/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ray.data import ActorPoolStrategy
 from ray.llm._internal.batch.stages.sglang_engine_stage import (
     SGLangEngineStage,
     SGLangEngineStageUDF,
@@ -116,7 +117,7 @@ def test_sglang_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
         ),
         map_batches_kwargs=dict(
             zero_copy_batch=True,
-            concurrency=1,
+            compute=ActorPoolStrategy(size=1),
             max_concurrency=4,
             accelerator_type=gpu_type,
         ),
@@ -131,9 +132,14 @@ def test_sglang_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
             "dp_size": 2,
         },
     }
+
+    compute = stage.map_batches_kwargs.pop("compute")
+    assert isinstance(compute, ActorPoolStrategy)
+    assert compute.min_size == 1
+    assert compute.max_size == 1
+
     assert stage.map_batches_kwargs == {
         "zero_copy_batch": True,
-        "concurrency": 1,
         "max_concurrency": 4,
         "accelerator_type": gpu_type,
         "num_gpus": 4,

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import BaseModel
 
 from ray.llm._internal.batch.constants import vLLMTaskType
+from ray.data import ActorPoolStrategy
 from ray.llm._internal.batch.stages.vllm_engine_stage import (
     vLLMEngineStage,
     vLLMEngineStageUDF,
@@ -81,7 +82,7 @@ def test_vllm_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
         ),
         map_batches_kwargs=dict(
             zero_copy_batch=True,
-            concurrency=1,
+            compute=ActorPoolStrategy(size=1),
             max_concurrency=4,
             accelerator_type=gpu_type,
         ),
@@ -98,9 +99,13 @@ def test_vllm_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
         },
     }
     ray_remote_args_fn = stage.map_batches_kwargs.pop("ray_remote_args_fn")
+    compute = stage.map_batches_kwargs.pop("compute")
+    assert isinstance(compute, ActorPoolStrategy)
+    assert compute.min_size == 1
+    assert compute.max_size == 1
+
     assert stage.map_batches_kwargs == {
         "zero_copy_batch": True,
-        "concurrency": 1,
         "max_concurrency": 4,
         "accelerator_type": gpu_type,
         "num_gpus": 0,

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -7,8 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
-from ray.llm._internal.batch.constants import vLLMTaskType
 from ray.data import ActorPoolStrategy
+from ray.llm._internal.batch.constants import vLLMTaskType
 from ray.llm._internal.batch.stages.vllm_engine_stage import (
     vLLMEngineStage,
     vLLMEngineStageUDF,


### PR DESCRIPTION
## Description
Ray Data deprecates `concurrency` in favor of `compute` to configure the size of the worker pool.
https://github.com/ray-project/ray/blob/10869d565047ae02b398802e1efaf04109f27249/python/ray/data/_internal/util.py#L599-L604

User experience remains unchanged after this change:
- Users continue to specify concurrency rather than compute; compute is used only internally within Ray Data LLM.
- Autoscaling behavior is unchanged:
  - GPU stages default to autoscaling disabled.
  - Chat template, tokenization, and detokenization stages default to autoscaling enabled.
  - HTTP request handling and Serve deployment stages default to autoscaling disabled.


## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
