### PR TITLE
[Core] Support labels for ray job submit --entrypoint-resource

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -872,8 +872,6 @@ python/ray/dashboard/modules/event/event_utils.py
     DOC201: Function `monitor_events` does not have a return section in docstring
 --------------------
 python/ray/dashboard/modules/job/cli.py
-    DOC101: Function `submit`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `submit`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], entrypoint: Tuple[str], entrypoint_memory: Optional[int], entrypoint_num_cpus: Optional[Union[int, float]], entrypoint_num_gpus: Optional[Union[int, float]], entrypoint_resources: Optional[str], headers: Optional[str], job_id: Optional[str], metadata_json: Optional[str], no_wait: bool, runtime_env: Optional[str], runtime_env_json: Optional[str], submission_id: Optional[str], verify: Union[bool, str], working_dir: Optional[str]].
     DOC101: Function `status`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `status`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], headers: Optional[str], job_id: str, verify: Union[bool, str]].
     DOC101: Function `stop`: Docstring contains fewer arguments than in function signature.
@@ -901,8 +899,6 @@ python/ray/dashboard/modules/job/job_supervisor.py
     DOC103: Method `JobSupervisor._exec_entrypoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [env: dict].
 --------------------
 python/ray/dashboard/modules/job/sdk.py
-    DOC104: Method `JobSubmissionClient.submit_job`: Arguments are the same in the docstring and the function signature, but are in a different order.
-    DOC105: Method `JobSubmissionClient.submit_job`: Argument names match, but type hints in these args do not match: entrypoint, job_id, runtime_env, metadata, submission_id, entrypoint_num_cpus, entrypoint_num_gpus, entrypoint_memory, entrypoint_resources
     DOC402: Method `JobSubmissionClient.tail_job_logs` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Method `JobSubmissionClient.tail_job_logs` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
 --------------------

--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -198,6 +198,13 @@ def job_cli_group():
     "separately from any tasks or actors that are launched by it",
 )
 @click.option(
+    "--entrypoint-label-selector",
+    required=False,
+    type=str,
+    help="a JSON-serialized dictionary mapping label keys to selector strings "
+    "describing placement constraints for the entrypoint command",
+)
+@click.option(
     "--no-wait",
     is_flag=True,
     type=bool,
@@ -221,6 +228,7 @@ def submit(
     entrypoint_num_gpus: Optional[Union[int, float]],
     entrypoint_memory: Optional[int],
     entrypoint_resources: Optional[str],
+    entrypoint_label_selector: Optional[str],
     no_wait: bool,
     verify: Union[bool, str],
     headers: Optional[str],
@@ -232,6 +240,24 @@ def submit(
 
     Example:
         `ray job submit -- python my_script.py --arg=val`
+
+    Args:
+        address: Job submission server address.
+        job_id: DEPRECATED. Use submission_id instead.
+        submission_id: Submission ID for the job.
+        runtime_env: Path to a runtime_env YAML file.
+        runtime_env_json: JSON-serialized runtime_env dictionary.
+        metadata_json: JSON-serialized metadata dictionary.
+        working_dir: Working directory for the job.
+        entrypoint: Entrypoint command.
+        entrypoint_num_cpus: CPU cores to reserve.
+        entrypoint_num_gpus: GPUs to reserve.
+        entrypoint_memory: Memory to reserve.
+        entrypoint_resources: JSON-serialized custom resources dict.
+        entrypoint_label_selector: JSON-serialized label selector dict.
+        no_wait: Do not wait for job completion.
+        verify: TLS verification flag or path.
+        headers: JSON-serialized headers.
     """
     if job_id:
         cli_logger.warning(
@@ -240,6 +266,13 @@ def submit(
     if entrypoint_resources is not None:
         entrypoint_resources = parse_resources_json(
             entrypoint_resources, cli_logger, cf, command_arg="entrypoint-resources"
+        )
+    if entrypoint_label_selector is not None:
+        entrypoint_label_selector = parse_resources_json(
+            entrypoint_label_selector,
+            cli_logger,
+            cf,
+            command_arg="entrypoint-label-selector",
         )
     if metadata_json is not None:
         metadata_json = parse_metadata_json(
@@ -263,6 +296,7 @@ def submit(
             entrypoint_num_gpus=entrypoint_num_gpus,
             entrypoint_memory=entrypoint_memory,
             entrypoint_resources=entrypoint_resources,
+            entrypoint_label_selector=entrypoint_label_selector,
             no_wait=no_wait,
         )
 
@@ -284,6 +318,7 @@ def submit(
         entrypoint_num_gpus=entrypoint_num_gpus,
         entrypoint_memory=entrypoint_memory,
         entrypoint_resources=entrypoint_resources,
+        entrypoint_label_selector=entrypoint_label_selector,
     )
 
     _log_big_success_msg(f"Job '{job_id}' submitted successfully")

--- a/python/ray/dashboard/modules/job/common.py
+++ b/python/ray/dashboard/modules/job/common.py
@@ -463,6 +463,8 @@ class JobSubmitRequest:
     # to reserve for the entrypoint command, separately from any Ray tasks
     # or actors that are created by it.
     entrypoint_resources: Optional[Dict[str, float]] = None
+    # Label selector for the entrypoint command.
+    entrypoint_label_selector: Optional[Dict[str, str]] = None
 
     def __post_init__(self):
         if not isinstance(self.entrypoint, str):
@@ -545,6 +547,25 @@ class JobSubmitRequest:
                     if not isinstance(v, (int, float)):
                         raise TypeError(
                             "entrypoint_resources values must be numbers, "
+                            f"got {type(v)}"
+                        )
+
+        if self.entrypoint_label_selector is not None:
+            if not isinstance(self.entrypoint_label_selector, dict):
+                raise TypeError(
+                    "entrypoint_label_selector must be a dict, "
+                    f"got {type(self.entrypoint_label_selector)}"
+                )
+            else:
+                for k, v in self.entrypoint_label_selector.items():
+                    if not isinstance(k, str):
+                        raise TypeError(
+                            "entrypoint_label_selector keys must be strings, "
+                            f"got {type(k)}"
+                        )
+                    if not isinstance(v, str):
+                        raise TypeError(
+                            "entrypoint_label_selector values must be strings, "
                             f"got {type(v)}"
                         )
 

--- a/python/ray/dashboard/modules/job/job_agent.py
+++ b/python/ray/dashboard/modules/job/job_agent.py
@@ -52,6 +52,7 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
                 entrypoint_num_gpus=submit_request.entrypoint_num_gpus,
                 entrypoint_memory=submit_request.entrypoint_memory,
                 entrypoint_resources=submit_request.entrypoint_resources,
+                entrypoint_label_selector=submit_request.entrypoint_label_selector,
             )
 
             resp = JobSubmitResponse(job_id=submission_id, submission_id=submission_id)

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -14,6 +14,7 @@ from ray._common.utils import Timer, run_background_task
 from ray._private.accelerators.npu import NOSET_ASCEND_RT_VISIBLE_DEVICES_ENV_VAR
 from ray._private.accelerators.nvidia_gpu import NOSET_CUDA_VISIBLE_DEVICES_ENV_VAR
 from ray._private.event.event_logger import get_event_logger
+from ray._private.label_utils import validate_label_selector
 from ray._raylet import GcsClient
 from ray.actor import ActorHandle
 from ray.core.generated.event_pb2 import Event
@@ -479,6 +480,7 @@ class JobManager:
         entrypoint_num_gpus: Optional[Union[int, float]] = None,
         entrypoint_memory: Optional[int] = None,
         entrypoint_resources: Optional[Dict[str, float]] = None,
+        entrypoint_label_selector: Optional[Dict[str, str]] = None,
         _start_signal_actor: Optional[ActorHandle] = None,
     ) -> str:
         """
@@ -513,6 +515,7 @@ class JobManager:
             entrypoint_resources: The quantity of various custom resources
                 to reserve for the entrypoint command, separately from any tasks or
                 actors launched by it.
+            entrypoint_label_selector: Label selector for the entrypoint command.
             _start_signal_actor: Used in testing only to capture state
                 transitions between PENDING -> RUNNING. Regular user shouldn't
                 need this.
@@ -535,6 +538,10 @@ class JobManager:
         await self._recover_running_jobs_event.wait()
 
         logger.info(f"Starting job with submission_id: {submission_id}")
+        if entrypoint_label_selector:
+            error_message = validate_label_selector(entrypoint_label_selector)
+            if error_message:
+                raise ValueError(error_message)
         job_info = JobInfo(
             entrypoint=entrypoint,
             status=JobStatus.PENDING,
@@ -566,6 +573,7 @@ class JobManager:
                     entrypoint_num_gpus is not None and entrypoint_num_gpus > 0,
                     entrypoint_memory is not None and entrypoint_memory > 0,
                     entrypoint_resources not in [None, {}],
+                    entrypoint_label_selector not in [None, {}],
                 ]
             )
             scheduling_strategy = await self._get_scheduling_strategy(
@@ -577,7 +585,7 @@ class JobManager:
                 )
 
             driver_logger.info("Runtime env is setting up.")
-            supervisor = self._supervisor_actor_cls.options(
+            supervisor_options = dict(
                 lifetime="detached",
                 name=JOB_ACTOR_NAME_TEMPLATE.format(job_id=submission_id),
                 num_cpus=entrypoint_num_cpus,
@@ -592,6 +600,11 @@ class JobManager:
                 # Don't pollute task events with system actor tasks that users don't
                 # know about.
                 enable_task_events=False,
+            )
+            if entrypoint_label_selector:
+                supervisor_options["label_selector"] = entrypoint_label_selector
+            supervisor = self._supervisor_actor_cls.options(
+                **supervisor_options
             ).remote(
                 submission_id,
                 entrypoint,

--- a/python/ray/dashboard/modules/job/sdk.py
+++ b/python/ray/dashboard/modules/job/sdk.py
@@ -135,6 +135,7 @@ class JobSubmissionClient(SubmissionClient):
         entrypoint_num_gpus: Optional[Union[int, float]] = None,
         entrypoint_memory: Optional[int] = None,
         entrypoint_resources: Optional[Dict[str, float]] = None,
+        entrypoint_label_selector: Optional[Dict[str, str]] = None,
     ) -> str:
         """Submit and execute a job asynchronously.
 
@@ -157,10 +158,10 @@ class JobSubmissionClient(SubmissionClient):
 
         Args:
             entrypoint: The shell command to run for this job.
-            submission_id: A unique ID for this job.
+            job_id: DEPRECATED. This has been renamed to submission_id.
             runtime_env: The runtime environment to install and run this job in.
             metadata: Arbitrary data to store along with this job.
-            job_id: DEPRECATED. This has been renamed to submission_id
+            submission_id: A unique ID for this job.
             entrypoint_num_cpus: The quantity of CPU cores to reserve for the execution
                 of the entrypoint command, separately from any tasks or actors launched
                 by it. Defaults to 0.
@@ -173,6 +174,7 @@ class JobSubmissionClient(SubmissionClient):
             entrypoint_resources: The quantity of custom resources to reserve for the
                 execution of the entrypoint command, separately from any tasks or
                 actors launched by it.
+            entrypoint_label_selector: Label selector for the entrypoint command.
 
         Returns:
             The submission ID of the submitted job.  If not specified,
@@ -187,11 +189,16 @@ class JobSubmissionClient(SubmissionClient):
                 "job_id kwarg is deprecated. Please use submission_id instead."
             )
 
-        if entrypoint_num_cpus or entrypoint_num_gpus or entrypoint_resources:
+        if (
+            entrypoint_num_cpus
+            or entrypoint_num_gpus
+            or entrypoint_resources
+            or entrypoint_label_selector
+        ):
             self._check_connection_and_version(
                 min_version="2.2",
                 version_error_message="`entrypoint_num_cpus`, `entrypoint_num_gpus`, "
-                "and `entrypoint_resources` kwargs "
+                "`entrypoint_resources`, and `entrypoint_label_selector` kwargs "
                 "are not supported on the Ray cluster. Please ensure the cluster is "
                 "running Ray 2.2 or higher.",
             )
@@ -237,6 +244,7 @@ class JobSubmissionClient(SubmissionClient):
             entrypoint_num_gpus=entrypoint_num_gpus,
             entrypoint_memory=entrypoint_memory,
             entrypoint_resources=entrypoint_resources,
+            entrypoint_label_selector=entrypoint_label_selector,
         )
 
         # Remove keys with value None so that new clients with new optional fields

--- a/python/ray/dashboard/modules/job/tests/test_backwards_compatibility.py
+++ b/python/ray/dashboard/modules/job/tests/test_backwards_compatibility.py
@@ -80,18 +80,20 @@ def test_error_message():
     )
     wait_for_condition(lambda: client.get_job_status(job_id) == JobStatus.SUCCEEDED)
 
-    # `entrypoint_num_cpus`, `entrypoint_num_gpus`, and `entrypoint_resources`
+    # `entrypoint_num_cpus`, `entrypoint_num_gpus`, `entrypoint_resources`, and
+    # `entrypoint_label_selector`
     # are not supported in ray<2.2.0.
     for unsupported_submit_kwargs in [
         {"entrypoint_num_cpus": 1},
         {"entrypoint_num_gpus": 1},
         {"entrypoint_resources": {"custom": 1}},
+        {"entrypoint_label_selector": {"fragile_node": "!1"}},
     ]:
         with pytest.raises(
             Exception,
             match="Ray version 2.0.1 is running on the cluster. "
-            "`entrypoint_num_cpus`, `entrypoint_num_gpus`, and "
-            "`entrypoint_resources` kwargs"
+            "`entrypoint_num_cpus`, `entrypoint_num_gpus`, "
+            "`entrypoint_resources`, and `entrypoint_label_selector` kwargs"
             " are not supported on the Ray cluster. Please ensure the cluster is "
             "running Ray 2.2 or higher.",
         ):

--- a/python/ray/dashboard/modules/job/tests/test_cli.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli.py
@@ -158,6 +158,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
             result = runner.invoke(
@@ -174,6 +175,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
             result = runner.invoke(
@@ -189,6 +191,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
     def test_runtime_env(self, mock_sdk_client, runtime_env_formats):
@@ -211,6 +214,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
             # Test passing via json.
@@ -228,6 +232,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
             # Test passing both throws an error.
@@ -270,6 +275,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
             result = runner.invoke(
@@ -294,6 +300,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
     def test_job_id(self, mock_sdk_client):
@@ -312,6 +319,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
             result = runner.invoke(
@@ -328,6 +336,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
     def test_entrypoint_num_cpus(self, mock_sdk_client):
@@ -349,6 +358,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
     def test_entrypoint_num_gpus(self, mock_sdk_client):
@@ -370,6 +380,7 @@ class TestSubmit:
                 entrypoint_num_gpus=2,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
     def test_entrypoint_memory(self, mock_sdk_client):
@@ -391,6 +402,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=4,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
             )
 
     @pytest.mark.parametrize(
@@ -424,6 +436,7 @@ class TestSubmit:
                 "entrypoint_num_gpus": None,
                 "entrypoint_memory": None,
                 "entrypoint_resources": None,
+                "entrypoint_label_selector": None,
             }
             expected_kwargs.update(resources[1])
             mock_client_instance.submit_job.assert_called_with(**expected_kwargs)
@@ -444,6 +457,33 @@ class TestSubmit:
             print(result.output)
             assert result.exit_code == 1
             assert "not a valid JSON string" in result.output
+
+    def test_entrypoint_label_selector(self, mock_sdk_client):
+        runner = CliRunner()
+        mock_client_instance = mock_sdk_client.return_value
+
+        with set_env_var("RAY_ADDRESS", "env_addr"):
+            result = runner.invoke(
+                job_cli_group,
+                [
+                    "submit",
+                    """--entrypoint-label-selector={"fragile_node":"!1"}""",
+                    "--",
+                    "echo hello",
+                ],
+            )
+            assert result.exit_code == 0
+            mock_client_instance.submit_job.assert_called_with(
+                entrypoint='"echo hello"',
+                submission_id=None,
+                runtime_env={},
+                metadata=None,
+                entrypoint_num_cpus=None,
+                entrypoint_num_gpus=None,
+                entrypoint_memory=None,
+                entrypoint_resources=None,
+                entrypoint_label_selector={"fragile_node": "!1"},
+            )
 
     def test_metadata(self, mock_sdk_client):
         runner = CliRunner()
@@ -469,6 +509,7 @@ class TestSubmit:
                 entrypoint_num_gpus=None,
                 entrypoint_memory=None,
                 entrypoint_resources=None,
+                entrypoint_label_selector=None,
                 metadata={"key": "value"},
             )
 

--- a/python/ray/dashboard/modules/job/tests/test_common.py
+++ b/python/ray/dashboard/modules/job/tests/test_common.py
@@ -89,6 +89,41 @@ class TestJobSubmitRequestValidation:
                 {"entrypoint": "abc", "metadata": {"hi": 1}}, JobSubmitRequest
             )
 
+    def test_validate_entrypoint_label_selector(self):
+        r = validate_request_type(
+            {
+                "entrypoint": "abc",
+                "entrypoint_label_selector": {"fragile_node": "!1"},
+            },
+            JobSubmitRequest,
+        )
+        assert r.entrypoint_label_selector == {"fragile_node": "!1"}
+
+        with pytest.raises(TypeError, match="must be a dict"):
+            validate_request_type(
+                {"entrypoint": "abc", "entrypoint_label_selector": "bad"},
+                JobSubmitRequest,
+            )
+
+        with pytest.raises(TypeError, match="keys must be strings"):
+            validate_request_type(
+                {"entrypoint": "abc", "entrypoint_label_selector": {1: "bad"}},
+                JobSubmitRequest,
+            )
+
+        with pytest.raises(TypeError, match="values must be strings"):
+            validate_request_type(
+                {"entrypoint": "abc", "entrypoint_label_selector": {"k": 1}},
+                JobSubmitRequest,
+            )
+
+    def test_entrypoint_resources_disallow_strings(self):
+        with pytest.raises(TypeError, match="values must be numbers"):
+            validate_request_type(
+                {"entrypoint": "abc", "entrypoint_resources": {"Custom": "1"}},
+                JobSubmitRequest,
+            )
+
 
 def test_uri_to_http_and_back():
     assert uri_to_http_components("gcs://hello.zip") == ("gcs", "hello.zip")


### PR DESCRIPTION
## Description
### Problem
Using --entrypoint-resources '{"fragile_node":"!1"}' with the Job API raises an error saying only numeric values are allowed.

### Expect
Add a corresponding `--entrypoint-label-selector`,  and `--entrypoint-label-selector` should accept label selectors just like ray.remote/PlacementGroups, so entrypoints can target or avoid nodes with specific labels.

for example:
```shell
ray job submit --entrypoint-label-selector='{"fragile_node":"true"}'
```

## Related issues
> Link related issues: "Fixes #58662 ", "Closes #58662", or "Related to #58662".

## Additional information

### Implementation approach
- CLI adds --entrypoint-label-selector (JSON dict of label selectors).
- SDK/JobSubmitRequest/JobManager plumb entrypoint_label_selector through.
- JobManager validates selectors and passes them to supervisor label_selector.
- entrypoint_resources stays numeric-only.



###  Just a quick local sanity check (single-node) 

#### Step 1: start ray head with lables

```shell
(clion-ray-ce) ➜  python git:(support-lable-entrypoint) ray start --head \
    --labels="fragile_node=true,zone=local" \
    --dashboard-agent-listen-port=52366
