### PR TITLE
[tune] Fix incorrect raise DeprecationWarning in tune.experiment

### DIFF
--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -372,7 +372,7 @@ class Experiment:
     @Deprecated("Replaced by `local_path`")
     def local_dir(self):
         # TODO(justinvyu): [Deprecated] Remove in 2.11.
-        raise DeprecationWarning("Use `local_path` instead of `local_dir`.")
+        raise AttributeError("Use `local_path` instead of `local_dir`.")
 
     @property
     def remote_path(self) -> Optional[str]:
@@ -390,7 +390,7 @@ class Experiment:
     @Deprecated("Replaced by `local_path`")
     def checkpoint_dir(self):
         # TODO(justinvyu): [Deprecated] Remove in 2.11.
-        raise DeprecationWarning("Use `local_path` instead of `checkpoint_dir`.")
+        raise AttributeError("Use `local_path` instead of `checkpoint_dir`.")
 
     @property
     def run_identifier(self):

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -543,7 +543,7 @@ class Trial:
     @Deprecated("Replaced by `local_path`")
     def logdir(self) -> Optional[str]:
         # TODO(justinvyu): [Deprecated] Remove in 2.11.
-        raise DeprecationWarning("Use `local_path` instead of `logdir`.")
+        raise AttributeError("Use `local_path` instead of `logdir`.")
 
     @property
     def local_path(self) -> Optional[str]:
@@ -629,7 +629,7 @@ class Trial:
     @Deprecated("Replaced by `init_local_path()`")
     def init_logdir(self):
         # TODO(justinvyu): [Deprecated] Remove in 2.11.
-        raise DeprecationWarning("Use `init_local_path` instead of `init_logdir`.")
+        raise AttributeError("Use `init_local_path` instead of `init_logdir`.")
 
     def init_local_path(self):
         """Init logdir."""


### PR DESCRIPTION
## Why are these changes needed?

`DeprecationWarning` should be issued via `warnings.warn()`, not raised as an exception. For deprecated properties/methods that are no longer valid, `AttributeError` is the appropriate exception type as it indicates the attribute no longer exists.

This fixes the following deprecated APIs:
- `Trial.logdir` → use `Trial.local_path`
- `Trial.init_logdir()` → use `Trial.init_local_path()`
- `Experiment.local_dir` → use `Experiment.local_path`
- `Experiment.checkpoint_dir` → use `Experiment.local_path`

## Related issue number

Follow-up to the pattern fix in PRs #59697, #59700, #59701, #59702, #59704, and #59705.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- [x] Testing Strategy
  - No new tests needed - this is a simple exception type fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)