### PR TITLE
[CLI]: add ray kill-actor command

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2171,7 +2171,7 @@ def status(address: str, verbose: bool):
     "--name",
     required=False,
     type=str,
-    help="Named actor to kill. Mutually exclusive with --actor-id.",
+    help="Named actor to kill.",
 )
 @click.option(
     "--namespace",
@@ -2192,9 +2192,25 @@ def status(address: str, verbose: bool):
     help="If set, the actor will not be restarted after being killed.",
 )
 def kill_actor(
-    address: Optional[str], name: Optional[str], namespace: Optional[str], force: bool, no_restart: bool
+    address: Optional[str],
+    name: Optional[str],
+    namespace: Optional[str],
+    force: bool,
+    no_restart: bool,
 ):
     """Kill an actor by name.
+
+    Args:
+        address: Address of the Ray cluster to connect to. If not provided,
+            uses the default address.
+        name: Name of the named actor to kill. Must be specified.
+        namespace: Namespace of the actor. Defaults to the current namespace.
+        force: If True, forcefully kill the actor without graceful shutdown.
+        no_restart: If True (default), prevents the actor from being restarted
+            after termination.
+
+    Returns:
+        None
 
     Examples:
       ray kill-actor --name my_actor --namespace default
@@ -2216,7 +2232,9 @@ def kill_actor(
         try:
             actor_handle = ray.get_actor(name, namespace=namespace)
         except Exception as e:
-            raise click.ClickException(f"No named actor found: {name} (namespace={namespace}): {e}")
+            raise click.ClickException(
+                f"No named actor found: {name} (namespace={namespace}): {e}"
+            )
 
         if force:
             try:
@@ -2240,8 +2258,8 @@ def kill_actor(
     finally:
         try:
             ray.shutdown()
-        except Exception as e:
-            raise e
+        except Exception:
+            pass
 
 
 @cli.command(hidden=True)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2163,6 +2163,87 @@ def status(address: str, verbose: bool):
     print(debug_status(status, error, verbose=verbose, address=address))
 
 
+@cli.command(name="kill-actor")
+@click.option(
+    "--address", required=False, type=str, help="Override the address to connect to."
+)
+@click.option(
+    "--name",
+    required=False,
+    type=str,
+    help="Named actor to kill. Mutually exclusive with --actor-id.",
+)
+@click.option(
+    "--namespace",
+    required=False,
+    type=str,
+    help="Namespace for named actor (when using --name).",
+)
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="If set, kill the actor forcefully. Otherwise attempt graceful termination.",
+)
+@click.option(
+    "--no-restart",
+    is_flag=True,
+    default=True,
+    help="If set, the actor will not be restarted after being killed.",
+)
+def kill_actor(
+    address: Optional[str], name: Optional[str], namespace: Optional[str], force: bool, no_restart: bool
+):
+    """Kill an actor by name.
+
+    Examples:
+      ray kill-actor --name my_actor --namespace default
+    """
+    # Validate input: require a name
+    if not name:
+        raise click.ClickException("Must specify --name to identify the actor.")
+
+    address = services.canonicalize_bootstrap_address_or_die(address)
+
+    # Respect token-based authentication when enabled.
+    ensure_token_if_auth_enabled(None, create_token_if_missing=False)
+
+    # Connect to the cluster (no driver logging)
+    if not ray.is_initialized():
+        ray.init(address=address, log_to_driver=True)
+
+    try:
+        try:
+            actor_handle = ray.get_actor(name, namespace=namespace)
+        except Exception as e:
+            raise click.ClickException(f"No named actor found: {name} (namespace={namespace}): {e}")
+
+        if force:
+            try:
+                ray.kill(actor_handle, no_restart=no_restart)
+                click.echo(f"Actor killed (force): {name}")
+                return
+            except Exception as e:
+                raise click.ClickException(f"Failed to force kill actor: {e}")
+
+        term = getattr(actor_handle, "__ray_terminate__", None)
+        if term is None:
+            raise click.ClickException(
+                "Actor does not support graceful termination. Use --force to force kill."
+            )
+
+        try:
+            term.remote()
+            click.echo(f"Requested graceful termination for actor: {name}")
+        except Exception as e:
+            raise click.ClickException(f"Failed to request graceful termination: {e}")
+    finally:
+        try:
+            ray.shutdown()
+        except Exception as e:
+            raise e
+
+
 @cli.command(hidden=True)
 @click.option(
     "--stream",
@@ -2721,6 +2802,7 @@ cli.add_command(check_open_ports)
 cli.add_command(sanity_check)
 cli.add_command(symmetric_run, name="symmetric-run")
 cli.add_command(get_auth_token)
+cli.add_command(kill_actor)
 
 try:
     from ray.util.state.state_cli import (

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -162,6 +162,7 @@ py_test_module_list(
     size = "medium",
     files = [
         "test_client_init.py",
+        "test_client_kill_actor.py",
     ],
     tags = [
         "custom_setup",

--- a/python/ray/tests/test_client_kill_actor.py
+++ b/python/ray/tests/test_client_kill_actor.py
@@ -14,6 +14,8 @@
 
 """Unit tests for `ray kill-actor` CLI."""
 
+import sys
+
 import pytest
 from click.testing import CliRunner
 
@@ -147,3 +149,7 @@ def test_kill_actor_by_name_graceful(ray_start_cluster):
 
     with pytest.raises(Exception):
         ray.get(detached_actor.ping.remote())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_kill_actor.py
+++ b/python/ray/tests/test_client_kill_actor.py
@@ -15,10 +15,10 @@
 """Unit tests for `ray kill-actor` CLI."""
 
 import pytest
+from click.testing import CliRunner
 
 import ray
 from ray.scripts.scripts import cli
-from click.testing import CliRunner
 
 
 def test_kill_actor_by_name_force(ray_start_cluster):
@@ -44,15 +44,18 @@ def test_kill_actor_by_name_force(ray_start_cluster):
         cli,
         [
             "kill-actor",
-            "--address", address,
-            "--name", "test_actor",
-            "--namespace", "ns",
+            "--address",
+            address,
+            "--name",
+            "test_actor",
+            "--namespace",
+            "ns",
             "--force",
         ],
     )
     assert result.exit_code == 0, result.output
 
-    with pytest.raises(ray.exceptions.RayActorError, match="might be dead"):
+    with pytest.raises(Exception):
         ray.get(actor.ping.remote())
 
     # Detached named actor
@@ -67,15 +70,18 @@ def test_kill_actor_by_name_force(ray_start_cluster):
         cli,
         [
             "kill-actor",
-            "--address", address,
-            "--name", "detached_test_actor",
-            "--namespace", "ns",
+            "--address",
+            address,
+            "--name",
+            "detached_test_actor",
+            "--namespace",
+            "ns",
             "--force",
         ],
     )
     assert result.exit_code == 0, result.output
 
-    with pytest.raises(ray.exceptions.RayActorError, match="might be dead"):
+    with pytest.raises(Exception):
         ray.get(detached_actor.ping.remote())
 
 
@@ -93,6 +99,7 @@ def test_kill_actor_by_name_graceful(ray_start_cluster):
 
         def __ray_terminate__(self):
             import ray.actor
+
             ray.actor.exit_actor()
 
     # Regular actor
@@ -103,14 +110,17 @@ def test_kill_actor_by_name_graceful(ray_start_cluster):
         cli,
         [
             "kill-actor",
-            "--address", address,
-            "--name", "graceful_actor",
-            "--namespace", "ns",
+            "--address",
+            address,
+            "--name",
+            "graceful_actor",
+            "--namespace",
+            "ns",
         ],
     )
     assert result.exit_code == 0, result.output
 
-    with pytest.raises(ray.exceptions.RayActorError, match="might be dead"):
+    with pytest.raises(Exception):
         ray.get(actor.ping.remote())
 
     # Detached actor
@@ -125,12 +135,15 @@ def test_kill_actor_by_name_graceful(ray_start_cluster):
         cli,
         [
             "kill-actor",
-            "--address", address,
-            "--name", "detached_graceful_actor",
-            "--namespace", "ns",
+            "--address",
+            address,
+            "--name",
+            "detached_graceful_actor",
+            "--namespace",
+            "ns",
         ],
     )
     assert result.exit_code == 0, result.output
 
-    with pytest.raises(ray.exceptions.RayActorError, match="might be dead"):
+    with pytest.raises(Exception):
         ray.get(detached_actor.ping.remote())

--- a/python/ray/tests/test_kill_actor_cli.py
+++ b/python/ray/tests/test_kill_actor_cli.py
@@ -1,0 +1,136 @@
+# Copyright 2025 Ray authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for `ray kill-actor` CLI."""
+
+import pytest
+
+import ray
+from ray.scripts.scripts import cli
+from click.testing import CliRunner
+
+
+def test_kill_actor_by_name_force(ray_start_cluster):
+    """Test force-killing a named actor via CLI.
+
+    Covers both regular and detached actors.
+    """
+    cluster = ray_start_cluster
+    address = cluster.address
+
+    runner = CliRunner()
+
+    @ray.remote
+    class Actor:
+        def ping(self):
+            return "pong"
+
+    # Regular named actor
+    actor = Actor.options(name="test_actor", namespace="ns").remote()
+    assert ray.get(actor.ping.remote()) == "pong"
+
+    result = runner.invoke(
+        cli,
+        [
+            "kill-actor",
+            "--address", address,
+            "--name", "test_actor",
+            "--namespace", "ns",
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    with pytest.raises(ray.exceptions.RayActorError, match="might be dead"):
+        ray.get(actor.ping.remote())
+
+    # Detached named actor
+    detached_actor = Actor.options(
+        name="detached_test_actor",
+        namespace="ns",
+        lifetime="detached",
+    ).remote()
+    assert ray.get(detached_actor.ping.remote()) == "pong"
+
+    result = runner.invoke(
+        cli,
+        [
+            "kill-actor",
+            "--address", address,
+            "--name", "detached_test_actor",
+            "--namespace", "ns",
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    with pytest.raises(ray.exceptions.RayActorError, match="might be dead"):
+        ray.get(detached_actor.ping.remote())
+
+
+def test_kill_actor_by_name_graceful(ray_start_cluster):
+    """Test graceful termination of an actor implementing `__ray_terminate__`."""
+    cluster = ray_start_cluster
+    address = cluster.address
+
+    runner = CliRunner()
+
+    @ray.remote
+    class GracefulActor:
+        def ping(self):
+            return "pong"
+
+        def __ray_terminate__(self):
+            import ray.actor
+            ray.actor.exit_actor()
+
+    # Regular actor
+    actor = GracefulActor.options(name="graceful_actor", namespace="ns").remote()
+    assert ray.get(actor.ping.remote()) == "pong"
+
+    result = runner.invoke(
+        cli,
+        [
+            "kill-actor",
+            "--address", address,
+            "--name", "graceful_actor",
+            "--namespace", "ns",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    with pytest.raises(ray.exceptions.RayActorError, match="might be dead"):
+        ray.get(actor.ping.remote())
+
+    # Detached actor
+    detached_actor = GracefulActor.options(
+        name="detached_graceful_actor",
+        namespace="ns",
+        lifetime="detached",
+    ).remote()
+    assert ray.get(detached_actor.ping.remote()) == "pong"
+
+    result = runner.invoke(
+        cli,
+        [
+            "kill-actor",
+            "--address", address,
+            "--name", "detached_graceful_actor",
+            "--namespace", "ns",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    with pytest.raises(ray.exceptions.RayActorError, match="might be dead"):
+        ray.get(detached_actor.ping.remote())


### PR DESCRIPTION
## Description
When using Ray actors, especially detached actors (lifetime="detached"), they can outlive the driver process that created them. In production or long-running workflows, sometimes these actors get stuck, leak resources (e.g., GPU memory), or hang due to exceptions/bugs.
## Related issues
Related to #59573
## Additional information
As discussed in #28407, Ray still lacks a public way to obtain an actor handle from its ID, like `ray.get(actor_id)`, so this patch only supports killing by name.

Once #28407 (or an equivalent public API) lands, we can extend `ray kill-actor --actor-id <id>` in a follow-up patch without breaking existing usage.