### PR TITLE
[3/n] catalog ray serve env vars

### DIFF
--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -74,6 +74,12 @@ Ray Serve allows you to fine-tune the backoff behavior of the request router, wh
 - `RAY_SERVE_ROUTER_RETRY_BACKOFF_MULTIPLIER`: The multiplier applied to the backoff time after each retry. Default is `2`.
 - `RAY_SERVE_ROUTER_RETRY_MAX_BACKOFF_S`: The maximum backoff time (in seconds) between retries. Default is `0.5`.
 
+### Configure proxy routing preferences
+
+Ray Serve proxies can route requests to replicas based on locality to reduce latency. You can configure this behavior using the following environment variables:
+
+- `RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING`: When enabled, the proxy prefers routing requests to replicas on the same node. Default is `1` (enabled).
+- `RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING`: When enabled, the proxy prefers routing requests to replicas in the same availability zone. Default is `1` (enabled).
 
 (serve-high-throughput)=
 ### Enable throughput-optimized serving
@@ -165,3 +171,4 @@ you can tune the following environment variables:
 
 - `RAY_SERVE_CONTROL_LOOP_INTERVAL_S`: The interval between cycles of the control loop (defaults to `0.1` seconds). Increasing this value gives the Controller more time to process requests and may help alleviate overload.
 - `RAY_SERVE_CONTROLLER_MAX_CONCURRENCY`: The maximum number of concurrent requests the Controller can handle (defaults to `15000`). The Controller accepts one long poll request per handle, so its concurrency needs scale with the number of handles. Increase this value if you have a large number of deployment handles.
+- `RAY_SERVE_MAX_CACHED_HANDLES`: The maximum number of cached deployment handles (defaults to `100`). Each handle maintains a long poll connection to the controller, so limiting the cache size reduces controller overhead. Decrease this value if you're experiencing controller overload due to many handles.

--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -74,12 +74,49 @@ Ray Serve allows you to fine-tune the backoff behavior of the request router, wh
 - `RAY_SERVE_ROUTER_RETRY_BACKOFF_MULTIPLIER`: The multiplier applied to the backoff time after each retry. Default is `2`.
 - `RAY_SERVE_ROUTER_RETRY_MAX_BACKOFF_S`: The maximum backoff time (in seconds) between retries. Default is `0.5`.
 
-### Configure proxy routing preferences
+### Configure locality-based routing
 
-Ray Serve proxies can route requests to replicas based on locality to reduce latency. You can configure this behavior using the following environment variables:
+Ray Serve routes requests to replicas based on locality to reduce network latency. The system applies locality routing in two scenarios: proxy-to-replica communication (HTTP/gRPC requests) and inter-deployment communication (replica-to-replica calls through `DeploymentHandle`).
+
+#### Routing priority
+
+When locality routing is enabled, the system selects replicas in the following priority order:
+
+1. **Same node**: Replicas running on the same node as the caller (lowest latency)
+2. **Same availability zone**: Replicas in the same availability zone as the caller
+3. **Any replica**: All available replicas (fallback when local replicas are busy)
+
+If replicas at a higher priority level are busy or unavailable, the system automatically falls back to the next level.
+
+#### Proxy-to-replica routing
+
+You can configure proxy routing behavior through environment variables:
 
 - `RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING`: When enabled, the proxy prefers routing requests to replicas on the same node. Default is `1` (enabled).
 - `RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING`: When enabled, the proxy prefers routing requests to replicas in the same availability zone. Default is `1` (enabled).
+
+#### Inter-deployment routing
+
+When one deployment calls another through a `DeploymentHandle`, you can enable locality routing to reduce latency between deployments.
+
+**Same-node routing**: By default, inter-deployment calls don't prefer same-node replicas. To enable same-node routing, initialize the handle with the `_prefer_local_routing` option:
+
+```python
+from ray import serve
+from ray.serve.handle import DeploymentHandle
+
+@serve.deployment
+class Caller:
+    def __init__(self, target_handle: DeploymentHandle):
+        # Enable same-node routing for this handle
+        self._handle = target_handle.options(_prefer_local_routing=True)
+
+    async def call_target(self):
+        # Requests prefer replicas on the same node as this Caller replica
+        return await self._handle.remote()
+```
+
+**Same-AZ routing**: The `RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING` environment variable controls availability zone routing for both proxy and inter-deployment communication. You can't configure AZ routing per-handle.
 
 (serve-high-throughput)=
 ### Enable throughput-optimized serving

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -397,8 +397,8 @@ export RAY_SERVE_HTTP_PROXY_CALLBACK_IMPORT_PATH="mymodule.callbacks:setup_proxy
 
 Ray Serve logs warnings when replicas take too long to start, helping you identify issues such as slow `__init__` methods, long-running `reconfigure` methods, or resource scheduling delays. You can configure this warning behavior with the following environment variables:
 
