### PR TITLE
[core][data] Make data cross az test weekly

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -712,7 +712,7 @@
     cluster_compute: dataset/cross_az_250_350_compute_gce.yaml
 
   run:
-    timeout: 10800
+    timeout: 14400
     # The network failure interval is set to 210 seconds since the test as is takes around double that to run without failures.
     # If the runtime of the test is dramatically reduced in the future, the interval will have to be retuned.
     script: >

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -698,7 +698,7 @@
 
 - name: "cross_az_map_batches_autoscaling_iptable_failure_injection"
   python: "3.10"
-  frequency: nightly
+  frequency: weekly
   env: gce
   working_dir: nightly_tests
 


### PR DESCRIPTION
## Description
This is a pretty expensive 250-350 node test, and we're pretty confident it's consistently working now so moving it to weekly. We also have smaller scale tests with network failures now, so running this nightly isn't as necessary.

Also increasing the timeout since it doesn't always finish within the current timeout, tasks are being kicked off near the end of the timeout.