### PR TITLE
[Data] Add random() and uuid() expression

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -747,6 +747,7 @@ autodoc_mock_imports = [
     "async_timeout",
     "backoff",
     "cachetools",
+    "comet_ml",
     "composer",
     "cupy",
     "dask",

--- a/doc/source/data/api/expressions.rst
+++ b/doc/source/data/api/expressions.rst
@@ -24,11 +24,13 @@ Public API
     pyarrow_udf
     download
     monotonically_increasing_id
+    random
+    uuid
 
 Expression Classes
 ------------------
 
-These classes represent the structure of expressions. You typically don't need to 
+These classes represent the structure of expressions. You typically don't need to
 instantiate them directly, but you may encounter them when working with expressions.
 
 .. autosummary::
@@ -42,6 +44,10 @@ instantiate them directly, but you may encounter them when working with expressi
     UnaryExpr
     UDFExpr
     StarExpr
+    DownloadExpr
+    MonotonicallyIncreasingIdExpr
+    RandomExpr
+    UUIDExpr
 
 Expression namespaces
 ------------------------------------

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -2114,3 +2114,17 @@ py_test(
         "//:ray_lib",
     ],
 )
+
+py_test(
+    name = "test_synthetic_expression",
+    size = "small",
+    srcs = ["tests/test_synthetic_expression.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -23,9 +23,11 @@ from ray.data.expressions import (
     LiteralExpr,
     MonotonicallyIncreasingIdExpr,
     Operation,
+    RandomExpr,
     StarExpr,
     UDFExpr,
     UnaryExpr,
+    UUIDExpr,
 )
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI
@@ -181,6 +183,22 @@ class _IcebergExpressionVisitor(
         """Monotonically increasing ID expressions cannot be converted to Iceberg expressions."""
         raise TypeError(
             "monotonically_increasing_id expressions cannot be converted to Iceberg filter expressions."
+        )
+
+    def visit_random(
+        self, expr: "RandomExpr"
+    ) -> "BooleanExpression | UnboundTerm[Any] | Literal[Any]":
+        """Random expressions cannot be converted to Iceberg expressions."""
+        raise TypeError(
+            "Random expressions cannot be converted to Iceberg filter expressions."
+        )
+
+    def visit_uuid(
+        self, expr: "UUIDExpr"
+    ) -> "BooleanExpression | UnboundTerm[Any] | Literal[Any]":
+        """UUID expressions cannot be converted to Iceberg expressions."""
+        raise TypeError(
+            "UUID expressions cannot be converted to Iceberg filter expressions."
         )
 
 

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -25,9 +25,11 @@ from ray.data.expressions import (
     LiteralExpr,
     MonotonicallyIncreasingIdExpr,
     Operation,
+    RandomExpr,
     StarExpr,
     UDFExpr,
     UnaryExpr,
+    UUIDExpr,
     _ExprVisitor,
     col,
 )
@@ -523,8 +525,12 @@ class _ConvertToNativeExpressionVisitor(ast.NodeVisitor):
         )
 
     def visit_Call(self, node: ast.Call) -> "Expr":
-        """Handle function calls for operations like is_null, is_not_null, is_nan."""
-        from ray.data.expressions import BinaryExpr, Operation, UnaryExpr
+        """Handle function calls for operations like is_null, is_not_null, is_nan, random."""
+        from ray.data.expressions import (
+            BinaryExpr,
+            Operation,
+            UnaryExpr,
+        )
 
         func_name = node.func.id if isinstance(node.func, ast.Name) else str(node.func)
 
@@ -552,6 +558,18 @@ class _ConvertToNativeExpressionVisitor(ast.NodeVisitor):
             left = self.visit(node.args[0])
             right = self.visit(node.args[1])
             return BinaryExpr(Operation.IN, left, right)
+        elif func_name == "random":
+            raise ValueError(
+                "random() is not supported in string expressions. "
+                "String expressions are deprecated. Please use the expression API instead: "
+                "from ray.data.expressions import random; ds.filter(expr=(random(seed=42)>0.5))"
+            )
+        elif func_name == "uuid":
+            raise ValueError(
+                "uuid() is not supported in string expressions. "
+                "String expressions are deprecated. Please use the expression API instead: "
+                "ds.filter(expr=uuid().str.starts_with('a'))"
+            )
         else:
             raise ValueError(f"Unsupported function: {func_name}")
 
@@ -746,6 +764,42 @@ class NativeExpressionEvaluator(_ExprVisitor[Union[BlockColumn, ScalarType]]):
             return pa.array(ids)
         else:
             raise TypeError(f"Unsupported block type: {block_type}")
+
+    def visit_random(self, expr: RandomExpr) -> Union[BlockColumn, ScalarType]:
+        """Visit a random expression and return the result of the operation.
+
+        Args:
+            expr: The random expression.
+
+        Returns:
+            The result of the random operation as a BlockColumn.
+        """
+        from ray.data._internal.planner.plan_expression.synthetic_impl import (
+            eval_random,
+        )
+
+        return eval_random(
+            self.block_accessor.num_rows(),
+            self.block_accessor.block_type(),
+            seed=expr.seed,
+            reseed_after_execution=expr.reseed_after_execution,
+            instance_id=expr._instance_id,
+        )
+
+    def visit_uuid(self, expr: UUIDExpr) -> Union[BlockColumn, ScalarType]:
+        """Visit a uuid expression and return the result of the operation.
+
+        Args:
+            expr: The uuid expression.
+
+        Returns:
+            The result of the uuid operation as a BlockColumn.
+        """
+        from ray.data._internal.planner.plan_expression.synthetic_impl import eval_uuid
+
+        return eval_uuid(
+            self.block_accessor.num_rows(), self.block_accessor.block_type()
+        )
 
 
 def eval_expr(expr: Expr, block: Block) -> Union[BlockColumn, ScalarType]:

--- a/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_visitors.py
@@ -10,9 +10,11 @@ from ray.data.expressions import (
     LiteralExpr,
     MonotonicallyIncreasingIdExpr,
     Operation,
+    RandomExpr,
     StarExpr,
     UDFExpr,
     UnaryExpr,
+    UUIDExpr,
     _CallableClassUDF,
     _ExprVisitor,
 )
@@ -83,6 +85,14 @@ class _ExprVisitorBase(_ExprVisitor[None]):
         self, expr: "MonotonicallyIncreasingIdExpr"
     ) -> None:
         """Visit a monotonically_increasing_id expression (no columns to collect)."""
