### PR TITLE
Fix 'non-existant' typo across codebase

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1516,7 +1516,7 @@ def update_envs(env_vars: Dict[str, str]):
 
     for key, value in env_vars.items():
         expanded = os.path.expandvars(value)
-        # Replace non-existant env vars with an empty string.
+        # Replace non-existent env vars with an empty string.
         result = re.sub(r"\$\{[A-Z0-9_]+\}", "", expanded)
         os.environ[key] = result
 

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -515,7 +515,7 @@ def hash_runtime_conf(
         # Add cluster_synced_files to the file_mounts_content hash
         if cluster_synced_files is not None:
             for local_path in sorted(cluster_synced_files):
-                # For cluster_synced_files, we let the path be non-existant
+                # For cluster_synced_files, we let the path be non-existent
                 # because its possible that the source directory gets set up
                 # anytime over the life of the head node.
                 add_content_hashes(local_path, allow_non_existing_paths=True)


### PR DESCRIPTION
## Why are these changes needed?

Fixes a spelling typo: "non-existant" → "non-existent" in two files:
- `python/ray/_private/utils.py`
- `python/ray/autoscaler/_private/util.py`

## Related issue number

N/A - Simple typo fix

## Checks

- [x] I've signed off every commit
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy: N/A - comment change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)