### PR TITLE
[tune] Fix incorrect raise DeprecationWarning in tune.run and tune.context

### DIFF
--- a/python/ray/tune/context.py
+++ b/python/ray/tune/context.py
@@ -51,8 +51,8 @@ class TuneContext(TrainV1Context):
 
     @Deprecated
     def get_metadata(self) -> Dict[str, Any]:
-        raise DeprecationWarning(
-            "`get_metadata` is deprecated for Ray Tune, as it has never been usable."
+        raise RuntimeError(
+            "`get_metadata` is not available for Ray Tune, as it has never been usable."
         )
 
     @Deprecated(

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -119,8 +119,8 @@ def _build_resume_config_from_legacy_config(
     resume_str = resume_settings[0]
 
     if resume_str in ("LOCAL", "REMOTE", "PROMPT", "ERRORED_ONLY"):
-        raise DeprecationWarning(
-            f"'{resume_str}' is deprecated. "
+        raise ValueError(
+            f"'{resume_str}' is no longer supported. "
             "Please pass in one of (True, False, 'AUTO')."
         )
 
@@ -576,16 +576,16 @@ def run(
         "persistent-storage.html#setting-the-local-staging-directory"
     )
     if os.environ.get("TUNE_RESULT_DIR"):
-        raise DeprecationWarning(ENV_VAR_DEPRECATION_MESSAGE.format("TUNE_RESULT_DIR"))
+        raise ValueError(ENV_VAR_DEPRECATION_MESSAGE.format("TUNE_RESULT_DIR"))
 
     if os.environ.get("RAY_AIR_LOCAL_CACHE_DIR"):
-        raise DeprecationWarning(
+        raise ValueError(
             ENV_VAR_DEPRECATION_MESSAGE.format("RAY_AIR_LOCAL_CACHE_DIR")
         )
 
     if local_dir is not None:
-        raise DeprecationWarning(
-            "The `local_dir` argument is deprecated. "
+        raise ValueError(
+            "The `local_dir` argument is no longer supported. "
             "You should set the `storage_path` instead. "
             "See the docs: https://docs.ray.io/en/latest/train/user-guides/"
             "persistent-storage.html#setting-the-local-staging-directory"
@@ -688,12 +688,11 @@ def run(
 
     # TODO(justinvyu): [Deprecated] Remove in 2.11.
     if chdir_to_trial_dir != _DEPRECATED_VALUE:
-        raise DeprecationWarning(
-            "`chdir_to_trial_dir` is deprecated. "
+        raise ValueError(
+            "`chdir_to_trial_dir` is no longer supported. "
             f"Use the {RAY_CHDIR_TO_TRIAL_DIR} environment variable instead. "
             "Set it to 0 to disable the default behavior of changing the "
-            "working directory.",
-            DeprecationWarning,
+            "working directory."
         )
 
     if num_samples == -1:


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes incorrect usage of `raise DeprecationWarning(...)` in `ray/tune/tune.py` and `ray/tune/context.py`.

`DeprecationWarning` is a warning category, not an exception type. Using `raise DeprecationWarning(...)` directly is incorrect Python - it happens to work because warning categories are exception subclasses, but the semantic meaning is wrong and it bypasses the warning filtering system.

For cases where deprecated functionality should hard-fail (as these are), the code should use appropriate exception types:
- **`ValueError`**: For deprecated/invalid parameter values and environment variables
- **`RuntimeError`**: For functionality that was never available/usable

## Related issue number

Fixes incorrect exception handling pattern across Ray Tune modules.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - [ ] I've added any new APIs to the API Reference. For example, if I added a
        temporary patch, I've added it in `doc/source/ray-core/api/temporary-patch.rst`.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
  - [x] Unit tests
  - [ ] Release tests
  - [ ] This PR is not tested :(