### PR TITLE
Fix `uv_runtime_env_hook.py` to pin worker Python version

### DIFF
--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -346,7 +346,11 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     # 4. platform.python_version() (since uv run uses the same Python as the driver)
     if not options.python:
         env_vars = runtime_env.get("env_vars") or {}
-        uv_python = env_vars.get("UV_PYTHON") or os.environ.get("UV_PYTHON") or platform.python_version()
+        uv_python = (
+            env_vars.get("UV_PYTHON")
+            or os.environ.get("UV_PYTHON")
+            or platform.python_version()
+        )
         remaining_uv_run_args = remaining_uv_run_args + ["--python", uv_python]
 
     runtime_env["py_executable"] = " ".join(remaining_uv_run_args)

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -131,10 +131,13 @@ def test_uv_run_runtime_env_hook():
     def check_uv_run(
         cmd, runtime_env, expected_output, subprocess_kwargs=None, expected_error=None
     ):
+        subprocess_kwargs = subprocess_kwargs or {}
+        env = dict(subprocess_kwargs.get("env") or os.environ)
+        env["UV_PYTHON"] = sys.executable
         result = subprocess.run(
             cmd + [json.dumps(runtime_env)],
             capture_output=True,
-            **(subprocess_kwargs if subprocess_kwargs else {}),
+            **{**subprocess_kwargs, "env": env},
         )
         output = result.stdout.strip().decode()
         if result.returncode != 0:
@@ -149,7 +152,7 @@ def test_uv_run_runtime_env_hook():
         cmd=[find_uv_bin(), "run", "--no-project", script],
         runtime_env={},
         expected_output={
-            "py_executable": f"{find_uv_bin()} run --no-project",
+            "py_executable": f"{find_uv_bin()} run --no-project --python {sys.executable}",
             "working_dir": os.getcwd(),
         },
     )
@@ -157,7 +160,7 @@ def test_uv_run_runtime_env_hook():
         cmd=[find_uv_bin(), "run", "--no-project", "--directory", "/tmp", script],
         runtime_env={},
         expected_output={
-            "py_executable": f"{find_uv_bin()} run --no-project",
+            "py_executable": f"{find_uv_bin()} run --no-project --python {sys.executable}",
             "working_dir": os.path.realpath("/tmp"),
         },
     )
@@ -165,7 +168,7 @@ def test_uv_run_runtime_env_hook():
         [find_uv_bin(), "run", "--no-project", script],
         {"working_dir": "/some/path"},
         {
-            "py_executable": f"{find_uv_bin()} run --no-project",
+            "py_executable": f"{find_uv_bin()} run --no-project --python {sys.executable}",
             "working_dir": "/some/path",
         },
     )
@@ -181,7 +184,7 @@ def test_uv_run_runtime_env_hook():
             cmd=[find_uv_bin(), "run", script],
             runtime_env={},
             expected_output={
-                "py_executable": f"{find_uv_bin()} run",
+                "py_executable": f"{find_uv_bin()} run --python {sys.executable}",
                 "working_dir": f"{tmp_dir}",
             },
             subprocess_kwargs={"cwd": tmp_dir},
@@ -197,7 +200,7 @@ def test_uv_run_runtime_env_hook():
             cmd=[find_uv_bin(), "run", "--with-requirements", requirements, script],
             runtime_env={},
             expected_output={
-                "py_executable": f"{find_uv_bin()} run --with-requirements {requirements}",
+                "py_executable": f"{find_uv_bin()} run --with-requirements {requirements} --python {sys.executable}",
                 "working_dir": f"{tmp_dir}",
             },
             subprocess_kwargs={"cwd": tmp_dir},
@@ -259,7 +262,7 @@ def test_uv_run_runtime_env_hook():
         cmd=[find_uv_bin(), "run", "--no-project", script],
         runtime_env={},
         expected_output={
-            "py_executable": f"{find_uv_bin()} run --no-project",
+            "py_executable": f"{find_uv_bin()} run --no-project --python {sys.executable}",
             "working_dir": os.getcwd(),
         },
         subprocess_kwargs={
@@ -272,7 +275,7 @@ def test_uv_run_runtime_env_hook():
         cmd=[find_uv_bin(), "run", "--no-project", script],
         runtime_env={},
         expected_output={
-            "py_executable": f"{find_uv_bin()} run --no-project",
+            "py_executable": f"{find_uv_bin()} run --no-project --python {sys.executable}",
             "working_dir": os.getcwd(),
         },
         subprocess_kwargs={
@@ -291,7 +294,7 @@ def test_uv_run_runtime_env_hook():
         ],
         runtime_env={},
         expected_output={
-            "py_executable": f"{find_uv_bin()} run --no-project",
+            "py_executable": f"{find_uv_bin()} run --no-project --python {sys.executable}",
             "working_dir": os.getcwd(),
         },
     )
@@ -309,7 +312,7 @@ def test_uv_run_runtime_env_hook():
         ],
         runtime_env={},
         expected_output={
-            "py_executable": f"{find_uv_bin()} run --no-project",
+            "py_executable": f"{find_uv_bin()} run --no-project --python {sys.executable}",
             "working_dir": os.getcwd(),
         },
     )


### PR DESCRIPTION
## Description

Fix `uv_runtime_env_hook.py` to pin worker Python version to driver version.

If the system python version is different from the driver python version, you can end up with a mismatch between python versions (e.g. driver 3.11 vs worker 3.12), which causes Ray to deliberately crash elsewhere.

This change ensures compatibility between the Ray driver and the worker by specifying the Python version, preventing version mismatches.

## Related issues

Fixes #59639.

## Additional information

