### PR TITLE
Fix 'Succesful' typo in C++ test code

### DIFF
--- a/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
@@ -1912,7 +1912,7 @@ TEST_F(NormalTaskSubmitterTest, TestCancelBeforeAfterQueueGeneratorForResubmit) 
   ASSERT_EQ(task_manager->num_tasks_failed, 1);
   ASSERT_EQ(task_manager->num_generator_failed_and_resubmitted, 0);
 
-  // Succesful queue generator for resubmit -> cancel -> successful execution -> no
+  // Successful queue generator for resubmit -> cancel -> successful execution -> no
   // resubmit.
   TaskSpecification task2 = BuildEmptyTaskSpec();
   submitter.SubmitTask(task2);


### PR DESCRIPTION
## Why are these changes needed?

Fixes spelling typo: "Succesful" → "Successful" in:
- `src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc`

## Related issue number

N/A - Simple typo fix

## Checks

- [x] I've signed off every commit
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy: N/A - comment change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)