### PR TITLE
[train] Fix incorrect raise DeprecationWarning in HorovodTrainer

### DIFF
--- a/python/ray/train/v2/horovod/horovod_trainer.py
+++ b/python/ray/train/v2/horovod/horovod_trainer.py
@@ -25,7 +25,7 @@ class HorovodTrainer(DataParallelTrainer):
         metadata: Optional[Dict[str, Any]] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
-        raise DeprecationWarning(
+        raise RuntimeError(
             "`HorovodTrainer` is not supported and is scheduled to be removed "
             "in the future. "
             "Please consider using `TorchTrainer` or `TensorflowTrainer`, "


### PR DESCRIPTION
## Why are these changes needed?

`DeprecationWarning` should be issued via `warnings.warn()`, not raised as an exception. In this case, `HorovodTrainer` is not supported and the intent is to fail with a clear error message when users try to instantiate it.

Using `raise DeprecationWarning(...)` is incorrect because:
1. `DeprecationWarning` is a warning category, not an exception meant to be raised
2. When raised, it produces a confusing traceback with "DeprecationWarning" as the exception type
3. For unsupported functionality that should fail, `RuntimeError` is the appropriate exception type

## Related issue number

Follow-up to the pattern fix in PRs #59697, #59700, and #59701.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
  - No new tests needed - this is a simple exception type fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)