### PR TITLE
[Data] Remove extra "the" from resource request comment

### DIFF
--- a/python/ray/data/_internal/execution/autoscaling_requester.py
+++ b/python/ray/data/_internal/execution/autoscaling_requester.py
@@ -56,7 +56,7 @@ class AutoscalingRequester:
         # Purge expired requests before making request to autoscaler.
         self._purge()
         # For the same execution_id, we track the latest resource request and
-        # the its expiration timestamp.
+        # its expiration timestamp.
         self._resource_requests[execution_id] = (
             req,
             time.time() + self._timeout,


### PR DESCRIPTION


## Description
Fixed a minor typo in the comment for execution_id resource tracking logic.

Remove the redundant "the" before "its expiration timestamp"

- From: `# For the same execution_id, we track the latest resource request and the its expiration timestamp.`
- To: `# For the same execution_id, we track the latest resource request and its expiration timestamp.`


## Impact
- No functional changes, just improves comment clarity
