### PR TITLE
[core] add missing grpc dependency

### DIFF
--- a/src/ray/pubsub/BUILD.bazel
+++ b/src/ray/pubsub/BUILD.bazel
@@ -33,6 +33,7 @@ ray_cc_library(
         "//src/ray/protobuf:common_cc_proto",
         "//src/ray/protobuf:pubsub_cc_grpc",
         "//src/ray/rpc:rpc_callback_types",
+        "@com_github_grpc_grpc//:grpc++",
     ],
 )
 


### PR DESCRIPTION
otherwise, it fails to build with missing header when grpc is upgraded.
