### PR TITLE
Fix typos: transfered, happend

### DIFF
--- a/rllib/utils/tests/test_actor_manager.py
+++ b/rllib/utils/tests/test_actor_manager.py
@@ -184,7 +184,7 @@ class TestActorManager(unittest.TestCase):
             ).ignore_errors()
         ]
 
-        # Results from blocking calls show the # of calls happend on
+        # Results from blocking calls show the # of calls happened on
         # each remote actor. 11 calls to each actor in total.
         self.assertEqual(results2, [11, 11, 11, 11])
 

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -133,7 +133,7 @@ class ObjectManager : public ObjectManagerInterface,
   /// Handle push request from remote object manager
   ///
   /// Push request will contain the object which is specified by pull request
-  /// the object will be transfered by a sequence of chunks.
+  /// the object will be transferred by a sequence of chunks.
   ///
   /// \param request Push request including the object chunk data
   /// \param reply Reply to the sender
@@ -318,7 +318,7 @@ class ObjectManager : public ObjectManagerInterface,
 
   /// Send one chunk of the object to remote object manager
   ///
-  /// Object will be transfered as a sequence of chunks, small object(defined in config)
+  /// Object will be transferred as a sequence of chunks, small object(defined in config)
   /// contains only one chunk
   /// \param push_id Unique push id to indicate this push request
   /// \param object_id Object id


### PR DESCRIPTION
## Why are these changes needed?

Fixes spelling typos:
- "transfered" → "transferred" in `src/ray/object_manager/object_manager.h` (2 occurrences)
- "happend" → "happened" in `rllib/utils/tests/test_actor_manager.py`

## Related issue number

N/A - Simple typo fix

## Checks

- [x] I've signed off every commit
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy: N/A - comment change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)