### PR TITLE
Fix 'retreive' typo in rllib policy code

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -953,7 +953,7 @@ class Policy(metaclass=ABCMeta):
             "num_grad_updates": self.num_grad_updates,
         }
 
-        # Add this Policy's spec so it can be retreived w/o access to the original
+        # Add this Policy's spec so it can be retrieved w/o access to the original
         # code.
         policy_spec = PolicySpec(
             policy_class=type(self),

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -94,7 +94,7 @@ def pad_batch_to_sequences_of_same_size(
         # parts of the API are stable and user-friendly.
         seq_lens = batch.get(SampleBatch.SEQ_LENS)
 
-        # state_in is a nested dict of tensors of states. We need to retreive the
+        # state_in is a nested dict of tensors of states. We need to retrieve the
         # length of the inner most tensor (which should be already the same as the
         # length of other tensors) and compare it to len(seq_lens).
         state_ins = tree.flatten(batch["state_in"])


### PR DESCRIPTION
## Why are these changes needed?

Fixes spelling typo: "retreive" → "retrieve" in two files:
- `rllib/policy/rnn_sequencing.py`
- `rllib/policy/policy.py`

## Related issue number

N/A - Simple typo fix

## Checks

- [x] I've signed off every commit
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy: N/A - comment change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)