### PR TITLE
Fix typos: refering, commiting, usefull

### DIFF
--- a/python/ray/autoscaler/_private/vsphere/cluster_operator_client.py
+++ b/python/ray/autoscaler/_private/vsphere/cluster_operator_client.py
@@ -57,7 +57,7 @@ class KubernetesHttpApiClient(object):
         token = SERVICE_ACCOUNT_TOKEN
         # If SERVICE_ACCOUNT_TOKEN not present, use local
         # ~/.kube/config file. Active context will be used.
-        # This is usefull when Ray CLI are used and local autoscaler needs
+        # This is useful when Ray CLI are used and local autoscaler needs
         # communicate with the k8s API server
         # If the token is present then use that for communication.
         if not token:

--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -349,7 +349,7 @@ class AgentCollector:
                     f"used_for_compute_actions flag is set to True. Please fix the "
                     f"discrepancy. Hint: If you are using a custom model make sure "
                     f"the view_requirements are initialized properly and is point "
-                    f"only refering to past timesteps during inference."
+                    f"only referring to past timesteps during inference."
                 )
 
             # Some columns don't exist yet

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -692,7 +692,7 @@ void GcsPlacementGroupScheduler::CommitBundleResources(
       // A placement group's wildcard resource has to be the sum of all related bundles.
       // Even though `ToNodeBundleResourcesMap` has already considered this,
       // it misses the scenario in which single (or subset of) bundle is rescheduled.
-      // When commiting this single bundle, its wildcard resource would wrongly overwrite
+      // When committing this single bundle, its wildcard resource would wrongly overwrite
       // the existing value, unless using the following additive operation.
       auto capacity = node_bundle_resources.Get(resource_id);
       if (IsPlacementGroupWildcardResource(resource_id.Binary())) {


### PR DESCRIPTION
## Why are these changes needed?

Fixes spelling typos:
- "refering" → "referring" in `rllib/evaluation/collectors/agent_collector.py`
- "commiting" → "committing" in `src/ray/gcs/gcs_placement_group_scheduler.cc`
- "usefull" → "useful" in `python/ray/autoscaler/_private/vsphere/cluster_operator_client.py`

## Related issue number

N/A - Simple typo fix

## Checks

- [x] I've signed off every commit
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy: N/A - comment/message change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)