### PR TITLE
[Data] Compute Expressions - Expr Arithmetic

### DIFF
--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -458,6 +458,72 @@ class Expr(ABC):
             self
         )
 
+    # arithmetic helpers
+    def negate(self) -> "UDFExpr":
+        """Compute the negation of the expression.
+        
+        Returns:
+            A UDFExpr that computes the negation (multiplies values by -1).
+            
+        Example:
+            >>> from ray.data.expressions import col
+            >>> import ray
+            >>> ds = ray.data.from_items([{"x": 5}, {"x": -3}])
+            >>> ds = ds.with_column("neg_x", col("x").negate())
+            >>> # Result: neg_x = [-5, 3]
+        """
+        return _create_pyarrow_compute_udf(pc.negate_checked)(self)
+
+    def sign(self) -> "UDFExpr":
+        """Compute the sign of the expression.
+        
+        Returns:
+            A UDFExpr that returns -1 for negative values, 0 for zero, and 1 for positive values.
+            
+        Example:
+            >>> from ray.data.expressions import col
+            >>> import ray
+            >>> ds = ray.data.from_items([{"x": 5}, {"x": -3}, {"x": 0}])
+            >>> ds = ds.with_column("sign_x", col("x").sign())
+            >>> # Result: sign_x = [1, -1, 0]
+        """
+        return _create_pyarrow_compute_udf(pc.sign)(self)
+
+    def power(self, exponent: Any) -> "UDFExpr":
+        """Raise the expression to the given power.
+        
+        Args:
+            exponent: The exponent to raise the expression to.
+            
+        Returns:
+            A UDFExpr that computes the power operation.
+            
+        Example:
+            >>> from ray.data.expressions import col, lit
+            >>> import ray
+            >>> ds = ray.data.from_items([{"x": 2}, {"x": 3}])
+            >>> ds = ds.with_column("x_squared", col("x").power(2))
+            >>> # Result: x_squared = [4, 9]
+            >>> ds = ds.with_column("x_cubed", col("x").power(3))
+            >>> # Result: x_cubed = [8, 27]
+        """
+        return _create_pyarrow_compute_udf(pc.power)(self, exponent)
+
+    def abs(self) -> "UDFExpr":
+        """Compute the absolute value of the expression.
+        
+        Returns:
+            A UDFExpr that computes the absolute value.
+            
+        Example:
+            >>> from ray.data.expressions import col
+            >>> import ray
+            >>> ds = ray.data.from_items([{"x": 5}, {"x": -3}])
+            >>> ds = ds.with_column("abs_x", col("x").abs())
+            >>> # Result: abs_x = [5, 3]
+        """
+        return _create_pyarrow_compute_udf(pc.abs_checked)(self)
+
     @property
     def list(self) -> "_ListNamespace":
         """Access list operations for this expression.

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -461,10 +461,10 @@ class Expr(ABC):
     # arithmetic helpers
     def negate(self) -> "UDFExpr":
         """Compute the negation of the expression.
-        
+
         Returns:
             A UDFExpr that computes the negation (multiplies values by -1).
-            
+
         Example:
             >>> from ray.data.expressions import col
             >>> import ray
@@ -476,10 +476,10 @@ class Expr(ABC):
 
     def sign(self) -> "UDFExpr":
         """Compute the sign of the expression.
-        
+
         Returns:
             A UDFExpr that returns -1 for negative values, 0 for zero, and 1 for positive values.
-            
+
         Example:
             >>> from ray.data.expressions import col
             >>> import ray
@@ -491,13 +491,13 @@ class Expr(ABC):
 
     def power(self, exponent: Any) -> "UDFExpr":
         """Raise the expression to the given power.
-        
+
         Args:
             exponent: The exponent to raise the expression to.
-            
+
         Returns:
             A UDFExpr that computes the power operation.
-            
+
         Example:
             >>> from ray.data.expressions import col, lit
             >>> import ray
@@ -511,10 +511,10 @@ class Expr(ABC):
 
     def abs(self) -> "UDFExpr":
         """Compute the absolute value of the expression.
-        
+
         Returns:
             A UDFExpr that computes the absolute value.
-            
+
         Example:
             >>> from ray.data.expressions import col
             >>> import ray


### PR DESCRIPTION
## Description

Completing the Expr Arithmetic operations: negate, sign, power, abs

``` 
import ray
from ray.data import from_items
from ray.data.expressions import col

ds = from_items([{"x": 5}, {"x": 2}, {"x": 0}])
for row in ds.iter_rows():
    print(row)

x_expr = col("x")

ds = ds.with_column("x_negate", x_expr.negate())

ds = ds.with_column("x_sign", x_expr.sign())

ds = ds.with_column("x_power", x_expr.power(2))

ds = ds.with_column("x_abs", x_expr.abs())

for row in ds.iter_rows():
    print(row)
```

## Related issues

Related to #58674

