### PR TITLE
[data][llm] Allow tokenized_prompt without prompt in vLLMEngineStage

### DIFF
--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -522,7 +522,9 @@ class vLLMEngineWrapper:
         async for request_output in stream:
             if request_output.finished:
                 # Bypass the original full prompt.
-                request_output.prompt = request.prompt if request.prompt is not None else ""
+                request_output.prompt = (
+                    request.prompt if request.prompt is not None else ""
+                )
                 return request_output
 
         raise RuntimeError(
@@ -651,7 +653,10 @@ class vLLMEngineStageUDF(StatefulStageUDF):
                 )
 
         original_expected_keys = self.expected_input_keys.copy()
-        self.expected_input_keys = self.expected_input_keys - {"prompt", "tokenized_prompt"}
+        self.expected_input_keys = self.expected_input_keys - {
+            "prompt",
+            "tokenized_prompt",
+        }
 
         try:
             super().validate_inputs(inputs)

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -632,7 +632,7 @@ class vLLMEngineStageUDF(StatefulStageUDF):
 
     def validate_inputs(self, inputs: List[Dict[str, Any]]):
         """Validate the inputs to make sure the required keys are present.
-        
+
         Overrides base class to handle the requirement for prompt/tokenized_prompt.
 
         Args:

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pydantic
 import pytest
+from transformers import AutoTokenizer
 
 import ray
 from ray.data.llm import build_processor, vLLMEngineProcessorConfig
@@ -248,7 +249,6 @@ def test_generation_model(gpu_type, model_opt_125m, backend):
 
 
 def test_generation_model_tokenized_prompt(gpu_type, model_opt_125m):
-    from transformers import AutoTokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_opt_125m, trust_remote_code=True)
 
     processor_config = vLLMEngineProcessorConfig(
@@ -339,7 +339,10 @@ def test_generation_model_missing_prompt_and_tokenized_prompt(gpu_type, model_op
         ds = ds.materialize()
 
     error_str = str(exc_info.value)
-    assert "Either 'prompt' (text) or 'tokenized_prompt' (tokens) must be provided" in error_str
+    assert (
+        "Either 'prompt' (text) or 'tokenized_prompt' (tokens) must be provided"
+        in error_str
+    )
 
 
 def test_embedding_model(gpu_type, model_smolvlm_256m):

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -7,6 +7,7 @@ from transformers import AutoTokenizer
 
 import ray
 from ray.data.llm import build_processor, vLLMEngineProcessorConfig
+from ray.exceptions import UserCodeException
 from ray.llm._internal.batch.constants import vLLMTaskType
 from ray.llm._internal.batch.processor import ProcessorBuilder
 from ray.llm._internal.batch.stages.configs import (
@@ -338,10 +339,10 @@ def test_generation_model_missing_prompt_and_tokenized_prompt(gpu_type, model_op
         ds = processor(ds)
         ds = ds.materialize()
 
-    error_str = str(exc_info.value)
-    assert (
-        "Either 'prompt' (text) or 'tokenized_prompt' (tokens) must be provided"
-        in error_str
+    assert isinstance(exc_info.value, ray.exceptions.RayTaskError)
+    assert isinstance(exc_info.value.cause, UserCodeException)
+    assert "Either 'prompt' or 'prompt_token_ids' must be provided" in str(
+        exc_info.value
     )
 
 


### PR DESCRIPTION
## Description
When using vLLMEngineProcessor, vLLMEngineStage only requires either `prompt` or `tokenized_prompt` to be present. However, the current implementation raises a validation error when prompt is missing.

This PR updates the validation logic in vLLMEngineStage to allow inputs where the `prompt` column is absent, as long as `tokenized_prompt` is provided. If both `prompt` and `tokenized_prompt` are present, the existing behavior is preserved where `tokenized_prompt` is preferred and tokens are passed directly to the engine.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
