### PR TITLE
[docs] Remove broken parametric actions link from RLlib algorithms docs

### DIFF
--- a/doc/source/rllib/rllib-algorithms.rst
+++ b/doc/source/rllib/rllib-algorithms.rst
@@ -108,7 +108,6 @@ Deep Q Networks (DQN, Rainbow, Parametric DQN)
 
 
 All of the DQN improvements evaluated in `Rainbow <https://arxiv.org/abs/1710.02298>`__ are available, though not all are enabled by default.
-See also how to use `parametric-actions in DQN <rllib-models.html#variable-length-parametric-action-spaces>`__.
 
 **Tuned examples:**
 `PongDeterministic-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/pong-dqn.yaml>`__,


### PR DESCRIPTION
## Why are these changes needed?

The link to `rllib-models.html#variable-length-parametric-action-spaces` in the DQN section of the RLlib algorithms documentation is broken - the target anchor no longer exists.

The parametric actions section is currently commented out in `rl-modules.rst` with a TODO to bring it back once the examples are translated to the new API stack.

## Changes made

Removed the broken link sentence:
```
See also how to use `parametric-actions in DQN <rllib-models.html#variable-length-parametric-action-spaces>`__.
```

The link can be restored when the parametric actions documentation is available again.

## Related issue number

Fixes #59079

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for <https://docs.ray.io/en/master/>.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)