### PR TITLE
[Data] Remove constructor from ClusterAutoscaler base class

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/__init__.py
+++ b/python/ray/data/_internal/cluster_autoscaler/__init__.py
@@ -33,7 +33,6 @@ def create_cluster_autoscaler(
 
     if selected_autoscaler == ClusterAutoscalerVersion.V2:
         return DefaultClusterAutoscalerV2(
-            topology,
             resource_manager,
             execution_id=execution_id,
         )

--- a/python/ray/data/_internal/cluster_autoscaler/__init__.py
+++ b/python/ray/data/_internal/cluster_autoscaler/__init__.py
@@ -40,7 +40,6 @@ def create_cluster_autoscaler(
     elif selected_autoscaler == ClusterAutoscalerVersion.V1:
         return DefaultClusterAutoscaler(
             topology,
-            resource_manager,
             execution_id=execution_id,
         )
 

--- a/python/ray/data/_internal/cluster_autoscaler/base_cluster_autoscaler.py
+++ b/python/ray/data/_internal/cluster_autoscaler/base_cluster_autoscaler.py
@@ -7,23 +7,11 @@ if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces.execution_options import (
         ExecutionResources,
     )
-    from ray.data._internal.execution.resource_manager import ResourceManager
-    from ray.data._internal.execution.streaming_executor_state import Topology
 
 
 @DeveloperAPI
 class ClusterAutoscaler(ABC):
     """Abstract interface for Ray Data cluster autoscaler."""
-
-    def __init__(
-        self,
-        topology: "Topology",
-        resource_manager: "ResourceManager",
-        execution_id: str,
-    ):
-        self._topology = topology
-        self._resource_manager = resource_manager
-        self._execution_id = execution_id
 
     @abstractmethod
     def try_trigger_scaling(self):

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler.py
@@ -11,7 +11,6 @@ from ray.data._internal.execution.autoscaling_requester import (
 from ray.data._internal.execution.interfaces import ExecutionResources
 
 if TYPE_CHECKING:
-    from ray.data._internal.execution.resource_manager import ResourceManager
     from ray.data._internal.execution.streaming_executor_state import Topology
 
 
@@ -26,12 +25,10 @@ class DefaultClusterAutoscaler(ClusterAutoscaler):
     def __init__(
         self,
         topology: "Topology",
-        resource_manager: "ResourceManager",
         *,
         execution_id: str,
     ):
         self._topology = topology
-        self._resource_manager = resource_manager
         self._execution_id = execution_id
 
         # Last time when a request was sent to Ray's autoscaler.

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler.py
@@ -30,7 +30,9 @@ class DefaultClusterAutoscaler(ClusterAutoscaler):
         *,
         execution_id: str,
     ):
-        super().__init__(topology, resource_manager, execution_id)
+        self._topology = topology
+        self._resource_manager = resource_manager
+        self._execution_id = execution_id
 
         # Last time when a request was sent to Ray's autoscaler.
         self._last_request_time = 0

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -19,7 +19,6 @@ from ray.data._internal.execution.interfaces.execution_options import ExecutionR
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.resource_manager import ResourceManager
-    from ray.data._internal.execution.streaming_executor_state import Topology
 
 logger = getLogger(__name__)
 
@@ -87,7 +86,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
 
     def __init__(
         self,
-        topology: "Topology",
         resource_manager: "ResourceManager",
         execution_id: str,
         resource_utilization_calculator: Optional[ResourceUtilizationGauge] = None,
@@ -118,7 +116,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         # Send an empty request to register ourselves as soon as possible,
         # so the first `get_total_resources` call can get the allocated resources.
         self._send_resource_request([])
-        super().__init__(topology, resource_manager, execution_id)
 
     def _get_node_resource_spec_and_count(self) -> Dict[_NodeResourceSpec, int]:
         """Get the unique node resource specs and their count in the cluster."""

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -333,7 +333,6 @@ def test_cluster_scaling():
 
     autoscaler = DefaultClusterAutoscaler(
         topology=topology,
-        resource_manager=MagicMock(),
         execution_id="execution_id",
     )
 

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -74,7 +74,6 @@ class TestClusterAutoscaling:
     def test_get_node_resource_spec_and_count(self):
         # Test _get_node_resource_spec_and_count
         autoscaler = DefaultClusterAutoscalerV2(
-            topology=MagicMock(),
             resource_manager=MagicMock(),
             execution_id="test_execution_id",
         )
@@ -145,7 +144,6 @@ class TestClusterAutoscaling:
         )
 
         autoscaler = DefaultClusterAutoscalerV2(
-            topology=MagicMock(),
             resource_manager=MagicMock(),
             execution_id="test_execution_id",
             cluster_scaling_up_delta=scale_up_delta,


### PR DESCRIPTION
## Description

The constructor in ClusterAutoscaler base class is not necessary, and it adds complexity because it requires all ClusterAutoscaling implementations to accept the same dependencies

This PR remove the constructor in ClusterAutoscaler. Sub-classes can prevent using the dependencies that are not used

## Related issues
Closes #59684

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