+        pass
+
+    def visit_random(self, expr: "RandomExpr") -> None:
+        """Visit a synthetic expression (no columns to collect)."""
+        pass
+
+    def visit_uuid(self, expr: "UUIDExpr") -> None:
+        """Visit a uuid expression (no columns to collect)."""
         pass
 
 
@@ -301,6 +311,28 @@ class _ColumnSubstitutionVisitor(_ExprVisitor[Expr]):
         """
         return expr
 
+    def visit_random(self, expr: "RandomExpr") -> Expr:
+        """Visit a random expression (no rewriting needed).
+
+        Args:
+            expr: The random expression.
+
+        Returns:
+            The original random expression.
+        """
+        return expr
+
+    def visit_uuid(self, expr: "UUIDExpr") -> Expr:
+        """Visit a uuid expression (no rewriting needed).
+
+        Args:
+            expr: The uuid expression.
+
+        Returns:
+            The original uuid expression.
+        """
+        return expr
+
 
 def _is_col_expr(expr: Expr) -> bool:
     return isinstance(expr, ColumnExpr) or (
@@ -433,6 +465,16 @@ class _TreeReprVisitor(_ExprVisitor[str]):
     ) -> str:
         return self._make_tree_lines("MONOTONICALLY_INCREASING_ID()", expr=expr)
 
+    def visit_random(self, expr: "RandomExpr") -> str:
+        if expr.seed is None:
+            label = "RANDOM()"
+        else:
+            label = f"RANDOM(seed={expr.seed}, reseed_after_execution={expr.reseed_after_execution})"
+        return self._make_tree_lines(label, expr=expr)
+
+    def visit_uuid(self, expr: "UUIDExpr") -> str:
+        return self._make_tree_lines("UUID()", expr=expr)
+
 
 class _InlineExprReprVisitor(_ExprVisitor[str]):
     """Visitor that generates concise inline string representations of expressions.
@@ -527,6 +569,14 @@ class _InlineExprReprVisitor(_ExprVisitor[str]):
     ) -> str:
         """Visit a monotonically_increasing_id expression and return its inline representation."""
         return "monotonically_increasing_id()"
+
+    def visit_random(self, expr: "RandomExpr") -> str:
+        """Visit a random expression and return its inline representation."""
+        return "random()"
+
+    def visit_uuid(self, expr: "UUIDExpr") -> str:
+        """Visit a uuid expression and return its inline representation."""
+        return "uuid()"
 
 
 def get_column_references(expr: Expr) -> List[str]:

