### PR TITLE
[data] Fix incorrect raise DeprecationWarning in dataset and read_api

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1758,7 +1758,7 @@ class Dataset:
         """  # noqa: E501
 
         if num_blocks is not None:
-            raise DeprecationWarning(
+            raise ValueError(
                 "`num_blocks` parameter is deprecated in Ray 2.9. random_shuffle() "
                 "does not support to change the number of output blocks. Use "
                 "repartition() instead.",  # noqa: E501

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3647,7 +3647,7 @@ def from_huggingface(
         return ray_ds
     if isinstance(dataset, (datasets.DatasetDict, datasets.IterableDatasetDict)):
         available_keys = list(dataset.keys())
-        raise DeprecationWarning(
+        raise ValueError(
             "You provided a Hugging Face DatasetDict or IterableDatasetDict, "
             "which contains multiple datasets, but `from_huggingface` now "
             "only accepts a single Hugging Face Dataset. To convert just "


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes incorrect usage of `raise DeprecationWarning(...)` in `ray/data/dataset.py` and `ray/data/read_api.py`.

`DeprecationWarning` is a warning category, not an exception type. Using `raise DeprecationWarning(...)` directly is incorrect Python - it happens to work because warning categories are exception subclasses, but the semantic meaning is wrong and it bypasses the warning filtering system.

For cases where deprecated functionality should hard-fail (as these are), the code should use appropriate exception types:
- **`ValueError`**: For deprecated/unsupported parameter values

### Changes:
- `dataset.py`: Use `ValueError` for deprecated `num_blocks` parameter in `random_shuffle()`
- `read_api.py`: Use `ValueError` for unsupported `DatasetDict` input type in `from_huggingface()`

## Related issue number

Fixes incorrect exception handling pattern in Ray Data modules.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - [ ] I've added any new APIs to the API Reference. For example, if I added a
        temporary patch, I've added it in `doc/source/ray-core/api/temporary-patch.rst`.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
  - [x] Unit tests
  - [ ] Release tests
  - [ ] This PR is not tested :(