### PR TITLE
Fix typos: additonal, reponsible, Managers

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -641,7 +641,7 @@ class DataContext:
     pandas_block_ignore_metadata: bool = DEFAULT_PANDAS_BLOCK_IGNORE_METADATA
 
     def __post_init__(self):
-        # The additonal ray remote args that should be added to
+        # The additional ray remote args that should be added to
         # the task-pool-based data tasks.
         self._task_pool_data_task_remote_args: Dict[str, Any] = {}
         # The extra key-value style configs.

--- a/src/ray/object_manager/grpc_client_manager.h
+++ b/src/ray/object_manager/grpc_client_manager.h
@@ -24,7 +24,7 @@
 
 namespace ray::rpc {
 
-// Managers multiple gRPC clients. It's reponsible for initializing
+// Manages multiple gRPC clients. It's responsible for initializing
 // gRPC clients with arguments, distributing requests between clients,
 // and destroying the clients.
 class ClientCallManager;


### PR DESCRIPTION
## Why are these changes needed?

Fixes spelling typos:
- "additonal" → "additional" in `python/ray/data/context.py`
- "reponsible" → "responsible" in `src/ray/object_manager/grpc_client_manager.h`
- "Managers" → "Manages" in `src/ray/object_manager/grpc_client_manager.h`

## Related issue number

N/A - Simple typo fix

## Checks

- [x] I've signed off every commit
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy: N/A - comment change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)