### PR TITLE
[Core] migrate dashboard agent ports to GcsNodeInfo

### DIFF
--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-import json
 import logging
 import os
 import signal
@@ -233,27 +232,10 @@ class DashboardAgent:
             self.listen_port if self.http_server and launch_http_server else -1,
         )
 
-        if launch_http_server:
-            # Writes agent address to kv.
-            # DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX: <node_id> -> (ip, http_port, grpc_port)
-            # DASHBOARD_AGENT_ADDR_IP_PREFIX: <ip> -> (node_id, http_port, grpc_port)
-            # -1 should indicate that http server is not started.
-            http_port = -1 if not self.http_server else self.http_server.http_port
-            grpc_port = -1 if not self.server else self.grpc_port
-            put_by_node_id = self.gcs_client.async_internal_kv_put(
-                f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{self.node_id}".encode(),
-                json.dumps([self.ip, http_port, grpc_port]).encode(),
-                True,
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
-            put_by_ip = self.gcs_client.async_internal_kv_put(
-                f"{dashboard_consts.DASHBOARD_AGENT_ADDR_IP_PREFIX}{self.ip}".encode(),
-                json.dumps([self.node_id, http_port, grpc_port]).encode(),
-                True,
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
-
-            await asyncio.gather(put_by_node_id, put_by_ip)
+        # Note: Port information is now communicated to GCS via Raylet.
+        # Raylet reads the persisted port files and includes the ports in
+        # GcsNodeInfo when registering with GCS. This ensures Raylet is the
+        # sole writer to GCS. See issue #59666.
 
         tasks = [m.run(self.server) for m in modules]
 

--- a/python/ray/dashboard/modules/aggregator/tests/test_ray_actor_events.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_ray_actor_events.py
@@ -6,7 +6,6 @@ import pytest
 
 import ray
 import ray.dashboard.consts as dashboard_consts
-from ray._private import ray_constants
 from ray._private.test_utils import wait_for_condition
 from ray._raylet import GcsClient
 from ray.dashboard.tests.conftest import *  # noqa
@@ -20,16 +19,24 @@ def httpserver_listen_address():
 
 
 def wait_for_dashboard_agent_available(cluster):
+    from ray import NodeID
+    from ray.core.generated import gcs_pb2
+
     gcs_client = GcsClient(address=cluster.address)
+    node_id = NodeID.from_hex(cluster.head_node.node_id)
 
-    def get_dashboard_agent_address():
-        return gcs_client.internal_kv_get(
-            f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{cluster.head_node.node_id}".encode(),
-            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+    def is_dashboard_agent_ready():
+        node_info_dict = gcs_client.get_all_node_info(
             timeout=dashboard_consts.GCS_RPC_TIMEOUT_SECONDS,
+            state_filter=gcs_pb2.GcsNodeInfo.GcsNodeState.ALIVE,
         )
+        if node_id not in node_info_dict:
+            return False
+        node_info = node_info_dict[node_id]
+        # Dashboard agent is ready when metrics_agent_port is set (grpc port)
+        return node_info.metrics_agent_port > 0
 
-    wait_for_condition(lambda: get_dashboard_agent_address() is not None)
+    wait_for_condition(is_dashboard_agent_ready)
 
 
 def test_ray_actor_events(ray_start_cluster, httpserver):

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -18,14 +18,12 @@ from ray import NodeID
 from ray._common.network_utils import build_address
 from ray._common.pydantic_compat import BaseModel, Extra, Field, validator
 from ray._common.utils import get_or_create_event_loop, load_class
-from ray._private.ray_constants import KV_NAMESPACE_DASHBOARD
 from ray._private.runtime_env.packaging import (
     package_exists,
     pin_runtime_env_uri,
     upload_package_to_gcs,
 )
 from ray.dashboard.consts import (
-    DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX,
     GCS_RPC_TIMEOUT_SECONDS,
     RAY_CLUSTER_ACTIVITY_HOOK,
     TRY_TO_GET_AGENT_INFO_INTERVAL_SECONDS,
@@ -289,25 +287,26 @@ class JobHead(SubprocessModule):
 
     async def _fetch_agent_info(self, target_node_id: NodeID) -> Tuple[str, int, int]:
         """
-        Fetches agent info by the Node ID. May raise exception if there's network error or the
-        agent info is not found.
+        Fetches agent info by the Node ID from GcsNodeInfo. May raise exception
+        if there's network error or the agent info is not found.
 
         Returns: (ip, http_port, grpc_port)
         """
-        key = f"{DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{target_node_id.hex()}"
-        value = await self.gcs_client.async_internal_kv_get(
-            key,
-            namespace=KV_NAMESPACE_DASHBOARD,
-            timeout=GCS_RPC_TIMEOUT_SECONDS,
+        node_info_dict = await self.gcs_client.async_get_all_node_info(
+            node_id=target_node_id, timeout=GCS_RPC_TIMEOUT_SECONDS
         )
-        if not value:
+        if not node_info_dict or target_node_id not in node_info_dict:
             raise KeyError(
-                f"Agent info not found in internal KV for node {target_node_id}. "
+                f"Agent info not found in GCS for node {target_node_id}. "
                 "It's possible that the agent didn't launch successfully due to "
                 "port conflicts or other issues. Please check `dashboard_agent.log` "
                 "for more details."
             )
-        return json.loads(value.decode())
+        node_info = node_info_dict[target_node_id]
+        ip = node_info.node_manager_address
+        http_port = node_info.dashboard_agent_listen_port
+        grpc_port = node_info.metrics_agent_port
+        return [ip, http_port, grpc_port]
 
     @routes.get("/api/version")
     async def get_version(self, req: Request) -> Response:

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -306,7 +306,7 @@ class JobHead(SubprocessModule):
         ip = node_info.node_manager_address
         http_port = node_info.dashboard_agent_listen_port
         grpc_port = node_info.metrics_agent_port
-        return [ip, http_port, grpc_port]
+        return (ip, http_port, grpc_port)
 
     @routes.get("/api/version")
     async def get_version(self, req: Request) -> Response:

--- a/python/ray/dashboard/modules/job/tests/test_sdk.py
+++ b/python/ray/dashboard/modules/job/tests/test_sdk.py
@@ -11,17 +11,13 @@ import pytest
 import ray.experimental.internal_kv as kv
 from ray._common.test_utils import wait_for_condition
 from ray._private import worker
-from ray._private.ray_constants import (
-    KV_NAMESPACE_DASHBOARD,
-    PROCESS_TYPE_DASHBOARD,
-)
+from ray._private.ray_constants import PROCESS_TYPE_DASHBOARD
 from ray._private.test_utils import (
     format_web_url,
     wait_until_server_available,
 )
 from ray._raylet import GcsClient
 from ray.dashboard.consts import (
-    DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX,
     GCS_RPC_TIMEOUT_SECONDS,
     RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR,
 )
@@ -170,12 +166,17 @@ def test_temporary_uri_reference(monkeypatch, expiration_s):
 
 
 def get_register_agents_number(gcs_client):
-    keys = gcs_client.internal_kv_keys(
-        prefix=DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX,
-        namespace=KV_NAMESPACE_DASHBOARD,
+    """Count the number of nodes with registered dashboard agents.
+
+    An agent is considered registered when its metrics_agent_port is set (> 0).
+    """
+    from ray.core.generated import gcs_pb2
+
+    node_info_dict = gcs_client.get_all_node_info(
         timeout=GCS_RPC_TIMEOUT_SECONDS,
+        state_filter=gcs_pb2.GcsNodeInfo.GcsNodeState.ALIVE,
     )
-    return len(keys)
+    return sum(1 for node in node_info_dict.values() if node.metrics_agent_port > 0)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -33,11 +33,7 @@ from ray.autoscaler._private.util import (
     parse_usage,
 )
 from ray.core.generated import gcs_pb2, node_manager_pb2, node_manager_pb2_grpc
-from ray.dashboard.consts import (
-    DASHBOARD_AGENT_ADDR_IP_PREFIX,
-    DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX,
-    GCS_RPC_TIMEOUT_SECONDS,
-)
+from ray.dashboard.consts import GCS_RPC_TIMEOUT_SECONDS
 from ray.dashboard.modules.node import actor_consts, node_consts
 from ray.dashboard.modules.node.datacenter import DataOrganizer, DataSource
 from ray.dashboard.modules.reporter.reporter_models import StatsPayload
@@ -264,22 +260,9 @@ class NodeHead(SubprocessModule):
         assert node["state"] in ["ALIVE", "DEAD"]
         is_alive = node["state"] == "ALIVE"
         if not is_alive:
-            # Remove the agent address from the internal KV.
-            keys = [
-                f"{DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{node_id}",
-                f"{DASHBOARD_AGENT_ADDR_IP_PREFIX}{node['nodeManagerAddress']}",
-            ]
-            tasks = [
-                self.gcs_client.async_internal_kv_del(
-                    key,
-                    del_by_prefix=False,
-                    namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-                    timeout=GCS_RPC_TIMEOUT_SECONDS,
-                )
-                for key in keys
-            ]
-            await asyncio.gather(*tasks)
-
+            # Note: Agent address cleanup from internal KV is no longer needed.
+            # Agent port info is now stored in GcsNodeInfo, which is automatically
+            # managed by GCS when nodes die. See issue #59666.
             self._dead_node_queue.append(node_id)
             if len(self._dead_node_queue) > node_consts.MAX_DEAD_NODES_TO_CACHE:
                 node_id = self._dead_node_queue.popleft()

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -25,7 +25,7 @@ from ray._private.ray_constants import (
     env_integer,
 )
 from ray.autoscaler._private.commands import debug_status
-from ray.core.generated import reporter_pb2, reporter_pb2_grpc
+from ray.core.generated import gcs_pb2, reporter_pb2, reporter_pb2_grpc
 from ray.dashboard.consts import GCS_RPC_TIMEOUT_SECONDS
 from ray.dashboard.modules.reporter.utils import HealthChecker
 from ray.dashboard.state_aggregator import StateAPIManager
@@ -856,6 +856,8 @@ class ReportHead(SubprocessModule):
             timeout=GCS_RPC_TIMEOUT_SECONDS
         )
         for node_id, node_info in node_info_dict.items():
+            if node_info.state != gcs_pb2.GcsNodeInfo.GcsNodeState.ALIVE:
+                continue
             if node_info.node_manager_address == ip:
                 http_port = node_info.dashboard_agent_listen_port
                 grpc_port = node_info.metrics_agent_port

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -147,17 +147,24 @@ def test_basic(ray_start_regular):
 
     check_agent_register(raylet_proc, agent_pid)
 
-    # Check kv keys are set.
-    logger.info("Check kv keys are set.")
+    # Check dashboard address kv key is set.
+    logger.info("Check dashboard kv keys are set.")
     dashboard_address = ray.experimental.internal_kv._internal_kv_get(
         ray_constants.DASHBOARD_ADDRESS, namespace=ray_constants.KV_NAMESPACE_DASHBOARD
     )
     assert dashboard_address is not None
-    key = f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{node_id}"
-    agent_addr = ray.experimental.internal_kv._internal_kv_get(
-        key, namespace=ray_constants.KV_NAMESPACE_DASHBOARD
-    )
-    assert agent_addr is not None
+
+    # Check agent port info is available in GcsNodeInfo
+    logger.info("Check agent port info in GcsNodeInfo.")
+
+    def is_agent_port_available():
+        nodes = ray.nodes()
+        for node in nodes:
+            if node["NodeID"] == node_id:
+                return node.get("MetricsAgentPort", 0) > 0
+        return False
+
+    wait_for_condition(is_agent_port_available)
 
 
 @pytest.mark.skipif(
@@ -382,14 +389,16 @@ def test_http_get(enable_test_module, ray_start_with_dashboard):
                 raise ex
             assert dump_info["result"] is True
 
-            # Get agent ip and http port
+            # Get agent ip and http port from GcsNodeInfo
             node_id_hex = ray_start_with_dashboard["node_id"]
-            agent_addr = ray.experimental.internal_kv._internal_kv_get(
-                f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{node_id_hex}",
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
-            assert agent_addr is not None
-            node_ip, http_port, _ = json.loads(agent_addr)
+            node_ip = None
+            http_port = None
+            for node in ray.nodes():
+                if node["NodeID"] == node_id_hex:
+                    node_ip = node["NodeManagerAddress"]
+                    http_port = node.get("DashboardAgentListenPort", 0)
+                    break
+            assert node_ip is not None and http_port > 0
 
             response = requests.get(
                 f"http://{build_address(node_ip, http_port)}"

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1630,6 +1630,15 @@ Integration tests
 """
 
 
+def is_dashboard_agent_ready(node_id_hex: str) -> bool:
+    """Wait for the dashboard agent to be ready by checking MetricsAgentPort."""
+    nodes = ray.nodes()
+    for node in nodes:
+        if node["NodeID"] == node_id_hex:
+            return node.get("MetricsAgentPort", 0) > 0
+    return False
+
+
 @pytest.mark.asyncio
 async def test_state_data_source_client(ray_start_cluster):
     cluster = ray_start_cluster
@@ -1705,14 +1714,6 @@ async def test_state_data_source_client(ray_start_cluster):
     Test runtime env
     """
     wait_for_condition(lambda: len(ray.nodes()) == 2)
-
-    def is_dashboard_agent_ready(node_id_hex: str) -> bool:
-        # Wait for the dashboard agent to be ready by checking metricsAgentPort
-        nodes = ray.nodes()
-        for node in nodes:
-            if node["NodeID"] == node_id_hex:
-                return node.get("MetricsAgentPort", 0) > 0
-        return False
 
     for node in ray.nodes():
         node_id = node["NodeID"]
@@ -1865,18 +1866,9 @@ async def test_state_data_source_client_limit_distributed_sources(ray_start_clus
     """
     Test runtime env
     """
-
-    def is_dashboard_agent_ready_v2(node_id_hex: str) -> bool:
-        # Wait for the dashboard agent to be ready by checking metricsAgentPort
-        nodes = ray.nodes()
-        for node in nodes:
-            if node["NodeID"] == node_id_hex:
-                return node.get("MetricsAgentPort", 0) > 0
-        return False
-
     for node in ray.nodes():
         node_id = node["NodeID"]
-        wait_for_condition(lambda nid=node_id: is_dashboard_agent_ready_v2(nid))
+        wait_for_condition(lambda nid=node_id: is_dashboard_agent_ready(nid))
 
     @ray.remote
     class Actor:


### PR DESCRIPTION
## Description

This PR makes Raylet the sole writer to GCS by removing the legacy logic where the dashboard agent writes its port information directly to GCS's internal KV store.

### Background

Previously, the dashboard agent wrote port information to two internal KV keys:
- **`DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX:{node_id}`** → `[ip, http_port, grpc_port]`
- **`DASHBOARD_AGENT_ADDR_IP_PREFIX:{ip}`** → `[node_id, http_port, grpc_port]`

After #59613, Raylet already:
1. Discovers agent ports via `persist_port()` files written by the dashboard agent
2. Includes port info in `GcsNodeInfo` during node registration
3. Serves as the single source of truth for node metadata in GCS

This PR removes the redundant KV writes and updates all consumers to read from `GcsNodeInfo` instead.


### Architecture After This Change

<img width="2037" height="1321" alt="image" src="https://github.com/user-attachments/assets/bd985b95-b927-46fe-a98d-32f7d81f6adc" />


## Related issues

Fixes #59666

## Additional information

### Files Modified

| Category | Files |
|----------|-------|
| Core logic | `dashboard/agent.py`, `util/state/state_manager.py`, `dashboard/modules/reporter/reporter_head.py`, `dashboard/modules/job/job_head.py`, `dashboard/modules/node/node_head.py` |
| Tests | `_private/test_utils.py`, `tests/test_state_api.py`, `tests/test_ray_event_export_task_events.py`, `dashboard/tests/test_dashboard.py`, `dashboard/modules/job/tests/test_sdk.py`, `dashboard/modules/aggregator/tests/test_aggregator_agent.py`, `dashboard/modules/aggregator/tests/test_ray_actor_events.py` |

### Backward Compatibility

- The internal KV keys are no longer written or read
- Constants `DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX` and `DASHBOARD_AGENT_ADDR_IP_PREFIX` still exist but are unused
- No external API changes
