### PR TITLE
[core] Fix incorrect raise DeprecationWarning in ray.util modules

### DIFF
--- a/python/ray/util/lightgbm/__init__.py
+++ b/python/ray/util/lightgbm/__init__.py
@@ -1,4 +1,4 @@
-raise DeprecationWarning(
+raise ImportError(
     "ray.util.lightgbm has been removed as of Ray 2.0. Instead, use the `lightgbm-ray` "
     "library directly or the `LightGBMTrainer` in Ray Train."
 )

--- a/python/ray/util/sgd/__init__.py
+++ b/python/ray/util/sgd/__init__.py
@@ -1,4 +1,4 @@
-raise DeprecationWarning(
+raise ImportError(
     "Ray SGD has been deprecated as of Ray 1.13. For distributed "
     "deep learning on Ray please use Ray Train instead."
 )

--- a/python/ray/util/xgboost/__init__.py
+++ b/python/ray/util/xgboost/__init__.py
@@ -1,4 +1,4 @@
-raise DeprecationWarning(
+raise ImportError(
     "ray.util.xgboost has been removed as of Ray 2.0. Instead, use the `xgboost-ray` "
     "library directly or the `XGBoostTrainer` in Ray Train."
 )


### PR DESCRIPTION
## Why are these changes needed?

`DeprecationWarning` should be issued via `warnings.warn()`, not raised as an exception. When these removed modules (`ray.util.xgboost`, `ray.util.sgd`, `ray.util.lightgbm`) are imported, the intent is to fail the import with a helpful message.

Using `raise DeprecationWarning(...)` is incorrect because:
1. `DeprecationWarning` is a warning category, not an exception meant to be raised
2. When raised, it produces a confusing traceback instead of a clear import error
3. The correct approach for removed modules is to use `ImportError` which clearly indicates the import failed

This is a follow-up to PR #59697 which fixed the same issue in `ray.util.horovod` and `ray.experimental.dynamic_resources`.

## Related issue number

Similar to the pattern discussed in #59697.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
  - No new tests needed - this is a simple exception type fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)