```

```
2026-01-05 00:37:43,088 - INFO - Note: NumExpr detected 10 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2026-01-05 00:37:43,088 - INFO - NumExpr defaulting to 8 threads.
Usage stats collection is enabled. To disable this, add `--disable-usage-stats` to the command that starts the cluster, or run the following command: `ray disable-usage-stats` before starting the cluster. See https://docs.ray.io/en/master/cluster/usage-stats.html for more details.

Local node IP: 127.0.0.1

--------------------
Ray runtime started.
--------------------

Next steps

  To connect to this Ray cluster:
    import ray
    ray.init()

  To submit a Ray job using the Ray Jobs CLI:
    RAY_API_SERVER_ADDRESS='http://127.0.0.1:8265' ray job submit --working-dir . -- python my_script.py

  See https://docs.ray.io/en/latest/cluster/running-applications/job-submission/index.html
  for more information on submitting Ray jobs to the Ray cluster.

  To terminate the Ray runtime, run
    ray stop

  To view the status of the cluster, use
    ray status

  To monitor and debug Ray, view the dashboard at
    127.0.0.1:8265

  If connection to the dashboard fails, check your firewall settings and network configuration.
```

#### Step 2: Submit the Ray job to nodes that match the label selector.

```bash
(clion-ray-ce) ➜  python git:(support-lable-entrypoint) ray job submit \
    --entrypoint-label-selector='{"fragile_node":"true"}' \
    -- python -c "import ray; ray.init(); print(ray.get_runtime_context().get_node_labels())"