-- `SERVE_SLOW_STARTUP_WARNING_S`: The time (in seconds) after which Ray Serve considers a replica to have a slow startup (defaults to `30`). If a replica takes longer than this to be scheduled or initialized, Ray Serve logs a warning.
-- `SERVE_SLOW_STARTUP_WARNING_PERIOD_S`: The minimum interval (in seconds) between slow startup warning messages (defaults to `30`). This prevents log spam when multiple replicas start slowly.
+- `RAY_SERVE_SLOW_STARTUP_WARNING_S`: The time (in seconds) after which Ray Serve considers a replica to have a slow startup (defaults to `30`). If a replica takes longer than this to be scheduled or initialized, Ray Serve logs a warning.
+- `RAY_SERVE_SLOW_STARTUP_WARNING_PERIOD_S`: The minimum interval (in seconds) between slow startup warning messages (defaults to `30`). This prevents log spam when multiple replicas start slowly.
 
 
 ### Set Request ID

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -370,6 +370,37 @@ Then set the environment variable before starting Ray:
 export RAY_SERVE_CONTROLLER_CALLBACK_IMPORT_PATH="mymodule.callbacks:setup_custom_logging"
 ```
 
+#### Run custom initialization code in the HTTP proxy
+
+Similarly, you can run custom initialization code when the HTTP proxy starts by setting the `RAY_SERVE_HTTP_PROXY_CALLBACK_IMPORT_PATH` environment variable. This variable should point to a callback function that runs during HTTP proxy initialization. The function doesn't need to return anything.
+
+For example:
+
+```python
+# mymodule/callbacks.py
+import logging
+
+def setup_proxy_logging():
+    logger = logging.getLogger("ray.serve")
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("[PROXY] %(message)s"))
+    logger.addHandler(handler)
+```
+
+Then set the environment variable before starting Ray:
+
+```bash
+export RAY_SERVE_HTTP_PROXY_CALLBACK_IMPORT_PATH="mymodule.callbacks:setup_proxy_logging"
+```
+
+#### Configure slow startup warnings
+
+Ray Serve logs warnings when replicas take too long to start, helping you identify issues such as slow `__init__` methods, long-running `reconfigure` methods, or resource scheduling delays. You can configure this warning behavior with the following environment variables:
+
+- `SERVE_SLOW_STARTUP_WARNING_S`: The time (in seconds) after which Ray Serve considers a replica to have a slow startup (defaults to `30`). If a replica takes longer than this to be scheduled or initialized, Ray Serve logs a warning.
+- `SERVE_SLOW_STARTUP_WARNING_PERIOD_S`: The minimum interval (in seconds) between slow startup warning messages (defaults to `30`). This prevents log spam when multiple replicas start slowly.
+
+
 ### Set Request ID
 You can set a custom request ID for each HTTP request by including `X-Request-ID` in the request header and retrieve request ID from response. For example
 

--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -61,6 +61,15 @@ The `proxy_location` field configures where to run proxies to handle traffic to 
 - HeadOnly: Only run a single proxy on the head node.
 - Disabled: Don't run proxies at all. Set this value if you are only making calls to your applications using deployment handles.
 
+By default, when `proxy_location` is set to `EveryNode`, Ray Serve always runs a proxy on the head node even if it has no replicas. You can disable this behavior by setting the environment variable `RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE=0`.
+
+You can also configure proxy health checks and lifecycle behavior with the following environment variables:
+
+- `RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S`: The timeout (in seconds) for each proxy health check. Default is `10.0`.
+- `RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S`: The period (in seconds) between proxy health checks. Default is `10.0`.
+- `RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S`: The timeout (in seconds) for checking if a proxy is ready. Default is `5.0`.
+- `RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S`: The minimum time (in seconds) a proxy stays in the draining state before termination. This gives the load balancer time to detect that the proxy is draining and stop sending traffic. Default is `30.0`.
+
 (http-config)=
 
 ## HTTP config 

--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -61,8 +61,6 @@ The `proxy_location` field configures where to run proxies to handle traffic to 
 - HeadOnly: Only run a single proxy on the head node.
 - Disabled: Don't run proxies at all. Set this value if you are only making calls to your applications using deployment handles.
 
-By default, when `proxy_location` is set to `EveryNode`, Ray Serve always runs a proxy on the head node even if it has no replicas. You can disable this behavior by setting the environment variable `RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE=0`.
-
 You can also configure proxy health checks and lifecycle behavior with the following environment variables:
 
 - `RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S`: How often (in seconds) the Serve controller checks if each proxy is healthy. Default is `10.0`.

--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -65,10 +65,10 @@ By default, when `proxy_location` is set to `EveryNode`, Ray Serve always runs a
 
 You can also configure proxy health checks and lifecycle behavior with the following environment variables:
 
-- `RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S`: The timeout (in seconds) for each proxy health check. Default is `10.0`.
-- `RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S`: The period (in seconds) between proxy health checks. Default is `10.0`.
-- `RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S`: The timeout (in seconds) for checking if a proxy is ready. Default is `5.0`.
-- `RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S`: The minimum time (in seconds) a proxy stays in the draining state before termination. This gives the load balancer time to detect that the proxy is draining and stop sending traffic. Default is `30.0`.
+- `RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S`: How often (in seconds) the Serve controller checks if each proxy is healthy. Default is `10.0`.
+- `RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S`: How long (in seconds) the controller waits for a proxy to respond to a health check before considering it failed. If a proxy fails 3 consecutive health checks, the controller marks it unhealthy and restarts it. Default is `10.0`.
+- `RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S`: How long (in seconds) to wait for a proxy to become ready during startup. Default is `5.0`.
+- `RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S`: The minimum time (in seconds) a proxy stays in the draining state before termination. During draining: (1) the proxy fails health checks, causing the load balancer to stop routing new traffic(because it sees the unhealthy health checks for that proxy), (2) ongoing requests complete normally, and (3) the proxy waits at least this period before terminating. Default is `30.0`.
 
 (http-config)=
 

--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -49,14 +49,20 @@ In a composable deployment graph, each deployment is responsible for its own hea
 
 ### Replica constructor retries
 
-When a replica's constructor (the `__init__` method) fails, Ray Serve automatically retries creating the replica. You can configure the maximum number of constructor retries per replica using the `RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT` environment variable. The default is `3` retries per replica.
+When a replica's constructor (the `__init__` method) fails, Ray Serve automatically retries creating the replica. You can configure this behavior in two ways:
 
-The total maximum constructor retries for a deployment is calculated as `min(num_replicas * RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT, RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT)`. You can also set `RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT` to control the absolute maximum retries across all replicas (no default limit).
+- **Per-deployment**: Use the `max_constructor_retry_count` option in `@serve.deployment()` to set the maximum retries for that deployment. Default is `20`.
+- **Per-replica**: Use the `RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT` environment variable to limit retries per replica. Default is `3`.
 
-For example, to increase the per-replica retry count:
+The total maximum constructor retries for a deployment is `min(num_replicas * RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT, max_constructor_retry_count)`.
 
-```bash
-export RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT=5
+For example:
+
+```python
+# Set max constructor retries for this deployment
+@serve.deployment(max_constructor_retry_count=10)
+class MyDeployment:
+    ...
 ```
 
 ### Worker node recovery

