### PR TITLE
[tune] use generated dataset for ResourceExhaustedTest

### DIFF
--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -12,6 +12,7 @@ from collections import Counter
 from typing import List
 from unittest import mock
 
+import numpy as np
 import pytest
 
 import ray
@@ -659,14 +660,12 @@ class ResourceExhaustedTest(unittest.TestCase):
         the objects captured in trainable/training function are too
         large and RESOURCES_EXHAUSTED error of gRPC is triggered."""
 
-        # generate some random data to be captured implicitly in training func.
-        from sklearn.datasets import fetch_olivetti_faces
-
         a_large_array = []
-        for i in range(50):
-            a_large_array.append(fetch_olivetti_faces())
+        for _ in range(50):
+            a_large_array.append(np.random.rand(400, 4096))
 
         def training_func(config):
+            del config  # unused var
             for item in a_large_array:
                 assert item
 


### PR DESCRIPTION
the original dataset is being fetched from the Internet and it is returning 403