```
```
2026-01-05 00:37:52,653 - INFO - Note: NumExpr detected 10 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2026-01-05 00:37:52,653 - INFO - NumExpr defaulting to 8 threads.
Job submission server address: http://127.0.0.1:8265

-------------------------------------------------------
Job 'raysubmit_n7f6Tz1KAaFSdG7C' submitted successfully
-------------------------------------------------------

Next steps
  Query the logs of the job:
    ray job logs raysubmit_n7f6Tz1KAaFSdG7C
  Query the status of the job:
    ray job status raysubmit_n7f6Tz1KAaFSdG7C
  Request the job to be stopped:
    ray job stop raysubmit_n7f6Tz1KAaFSdG7C

Tailing logs until the job exits (disable with --no-wait):
2026-01-05 00:37:53,644	INFO job_manager.py:587 -- Runtime env is setting up.
Running entrypoint for job raysubmit_n7f6Tz1KAaFSdG7C: python -c "import ray; ray.init(); print(ray.get_runtime_context().get_node_labels())"
2026-01-05 00:37:54,801	INFO worker.py:1670 -- Using address 127.0.0.1:6379 set in the environment variable RAY_ADDRESS
2026-01-05 00:37:54,805	INFO worker.py:1811 -- Connecting to existing Ray cluster at address: 127.0.0.1:6379...
2026-01-05 00:37:54,839	INFO worker.py:1991 -- Connected to Ray cluster. View the dashboard at 127.0.0.1:8265
/Users/xxx/work/community/ray/python/ray/_private/worker.py:2039: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
{'fragile_node': 'true', 'zone': 'local', 'ray.io/node-id': 'a177e603a402ced417f3d88c80f0872f6a4adcab5f4eb359caaf4491'}

