### PR TITLE
[Data] Improve reproducibility for random APIs

### DIFF
--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -46,6 +46,7 @@ Developer API
   block.BlockExecStats
   block.BlockMetadata
   block.BlockAccessor
+  RandomSeedConfig
 
 Deprecated API
 --------------

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -2100,3 +2100,17 @@ py_test(
         "//:ray_lib",
     ],
 )
+
+py_test(
+    name = "test_random_api",
+    size = "small",
+    srcs = ["tests/test_random_api.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -13,6 +13,7 @@ from ray.data._internal.execution.interfaces import (
     NodeIdStr,
 )
 from ray.data._internal.logging import configure_logging
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data.context import DataContext, DatasetContext
 from ray.data.dataset import (
     Dataset,
@@ -138,6 +139,7 @@ __all__ = [
     "ExecutionResources",
     "FileShuffleConfig",
     "NodeIdStr",
+    "RandomSeedConfig",
     "ReadTask",
     "RowBasedFileDatasink",
     "Schema",

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -8,6 +8,7 @@ from ray.data._internal.logical.interfaces import (
 from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
 from ray.data._internal.planner.exchange.shuffle_task_spec import ShuffleTaskSpec
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey, SortTaskSpec
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data.aggregate import AggregateFn
 from ray.data.block import BlockMetadata
 
@@ -71,13 +72,13 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
     def __init__(
         self,
         input_op: LogicalOperator,
-        seed: Optional[int] = None,
+        seed_config: Optional[RandomSeedConfig] = None,
     ):
         super().__init__(
             input_op,
             name="RandomizeBlockOrder",
         )
-        self.seed = seed
+        self.seed_config = seed_config or RandomSeedConfig()
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -103,7 +104,7 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
         self,
         input_op: LogicalOperator,
         name: str = "RandomShuffle",
-        seed: Optional[int] = None,
+        seed_config: Optional[RandomSeedConfig] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
@@ -115,7 +116,7 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
             ray_remote_args=ray_remote_args,
             name=name,
         )
-        self.seed = seed
+        self.seed_config = seed_config or RandomSeedConfig()
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -104,7 +104,7 @@ def plan_all_to_all_op(
     input_physical_dag = physical_children[0]
 
     if isinstance(op, RandomizeBlocks):
-        fn = generate_randomize_blocks_fn(op)
+        fn = generate_randomize_blocks_fn(op, data_context)
         # Randomize block order does not actually compute anything, so we
         # want to inherit the upstream op's target max block size.
 
@@ -114,7 +114,7 @@ def plan_all_to_all_op(
         )
         fn = generate_random_shuffle_fn(
             data_context,
-            op.seed,
+            op.seed_config,
             op.num_outputs,
             op.ray_remote_args,
             debug_limit_shuffle_execution_to_num_blocks,

--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -1,4 +1,3 @@
-import time
 from typing import Any, Dict, List, Optional
 
 from ray.data._internal.execution.interfaces import (
@@ -17,13 +16,16 @@ from ray.data._internal.planner.exchange.push_based_shuffle_task_scheduler impor
     PushBasedShuffleTaskScheduler,
 )
 from ray.data._internal.planner.exchange.shuffle_task_spec import ShuffleTaskSpec
+from ray.data._internal.random_config import (
+    RandomSeedConfig,
+    get_single_integer_random_seed,
+)
 from ray.data.context import DataContext, ShuffleStrategy
-from ray.util.common import INT32_MAX
 
 
 def generate_random_shuffle_fn(
     data_context: DataContext,
-    seed: Optional[int],
+    seed_config: RandomSeedConfig,
     num_outputs: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     _debug_limit_shuffle_execution_to_num_blocks: Optional[int] = None,
@@ -32,7 +34,7 @@ def generate_random_shuffle_fn(
 
     # If no seed has been specified, pin timestamp based one
     # so that task could be safely retried (w/o changing their output)
-    seed = seed if seed is not None else (time.time_ns() % INT32_MAX)
+    seed = get_single_integer_random_seed(seed_config, data_context)
 
     def fn(
         refs: List[RefBundle],

--- a/python/ray/data/_internal/planner/randomize_blocks.py
+++ b/python/ray/data/_internal/planner/randomize_blocks.py
@@ -1,5 +1,7 @@
 from typing import List
 
+import numpy as np
+
 from ray.data._internal.execution.interfaces import (
     AllToAllTransformFn,
     RefBundle,
@@ -9,18 +11,22 @@ from ray.data._internal.execution.interfaces.transform_fn import (
     AllToAllTransformFnResult,
 )
 from ray.data._internal.logical.operators import RandomizeBlocks
+from ray.data._internal.random_config import get_single_integer_random_seed
+from ray.data.context import DataContext
 
 
 def generate_randomize_blocks_fn(
     op: RandomizeBlocks,
+    data_context: DataContext,
 ) -> AllToAllTransformFn:
     """Generate function to randomize order of blocks."""
+
+    seed = get_single_integer_random_seed(op.seed_config, data_context)
 
     def fn(
         refs: List[RefBundle],
         context: TaskContext,
     ) -> AllToAllTransformFnResult:
-        import random
 
         nonlocal op
         blocks_with_metadata = []
@@ -34,10 +40,9 @@ def generate_randomize_blocks_fn(
         if len(blocks_with_metadata) == 0:
             return refs, {op.name: []}
         else:
-            if op.seed is not None:
-                random.seed(op.seed)
+            rng = np.random.default_rng(seed)
             input_owned = all(b.owns_blocks for b in refs)
-            random.shuffle(blocks_with_metadata)
+            rng.shuffle(blocks_with_metadata)
             output = []
             stats_list = []
             for block, meta, i in blocks_with_metadata:

--- a/python/ray/data/_internal/random_config.py
+++ b/python/ray/data/_internal/random_config.py
@@ -139,8 +139,11 @@ class RandomSeedConfig:
                 use_timestamp_as_default=use_timestamp_as_default,
             )
         elif isinstance(seed, RandomSeedConfig):
-            seed.use_timestamp_as_default = use_timestamp_as_default
-            return seed
+            return cls(
+                seed=seed.seed,
+                reseed_after_execution=seed.reseed_after_execution,
+                use_timestamp_as_default=use_timestamp_as_default,
+            )
 
         raise ValueError(f"Invalid seed type: {type(seed)}")
 

--- a/python/ray/data/_internal/random_config.py
+++ b/python/ray/data/_internal/random_config.py
@@ -4,13 +4,11 @@ import time
 from dataclasses import dataclass
 from typing import Optional
 
-import numpy as np
-
 from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
 
 # NumPy's RandomState/seed range is [0, 2**32 - 1].
-NUMPY_RNG_SEED_MAX = np.iinfo(np.uint32).max + 1
+NUMPY_RNG_SEED_MAX = 2**32
 
 
 @dataclass(frozen=True)

--- a/python/ray/data/_internal/random_config.py
+++ b/python/ray/data/_internal/random_config.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from ray.data.context import DataContext
+from ray.util.annotations import DeveloperAPI
+
+# NumPy's RandomState/seed range is [0, 2**32 - 1].
+NUMPY_RNG_SEED_MAX = np.iinfo(np.uint32).max + 1
+
+
+@dataclass(frozen=True)
+class SeedTuple:
+    """A seed for random number generation, optionally including execution index for reseeding.
+
+    Args:
+        seed: The base seed.
+        execution_idx: The execution index. If None, the seed is not reseeded after execution.
+
+    """
+
+    seed: int
+    execution_idx: Optional[int] = None
+
+    def to_rng_args(self, task_idx: int) -> tuple[int, ...]:
+        """Return seed parts for np.random.default_rng((task_idx, ...)).
+
+        Args:
+            task_idx: The task index.
+
+        Returns:
+            A tuple of seed parts.
+        """
+        if self.execution_idx is None:
+            return (task_idx, self.seed)
+        return (task_idx, self.execution_idx, self.seed)
+
+
+@DeveloperAPI
+@dataclass
+class RandomSeedConfig:
+    """This configuration object controls the random seed behavior for operations
+    such as :meth:`~Dataset.random_shuffle`, :meth:`~Dataset.randomize_block_order`,
+    and :meth:`~Dataset.random_sample`. The random seed behavior is determined by
+    the combination of the base seed ``seed`` and the ``reseed_after_execution`` parameter:
+
+    - If ``seed`` is None, the random seed is always None (non-deterministic shuffling).
+    - If ``seed`` is not None and ``reseed_after_execution`` is False, the base seed is
+      used as the random seed for each execution.
+    - If ``seed`` is not None and ``reseed_after_execution`` is True, the base seed is
+      combined with the (incremental) execution index ``execution_idx`` to produce a
+      different random seed tuple for each execution.
+
+    .. note::
+        Even if you provided a seed, you might still observe a non-deterministic row
+        order. This is because tasks are executed in parallel and their completion
+        order might vary. If you need to preserve the order of rows, set
+        ``DataContext.get_current().execution_options.preserve_order``.
+
+    Args:
+        seed: An optional integer base seed. If None, the operation is
+            non-deterministic. If provided, the operation is deterministic based on the base
+            seed and the ``reseed_after_execution`` parameter.
+        reseed_after_execution: If True, the random seed considers both ``seed`` and
+            ``execution_idx``, resulting in different shuffling orders across executions.
+            If False, the base seed is used as the random seed for each execution, resulting in the same
+            shuffling order across executions. Only takes effect when a base seed is provided.
+            Defaults to True.
+        use_timestamp_as_default: When enabled, it supports a legacy behavior that relies on
+            the timestamp as the default seed. This parameter is only used when the base seed
+            is None. Defaults to False. See ``get_single_integer_random_seed`` for more details.
+
+    """  # noqa: E501
+
+    seed: Optional[int] = None
+    reseed_after_execution: bool = True
+    use_timestamp_as_default: bool = False
+
+    def __post_init__(self):
+        """Ensure that the seed is either None or an integer."""
+        if self.seed is not None and not isinstance(self.seed, int):
+            raise ValueError("Seed must be an integer or None.")
+
+    def get_seed_tuple(
+        self,
+        *,
+        data_context: DataContext,
+    ) -> SeedTuple | None:
+        """Return a seed for random number generation.
+
+        Args:
+            data_context: A DataContext object for extracting the
+                execution index.
+
+        Returns:
+            A SeedTuple, or None for non-deterministic behavior.
+        """
+        if self.seed is None:
+            return None
+        elif self.reseed_after_execution:
+            return SeedTuple(
+                seed=self.seed,
+                execution_idx=data_context._execution_idx,
+            )
+        else:
+            return SeedTuple(seed=self.seed, execution_idx=None)
+
+    @classmethod
+    def create_seed_config(
+        cls,
+        seed: int | RandomSeedConfig | None,
+        *,
+        use_timestamp_as_default: bool = False,
+    ) -> RandomSeedConfig:
+        """Create a ``RandomSeedConfig`` object from the ``seed`` argument in Ray Data public random APIs.
+
+        This is a helper function that converts an integer seed into a ``RandomSeedConfig`` object. In this case,
+        ``reseed_after_execution`` is set to False, which matches the standard behavior for a data pipeline
+        (i.e., same seed across executions). To override this behavior, use a ``RandomSeedConfig`` object
+        directly.
+
+        Args:
+            seed: This optional argument can be an integer or an existing ``RandomSeedConfig`` object.
+            use_timestamp_as_default: If True, a timestamp-based seed is used when
+                ``seed`` is None. This pins the seed at plan time so that task retries
+                produce identical output. When ``seed`` is an existing
+                ``RandomSeedConfig``, this value overrides its
+                ``use_timestamp_as_default`` field.
+
+        Returns:
+            A ``RandomSeedConfig`` object.
+        """
+        if seed is None or isinstance(seed, int):
+            return RandomSeedConfig(
+                seed=seed,
+                reseed_after_execution=False,
+                use_timestamp_as_default=use_timestamp_as_default,
+            )
+        elif isinstance(seed, RandomSeedConfig):
+            seed.use_timestamp_as_default = use_timestamp_as_default
+            return seed
+
+        raise ValueError(f"Invalid seed type: {type(seed)}")
+
+
+def get_timestamp_seed() -> int:
+    """Returns a timestamp-based seed."""
+    return time.time_ns() % NUMPY_RNG_SEED_MAX
+
+
+def get_single_integer_random_seed(
+    seed_config: RandomSeedConfig,
+    data_context: DataContext,
+) -> Optional[int]:
+    """Returns a single integer seed based on the ``RandomSeedConfig`` object. This is useful
+    if the caller expects a single integer to seed the RNG. When the base seed is None,
+    and ``seed_config.use_timestamp_as_default`` is True, a timestamp is used as the seed.
+    Otherwise, the seed tuple is hashed to produce a single integer seed.
+
+    Args:
+        seed_config: The ``RandomSeedConfig`` object.
+        data_context: The ``DataContext`` object used to generate the seed tuple.
+
+    Returns:
+        A single integer random seed, or None for non-deterministic behavior.
+    """
+    seed_result = seed_config.get_seed_tuple(data_context=data_context)
+
+    if seed_result is None:
+        # This is a legacy behavior for some random operations.
+        return get_timestamp_seed() if seed_config.use_timestamp_as_default else None
+    elif seed_result.execution_idx is None:
+        return seed_result.seed
+
+    # The modulo is only needed because some random implementations are using the
+    # older type RandomState or np.random.seed(). Otherwise, the seed can be
+    # as large as 128-bit integer. See
+    # https://blog.scientific-python.org/numpy/numpy-rng/
+    return hash(seed_result) % NUMPY_RNG_SEED_MAX

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -80,6 +80,7 @@ from ray.data._internal.logical.operators import (
 from ray.data._internal.pandas_block import PandasBlockBuilder, PandasBlockSchema
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.split import _get_num_rows, _split_at_indices
 from ray.data._internal.stats import DatasetStats, DatasetStatsSummary, _StatsManager
@@ -1813,7 +1814,7 @@ class Dataset:
     def random_shuffle(
         self,
         *,
-        seed: Optional[int] = None,
+        seed: Optional[int | RandomSeedConfig] = None,
         num_blocks: Optional[int] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -1827,17 +1828,34 @@ class Dataset:
 
         Examples:
             >>> import ray
+            >>> from ray.data import RandomSeedConfig
             >>> ds = ray.data.range(100)
             >>> ds.random_shuffle().take(3)  # doctest: +SKIP
-            {'id': 41}, {'id': 21}, {'id': 92}]
+            [{'id': 41}, {'id': 21}, {'id': 92}]
             >>> ds.random_shuffle(seed=42).take(3)  # doctest: +SKIP
-            {'id': 77}, {'id': 21}, {'id': 63}]
+            [{'id': 24}, {'id': 97}, {'id': 17}]
+
+            Fully deterministic across executions:
+            >>> ds = ray.data.range(100)
+            >>> ds.random_shuffle(seed=RandomSeedConfig(seed=42, reseed_after_execution=False)).take(3)  # doctest: +SKIP
+            [{'id': 24}, {'id': 97}, {'id': 17}]
+            >>> ds.random_shuffle(seed=RandomSeedConfig(seed=42, reseed_after_execution=False)).take(3)  # doctest: +SKIP
+            [{'id': 24}, {'id': 97}, {'id': 17}]
+
+            Reproducible but non-deterministic across executions (e.g., training epochs):
+            >>> ds = ray.data.range(100)
+            >>> ds.random_shuffle(seed=RandomSeedConfig(seed=42, reseed_after_execution=True)).take(3)  # doctest: +SKIP
+            [{'id': 29}, {'id': 79}, {'id': 39}]
+            >>> ds.random_shuffle(seed=RandomSeedConfig(seed=42, reseed_after_execution=True)).take(3)  # doctest: +SKIP
+            [{'id': 40}, {'id': 7}, {'id': 90}]
 
         Time complexity: O(dataset size / parallelism)
 
         Args:
-            seed: Fix the random seed to use, otherwise one is chosen
-                based on system randomness.
+            seed: An optional random seed. Can be an integer or a :class:`RandomSeedConfig`
+                object. If an integer is provided, it defaults to fully deterministic
+                behavior (same shuffle order across executions). If None, the shuffle
+                is non-deterministic. See :class:`RandomSeedConfig` for more details on seed behavior.
             num_blocks: This parameter is deprecated. It was previously intended to
                 specify the number of output blocks in the shuffled dataset, but is no
                 longer supported. To control the number of output blocks, use
@@ -1856,10 +1874,18 @@ class Dataset:
                 "does not support to change the number of output blocks. Use "
                 "repartition() instead.",  # noqa: E501
             )
+
+        # We set use_timestamp_as_default=True to pin the seed at plan time
+        # so that retried shuffle tasks produce the same output.
+        # See https://github.com/ray-project/ray/pull/50924.
+        seed_config = RandomSeedConfig.create_seed_config(
+            seed, use_timestamp_as_default=True
+        )
+
         plan = self._plan.copy()
         op = RandomShuffle(
             self._logical_plan.dag,
-            seed=seed,
+            seed_config=seed_config,
             ray_remote_args=ray_remote_args,
         )
         logical_plan = LogicalPlan(op, self.context)
@@ -1870,7 +1896,7 @@ class Dataset:
     def randomize_block_order(
         self,
         *,
-        seed: Optional[int] = None,
+        seed: Optional[int | RandomSeedConfig] = None,
     ) -> "Dataset":
         """Randomly shuffle the :ref:`blocks <dataset_concept>` of this :class:`Dataset`.
 
@@ -1885,28 +1911,46 @@ class Dataset:
             [{'id': 0}, {'id': 1}, {'id': 2}, {'id': 3}, {'id': 4}]
             >>> ds.randomize_block_order().take(5)  # doctest: +SKIP
             {'id': 15}, {'id': 16}, {'id': 17}, {'id': 18}, {'id': 19}]
+            >>> ds.randomize_block_order(seed=RandomSeedConfig(seed=42, reseed_after_execution=False)).take(5)  # doctest: +SKIP
+            [{'id': 44}, {'id': 45}, {'id': 46}, {'id': 47}, {'id': 80}]
+            >>> ds.randomize_block_order(seed=RandomSeedConfig(seed=42, reseed_after_execution=False)).take(5)  # doctest: +SKIP
+            [{'id': 44}, {'id': 45}, {'id': 46}, {'id': 47}, {'id': 80}]
+
+            Reproducible but non-deterministic across executions (e.g., training epochs):
+            >>> ds = ray.data.range(100)
+            >>> ds.randomize_block_order(seed=RandomSeedConfig(seed=42, reseed_after_execution=True)).take(5)  # doctest: +SKIP
+            [{'id': 40}, {'id': 41}, {'id': 42}, {'id': 43}, {'id': 28}]
+            >>> ds.randomize_block_order(seed=RandomSeedConfig(seed=42, reseed_after_execution=True)).take(5)  # doctest: +SKIP
+            [{'id': 92}, {'id': 93}, {'id': 94}, {'id': 95}, {'id': 88}]
 
         Args:
-            seed: Fix the random seed to use, otherwise one is chosen
-                based on system randomness.
+            seed: An optional random seed. Can be an integer or a :class:`RandomSeedConfig`
+                object. If an integer is provided, it defaults to fully deterministic
+                behavior (same block order across executions). If None, the block
+                order is non-deterministic. See :class:`RandomSeedConfig` for more details on
+                seed behavior.
 
         Returns:
             The block-shuffled :class:`Dataset`.
         """  # noqa: E501
 
+        seed_config = RandomSeedConfig.create_seed_config(seed)
+
         plan = self._plan.copy()
         op = RandomizeBlocks(
             self._logical_plan.dag,
-            seed=seed,
+            seed_config=seed_config,
         )
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
 
     @PublicAPI(api_group=BT_API_GROUP)
     def random_sample(
-        self, fraction: float, *, seed: Optional[int] = None
+        self, fraction: float, *, seed: Optional[int | RandomSeedConfig] = None
     ) -> "Dataset":
         """Returns a new :class:`Dataset` containing a random fraction of the rows.
+        In other words, this method "randomly filters" the rows of the dataset without
+        shuffling (i.e., changing the order of the rows).
 
         .. note::
 
@@ -1915,18 +1959,29 @@ class Dataset:
 
         Examples:
             >>> import ray
+            >>> from ray.data import RandomSeedConfig
             >>> ds1 = ray.data.range(100)
             >>> ds1.random_sample(0.1).count()  # doctest: +SKIP
             10
+            >>> # Deterministic across executions
             >>> ds2 = ray.data.range(1000)
             >>> ds2.random_sample(0.123, seed=42).take(2)  # doctest: +SKIP
             [{'id': 2}, {'id': 9}]
             >>> ds2.random_sample(0.123, seed=42).take(2)  # doctest: +SKIP
             [{'id': 2}, {'id': 9}]
+            >>> # Different sample each execution
+            >>> ds2.random_sample(0.123, seed=RandomSeedConfig(seed=42, reseed_after_execution=True)).take(2)  # doctest: +SKIP
+            [{'id': 2}, {'id': 9}]
+            >>> ds2.random_sample(0.123, seed=RandomSeedConfig(seed=42, reseed_after_execution=True)).take(2)  # doctest: +SKIP
+            [{'id': 15}, {'id': 23}]
 
         Args:
-            fraction: The fraction of elements to sample.
-            seed: Seeds the python random pRNG generator.
+            fraction: The fraction of elements to sample. It must be between 0 and 1 (inclusive).
+            seed: An optional random seed. Can be an integer or a :class:`RandomSeedConfig`
+                object. If an integer is provided, it defaults to fully deterministic
+                behavior (same sample across executions). If None, the sample
+                is non-deterministic. See :class:`RandomSeedConfig` for more details on
+                seed behavior.
 
         Returns:
             Returns a :class:`Dataset` containing the sampled rows.
@@ -1940,18 +1995,24 @@ class Dataset:
         if fraction < 0 or fraction > 1:
             raise ValueError("Fraction must be between 0 and 1.")
 
+        seed_config = RandomSeedConfig.create_seed_config(seed)
+
         from ray.data._internal.execution.interfaces.task_context import TaskContext
 
-        def random_sample(batch: DataBatch, seed: Optional[int]):
+        def random_sample(
+            batch: DataBatch, seed_config: RandomSeedConfig, data_context: DataContext
+        ):
             ctx = TaskContext.get_current()
+
+            seed_result = seed_config.get_seed_tuple(data_context=data_context)
 
             if "rng" in ctx.kwargs:
                 rng = ctx.kwargs["rng"]
-            elif seed is None:
+            elif seed_result is None:
                 rng = np.random.default_rng()
                 ctx.kwargs["rng"] = rng
             else:
-                rng = np.random.default_rng([ctx.task_idx, seed])
+                rng = np.random.default_rng(seed_result.to_rng_args(ctx.task_idx))
                 ctx.kwargs["rng"] = rng
 
             mask_idx = np.where(rng.random(len(batch)) < fraction)[0]
@@ -1964,7 +2025,7 @@ class Dataset:
 
         return self.map_batches(
             random_sample,
-            fn_args=[seed],
+            fn_args=(seed_config, self.context),
             batch_format=None,
             batch_size=None,
         )

--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -34,6 +34,7 @@ from ray.data._internal.logical.rules import (
 )
 from ray.data._internal.planner import create_planner
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data._internal.stats import DatasetStats
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
@@ -49,7 +50,7 @@ def test_random_shuffle_operator(ray_start_regular_shared_2_cpus):
     read_op = get_parquet_read_logical_op()
     op = RandomShuffle(
         read_op,
-        seed=0,
+        seed_config=RandomSeedConfig(seed=0),
     )
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag

--- a/python/ray/data/tests/test_random_api.py
+++ b/python/ray/data/tests/test_random_api.py
@@ -1,0 +1,196 @@
+"""
+This file tests the reproducibility of the random API with different seed configurations.
+"""
+
+import pytest
+
+import ray
+from ray.data import RandomSeedConfig
+from ray.data.context import DataContext
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+DATASET_SIZE = 40
+NUM_BLOCKS = 8
+
+METHODS = ["random_shuffle", "random_sample", "randomize_block_order"]
+
+
+@pytest.fixture
+def base_dataset(ray_start_regular_shared) -> ray.data.Dataset:
+    """Create a base dataset for testing."""
+    ctx = DataContext.get_current()
+    ctx.enable_progress_bars = False
+    return ray.data.range(DATASET_SIZE, override_num_blocks=NUM_BLOCKS)
+
+
+@pytest.fixture(params=METHODS)
+def method(request):
+    return request.param
+
+
+def create_seed_config(seed_param):
+    """Create seed config from parametrized values."""
+    if seed_param is None:
+        return None
+    if isinstance(seed_param, int):
+        return seed_param
+    if seed_param == "RandomSeedConfig_false":
+        return RandomSeedConfig(seed=42, reseed_after_execution=False)
+    if seed_param == "RandomSeedConfig_true":
+        return RandomSeedConfig(seed=42, reseed_after_execution=True)
+    raise ValueError(f"Unknown seed_param: {seed_param}")
+
+
+def collect_batches_from_epochs(ds, num_epochs=3, batch_size=5):
+    """Collect batches from multiple epochs of iter_batches."""
+    epochs = []
+    for _ in range(num_epochs):
+        epoch_data = []
+        for batch in ds.iter_batches(batch_size=batch_size, batch_format="pandas"):
+            epoch_data.extend(batch["id"].tolist())
+        epochs.append(epoch_data)
+    return epochs
+
+
+def apply_random_operation(ds, method, seed, fraction=None):
+    """Apply the specified random operation to the dataset."""
+    if method == "random_shuffle":
+        return ds.random_shuffle(seed=seed)
+    if method == "random_sample":
+        return ds.random_sample(fraction=fraction or 0.5, seed=seed)
+    if method == "randomize_block_order":
+        return ds.randomize_block_order(seed=seed)
+    raise ValueError(f"Unknown method: {method}")
+
+
+def _normalize_results(method, result):
+    """Sort random_sample results to ignore parallelism-induced ordering differences."""
+    if method == "random_sample":
+        return sorted(result, key=lambda x: x["id"])
+    return result
+
+
+@pytest.mark.parametrize(
+    "seeds,expect_same",
+    [
+        ((42, 42), True),
+        ((42, 123), False),
+    ],
+)
+def test_random_api_seed_determinism(base_dataset, method, seeds, expect_same):
+    """Test that same seeds produce same results and different seeds produce different
+    results."""
+    seed1, seed2 = seeds
+    ds1 = apply_random_operation(base_dataset, method, seed1)
+    ds2 = apply_random_operation(base_dataset, method, seed2)
+    result1 = _normalize_results(method, ds1.take_all())
+    result2 = _normalize_results(method, ds2.take_all())
+
+    if expect_same:
+        assert result1 == result2, f"Same seed should produce same results for {method}"
+    else:
+        assert (
+            result1 != result2
+        ), f"Different seeds should produce different results for {method}"
+
+
+def test_random_api_none_seed(base_dataset, method):
+    """Test that seed=None produces non-deterministic results.
+
+    For random_sample, results are sorted so we compare which items were
+    sampled rather than task completion order. For shuffle methods, ordering
+    *is* the randomness being tested.
+    """
+    ds1 = apply_random_operation(base_dataset, method, None)
+    ds2 = apply_random_operation(base_dataset, method, None)
+    result1 = _normalize_results(method, ds1.take_all())
+    result2 = _normalize_results(method, ds2.take_all())
+
+    assert (
+        result1 != result2
+    ), f"seed=None should produce non-deterministic results for {method}"
+
+
+def test_random_api_reseed_behavior(base_dataset):
+    """Test reseed_after_execution behavior across multiple epochs.
+
+    For shuffle/block_order we compare full row order (no sort); for random_sample
+    we compare sorted items so we only assert same set of sampled rows.
+    """
+    seed_value = 42
+    seed_false = RandomSeedConfig(seed=seed_value, reseed_after_execution=False)
+    seed_true = RandomSeedConfig(seed=seed_value, reseed_after_execution=True)
+
+    # Test random_shuffle with reseed_after_execution=False
+    ds = base_dataset.random_shuffle(seed=seed_false)
+    epochs = collect_batches_from_epochs(ds, num_epochs=3, batch_size=5)
+    assert (
+        epochs[0] == epochs[1] == epochs[2]
+    ), "reseed_after_execution=False should produce same results"
+
+    # Test random_shuffle with reseed_after_execution=True
+    ds = base_dataset.random_shuffle(seed=seed_true)
+    epochs = collect_batches_from_epochs(ds, num_epochs=3, batch_size=5)
+    assert (epochs[0] != epochs[1]) or (
+        epochs[1] != epochs[2]
+    ), "reseed_after_execution=True should produce different results per epoch"
+
+    # Test random_sample with reseed_after_execution=False
+    ds = base_dataset.random_sample(fraction=0.5, seed=seed_false)
+    epochs = collect_batches_from_epochs(ds, num_epochs=2, batch_size=5)
+    assert sorted(epochs[0]) == sorted(
+        epochs[1]
+    ), "reseed_after_execution=False should produce same sampled items"
+
+    # Test randomize_block_order with reseed_after_execution=False
+    ds = base_dataset.randomize_block_order(seed=seed_false)
+    epochs = collect_batches_from_epochs(ds, num_epochs=2, batch_size=5)
+    assert (
+        epochs[0] == epochs[1]
+    ), "reseed_after_execution=False should produce same block order"
+
+
+@pytest.mark.parametrize(
+    "seed_param", [None, 42, "RandomSeedConfig_false", "RandomSeedConfig_true"]
+)
+def test_random_api_multiple_epochs(base_dataset, method, seed_param):
+    """Comprehensive test for all methods and seed configurations across multiple
+    epochs."""
+    seed = create_seed_config(seed_param)
+    ds = apply_random_operation(
+        base_dataset, method, seed, fraction=0.5 if method == "random_sample" else None
+    )
+    epochs = collect_batches_from_epochs(ds, num_epochs=3, batch_size=5)
+
+    assert len(epochs) == 3
+    for i, epoch in enumerate(epochs):
+        if method == "random_sample":
+            assert len(epoch) > 0, f"Epoch {i} should have data"
+        else:
+            assert (
+                len(epoch) == DATASET_SIZE
+            ), f"Epoch {i} should have all {DATASET_SIZE} items"
+
+    if seed_param is None:
+        all_same = all(epoch == epochs[0] for epoch in epochs)
+        assert (
+            not all_same
+        ), f"seed=None should produce different results across epochs for {method}"
+
+    elif seed_param == 42 or seed_param == "RandomSeedConfig_false":
+        assert (
+            epochs[0] == epochs[1] == epochs[2]
+        ), f"Fixed seed should produce same results across epochs for {method}"
+
+    elif seed_param == "RandomSeedConfig_true":
+        # Require at least two consecutive epochs to differ (reseed produces new orderings).
+        assert (epochs[0] != epochs[1]) or (
+            epochs[1] != epochs[2]
+        ), f"reseed_after_execution=True should produce different results per epoch for {method}"
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -7,6 +7,7 @@ from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators import RandomizeBlocks
 from ray.data._internal.planner import create_planner
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data.context import DataContext
 from ray.data.tests.test_util import get_parquet_read_logical_op
 
@@ -18,7 +19,7 @@ def test_randomize_blocks_operator(ray_start_regular_shared):
     read_op = get_parquet_read_logical_op()
     op = RandomizeBlocks(
         read_op,
-        seed=0,
+        seed_config=RandomSeedConfig(seed=0),
     )
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag


### PR DESCRIPTION
## Description

This PR introduces `RandomSeedConfig` to handle random number generation initialization in `random_*` APIs and allow extra options for reproducibility across pipeline re-executions (e.g., training epochs). The class is modeled after `FileShuffleConfig` which uses `DataContext._execution_idx` as an extra seed.

When `RandomSeedConfig(seed, reseed_after_execution=True)` is set, the random ops will be re-seeded after each execution. This means that for random_* APIs, the results will be different for a new call to `iter_*_batches` APIs (i.e., `DataIterator`). In terms of model training, this means the data will be shuffle differently for each epoch, even when a initial random seed is set.

### Changes
* the following APIs now accept a `RandomSeedConfig` object as `seed`:
  * `random_sample()`
  * `random_shuffle()`
  * `randomize_block_order()`

## Related issues
Closes #55275

## Additional information
### Implementation

* Numpy's `default_rng()` takes an integer or a tuple of them. So when `reseed_after_execution` is set, we use `(execution_idx, base_seed)` to initialize. This needs to happens somewhere lower-level in Ray Data that is re-run during multiple execution.
* The seed tuple remains "deterministic" as the `execution_idx` is incremented by 1 each time the pipeline gets rerun. This in principle allows the multiple-epoch model training to be reproducible (minus other usual things that affect reproducibility, e.g., ordering, cluster configs, etc)
* This PR consolidates the `seed` argument. So the original integer/None seed is wrapped inside `RandomSeedConfig` before passing into the op definitions. In principle, we could make a default value of `reseed_after_execution` in `DataContext` to control all seed handling at once.

### Example

When `reseed_after_execution` is set to True, re-execution of the pipeline (second line) will return different results.
```python
ds = ray.data.range(10)
ds.random_shuffle(seed=RandomSeedConfig(1234, reseed_after_execution=True)).take_all()
```
Setting `reseed_after_execution` to `False` (or use integer seed directly) will produce the same (random) result when the pipeline is executed multiple times.

### Notes
* For a materialized Ray Dataset (i.e., `materialize()` is called), there is no effect as the pipeline is not re-executed in this case.
* There are a few other APIs with `seed` argument that I didn't touch.