### PR TITLE
[Autoscaler] Add --force-setup-commands flag to ray up

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1418,6 +1418,16 @@ def stop(force: bool, grace_period: int):
     ),
 )
 @click.option(
+    "--force-setup-commands",
+    is_flag=True,
+    default=False,
+    help=(
+        "Whether to force re-running setup commands even if the cluster "
+        "configuration has not changed. Useful when installing packages "
+        "from external sources (e.g., GitHub) that may have been updated."
+    ),
+)
+@click.option(
     "--yes", "-y", is_flag=True, default=False, help="Don't ask for confirmation."
 )
 @click.option(
@@ -1463,6 +1473,7 @@ def up(
     max_workers,
     no_restart,
     restart_only,
+    force_setup_commands,
     yes,
     cluster_name,
     no_config_cache,
@@ -1485,6 +1496,17 @@ def up(
             restart_only != no_restart
         ), "Cannot set both 'restart_only' and 'no_restart' at the same time!"
 
+    if force_setup_commands and restart_only:
+        cli_logger.doassert(
+            False,
+            "`{}` is incompatible with `{}`.",
+            cf.bold("--force-setup-commands"),
+            cf.bold("--restart-only"),
+        )
+        assert False, (
+            "Cannot set both 'force_setup_commands' and 'restart_only' at the same time!"
+        )
+
     if urllib.parse.urlparse(cluster_config_file).scheme in ("http", "https"):
         try:
             response = urllib.request.urlopen(cluster_config_file, timeout=5)
@@ -1502,6 +1524,7 @@ def up(
         override_max_workers=max_workers,
         no_restart=no_restart,
         restart_only=restart_only,
+        force_setup_commands=force_setup_commands,
         yes=yes,
         override_cluster_name=cluster_name,
         no_config_cache=no_config_cache,


### PR DESCRIPTION
## Why are these changes needed?

This PR addresses issue #12325 by adding a `--force-setup-commands` flag to `ray up` that forces re-running setup commands even when the cluster configuration hash has not changed.

### Problem
Currently, when running `ray up` on an existing cluster, setup commands are skipped if the configuration hash matches. This is problematic when:
- Installing packages from GitHub repos that may have been updated
- Debugging setup command issues
- Needing a fresh installation of dependencies

Users had to resort to workarounds like modifying dummy `echo` commands to trigger re-runs.

### Solution
Add a new `--force-setup-commands` flag that bypasses the hash check and always runs the setup commands.

```bash
# Force re-running setup commands
ray up cluster.yaml --force-setup-commands
```

The flag is incompatible with `--restart-only` since that flag explicitly skips setup commands.

## Related issue number

Fixes #12325

## Changes Made

| File | Changes |
|------|---------|
| `python/ray/scripts/scripts.py` | Added `--force-setup-commands` CLI flag with validation |
| `python/ray/autoscaler/_private/commands.py` | Thread flag through `create_or_update_cluster` and `get_or_create_head_node` |
| `python/ray/autoscaler/_private/updater.py` | Added `force_setup_commands` parameter to `NodeUpdater` and bypass hash check when True |

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Release tests
  - [x] Manual testing of the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)