### PR TITLE
Fix 'overriden' typo in comments and docstrings

### DIFF
--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -93,7 +93,7 @@ class NodeUpdater:
         # 1) use_internal_ip arg is True -> use_internal_ip is True
         # 2) worker node -> use value of provider_config["use_internal_ips"]
         # 3) head node -> use value of provider_config["use_internal_ips"] unless
-        #                 overriden by provider_config["use_external_head_ip"]
+        #                 overridden by provider_config["use_external_head_ip"]
         use_internal_ip = use_internal_ip or (
             provider_config.get("use_internal_ips", False)
             and not (

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -42,7 +42,7 @@ HTTP_EXPOSABLE_EVENT_TYPES = os.environ.get(
 )
 
 # GCS Publisher specific configurations
-# List of event types that are allowed to be exposed to GCS, not overriden by environment variable
+# List of event types that are allowed to be exposed to GCS, not overridden by environment variable
 # as GCS only supports Task event types
 GCS_EXPOSABLE_EVENT_TYPES = [
     "TASK_DEFINITION_EVENT",

--- a/python/ray/data/_internal/datasource/huggingface_datasource.py
+++ b/python/ray/data/_internal/datasource/huggingface_datasource.py
@@ -142,7 +142,7 @@ class HuggingFaceDatasource(Datasource):
             # HuggingFace IterableDatasets do not fully support methods like
             # `set_format`, `with_format`, and `formatted_as`, so the dataset
             # can return whatever is the default configured batch type, even if
-            # the format is manually overriden before iterating above.
+            # the format is manually overridden before iterating above.
             # Therefore, we limit support to batch formats which have native
             # block types in Ray Data (pyarrow.Table, pd.DataFrame),
             # or can easily be converted to such (dict, np.array).

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -386,7 +386,7 @@ class Preprocessor(abc.ABC):
         The preferred batch format to use if both `_transform_pandas` and
         `_transform_numpy` are implemented. Defaults to Pandas.
 
-        Can be overriden by Preprocessor classes depending on which transform
+        Can be overridden by Preprocessor classes depending on which transform
         path is the most optimal.
         """
         return BatchFormat.PANDAS

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -14,7 +14,7 @@ class DataConfig:
     """Class responsible for configuring Train dataset preprocessing.
 
     For advanced use cases, this class can be subclassed and the `configure()` method
-    overriden for custom data preprocessing.
+    overridden for custom data preprocessing.
     """
 
     def __init__(
@@ -117,7 +117,7 @@ class DataConfig:
             execution_options = self._get_execution_options(name)
 
             if execution_options.is_resource_limits_default():
-                # If "resource_limits" is not overriden by the user,
+                # If "resource_limits" is not overridden by the user,
                 # add training-reserved resources to Data's exclude_resources.
                 execution_options.exclude_resources = (
                     execution_options.exclude_resources.add(

--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -201,7 +201,7 @@ class DataParallelTrainer(BaseTrainer):
     """
 
     # Exposed here for testing purposes. Should never need
-    # to be overriden.
+    # to be overridden.
     _backend_executor_cls: Type[BackendExecutor] = BackendExecutor
     _training_iterator_cls: Type[TrainingIterator] = TrainingIterator
 

--- a/python/ray/train/predictor.py
+++ b/python/ray/train/predictor.py
@@ -132,7 +132,7 @@ class Predictor(abc.ABC):
         The preferred batch format to use if both `_predict_pandas` and
         `_predict_numpy` are implemented. Defaults to Pandas.
 
-        Can be overriden by predictor classes depending on the framework type,
+        Can be overridden by predictor classes depending on the framework type,
         e.g. TorchPredictor prefers Numpy and XGBoostPredictor prefers Pandas as
         native batch format.
 

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -1060,7 +1060,7 @@ class Trial:
             if key in state:
                 state[key] = cloudpickle.loads(hex_to_binary(state[key]))
 
-        # Ensure that stub doesn't get overriden
+        # Ensure that stub doesn't get overridden
         stub = state.pop("stub", True)
         self.__dict__.update(state)
         self.stub = stub or getattr(self, "stub", False)


### PR DESCRIPTION
## Why are these changes needed?

Fixes spelling typo: "overriden" → "overridden" in comments and docstrings across multiple files:
- `python/ray/dashboard/modules/aggregator/publisher/configs.py`
- `python/ray/tune/experiment/trial.py`
- `python/ray/train/predictor.py`
- `python/ray/train/_internal/data_config.py` (2 occurrences)
- `python/ray/train/data_parallel_trainer.py`
- `python/ray/data/_internal/datasource/huggingface_datasource.py`
- `python/ray/data/preprocessor.py`
- `python/ray/autoscaler/_private/updater.py`

Note: Some occurrences are in variable names which are not changed in this PR to avoid breaking changes.

## Related issue number

N/A - Simple typo fix

## Checks

- [x] I've signed off every commit
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy: N/A - comment/docstring change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)