### PR TITLE
[docs, rllib] Linkcheck

### DIFF
--- a/doc/source/cluster/kubernetes/k8s-ecosystem/kai-scheduler.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/kai-scheduler.md
@@ -111,7 +111,7 @@ Note: To make this demo easier to follow, it combined these queue definitions wi
 
 ## Step 3: Gang scheduling with KAI Scheduler
 
-The key pattern is to add the queue label to your RayCluster. [Here's a basic example](https://github.com/ray-project/kuberay/tree/master/ray-operator/config/samples/ray-cluster.kai-scheduler.yaml) from the KubeRay repository:
+The key pattern is to add the queue label to your RayCluster. [Here's a basic example](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.kai-scheduler.yaml) from the KubeRay repository:
 
 ```yaml
 metadata:
@@ -174,7 +174,7 @@ See the [documentation](https://github.com/NVIDIA/KAI-Scheduler/tree/main/docs/p
 
 ## Step 4: Submitting Ray workers with GPU sharing 
 
-This example creates two workers that share a single GPU, 0.5 each with time-slicing, within a RayCluster. See the [YAML file](https://github.com/ray-project/kuberay/tree/master/ray-operator/config/samples/ray-cluster.kai-gpu-sharing.yaml)):
+This example creates two workers that share a single GPU, 0.5 each with time-slicing, within a RayCluster. See the [YAML file](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.kai-gpu-sharing.yaml)):
 
 ```bash
 curl -LO https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-cluster.kai-gpu-sharing.yaml

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
@@ -37,7 +37,7 @@ kubectl get all -n prometheus-system
   * Install the [kube-prometheus-stack v48.2.1](https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-48.2.1/charts/kube-prometheus-stack) chart and related custom resources, including **PodMonitor** for Ray Pods and **PrometheusRule**, in the namespace `prometheus-system` automatically. 
   * Import Ray Dashboard's [Grafana JSON files](https://github.com/ray-project/kuberay/tree/master/config/grafana) into Grafana using the `--auto-load-dashboard true` flag. If the flag isn't set, the following step also provides instructions for manual import. See [Step 12: Import Grafana dashboards manually (optional)](#step-12-import-grafana-dashboards-manually-optional) for more details.
 
-* We made some modifications to the original `values.yaml` in kube-prometheus-stack chart to allow embedding Grafana panels in Ray Dashboard. See [overrides.yaml](https://github.com/ray-project/kuberay/tree/master/install/prometheus/overrides.yaml) for more details.
+* We made some modifications to the original `values.yaml` in kube-prometheus-stack chart to allow embedding Grafana panels in Ray Dashboard. See [overrides.yaml](https://github.com/ray-project/kuberay/blob/master/install/prometheus/overrides.yaml) for more details.
   ```yaml
   grafana:
     grafana.ini:

--- a/doc/source/cluster/vms/user-guides/community/index.rst
+++ b/doc/source/cluster/vms/user-guides/community/index.rst
@@ -29,7 +29,7 @@ The following is a list of community supported cluster managers.
 Using a custom cloud or cluster manager
 =======================================
 
-The Ray cluster launcher currently supports AWS, Azure, GCP, Aliyun, vSphere and KubeRay out of the box. To use the Ray cluster launcher and Autoscaler on other cloud providers or cluster managers, you can implement the `node_provider.py <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/node_provider.py>`_ interface (100 LOC).
+The Ray cluster launcher currently supports AWS, Azure, GCP, Aliyun, vSphere and KubeRay out of the box. To use the Ray cluster launcher and Autoscaler on other cloud providers or cluster managers, you can implement the `node_provider.py <https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/node_provider.py>`_ interface (100 LOC).
 Once the node provider is implemented, you can register it in the `provider section <https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/local/example-full.yaml#L18>`_ of the cluster launcher config.
 
 .. code-block:: yaml

--- a/doc/source/cluster/vms/user-guides/launching-clusters/aws.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/aws.md
@@ -36,7 +36,7 @@ aws_session_token=baz" >> ~/.aws/credentials
 
 ## Start Ray with the Ray cluster launcher
 
-Once Boto3 is configured to manage resources in your AWS account, you should be ready to launch your cluster using the cluster launcher. The provided [cluster config file](https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/aws/example-full.yaml) will create a small cluster with an m5.large head node (on-demand) configured to autoscale to up to two m5.large [spot-instance](https://aws.amazon.com/ec2/spot/) workers.
+Once Boto3 is configured to manage resources in your AWS account, you should be ready to launch your cluster using the cluster launcher. The provided [cluster config file](https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-full.yaml) will create a small cluster with an m5.large head node (on-demand) configured to autoscale to up to two m5.large [spot-instance](https://aws.amazon.com/ec2/spot/) workers.
 
 Test that it works by running the following commands from your local machine:
 

--- a/doc/source/cluster/vms/user-guides/launching-clusters/azure.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/azure.md
@@ -42,7 +42,7 @@ pip install azure-core azure-mgmt-network azure-mgmt-common azure-mgmt-resource 
 
 ### Start Ray with the Ray cluster launcher
 
-The provided [cluster config file](https://github.com/ray-project/ray/tree/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/azure/example-full.yaml) will create a small cluster with a Standard DS2v3 on-demand head node that is configured to autoscale to up to two Standard DS2v3 [spot-instance](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/spot-vms) worker nodes.
+The provided [cluster config file](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/azure/example-full.yaml) will create a small cluster with a Standard DS2v3 on-demand head node that is configured to autoscale to up to two Standard DS2v3 [spot-instance](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/spot-vms) worker nodes.
 
 Note that you'll need to fill in your Azure [resource_group](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/azure/example-full.yaml#L42) and [location](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/azure/example-full.yaml#L41) in those templates. You also need set the subscription to use. You can do this from the command line with `az account set -s <subscription_id>` or by filling in the [subscription_id](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/azure/example-full.yaml#L44) in the cluster config file.
 

--- a/doc/source/cluster/vms/user-guides/launching-clusters/gcp.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/gcp.md
@@ -25,7 +25,7 @@ pip install google-api-python-client
 
 ## Start Ray with the Ray cluster launcher
 
-Once the Google API client is configured to manage resources on your GCP account, you should be ready to launch your cluster. The provided [cluster config file](https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/gcp/example-full.yaml) will create a small cluster with an on-demand n1-standard-2 head node and is configured to autoscale to up to two n1-standard-2 [preemptible workers](https://cloud.google.com/preemptible-vms/). Note that you'll need to fill in your GCP [project_id](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/gcp/example-full.yaml#L42) in those templates.
+Once the Google API client is configured to manage resources on your GCP account, you should be ready to launch your cluster. The provided [cluster config file](https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/gcp/example-full.yaml) will create a small cluster with an on-demand n1-standard-2 head node and is configured to autoscale to up to two n1-standard-2 [preemptible workers](https://cloud.google.com/preemptible-vms/). Note that you'll need to fill in your GCP [project_id](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/gcp/example-full.yaml#L42) in those templates.
 
 Test that it works by running the following commands from your local machine:
 

--- a/doc/source/cluster/vms/user-guides/launching-clusters/on-premises.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/on-premises.md
@@ -89,7 +89,7 @@ pip install "ray[default]"
 
 ### Start Ray with the Ray cluster launcher
 
-The provided [example-full.yaml](https://github.com/ray-project/ray/tree/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/local/example-full.yaml) cluster config file will create a Ray cluster given a list of nodes.
+The provided [example-full.yaml](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/local/example-full.yaml) cluster config file will create a Ray cluster given a list of nodes.
 
 Note that you'll need to fill in your [head_ip](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/local/example-full.yaml#L20), a list of [worker_ips](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/local/example-full.yaml#L26), and the [ssh_user](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/local/example-full.yaml#L34) field in those templates
 

--- a/doc/source/ray-contribute/docs.md
+++ b/doc/source/ray-contribute/docs.md
@@ -250,8 +250,8 @@ In some cases you may be required to choose an image for the panel. Images are l
 ## Creating a notebook example
 
 To add a new executable example to the Ray documentation, you can start from our
-[MyST notebook template](https://github.com/ray-project/ray/tree/master/doc/source/_templates/template.md) or
-[Jupyter notebook template](https://github.com/ray-project/ray/tree/master/doc/source/_templates/template.ipynb).
+[MyST notebook template](https://github.com/ray-project/ray/blob/master/doc/source/_templates/template.md) or
+[Jupyter notebook template](https://github.com/ray-project/ray/blob/master/doc/source/_templates/template.ipynb).
 You could also simply download the document you're reading right now (click on the respective download button at the
 top of this page to get the `.ipynb` file) and start modifying it.
 All the example notebooks in Ray Tune get automatically tested by our CI system, provided you place them in the

--- a/doc/source/ray-overview/examples/mcp-ray-serve/README.ipynb
+++ b/doc/source/ray-overview/examples/mcp-ray-serve/README.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "Learn more about Anyscale Workspaces in the [official documentation](https://docs.anyscale.com/platform/workspaces/).\n",
     "\n",
-    "**Note**: Run the entire tutorial for free on [Anyscale](https://console.anyscale.com/)—all dependencies come pre-installed, and compute autoscales automatically. To run it elsewhere, install the dependencies from the [`Dockerfiles`](https://github.com/ray-project/ray/blob/master/doc/source/ray-overview/examples/mcp-ray-serve/build-mcp-docker-image/) provided and provision the appropriate resources..\n",
+    "**Note**: Run the entire tutorial for free on [Anyscale](https://console.anyscale.com/)—all dependencies come pre-installed, and compute autoscales automatically. To run it elsewhere, install the dependencies from the [`Dockerfiles`](https://github.com/ray-project/ray/tree/master/doc/source/ray-overview/examples/mcp-ray-serve/build-mcp-docker-image) provided and provision the appropriate resources..\n",
     "\n",
     "## Production\n",
     "\n",

--- a/doc/source/rllib/checkpoints.rst
+++ b/doc/source/rllib/checkpoints.rst
@@ -158,7 +158,7 @@ file inside all checkpoint directories.
 Also starting from `Ray 2.40`, RLlib checkpoints are backward compatible. This means that
 a checkpoint created with Ray `2.x` can be read and handled by `Ray 2.x+n`, as long as `x >= 40`.
 The Ray team ensures backward compatibility with
-`comprehensive CI tests on checkpoints taken with previous Ray versions <https://github.com/ray-project/ray/tree/master/rllib/utils/tests/test_checkpointable.py>`__.
+`comprehensive CI tests on checkpoints taken with previous Ray versions <https://github.com/ray-project/ray/blob/master/rllib/utils/tests/test_checkpointable.py>`__.
 
 
 .. _rllib-checkpoints-structure-of-checkpoint-dir:
@@ -241,7 +241,7 @@ RLlib obtains this state dict, when saving a checkpoint, through calling the obj
     the python version. At the time of loading from checkpoint, the user would have to provide the latter/architecture part
     of the checkpoint.
 
-    `See here for an example that illustrates this in more detail <https://github.com/ray-project/ray/tree/master/rllib/examples/checkpoints/change_config_during_training.py>`__.
+    `See here for an example that illustrates this in more detail <https://github.com/ray-project/ray/blob/master/rllib/examples/checkpoints/change_config_during_training.py>`__.
 
 
 .. _rllib-checkpoints-component-tree:

--- a/doc/source/rllib/index.rst
+++ b/doc/source/rllib/index.rst
@@ -299,7 +299,7 @@ Why chose RLlib?
     **Ray.Data** has been integrated into RLlib, enabling **large-scale data ingestion** for offline RL and behavior
     cloning (BC) workloads.
 
-    See here for a basic `tuned example for the behavior cloning algo <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/bc/cartpole_bc.py>`__
+    See here for a basic `tuned example for the behavior cloning algo <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/bc/cartpole_bc.py>`__
     and here for how to `pre-train a policy with BC, then finetuning it with online PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/offline_rl/train_w_bc_finetune_w_ppo.py>`__.
 
 .. dropdown:: **Support for External Env Clients**

--- a/doc/source/rllib/learner-connector.rst
+++ b/doc/source/rllib/learner-connector.rst
@@ -243,7 +243,7 @@ you have to apply the stacking logic twice (in the :ref:`env-to-module pipeline 
 The following is an example for implementing such a frame-stacking mechanism using
 the :py:class:`~ray.rllib.connectors.connector_v2.ConnectorV2` APIs with an RL environment, in which observations are plain 1D tensors.
 
-See here for a `more complex end-to-end Atari example for PPO <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/atari_ppo.py>`__.
+See here for a `more complex end-to-end Atari example for PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/atari_ppo.py>`__.
 
 You can write a single :py:class:`~ray.rllib.connectors.connector_v2.ConnectorV2` class to cover both the env-to-module as well as
 the Learner custom connector part:

--- a/doc/source/rllib/new-api-stack-migration-guide.rst
+++ b/doc/source/rllib/new-api-stack-migration-guide.rst
@@ -278,7 +278,7 @@ AlgorithmConfig.env_runners()
     If you want to IDE-debug what's going on inside your `EnvRunners`, set `num_env_runners=0`
     and make sure you are running your experiment locally and not through Ray Tune.
     In order to do this with any of RLlib's `example <https://github.com/ray-project/ray/tree/master/rllib/examples>`__
-    or `tuned_example <https://github.com/ray-project/ray/tree/master/rllib/tuned_examples>`__ scripts,
+    or `tuned_example <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms>`__ scripts,
     simply set the command line args: `--no-tune --num-env-runners=0`.
 
 In case you were using the `observation_filter` setting, perform the following translations:

--- a/doc/source/rllib/rl-modules.rst
+++ b/doc/source/rllib/rl-modules.rst
@@ -213,7 +213,7 @@ see :py:class:`~ray.rllib.core.rl_module.default_model_config.DefaultModelConfig
     ``DefaultModelConfig.use_lstm`` setting in combination with the
     ``DefaultModelConfig.lstm_cell_size`` and ``DefaultModelConfig.max_seq_len`` settings.
     See here for a tuned
-    `example that uses a default RLModule with an LSTM layer <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/stateless_cartpole_ppo.py>`__.
+    `example that uses a default RLModule with an LSTM layer <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/stateless_cartpole_ppo.py>`__.
 
 .. TODO: mention attention example once done
 

--- a/doc/source/rllib/rllib-advanced-api.rst
+++ b/doc/source/rllib/rllib-advanced-api.rst
@@ -111,7 +111,7 @@ RLlib offers a unified top-level API to configure and customize an agent’s
 exploration behavior, including the decisions, like how and whether, to sample
 actions from distributions, stochastically or deterministically.
 Set up the behavior using built-in Exploration classes.
-See `this package <https://github.com/ray-project/ray/blob/master/rllib/utils/exploration/>`__),
+See `this package <https://github.com/ray-project/ray/tree/master/rllib/utils/exploration>`__),
 which you specify and further configure inside
 ``AlgorithmConfig().env_runners(..)``.
 Besides using one of the available classes, you can sub-class any of

--- a/doc/source/rllib/rllib-algorithms.rst
+++ b/doc/source/rllib/rllib-algorithms.rst
@@ -74,9 +74,9 @@ Proximal Policy Optimization (PPO)
 
 
 **Tuned examples:**
-`Pong-v5 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/atari_ppo.py>`__,
-`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/cartpole_ppo.py>`__.
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/pendulum_ppo.py>`__.
+`Pong-v5 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/atari_ppo.py>`__,
+`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/cartpole_ppo.py>`__.
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/pendulum_ppo.py>`__.
 
 
 **PPO-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
@@ -111,11 +111,11 @@ All of the DQN improvements evaluated in `Rainbow <https://arxiv.org/abs/1710.02
 See also how to use `parametric-actions in DQN <rllib-models.html#variable-length-parametric-action-spaces>`__.
 
 **Tuned examples:**
-`PongDeterministic-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/pong-dqn.yaml>`__,
-`Rainbow configuration <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/pong-rainbow.yaml>`__,
-`{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/atari-dqn.yaml>`__,
-`with Dueling and Double-Q <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/atari-duel-ddqn.yaml>`__,
-`with Distributional DQN <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dqn/atari-dist-dqn.yaml>`__.
+`PongDeterministic-v4 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dqn/pong-dqn.yaml>`__,
+`Rainbow configuration <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dqn/pong-rainbow.yaml>`__,
+`{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dqn/atari-dqn.yaml>`__,
+`with Dueling and Double-Q <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dqn/atari-duel-ddqn.yaml>`__,
+`with Distributional DQN <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dqn/atari-dist-dqn.yaml>`__.
 
 .. hint::
     For a complete `rainbow <https://arxiv.org/pdf/1710.02298.pdf>`__ setup,
@@ -154,8 +154,8 @@ Soft Actor Critic (SAC)
 
 
 **Tuned examples:**
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/sac/pendulum-sac.yaml>`__,
-`HalfCheetah-v3 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/sac/halfcheetah_sac.py>`__,
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/sac/pendulum-sac.yaml>`__,
+`HalfCheetah-v3 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/sac/halfcheetah_sac.py>`__,
 
 **SAC-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -195,8 +195,8 @@ Asynchronous Proximal Policy Optimization (APPO)
 
 
 **Tuned examples:**
-`Pong-v5 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/appo/pong_appo.py>`__
-`HalfCheetah-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/appo/halfcheetah_appo.py>`__
+`Pong-v5 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/appo/pong_appo.py>`__
+`HalfCheetah-v4 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/appo/halfcheetah_appo.py>`__
 
 **APPO-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -226,10 +226,10 @@ Importance Weighted Actor-Learner Architecture (IMPALA)
 
 
 Tuned examples:
-`PongNoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/impala/pong-impala.yaml>`__,
-`vectorized configuration <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/impala/pong-impala-vectorized.yaml>`__,
-`multi-gpu configuration <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/impala/pong-impala-fast.yaml>`__,
-`{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/impala/atari-impala.yaml>`__.
+`PongNoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/impala/pong-impala.yaml>`__,
+`vectorized configuration <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/impala/pong-impala-vectorized.yaml>`__,
+`multi-gpu configuration <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/impala/pong-impala-fast.yaml>`__,
+`{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/impala/atari-impala.yaml>`__.
 
 .. figure:: images/impala.png
     :width: 650
@@ -274,9 +274,9 @@ Also see `this README here for more details on how to run experiments <https://g
 
 
 **Tuned examples:**
-`Atari 100k <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dreamerv3/atari_100k_dreamerv3.py>`__,
-`Atari 200M <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dreamerv3/atari_200M_dreamerv3.py>`__,
-`DeepMind Control Suite <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/dreamerv3/dm_control_suite_vision_dreamerv3.py>`__
+`Atari 100k <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dreamerv3/atari_100k_dreamerv3.py>`__,
+`Atari 200M <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dreamerv3/atari_200M_dreamerv3.py>`__,
+`DeepMind Control Suite <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dreamerv3/dm_control_suite_vision_dreamerv3.py>`__
 
 
 **Pong-v5 results (1, 2, and 4 GPUs)**:
@@ -332,8 +332,8 @@ Behavior Cloning (BC)
     BC try to match the behavior policy, which generated the offline data, disregarding any resulting rewards.
 
 **Tuned examples:**
-`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/bc/cartpole_bc.py>`__
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/bc/pendulum_bc.py>`__
+`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/bc/cartpole_bc.py>`__
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/bc/pendulum_bc.py>`__
 
 **BC-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -359,7 +359,7 @@ Conservative Q-Learning (CQL)
 
 
 **Tuned examples:**
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/cql/pendulum_cql.py>`__
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/cql/pendulum_cql.py>`__
 
 **CQL-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -384,7 +384,7 @@ Implicit Q-Learning (IQL)
     high-advantage actions—enabling substantial performance gains over the behavior policy using only in-dataset actions.
 
 **Tuned examples:**
-`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/iql/pendulum_iql.py>`__
+`Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/iql/pendulum_iql.py>`__
 
 **IQL-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 
@@ -411,7 +411,7 @@ Monotonic Advantage Re-Weighted Imitation Learning (MARWIL)
 
 
 **Tuned examples:**
-`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/marwil/cartpole_marwil.py>`__
+`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/marwil/cartpole_marwil.py>`__
 
 **MARWIL-specific configs** (see also :ref:`generic algorithm settings <rllib-algo-configuration-generic-settings>`):
 

--- a/doc/source/rllib/rllib-dev.rst
+++ b/doc/source/rllib/rllib-dev.rst
@@ -56,7 +56,7 @@ or as a fully-integrated RLlib Algorithm in `rllib/algorithms <https://github.co
     - must offer substantial new functionality not possible to add to other algorithms
     - should support custom RLModules
     - should use RLlib abstractions and support distributed execution
-    - should include at least one `tuned hyperparameter example <https://github.com/ray-project/ray/tree/master/rllib/tuned_examples>`__, testing of which is part of the CI
+    - should include at least one `tuned hyperparameter example <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms>`__, testing of which is part of the CI
 
 Both integrated and contributed algorithms ship with the ``ray`` PyPI package, and are tested as part of Ray's automated tests.
 
@@ -92,7 +92,7 @@ Benchmarks
 ==========
 
 A number of training run results are available in the `rl-experiments repo <https://github.com/ray-project/rl-experiments>`__,
-and there is also a list of working hyperparameter configurations in `tuned_examples <https://github.com/ray-project/ray/tree/master/rllib/tuned_examples>`__, sorted by algorithm.
+and there is also a list of working hyperparameter configurations in `examples/algorithms <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms>`__, sorted by algorithm.
 Benchmark results are extremely valuable to the community, so if you happen to have results that may be of interest, consider making a pull request to either repo.
 
 

--- a/doc/source/rllib/rllib-examples.rst
+++ b/doc/source/rllib/rllib-examples.rst
@@ -58,17 +58,17 @@ Actions
 
 .. _rllib-examples-overview-autoregressive-actions:
 
-- `Auto-regressive actions <https://github.com/ray-project/ray/tree/master/rllib/examples/actions/autoregressive_actions.py>`__:
+- `Auto-regressive actions <https://github.com/ray-project/ray/blob/master/rllib/examples/actions/autoregressive_actions.py>`__:
    Configures an RL module that generates actions in an autoregressive manner, where the second component of an action depends on
    the previously sampled first component of the same action.
 
-- `Custom action distribution class <https://github.com/ray-project/ray/tree/master/rllib/examples/actions/custom_action_distribution.py>`__:
+- `Custom action distribution class <https://github.com/ray-project/ray/blob/master/rllib/examples/actions/custom_action_distribution.py>`__:
    Demonstrates how to write a custom action distribution class, taking an additional temperature parameter on top of a Categorical
    distribution, and how to configure this class inside your :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` implementation.
    Further explains how to define different such classes for the different forward methods of your :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`
    in case you need more granularity.
 
-- `Nested Action Spaces <https://github.com/ray-project/ray/tree/master/rllib/examples/actions/nested_action_spaces.py>`__:
+- `Nested Action Spaces <https://github.com/ray-project/ray/blob/master/rllib/examples/actions/nested_action_spaces.py>`__:
    Sets up an environment with nested action spaces using custom single- or multi-agent
    configurations. This example demonstrates how RLlib manages complex action structures,
    such as multi-dimensional or hierarchical action spaces.
@@ -77,18 +77,18 @@ Actions
 Algorithms
 ++++++++++
 
-- `Custom implementation of the Model-Agnostic Meta-Learning (MAML) algorithm <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/maml_lr_supervised_learning.py>`__:
+- `Custom implementation of the Model-Agnostic Meta-Learning (MAML) algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/maml_lr_supervised_learning.py>`__:
    Shows how to stably train a model in an "infinite-task" environment, where each task corresponds
    to a sinusoidal function with randomly sampled amplitude and phase. Because each new task introduces
    a shift in data distribution, traditional learning algorithms would fail to generalize.
 
-- `Custom "vanilla policy gradient" (VPG) algorithm <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/vpg_custom_algorithm.py>`__:
+- `Custom "vanilla policy gradient" (VPG) algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/vpg_custom_algorithm.py>`__:
    Shows how to write a very simple policy gradient :py:class:`~ray.rllib.algorithms.algorithm.Algorithm` from scratch,
    including a matching :py:class:`~ray.rllib.algorithms.algorithm_config.AlgorithmConfig`,
    a matching :py:class:`~ray.rllib.core.learner.learner.Learner` which defines the loss function,
    and the Algorithm's :py:meth:`~ray.rllib.algorithms.algorithm.Algorithm.training_step` implementation.
 
-- `Custom algorithm with a global, shared data actor for sending manipulated rewards from EnvRunners to Learners <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/appo_custom_algorithm_w_shared_data_actor.py>`__:
+- `Custom algorithm with a global, shared data actor for sending manipulated rewards from EnvRunners to Learners <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/appo_custom_algorithm_w_shared_data_actor.py>`__:
    Shows how to write a custom shared data actor accessible from any of the Algorithm's other actors,
    like :py:class:`~ray.rllib.env.env_runner.EnvRunner` and :py:class:`~ray.rllib.core.learner.learner.Learner` actors.
    The new actor stores manipulated rewards from sampled episodes under unique, per-episode keys and then serves
@@ -99,13 +99,13 @@ Algorithms
 Checkpoints
 +++++++++++
 
-- `Checkpoint by custom criteria <https://github.com/ray-project/ray/tree/master/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py>`__:
+- `Checkpoint by custom criteria <https://github.com/ray-project/ray/blob/master/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py>`__:
    Shows how to create checkpoints based on custom criteria, giving users control over when to save model snapshots during training.
 
-- `Continue training from checkpoint <https://github.com/ray-project/ray/tree/master/rllib/examples/checkpoints/continue_training_from_checkpoint.py>`__:
+- `Continue training from checkpoint <https://github.com/ray-project/ray/blob/master/rllib/examples/checkpoints/continue_training_from_checkpoint.py>`__:
    Illustrates resuming training from a saved checkpoint, useful for extending training sessions or recovering from interruptions.
 
-- `Restore 1 out of N agents from checkpoint <https://github.com/ray-project/ray/tree/master/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py>`__:
+- `Restore 1 out of N agents from checkpoint <https://github.com/ray-project/ray/blob/master/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py>`__:
    Restores one specific agent from a multi-agent checkpoint, allowing selective loading for environments where only certain agents need
    to resume training.
 
@@ -119,31 +119,31 @@ Connectors
     to distinguish against the ``Connector`` class, which only continue to work on the old API stack.
 
 
-- `Flatten and one-hot observations <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/flatten_observations_dict_space.py>`__:
+- `Flatten and one-hot observations <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/flatten_observations_dict_space.py>`__:
    Demonstrates how to one-hot discrete observation spaces and/or flatten complex observations, Dict or Tuple, allowing RLlib to process arbitrary
    observation data as flattened 1D vectors. Useful for environments with complex, discrete, or hierarchical observations.
 
-- `Observation frame-stacking <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/frame_stacking.py>`__:
+- `Observation frame-stacking <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/frame_stacking.py>`__:
    Implements frame stacking, where N consecutive frames stack together to provide temporal context to the agent.
    This technique is common in environments with continuous state changes, like video frames in Atari games.
    Using connectors for frame stacking is more efficient as it avoids having to send large observation tensors through
    ray remote calls.
 
-- `Mean/Std filtering <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/mean_std_filtering.py>`__:
+- `Mean/Std filtering <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/mean_std_filtering.py>`__:
    Adds mean and standard deviation normalization for observations, shifting by the mean and dividing by std-dev.
    This type of filtering can improve learning stability in environments with highly variable state magnitudes
    by scaling observations to a normalized range.
 
-- `Multi-agent observation preprocessor enhancing non-Markovian observations to Markovian ones <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/multi_agent_observation_preprocessor.py>`__:
+- `Multi-agent observation preprocessor enhancing non-Markovian observations to Markovian ones <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/multi_agent_observation_preprocessor.py>`__:
    A multi-agent preprocessor enhances the per-agent observations of a multi-agent env, which by themselves are non-Markovian,
    partial observations and converts them into Markovian observations by adding information from
    the respective other agent. A policy can only be trained optimally through this additional information.
 
-- `Prev-actions, prev-rewards connector <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/prev_actions_prev_rewards.py>`__:
+- `Prev-actions, prev-rewards connector <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/prev_actions_prev_rewards.py>`__:
    Augments observations with previous actions and rewards, giving the agent a short-term memory of past events, which can improve
    decision-making in partially observable or sequentially dependent tasks.
 
-- `Single-agent observation preprocessor <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/single_agent_observation_preprocessor.py>`__:
+- `Single-agent observation preprocessor <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/single_agent_observation_preprocessor.py>`__:
    A connector alters the CartPole-v1 environment observations from the Markovian 4-tuple (x-pos,
    angular-pos, x-velocity, angular-velocity) to a non-Markovian, simpler 2-tuple (only
    x-pos and angular-pos). The resulting problem can only be solved through a
@@ -153,17 +153,17 @@ Connectors
 Curiosity
 +++++++++
 
-- `Count-based curiosity <https://github.com/ray-project/ray/tree/master/rllib/examples/curiosity/count_based_curiosity.py>`__:
+- `Count-based curiosity <https://github.com/ray-project/ray/blob/master/rllib/examples/curiosity/count_based_curiosity.py>`__:
    Implements count-based intrinsic motivation to encourage exploration of less visited states.
    Using curiosity is beneficial in sparse-reward environments where agents may struggle to find rewarding paths.
    However, count-based methods are only feasible for environments with small observation spaces.
 
-- `Euclidean distance-based curiosity <https://github.com/ray-project/ray/tree/master/rllib/examples/curiosity/euclidian_distance_based_curiosity.py>`__:
+- `Euclidean distance-based curiosity <https://github.com/ray-project/ray/blob/master/rllib/examples/curiosity/euclidian_distance_based_curiosity.py>`__:
    Uses Euclidean distance between states and the initial state to measure novelty, encouraging exploration by rewarding the agent for reaching "far away"
    regions of the environment.
    Suitable for sparse-reward tasks, where diverse exploration is key to success.
 
-- `Intrinsic-curiosity-model (ICM) Based Curiosity <https://github.com/ray-project/ray/tree/master/rllib/examples/curiosity/intrinsic_curiosity_model_based_curiosity.py>`__:
+- `Intrinsic-curiosity-model (ICM) Based Curiosity <https://github.com/ray-project/ray/blob/master/rllib/examples/curiosity/intrinsic_curiosity_model_based_curiosity.py>`__:
    Adds an `Intrinsic Curiosity Model (ICM) <https://arxiv.org/pdf/1705.05363.pdf>`__ that learns to predict the next state as well as the action in
    between two states to measure novelty. The higher the loss of the ICM, the higher the "novelty" and thus the intrinsic reward.
    Ideal for complex environments with large observation spaces where reward signals are sparse.
@@ -172,12 +172,12 @@ Curiosity
 Curriculum learning
 +++++++++++++++++++
 
-- `Custom env rendering method <https://github.com/ray-project/ray/tree/master/rllib/examples/curriculum/curriculum_learning.py>`__:
+- `Custom env rendering method <https://github.com/ray-project/ray/blob/master/rllib/examples/curriculum/curriculum_learning.py>`__:
    Demonstrates curriculum learning, where the environment difficulty increases as the agent improves.
    This approach enables gradual learning, allowing agents to master simpler tasks before progressing to more challenging ones,
    ideal for environments with hierarchical or staged difficulties. Also see the :doc:`curriculum learning how-to </rllib/rllib-advanced-api>` from the documentation.
 
-- `Curriculum learning for Atari Pong <https://github.com/ray-project/ray/tree/master/rllib/examples/curriculum/pong_curriculum_learning.py>`__:
+- `Curriculum learning for Atari Pong <https://github.com/ray-project/ray/blob/master/rllib/examples/curriculum/pong_curriculum_learning.py>`__:
    Demonstrates curriculum learning for Atari Pong using the `frameskip` to increase difficulty of the task.
    This approach enables gradual learning, allowing agents to master slower reactions (lower `frameskip`) before progressing to more faster ones (higher `frameskip`).
    Also see the :doc:`curriculum learning how-to </rllib/rllib-advanced-api>` from the documentation.
@@ -186,7 +186,7 @@ Curriculum learning
 Debugging
 +++++++++
 
-- `Deterministic sampling and training <https://github.com/ray-project/ray/tree/master/rllib/examples/debugging/deterministic_sampling_and_training.py>`__:
+- `Deterministic sampling and training <https://github.com/ray-project/ray/blob/master/rllib/examples/debugging/deterministic_sampling_and_training.py>`__:
    Demonstrates the possibility to seed an experiment through the algorithm config. RLlib passes the seed through to all components that have a copy of the
    :ref:`RL environment <rllib-environments-doc>` and the :ref:`RLModule <rlmodule-guide>` and thus makes sure these components behave deterministically.
    When using a seed, train results should become repeatable. Note that some algorithms, such as :ref:`APPO <appo>` which rely on asynchronous sampling
@@ -196,27 +196,27 @@ Debugging
 Environments
 ++++++++++++
 
-- `Async gym vectorization, parallelizing sub-environments <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/async_gym_env_vectorization.py>`__:
+- `Async gym vectorization, parallelizing sub-environments <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/async_gym_env_vectorization.py>`__:
    Shows how the `gym_env_vectorize_mode` config setting can significantly speed up your
    :py:class:`~ray.rllib.env.env_runner.EnvRunner` actors, if your RL environment is slow and you're
    using `num_envs_per_env_runner > 1`. The reason for the performance gain is that each sub-environment runs in its own process.
 
-- `Custom env rendering method <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/custom_env_render_method.py>`__:
+- `Custom env rendering method <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/custom_env_render_method.py>`__:
    Demonstrates how to add a custom `render()` method to a (custom) environment, allowing visualizations of agent interactions.
 
-- `Custom gymnasium env <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/custom_gym_env.py>`__:
+- `Custom gymnasium env <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/custom_gym_env.py>`__:
    Implements a custom `gymnasium <https://gymnasium.farama.org>`__ environment from scratch, showing how to define observation and action spaces,
    arbitrary reward functions, as well as, step- and reset logic.
 
-- `Env connecting to RLlib through a tcp client <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/env_connecting_to_rllib_w_tcp_client.py>`__:
+- `Env connecting to RLlib through a tcp client <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/env_connecting_to_rllib_w_tcp_client.py>`__:
    An external environment, running outside of RLlib and acting as a client, connects to RLlib as a server. The external env performs its own
    action inference using an ONNX model, sends collected data back to RLlib for training, and receives model updates from time to time from RLlib.
 
-- `Env rendering and recording <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/env_rendering_and_recording.py>`__:
+- `Env rendering and recording <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/env_rendering_and_recording.py>`__:
    Illustrates environment rendering and recording setups within RLlib, capturing visual outputs for later review (ex. on WandB), which is essential
    for tracking agent behavior in training.
 
-- `Env with protobuf observations <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/env_w_protobuf_observations.py>`__:
+- `Env with protobuf observations <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/env_w_protobuf_observations.py>`__:
    Uses Protobuf for observations, demonstrating an advanced way of handling serialized data in environments. This approach is useful for
    integrating complex external data sources as observations.
 
@@ -224,10 +224,10 @@ Environments
 Evaluation
 ++++++++++
 
-- `Custom evaluation <https://github.com/ray-project/ray/tree/master/rllib/examples/evaluation/custom_evaluation.py>`__:
+- `Custom evaluation <https://github.com/ray-project/ray/blob/master/rllib/examples/evaluation/custom_evaluation.py>`__:
    Configures custom evaluation metrics for agent performance, allowing users to define specific success criteria beyond standard RLlib evaluation metrics.
 
-- `Evaluation parallel to training <https://github.com/ray-project/ray/tree/master/rllib/examples/evaluation/evaluation_parallel_to_training.py>`__:
+- `Evaluation parallel to training <https://github.com/ray-project/ray/blob/master/rllib/examples/evaluation/evaluation_parallel_to_training.py>`__:
    Runs evaluation episodes in parallel with training, reducing training time by offloading evaluation to separate processes.
    This method is beneficial when you require frequent evaluation without interrupting learning.
 
@@ -235,7 +235,7 @@ Evaluation
 Fault tolerance
 +++++++++++++++
 
-- `Crashing and stalling env <https://github.com/ray-project/ray/tree/master/rllib/examples/fault_tolerance/crashing_and_stalling_env.py>`__:
+- `Crashing and stalling env <https://github.com/ray-project/ray/blob/master/rllib/examples/fault_tolerance/crashing_and_stalling_env.py>`__:
    Simulates an environment that randomly crashes or stalls, allowing users to test RLlib's fault-tolerance mechanisms.
    This script is useful for evaluating how RLlib handles interruptions and recovers from unexpected failures during training.
 
@@ -243,19 +243,19 @@ Fault tolerance
 GPUs for training and sampling
 ++++++++++++++++++++++++++++++
 
-- `Float16 training and inference <https://github.com/ray-project/ray/tree/master/rllib/examples/gpus/float16_training_and_inference.py>`__:
+- `Float16 training and inference <https://github.com/ray-project/ray/blob/master/rllib/examples/gpus/float16_training_and_inference.py>`__:
    Configures a setup for float16 training and inference, optimizing performance by reducing memory usage and speeding up computation.
    This is especially useful for large-scale models on compatible GPUs.
 
-- `Fractional GPUs per Learner <https://github.com/ray-project/ray/tree/master/rllib/examples/gpus/fractional_gpus_per_learner.py>`__:
+- `Fractional GPUs per Learner <https://github.com/ray-project/ray/blob/master/rllib/examples/gpus/fractional_gpus_per_learner.py>`__:
    Demonstrates allocating fractional GPUs to individual learners, enabling finer resource allocation in multi-model setups.
    Useful for saving resources when training smaller models, many of which can fit on a single GPU.
 
-- `Mixed precision training and float16 inference <https://github.com/ray-project/ray/tree/master/rllib/examples/gpus/mixed_precision_training_float16_inference.py>`__:
+- `Mixed precision training and float16 inference <https://github.com/ray-project/ray/blob/master/rllib/examples/gpus/mixed_precision_training_float16_inference.py>`__:
    Uses mixed precision, float32 and float16, for training, while switching to float16 precision for inference, balancing stability during training
    with performance improvements during evaluation.
 
-- `Using GPUs on EnvRunners <https://github.com/ray-project/ray/tree/master/rllib/examples/gpus/gpus_on_env_runners.py>`__:
+- `Using GPUs on EnvRunners <https://github.com/ray-project/ray/blob/master/rllib/examples/gpus/gpus_on_env_runners.py>`__:
    Demos how :py:class:`~ray.rllib.env.env_runner.EnvRunner` instances, single- or multi-agent, can request GPUs through
    the `config.env_runners(num_gpus_per_env_runner=..)` setting.
 
@@ -263,7 +263,7 @@ GPUs for training and sampling
 Hierarchical training
 +++++++++++++++++++++
 
-- `Hierarchical RL training <https://github.com/ray-project/ray/tree/master/rllib/examples/hierarchical/hierarchical_training.py>`__:
+- `Hierarchical RL training <https://github.com/ray-project/ray/blob/master/rllib/examples/hierarchical/hierarchical_training.py>`__:
    Showcases a hierarchical RL setup inspired by automatic subgoal discovery and subpolicy specialization. A high-level policy selects subgoals and assigns one of three
    specialized low-level policies to achieve them within a time limit, encouraging specialization and efficient task-solving.
    The agent has to navigate a complex grid-world environment. The example highlights the advantages of hierarchical
@@ -273,12 +273,12 @@ Hierarchical training
 Inference of models or policies
 +++++++++++++++++++++++++++++++
 
-- `Policy inference after training <https://github.com/ray-project/ray/tree/master/rllib/examples/inference/policy_inference_after_training.py>`__:
+- `Policy inference after training <https://github.com/ray-project/ray/blob/master/rllib/examples/inference/policy_inference_after_training.py>`__:
    Demonstrates performing inference using a checkpointed :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` or an `ONNX runtime <https://onnx.ai/>`__.
    First trains the :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`, creates a checkpoint, then re-loads the module from this checkpoint or ONNX file, and computes
    actions in a simulated environment.
 
-- `Policy inference after training, with ConnectorV2 <https://github.com/ray-project/ray/tree/master/rllib/examples/inference/policy_inference_after_training_w_connector.py>`__:
+- `Policy inference after training, with ConnectorV2 <https://github.com/ray-project/ray/blob/master/rllib/examples/inference/policy_inference_after_training_w_connector.py>`__:
    Runs inference with a trained, LSTM-based :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` or an `ONNX runtime <https://onnx.ai/>`__.
    Two connector pipelines, env-to-module and module-to-env, preprocess observations and LSTM-states and postprocess model outputs into actions,
    allowing for very modular and flexible inference setups.
@@ -287,15 +287,15 @@ Inference of models or policies
 Learners
 ++++++++
 
-- `Custom loss function, simple <https://github.com/ray-project/ray/tree/master/rllib/examples/learners/ppo_with_custom_loss_fn.py>`__:
+- `Custom loss function, simple <https://github.com/ray-project/ray/blob/master/rllib/examples/learners/ppo_with_custom_loss_fn.py>`__:
    Implements a custom loss function for training, demonstrating how users can define tailored loss objectives for specific environments or
    behaviors.
 
-- `Custom torch learning rate schedulers <https://github.com/ray-project/ray/tree/master/rllib/examples/learners/ppo_with_torch_lr_schedulers.py>`__:
+- `Custom torch learning rate schedulers <https://github.com/ray-project/ray/blob/master/rllib/examples/learners/ppo_with_torch_lr_schedulers.py>`__:
    Adds learning rate scheduling to PPO, showing how to adjust the learning rate dynamically using PyTorch schedulers for improved
    training stability.
 
-- `Separate learning rate and optimizer for value function <https://github.com/ray-project/ray/tree/master/rllib/examples/learners/separate_vf_lr_and_optimizer.py>`__:
+- `Separate learning rate and optimizer for value function <https://github.com/ray-project/ray/blob/master/rllib/examples/learners/separate_vf_lr_and_optimizer.py>`__:
    Configures a separate learning rate and a separate optimizer for the value function vs the policy network,
    enabling differentiated training dynamics between policy and value estimation in RL algorithms.
 
@@ -303,12 +303,12 @@ Learners
 Metrics
 +++++++
 
-- `Logging custom metrics in Algorithm.training_step <https://github.com/ray-project/ray/tree/master/rllib/examples/metrics/custom_metrics_in_algorithm_training_step.py>`__:
+- `Logging custom metrics in Algorithm.training_step <https://github.com/ray-project/ray/blob/master/rllib/examples/metrics/custom_metrics_in_algorithm_training_step.py>`__:
    Shows how to log custom metrics inside a custom :py:class:`~ray.rllib.algorithms.algorithm.Algorithm` through overriding
    the :py:meth:`` method and making calls to the :py:meth:`~ray.rllib.utils.metrics.metrics_logger.MetricsLogger.log_value` method
    of the :py:class:`~ray.rllib.utils.metrics.metrics_logger.MetricsLogger` instance.
 
-- `Logging custom metrics in EnvRunners <https://github.com/ray-project/ray/tree/master/rllib/examples/metrics/custom_metrics_in_env_runners.py>`__:
+- `Logging custom metrics in EnvRunners <https://github.com/ray-project/ray/blob/master/rllib/examples/metrics/custom_metrics_in_env_runners.py>`__:
    Demonstrates adding custom metrics to :py:class:`~ray.rllib.env.env_runner.EnvRunner` actors, providing a way to track specific
    performance- and environment indicators beyond the standard RLlib metrics.
 
@@ -316,38 +316,38 @@ Metrics
 Multi-agent RL
 ++++++++++++++
 
-- `Custom heuristic policy <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/custom_heuristic_policy.py>`__:
+- `Custom heuristic policy <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/custom_heuristic_policy.py>`__:
    Demonstrates running a hybrid policy setup within the `MultiAgentCartPole` environment, where one agent follows
    a hand-coded random policy while another agent trains with PPO. This example highlights integrating static and dynamic policies,
    suitable for environments with a mix of fixed-strategy and adaptive agents.
 
-- `Different observation- and action spaces for different agents <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/different_spaces_for_agents.py>`__:
+- `Different observation- and action spaces for different agents <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/different_spaces_for_agents.py>`__:
    Configures agents with differing observation and action spaces within the same environment, showcasing RLlib's support for heterogeneous agents with varying space requirements in a single multi-agent environment.
    Another example, which also makes use of connectors, and that covers the same topic, agents having different spaces, can be found
-   `here <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/multi_agent_observation_preprocessor.py>`__.
+   `here <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/multi_agent_observation_preprocessor.py>`__.
 
-- `Grouped agents, two-step game <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/two_step_game_with_grouped_agents.py>`__:
+- `Grouped agents, two-step game <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/two_step_game_with_grouped_agents.py>`__:
    Implements a multi-agent, grouped setup within a two-step game environment from the `QMIX paper <https://arxiv.org/pdf/1803.11485.pdf>`__.
    N agents form M teams in total, where N >= M, and agents in each team share rewards and one policy.
    This example demonstrates RLlib's ability to manage collective objectives and interactions among grouped agents.
 
-- `Multi-agent CartPole <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/multi_agent_cartpole.py>`__:
+- `Multi-agent CartPole <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/multi_agent_cartpole.py>`__:
    Runs a multi-agent version of the CartPole environment with each agent independently learning to balance its pole.
    This example serves as a foundational test for multi-agent reinforcement learning scenarios in simple, independent tasks.
 
-- `Multi-agent Pendulum <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/multi_agent_pendulum.py>`__:
+- `Multi-agent Pendulum <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/multi_agent_pendulum.py>`__:
    Extends the classic Pendulum environment into a multi-agent setting, where multiple agents attempt to balance
    their respective pendulums.
    This example highlights RLlib's support for environments with replicated dynamics but distinct agent policies.
 
-- `PettingZoo independent learning <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/pettingzoo_independent_learning.py>`__:
+- `PettingZoo independent learning <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/pettingzoo_independent_learning.py>`__:
    Integrates RLlib with `PettingZoo <https://pettingzoo.farama.org/>`__ to facilitate independent learning among multiple agents.
    Each agent independently optimizes its policy within a shared environment.
 
-- `PettingZoo parameter sharing <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/pettingzoo_parameter_sharing.py>`__:
+- `PettingZoo parameter sharing <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/pettingzoo_parameter_sharing.py>`__:
    Uses `PettingZoo <https://pettingzoo.farama.org/>`__ for an environment where all agents share a single policy.
 
-- `Rock-paper-scissors heuristic vs learned <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/rock_paper_scissors_heuristic_vs_learned.py>`__:
+- `Rock-paper-scissors heuristic vs learned <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/rock_paper_scissors_heuristic_vs_learned.py>`__:
    Simulates a rock-paper-scissors game with one heuristic-driven agent and one learning agent.
    It provides insights into performance when combining fixed and adaptive strategies in adversarial games.
 
@@ -355,16 +355,16 @@ Multi-agent RL
    Sets up a rock-paper-scissors game where you train both agents to learn strategies on how to play against each other.
    Useful for evaluating performance in simple adversarial settings.
 
-- `Self-play, league-based, with OpenSpiel <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/self_play_league_based_with_open_spiel.py>`__:
+- `Self-play, league-based, with OpenSpiel <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/self_play_league_based_with_open_spiel.py>`__:
    Uses OpenSpiel to demonstrate league-based self-play, where agents play against various
    versions of themselves, frozen or in-training, to improve through competitive interaction.
 
-- `Self-play with Footsies and PPO algorithm <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py>`__:
+- `Self-play with Footsies and PPO algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py>`__:
     Implements self-play with the Footsies environment (two player zero-sum game).
     This example highlights RLlib's capabilities in connecting to the external binaries running the game engine, as well as
     setting up a multi-agent self-play training scenario.
 
-- `Self-play with OpenSpiel <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/self_play_with_open_spiel.py>`__:
+- `Self-play with OpenSpiel <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/self_play_with_open_spiel.py>`__:
    Similar to the league-based self-play, but simpler. This script leverages OpenSpiel for two-player games, allowing agents to improve
    through direct self-play without building a complex, structured league.
 
@@ -372,7 +372,7 @@ Multi-agent RL
 Offline RL
 ++++++++++
 
-- `Train with behavioral cloning (BC), Finetune with PPO <https://github.com/ray-project/ray/tree/master/rllib/examples/offline_rl/train_w_bc_finetune_w_ppo.py>`__:
+- `Train with behavioral cloning (BC), Finetune with PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/offline_rl/train_w_bc_finetune_w_ppo.py>`__:
    Combines behavioral cloning pre-training with PPO fine-tuning, providing a two-phase
    training strategy. Offline imitation learning as a first step followed by online reinforcement learning.
 
@@ -380,7 +380,7 @@ Offline RL
 Ray Serve and RLlib
 +++++++++++++++++++
 
-- `Using Ray Serve with RLlib <https://github.com/ray-project/ray/tree/master/rllib/examples/ray_serve/ray_serve_with_rllib.py>`__:
+- `Using Ray Serve with RLlib <https://github.com/ray-project/ray/blob/master/rllib/examples/ray_serve/ray_serve_with_rllib.py>`__:
    Integrates RLlib with `Ray Serve <https://docs.ray.io/en/latest/serve/index.html>`__, showcasing how to deploy trained
    :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` instances as RESTful services. This setup is ideal for deploying models
    in production environments with API-based interactions.
@@ -389,15 +389,15 @@ Ray Serve and RLlib
 Ray Tune and RLlib
 ++++++++++++++++++
 
-- `Custom experiment <https://github.com/ray-project/ray/tree/master/rllib/examples/ray_tune/custom_experiment.py>`__:
+- `Custom experiment <https://github.com/ray-project/ray/blob/master/rllib/examples/ray_tune/custom_experiment.py>`__:
    Configures a custom experiment with `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`__, demonstrating advanced options
    for custom training- and evaluation phases
 
-- `Custom logger <https://github.com/ray-project/ray/tree/master/rllib/examples/ray_tune/custom_logger.py>`__:
+- `Custom logger <https://github.com/ray-project/ray/blob/master/rllib/examples/ray_tune/custom_logger.py>`__:
    Shows how to implement a custom logger within `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`__,
    allowing users to define specific logging behaviors and outputs during training.
 
-- `Custom progress reporter <https://github.com/ray-project/ray/tree/master/rllib/examples/ray_tune/custom_progress_reporter.py>`__:
+- `Custom progress reporter <https://github.com/ray-project/ray/blob/master/rllib/examples/ray_tune/custom_progress_reporter.py>`__:
    Demonstrates a custom progress reporter in `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`__, which enables
    tracking and displaying specific training metrics or status updates in a customized format.
 
@@ -405,14 +405,14 @@ Ray Tune and RLlib
 RLModules
 +++++++++
 
-- `Action masking <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/action_masking_rl_module.py>`__:
+- `Action masking <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/action_masking_rl_module.py>`__:
    Implements an :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` with action masking, where certain disallowed actions are
    masked based on parts of the observation dict, useful for environments with conditional action availability.
 
-- `Auto-regressive actions <https://github.com/ray-project/ray/tree/master/rllib/examples/actions/autoregressive_actions.py>`__:
+- `Auto-regressive actions <https://github.com/ray-project/ray/blob/master/rllib/examples/actions/autoregressive_actions.py>`__:
    :ref:`See here for more details <rllib-examples-overview-autoregressive-actions>`.
 
-- `Custom CNN-based RLModule <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/custom_cnn_rl_module.py>`__:
+- `Custom CNN-based RLModule <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/custom_cnn_rl_module.py>`__:
    Demonstrates a custom CNN architecture realized as an :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`, enabling convolutional
    feature extraction tailored to the environment's visual observations.
 
@@ -420,15 +420,15 @@ RLModules
    Uses a custom LSTM within an :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`, allowing for temporal sequence processing,
    beneficial for partially observable environments with sequential dependencies.
 
-- `Migrate ModelV2 to RLModule by config <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/migrate_modelv2_to_new_api_stack_by_config.py>`__:
+- `Migrate ModelV2 to RLModule by config <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/migrate_modelv2_to_new_api_stack_by_config.py>`__:
    Shows how to migrate a ModelV2-based setup (old API stack) to the new API stack's :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`,
    using an (old API stack) :py:class:`~ray.rllib.algorithm.algorithm_config.AlgorithmConfig` instance.
 
-- `Migrate ModelV2 to RLModule by Policy Checkpoint <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/migrate_modelv2_to_new_api_stack_by_policy_checkpoint.py>`__:
+- `Migrate ModelV2 to RLModule by Policy Checkpoint <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/migrate_modelv2_to_new_api_stack_by_policy_checkpoint.py>`__:
    Migrates a ModelV2 (old API stack) to the new API stack's :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` by directly loading a
    policy checkpoint, enabling smooth transitions to the new API stack while preserving learned parameters.
 
-- `Pretrain single-agent policy, then train in multi-agent Env <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/pretraining_single_agent_training_multi_agent.py>`__:
+- `Pretrain single-agent policy, then train in multi-agent Env <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/pretraining_single_agent_training_multi_agent.py>`__:
    Demonstrates pretraining a single-agent model and transferring it to a multi-agent setting, useful for initializing
    multi-agent scenarios with pre-trained policies.
 
@@ -442,7 +442,7 @@ The `tuned examples <https://github.com/ray-project/ray/tree/master/rllib/exampl
 contains python config files that you can execute analogously to all other example scripts described
 here to run tuned learning experiments for the different algorithms and environment types.
 
-For example, see this `tuned Atari example for PPO <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/ppo/atari_ppo.py>`__,
+For example, see this `tuned Atari example for PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/atari_ppo.py>`__,
 which learns to solve the Pong environment in roughly 5 minutes. You can run it as follows on a single
 g5.24xlarge or g6.24xlarge machine with 4 GPUs and 96 CPUs:
 

--- a/doc/source/rllib/rllib-examples.rst
+++ b/doc/source/rllib/rllib-examples.rst
@@ -8,7 +8,7 @@ Examples
 .. include:: /_includes/rllib/new_api_stack.rst
 
 This page contains an index of all the python scripts in the
-`examples folder <https://github.com/ray-project/ray/blob/master/rllib/examples>`__
+`examples folder <https://github.com/ray-project/ray/tree/master/rllib/examples>`__
 of RLlib, demonstrating the different use cases and features of the library.
 
 .. note::
@@ -26,7 +26,7 @@ of RLlib, demonstrating the different use cases and features of the library.
 
 Folder structure
 ----------------
-The `examples folder <https://github.com/ray-project/ray/blob/master/rllib/examples>`__ has
+The `examples folder <https://github.com/ray-project/ray/tree/master/rllib/examples>`__ has
 several sub-directories described in detail below.
 
 
@@ -58,17 +58,17 @@ Actions
 
 .. _rllib-examples-overview-autoregressive-actions:
 
-- `Auto-regressive actions <https://github.com/ray-project/ray/blob/master/rllib/examples/actions/autoregressive_actions.py>`__:
+- `Auto-regressive actions <https://github.com/ray-project/ray/tree/master/rllib/examples/actions/autoregressive_actions.py>`__:
    Configures an RL module that generates actions in an autoregressive manner, where the second component of an action depends on
    the previously sampled first component of the same action.
 
-- `Custom action distribution class <https://github.com/ray-project/ray/blob/master/rllib/examples/actions/custom_action_distribution.py>`__:
+- `Custom action distribution class <https://github.com/ray-project/ray/tree/master/rllib/examples/actions/custom_action_distribution.py>`__:
    Demonstrates how to write a custom action distribution class, taking an additional temperature parameter on top of a Categorical
    distribution, and how to configure this class inside your :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` implementation.
    Further explains how to define different such classes for the different forward methods of your :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`
    in case you need more granularity.
 
-- `Nested Action Spaces <https://github.com/ray-project/ray/blob/master/rllib/examples/actions/nested_action_spaces.py>`__:
+- `Nested Action Spaces <https://github.com/ray-project/ray/tree/master/rllib/examples/actions/nested_action_spaces.py>`__:
    Sets up an environment with nested action spaces using custom single- or multi-agent
    configurations. This example demonstrates how RLlib manages complex action structures,
    such as multi-dimensional or hierarchical action spaces.
@@ -77,18 +77,18 @@ Actions
 Algorithms
 ++++++++++
 
-- `Custom implementation of the Model-Agnostic Meta-Learning (MAML) algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/maml_lr_supervised_learning.py>`__:
+- `Custom implementation of the Model-Agnostic Meta-Learning (MAML) algorithm <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/maml_lr_supervised_learning.py>`__:
    Shows how to stably train a model in an "infinite-task" environment, where each task corresponds
    to a sinusoidal function with randomly sampled amplitude and phase. Because each new task introduces
    a shift in data distribution, traditional learning algorithms would fail to generalize.
 
-- `Custom "vanilla policy gradient" (VPG) algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/vpg_custom_algorithm.py>`__:
+- `Custom "vanilla policy gradient" (VPG) algorithm <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/vpg_custom_algorithm.py>`__:
    Shows how to write a very simple policy gradient :py:class:`~ray.rllib.algorithms.algorithm.Algorithm` from scratch,
    including a matching :py:class:`~ray.rllib.algorithms.algorithm_config.AlgorithmConfig`,
    a matching :py:class:`~ray.rllib.core.learner.learner.Learner` which defines the loss function,
    and the Algorithm's :py:meth:`~ray.rllib.algorithms.algorithm.Algorithm.training_step` implementation.
 
-- `Custom algorithm with a global, shared data actor for sending manipulated rewards from EnvRunners to Learners <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/appo_custom_algorithm_w_shared_data_actor.py>`__:
+- `Custom algorithm with a global, shared data actor for sending manipulated rewards from EnvRunners to Learners <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/appo_custom_algorithm_w_shared_data_actor.py>`__:
    Shows how to write a custom shared data actor accessible from any of the Algorithm's other actors,
    like :py:class:`~ray.rllib.env.env_runner.EnvRunner` and :py:class:`~ray.rllib.core.learner.learner.Learner` actors.
    The new actor stores manipulated rewards from sampled episodes under unique, per-episode keys and then serves
@@ -99,13 +99,13 @@ Algorithms
 Checkpoints
 +++++++++++
 
-- `Checkpoint by custom criteria <https://github.com/ray-project/ray/blob/master/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py>`__:
+- `Checkpoint by custom criteria <https://github.com/ray-project/ray/tree/master/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py>`__:
    Shows how to create checkpoints based on custom criteria, giving users control over when to save model snapshots during training.
 
-- `Continue training from checkpoint <https://github.com/ray-project/ray/blob/master/rllib/examples/checkpoints/continue_training_from_checkpoint.py>`__:
+- `Continue training from checkpoint <https://github.com/ray-project/ray/tree/master/rllib/examples/checkpoints/continue_training_from_checkpoint.py>`__:
    Illustrates resuming training from a saved checkpoint, useful for extending training sessions or recovering from interruptions.
 
-- `Restore 1 out of N agents from checkpoint <https://github.com/ray-project/ray/blob/master/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py>`__:
+- `Restore 1 out of N agents from checkpoint <https://github.com/ray-project/ray/tree/master/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py>`__:
    Restores one specific agent from a multi-agent checkpoint, allowing selective loading for environments where only certain agents need
    to resume training.
 
@@ -119,31 +119,31 @@ Connectors
     to distinguish against the ``Connector`` class, which only continue to work on the old API stack.
 
 
-- `Flatten and one-hot observations <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/flatten_observations_dict_space.py>`__:
+- `Flatten and one-hot observations <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/flatten_observations_dict_space.py>`__:
    Demonstrates how to one-hot discrete observation spaces and/or flatten complex observations, Dict or Tuple, allowing RLlib to process arbitrary
    observation data as flattened 1D vectors. Useful for environments with complex, discrete, or hierarchical observations.
 
-- `Observation frame-stacking <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/frame_stacking.py>`__:
+- `Observation frame-stacking <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/frame_stacking.py>`__:
    Implements frame stacking, where N consecutive frames stack together to provide temporal context to the agent.
    This technique is common in environments with continuous state changes, like video frames in Atari games.
    Using connectors for frame stacking is more efficient as it avoids having to send large observation tensors through
    ray remote calls.
 
-- `Mean/Std filtering <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/mean_std_filtering.py>`__:
+- `Mean/Std filtering <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/mean_std_filtering.py>`__:
    Adds mean and standard deviation normalization for observations, shifting by the mean and dividing by std-dev.
    This type of filtering can improve learning stability in environments with highly variable state magnitudes
    by scaling observations to a normalized range.
 
-- `Multi-agent observation preprocessor enhancing non-Markovian observations to Markovian ones <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/multi_agent_observation_preprocessor.py>`__:
+- `Multi-agent observation preprocessor enhancing non-Markovian observations to Markovian ones <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/multi_agent_observation_preprocessor.py>`__:
    A multi-agent preprocessor enhances the per-agent observations of a multi-agent env, which by themselves are non-Markovian,
    partial observations and converts them into Markovian observations by adding information from
    the respective other agent. A policy can only be trained optimally through this additional information.
 
-- `Prev-actions, prev-rewards connector <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/prev_actions_prev_rewards.py>`__:
+- `Prev-actions, prev-rewards connector <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/prev_actions_prev_rewards.py>`__:
    Augments observations with previous actions and rewards, giving the agent a short-term memory of past events, which can improve
    decision-making in partially observable or sequentially dependent tasks.
 
-- `Single-agent observation preprocessor <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/single_agent_observation_preprocessor.py>`__:
+- `Single-agent observation preprocessor <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/single_agent_observation_preprocessor.py>`__:
    A connector alters the CartPole-v1 environment observations from the Markovian 4-tuple (x-pos,
    angular-pos, x-velocity, angular-velocity) to a non-Markovian, simpler 2-tuple (only
    x-pos and angular-pos). The resulting problem can only be solved through a
@@ -153,17 +153,17 @@ Connectors
 Curiosity
 +++++++++
 
-- `Count-based curiosity <https://github.com/ray-project/ray/blob/master/rllib/examples/curiosity/count_based_curiosity.py>`__:
+- `Count-based curiosity <https://github.com/ray-project/ray/tree/master/rllib/examples/curiosity/count_based_curiosity.py>`__:
    Implements count-based intrinsic motivation to encourage exploration of less visited states.
    Using curiosity is beneficial in sparse-reward environments where agents may struggle to find rewarding paths.
    However, count-based methods are only feasible for environments with small observation spaces.
 
-- `Euclidean distance-based curiosity <https://github.com/ray-project/ray/blob/master/rllib/examples/curiosity/euclidian_distance_based_curiosity.py>`__:
+- `Euclidean distance-based curiosity <https://github.com/ray-project/ray/tree/master/rllib/examples/curiosity/euclidian_distance_based_curiosity.py>`__:
    Uses Euclidean distance between states and the initial state to measure novelty, encouraging exploration by rewarding the agent for reaching "far away"
    regions of the environment.
    Suitable for sparse-reward tasks, where diverse exploration is key to success.
 
-- `Intrinsic-curiosity-model (ICM) Based Curiosity <https://github.com/ray-project/ray/blob/master/rllib/examples/curiosity/intrinsic_curiosity_model_based_curiosity.py>`__:
+- `Intrinsic-curiosity-model (ICM) Based Curiosity <https://github.com/ray-project/ray/tree/master/rllib/examples/curiosity/intrinsic_curiosity_model_based_curiosity.py>`__:
    Adds an `Intrinsic Curiosity Model (ICM) <https://arxiv.org/pdf/1705.05363.pdf>`__ that learns to predict the next state as well as the action in
    between two states to measure novelty. The higher the loss of the ICM, the higher the "novelty" and thus the intrinsic reward.
    Ideal for complex environments with large observation spaces where reward signals are sparse.
@@ -172,12 +172,12 @@ Curiosity
 Curriculum learning
 +++++++++++++++++++
 
-- `Custom env rendering method <https://github.com/ray-project/ray/blob/master/rllib/examples/curriculum/curriculum_learning.py>`__:
+- `Custom env rendering method <https://github.com/ray-project/ray/tree/master/rllib/examples/curriculum/curriculum_learning.py>`__:
    Demonstrates curriculum learning, where the environment difficulty increases as the agent improves.
    This approach enables gradual learning, allowing agents to master simpler tasks before progressing to more challenging ones,
    ideal for environments with hierarchical or staged difficulties. Also see the :doc:`curriculum learning how-to </rllib/rllib-advanced-api>` from the documentation.
 
-- `Curriculum learning for Atari Pong <https://github.com/ray-project/ray/blob/master/rllib/examples/curriculum/pong_curriculum_learning.py>`__:
+- `Curriculum learning for Atari Pong <https://github.com/ray-project/ray/tree/master/rllib/examples/curriculum/pong_curriculum_learning.py>`__:
    Demonstrates curriculum learning for Atari Pong using the `frameskip` to increase difficulty of the task.
    This approach enables gradual learning, allowing agents to master slower reactions (lower `frameskip`) before progressing to more faster ones (higher `frameskip`).
    Also see the :doc:`curriculum learning how-to </rllib/rllib-advanced-api>` from the documentation.
@@ -186,7 +186,7 @@ Curriculum learning
 Debugging
 +++++++++
 
-- `Deterministic sampling and training <https://github.com/ray-project/ray/blob/master/rllib/examples/debugging/deterministic_sampling_and_training.py>`__:
+- `Deterministic sampling and training <https://github.com/ray-project/ray/tree/master/rllib/examples/debugging/deterministic_sampling_and_training.py>`__:
    Demonstrates the possibility to seed an experiment through the algorithm config. RLlib passes the seed through to all components that have a copy of the
    :ref:`RL environment <rllib-environments-doc>` and the :ref:`RLModule <rlmodule-guide>` and thus makes sure these components behave deterministically.
    When using a seed, train results should become repeatable. Note that some algorithms, such as :ref:`APPO <appo>` which rely on asynchronous sampling
@@ -196,27 +196,27 @@ Debugging
 Environments
 ++++++++++++
 
-- `Async gym vectorization, parallelizing sub-environments <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/async_gym_env_vectorization.py>`__:
+- `Async gym vectorization, parallelizing sub-environments <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/async_gym_env_vectorization.py>`__:
    Shows how the `gym_env_vectorize_mode` config setting can significantly speed up your
    :py:class:`~ray.rllib.env.env_runner.EnvRunner` actors, if your RL environment is slow and you're
    using `num_envs_per_env_runner > 1`. The reason for the performance gain is that each sub-environment runs in its own process.
 
-- `Custom env rendering method <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/custom_env_render_method.py>`__:
+- `Custom env rendering method <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/custom_env_render_method.py>`__:
    Demonstrates how to add a custom `render()` method to a (custom) environment, allowing visualizations of agent interactions.
 
-- `Custom gymnasium env <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/custom_gym_env.py>`__:
+- `Custom gymnasium env <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/custom_gym_env.py>`__:
    Implements a custom `gymnasium <https://gymnasium.farama.org>`__ environment from scratch, showing how to define observation and action spaces,
    arbitrary reward functions, as well as, step- and reset logic.
 
-- `Env connecting to RLlib through a tcp client <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/env_connecting_to_rllib_w_tcp_client.py>`__:
+- `Env connecting to RLlib through a tcp client <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/env_connecting_to_rllib_w_tcp_client.py>`__:
    An external environment, running outside of RLlib and acting as a client, connects to RLlib as a server. The external env performs its own
    action inference using an ONNX model, sends collected data back to RLlib for training, and receives model updates from time to time from RLlib.
 
-- `Env rendering and recording <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/env_rendering_and_recording.py>`__:
+- `Env rendering and recording <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/env_rendering_and_recording.py>`__:
    Illustrates environment rendering and recording setups within RLlib, capturing visual outputs for later review (ex. on WandB), which is essential
    for tracking agent behavior in training.
 
-- `Env with protobuf observations <https://github.com/ray-project/ray/blob/master/rllib/examples/envs/env_w_protobuf_observations.py>`__:
+- `Env with protobuf observations <https://github.com/ray-project/ray/tree/master/rllib/examples/envs/env_w_protobuf_observations.py>`__:
    Uses Protobuf for observations, demonstrating an advanced way of handling serialized data in environments. This approach is useful for
    integrating complex external data sources as observations.
 
@@ -224,10 +224,10 @@ Environments
 Evaluation
 ++++++++++
 
-- `Custom evaluation <https://github.com/ray-project/ray/blob/master/rllib/examples/evaluation/custom_evaluation.py>`__:
+- `Custom evaluation <https://github.com/ray-project/ray/tree/master/rllib/examples/evaluation/custom_evaluation.py>`__:
    Configures custom evaluation metrics for agent performance, allowing users to define specific success criteria beyond standard RLlib evaluation metrics.
 
-- `Evaluation parallel to training <https://github.com/ray-project/ray/blob/master/rllib/examples/evaluation/evaluation_parallel_to_training.py>`__:
+- `Evaluation parallel to training <https://github.com/ray-project/ray/tree/master/rllib/examples/evaluation/evaluation_parallel_to_training.py>`__:
    Runs evaluation episodes in parallel with training, reducing training time by offloading evaluation to separate processes.
    This method is beneficial when you require frequent evaluation without interrupting learning.
 
@@ -235,7 +235,7 @@ Evaluation
 Fault tolerance
 +++++++++++++++
 
-- `Crashing and stalling env <https://github.com/ray-project/ray/blob/master/rllib/examples/fault_tolerance/crashing_and_stalling_env.py>`__:
+- `Crashing and stalling env <https://github.com/ray-project/ray/tree/master/rllib/examples/fault_tolerance/crashing_and_stalling_env.py>`__:
    Simulates an environment that randomly crashes or stalls, allowing users to test RLlib's fault-tolerance mechanisms.
    This script is useful for evaluating how RLlib handles interruptions and recovers from unexpected failures during training.
 
@@ -243,19 +243,19 @@ Fault tolerance
 GPUs for training and sampling
 ++++++++++++++++++++++++++++++
 
-- `Float16 training and inference <https://github.com/ray-project/ray/blob/master/rllib/examples/gpus/float16_training_and_inference.py>`__:
+- `Float16 training and inference <https://github.com/ray-project/ray/tree/master/rllib/examples/gpus/float16_training_and_inference.py>`__:
    Configures a setup for float16 training and inference, optimizing performance by reducing memory usage and speeding up computation.
    This is especially useful for large-scale models on compatible GPUs.
 
-- `Fractional GPUs per Learner <https://github.com/ray-project/ray/blob/master/rllib/examples/gpus/fractional_gpus_per_learner.py>`__:
+- `Fractional GPUs per Learner <https://github.com/ray-project/ray/tree/master/rllib/examples/gpus/fractional_gpus_per_learner.py>`__:
    Demonstrates allocating fractional GPUs to individual learners, enabling finer resource allocation in multi-model setups.
    Useful for saving resources when training smaller models, many of which can fit on a single GPU.
 
-- `Mixed precision training and float16 inference <https://github.com/ray-project/ray/blob/master/rllib/examples/gpus/mixed_precision_training_float16_inference.py>`__:
+- `Mixed precision training and float16 inference <https://github.com/ray-project/ray/tree/master/rllib/examples/gpus/mixed_precision_training_float16_inference.py>`__:
    Uses mixed precision, float32 and float16, for training, while switching to float16 precision for inference, balancing stability during training
    with performance improvements during evaluation.
 
-- `Using GPUs on EnvRunners <https://github.com/ray-project/ray/blob/master/rllib/examples/gpus/gpus_on_env_runners.py>`__:
+- `Using GPUs on EnvRunners <https://github.com/ray-project/ray/tree/master/rllib/examples/gpus/gpus_on_env_runners.py>`__:
    Demos how :py:class:`~ray.rllib.env.env_runner.EnvRunner` instances, single- or multi-agent, can request GPUs through
    the `config.env_runners(num_gpus_per_env_runner=..)` setting.
 
@@ -263,7 +263,7 @@ GPUs for training and sampling
 Hierarchical training
 +++++++++++++++++++++
 
-- `Hierarchical RL training <https://github.com/ray-project/ray/blob/master/rllib/examples/hierarchical/hierarchical_training.py>`__:
+- `Hierarchical RL training <https://github.com/ray-project/ray/tree/master/rllib/examples/hierarchical/hierarchical_training.py>`__:
    Showcases a hierarchical RL setup inspired by automatic subgoal discovery and subpolicy specialization. A high-level policy selects subgoals and assigns one of three
    specialized low-level policies to achieve them within a time limit, encouraging specialization and efficient task-solving.
    The agent has to navigate a complex grid-world environment. The example highlights the advantages of hierarchical
@@ -273,12 +273,12 @@ Hierarchical training
 Inference of models or policies
 +++++++++++++++++++++++++++++++
 
-- `Policy inference after training <https://github.com/ray-project/ray/blob/master/rllib/examples/inference/policy_inference_after_training.py>`__:
+- `Policy inference after training <https://github.com/ray-project/ray/tree/master/rllib/examples/inference/policy_inference_after_training.py>`__:
    Demonstrates performing inference using a checkpointed :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` or an `ONNX runtime <https://onnx.ai/>`__.
    First trains the :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`, creates a checkpoint, then re-loads the module from this checkpoint or ONNX file, and computes
    actions in a simulated environment.
 
-- `Policy inference after training, with ConnectorV2 <https://github.com/ray-project/ray/blob/master/rllib/examples/inference/policy_inference_after_training_w_connector.py>`__:
+- `Policy inference after training, with ConnectorV2 <https://github.com/ray-project/ray/tree/master/rllib/examples/inference/policy_inference_after_training_w_connector.py>`__:
    Runs inference with a trained, LSTM-based :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` or an `ONNX runtime <https://onnx.ai/>`__.
    Two connector pipelines, env-to-module and module-to-env, preprocess observations and LSTM-states and postprocess model outputs into actions,
    allowing for very modular and flexible inference setups.
@@ -287,15 +287,15 @@ Inference of models or policies
 Learners
 ++++++++
 
-- `Custom loss function, simple <https://github.com/ray-project/ray/blob/master/rllib/examples/learners/ppo_with_custom_loss_fn.py>`__:
+- `Custom loss function, simple <https://github.com/ray-project/ray/tree/master/rllib/examples/learners/ppo_with_custom_loss_fn.py>`__:
    Implements a custom loss function for training, demonstrating how users can define tailored loss objectives for specific environments or
    behaviors.
 
-- `Custom torch learning rate schedulers <https://github.com/ray-project/ray/blob/master/rllib/examples/learners/ppo_with_torch_lr_schedulers.py>`__:
+- `Custom torch learning rate schedulers <https://github.com/ray-project/ray/tree/master/rllib/examples/learners/ppo_with_torch_lr_schedulers.py>`__:
    Adds learning rate scheduling to PPO, showing how to adjust the learning rate dynamically using PyTorch schedulers for improved
    training stability.
 
-- `Separate learning rate and optimizer for value function <https://github.com/ray-project/ray/blob/master/rllib/examples/learners/separate_vf_lr_and_optimizer.py>`__:
+- `Separate learning rate and optimizer for value function <https://github.com/ray-project/ray/tree/master/rllib/examples/learners/separate_vf_lr_and_optimizer.py>`__:
    Configures a separate learning rate and a separate optimizer for the value function vs the policy network,
    enabling differentiated training dynamics between policy and value estimation in RL algorithms.
 
@@ -303,12 +303,12 @@ Learners
 Metrics
 +++++++
 
-- `Logging custom metrics in Algorithm.training_step <https://github.com/ray-project/ray/blob/master/rllib/examples/metrics/custom_metrics_in_algorithm_training_step.py>`__:
+- `Logging custom metrics in Algorithm.training_step <https://github.com/ray-project/ray/tree/master/rllib/examples/metrics/custom_metrics_in_algorithm_training_step.py>`__:
    Shows how to log custom metrics inside a custom :py:class:`~ray.rllib.algorithms.algorithm.Algorithm` through overriding
    the :py:meth:`` method and making calls to the :py:meth:`~ray.rllib.utils.metrics.metrics_logger.MetricsLogger.log_value` method
    of the :py:class:`~ray.rllib.utils.metrics.metrics_logger.MetricsLogger` instance.
 
-- `Logging custom metrics in EnvRunners <https://github.com/ray-project/ray/blob/master/rllib/examples/metrics/custom_metrics_in_env_runners.py>`__:
+- `Logging custom metrics in EnvRunners <https://github.com/ray-project/ray/tree/master/rllib/examples/metrics/custom_metrics_in_env_runners.py>`__:
    Demonstrates adding custom metrics to :py:class:`~ray.rllib.env.env_runner.EnvRunner` actors, providing a way to track specific
    performance- and environment indicators beyond the standard RLlib metrics.
 
@@ -316,59 +316,55 @@ Metrics
 Multi-agent RL
 ++++++++++++++
 
-- `Custom heuristic policy <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/custom_heuristic_policy.py>`__:
+- `Custom heuristic policy <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/custom_heuristic_policy.py>`__:
    Demonstrates running a hybrid policy setup within the `MultiAgentCartPole` environment, where one agent follows
    a hand-coded random policy while another agent trains with PPO. This example highlights integrating static and dynamic policies,
    suitable for environments with a mix of fixed-strategy and adaptive agents.
 
-- `Different observation- and action spaces for different agents <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/different_spaces_for_agents.py>`__:
+- `Different observation- and action spaces for different agents <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/different_spaces_for_agents.py>`__:
    Configures agents with differing observation and action spaces within the same environment, showcasing RLlib's support for heterogeneous agents with varying space requirements in a single multi-agent environment.
    Another example, which also makes use of connectors, and that covers the same topic, agents having different spaces, can be found
-   `here <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors/multi_agent_observation_preprocessor.py>`__.
+   `here <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors/multi_agent_observation_preprocessor.py>`__.
 
-- `Grouped agents, two-step game <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/two_step_game_with_grouped_agents.py>`__:
+- `Grouped agents, two-step game <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/two_step_game_with_grouped_agents.py>`__:
    Implements a multi-agent, grouped setup within a two-step game environment from the `QMIX paper <https://arxiv.org/pdf/1803.11485.pdf>`__.
    N agents form M teams in total, where N >= M, and agents in each team share rewards and one policy.
    This example demonstrates RLlib's ability to manage collective objectives and interactions among grouped agents.
 
-- `Multi-agent CartPole <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/multi_agent_cartpole.py>`__:
+- `Multi-agent CartPole <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/multi_agent_cartpole.py>`__:
    Runs a multi-agent version of the CartPole environment with each agent independently learning to balance its pole.
    This example serves as a foundational test for multi-agent reinforcement learning scenarios in simple, independent tasks.
 
-- `Multi-agent Pendulum <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/multi_agent_pendulum.py>`__:
+- `Multi-agent Pendulum <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/multi_agent_pendulum.py>`__:
    Extends the classic Pendulum environment into a multi-agent setting, where multiple agents attempt to balance
    their respective pendulums.
    This example highlights RLlib's support for environments with replicated dynamics but distinct agent policies.
 
-- `PettingZoo independent learning <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/pettingzoo_independent_learning.py>`__:
+- `PettingZoo independent learning <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/pettingzoo_independent_learning.py>`__:
    Integrates RLlib with `PettingZoo <https://pettingzoo.farama.org/>`__ to facilitate independent learning among multiple agents.
    Each agent independently optimizes its policy within a shared environment.
 
-- `PettingZoo parameter sharing <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/pettingzoo_parameter_sharing.py>`__:
+- `PettingZoo parameter sharing <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/pettingzoo_parameter_sharing.py>`__:
    Uses `PettingZoo <https://pettingzoo.farama.org/>`__ for an environment where all agents share a single policy.
 
-- `PettingZoo shared value function <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/pettingzoo_shared_value_function.py>`__:
-   Also using PettingZoo, this example explores shared value functions among agents.
-   It demonstrates collaborative learning scenarios where agents collectively estimate a value function rather than individual policies.
-
-- `Rock-paper-scissors heuristic vs learned <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/rock_paper_scissors_heuristic_vs_learned.py>`__:
+- `Rock-paper-scissors heuristic vs learned <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/rock_paper_scissors_heuristic_vs_learned.py>`__:
    Simulates a rock-paper-scissors game with one heuristic-driven agent and one learning agent.
    It provides insights into performance when combining fixed and adaptive strategies in adversarial games.
 
-- `Rock-paper-scissors learned vs learned <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/rock_paper_scissors_learned_vs_learned.py>`__:
+- `Rock-paper-scissors learned vs learned <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/rock_paper_scissors_learned_vs_learned.py>`__:
    Sets up a rock-paper-scissors game where you train both agents to learn strategies on how to play against each other.
    Useful for evaluating performance in simple adversarial settings.
 
-- `Self-play, league-based, with OpenSpiel <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/self_play_league_based_with_open_spiel.py>`__:
+- `Self-play, league-based, with OpenSpiel <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/self_play_league_based_with_open_spiel.py>`__:
    Uses OpenSpiel to demonstrate league-based self-play, where agents play against various
    versions of themselves, frozen or in-training, to improve through competitive interaction.
 
-- `Self-play with Footsies and PPO algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py>`__:
+- `Self-play with Footsies and PPO algorithm <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py>`__:
     Implements self-play with the Footsies environment (two player zero-sum game).
     This example highlights RLlib's capabilities in connecting to the external binaries running the game engine, as well as
     setting up a multi-agent self-play training scenario.
 
-- `Self-play with OpenSpiel <https://github.com/ray-project/ray/blob/master/rllib/examples/multi_agent/self_play_with_open_spiel.py>`__:
+- `Self-play with OpenSpiel <https://github.com/ray-project/ray/tree/master/rllib/examples/multi_agent/self_play_with_open_spiel.py>`__:
    Similar to the league-based self-play, but simpler. This script leverages OpenSpiel for two-player games, allowing agents to improve
    through direct self-play without building a complex, structured league.
 
@@ -376,7 +372,7 @@ Multi-agent RL
 Offline RL
 ++++++++++
 
-- `Train with behavioral cloning (BC), Finetune with PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/offline_rl/train_w_bc_finetune_w_ppo.py>`__:
+- `Train with behavioral cloning (BC), Finetune with PPO <https://github.com/ray-project/ray/tree/master/rllib/examples/offline_rl/train_w_bc_finetune_w_ppo.py>`__:
    Combines behavioral cloning pre-training with PPO fine-tuning, providing a two-phase
    training strategy. Offline imitation learning as a first step followed by online reinforcement learning.
 
@@ -384,7 +380,7 @@ Offline RL
 Ray Serve and RLlib
 +++++++++++++++++++
 
-- `Using Ray Serve with RLlib <https://github.com/ray-project/ray/blob/master/rllib/examples/ray_serve/ray_serve_with_rllib.py>`__:
+- `Using Ray Serve with RLlib <https://github.com/ray-project/ray/tree/master/rllib/examples/ray_serve/ray_serve_with_rllib.py>`__:
    Integrates RLlib with `Ray Serve <https://docs.ray.io/en/latest/serve/index.html>`__, showcasing how to deploy trained
    :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` instances as RESTful services. This setup is ideal for deploying models
    in production environments with API-based interactions.
@@ -393,15 +389,15 @@ Ray Serve and RLlib
 Ray Tune and RLlib
 ++++++++++++++++++
 
-- `Custom experiment <https://github.com/ray-project/ray/blob/master/rllib/examples/ray_tune/custom_experiment.py>`__:
+- `Custom experiment <https://github.com/ray-project/ray/tree/master/rllib/examples/ray_tune/custom_experiment.py>`__:
    Configures a custom experiment with `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`__, demonstrating advanced options
    for custom training- and evaluation phases
 
-- `Custom logger <https://github.com/ray-project/ray/blob/master/rllib/examples/ray_tune/custom_logger.py>`__:
+- `Custom logger <https://github.com/ray-project/ray/tree/master/rllib/examples/ray_tune/custom_logger.py>`__:
    Shows how to implement a custom logger within `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`__,
    allowing users to define specific logging behaviors and outputs during training.
 
-- `Custom progress reporter <https://github.com/ray-project/ray/blob/master/rllib/examples/ray_tune/custom_progress_reporter.py>`__:
+- `Custom progress reporter <https://github.com/ray-project/ray/tree/master/rllib/examples/ray_tune/custom_progress_reporter.py>`__:
    Demonstrates a custom progress reporter in `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`__, which enables
    tracking and displaying specific training metrics or status updates in a customized format.
 
@@ -409,30 +405,30 @@ Ray Tune and RLlib
 RLModules
 +++++++++
 
-- `Action masking <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/action_masking_rl_module.py>`__:
+- `Action masking <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/action_masking_rl_module.py>`__:
    Implements an :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` with action masking, where certain disallowed actions are
    masked based on parts of the observation dict, useful for environments with conditional action availability.
 
-- `Auto-regressive actions <https://github.com/ray-project/ray/blob/master/rllib/examples/actions/autoregressive_actions.py>`__:
+- `Auto-regressive actions <https://github.com/ray-project/ray/tree/master/rllib/examples/actions/autoregressive_actions.py>`__:
    :ref:`See here for more details <rllib-examples-overview-autoregressive-actions>`.
 
-- `Custom CNN-based RLModule <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/custom_cnn_rl_module.py>`__:
+- `Custom CNN-based RLModule <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/custom_cnn_rl_module.py>`__:
    Demonstrates a custom CNN architecture realized as an :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`, enabling convolutional
    feature extraction tailored to the environment's visual observations.
 
-- `Custom LSTM-based RLModule <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/custom_lstm_rl_module.py>`__:
+- `Custom LSTM-based RLModule <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/custom_lstm_rl_module.py>`__:
    Uses a custom LSTM within an :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`, allowing for temporal sequence processing,
    beneficial for partially observable environments with sequential dependencies.
 
-- `Migrate ModelV2 to RLModule by config <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/migrate_modelv2_to_new_api_stack_by_config.py>`__:
+- `Migrate ModelV2 to RLModule by config <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/migrate_modelv2_to_new_api_stack_by_config.py>`__:
    Shows how to migrate a ModelV2-based setup (old API stack) to the new API stack's :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`,
    using an (old API stack) :py:class:`~ray.rllib.algorithm.algorithm_config.AlgorithmConfig` instance.
 
-- `Migrate ModelV2 to RLModule by Policy Checkpoint <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/migrate_modelv2_to_new_api_stack_by_policy_checkpoint.py>`__:
+- `Migrate ModelV2 to RLModule by Policy Checkpoint <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/migrate_modelv2_to_new_api_stack_by_policy_checkpoint.py>`__:
    Migrates a ModelV2 (old API stack) to the new API stack's :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` by directly loading a
    policy checkpoint, enabling smooth transitions to the new API stack while preserving learned parameters.
 
-- `Pretrain single-agent policy, then train in multi-agent Env <https://github.com/ray-project/ray/blob/master/rllib/examples/rl_modules/pretraining_single_agent_training_multi_agent.py>`__:
+- `Pretrain single-agent policy, then train in multi-agent Env <https://github.com/ray-project/ray/tree/master/rllib/examples/rl_modules/pretraining_single_agent_training_multi_agent.py>`__:
    Demonstrates pretraining a single-agent model and transferring it to a multi-agent setting, useful for initializing
    multi-agent scenarios with pre-trained policies.
 
@@ -442,11 +438,11 @@ RLModules
 Tuned examples
 --------------
 
-The `tuned examples <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms>`__ folder
+The `tuned examples <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms>`__ folder
 contains python config files that you can execute analogously to all other example scripts described
 here to run tuned learning experiments for the different algorithms and environment types.
 
-For example, see this `tuned Atari example for PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/atari_ppo.py>`__,
+For example, see this `tuned Atari example for PPO <https://github.com/ray-project/ray/tree/master/rllib/examples/algorithms/ppo/atari_ppo.py>`__,
 which learns to solve the Pong environment in roughly 5 minutes. You can run it as follows on a single
 g5.24xlarge or g6.24xlarge machine with 4 GPUs and 96 CPUs:
 

--- a/doc/source/rllib/rllib-examples.rst
+++ b/doc/source/rllib/rllib-examples.rst
@@ -363,7 +363,7 @@ Multi-agent RL
    Uses OpenSpiel to demonstrate league-based self-play, where agents play against various
    versions of themselves, frozen or in-training, to improve through competitive interaction.
 
-- `Self-play with Footsies and PPO algorithm <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/multi_agent_footsies_ppo.py>`__:
+- `Self-play with Footsies and PPO algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py>`__:
     Implements self-play with the Footsies environment (two player zero-sum game).
     This example highlights RLlib's capabilities in connecting to the external binaries running the game engine, as well as
     setting up a multi-agent self-play training scenario.
@@ -442,17 +442,17 @@ RLModules
 Tuned examples
 --------------
 
-The `tuned examples <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples>`__ folder
+The `tuned examples <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms>`__ folder
 contains python config files that you can execute analogously to all other example scripts described
 here to run tuned learning experiments for the different algorithms and environment types.
 
-For example, see this `tuned Atari example for PPO <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ppo/atari_ppo.py>`__,
+For example, see this `tuned Atari example for PPO <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/ppo/atari_ppo.py>`__,
 which learns to solve the Pong environment in roughly 5 minutes. You can run it as follows on a single
 g5.24xlarge or g6.24xlarge machine with 4 GPUs and 96 CPUs:
 
 .. code-block:: bash
 
-    $ cd ray/rllib/tuned_examples/ppo
+    $ cd ray/rllib/examples/algorithms/ppo
     $ python atari_ppo.py --env=ale_py:ALE/Pong-v5 --num-learners=4 --num-env-runners=95
 
 Note that RLlib's daily or weekly release tests use some of the files in this folder as well.

--- a/doc/source/rllib/rllib-offline.rst
+++ b/doc/source/rllib/rllib-offline.rst
@@ -1239,10 +1239,10 @@ Customization of the Offline RL components in RLlib, such as the :py:class:`~ray
 Connector level
 ***************
 Small data transformations on instances of :py:class:`~ray.rllib.env.single_agent_episode.SingleAgentEpisode` can be easily implemented by modifying the :py:class:`~ray.rllib.connectors.connector_pipeline_v2.ConnectorPipelineV2`, which is part of the :py:class:`~ray.rllib.offline.offline_prelearner.OfflinePreLearner` and prepares episodes for training. You can leverage any connector from
-RLlib's library (see `RLlib's default connectors <https://github.com/ray-project/ray/blob/master/rllib/connectors>`__) or create a custom connector (see `RLlib's ConnectorV2 examples <https://github.com/ray-project/ray/blob/master/rllib/examples/connectors>`__) to integrate into the :py:class:`~ray.rllib.core.learner.learner.Learner`'s :py:class:`~ray.rllib.connectors.connector_pipeline_v2.ConnectorPipelineV2`.
-Careful consideration must be given to the order in which :py:class:`~ray.rllib.connectors.connector_v2.ConnectorV2` instances are applied, as demonstrated in the implementation of `RLlib's MARWIL algorithm <https://github.com/ray-project/ray/blob/master/rllib/algorithms/marwil>`__ (see the `MARWIL paper <https://www.nematilab.info/bmijc/assets/012819_paper.pdf>`__).
+RLlib's library (see `RLlib's default connectors <https://github.com/ray-project/ray/tree/master/rllib/connectors>`__) or create a custom connector (see `RLlib's ConnectorV2 examples <https://github.com/ray-project/ray/tree/master/rllib/examples/connectors>`__) to integrate into the :py:class:`~ray.rllib.core.learner.learner.Learner`'s :py:class:`~ray.rllib.connectors.connector_pipeline_v2.ConnectorPipelineV2`.
+Careful consideration must be given to the order in which :py:class:`~ray.rllib.connectors.connector_v2.ConnectorV2` instances are applied, as demonstrated in the implementation of `RLlib's MARWIL algorithm <https://github.com/ray-project/ray/tree/master/rllib/algorithms/marwil>`__ (see the `MARWIL paper <https://www.nematilab.info/bmijc/assets/012819_paper.pdf>`__).
 
-The `MARWIL algorithm <https://github.com/ray-project/ray/blob/master/rllib/algorithms/marwil>`__ computes a loss that extends beyond behavior cloning by improving the expert's strategy during training using advantages. These advantages are calculated through `General Advantage Estimation (GAE) <https://arxiv.org/abs/1506.02438>`__ using a value model. GAE is computed on-the-fly through the
+The `MARWIL algorithm <https://github.com/ray-project/ray/tree/master/rllib/algorithms/marwil>`__ computes a loss that extends beyond behavior cloning by improving the expert's strategy during training using advantages. These advantages are calculated through `General Advantage Estimation (GAE) <https://arxiv.org/abs/1506.02438>`__ using a value model. GAE is computed on-the-fly through the
 :py:class:`~ray.rllib.connectors.learner.general_advantage_estimation.GeneralAdvantageEstimation` connector. This connector has specific requirements: it processes a list of :py:class:`~ray.rllib.env.single_agent_episode.SingleAgentEpisode` instances and must be one of the final components in the :py:class:`~ray.rllib.connectors.connector_pipeline_v2.ConnectorPipelineV2`. This is because
 it relies on fully prepared batches containing `OBS`, `REWARDS`, `NEXT_OBS`, `TERMINATED`, and `TRUNCATED` fields. Additionally, the incoming :py:class:`~ray.rllib.env.single_agent_episode.SingleAgentEpisode` instances must already include one artificially elongated timestep.
 
@@ -1253,7 +1253,7 @@ To meet these requirements, the pipeline must include the following sequence of 
 3. :py:class:`ray.rllib.connectors.learner.add_next_observations_from_episodes_to_train_batch.AddNextObservationsFromEpisodesToTrainBatch` adds the next observations (`NEXT_OBS`).
 4. Finally, the :py:class:`ray.rllib.connectors.learner.general_advantage_estimation.GeneralAdvantageEstimation` connector piece is applied.
 
-Below is the example code snippet from `RLlib's MARWIL algorithm <https://github.com/ray-project/ray/blob/master/rllib/algorithms/marwil>`__ demonstrating this setup:
+Below is the example code snippet from `RLlib's MARWIL algorithm <https://github.com/ray-project/ray/tree/master/rllib/algorithms/marwil>`__ demonstrating this setup:
 
 .. code-block:: python
 

--- a/doc/source/train/examples/pytorch/dreambooth_finetuning.rst
+++ b/doc/source/train/examples/pytorch/dreambooth_finetuning.rst
@@ -47,7 +47,7 @@ Data loading
 ^^^^^^^^^^^^
 
 .. note::
-    Find the latest version of the code at `dataset.py <https://github.com/ray-project/ray/tree/master/doc/source/templates/05_dreambooth_finetuning/dreambooth/dataset.py>`_
+    Find the latest version of the code at `dataset.py <https://github.com/ray-project/ray/blob/master/doc/source/templates/05_dreambooth_finetuning/dreambooth/dataset.py>`_
 
     The latest version might differ slightly from the code presented here.
 
@@ -93,7 +93,7 @@ Distributed training
 
 
 .. note::
-    Find the latest version of the code at `train.py <https://github.com/ray-project/ray/tree/master/doc/source/templates/05_dreambooth_finetuning/dreambooth/train.py>`_
+    Find the latest version of the code at `train.py <https://github.com/ray-project/ray/blob/master/doc/source/templates/05_dreambooth_finetuning/dreambooth/train.py>`_
 
     The latest version might differ slightly from the code presented here.
 
@@ -109,7 +109,7 @@ Remember that you want to do data-parallel training for all the models.
 #. Iterate over the dataset with `train_dataset.iter_torch_batches()``
 #. Report results to Ray Train with `session.report(results)``
 
-The code is compacted for brevity. The `full code <https://github.com/ray-project/ray/tree/master/doc/source/templates/05_dreambooth_finetuning/dreambooth/train.py>`_ is more thoroughly annotated.
+The code is compacted for brevity. The `full code <https://github.com/ray-project/ray/blob/master/doc/source/templates/05_dreambooth_finetuning/dreambooth/train.py>`_ is more thoroughly annotated.
 
 
 .. literalinclude:: /templates/05_dreambooth_finetuning/dreambooth/train.py

--- a/doc/source/tune/tutorials/tune-lifecycle.rst
+++ b/doc/source/tune/tutorials/tune-lifecycle.rst
@@ -174,7 +174,7 @@ errors, and every time a trial completes.
 
 TrialScheduler
 ~~~~~~~~~~~~~~
-[`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/schedulers>`__]
+[`source code <https://github.com/ray-project/ray/tree/master/python/ray/tune/schedulers>`__]
 TrialSchedulers operate over a set of possible trials to run,
 prioritizing trial execution given available cluster resources.
 


### PR DESCRIPTION
## Description
Runs linkcheck on docs, in particular for RLlib where we've moved tuned-examples to examples/algorithms
Further, updated github links that were automatically redirected

There are problems with some of the RLlib examples missing but I'm going to fix these in the algorithm premerge PRs, i.e., https://github.com/ray-project/ray/pull/59007