### PR TITLE
[train][air][core] Fix incorrect raise DeprecationWarning in train, air, and core modules

### DIFF
--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -432,7 +432,7 @@ class RayParams:
             )
 
         if self.redirect_output is not None:
-            raise DeprecationWarning("The redirect_output argument is deprecated.")
+            raise ValueError("The redirect_output argument has been removed.")
 
         if self.temp_dir is not None and not os.path.isabs(self.temp_dir):
             raise ValueError("temp_dir must be absolute path or None.")

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -423,8 +423,8 @@ class CheckpointConfig:
 
     def __post_init__(self):
         if self._checkpoint_keep_all_ranks != _DEPRECATED_VALUE:
-            raise DeprecationWarning(
-                "The experimental `_checkpoint_keep_all_ranks` config is deprecated. "
+            raise ValueError(
+                "The experimental `_checkpoint_keep_all_ranks` config has been removed. "
                 "This behavior is now controlled by reporting `checkpoint=None` "
                 "in the workers that shouldn't persist a checkpoint. "
                 "For example, if you only want the rank 0 worker to persist a "
@@ -435,9 +435,9 @@ class CheckpointConfig:
             )
 
         if self._checkpoint_upload_from_workers != _DEPRECATED_VALUE:
-            raise DeprecationWarning(
-                "The experimental `_checkpoint_upload_from_workers` config is "
-                "deprecated. Uploading checkpoint directly from the worker is "
+            raise ValueError(
+                "The experimental `_checkpoint_upload_from_workers` config has been "
+                "removed. Uploading checkpoint directly from the worker is "
                 "now the default behavior."
             )
 
@@ -588,9 +588,9 @@ class RunConfig:
         from ray.tune.experimental.output import AirVerbosity, get_air_verbosity
 
         if self.local_dir is not None:
-            raise DeprecationWarning(
-                "The `RunConfig(local_dir)` argument is deprecated. "
-                "You should set the `RunConfig(storage_path)` instead."
+            raise ValueError(
+                "The `RunConfig(local_dir)` argument has been removed. "
+                "You should set the `RunConfig(storage_path)` instead. "
                 "See the docs: https://docs.ray.io/en/latest/train/user-guides/"
                 "persistent-storage.html#setting-the-local-staging-directory"
             )

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -541,7 +541,7 @@ class BaseTrainer(abc.ABC):
         from ray.train.v2._internal.constants import V2_ENABLED_ENV_VAR, is_v2_enabled
 
         if is_v2_enabled():
-            raise DeprecationWarning(
+            raise RuntimeError(
                 f"Detected use of a deprecated Trainer import from `{self.__class__.__module__}`. "
                 "This Trainer class is not compatible with Ray Train V2.\n"
                 "To fix this:\n"
@@ -619,7 +619,7 @@ class BaseTrainer(abc.ABC):
 
     def preprocess_datasets(self) -> None:
         """Deprecated."""
-        raise DeprecationWarning(
+        raise RuntimeError(
             "`preprocess_datasets` is no longer used, since preprocessors "
             f"are no longer accepted by Trainers.\n{PREPROCESSOR_DEPRECATION_MESSAGE}"
         )

--- a/python/ray/train/tensorflow/tensorflow_predictor.py
+++ b/python/ray/train/tensorflow/tensorflow_predictor.py
@@ -94,8 +94,8 @@ class TensorflowPredictor(DLPredictor):
             use_gpu: Whether GPU should be used during prediction.
         """
         if model_definition:
-            raise DeprecationWarning(
-                "`model_definition` is deprecated. `TensorflowCheckpoint.from_model` "
+            raise ValueError(
+                "`model_definition` has been removed. `TensorflowCheckpoint.from_model` "
                 "now saves the full model definition in .keras format."
             )
 

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -352,8 +352,8 @@ class TorchWorkerProfiler:
     WORKER_TRACE_DIR_NAME = "pytorch_profiler_worker_traces"
 
     def __init__(self, trace_dir: Optional[str] = None):
-        raise DeprecationWarning(
-            "The `ray.train.torch.TorchWorkerProfiler` API is deprecated in Ray 2.0.",
+        raise RuntimeError(
+            "The `ray.train.torch.TorchWorkerProfiler` API has been removed in Ray 2.0.",
         )
 
 


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes incorrect usage of `raise DeprecationWarning(...)` across multiple Ray modules.

`DeprecationWarning` is a warning category, not an exception type. Using `raise DeprecationWarning(...)` directly is incorrect Python - it happens to work because warning categories are exception subclasses, but the semantic meaning is wrong and it bypasses the warning filtering system.

For cases where deprecated functionality should hard-fail (as these are), the code should use appropriate exception types:
- **`ValueError`**: For removed/invalid configuration options and parameters
- **`RuntimeError`**: For incompatible usage patterns and removed APIs

### Changes:
- `ray/air/config.py`: Use `ValueError` for removed checkpoint config options and `local_dir` parameter
- `ray/train/base_trainer.py`: Use `RuntimeError` for V2 incompatibility and removed `preprocess_datasets` method
- `ray/train/tensorflow/tensorflow_predictor.py`: Use `ValueError` for removed `model_definition` parameter
- `ray/train/torch/train_loop_utils.py`: Use `RuntimeError` for removed `TorchWorkerProfiler` class
- `ray/_private/parameter.py`: Use `ValueError` for removed `redirect_output` argument

## Related issue number

Fixes incorrect exception handling pattern across Ray Train, Air, and Core modules.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - [ ] I've added any new APIs to the API Reference. For example, if I added a
        temporary patch, I've added it in `doc/source/ray-core/api/temporary-patch.rst`.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
  - [x] Unit tests
  - [ ] Release tests
  - [ ] This PR is not tested :(