### PR TITLE
[tune] Fix incorrect raise DeprecationWarning in tune integrations

### DIFF
--- a/python/ray/tune/integration/keras.py
+++ b/python/ray/tune/integration/keras.py
@@ -16,7 +16,7 @@ class TuneReportCallback:
     Use :class:`ray.train.tensorflow.keras.ReportCheckpointCallback` instead."""
 
     def __new__(cls, *args, **kwargs):
-        raise DeprecationWarning(_DEPRECATION_MESSAGE)
+        raise RuntimeError(_DEPRECATION_MESSAGE)
 
 
 class _TuneCheckpointCallback:
@@ -24,7 +24,7 @@ class _TuneCheckpointCallback:
     Use :class:`ray.train.tensorflow.keras.ReportCheckpointCallback` instead."""
 
     def __new__(cls, *args, **kwargs):
-        raise DeprecationWarning(_DEPRECATION_MESSAGE)
+        raise RuntimeError(_DEPRECATION_MESSAGE)
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/tune/integration/lightgbm.py
+++ b/python/ray/tune/integration/lightgbm.py
@@ -78,7 +78,7 @@ class TuneReportCheckpointCallback(RayReportCallback):
 class TuneReportCallback:
     def __new__(cls: type, *args, **kwargs):
         # TODO(justinvyu): [code_removal] Remove in 2.11.
-        raise DeprecationWarning(
-            "`TuneReportCallback` is deprecated. "
+        raise RuntimeError(
+            "`TuneReportCallback` is deprecated and no longer supported. "
             "Use `ray.tune.integration.lightgbm.TuneReportCheckpointCallback` instead."
         )

--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -181,9 +181,9 @@ class TuneReportCheckpointCallback(TuneCallback):
 
 class _TuneCheckpointCallback(TuneCallback):
     def __init__(self, *args, **kwargs):
-        raise DeprecationWarning(
+        raise RuntimeError(
             "`ray.tune.integration.pytorch_lightning._TuneCheckpointCallback` "
-            "is deprecated."
+            "is deprecated and no longer supported."
         )
 
 

--- a/python/ray/tune/integration/xgboost.py
+++ b/python/ray/tune/integration/xgboost.py
@@ -96,7 +96,7 @@ class TuneReportCheckpointCallback(RayReportCallback):
 class TuneReportCallback:
     def __new__(cls: type, *args, **kwargs):
         # TODO(justinvyu): [code_removal] Remove in 2.11.
-        raise DeprecationWarning(
-            "`TuneReportCallback` is deprecated. "
+        raise RuntimeError(
+            "`TuneReportCallback` is deprecated and no longer supported. "
             "Use `ray.tune.integration.xgboost.TuneReportCheckpointCallback` instead."
         )


### PR DESCRIPTION
## Why are these changes needed?

`DeprecationWarning` should be issued via `warnings.warn()`, not raised as an exception. For deprecated classes that should fail when instantiated, `RuntimeError` is the appropriate exception type.

Using `raise DeprecationWarning(...)` is incorrect because:
1. `DeprecationWarning` is a warning category, not an exception meant to be raised
2. When raised, it produces a confusing traceback with "DeprecationWarning" as the exception type
3. For unsupported functionality that should fail, `RuntimeError` is the appropriate exception type

This fixes the following files:
- `ray/tune/integration/pytorch_lightning.py` - `_TuneCheckpointCallback`
- `ray/tune/integration/lightgbm.py` - `TuneReportCallback`
- `ray/tune/integration/keras.py` - `TuneReportCallback`, `_TuneCheckpointCallback`
- `ray/tune/integration/xgboost.py` - `TuneReportCallback`

## Related issue number

Follow-up to the pattern fix in PRs #59697, #59700, #59701, and #59702.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
  - No new tests needed - this is a simple exception type fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)