### PR TITLE
[Core] Fix memory monitor to exclude cache when CGroup limit is more than total bytes

### DIFF
--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -100,7 +100,7 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetMemoryBytes() {
   RAY_CHECK(false) << "Memory monitor currently supports only linux";
 #endif
   auto [system_used_bytes, system_total_bytes] = GetLinuxMemoryBytes();
-  
+
   if (cgroup_used_bytes != kNull && cgroup_total_bytes != kNull) {
     if (cgroup_total_bytes < system_total_bytes) {
       // Cgroup limit is less than system memory, use cgroup data

--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -102,6 +102,10 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetMemoryBytes() {
   auto [system_used_bytes, system_total_bytes] = GetLinuxMemoryBytes();
 
   if (cgroup_used_bytes != kNull && cgroup_total_bytes != kNull) {
+    // If system memory data is invalid, use cgroup data
+    if (system_total_bytes == kNull || system_used_bytes == kNull) {
+      return {cgroup_used_bytes, cgroup_total_bytes};
+    }
     if (cgroup_total_bytes < system_total_bytes) {
       // Cgroup limit is less than system memory, use cgroup data
       return {cgroup_used_bytes, cgroup_total_bytes};

--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -100,15 +100,24 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetMemoryBytes() {
   RAY_CHECK(false) << "Memory monitor currently supports only linux";
 #endif
   auto [system_used_bytes, system_total_bytes] = GetLinuxMemoryBytes();
-  /// cgroup memory limit can be higher than system memory limit when it is
-  /// not used. We take its value only when it is less than or equal to system memory
-  /// limit. TODO(clarng): find a better way to detect cgroup memory limit is used.
-  system_total_bytes = NullableMin(system_total_bytes, cgroup_total_bytes);
-  /// This assumes cgroup total bytes will look different than system (meminfo)
-  if (system_total_bytes == cgroup_total_bytes) {
-    system_used_bytes = cgroup_used_bytes;
+  
+  if (cgroup_used_bytes != kNull && cgroup_total_bytes != kNull) {
+    if (cgroup_total_bytes < system_total_bytes) {
+      // Cgroup limit is less than system memory, use cgroup data
+      return {cgroup_used_bytes, cgroup_total_bytes};
+    }
+    // Cgroup limit >= system memory, use cgroup used_bytes but system total_bytes
+    if (cgroup_used_bytes > system_total_bytes) {
+      // If cgroup used_bytes exceeds system total_bytes, fall back to system data
+      RAY_LOG_EVERY_MS(WARNING, kLogIntervalMs)
+          << "Cgroup used_bytes (" << cgroup_used_bytes
+          << ") exceeds system total_bytes (" << system_total_bytes
+          << "), falling back to system memory data";
+      return {system_used_bytes, system_total_bytes};
+    }
+    return {cgroup_used_bytes, system_total_bytes};
   }
-  return std::tuple(system_used_bytes, system_total_bytes);
+  return {system_used_bytes, system_total_bytes};
 }
 
 int64_t MemoryMonitor::GetCGroupMemoryUsedBytes(const char *stat_path,

--- a/src/ray/common/tests/memory_monitor_test.cc
+++ b/src/ray/common/tests/memory_monitor_test.cc
@@ -482,7 +482,6 @@ TEST_F(MemoryMonitorTest, TestGetProcessMemoryUsageFiltersBadPids) {
   ASSERT_TRUE(usage.contains(1));
 }
 
-
 TEST_F(MemoryMonitorTest, TestGetMemoryBytesUsesCGroupWhenLimitUnlimited) {
   auto &monitor = MakeMemoryMonitor(
       0,
@@ -491,10 +490,10 @@ TEST_F(MemoryMonitorTest, TestGetMemoryBytesUsesCGroupWhenLimitUnlimited) {
       [](bool is_usage_above_threshold,
          MemorySnapshot system_memory,
          float usage_threshold) { FAIL() << "Expected monitor to not run"; });
-  
+
   auto [cgroup_used_bytes, cgroup_total_bytes] = monitor.GetCGroupMemoryBytes();
   auto [used_bytes, total_bytes] = monitor.GetMemoryBytes();
-  
+
   ASSERT_LE(used_bytes, total_bytes);
   
   if (cgroup_used_bytes != kNull && cgroup_total_bytes != kNull) {

--- a/src/ray/common/tests/memory_monitor_test.cc
+++ b/src/ray/common/tests/memory_monitor_test.cc
@@ -495,7 +495,7 @@ TEST_F(MemoryMonitorTest, TestGetMemoryBytesUsesCGroupWhenLimitUnlimited) {
   auto [used_bytes, total_bytes] = monitor.GetMemoryBytes();
 
   ASSERT_LE(used_bytes, total_bytes);
-  
+
   if (cgroup_used_bytes != kNull && cgroup_total_bytes != kNull) {
     struct sysinfo info;
     ASSERT_EQ(sysinfo(&info), 0) << "Failed to get system info";

--- a/src/ray/common/tests/memory_monitor_test.cc
+++ b/src/ray/common/tests/memory_monitor_test.cc
@@ -495,17 +495,13 @@ TEST_F(MemoryMonitorTest, TestGetMemoryBytesUsesCGroupWhenLimitUnlimited) {
   auto [cgroup_used_bytes, cgroup_total_bytes] = monitor.GetCGroupMemoryBytes();
   auto [used_bytes, total_bytes] = monitor.GetMemoryBytes();
   
-  // Ensure used_bytes <= total_bytes
   ASSERT_LE(used_bytes, total_bytes);
   
   if (cgroup_used_bytes != kNull && cgroup_total_bytes != kNull) {
     if (cgroup_total_bytes < total_bytes) {
-      // When cgroup limit < system memory, should use cgroup data
       ASSERT_EQ(used_bytes, cgroup_used_bytes);
       ASSERT_EQ(total_bytes, cgroup_total_bytes);
     } else {
-      // When cgroup limit >= system memory, should use cgroup used_bytes
-      // but system total_bytes (or fall back to system if cgroup_used > system_total)
       ASSERT_LE(used_bytes, total_bytes);
       ASSERT_GT(total_bytes, 0);
     }


### PR DESCRIPTION
## Description

Fix memory monitor to exclude cache when CGroup limit is not set. Previously, the code only used CGroup memory data (excluding cache) when `system_total_bytes == cgroup_total_bytes`, which never matches when limit is unlimited, causing false OOM kills.

## Related issues

Fixes #59796

## Additional information

Refactor `GetMemoryBytes()` to use CGroup `used_bytes` when available, even if `cgroup_total_bytes >= system_total_bytes`. Add boundary check to ensure `used_bytes <= total_bytes` constraint.