--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -47,6 +47,18 @@ You shouldn't call ``check_health`` directly through a deployment handle (e.g., 
 In a composable deployment graph, each deployment is responsible for its own health, independent of the other deployments it's bound to. For example, in an application defined by ``app = ParentDeployment.bind(ChildDeployment.bind())``, ``ParentDeployment`` doesn't restart if ``ChildDeployment`` replicas fail their health checks. When the ``ChildDeployment`` replicas recover, the handle in ``ParentDeployment`` updates automatically to route requests to the healthy replicas.
 :::
 
+### Replica constructor retries
+
+When a replica's constructor (the `__init__` method) fails, Ray Serve automatically retries creating the replica. You can configure the maximum number of constructor retries per replica using the `RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT` environment variable. The default is `3` retries per replica.
+
+The total maximum constructor retries for a deployment is calculated as `min(num_replicas * RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT, RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT)`. You can also set `RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT` to control the absolute maximum retries across all replicas (no default limit).
+
+For example, to increase the per-replica retry count:
+
+```bash
+export RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT=5
+```
+
 ### Worker node recovery
 
 :::{admonition} KubeRay Required

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -59,16 +59,12 @@ HTTP_PROXY_TIMEOUT = 60
 #: This constant is deprecated and will be removed in the future.
 #: Please use 'max_constructor_retry_count' instead in configurations.
 MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT = get_env_int(
-    "RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT",
-    get_env_int("MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT", None),
+    "RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT", None
 )
 
 # Max retry on deployment constructor is
 # min(num_replicas * MAX_PER_REPLICA_RETRY_COUNT, MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT)
