### PR TITLE
[train] Fix incorrect raise DeprecationWarning in train/v2 modules

### DIFF
--- a/python/ray/train/v2/_internal/util.py
+++ b/python/ray/train/v2/_internal/util.py
@@ -257,7 +257,7 @@ def requires_train_worker(raise_in_tune_session: bool = False) -> Callable:
 
     Args:
         raise_in_tune_session: Whether to raise a specific error message if the caller
-            is in a Tune session. If True, will raise a DeprecationWarning.
+            is in a Tune session. If True, will raise a RuntimeError.
 
     Returns:
         A decorator that performs this check, which raises an error if the caller

--- a/python/ray/train/v2/_internal/util.py
+++ b/python/ray/train/v2/_internal/util.py
@@ -270,7 +270,7 @@ def requires_train_worker(raise_in_tune_session: bool = False) -> Callable:
             from ray.tune.trainable.trainable_fn_utils import _in_tune_session
 
             if raise_in_tune_session and _in_tune_session():
-                raise DeprecationWarning(
+                raise RuntimeError(
                     f"`ray.train.{fn.__name__}` is deprecated when running in a function "
                     "passed to Ray Tune. Please use the equivalent `ray.tune` API instead. "
                     "See this issue for more context: "

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -76,7 +76,7 @@ class ScalingConfig(ScalingConfigV1):
 
     def __post_init__(self):
         if self.trainer_resources is not None:
-            raise DeprecationWarning(TRAINER_RESOURCES_DEPRECATION_MESSAGE)
+            raise ValueError(TRAINER_RESOURCES_DEPRECATION_MESSAGE)
 
         if self.use_gpu and self.use_tpu:
             raise ValueError("Cannot specify both `use_gpu=True` and `use_tpu=True`.")
@@ -183,14 +183,14 @@ class CheckpointConfig:
 
     def __post_init__(self):
         if self.checkpoint_frequency != _DEPRECATED:
-            raise DeprecationWarning(
+            raise ValueError(
                 "`checkpoint_frequency` is deprecated since it does not "
                 "apply to user-defined training functions. "
                 "Please remove this argument from your CheckpointConfig."
             )
 
         if self.checkpoint_at_end != _DEPRECATED:
-            raise DeprecationWarning(
+            raise ValueError(
                 "`checkpoint_at_end` is deprecated since it does not "
                 "apply to user-defined training functions. "
                 "Please remove this argument from your CheckpointConfig."
@@ -228,7 +228,7 @@ class FailureConfig(FailureConfigV1):
 
     def __post_init__(self):
         if self.fail_fast != _DEPRECATED:
-            raise DeprecationWarning(FAIL_FAST_DEPRECATION_MESSAGE)
+            raise ValueError(FAIL_FAST_DEPRECATION_MESSAGE)
 
 
 @dataclass
@@ -303,7 +303,7 @@ class RunConfig:
         ]
         for param in unsupported_params:
             if getattr(self, param) != _DEPRECATED:
-                raise DeprecationWarning(run_config_deprecation_message.format(param))
+                raise ValueError(run_config_deprecation_message.format(param))
 
         if not self.name:
             self.name = f"ray_train_run-{date_str()}"

--- a/python/ray/train/v2/api/context.py
+++ b/python/ray/train/v2/api/context.py
@@ -16,14 +16,14 @@ class TrainContext(ABC):
         """[Deprecated] User metadata dict passed to the Trainer constructor."""
         from ray.train.context import _GET_METADATA_DEPRECATION_MESSAGE
 
-        raise DeprecationWarning(_GET_METADATA_DEPRECATION_MESSAGE)
+        raise RuntimeError(_GET_METADATA_DEPRECATION_MESSAGE)
 
     @Deprecated
     def get_trial_name(self) -> str:
         """[Deprecated] Trial name for the corresponding trial."""
         from ray.train.context import _TUNE_SPECIFIC_CONTEXT_DEPRECATION_MESSAGE
 
-        raise DeprecationWarning(
+        raise RuntimeError(
             _TUNE_SPECIFIC_CONTEXT_DEPRECATION_MESSAGE.format("get_trial_name")
         )
 
@@ -32,7 +32,7 @@ class TrainContext(ABC):
         """[Deprecated] Trial id for the corresponding trial."""
         from ray.train.context import _TUNE_SPECIFIC_CONTEXT_DEPRECATION_MESSAGE
 
-        raise DeprecationWarning(
+        raise RuntimeError(
             _TUNE_SPECIFIC_CONTEXT_DEPRECATION_MESSAGE.format("get_trial_id")
         )
 
@@ -41,7 +41,7 @@ class TrainContext(ABC):
         """[Deprecated] Trial resources for the corresponding trial."""
         from ray.train.context import _TUNE_SPECIFIC_CONTEXT_DEPRECATION_MESSAGE
 
-        raise DeprecationWarning(
+        raise RuntimeError(
             _TUNE_SPECIFIC_CONTEXT_DEPRECATION_MESSAGE.format("get_trial_resources")
         )
 
@@ -54,7 +54,7 @@ class TrainContext(ABC):
         """
         from ray.train.context import _TUNE_SPECIFIC_CONTEXT_DEPRECATION_MESSAGE
 
-        raise DeprecationWarning(
+        raise RuntimeError(
             _TUNE_SPECIFIC_CONTEXT_DEPRECATION_MESSAGE.format("get_trial_dir")
         )
 

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -106,10 +106,10 @@ class DataParallelTrainer:
         )
 
         if resume_from_checkpoint is not None:
-            raise DeprecationWarning(_RESUME_FROM_CHECKPOINT_DEPRECATION_WARNING)
+            raise ValueError(_RESUME_FROM_CHECKPOINT_DEPRECATION_WARNING)
 
         if metadata is not None:
-            raise DeprecationWarning(_GET_METADATA_DEPRECATION_MESSAGE)
+            raise ValueError(_GET_METADATA_DEPRECATION_MESSAGE)
 
         self._validate_configs()
 
@@ -316,7 +316,7 @@ class DataParallelTrainer:
 
         This method is deprecated and will be removed in a future release.
         """
-        raise DeprecationWarning(_TRAINER_RESTORE_DEPRECATION_WARNING)
+        raise RuntimeError(_TRAINER_RESTORE_DEPRECATION_WARNING)
 
     @classmethod
     @Deprecated
@@ -326,4 +326,4 @@ class DataParallelTrainer:
 
         This method is deprecated and will be removed in a future release.
         """
-        raise DeprecationWarning(_TRAINER_RESTORE_DEPRECATION_WARNING)
+        raise RuntimeError(_TRAINER_RESTORE_DEPRECATION_WARNING)

--- a/python/ray/train/v2/api/result.py
+++ b/python/ray/train/v2/api/result.py
@@ -130,7 +130,7 @@ class Result(ResultV1):
     @property
     @Deprecated
     def config(self) -> Optional[Dict[str, Any]]:
-        raise DeprecationWarning(
+        raise RuntimeError(
             "The `config` property for a `ray.train.Result` is deprecated, "
             "since it is only relevant in the context of Ray Tune."
         )

--- a/python/ray/train/v2/horovod/horovod_trainer.py
+++ b/python/ray/train/v2/horovod/horovod_trainer.py
@@ -25,7 +25,7 @@ class HorovodTrainer(DataParallelTrainer):
         metadata: Optional[Dict[str, Any]] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
-        raise DeprecationWarning(
+        raise RuntimeError(
             "`HorovodTrainer` is not supported and is scheduled to be removed "
             "in the future. "
             "Please consider using `TorchTrainer` or `TensorflowTrainer`, "

--- a/python/ray/train/v2/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/v2/lightgbm/lightgbm_trainer.py
@@ -134,7 +134,7 @@ class LightGBMTrainer(DataParallelTrainer):
             or params is not None
             or num_boost_round is not None
         ):
-            raise DeprecationWarning(
+            raise ValueError(
                 "The legacy LightGBMTrainer API is deprecated. "
                 "Please switch to passing in a custom `train_loop_per_worker` "
                 "function instead. "
@@ -165,7 +165,7 @@ class LightGBMTrainer(DataParallelTrainer):
 
         This API is deprecated. Use `RayTrainReportCallback.get_model` instead.
         """
-        raise DeprecationWarning(
+        raise RuntimeError(
             "`LightGBMTrainer.get_model` is deprecated. "
             "Use `RayTrainReportCallback.get_model` instead."
         )

--- a/python/ray/train/v2/tests/test_local_mode.py
+++ b/python/ray/train/v2/tests/test_local_mode.py
@@ -521,7 +521,7 @@ def test_xgboost_trainer_local_mode(ray_start_4_cpus):
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
     )
     result = trainer.fit()
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(RuntimeError):
         XGBoostTrainer.get_model(result.checkpoint)
 
 

--- a/python/ray/train/v2/tests/test_v2_api.py
+++ b/python/ray/train/v2/tests/test_v2_api.py
@@ -21,7 +21,7 @@ from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 )
 def test_api_configs(operation, raise_error):
     if raise_error:
-        with pytest.raises(DeprecationWarning):
+        with pytest.raises(ValueError):
             operation()
     else:
         try:
@@ -68,10 +68,10 @@ def test_scaling_config_total_resources():
 
 
 def test_trainer_restore():
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(RuntimeError):
         DataParallelTrainer.restore("dummy")
 
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(RuntimeError):
         DataParallelTrainer.can_restore("dummy")
 
 

--- a/python/ray/train/v2/tests/test_xgboost_trainer.py
+++ b/python/ray/train/v2/tests/test_xgboost_trainer.py
@@ -91,7 +91,7 @@ def test_fit(ray_start_4_cpus):
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
     )
     result = trainer.fit()
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(RuntimeError):
         XGBoostTrainer.get_model(result.checkpoint)
 
 

--- a/python/ray/train/v2/torch/train_loop_utils.py
+++ b/python/ray/train/v2/torch/train_loop_utils.py
@@ -385,17 +385,17 @@ def prepare_data_loader(
 
 @Deprecated
 def accelerate(amp: bool = False) -> None:
-    raise DeprecationWarning(_TORCH_AMP_DEPRECATION_MESSAGE)
+    raise RuntimeError(_TORCH_AMP_DEPRECATION_MESSAGE)
 
 
 @Deprecated
 def prepare_optimizer(optimizer: torch.optim.Optimizer) -> torch.optim.Optimizer:
-    raise DeprecationWarning(_TORCH_AMP_DEPRECATION_MESSAGE)
+    raise RuntimeError(_TORCH_AMP_DEPRECATION_MESSAGE)
 
 
 @Deprecated
 def backward(tensor: torch.Tensor) -> None:
-    raise DeprecationWarning(_TORCH_AMP_DEPRECATION_MESSAGE)
+    raise RuntimeError(_TORCH_AMP_DEPRECATION_MESSAGE)
 
 
 @PublicAPI(stability="stable")

--- a/python/ray/train/v2/xgboost/xgboost_trainer.py
+++ b/python/ray/train/v2/xgboost/xgboost_trainer.py
@@ -130,7 +130,7 @@ class XGBoostTrainer(DataParallelTrainer):
             or params is not None
             or num_boost_round is not None
         ):
-            raise DeprecationWarning(
+            raise ValueError(
                 "The legacy XGBoostTrainer API is deprecated. "
                 "Please switch to passing in a custom `train_loop_per_worker` "
                 "function instead. "
@@ -156,7 +156,7 @@ class XGBoostTrainer(DataParallelTrainer):
     @Deprecated
     def get_model(cls, checkpoint: Checkpoint):
         """[Deprecated] Retrieve the XGBoost model stored in this checkpoint."""
-        raise DeprecationWarning(
+        raise RuntimeError(
             "`XGBoostTrainer.get_model` is deprecated. "
             "Use `RayTrainReportCallback.get_model` instead."
         )


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes incorrect usage of `raise DeprecationWarning(...)` across all Ray Train V2 modules.

`DeprecationWarning` is a warning category, not an exception type. Using `raise DeprecationWarning(...)` directly is incorrect Python - it happens to work because warning categories are exception subclasses, but the semantic meaning is wrong and it bypasses the warning filtering system.

For cases where deprecated functionality should hard-fail (as these are), the code should use appropriate exception types:
- **`ValueError`**: For deprecated/invalid parameter values and configuration options
- **`RuntimeError`**: For incompatible usage patterns and removed APIs/methods

### Files changed (9):
- `api/config.py`: Use `ValueError` for deprecated config options (trainer_resources, checkpoint_frequency, checkpoint_at_end, fail_fast, RunConfig params)
- `api/context.py`: Use `RuntimeError` for deprecated context methods (get_metadata, get_trial_*)
- `api/data_parallel_trainer.py`: Use `ValueError`/`RuntimeError` for deprecated params/methods
- `api/result.py`: Use `RuntimeError` for deprecated config property
- `_internal/util.py`: Use `RuntimeError` for deprecated API usage in Tune sessions
- `torch/train_loop_utils.py`: Use `RuntimeError` for deprecated AMP functions (accelerate, prepare_optimizer, backward)
- `xgboost/xgboost_trainer.py`: Use `ValueError`/`RuntimeError` for deprecated legacy API
- `lightgbm/lightgbm_trainer.py`: Use `ValueError`/`RuntimeError` for deprecated legacy API
- `horovod/horovod_trainer.py`: Use `RuntimeError` for unsupported trainer

## Related issue number

Fixes incorrect exception handling pattern across Ray Train V2 modules.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests