### PR TITLE
[tune] Fix incorrect raise DeprecationWarning in ray.tune.automl

### DIFF
--- a/python/ray/tune/automl/__init__.py
+++ b/python/ray/tune/automl/__init__.py
@@ -1,1 +1,1 @@
-raise DeprecationWarning("`ray.tune.automl` is deprecated in Ray 2.6.")
+raise ImportError("`ray.tune.automl` has been removed as of Ray 2.6.")


### PR DESCRIPTION
## Why are these changes needed?

`DeprecationWarning` should be issued via `warnings.warn()`, not raised as an exception. When the removed `ray.tune.automl` module is imported, the intent is to fail the import with a helpful message.

Using `raise DeprecationWarning(...)` is incorrect because:
1. `DeprecationWarning` is a warning category, not an exception meant to be raised
2. When raised, it produces a confusing traceback instead of a clear import error
3. The correct approach for removed modules is to use `ImportError`

## Related issue number

Follow-up to the pattern fix in PRs #59697 and #59700.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
  - No new tests needed - this is a simple exception type fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)