### PR TITLE
[tune] Fix incorrect raise DeprecationWarning in tune.resources

### DIFF
--- a/python/ray/tune/resources.py
+++ b/python/ray/tune/resources.py
@@ -51,8 +51,8 @@ class Resources(
         extra_custom_resources: Optional[dict] = None,
         has_placement_group: bool = False,
     ):
-        raise DeprecationWarning(
-            "tune.Resources is depracted. Use tune.PlacementGroupFactory instead."
+        raise RuntimeError(
+            "tune.Resources has been removed. Use tune.PlacementGroupFactory instead."
         )
 
 
@@ -87,6 +87,6 @@ def json_to_resources(data: Optional[str]) -> Optional[PlacementGroupFactory]:
 
 @Deprecated
 def resources_to_json(*args, **kwargs):
-    raise DeprecationWarning(
-        "tune.Resources is depracted. Use tune.PlacementGroupFactory instead."
+    raise RuntimeError(
+        "tune.Resources has been removed. Use tune.PlacementGroupFactory instead."
     )


### PR DESCRIPTION
## Why are these changes needed?

`DeprecationWarning` should be issued via `warnings.warn()`, not raised as an exception. For deprecated classes/functions that should fail when used, `RuntimeError` is the appropriate exception type.

This fixes the `Resources` class and `resources_to_json` function in `ray/tune/resources.py`.

Also fixed a typo: 'depracted' → 'removed' for clearer messaging.

## Related issue number

Follow-up to the pattern fix in PRs #59697, #59700, #59701, #59702, and #59704.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
  - No new tests needed - this is a simple exception type fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)