### PR TITLE
[data] Remove obsolete _DatasetWrapper class

### DIFF
--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -25,13 +25,6 @@ logger = logging.getLogger(__name__)
 BLOCKED_CLIENT_WARN_TIMEOUT = 30
 
 
-class _DatasetWrapper:
-    # A temporary workaround for https://github.com/ray-project/ray/issues/52549
-
-    def __init__(self, dataset: "Dataset") -> None:
-        self._dataset = dataset
-
-
 class StreamSplitDataIterator(DataIterator):
     """Implements a collection of iterators over a shared data stream."""
 
@@ -52,7 +45,7 @@ class StreamSplitDataIterator(DataIterator):
             scheduling_strategy=NodeAffinitySchedulingStrategy(
                 ray.get_runtime_context().get_node_id(), soft=False
             ),
-        ).remote(_DatasetWrapper(base_dataset), n, locality_hints)
+        ).remote(base_dataset, n, locality_hints)
 
         return [
             StreamSplitDataIterator(base_dataset, coord_actor, i, n) for i in range(n)
@@ -135,12 +128,10 @@ class SplitCoordinator:
 
     def __init__(
         self,
-        dataset_wrapper: _DatasetWrapper,
+        dataset: "Dataset",
         n: int,
         locality_hints: Optional[List[NodeIdStr]],
     ):
-        dataset = dataset_wrapper._dataset
-
         # Set current DataContext.
         # This needs to be a deep copy so that updates to the base dataset's
         # context does not affect this process's global DataContext.


### PR DESCRIPTION
## Why are these changes needed?

The `_DatasetWrapper` class was a temporary workaround for issue #52549. Since that issue has been resolved, this wrapper is no longer needed and can be removed to simplify the codebase.

## Changes made

- Removed the `_DatasetWrapper` class
- Updated `StreamSplitDataIterator.create()` to pass dataset directly to `SplitCoordinator`
- Updated `SplitCoordinator.__init__()` to accept `Dataset` directly instead of `_DatasetWrapper`

## Related issue number

Fixes #59300

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for <https://docs.ray.io/en/master/>.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Existing tests should cover this refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)