-MAX_PER_REPLICA_RETRY_COUNT = get_env_int(
-    "RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT",
-    get_env_int("MAX_PER_REPLICA_RETRY_COUNT", 3),
-)
+MAX_PER_REPLICA_RETRY_COUNT = get_env_int("RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT", 3)
 
 
 # If you are wondering why we are using histogram buckets, please refer to
@@ -209,9 +205,7 @@ RECONFIGURE_METHOD = "reconfigure"
 
 #: Limit the number of cached handles because each handle has long poll
 #: overhead. See https://github.com/ray-project/ray/issues/18980
-MAX_CACHED_HANDLES = get_env_int_positive(
-    "RAY_SERVE_MAX_CACHED_HANDLES", get_env_int_positive("MAX_CACHED_HANDLES", 100)
-)
+MAX_CACHED_HANDLES = get_env_int_positive("RAY_SERVE_MAX_CACHED_HANDLES", 100)
 
 #: Because ServeController will accept one long poll request per handle, its
 #: concurrency needs to scale as O(num_handles)

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -52,18 +52,8 @@ CONTROL_LOOP_INTERVAL_S = get_env_float_non_negative(
 #: Max time to wait for HTTP proxy in `serve.start()`.
 HTTP_PROXY_TIMEOUT = 60
 
-#: Max retry count for allowing failures in replica constructor.
-#: If no replicas at target version is running by the time we're at
-#: max constructor retry count, deploy() is considered failed.
-#: By default we set threshold as min(num_replicas * 3, this value)
-#: This constant is deprecated and will be removed in the future.
-#: Please use 'max_constructor_retry_count' instead in configurations.
-MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT = get_env_int(
-    "RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT", None
-)
-
 # Max retry on deployment constructor is
-# min(num_replicas * MAX_PER_REPLICA_RETRY_COUNT, MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT)
+# min(num_replicas * MAX_PER_REPLICA_RETRY_COUNT, max_constructor_retry_count)
 MAX_PER_REPLICA_RETRY_COUNT = get_env_int("RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT", 3)
 
 

--- a/python/ray/serve/_private/constants_utils.py
+++ b/python/ray/serve/_private/constants_utils.py
@@ -49,8 +49,6 @@ T = TypeVar("T")
 
 # todo: remove for the '3.0.0' release.
 _wrong_names_white_list = {
-    "MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT",
-    "MAX_PER_REPLICA_RETRY_COUNT",
     "REQUEST_LATENCY_BUCKETS_MS",
     "MODEL_LOAD_LATENCY_BUCKETS_MS",
     "MAX_CACHED_HANDLES",


### PR DESCRIPTION
This PR adds documentation for several Ray Serve environment variables that were defined in `constants.py` but missing from the documentation, and also cleans up deprecated legacy environment variable names.

### Changes Made

#### Documentation additions

**`doc/source/serve/production-guide/config.md`** (Proxy config section):
- `RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE` - Control whether to always run a proxy on the head node
- `RAY_SERVE_PROXY_HEALTH_CHECK_TIMEOUT_S` - Proxy health check timeout
- `RAY_SERVE_PROXY_HEALTH_CHECK_PERIOD_S` - Proxy health check period
- `RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S` - Proxy ready check timeout
- `RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S` - Minimum proxy draining period

**`doc/source/serve/production-guide/fault-tolerance.md`** (New "Replica constructor retries" section):
- `RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT` - Max constructor retries per replica
- `RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT` - Max constructor retries per deployment

**`doc/source/serve/advanced-guides/performance.md`**:
- `RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING` - Proxy node locality routing preference
- `RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING` - Proxy AZ locality routing preference
- `RAY_SERVE_MAX_CACHED_HANDLES` - Max cached deployment handles (controller debugging section)

**`doc/source/serve/monitoring.md`**:
- `RAY_SERVE_HTTP_PROXY_CALLBACK_IMPORT_PATH` - HTTP proxy initialization callback
- `SERVE_SLOW_STARTUP_WARNING_S` - Slow startup warning threshold
- `SERVE_SLOW_STARTUP_WARNING_PERIOD_S` - Slow startup warning interval

#### Code cleanup

**`python/ray/serve/_private/constants.py`**:
- Removed legacy fallback for `MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT` (now only `RAY_SERVE_MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT`)
- Removed legacy fallback for `MAX_PER_REPLICA_RETRY_COUNT` (now only `RAY_SERVE_MAX_PER_REPLICA_RETRY_COUNT`)
- Removed legacy fallback for `MAX_CACHED_HANDLES` (now only `RAY_SERVE_MAX_CACHED_HANDLES`)

**`python/ray/serve/_private/constants_utils.py`**:
- Removed `MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT` and `MAX_PER_REPLICA_RETRY_COUNT` from the deprecated names whitelist