### PR TITLE
[release test] remove `--cluster-id` and `--cluster-env-id` flags

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -399,8 +399,6 @@ def run_release_test(
     anyscale_project: Optional[str] = None,
     reporters: Optional[List[Reporter]] = None,
     smoke_test: bool = False,
-    cluster_id: Optional[str] = None,
-    cluster_env_id: Optional[str] = None,
     test_definition_root: Optional[str] = None,
     log_streaming_limit: int = LAST_LOGS_LENGTH,
     image: Optional[str] = None,
@@ -418,8 +416,6 @@ def run_release_test(
         result=result,
         reporters=reporters,
         smoke_test=smoke_test,
-        cluster_id=cluster_id,
-        cluster_env_id=cluster_env_id,
         test_definition_root=test_definition_root,
         log_streaming_limit=log_streaming_limit,
         image=image,
@@ -521,14 +517,16 @@ def run_release_test_anyscale(
         )
         buildkite_group(":nut_and_bolt: Setting up cluster environment")
 
+        cluster_env_id = None
         # If image is provided, create/reuse a custom cluster environment
-        if image and not cluster_env_id:
+        if image:
             cluster_env_id = create_cluster_env_from_image(
                 image, test.get_name(), test.get_byod_runtime_env()
             )
             cluster_manager.cluster_env_name = get_custom_cluster_env_name(
                 image, test.get_name()
             )
+
         (
             prepare_cmd,
             prepare_timeout,

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -48,18 +48,6 @@ from ray_release.result import Result
     help="Report results to database",
 )
 @click.option(
-    "--cluster-id",
-    default=None,
-    type=str,
-    help="Cluster ID of existing cluster to be re-used.",
-)
-@click.option(
-    "--cluster-env-id",
-    default=None,
-    type=str,
-    help="Cluster env ID of existing cluster env to be re-used.",
-)
-@click.option(
     "--env",
     default=None,
     # Get the names without suffixes of all files in "../environments"
@@ -99,8 +87,6 @@ def main(
     test_collection_file: Tuple[str],
     smoke_test: bool = False,
     report: bool = False,
-    cluster_id: Optional[str] = None,
-    cluster_env_id: Optional[str] = None,
     env: Optional[str] = None,
     global_config: str = "oss_config.yaml",
     test_definition_root: Optional[str] = None,
@@ -159,8 +145,6 @@ def main(
             result=result,
             reporters=reporters,
             smoke_test=smoke_test,
-            cluster_id=cluster_id,
-            cluster_env_id=cluster_env_id,
             test_definition_root=test_definition_root,
             log_streaming_limit=log_streaming_limit,
             image=image,


### PR DESCRIPTION
they are never used, do not apply to kuberay, and will not work with new anyscale SDK/CLI.
