### PR TITLE
[Core] Fix symmetric_run using wrong condition to check GCS readiness

### DIFF
--- a/python/ray/scripts/symmetric_run.py
+++ b/python/ray/scripts/symmetric_run.py
@@ -11,6 +11,7 @@ import click
 import ray
 from ray._private.ray_constants import env_integer
 from ray._raylet import GcsClient
+from ray.exceptions import RpcError
 
 import psutil
 
@@ -54,7 +55,7 @@ def check_head_node_ready(address: str, timeout=CLUSTER_WAIT_TIMEOUT):
             gcs_client.check_alive([], timeout=1)
             click.echo("Ray cluster is ready!")
             return True
-        except Exception:
+        except RpcError:
             pass
         time.sleep(5)
     return False

--- a/python/ray/scripts/symmetric_run.py
+++ b/python/ray/scripts/symmetric_run.py
@@ -50,9 +50,12 @@ def check_head_node_ready(address: str, timeout=CLUSTER_WAIT_TIMEOUT):
     start_time = time.time()
     gcs_client = GcsClient(address=address)
     while time.time() - start_time < timeout:
-        if gcs_client.check_alive([], timeout=1):
+        try:
+            gcs_client.check_alive([], timeout=1)
             click.echo("Ray cluster is ready!")
             return True
+        except Exception:
+            pass
         time.sleep(5)
     return False
 


### PR DESCRIPTION
## Description

The `check_head_node_ready` function in `symmetric_run.py` always returns `False` because `gcs_client.check_alive([])` returns an empty list `[]` when GCS is reachable, and since `if []:` evaluates to `False` in Python, worker nodes incorrectly believe the head node is not ready, causing them to timeout. 

Passing `[]` to `check_alive` tests GCS connectivity without checking any specific node - it verifies whether the head node's GCS service is up and accessible. When GCS is unreachable, `check_alive` raises an `RpcError`; when reachable, it returns `[]`. 

The fix changes from checking the return value to using try/except pattern.

## Related issues
Fixes #59795

