### PR TITLE
[build] workaround for bazel.build cert expiry

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,3 @@
+# Using GitHub mirror for BCR to work around bcr.bazel.build outages
+# Fix for https://github.com/bazelbuild/bazel/issues/28101
+BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download

--- a/.bazelrc
+++ b/.bazelrc
@@ -240,3 +240,7 @@ build:macos --sandbox_block_path=/usr/local/
 build:macos --copt="-Wno-error=deprecated-declarations"
 # This option controls whether javac checks for missing direct dependencies.
 build --experimental_strict_java_deps=off
+
+# Using GitHub mirror for BCR to work around bcr.bazel.build outages
+# Fix for https://github.com/bazelbuild/bazel/issues/28101
+common --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/

--- a/.bazelrc
+++ b/.bazelrc
@@ -241,6 +241,9 @@ build:macos --copt="-Wno-error=deprecated-declarations"
 # This option controls whether javac checks for missing direct dependencies.
 build --experimental_strict_java_deps=off
 
+# TODO(bazel-cert-expiry): Remove this once https://github.com/bazelbuild/bazel/issues/28101 is resolved.
 # Using GitHub mirror for BCR to work around bcr.bazel.build outages
 # Fix for https://github.com/bazelbuild/bazel/issues/28101
 common --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/
+# Rewrite mirror.bazel.build URLs to original sources (GitHub, golang.org)
+common --experimental_downloader_config=bazel/mirror_fallback.cfg

