### PR TITLE
[Data] Make `ReservationOpResourceAllocator. _get_ineligible_ops_with_usage` a utility function

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -934,7 +934,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
 def get_ineligible_op_usage(
     topology: "Topology", resource_manager: "ResourceManager"
-) -> List[PhysicalOperator]:
+) -> ExecutionResources:
     """
     Resource reservation is based on the number of eligible operators.
     However, there might be completed operators that still have blocks in their output queue, which we need to exclude them from the reservation.

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -670,37 +670,6 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
         self._idle_detector = self.IdleDetector()
 
-    def _get_ineligible_ops_with_usage(self) -> List[PhysicalOperator]:
-        """
-        Resource reservation is based on the number of eligible operators.
-        However, there might be completed operators that still have blocks in their output queue, which we need to exclude them from the reservation.
-        And we also need to exclude the downstream ineligible operators.
-
-        E.g., for the following pipeline:
-        ```
-        map1 (completed, but still has blocks in its output queue) -> limit1 (ineligible, not completed) -> map2 (not completed) -> limit2 -> map3
-        ```
-
-        The reservation is based on the number of eligible operators (map2 and map3), but we need to exclude map1 and limit1 from the reservation.
-        """
-        last_completed_ops = []
-        ops_to_exclude_from_reservation = []
-        # Traverse operator tree collecting all operators that have already finished
-        for op in self._topology:
-            if not op.has_execution_finished():
-                for dep in op.input_dependencies:
-                    if dep.has_execution_finished():
-                        last_completed_ops.append(dep)
-
-        # In addition to completed operators,
-        # filter out downstream ineligible operators since they are omitted from reservation calculations.
-        for op in last_completed_ops:
-            ops_to_exclude_from_reservation.extend(
-                list(self._resource_manager.get_downstream_ineligible_ops(op))
-            )
-            ops_to_exclude_from_reservation.append(op)
-        return list(set(ops_to_exclude_from_reservation))
-
     def _update_reservation(self, limits: ExecutionResources):
         eligible_ops = self._resource_manager.get_eligible_ops()
 
@@ -829,12 +798,10 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         *,
         limits: ExecutionResources,
     ):
-        op_to_exclude_from_reservation = self._get_ineligible_ops_with_usage()
-        for completed_op in op_to_exclude_from_reservation:
-            completed_op_usage = self._resource_manager.get_op_usage(completed_op)
-
-            limits = limits.subtract(completed_op_usage)
-            limits = limits.max(ExecutionResources.zero())
+        ineligible_op_usage = get_ineligible_op_usage(
+            self._topology, self._resource_manager
+        )
+        limits = limits.subtract(ineligible_op_usage).max(ExecutionResources.zero())
 
         # Remaining resources to be distributed across operators
         remaining_shared = self._update_reservation(limits)
@@ -963,3 +930,42 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
                 self._op_budgets[op] = self._op_budgets[op].copy(
                     object_store_memory=float("inf")
                 )
+
+
+def get_ineligible_op_usage(
+    topology: "Topology", resource_manager: "ResourceManager"
+) -> List[PhysicalOperator]:
+    """
+    Resource reservation is based on the number of eligible operators.
+    However, there might be completed operators that still have blocks in their output queue, which we need to exclude them from the reservation.
+    And we also need to exclude the downstream ineligible operators.
+
+    E.g., for the following pipeline:
+    ```
+    map1 (completed, but still has blocks in its output queue) -> limit1 (ineligible, not completed) -> map2 (not completed) -> limit2 -> map3
+    ```
+
+    The reservation is based on the number of eligible operators (map2 and map3), but we need to exclude map1 and limit1 from the reservation.
+    """
+    last_completed_ops = []
+    ops_to_exclude_from_reservation = []
+    # Traverse operator tree collecting all operators that have already finished
+    for op in topology:
+        if not op.has_execution_finished():
+            for dep in op.input_dependencies:
+                if dep.has_execution_finished():
+                    last_completed_ops.append(dep)
+
+    # In addition to completed operators,
+    # filter out downstream ineligible operators since they are omitted from reservation calculations.
+    for op in last_completed_ops:
+        ops_to_exclude_from_reservation.extend(
+            list(resource_manager.get_downstream_ineligible_ops(op))
+        )
+        ops_to_exclude_from_reservation.append(op)
+
+    ineligible_op_usage = ExecutionResources.zero()
+    for op in set(ops_to_exclude_from_reservation):
+        ineligible_op_usage = ineligible_op_usage.add(resource_manager.get_op_usage(op))
+
+    return ineligible_op_usage

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -960,7 +960,7 @@ def get_ineligible_op_usage(
     # filter out downstream ineligible operators since they are omitted from reservation calculations.
     for op in last_completed_ops:
         ops_to_exclude_from_reservation.extend(
-            list(resource_manager.get_downstream_ineligible_ops(op))
+            resource_manager.get_downstream_ineligible_ops(op)
         )
         ops_to_exclude_from_reservation.append(op)
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -20,6 +20,7 @@ from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.resource_manager import (
     ReservationOpResourceAllocator,
     ResourceManager,
+    get_ineligible_op_usage,
 )
 from ray.data._internal.execution.streaming_executor_state import (
     build_streaming_topology,
@@ -1008,36 +1009,39 @@ class TestReservationOpResourceAllocator:
 
         assert allocator._op_budgets[o2].gpu == 0
 
-    def test_get_ineligible_ops_with_usage(self, restore_data_context):
+    def test_get_ineligible_op_usage(self, restore_data_context):
         DataContext.get_current().op_resource_reservation_enabled = True
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
-        o2 = mock_map_op(
-            o1,
-        )
+        o2 = mock_map_op(o1)
         o3 = LimitOperator(1, o2, DataContext.get_current())
-        o4 = mock_map_op(
-            o3,
-        )
-        o5 = mock_map_op(
-            o4,
-        )
+        o4 = mock_map_op(o3)
+        o5 = mock_map_op(o4)
         o1.mark_execution_finished()
         o2.mark_execution_finished()
 
         topo = build_streaming_topology(o5, ExecutionOptions())
 
+        op_usages = {
+            o1: ExecutionResources.zero(),
+            o2: ExecutionResources(cpu=1, object_store_memory=1),
+            o3: ExecutionResources(cpu=2, object_store_memory=2),
+            o4: ExecutionResources(cpu=3, object_store_memory=3),
+            o5: ExecutionResources(cpu=4, object_store_memory=4),
+        }
+
         resource_manager = ResourceManager(
             topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
         )
+        resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
 
-        allocator = resource_manager._op_resource_allocator
+        # Ineligible: o1 (finished), o2 (finished), o3 (throttling disabled)
+        ineligible_usage = get_ineligible_op_usage(topo, resource_manager)
 
-        ops_to_exclude = allocator._get_ineligible_ops_with_usage()
-        assert len(ops_to_exclude) == 2
-        assert set(ops_to_exclude) == {o2, o3}
+        # Expected: o1 + o2 + o3 = (0+1+2, 0+10+20)
+        assert ineligible_usage == ExecutionResources(cpu=3, object_store_memory=3)
 
-    def test_get_ineligible_ops_with_usage_complex_graph(self, restore_data_context):
+    def test_get_ineligible_op_usage_complex_graph(self, restore_data_context):
         """
         o1 (InputDataBuffer)
                 |
