### PR TITLE
[core] Refactor validate_actor_state_name to use ACTOR_STATUS from custom_types

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -33,6 +33,7 @@ from ray._common.utils import (
     get_ray_address_file,
     get_system_memory,
 )
+from ray._private.custom_types import ACTOR_STATUS
 from ray.core.generated.runtime_environment_pb2 import (
     RuntimeEnvInfo as ProtoRuntimeEnvInfo,
 )
@@ -1554,18 +1555,11 @@ def parse_pg_formatted_resources_to_original(
 def validate_actor_state_name(actor_state_name):
     if actor_state_name is None:
         return
-    actor_state_names = [
-        "DEPENDENCIES_UNREADY",
-        "PENDING_CREATION",
-        "ALIVE",
-        "RESTARTING",
-        "DEAD",
-    ]
-    if actor_state_name not in actor_state_names:
+    if actor_state_name not in ACTOR_STATUS:
+        valid_states = ", ".join(f'"{s}"' for s in ACTOR_STATUS)
         raise ValueError(
             f'"{actor_state_name}" is not a valid actor state name, '
-            'it must be one of the following: "DEPENDENCIES_UNREADY", '
-            '"PENDING_CREATION", "ALIVE", "RESTARTING", or "DEAD"'
+            f"it must be one of the following: {valid_states}"
         )
 
 


### PR DESCRIPTION
## Why are these changes needed?

The `validate_actor_state_name` function in `utils.py` hardcodes a list of actor state names instead of using the `ACTOR_STATUS` constant from `custom_types.py`. This leads to:

1. Code duplication
2. Potential inconsistency if states are added/removed
3. Manual maintenance burden

## Changes made

- Import `ACTOR_STATUS` from `ray._private.custom_types`
- Replace hardcoded list with `ACTOR_STATUS` constant
- Dynamically generate the error message from `ACTOR_STATUS`

This ensures that `validate_actor_state_name` stays in sync with the protobuf-validated `ACTOR_STATUS` list automatically.

## Related issue number

Fixes #50397

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for <https://docs.ray.io/en/master/>.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Existing tests should cover this refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)