--- a/bazel/mirror_fallback.cfg
+++ b/bazel/mirror_fallback.cfg
@@ -1,0 +1,11 @@
+# Bazel downloader configuration for mirror.bazel.build fallback
+# TODO(bazel-cert-expiry): Remove this once https://github.com/bazelbuild/bazel/issues/28101 is resolved.
+#
+# Rewrites mirror.bazel.build URLs to working alternatives to work around
+# SSL certificate validation failures on mirror.bazel.build.
+
+# golang.org is not on GCS mirror - rewrite to original source
+rewrite mirror\.bazel\.build/golang\.org/(.*) golang.org/$1
+
+# Everything else -> GCS mirror (github.com paths, coverage tools, etc.)
+rewrite mirror\.bazel\.build/(.*) storage.googleapis.com/bazel-mirror/$1

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -40,7 +40,7 @@ def auto_http_archive(
     # Using GitHub mirror for BCR to work around bcr.bazel.build outages
     # Fix for https://github.com/bazelbuild/bazel/issues/28101
     # mirror_prefixes = ["https://mirror.bazel.build/", "https://storage.googleapis.com/bazel-mirror"]
-    mirror_prefixes = ["https://storage.googleapis.com/bazel-mirror"]
+    mirror_prefixes = ["https://storage.googleapis.com/bazel-mirror/"]
 
     canonical_url = url if url != None else urls[0]
     url_parts = urlsplit(canonical_url)

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -37,7 +37,10 @@ def auto_http_archive(
     If strip_prefix == True , it is auto-deduced.
     """
     DOUBLE_SUFFIXES_LOWERCASE = [("tar", "bz2"), ("tar", "gz"), ("tar", "xz")]
-    mirror_prefixes = ["https://mirror.bazel.build/", "https://storage.googleapis.com/bazel-mirror"]
+    # Using GitHub mirror for BCR to work around bcr.bazel.build outages
+    # Fix for https://github.com/bazelbuild/bazel/issues/28101
+    # mirror_prefixes = ["https://mirror.bazel.build/", "https://storage.googleapis.com/bazel-mirror"]
+    mirror_prefixes = ["https://storage.googleapis.com/bazel-mirror"]
 
     canonical_url = url if url != None else urls[0]
     url_parts = urlsplit(canonical_url)

--- a/ci/docker/base.build.aarch64.wanda.yaml
+++ b/ci/docker/base.build.aarch64.wanda.yaml
@@ -3,6 +3,7 @@ froms: ["cr.ray.io/rayproject/oss-ci-base_test-aarch64"]
 dockerfile: ci/docker/base.build.Dockerfile
 srcs:
   - .bazelrc
+  - .bazeliskrc
   - ci/ci.sh
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.build.aarch64.wanda.yaml
+++ b/ci/docker/base.build.aarch64.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/base.build.Dockerfile
 srcs:
   - .bazelrc
   - .bazeliskrc
+  - bazel/mirror_fallback.cfg
   - ci/ci.sh
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.build.wanda.yaml
+++ b/ci/docker/base.build.wanda.yaml
@@ -3,6 +3,7 @@ froms: ["cr.ray.io/rayproject/oss-ci-base_test-py$PYTHON"]
 dockerfile: ci/docker/base.build.Dockerfile
 srcs:
   - .bazelrc
+  - .bazeliskrc
   - ci/ci.sh
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.build.wanda.yaml
+++ b/ci/docker/base.build.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/base.build.Dockerfile
 srcs:
   - .bazelrc
   - .bazeliskrc
+  - bazel/mirror_fallback.cfg
   - ci/ci.sh
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.cu128.wanda.yaml
+++ b/ci/docker/base.cu128.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
   - .bazeliskrc
+  - bazel/mirror_fallback.cfg
   - .bazelversion
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.cu128.wanda.yaml
+++ b/ci/docker/base.cu128.wanda.yaml
@@ -3,6 +3,7 @@ froms: ["nvidia/cuda:12.8.1-cudnn-devel-ubuntu20.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
+  - .bazeliskrc
   - .bazelversion
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.gpu.py39.wanda.yaml
+++ b/ci/docker/base.gpu.py39.wanda.yaml
@@ -9,6 +9,7 @@ froms: ["nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
+  - .bazeliskrc
   - .bazelversion
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.gpu.py39.wanda.yaml
+++ b/ci/docker/base.gpu.py39.wanda.yaml
@@ -10,6 +10,7 @@ dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
   - .bazeliskrc
+  - bazel/mirror_fallback.cfg
   - .bazelversion
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.gpu.wanda.yaml
+++ b/ci/docker/base.gpu.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
   - .bazeliskrc
+  - bazel/mirror_fallback.cfg
   - .bazelversion
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.gpu.wanda.yaml
+++ b/ci/docker/base.gpu.wanda.yaml
@@ -3,6 +3,7 @@ froms: ["nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
+  - .bazeliskrc
   - .bazelversion
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.ml.wanda.yaml
+++ b/ci/docker/base.ml.wanda.yaml
@@ -3,6 +3,7 @@ froms: ["cr.ray.io/rayproject/oss-ci-base_test-py$PYTHON"]
 dockerfile: ci/docker/base.ml.Dockerfile
 srcs:
   - .bazelrc
+  - .bazeliskrc
   - ci/ci.sh
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.ml.wanda.yaml
+++ b/ci/docker/base.ml.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/base.ml.Dockerfile
 srcs:
   - .bazelrc
   - .bazeliskrc
+  - bazel/mirror_fallback.cfg
   - ci/ci.sh
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh

--- a/ci/docker/base.test.aarch64.wanda.yaml
+++ b/ci/docker/base.test.aarch64.wanda.yaml
@@ -6,6 +6,7 @@ srcs:
   - ci/env/install-miniforge.sh
   - ci/suppress_output
   - .bazelversion
+  - .bazeliskrc
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON=3.10

--- a/ci/docker/base.test.py39.wanda.yaml
+++ b/ci/docker/base.test.py39.wanda.yaml
@@ -6,6 +6,7 @@ srcs:
   - ci/env/install-miniforge.sh
   - ci/suppress_output
   - .bazelversion
+  - .bazeliskrc
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
 tags:

--- a/ci/docker/base.test.wanda.yaml
+++ b/ci/docker/base.test.wanda.yaml
@@ -6,6 +6,7 @@ srcs:
   - ci/env/install-miniforge.sh
   - ci/suppress_output
   - .bazelversion
+  - .bazeliskrc
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON

--- a/ci/docker/ray-core.Dockerfile
+++ b/ci/docker/ray-core.Dockerfile
@@ -29,7 +29,7 @@ if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
   echo "build --remote_upload_local_results=false" >> "$HOME/.bazelrc"
 fi
 
-bazelisk build --config=ci //:ray_pkg_zip //:ray_py_proto_zip
+bazelisk build --config=ci --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/ //:ray_pkg_zip //:ray_py_proto_zip
 
 cp bazel-bin/ray_pkg.zip /home/forge/ray_pkg.zip
 cp bazel-bin/ray_py_proto.zip /home/forge/ray_py_proto.zip

--- a/ci/docker/ray-core.wanda.yaml
+++ b/ci/docker/ray-core.wanda.yaml
@@ -5,6 +5,7 @@ srcs:
   - .bazelversion
   - .bazelrc
   - .bazeliskrc
+  - bazel/mirror_fallback.cfg
   - WORKSPACE
   - BUILD.bazel
   - bazel/

--- a/ci/docker/ray-core.wanda.yaml
+++ b/ci/docker/ray-core.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/ray-core.Dockerfile
 srcs:
   - .bazelversion
   - .bazelrc
+  - .bazeliskrc
   - WORKSPACE
   - BUILD.bazel
   - bazel/

--- a/ci/docker/ray-java.Dockerfile
+++ b/ci/docker/ray-java.Dockerfile
@@ -22,7 +22,7 @@ if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
   echo "build --remote_upload_local_results=false" >> "$HOME/.bazelrc"
 fi
 
-bazelisk run --config=ci //java:gen_ray_java_pkg
+bazelisk run --config=ci --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/ //java:gen_ray_java_pkg
 
 cp bazel-bin/java/ray_java_pkg.zip /home/forge/ray_java_pkg.zip
 

--- a/ci/docker/ray-java.wanda.yaml
+++ b/ci/docker/ray-java.wanda.yaml
@@ -4,6 +4,7 @@ dockerfile: ci/docker/ray-java.Dockerfile
 srcs:
   - .bazelversion
   - .bazelrc
+  - .bazeliskrc
   - WORKSPACE
   - BUILD.bazel
   - bazel/

--- a/ci/docker/ray-java.wanda.yaml
+++ b/ci/docker/ray-java.wanda.yaml
@@ -5,6 +5,7 @@ srcs:
   - .bazelversion
   - .bazelrc
   - .bazeliskrc
+  - bazel/mirror_fallback.cfg
   - WORKSPACE
   - BUILD.bazel
   - bazel/

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -99,6 +99,14 @@ fi
 # Download Bazel itself from GitHub releases (avoids releases.bazel.build TLS outages)
 export BAZELISK_FORMAT_URL='https://github.com/bazelbuild/bazel/releases/download/%v/bazel-%v-%o-%m%e'
 export BAZELISK_BASE_URL="https://github.com/bazelbuild/bazel/releases/download"
+
+# Recreate ~/.bazeliskrc to ensure it is up to date.
+touch ~/.bazeliskrc
+{
+  echo "BAZELISK_FORMAT_URL=${BAZELISK_FORMAT_URL}"
+  echo "BAZELISK_BASE_URL=${BAZELISK_BASE_URL}"
+} >> ~/.bazeliskrc
+
 bazel --version
 
 if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -100,12 +100,10 @@ fi
 export BAZELISK_FORMAT_URL='https://github.com/bazelbuild/bazel/releases/download/%v/bazel-%v-%o-%m%e'
 export BAZELISK_BASE_URL="https://github.com/bazelbuild/bazel/releases/download"
 
-# Recreate ~/.bazeliskrc to ensure it is up to date.
-touch ~/.bazeliskrc
-{
-  echo "BAZELISK_FORMAT_URL=${BAZELISK_FORMAT_URL}"
-  echo "BAZELISK_BASE_URL=${BAZELISK_BASE_URL}"
-} >> ~/.bazeliskrc
+cat > ~/.bazeliskrc <<EOF
+BAZELISK_FORMAT_URL=${BAZELISK_FORMAT_URL}
+BAZELISK_BASE_URL=${BAZELISK_BASE_URL}
+EOF
 
 bazel --version
 

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -96,7 +96,9 @@ fi
 # Using GitHub mirror for BCR to work around bcr.bazel.build outages
 # Fix for https://github.com/bazelbuild/bazel/issues/28101
 # TODO: Check to see why ~/.bazeliskrc is not working.
-export BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download
+# Download Bazel itself from GitHub releases (avoids releases.bazel.build TLS outages)
+export BAZELISK_FORMAT_URL='https://github.com/bazelbuild/bazel/releases/download/%v/bazel-%v-%o-%m%e'
+export BAZELISK_BASE_URL="https://github.com/bazelbuild/bazel/releases/download"
 bazel --version
 
 if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -101,8 +101,13 @@ if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then
 
   # Ask bazel to anounounce the config it finds in bazelrcs, which makes
   # understanding how to reproduce bazel easier.
-  echo "build --announce_rc" >> ~/.bazelrc
-  echo "build --config=ci" >> ~/.bazelrc
+  {
+    echo "build --announce_rc"
+    echo "build --config=ci"
+    # Using GitHub mirror for BCR to work around bcr.bazel.build outages
+    # Fix for https://github.com/bazelbuild/bazel/issues/28101
+    echo "common --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/"
+  } >> ~/.bazelrc
 
   # In Windows CI we want to use this to avoid long path issue
   # https://docs.bazel.build/versions/main/windows.html#avoid-long-path-issues

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -93,6 +93,10 @@ if [[ "${BAZEL_CONFIG_ONLY-}" != "1" ]]; then
   fi
 fi
 
+# Using GitHub mirror for BCR to work around bcr.bazel.build outages
+# Fix for https://github.com/bazelbuild/bazel/issues/28101
+# TODO: Check to see why ~/.bazeliskrc is not working.
+export BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download
 bazel --version
 
 if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then

--- a/cpp/example/_.bazelrc
+++ b/cpp/example/_.bazelrc
@@ -1,2 +1,9 @@
 build --cxxopt="-std=c++17"
 build --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0"
+
+# TODO(bazel-cert-expiry): Remove this once https://github.com/bazelbuild/bazel/issues/28101 is resolved.
+# Using GitHub mirror for BCR to work around bcr.bazel.build outages
+# Fix for https://github.com/bazelbuild/bazel/issues/28101
+common --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/
+# Rewrite mirror.bazel.build URLs to original sources (GitHub, golang.org)
+common --experimental_downloader_config=bazel/mirror_fallback.cfg

--- a/cpp/example/_.bazelrc
+++ b/cpp/example/_.bazelrc
@@ -5,5 +5,3 @@ build --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0"
 # Using GitHub mirror for BCR to work around bcr.bazel.build outages
 # Fix for https://github.com/bazelbuild/bazel/issues/28101
 common --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/
-# Rewrite mirror.bazel.build URLs to original sources (GitHub, golang.org)
-common --experimental_downloader_config=bazel/mirror_fallback.cfg


### PR DESCRIPTION
Datadog used a workaround on their end that should work for us as well. Once upstream issue is resolved, we can remove this
https://github.com/DataDog/datadog-agent/pull/44621

See: https://github.com/bazelbuild/bazel/issues/28101