### PR TITLE
[core] Fix incorrect raise DeprecationWarning in experimental and util.horovod

### DIFF
--- a/python/ray/experimental/dynamic_resources.py
+++ b/python/ray/experimental/dynamic_resources.py
@@ -1,6 +1,6 @@
 def set_resource(resource_name, capacity, node_id=None):
-    raise DeprecationWarning(
-        "Dynamic custom resources are deprecated. Consider using placement "
+    raise RuntimeError(
+        "Dynamic custom resources have been removed. Consider using placement "
         "groups instead (docs.ray.io/en/master/placement-group.html). You "
         "can also specify resources at Ray start time with the 'resources' "
         "field in the cluster autoscaler."

--- a/python/ray/util/horovod/__init__.py
+++ b/python/ray/util/horovod/__init__.py
@@ -1,4 +1,4 @@
-raise DeprecationWarning(
+raise ImportError(
     "ray.util.horovod has been removed as of Ray 2.0. Instead, use the `horovod` "
     "library directly or the `HorovodTrainer` in Ray Train."
 )


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes incorrect usage of `raise DeprecationWarning(...)` in `ray/experimental/dynamic_resources.py` and `ray/util/horovod/__init__.py`.

`DeprecationWarning` is a warning category, not an exception type. Using `raise DeprecationWarning(...)` directly is incorrect Python - it happens to work because warning categories are exception subclasses, but the semantic meaning is wrong and it bypasses the warning filtering system.

For cases where deprecated functionality should hard-fail (as these are), the code should use appropriate exception types:
- **`RuntimeError`**: For removed functionality (dynamic_resources)
- **`ImportError`**: For removed module imports (horovod)

## Related issue number

Fixes incorrect exception handling pattern across Ray modules.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - [ ] I've added any new APIs to the API Reference. For example, if I added a
        temporary patch, I've added it in `doc/source/ray-core/api/temporary-patch.rst`.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
  - [x] Unit tests
  - [ ] Release tests
  - [ ] This PR is not tested :(