### PR TITLE
[Data] Remove unnecessary `PhysicalOperator.implements_accurate_memory_accounting`

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -757,21 +757,6 @@ class PhysicalOperator(Operator):
         """Return a list of `AutoscalingActorPool`s managed by this operator."""
         return []
 
-    def implements_accurate_memory_accounting(self) -> bool:
-        """Return whether this operator implements accurate memory accounting.
-
-        An operator that implements accurate memory accounting should properly
-        report its memory usage via the following APIs:
-          - `self._metrics.on_input_queued`.
-          - `self._metrics.on_input_dequeued`.
-          - `self._metrics.on_output_queued`.
-          - `self._metrics.on_output_dequeued`.
-        """
-        # TODO(hchen): Currently we only enable `ReservationOpResourceAllocator` when
-        # all operators in the dataset have implemented accurate memory accounting.
-        # Eventually all operators should implement accurate memory accounting.
-        return False
-
     def supports_fusion(self) -> bool:
         """Returns ```True``` if this operator can be fused with other operators."""
         return False

--- a/python/ray/data/_internal/execution/operators/aggregate_num_rows.py
+++ b/python/ray/data/_internal/execution/operators/aggregate_num_rows.py
@@ -59,6 +59,3 @@ class AggregateNumRows(PhysicalOperator):
 
     def throttling_disabled(self) -> bool:
         return True
-
-    def implements_accurate_memory_accounting(self) -> bool:
-        return True

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -228,9 +228,6 @@ class AllToAllOperator(
     def supports_fusion(self):
         return True
 
-    def implements_accurate_memory_accounting(self):
-        return True
-
 
 class NAryOperator(PhysicalOperator):
     """An operator that has multiple input dependencies and one output.

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1002,9 +1002,6 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
         # TODO separate marking as completed from the check
         return self._is_finalized() and super().completed()
 
-    def implements_accurate_memory_accounting(self) -> bool:
-        return True
-
     def _is_finalized(self):
         return len(self._pending_finalization_partition_ids) == 0
 

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -94,6 +94,3 @@ class InputDataBuffer(PhysicalOperator):
         self._stats = {
             "input": block_metadata,
         }
-
-    def implements_accurate_memory_accounting(self) -> bool:
-        return True

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -131,6 +131,3 @@ class LimitOperator(OneToOneOperator):
 
     def throttling_disabled(self) -> bool:
         return True
-
-    def implements_accurate_memory_accounting(self) -> bool:
-        return True

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -701,9 +701,6 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     def incremental_resource_usage(self) -> ExecutionResources:
         raise NotImplementedError
 
-    def implements_accurate_memory_accounting(self) -> bool:
-        return True
-
     def supports_fusion(self) -> bool:
         return self._supports_fusion
 

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -282,9 +282,6 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
 
         return preferred_locations.keys()
 
-    def implements_accurate_memory_accounting(self) -> bool:
-        return True
-
 
 def _split(bundle: RefBundle, left_size: int) -> Tuple[RefBundle, RefBundle]:
     left_blocks, left_meta = [], []

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -134,6 +134,3 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
 
     def get_stats(self) -> StatsDict:
         return self._stats
-
-    def implements_accurate_memory_accounting(self):
-        return True

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -149,9 +149,6 @@ class ZipOperator(InternalQueueOperatorMixin, NAryOperator):
     def get_stats(self) -> StatsDict:
         return self._stats
 
-    def implements_accurate_memory_accounting(self):
-        return True
-
     def _zip(
         self,
         left_input: collections.deque[RefBundle],

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -91,15 +91,9 @@ class ResourceManager:
         self._op_resource_allocator: Optional["OpResourceAllocator"] = None
 
         if data_context.op_resource_reservation_enabled:
-            # We'll enable memory reservation if all operators have
-            # implemented accurate memory accounting.
-            should_enable = all(
-                op.implements_accurate_memory_accounting() for op in topology
+            self._op_resource_allocator = ReservationOpResourceAllocator(
+                self, data_context.op_resource_reservation_ratio
             )
-            if should_enable:
-                self._op_resource_allocator = ReservationOpResourceAllocator(
-                    self, data_context.op_resource_reservation_ratio
-                )
 
         self._object_store_memory_limit_fraction = (
             data_context.override_object_store_memory_limit_fraction


### PR DESCRIPTION
`PhysicalOperator` has an `implements_accurate_memory_accounting` method. Subclasses override it and return `True` if they properly call the `OpRuntimeMetrics` hooks like `on_input_queued`.

We previously needed this method because operators like `AllToAllOperator` didn't update `OpRuntimeMetrics`, and that would cause issues for resource allocation. However, now that all operators implement accurate memory accounting, this method isn't necessary anymore.

(Sanity check from Claude below)
```
⏺ Based on my search, no concrete PhysicalOperator subclass returns False for implements_accurate_memory_accounting.

  Here's the breakdown:

  Base class default: PhysicalOperator returns False at physical_operator.py:773

  All concrete operators return True:

  | Operator                | Source                                                         |
  |-------------------------|----------------------------------------------------------------|
  | MapOperator             | Overrides at map_operator.py:704                               |
  | TaskPoolMapOperator     | Inherits from MapOperator                                      |
  | ActorPoolMapOperator    | Inherits from MapOperator                                      |
  | LimitOperator           | Overrides at limit_operator.py:135                             |
  | InputDataBuffer         | Overrides at input_data_buffer.py:98                           |
  | OutputSplitter          | Overrides at output_splitter.py:285                            |
  | AggregateNumRows        | Overrides at aggregate_num_rows.py:63                          |
  | UnionOperator           | Overrides at union_operator.py:138                             |
  | ZipOperator             | Overrides at zip_operator.py:152                               |
  | HashShuffleOperator     | Inherits from HashShufflingOperatorBase (hash_shuffle.py:1005) |
  | JoinOperator            | Inherits from HashShufflingOperatorBase                        |
  | HashAggregateOperator   | Inherits from HashShufflingOperatorBase                        |
  | OneToOneOperator (base) | Overrides at base_physical_operator.py:231                     |

  The only class that returns False (by inheritance) is the abstract NAryOperator base class, but its two concrete subclasses (UnionOperator and ZipOperator) both override it to return True.
```