--- a/python/ray/data/_internal/planner/plan_expression/synthetic_impl.py
+++ b/python/ray/data/_internal/planner/plan_expression/synthetic_impl.py
@@ -1,0 +1,124 @@
+import uuid
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+from ray.data._internal.execution.interfaces.task_context import TaskContext
+from ray.data.block import BlockColumn, BlockType
+
+
+def eval_random(
+    num_rows: int,
+    block_type: BlockType,
+    *,
+    seed: int | None = None,
+    reseed_after_execution: bool = True,
+    instance_id: str | None = None,
+) -> BlockColumn:
+    """Implementation of the random expression.
+
+    Args:
+        num_rows: The number of rows to generate random values for.
+        block_type: The type of block to generate random values for.
+        seed: The seed to use for the random number generator.
+        reseed_after_execution: Whether to reseed the random number generator after each execution.
+        instance_id: Unique identifier for the random expression instance, used to isolate
+            block count state when a single task processes multiple blocks.
+
+    Returns:
+        A BlockColumn containing the random values.
+
+    Raises:
+        TypeError: If the block type is not supported.
+    """
+
+    if seed is not None:
+        # Numpy allows using a seed sequence (list of integers) to initialize
+        # a random number generator. This allows us to maintain reproduciblity while
+        # ensuring randomness in parallel execution.
+        # See https://numpy.org/doc/2.2/reference/random/parallel.html#sequence-of-integer-seeds
+        # Below we uses four components to create a seed sequence (fastest changing component first):
+        # 1. A per-block counter within the task (to differentiate blocks in the same task)
+        # 2. An index based on the remote task in Ray Data
+        # 3. An incrementing index of Ray Dataset execution (e.g., multiple training epochs)
+        # 4. A base seed fixed by the user
+
+        ctx = TaskContext.get_current()
+
+        if ctx is None:
+            import warnings
+
+            warnings.warn(
+                "TaskContext is not available for random() expression with seed. "
+                "Falling back to task_idx=0 for all tasks, which reduces the parallelism "
+                "benefits of random number generation. If you see this warning, please "
+                "report it as it may indicate an execution context issue.",
+                stacklevel=2,
+            )
+            task_idx = 0
+            block_idx = 0
+        else:
+            task_idx = ctx.task_idx
+
+            # Key the counter by expression instance ID so that multiple expressions
+            # in the same projection will have isolated block count state.
+            # This is required because a single task may process multiple blocks if
+            # the upstream data source does not compress the data into a single block.
+            if instance_id is not None:
+                counter_key = f"_random_{instance_id}_counter"
+                block_idx = ctx.kwargs.get(counter_key, 0)
+                ctx.kwargs[counter_key] = block_idx + 1
+            else:
+                block_idx = 0
+
+        if reseed_after_execution:
+            from ray.data.context import DataContext
+
+            data_context = (
+                DataContext.get_current()
+            )  # get or create DataContext, never None
+            execution_idx = data_context._execution_idx
+        else:
+            execution_idx = 0
+
+        # Numpy recommends fastest changing component to be the first element
+        block_seed = [block_idx, task_idx, execution_idx, seed]
+    else:
+        block_seed = None
+
+    rng = np.random.default_rng(block_seed)
+    random_values = rng.random(num_rows)
+
+    # Convert to appropriate format based on block type
+    if block_type == BlockType.PANDAS:
+        return pd.Series(random_values, dtype=np.float64)
+    elif block_type == BlockType.ARROW:
+        return pa.array(random_values, type=pa.float64())
+
+    raise TypeError(f"Unsupported block type: {block_type}")
+
+
+def eval_uuid(
+    num_rows: int,
+    block_type: BlockType,
+) -> BlockColumn:
+    """Implementation of the uuid expression.
+
+    Args:
+        num_rows: The number of rows to generate uuid values for.
+        block_type: The type of block to generate uuid values for.
+
+    Returns:
+        A BlockColumn containing the uuid values.
+
+    Raises:
+        TypeError: If the block type is not supported.
+    """
+    arr = [str(uuid.uuid4()) for _ in range(num_rows)]
+    if block_type == BlockType.PANDAS:
+        return pd.Series(arr, dtype=pd.StringDtype())
+    elif block_type == BlockType.ARROW:
+        return pa.array(arr, type=pa.string())
+
+    raise TypeError(f"Unsupported block type: {block_type}")

