### PR TITLE
[Core] Fix psutil internal API usage in dashboard disk usage reporting

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -869,9 +869,8 @@ class ReporterAgent(
     def _get_disk_usage():
         if IN_KUBERNETES_POD and not ENABLE_K8S_DISK_USAGE:
             # If in a K8s pod, disable disk display by passing in dummy values.
-            return {
-                "/": psutil._common.sdiskusage(total=1, used=0, free=1, percent=0.0)
-            }
+            sdiskusage = type(psutil.disk_usage("/"))
+            return {"/": sdiskusage(total=1, used=0, free=1, percent=0.0)}
         if sys.platform == "win32":
             root = psutil.disk_partitions()[0].mountpoint
         else:


### PR DESCRIPTION
## Description

The current code uses `psutil._common.sdiskusage` which is an internal API and may not be available in all versions of psutil. This causes `AttributeError` in CI. Fixes test failure in `test_enable_k8s_disk_usage` by using [psutil.disk_usage ](https://psutil.readthedocs.io/en/latest/#psutil.disk_usage).


https://buildkite.com/ray-project/microcheck/builds/34236/steps/canvas?sid=019b541c-00fd-4d23-8482-f03fd5f994c1#019b5460-d155-46b4-b46c-ed20919d1ec3/L899
```shell
[2025-12-25T07:43:14Z] =================================== FAILURES ===================================
--
[2025-12-25T07:43:14Z] ______________________ test_enable_k8s_disk_usage[False] _______________________
[2025-12-25T07:43:14Z]
[2025-12-25T07:43:14Z] enable_k8s_disk_usage = False
[2025-12-25T07:43:14Z]
[2025-12-25T07:43:14Z]     @pytest.mark.parametrize("enable_k8s_disk_usage", [True, False])
[2025-12-25T07:43:14Z]     def test_enable_k8s_disk_usage(enable_k8s_disk_usage: bool):
[2025-12-25T07:43:14Z]         """Test enabling display of K8s node disk usage when in a K8s pod."""
[2025-12-25T07:43:14Z]         with patch.multiple(
[2025-12-25T07:43:14Z]             "ray.dashboard.modules.reporter.reporter_agent",
[2025-12-25T07:43:14Z]             IN_KUBERNETES_POD=True,
[2025-12-25T07:43:14Z]             ENABLE_K8S_DISK_USAGE=enable_k8s_disk_usage,
[2025-12-25T07:43:14Z]         ):
[2025-12-25T07:43:14Z] >           root_usage = ReporterAgent._get_disk_usage()["/"]
[2025-12-25T07:43:14Z]
[2025-12-25T07:43:14Z] python/ray/dashboard/modules/reporter/tests/test_reporter.py:855:
[2025-12-25T07:43:14Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
[2025-12-25T07:43:14Z]
[2025-12-25T07:43:14Z]     @staticmethod
[2025-12-25T07:43:14Z]     def _get_disk_usage():
[2025-12-25T07:43:14Z]         if IN_KUBERNETES_POD and not ENABLE_K8S_DISK_USAGE:
[2025-12-25T07:43:14Z]             # If in a K8s pod, disable disk display by passing in dummy values.
[2025-12-25T07:43:14Z]             return {
[2025-12-25T07:43:14Z] >               "/": psutil._common.sdiskusage(total=1, used=0, free=1, percent=0.0)
[2025-12-25T07:43:14Z]             }
[2025-12-25T07:43:14Z] E           AttributeError: module 'psutil._common' has no attribute 'sdiskusage'
[2025-12-25T07:43:14Z]



```

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