------------------------------------------
Job 'raysubmit_n7f6Tz1KAaFSdG7C' succeeded
------------------------------------------
```

#### Step 3: Submit the Ray job to nodes that not match the label selector.
```
(clion-ray-ce) ➜  python git:(support-lable-entrypoint) ray job submit \
    --entrypoint-label-selector='{"fragile_node":"!true"}' \
    -- python -c "print('should not run')"
```
```
2026-01-05 00:41:26,863 - INFO - Note: NumExpr detected 10 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2026-01-05 00:41:26,863 - INFO - NumExpr defaulting to 8 threads.
Job submission server address: http://127.0.0.1:8265

-------------------------------------------------------
Job 'raysubmit_LNK3KgVwtrDtEAYX' submitted successfully
-------------------------------------------------------

Next steps
  Query the logs of the job:
    ray job logs raysubmit_LNK3KgVwtrDtEAYX
  Query the status of the job:
    ray job status raysubmit_LNK3KgVwtrDtEAYX
  Request the job to be stopped:
    ray job stop raysubmit_LNK3KgVwtrDtEAYX

Tailing logs until the job exits (disable with --no-wait):
```

<img width="2892" height="1378" alt="image" src="https://github.com/user-attachments/assets/62f61fcd-ffe4-49a2-96be-b6f4cd09bfd2" />