@@ -1061,14 +1065,10 @@ class TestReservationOpResourceAllocator:
         DataContext.get_current().op_resource_reservation_enabled = True
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
-        o2 = mock_map_op(
-            o1,
-        )
+        o2 = mock_map_op(o1)
         o3 = LimitOperator(1, o2, DataContext.get_current())
         o4 = InputDataBuffer(DataContext.get_current(), [])
-        o5 = mock_map_op(
-            o4,
-        )
+        o5 = mock_map_op(o4)
         o6 = mock_union_op([o3, o5])
         o7 = InputDataBuffer(DataContext.get_current(), [])
         o8 = mock_join_op(o7, o6)
@@ -1081,15 +1081,26 @@ class TestReservationOpResourceAllocator:
 
         topo = build_streaming_topology(o8, ExecutionOptions())
 
+        op_usages = {
+            o1: ExecutionResources.zero(),
+            o2: ExecutionResources(cpu=2, object_store_memory=2),
+            o3: ExecutionResources(cpu=3, object_store_memory=3),
+            o4: ExecutionResources.zero(),
+            o5: ExecutionResources(cpu=5, object_store_memory=5),
+            o6: ExecutionResources(cpu=6, object_store_memory=6),
+            o7: ExecutionResources.zero(),
+            o8: ExecutionResources(cpu=8, object_store_memory=8),
+        }
+
         resource_manager = ResourceManager(
             topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
         )
+        resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
 
-        allocator = resource_manager._op_resource_allocator
+        ineligible_usage = get_ineligible_op_usage(topo, resource_manager)
 
-        ops_to_exclude = allocator._get_ineligible_ops_with_usage()
-        assert len(ops_to_exclude) == 4
-        assert set(ops_to_exclude) == {o2, o3, o5, o7}
+        # Ineligible: o1, o2, o3, o4, o5, o7 -> sum = 2+3+5 = 10
+        assert ineligible_usage == ExecutionResources(cpu=10, object_store_memory=10)
 
     def test_reservation_accounts_for_completed_ops(self, restore_data_context):
         """Test that resource reservation properly accounts for completed ops."""


### PR DESCRIPTION
This PR makes the `ReservationOpResourceAllocator. _get_ineligible_ops_with_usage` method a utility function named `get_ineligible_op_usage`. The motivation is so that the logic can be reused by other allocator implementations.