--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -54,6 +54,7 @@ def generate_random_shuffle_fn(
             map_transformer.override_target_max_block_size(None)
 
             def upstream_map_fn(blocks):
+                DataContext._set_current(data_context)
                 return map_transformer.apply_transform(blocks, ctx)
 
             # If there is a fused upstream operator,

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -46,6 +46,7 @@ def generate_repartition_fn(
             map_transformer.override_target_max_block_size(None)
 
             def upstream_map_fn(blocks):
+                DataContext._set_current(data_context)
                 return map_transformer.apply_transform(blocks, ctx)
 
         shuffle_spec = ShuffleTaskSpec(

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-import uuid
+import uuid as builtin_uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -27,6 +27,8 @@ from ray.data.datatype import DataType
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
+    import pyarrow.compute
+
     from ray.data.namespace_expressions.arr_namespace import _ArrayNamespace
     from ray.data.namespace_expressions.dt_namespace import _DatetimeNamespace
     from ray.data.namespace_expressions.list_namespace import _ListNamespace
@@ -39,9 +41,12 @@ T = TypeVar("T")
 UDFCallable = Callable[..., "UDFExpr"]
 Decorated = Union[UDFCallable, Type[T]]
 
+# Whether to reseed the random number generator after each Ray Dataset execution.
+DEFAULT_RESEED_AFTER_EXECUTION = True
+
 
 @DeveloperAPI(stability="alpha")
-class Operation(Enum):
+class Operation(str, Enum):
     """Enumeration of supported operations in expressions.
 
     This enum defines all the binary operations that can be performed
@@ -112,6 +117,10 @@ class _ExprVisitor(ABC, Generic[T]):
             return self.visit_star(expr)
         elif isinstance(expr, MonotonicallyIncreasingIdExpr):
             return self.visit_monotonically_increasing_id(expr)
+        elif isinstance(expr, RandomExpr):
+            return self.visit_random(expr)
+        elif isinstance(expr, UUIDExpr):
+            return self.visit_uuid(expr)
         else:
             raise TypeError(f"Unsupported expression type for conversion: {type(expr)}")
 
@@ -151,6 +160,14 @@ class _ExprVisitor(ABC, Generic[T]):
     def visit_monotonically_increasing_id(
         self, expr: "MonotonicallyIncreasingIdExpr"
     ) -> T:
+        pass
+
+    @abstractmethod
+    def visit_random(self, expr: "RandomExpr") -> T:
+        pass
+
+    @abstractmethod
+    def visit_uuid(self, expr: "UUIDExpr") -> T:
         pass
 
 
@@ -226,6 +243,12 @@ class _PyArrowExpressionVisitor(_ExprVisitor["pyarrow.compute.Expression"]):
         raise TypeError(
             "Monotonically Increasing ID expressions cannot be converted to PyArrow expressions"
         )
+
+    def visit_random(self, expr: "RandomExpr") -> "pyarrow.compute.Expression":
+        raise TypeError("Random expressions cannot be converted to PyArrow expressions")
+
+    def visit_uuid(self, expr: "UUIDExpr") -> "pyarrow.compute.Expression":
+        raise TypeError("UUID expressions cannot be converted to PyArrow expressions")
 
 
 @DeveloperAPI(stability="alpha")
@@ -1535,13 +1558,65 @@ class MonotonicallyIncreasingIdExpr(Expr):
     """Expression that represents a monotonically increasing ID column."""
 
     # Unique identifier for each expression to isolate row count state
-    _instance_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    _instance_id: str = field(default_factory=lambda: str(builtin_uuid.uuid4()))
 
     data_type: DataType = field(default_factory=lambda: DataType.int64(), init=False)
 
     def structurally_equals(self, other: Any) -> bool:
         # Non-deterministic, never structurally equal to another expression
         return False
+
+
+@DeveloperAPI
+@dataclass(frozen=True, eq=False, repr=False)
+class RandomExpr(Expr):
+    """Expression that represents a random number generation operation.
+
+    Args:
+        seed: The seed to use for the random number generator.
+        reseed_after_execution: Whether to reseed the random number generator after each execution.
+            This parameter is ignored when ``seed`` is None.
+
+    Example:
+        >>> from ray.data.expressions import random
+        >>> random()
+        RANDOM()
+        >>> random(seed=1234)
+        RANDOM(seed=1234, reseed_after_execution=True)
+    """
+
+    seed: int | None = None
+    reseed_after_execution: bool = DEFAULT_RESEED_AFTER_EXECUTION
+    data_type: DataType = field(default_factory=lambda: DataType.float64(), init=False)
+
+    # Unique identifier for each expression to isolate block count state
+    _instance_id: str = field(default_factory=lambda: str(builtin_uuid.uuid4()))
+
+    def structurally_equals(self, other: Any) -> bool:
+        return (
+            isinstance(other, RandomExpr)
+            and self.data_type == other.data_type
+            and self.seed == other.seed
+            and self.reseed_after_execution == other.reseed_after_execution
+        )
+
+
+@DeveloperAPI
+@dataclass(frozen=True, eq=False, repr=False)
+class UUIDExpr(Expr):
+    """Expression that represents a UUID generation operation.
+
+    Example:
+        >>> from ray.data.expressions import UUIDExpr
+        >>> # Generate UUIDs
+        >>> UUIDExpr()
+        UUID()
+    """
+
+    data_type: DataType = field(default_factory=lambda: DataType.string(), init=False)
+
+    def structurally_equals(self, other: Any) -> bool:
+        return isinstance(other, UUIDExpr)
 
 
 @PublicAPI(stability="beta")
@@ -1687,6 +1762,104 @@ def monotonically_increasing_id() -> MonotonicallyIncreasingIdExpr:
     return MonotonicallyIncreasingIdExpr()
 
 
+@PublicAPI(stability="alpha")
+def random(
+    *,
+    seed: int | None = None,
+    reseed_after_execution: bool = DEFAULT_RESEED_AFTER_EXECUTION,
+) -> RandomExpr:
+    """
+    Create an expression that generates random numbers.
+
+    This creates an expression that generates random floating-point numbers
+    between 0 (inclusive) and 1 (exclusive) for each row. The generator can
+    be optionally seeded for reproducibility.
+
+    Args:
+        seed: An optional integer seed for the random number generator. If None,
+            uses system randomness (non-deterministic).
+        reseed_after_execution: If False, the random number generator (RNG) will be
+            initialized with the provided ``seed``. Each dataset execution will produce
+            the same set of random values (except for the usual randomness due to task
+            parallelism and ordering of the data). If True, the provided seed is treated
+            as an "initial" seed and each dataset execution will generate new random
+            values. This is useful for reproducibility across multiple epochs in model
+            training. Under the hood, the seed sequence used to initialize the RNG consists
+            of three components: an index of the Ray task, an index of the dataset execution,
+            and the provided ``seed``. Defaults to True.
+
+    Returns:
+        A :class:`RandomExpr` that generates random numbers
+
+    Example:
+        >>> from ray.data.expressions import random
+        >>> random()
+        RANDOM()
+
+        >>> from ray.data.expressions import random
+        >>> import ray
+        >>> ds = ray.data.range(10)
+        >>> # Add random column without seed
+        >>> ds.with_column("rand", random()).take(3)  # doctest: +SKIP
+        [{'id': 0, 'rand': 0.013528930983987442},
+         {'id': 1, 'rand': 0.7534846535881974},
+         {'id': 4, 'rand': 0.13351018846379803}]
+
+        For reproducibility, we can provide an integer seed.
+
+        >>> ds.with_column("rand", random(seed=42)).take_batch(batch_size=3)  # doctest: +SKIP
+        {'id': array([0, 1, 2]), 'rand': array([0.67791253, 0.48577076, 0.48211206])}
+
+        By default, `reseed_after_execution` is True, so each dataset execution will
+        generate new random values. This is useful for reproducibility across multiple
+        epochs in model training.
+
+        >>> # Same dataset but executed for the second time
+        >>> ds.with_column("rand", random(seed=42)).take_batch(batch_size=3)  # doctest: +SKIP
+        {'id': array([0, 1, 2]), 'rand': array([0.49661147, 0.36291881, 0.8829356 ])}
+
+        When `reseed_after_execution` is False, the random numbers are fully reproducible across
+        executions.
+
+        >>> # 1st execution
+        >>> ds.with_column("rand", random(seed=42, reseed_after_execution=False)).take_batch(batch_size=3)  # doctest: +SKIP
+        {'id': array([0, 1, 2]), 'rand': array([0.23680187, 0.09952025, 0.09413677])}
+        >>> # 2nd execution
+        >>> ds.with_column("rand", random(seed=42, reseed_after_execution=False)).take_batch(batch_size=3)  # doctest: +SKIP
+        {'id': array([0, 1, 2]), 'rand': array([0.23680187, 0.09952025, 0.09413677])}
+    """
+    return RandomExpr(
+        seed=seed,
+        reseed_after_execution=reseed_after_execution,
+    )
+
+
+@PublicAPI(stability="alpha")
+def uuid() -> UUIDExpr:
+    """
+    Create a UUID expression that generates unique identifiers.
+
+    This creates an expression that generates unique identifiers (strings) for each row.
+    The identifiers are generated using the UUID4 algorithm.
+
+    Returns:
+        A :class:`UUIDExpr` that generates unique identifiers
+
+    Example:
+        >>> from ray.data.expressions import uuid
+        >>> import ray
+        >>> ds = ray.data.range(10)
+        >>> ds.with_column("uuid", uuid().str.replace("-", "")).take(5)  # doctest: +SKIP
+        [{'id': 0, 'uuid': '2899f7bd87164b98a774df730a99c8b3'},
+         {'id': 1, 'uuid': 'e398656a73b0475fb6d9d5d4389a23e6'},
+         {'id': 2, 'uuid': '6ef8e2a18c6c4b7e8a4089b3fcfd8094'},
+         {'id': 3, 'uuid': 'c4abbc54bc8947899ed3ab0bf1eaf75a'},
+         {'id': 4, 'uuid': 'b6265f98e2d0431ea86d837e8a16d31c'}]
+
+    """
+    return UUIDExpr()
+
+
 # ──────────────────────────────────────
 # Public API for evaluation
 # ──────────────────────────────────────
@@ -1700,6 +1873,8 @@ __all__ = [
     "ColumnExpr",
     "LiteralExpr",
     "BinaryExpr",
+    "RandomExpr",
+    "UUIDExpr",
     "UnaryExpr",
     "UDFExpr",
     "DownloadExpr",
@@ -1711,8 +1886,10 @@ __all__ = [
     "col",
     "lit",
     "download",
-    "star",
     "monotonically_increasing_id",
+    "random",
+    "star",
+    "uuid",
     "_ArrayNamespace",
     "_ListNamespace",
     "_StringNamespace",

--- a/python/ray/data/tests/test_synthetic_expression.py
+++ b/python/ray/data/tests/test_synthetic_expression.py
@@ -1,0 +1,437 @@
+import uuid as uuid_module
+
+import numpy as np
+import pytest
+
+import ray
+from ray.data.expressions import RandomExpr, UUIDExpr, col, random, uuid
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+
+def test_random_expression_creation():
+    """Test that random() creates a RandomExpr with correct fields."""
+    # Test without seed
+    expr = random()
+    assert isinstance(expr, RandomExpr)
+    assert expr.seed is None
+    assert expr.reseed_after_execution is True
+
+    # Test with seed
+    expr = random(seed=42)
+    assert isinstance(expr, RandomExpr)
+    assert expr.seed == 42
+    assert expr.reseed_after_execution is True
+
+    # Test with seed and reseed_after_execution=False
+    expr = random(seed=42, reseed_after_execution=False)
+    assert isinstance(expr, RandomExpr)
+    assert expr.seed == 42
+    assert expr.reseed_after_execution is False
+
+
+@pytest.mark.parametrize(
+    "seed1,seed2,reseed1,reseed2,expected_equal",
+    [
+        (42, 42, True, True, True),
+        (42, 123, True, True, False),
+        (None, None, True, True, True),
+        (None, None, True, False, False),
+        (42, None, True, True, False),
+        (42, 42, True, False, False),
+        (42, 42, False, False, True),
+    ],
+)
+def test_random_expression_structural_equality(
+    seed1, seed2, reseed1, reseed2, expected_equal
+):
+    """Test structural equality comparison for random expressions."""
+    expr1 = random(seed=seed1, reseed_after_execution=reseed1)
+    expr2 = random(seed=seed2, reseed_after_execution=reseed2)
+
+    assert expr1.structurally_equals(expr2) == expected_equal
+    assert expr2.structurally_equals(expr1) == expected_equal
+
+
+def test_random_expression_structural_equality_with_non_random_expr():
+    """Test structural equality comparison with non-synthetic expression."""
+    random_expr = random(seed=42)
+    non_random_expr = col("id")
+
+    assert not random_expr.structurally_equals(non_random_expr)
+    assert not non_random_expr.structurally_equals(random_expr)
+
+
+def test_random_values_range(ray_start_regular_shared):
+    """Test that random values are in range [0, 1)."""
+    ds = ray.data.range(1000).with_column("rand", random())
+    results = ds.take_all()
+
+    assert len(results) == 1000
+    for result in results:
+        assert isinstance(result["rand"], (float, np.floating))
+        assert 0.0 <= result["rand"] < 1.0
+        assert "id" in result  # Verify other columns are preserved
+
+
+def test_random_without_seed_non_deterministic(ray_start_regular_shared):
+    """Test that without seed produces non-deterministic values."""
+    ds1 = ray.data.range(100).with_column("rand", random())
+    ds2 = ray.data.range(100).with_column("rand", random())
+
+    values1 = [r["rand"] for r in ds1.take_all()]
+    values2 = [r["rand"] for r in ds2.take_all()]
+
+    # Should be different (very unlikely to be identical)
+    assert values1 != values2
+
+
+@pytest.mark.parametrize("seed", [0, 42, 123])
+@pytest.mark.parametrize("num_blocks", [None, 1, 4, 8])
+def test_random_with_seed_deterministic(ray_start_regular_shared, seed, num_blocks):
+    """Test that with seed produces deterministic values."""
+    kwargs = {"override_num_blocks": num_blocks} if num_blocks is not None else {}
+    ds1 = ray.data.range(100, **kwargs).with_column("rand", random(seed=seed))
+    ds2 = ray.data.range(100, **kwargs).with_column("rand", random(seed=seed))
+
+    values1 = [r["rand"] for r in ds1.take_all()]
+    values2 = [r["rand"] for r in ds2.take_all()]
+
+    assert values1 == values2
+
+
+@pytest.mark.parametrize("batch_format", ["default", "pandas", "pyarrow"])
+def test_random_with_different_batch_formats(ray_start_regular_shared, batch_format):
+    """Test random expression works with different batch formats."""
+    import pandas as pd
+    import pyarrow as pa
+
+    ds = ray.data.range(100).with_column("rand", random(seed=42))
+
+    all_values = []
+    for batch in ds.iter_batches(batch_format=batch_format):
+        rand_col = batch["rand"]
+        if batch_format == "pandas" and isinstance(rand_col, pd.Series):
+            all_values.extend(rand_col.tolist())
+        elif batch_format == "pyarrow" and isinstance(rand_col, pa.ChunkedArray):
+            all_values.extend(rand_col.to_pylist())  # type: ignore
+        else:
+            all_values.extend(
+                list(rand_col) if hasattr(rand_col, "__iter__") else [rand_col]
+            )
+
+    assert len(all_values) == 100
+    for val in all_values:
+        assert 0.0 <= val < 1.0
+
+
+@pytest.mark.parametrize("op", [random, uuid])
+def test_synthetic_empty_dataset(ray_start_regular_shared, op):
+    """Test synthetic expression with empty dataset."""
+    ds = ray.data.range(0).with_column("col", op())
+    assert len(ds.take_all()) == 0
+
+
+@pytest.mark.parametrize(
+    "reseed_after_execution,expected_all_equal",
+    [
+        (True, False),
+        (False, True),
+    ],
+)
+def test_reproducibility_across_epochs(
+    ray_start_regular_shared, reseed_after_execution, expected_all_equal
+):
+    """Test reproducibility across multiple iter_batches() epochs."""
+    ds = ray.data.range(100).with_column(
+        "rand", random(seed=42, reseed_after_execution=reseed_after_execution)
+    )
+
+    # Collect values from multiple epochs
+    epoch_values = []
+    for _ in range(3):
+        values = []
+        for batch in ds.iter_batches():
+            rand_col = batch["rand"]
+            if isinstance(rand_col, np.ndarray):
+                values.extend(rand_col.tolist())
+            else:
+                values.extend(list(rand_col))
+        epoch_values.append(values)
+
+    if expected_all_equal:
+        # Same across epochs when reseed_after_execution=False
+        assert epoch_values[0] == epoch_values[1]
+        assert epoch_values[1] == epoch_values[2]
+    else:
+        # Different across epochs when reseed_after_execution=True
+        assert epoch_values[0] != epoch_values[1]
+        assert epoch_values[1] != epoch_values[2]
+
+
+@pytest.mark.parametrize("num_blocks1,num_blocks2", [(1, 4), (4, 8)])
+def test_different_num_blocks_produces_different_values(
+    ray_start_regular_shared, num_blocks1, num_blocks2
+):
+    """Test that different num_blocks with same seed produces different values."""
+    ds1 = ray.data.range(100, override_num_blocks=num_blocks1).with_column(
+        "rand", random(seed=42)
+    )
+    ds2 = ray.data.range(100, override_num_blocks=num_blocks2).with_column(
+        "rand", random(seed=42)
+    )
+
+    values1 = [r["rand"] for r in ds1.take_all()]
+    values2 = [r["rand"] for r in ds2.take_all()]
+
+    # Should be different (expected behavior due to different task_idx)
+    assert values1 != values2
+
+
+@pytest.mark.parametrize(
+    "args,kwargs,expected_error,error_message",
+    [
+        # Too many positional arguments
+        (
+            (1, 2, 3),
+            {},
+            TypeError,
+            "random\\(\\) takes 0 positional arguments but 3 were given",
+        ),
+        # Keyword "seed" with 1 positional arg (duplicate)
+        (
+            (42,),
+            {"seed": 123},
+            TypeError,
+            "random\\(\\) takes 0 positional arguments but 1 positional argument",
+        ),
+        # Unexpected keyword argument
+        (
+            (),
+            {"invalid_arg": 42},
+            TypeError,
+            "random\\(\\) got an unexpected keyword argument 'invalid_arg'",
+        ),
+        (
+            (),
+            {"seed": 42, "invalid_arg": True},
+            TypeError,
+            "random\\(\\) got an unexpected keyword argument 'invalid_arg'",
+        ),
+    ],
+)
+def test_random_validation_errors(
+    ray_start_regular_shared, args, kwargs, expected_error, error_message
+):
+    """Test that random() validates arguments correctly."""
+    with pytest.raises(expected_error, match=error_message):
+        random(*args, **kwargs)
+
+
+def test_random_multi_block_per_task(ray_start_regular_shared):
+    """Test that random values are unique when a single task processes multiple blocks.
+
+    This test verifies the fix for the issue where random() with seed would produce
+    duplicate values when a single task processed multiple blocks. Unlike
+    monotonically_increasing_id(), which uses a per-task counter in ctx.kwargs to
+    differentiate blocks, random() previously had no such mechanism, leading to
+    duplicated random data.
+    """
+    ctx = ray.data.DataContext.get_current()
+    original_max_block_size = ctx.target_max_block_size
+    try:
+        # Set max block size to 32 bytes ~ 4 int64 rows per block.
+        # With 5 read tasks of 20 rows each, every task should see 5 blocks.
+        ctx.target_max_block_size = 32
+
+        ds = ray.data.range(100, override_num_blocks=5)
+        ds = ds.with_column("rand", random(seed=42))
+        result = ds.take_all()
+
+        rand_values = [row["rand"] for row in result]
+        assert len(rand_values) == 100, f"expected 100 rows, got {len(rand_values)}"
+        assert len(rand_values) == len(
+            set(rand_values)
+        ), "Random values are not unique across blocks within the same task"
+    finally:
+        ctx.target_max_block_size = original_max_block_size
+
+
+def test_random_with_column_then_random_shuffle_deterministic(ray_start_regular_shared):
+    """Test that random() with seed produces deterministic results even after random_shuffle."""
+    from ray.data.expressions import random
+
+    # Create two identical pipelines
+    ds1 = ray.data.range(100).with_column("rand", random(seed=42))
+    ds1 = ds1.random_shuffle(seed=1)
+
+    ds2 = ray.data.range(100).with_column("rand", random(seed=42))
+    ds2 = ds2.random_shuffle(seed=1)
+
+    # The random column values should be deterministic (same seed)
+    # but the row order may differ due to shuffle
+    results1 = sorted(ds1.take_all(), key=lambda x: x["id"])
+    results2 = sorted(ds2.take_all(), key=lambda x: x["id"])
+
+    # Same random values for same id
+    for r1, r2 in zip(results1, results2):
+        assert r1["rand"] == r2["rand"]
+
+
+@pytest.mark.parametrize(
+    "all_to_all_op,op_kwargs",
+    [
+        ("random_shuffle", {"seed": 100}),
+        ("repartition", {"num_blocks": 5, "shuffle": True}),
+        ("sort", {"key": "id"}),
+        ("randomize_block_order", {"seed": 100}),
+    ],
+)
+def test_random_reseed_after_execution_with_all_to_all_ops(
+    ray_start_regular_shared, all_to_all_op, op_kwargs
+):
+    """Test that reseed_after_execution works correctly when fused with all-to-all ops.
+
+    This test verifies the fix for the issue where random() expressions with
+    reseed_after_execution=True would not properly reseed across epochs when
+    fused with all-to-all operations (shuffle, repartition, sort, etc.). The issue
+    was that DataContext was not propagated to all-to-all tasks, causing
+    execution_idx to always be 0.
+    """
+    from ray.data.expressions import random
+
+    # Create a dataset with random column
+    ds = ray.data.range(10, override_num_blocks=1).with_column(
+        "rand", random(seed=42, reseed_after_execution=True)
+    )
+
+    # Apply the all-to-all operation
+    ds_transformed = getattr(ds, all_to_all_op)(**op_kwargs)
+
+    # First execution
+    first_results = sorted(ds_transformed.take_all(), key=lambda x: x["id"])
+
+    # Second execution - should have different random values
+    second_results = sorted(ds_transformed.take_all(), key=lambda x: x["id"])
+
+    # Verify random values are different across executions
+    first_rand_values = [r["rand"] for r in first_results]
+    second_rand_values = [r["rand"] for r in second_results]
+
+    assert first_rand_values != second_rand_values, (
+        f"Random values should differ across executions when "
+        f"reseed_after_execution=True, even with {all_to_all_op} fusion"
+    )
+
+    # Verify the row ids are the same (just checking we have the same data)
+    first_ids = [r["id"] for r in first_results]
+    second_ids = [r["id"] for r in second_results]
+    assert first_ids == second_ids == list(range(10))
+
+
+def test_uuid_expression_creation():
+    """Test that uuid() creates a UUIDExpr."""
+    expr = uuid()
+    assert isinstance(expr, UUIDExpr)
+
+
+def test_uuid_expression_structural_equality():
+    """Test structural equality comparison for uuid expressions."""
+    expr1 = uuid()
+    expr2 = uuid()
+
+    # All uuid() expressions should be structurally equal (no parameters)
+    assert expr1.structurally_equals(expr2)
+    assert expr2.structurally_equals(expr1)
+
+
+def test_uuid_expression_structural_equality_with_non_uuid_expr():
+    """Test structural equality comparison with non-synthetic expression."""
+    uuid_expr = uuid()
+    non_uuid_expr = col("id")
+
+    assert not uuid_expr.structurally_equals(non_uuid_expr)
+    assert not non_uuid_expr.structurally_equals(uuid_expr)
+
+
+def test_uuid_values_format(ray_start_regular_shared):
+    """Test that uuid values are valid UUID strings."""
+    ds = ray.data.range(100).with_column("uuid_col", uuid())
+    results = ds.take_all()
+
+    assert len(results) == 100
+    for result in results:
+        uuid_value = result["uuid_col"]
+        assert isinstance(uuid_value, str)
+        # Validate UUID format
+        uuid_module.UUID(uuid_value)  # Will raise ValueError if invalid
+        assert "id" in result  # Verify other columns are preserved
+
+
+def test_uuid_values_unique(ray_start_regular_shared):
+    """Test that uuid values are unique."""
+    ds = ray.data.range(1000).with_column("uuid_col", uuid())
+    results = ds.take_all()
+
+    uuid_values = [r["uuid_col"] for r in results]
+    # All UUIDs should be unique
+    assert len(uuid_values) == len(set(uuid_values))
+
+
+@pytest.mark.parametrize("batch_format", ["default", "pandas", "pyarrow"])
+def test_uuid_with_different_batch_formats(ray_start_regular_shared, batch_format):
+    """Test uuid expression works with different batch formats."""
+    import pandas as pd
+    import pyarrow as pa
+
+    ds = ray.data.range(100).with_column("uuid_col", uuid())
+
+    all_values = []
+    for batch in ds.iter_batches(batch_format=batch_format):
+        uuid_col = batch["uuid_col"]
+        if batch_format == "pandas" and isinstance(uuid_col, pd.Series):
+            all_values.extend(uuid_col.tolist())
+        elif batch_format == "pyarrow" and isinstance(uuid_col, pa.ChunkedArray):
+            all_values.extend(uuid_col.to_pylist())  # type: ignore
+        else:
+            all_values.extend(
+                list(uuid_col) if hasattr(uuid_col, "__iter__") else [uuid_col]
+            )
+
+    assert len(all_values) == 100
+    for val in all_values:
+        assert isinstance(val, str)
+        uuid_module.UUID(val)  # Validate UUID format
+
+
+@pytest.mark.parametrize(
+    "args,kwargs,expected_error,error_message",
+    [
+        # Too many positional arguments
+        (
+            (1,),
+            {},
+            TypeError,
+            "uuid\\(\\) takes 0 positional arguments but 1 was given",
+        ),
+        # Unexpected keyword argument
+        (
+            (),
+            {"invalid_arg": 42},
+            TypeError,
+            "uuid\\(\\) got an unexpected keyword argument 'invalid_arg'",
+        ),
+    ],
+)
+def test_uuid_validation_errors(
+    ray_start_regular_shared, args, kwargs, expected_error, error_message
+):
+    """Test that uuid() validates arguments correctly."""
+    with pytest.raises(expected_error, match=error_message):
+        uuid(*args, **kwargs)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

Adding two new expressions:
* `random()` for generating a column of uniform random number.
* `uuid()` for generating UUID (a column of unique strings)

`random()` accepts two arguments, related to reproducibility:
* `seed`: a "base" random seed. Default is `None`.
* `reseed_after_execution`: This is a flag that affects the random number generation across different iteration of `iter_batches` (i.e., across different epochs in the context of epochs). See also, https://github.com/ray-project/ray/pull/59528. It only matters when the `seed` is set. If False, each dataset execution will generate the same set of random number. If True, each dataset execution (i.e., training epoch) will give a new but reproducible set of random number.

`uuid()` takes no argument.

## Related issues
Related to #55275

Related to #59662 as well. I did this PR first...so probably I could use the same `RandomSeedConfig` in that PR.

## Additional information

[Random seed business] The actual seed sequence used to initialize the random number generator is `[block_idx, task_idx, execution_idx, base_seed]`. The block idx is tracked by a counter (like in `monotonically_increasing_id()`). The task and execution indices are coming from `TaskContext` and `DataContext`, respectively. The way I used `execution_idx` is slightly different to what `FileShuffleConfig` is doing, but I think all these random seed business could be consolidated in the future (e.g., random_sample)

[Independent visit functions] Following the discussion in https://github.com/ray-project/ray/pull/59290, there are separate `visit_uuid()` and `visit_random` for these expressions.