### PR TITLE
[Doc] Improve docs for ray.data.Datasource

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -617,7 +617,7 @@ def setup(app):
             return True  # Log all other warnings
 
     logging.getLogger("sphinx").addFilter(DuplicateObjectFilter())
-    
+
     # Register hook to mark orphan documents
     example_orphan_documents = collect_example_orphans(app.confdir, app.srcdir)
     def mark_orphans(app, docname, _source):

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -225,7 +225,43 @@ class _DatasourcePredicatePushdownMixin:
 class Datasource(_DatasourceProjectionPushdownMixin, _DatasourcePredicatePushdownMixin):
     """Interface for defining a custom :class:`~ray.data.Dataset` datasource.
 
+    User may subclass this class to implement a custom datasource. The subclass should
+    implement :meth:`.get_read_tasks` and
+    :meth:`.estimate_inmemory_data_size` to read the data and estimate the in-memory data size, respectively.
+
     To read a datasource into a dataset, use :meth:`~ray.data.read_datasource`.
+
+    Example:
+        >>> from ray.data.context import DataContext
+        >>> class MyDatasource(Datasource):
+        ...     def __init__(self, num_rows: int = 100):
+        ...         super().__init__()
+        ...         self.num_rows = num_rows
+        ...     def get_read_tasks(
+        ...         self,
+        ...         parallelism: int,
+        ...         per_task_row_limit: int | None = None,
+        ...         data_context: DataContext | None = None,
+        ...     ) -> List["ReadTask"]:
+        ...         # Split num_rows across parallelism tasks
+        ...         rows_per_task = self.num_rows // parallelism
+        ...         return [
+        ...             ReadTask(
+        ...                 lambda: [pa.Table.from_pydict({"data": range(rows_per_task)})],
+        ...                 BlockMetadata(rows_per_task, rows_per_task * 8, None, None),
+        ...             ) for _ in range(parallelism)
+        ...         ]
+        ...     def estimate_inmemory_data_size(self) -> Optional[int]:
+        ...         # Return total size for all data (independent of parallelism)
+        ...         return self.num_rows * 8
+        >>> ds = MyDatasource(num_rows=100)
+        >>> tasks = ds.get_read_tasks(parallelism=5)
+        >>> len(tasks) == 5
+        True
+        >>> tasks[0].metadata.num_rows == 20
+        True
+        >>> ds.estimate_inmemory_data_size() == sum(t.metadata.size_bytes for t in tasks)
+        True
     """  # noqa: E501
 
     def __init__(self):
@@ -286,6 +322,8 @@ class Datasource(_DatasourceProjectionPushdownMixin, _DatasourcePredicatePushdow
 
     @property
     def should_create_reader(self) -> bool:
+        """Return True if the datasource should create a legacy reader"""
+
         has_implemented_get_read_tasks = (
             type(self).get_read_tasks is not Datasource.get_read_tasks
         )
@@ -293,9 +331,10 @@ class Datasource(_DatasourceProjectionPushdownMixin, _DatasourcePredicatePushdow
             type(self).estimate_inmemory_data_size
             is not Datasource.estimate_inmemory_data_size
         )
-        return (
-            not has_implemented_get_read_tasks
-            or not has_implemented_estimate_inmemory_data_size
+        # False when both get_read_tasks and estimate_inmemory_data_size are implemented
+        return not (
+            has_implemented_get_read_tasks
+            and has_implemented_estimate_inmemory_data_size
         )
 
     @property

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -109,7 +109,7 @@ from ray.data.datasource.util import (
     _validate_head_node_resources_for_local_scheduling,
 )
 from ray.types import ObjectRef
-from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI, RayDeprecationWarning
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if TYPE_CHECKING:
@@ -4537,7 +4537,7 @@ def _get_datasource_or_legacy_reader(
             "`create_reader` has been deprecated in Ray 2.9. Instead of creating a "
             "`Reader`, implement `Datasource.get_read_tasks` and "
             "`Datasource.estimate_inmemory_data_size`.",
-            DeprecationWarning,
+            RayDeprecationWarning,
         )
         datasource_or_legacy_reader = ds.create_reader(**kwargs)
     else:


### PR DESCRIPTION
## Description

Minor updates related to `Datasource`:
* There is a warning when the datasource has not implemented all the necessary functions. This PR updates it to use `RayDeprecatedWarning` instead of the generic one (which got suppressed for some reason)
* Added a line in the doc about which two functions to implement when subclassing `Datasource`.
