### PR TITLE
[Data] Optimize metadata-only read performance

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    cast,
 )
 
 import numpy as np
@@ -600,6 +601,14 @@ class ParquetDatasource(Datasource):
 
     def supports_predicate_pushdown(self) -> bool:
         return True
+
+    def apply_projection(
+        self, projection_map: Optional[Dict[str, str]]
+    ) -> "ParquetDatasource":
+        clone = cast("ParquetDatasource", super().apply_projection(projection_map))
+        # Projections change schemas; force the clone to recompute metadata.
+        clone._static_metadata_cache = None
+        return clone
 
     def get_current_projection(self) -> Optional[List[str]]:
         """Override to include partition columns in addition to data columns."""

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -119,6 +119,10 @@ class Read(
             self._cached_metadata = metadata
         return metadata
 
+    def _reset_metadata_cache(self) -> None:
+        self._cached_metadata = None
+        self._cached_expensive_metadata = None
+
     def _build_output_metadata(
         self, allow_expensive: bool
     ) -> "BlockMetadataWithSchema":
@@ -197,6 +201,7 @@ class Read(
         projection_map: Optional[Dict[str, str]],
     ) -> "Read":
         clone = copy.copy(self)
+        clone._reset_metadata_cache()
 
         projected_datasource = self._datasource.apply_projection(projection_map)
         clone._datasource = projected_datasource
@@ -217,6 +222,7 @@ class Read(
         predicated_datasource = self._datasource.apply_predicate(predicate_expr)
 
         clone = copy.copy(self)
+        clone._reset_metadata_cache()
         clone._datasource = predicated_datasource
         clone._datasource_or_legacy_reader = predicated_datasource
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3893,8 +3893,9 @@ class Dataset:
             in-memory size is not known.
         """
         dag = self._logical_plan.dag
-        if isinstance(dag, Read):
-            dag.get_metadata(allow_expensive=True)
+        for op in dag.post_order_iter():
+            if isinstance(op, Read):
+                op.get_metadata(allow_expensive=True)
 
         # If the size is known from metadata, return it.
         metadata = dag.infer_metadata()

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -5,7 +5,7 @@ import numpy as np
 import pyarrow as pa
 
 from ray.data._internal.util import _check_pyarrow_version
-from ray.data.block import Block, BlockMetadata, Schema
+from ray.data.block import Block, BlockMetadata, BlockMetadataWithSchema, Schema
 from ray.data.datasource.util import _iter_sliced_blocks
 from ray.data.expressions import Expr
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
@@ -276,6 +276,25 @@ class Datasource(_DatasourceProjectionPushdownMixin, _DatasourcePredicatePushdow
             datasource in parallel.
         """
         raise NotImplementedError
+
+    def get_static_metadata(
+        self, allow_expensive_metadata: bool = False
+    ) -> Optional[BlockMetadataWithSchema]:
+        """Return best-effort static metadata without constructing read tasks.
+
+        Args:
+            allow_expensive_metadata: Whether the caller requires precise metadata
+                and is willing to pay the I/O cost (for example, sampling remote
+                files). Datasources can ignore this flag if they don't support
+                inexpensive metadata gathering.
+
+        Datasources can override this to supply cheap metadata (e.g., file schema) so
+        that logical-plan introspection doesn't need to build read tasks eagerly.
+
+        Returns:
+            Static metadata if it can be produced cheaply, otherwise ``None``.
+        """
+        return None
 
     @property
     def should_create_reader(self) -> bool:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -427,7 +427,9 @@ def read_datasource(
     cur_pg = ray.util.get_current_placement_group()
     static_metadata = None
     mem_size_for_autodetect: Optional[int] = None
-    if isinstance(datasource_or_legacy_reader, Datasource):
+    if override_num_blocks is None and isinstance(
+        datasource_or_legacy_reader, Datasource
+    ):
         static_metadata = datasource_or_legacy_reader.get_static_metadata()
         if (
             static_metadata is not None
@@ -449,7 +451,7 @@ def read_datasource(
             metadata={"Read": [static_metadata.metadata]},
             parent=None,
         )
-        num_outputs = None
+        num_outputs = requested_parallelism
     else:
         # TODO(hchen/chengsu): Remove the duplicated get_read_tasks call here after
         # removing LazyBlockList code path.

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -610,10 +610,10 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
         ), "actual data size is out of expected bound"
 
         datasource = ParquetDatasource(tensor_output_path)
+        data_size = datasource.estimate_inmemory_data_size()
         assert (
             datasource._encoding_ratio >= 300 and datasource._encoding_ratio <= 600
         ), "encoding ratio is out of expected bound"
-        data_size = datasource.estimate_inmemory_data_size()
         assert (
             data_size >= 6_000_000 and data_size <= 10_000_000
         ), "estimated data size is either out of expected bound"
@@ -638,10 +638,10 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
         ), "actual data size is out of expected bound"
 
         datasource = ParquetDatasource(text_output_path)
+        data_size = datasource.estimate_inmemory_data_size()
         assert (
             datasource._encoding_ratio >= 6 and datasource._encoding_ratio <= 300
         ), "encoding ratio is out of expected bound"
-        data_size = datasource.estimate_inmemory_data_size()
         assert (
             data_size >= 700_000 and data_size <= 2_200_000
         ), "estimated data size is out of expected bound"


### PR DESCRIPTION
## Description

#### Problem
Metadata-only operations (e.g., Dataset.schema()) currently build a Dataset via read_parquet(), but before .schema() is even invoked, the read API calls `ParquetDatasource.get_read_tasks()` to collect stats. 
That eagerly runs Parquet’s sampling logic (10 files by default) to estimate the encoding ratio and batch size, so even lightweight calls like schema() end up reading data from S3 and taking several seconds.


#### Approach

  1. Static metadata hook – Introduced Datasource.get_static_metadata(allow_expensive_metadata=False). By default it returns None, but ParquetDatasource now returns the schema, file list, and a conservative size estimate that PyArrow already gathers from file footers. Metadata-only consumers hit this cache and avoid sampling. When callers pass allow_expensive_metadata=True (for example size_bytes() or auto-parallelism detection), Parquet lazily performs sampling, refreshes the encoding ratio/size, and updates the cache.
  2. Read operator integration – read_datasource() and the Read logical operator consult the datasource for static metadata before falling back to get_read_tasks(). Read maintains light/heavy caches: schema()/infer_metadata() only return the light cache, while _plan.initial_num_blocks() and Dataset.size_bytes() request the “expensive” metadata to ensure accurate estimates when needed.
  3. Lazy sampling & cache updates – Parquet sampling now runs only when the datasource is about to materialize real data (get_read_tasks() with no per-task limit) or when an API explicitly allows expensive metadata. Once sampling completes, the new encoding ratio and size are written back to the cached metadata so future estimates stay consistent.
  4. Test updates – test_parquet_reader_estimate_data_size first calls estimate_inmemory_data_size() to trigger sampling, then asserts on the encoding ratio and size ranges to guarantee we still provide accurate estimates when they’re required.


#### Test demo
`Note: the output below is from my local network (remote S3 reads are quite slow here), so the ~15s latency is mostly network-bound—the numbers will vary depending on connectivity.`

##### Before
```shell
>>> import time
>>> import ray
>>> ray.init(include_dashboard=False, ignore_reinit_error=True)
2025-12-27 19:53:26,994	INFO worker.py:2010 -- Started a local Ray instance.
/Users/xxx/work/community/ray/python/ray/_private/worker.py:2049: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
RayContext(dashboard_url='', python_version='3.10.19', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}')
>>>
>>> start_time = time.time()
>>> ds = ray.data.read_parquet("s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem").schema()
Parquet dataset sampling 0: 100%|█████████████████████████████████████████████████████████████████████| 10.0/10.0 [00:04<00:00, 2.35 file/s]
2025-12-27 19:53:42,231	INFO parquet_datasource.py:1048 -- Estimated parquet encoding ratio is 2.983.
2025-12-27 19:53:42,234	INFO parquet_datasource.py:1108 -- Estimated parquet reader batch size at 916807 rows
>>> print(time.time() - start_time)
15.418923616409302
```

##### After
```shell
>>> import time
>>> import ray
>>> ray.init(include_dashboard=False, ignore_reinit_error=True)
2025-12-27 19:40:41,907	INFO worker.py:2010 -- Started a local Ray instance.
/Users/xxxx/work/community/ray/python/ray/_private/worker.py:2049: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
RayContext(dashboard_url='', python_version='3.10.19', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}')
>>>
>>> start_time = time.time()
>>> ds = ray.data.read_parquet("s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem").schema()
>>> print(time.time() - start_time)
11.256407976150513
```

#### Result
ray.data.read_parquet(...).schema() and similar metadata-only calls no longer show the “Parquet dataset sampling …” progress bar or issue extra S3 reads—they return as soon as PyArrow finishes listing files and reading footers. At the same time, any API that truly needs precise size/block estimates (size_bytes(), auto-parallelism, estimate_inmemory_data_size(), etc.) still triggers a single sampling pass and reuses the updated numbers, so runtime behavior for heavy operations remains unchanged. Other datasources are unaffected.

## Related issues
> Link related issues: "Fixes https://github.com/ray-project/ray/issues/59439", "Closes https://github.com/ray-project/ray/issues/59439", or "Related to https://github.com/ray-project/ray/issues/59439".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
