### PR TITLE
[data][llm] Avoid passing enums through fn_constructor_kwargs

### DIFF
--- a/python/ray/llm/_internal/batch/constants.py
+++ b/python/ray/llm/_internal/batch/constants.py
@@ -1,7 +1,18 @@
 from typing import Literal
 
 
-class vLLMTaskType:
+class TaskType:
+    @classmethod
+    def values(cls):
+        """Return a set of all valid task type values."""
+        return {
+            value
+            for key, value in vars(cls).items()
+            if not key.startswith("_") and isinstance(value, str)
+        }
+
+
+class vLLMTaskType(TaskType):
     """The type of task to run on the vLLM engine."""
 
     # Generate text.
@@ -16,14 +27,13 @@ class vLLMTaskType:
     # Scoring (e.g., cross-encoder models).
     SCORE = "score"
 
-    @classmethod
-    def values(cls):
-        """Return a set of all valid task type values."""
-        return {
-            value
-            for key, value in vars(cls).items()
-            if not key.startswith("_") and isinstance(value, str)
-        }
+
+class SGLangTaskType(TaskType):
+    """The type of task to run on the SGLang engine."""
+
+    # Generate text.
+    GENERATE = "generate"
 
 
 TypeVLLMTaskType = Literal[tuple(vLLMTaskType.values())]
+TypeSGLangTaskType = Literal[tuple(SGLangTaskType.values())]

--- a/python/ray/llm/_internal/batch/constants.py
+++ b/python/ray/llm/_internal/batch/constants.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+
 class vLLMTaskType:
     """The type of task to run on the vLLM engine."""
 
@@ -23,5 +24,6 @@ class vLLMTaskType:
             for key, value in vars(cls).items()
             if not key.startswith("_") and isinstance(value, str)
         }
+
 
 TypeVLLMTaskType = Literal[tuple(vLLMTaskType.values())]

--- a/python/ray/llm/_internal/batch/constants.py
+++ b/python/ray/llm/_internal/batch/constants.py
@@ -1,0 +1,27 @@
+from typing import Literal
+
+class vLLMTaskType:
+    """The type of task to run on the vLLM engine."""
+
+    # Generate text.
+    GENERATE = "generate"
+
+    # Generate embeddings.
+    EMBED = "embed"
+
+    # Classification (e.g., sequence classification models).
+    CLASSIFY = "classify"
+
+    # Scoring (e.g., cross-encoder models).
+    SCORE = "score"
+
+    @classmethod
+    def values(cls):
+        """Return a set of all valid task type values."""
+        return {
+            value
+            for key, value in vars(cls).items()
+            if not key.startswith("_") and isinstance(value, str)
+        }
+
+TypeVLLMTaskType = Literal[tuple(vLLMTaskType.values())]

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -1,5 +1,6 @@
 """The vLLM engine processor."""
 
+import logging
 from typing import Any, Dict, List, Literal, Optional
 
 import transformers
@@ -7,6 +8,7 @@ from pydantic import ConfigDict, Field, root_validator
 
 import ray
 from ray.data.block import UserDefinedFunction
+from ray.llm._internal.batch.constants import TypeVLLMTaskType, vLLMTaskType
 from ray.llm._internal.batch.observability.usage_telemetry.usage import (
     BatchModelTelemetry,
     TelemetryAgent,
@@ -38,7 +40,6 @@ from ray.llm._internal.batch.stages.configs import (
     TokenizerStageConfig,
     resolve_stage_config,
 )
-from ray.llm._internal.batch.stages.vllm_engine_stage import vLLMTaskType
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.observability.telemetry_utils import DEFAULT_GPU_TYPE
 from ray.llm._internal.common.utils.download_utils import (
@@ -46,6 +47,9 @@ from ray.llm._internal.common.utils.download_utils import (
     NodeModelDownloadable,
     download_model_files,
 )
+
+logger = logging.getLogger(__name__)
+
 
 DEFAULT_MODEL_ARCHITECTURE = "UNKNOWN_MODEL_ARCHITECTURE"
 
@@ -75,7 +79,7 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
         "https://docs.vllm.ai/en/latest/serving/engine_args.html "
         "for more details.",
     )
-    task_type: vLLMTaskType = Field(
+    task_type: TypeVLLMTaskType = Field(
         default=vLLMTaskType.GENERATE,
         description="The task type to use. If not specified, will use "
         "'generate' by default.",
@@ -100,8 +104,22 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
 
     @root_validator(pre=True)
     def validate_task_type(cls, values):
-        task_type_str = values.get("task_type", "generate")
-        values["task_type"] = vLLMTaskType(task_type_str)
+        task_type = values.get("task_type", vLLMTaskType.GENERATE)
+        if task_type not in vLLMTaskType.values():
+            raise ValueError(f"Invalid task type: {task_type}")
+
+        engine_kwargs = values.get("engine_kwargs", {})
+        engine_kwargs_task = engine_kwargs.get("task", "")
+        if engine_kwargs_task != task_type:
+            logger.warning(
+                "The task set in engine kwargs (%s) is different from the "
+                "stage (%s). Overriding the task in engine kwargs to %s.",
+                engine_kwargs_task,
+                task_type,
+                task_type
+            )
+            engine_kwargs["task"] = task_type
+        values["engine_kwargs"] = engine_kwargs
         return values
 
     @root_validator(pre=True)
@@ -325,7 +343,7 @@ def build_vllm_engine_processor(
             batch_size=config.batch_size,
             accelerator_type=config.accelerator_type or DEFAULT_GPU_TYPE,
             concurrency=config.concurrency,
-            task_type=vLLMTaskType(config.task_type),
+            task_type=config.task_type,
             pipeline_parallel_size=config.engine_kwargs.get(
                 "pipeline_parallel_size", 1
             ),

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -116,7 +116,7 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
                 "stage (%s). Overriding the task in engine kwargs to %s.",
                 engine_kwargs_task,
                 task_type,
-                task_type
+                task_type,
             )
             engine_kwargs["task"] = task_type
         values["engine_kwargs"] = engine_kwargs

--- a/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
@@ -5,11 +5,11 @@ import logging
 import time
 import uuid
 from contextlib import nullcontext
-from enum import Enum
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Type
 
 from pydantic import BaseModel, root_validator
 
+from ray.llm._internal.batch.constants import SGLangTaskType, TypeSGLangTaskType
 from ray.llm._internal.batch.stages.base import (
     StatefulStage,
     StatefulStageUDF,
@@ -17,13 +17,6 @@ from ray.llm._internal.batch.stages.base import (
 from ray.llm._internal.batch.stages.common import maybe_convert_ndarray_to_list
 
 logger = logging.getLogger(__name__)
-
-
-class SGLangTaskType(str, Enum):
-    """The type of task to run on the SGLang engine."""
-
-    """Generate text."""
-    GENERATE = "generate"
 
 
 class SGLangEngineRequest(BaseModel):
@@ -240,7 +233,7 @@ class SGLangEngineStageUDF(StatefulStageUDF):
         expected_input_keys: List[str],
         model: str,
         engine_kwargs: Dict[str, Any],
-        task_type: SGLangTaskType = SGLangTaskType.GENERATE,
+        task_type: TypeSGLangTaskType = SGLangTaskType.GENERATE,
         max_pending_requests: Optional[int] = None,
     ):
         """
@@ -260,7 +253,7 @@ class SGLangEngineStageUDF(StatefulStageUDF):
 
         # Setup SGLang engine kwargs.
         self.task_type = task_type
-        self.engine_kwargs = self.normalize_engine_kwargs(task_type, engine_kwargs)
+        self.engine_kwargs = self.normalize_engine_kwargs(engine_kwargs)
 
         # Set up the max pending requests.
         # Disable the semaphore if max_pending_requests is not set.
@@ -278,14 +271,12 @@ class SGLangEngineStageUDF(StatefulStageUDF):
 
     def normalize_engine_kwargs(
         self,
-        task_type: SGLangTaskType,
         engine_kwargs: Dict[str, Any],
     ) -> Dict[str, Any]:
         """
         Normalize the engine kwargs.
 
         Args:
-            task_type: The task to use for the SGLang engine (e.g., "generate", etc).
             engine_kwargs: The kwargs to normalize.
 
         Returns:
@@ -300,18 +291,6 @@ class SGLangEngineStageUDF(StatefulStageUDF):
                 model,
                 self.model,
             )
-
-        # Override the task if it is different from the stage.
-        task = SGLangTaskType(engine_kwargs.get("task", task_type))
-        if task != task_type:
-            logger.warning(
-                "The task set in engine kwargs (%s) is different from the "
-                "stage (%s). Overriding the task in engine kwargs to %s.",
-                task,
-                task_type,
-                task_type,
-            )
-        engine_kwargs["task"] = task_type
         return engine_kwargs
 
     async def udf(self, batch: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -543,6 +543,7 @@ class vLLMEngineStageUDF(StatefulStageUDF):
         self.should_continue_on_error = should_continue_on_error
 
         # Setup vLLM engine kwargs.
+        self.task_type = task_type
         self.engine_kwargs = self.normalize_engine_kwargs(engine_kwargs)
 
         # Set up the max pending requests.

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -8,7 +8,6 @@ import math
 import time
 import uuid
 from collections import Counter
-from enum import Enum
 from functools import partial
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Tuple, Type
 
@@ -22,6 +21,7 @@ else:
     MultiModalDataDict = Any
 
 import ray
+from ray.llm._internal.batch.constants import TypeVLLMTaskType, vLLMTaskType
 from ray.llm._internal.batch.stages.base import (
     StatefulStage,
     StatefulStageUDF,
@@ -52,22 +52,6 @@ except ImportError:
 
 # Length of prompt snippet to surface in case of recoverable error
 _MAX_PROMPT_LENGTH_IN_ERROR = 500
-
-
-class vLLMTaskType(str, Enum):
-    """The type of task to run on the vLLM engine."""
-
-    """Generate text."""
-    GENERATE = "generate"
-
-    """Generate embeddings."""
-    EMBED = "embed"
-
-    """Classification (e.g., sequence classification models)."""
-    CLASSIFY = "classify"
-
-    """Scoring (e.g., cross-encoder models)."""
-    SCORE = "score"
 
 
 class vLLMEngineRequest(BaseModel):
@@ -249,9 +233,6 @@ class vLLMEngineWrapper:
         self.lora_lock = asyncio.Lock()
         self.lora_name_to_request = {}
 
-        # Convert the task type back to a string to pass to the engine.
-        kwargs["task"] = self.task_type.value
-
         try:
             import vllm
         except ImportError as e:
@@ -398,7 +379,7 @@ class vLLMEngineWrapper:
             pooling_params = row.pop("pooling_params", {})
             params = vllm.PoolingParams(
                 **maybe_convert_ndarray_to_list(pooling_params),
-                task=self.task_type.value,
+                task=self.task_type,
             )
         else:
             raise ValueError(f"Unsupported task type: {self.task_type}")
@@ -535,7 +516,7 @@ class vLLMEngineStageUDF(StatefulStageUDF):
         max_concurrent_batches: int,
         model: str,
         engine_kwargs: Dict[str, Any],
-        task_type: vLLMTaskType = vLLMTaskType.GENERATE,
+        task_type: TypeVLLMTaskType = vLLMTaskType.GENERATE,
         max_pending_requests: Optional[int] = None,
         dynamic_lora_loading_path: Optional[str] = None,
         should_continue_on_error: bool = False,
@@ -562,8 +543,7 @@ class vLLMEngineStageUDF(StatefulStageUDF):
         self.should_continue_on_error = should_continue_on_error
 
         # Setup vLLM engine kwargs.
-        self.task_type = task_type
-        self.engine_kwargs = self.normalize_engine_kwargs(task_type, engine_kwargs)
+        self.engine_kwargs = self.normalize_engine_kwargs(engine_kwargs)
 
         # Set up the max pending requests.
         pp_size = self.engine_kwargs.get("pipeline_parallel_size", 1)
@@ -615,14 +595,12 @@ class vLLMEngineStageUDF(StatefulStageUDF):
 
     def normalize_engine_kwargs(
         self,
-        task_type: vLLMTaskType,
         engine_kwargs: Dict[str, Any],
     ) -> Dict[str, Any]:
         """
         Normalize the engine kwargs.
 
         Args:
-            task_type: The task to use for the vLLM engine (e.g., "generate", "embed", etc).
             engine_kwargs: The kwargs to normalize.
 
         Returns:
@@ -637,18 +615,6 @@ class vLLMEngineStageUDF(StatefulStageUDF):
                 model,
                 self.model,
             )
-
-        # Override the task if it is different from the stage.
-        task = vLLMTaskType(engine_kwargs.get("task", task_type))
-        if task != task_type:
-            logger.warning(
-                "The task set in engine kwargs (%s) is different from the "
-                "stage (%s). Overriding the task in engine kwargs to %s.",
-                task,
-                task_type,
-                task_type,
-            )
-        engine_kwargs["task"] = task_type
         return engine_kwargs
 
     async def _generate_with_error_handling(
@@ -871,7 +837,7 @@ class vLLMEngineStage(StatefulStage):
         map_batches_kwargs.update(ray_remote_args)
         return values
 
-    def _get_task_type(self) -> vLLMTaskType:
+    def _get_task_type(self) -> TypeVLLMTaskType:
         return self.fn_constructor_kwargs.get("task_type", vLLMTaskType.GENERATE)
 
     def get_required_input_keys(self) -> Dict[str, str]:

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -6,6 +6,7 @@ import pytest
 
 import ray
 from ray.data.llm import SGLangEngineProcessorConfig
+from ray.llm._internal.batch.constants import SGLangTaskType
 from ray.llm._internal.batch.processor import ProcessorBuilder
 
 
@@ -50,8 +51,9 @@ def test_sglang_engine_processor(gpu_type, model_llama_3_2_216M):
             "dp_size": 2,
             "disable_cuda_graph": True,
             "dtype": "half",
+            "task": SGLangTaskType.GENERATE,
         },
-        "task_type": "generate",
+        "task_type": SGLangTaskType.GENERATE,
         "max_pending_requests": 111,
     }
 

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -96,7 +96,9 @@ def test_vllm_engine_processor_task_override(model_opt_125m):
 
 
 def test_vllm_engine_processor_invalid_task(model_opt_125m):
-    with pytest.raises(pydantic.ValidationError, match="Invalid task type: invalid_task"):
+    with pytest.raises(
+        pydantic.ValidationError, match="Invalid task type: invalid_task"
+    ):
         vLLMEngineProcessorConfig(
             model_source=model_opt_125m,
             engine_kwargs=dict(
@@ -110,6 +112,7 @@ def test_vllm_engine_processor_invalid_task(model_opt_125m):
             detokenize_stage=DetokenizeStageConfig(enabled=True),
             prepare_image_stage=PrepareImageStageConfig(enabled=True),
         )
+
 
 def test_vllm_engine_processor_placement_group(gpu_type, model_opt_125m):
     config = vLLMEngineProcessorConfig(

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -1,10 +1,12 @@
 import sys
 from unittest.mock import MagicMock, patch
 
+import pydantic
 import pytest
 
 import ray
 from ray.data.llm import build_processor, vLLMEngineProcessorConfig
+from ray.llm._internal.batch.constants import vLLMTaskType
 from ray.llm._internal.batch.processor import ProcessorBuilder
 from ray.llm._internal.batch.stages.configs import (
     ChatTemplateStageConfig,
@@ -71,6 +73,43 @@ def test_vllm_engine_processor(gpu_type, model_opt_125m):
         "num_gpus": 1,
     }
 
+
+def test_vllm_engine_processor_task_override(model_opt_125m):
+    config = vLLMEngineProcessorConfig(
+        model_source=model_opt_125m,
+        engine_kwargs=dict(
+            task=vLLMTaskType.EMBED,
+        ),
+        task_type=vLLMTaskType.GENERATE,
+        concurrency=4,
+        batch_size=64,
+        chat_template_stage=ChatTemplateStageConfig(enabled=True),
+        tokenize_stage=TokenizerStageConfig(enabled=True),
+        detokenize_stage=DetokenizeStageConfig(enabled=True),
+        prepare_image_stage=PrepareImageStageConfig(enabled=True),
+    )
+    processor = ProcessorBuilder.build(config)
+    stage = processor.get_stage_by_name("vLLMEngineStage")
+
+    assert stage.fn_constructor_kwargs["task_type"] == vLLMTaskType.GENERATE
+    assert stage.fn_constructor_kwargs["engine_kwargs"]["task"] == vLLMTaskType.GENERATE
+
+
+def test_vllm_engine_processor_invalid_task(model_opt_125m):
+    with pytest.raises(pydantic.ValidationError, match="Invalid task type: invalid_task"):
+        vLLMEngineProcessorConfig(
+            model_source=model_opt_125m,
+            engine_kwargs=dict(
+                task=vLLMTaskType.EMBED,
+            ),
+            task_type="invalid_task",
+            concurrency=4,
+            batch_size=64,
+            chat_template_stage=ChatTemplateStageConfig(enabled=True),
+            tokenize_stage=TokenizerStageConfig(enabled=True),
+            detokenize_stage=DetokenizeStageConfig(enabled=True),
+            prepare_image_stage=PrepareImageStageConfig(enabled=True),
+        )
 
 def test_vllm_engine_processor_placement_group(gpu_type, model_opt_125m):
     config = vLLMEngineProcessorConfig(

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -52,8 +52,9 @@ def test_vllm_engine_processor(gpu_type, model_opt_125m):
         "engine_kwargs": {
             "max_model_len": 8192,
             "distributed_executor_backend": "mp",
+            "task": vLLMTaskType.GENERATE,
         },
-        "task_type": "generate",
+        "task_type": vLLMTaskType.GENERATE,
         "max_pending_requests": 111,
         "dynamic_lora_loading_path": None,
         "max_concurrent_batches": 8,

--- a/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
@@ -151,6 +151,9 @@ async def test_sglang_engine_udf_basic(mock_sglang_wrapper, model_llama_3_2_216M
         engine_kwargs={
             # Test that this should be overridden by the stage.
             "model": "random-model",
+            # When reaching SGLangEngineStageUDF, this kwargs has been inserted by the processor
+            # even though it is unset in the processor config.
+            "task": SGLangTaskType.GENERATE,
         },
     )
 

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -7,12 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
+from ray.llm._internal.batch.constants import vLLMTaskType
 from ray.llm._internal.batch.stages.vllm_engine_stage import (
     vLLMEngineStage,
     vLLMEngineStageUDF,
     vLLMEngineWrapper,
     vLLMOutputData,
-    vLLMTaskType,
 )
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -129,7 +129,8 @@ async def test_vllm_engine_udf_basic(mock_vllm_wrapper, model_llama_3_2_216M):
         engine_kwargs={
             # Test that this should be overridden by the stage.
             "model": "random-model",
-            # Test that this should be overridden by the stage.
+            # This is overriden in the processor, so it remains unchanged when we bypass
+            # the processor and pass it directly to the stage via vLLMEngineStageUDF.
             "task": vLLMTaskType.EMBED,
             "max_num_seqs": 100,
             "disable_log_stats": False,
@@ -138,7 +139,7 @@ async def test_vllm_engine_udf_basic(mock_vllm_wrapper, model_llama_3_2_216M):
 
     assert udf.model == model_llama_3_2_216M
     assert udf.task_type == vLLMTaskType.GENERATE
-    assert udf.engine_kwargs["task"] == vLLMTaskType.GENERATE
+    assert udf.engine_kwargs["task"] == vLLMTaskType.EMBED
     assert udf.engine_kwargs["max_num_seqs"] == 100
     assert udf.max_pending_requests == math.ceil(100 * 1.1)
 
@@ -169,7 +170,7 @@ async def test_vllm_engine_udf_basic(mock_vllm_wrapper, model_llama_3_2_216M):
         idx_in_batch_column="__idx_in_batch",
         disable_log_stats=False,
         max_pending_requests=111,
-        task=vLLMTaskType.GENERATE,
+        task=vLLMTaskType.EMBED,
         max_num_seqs=100,
         dynamic_lora_loading_path=None,
         enable_log_requests=False,


### PR DESCRIPTION
## Description
Ray Data LLM CI tests are failing on master with the following error:
```
E   KeyError: (109362531555888, '()', "{'batch_size': 16, 'max_concurrent_batches': 8, 'model': '/tmp/ray-llm-test-modelu44ykkdc',
'engine_kwargs': {'enable_prefix_caching': False, 'enable_chunked_prefill': True, 'max_num_batched_tokens': 2048,
'max_model_len': 2048, 'enforce_eager': True, 'distributed_executor_backend': 'ray', 'task': <vLLMTaskType.GENERATE: 'generate'>},
'task_type': <vLLMTaskType.GENERATE: 'generate'>, 'max_pending_requests': None, 'dynamic_lora_loading_path': None,
'should_continue_on_error': False, 'data_column': '__data', 'expected_input_keys': ['prompt', 'sampling_params']}")
```
This issue originates from #56725, which introduced hashing of `fn_constructor_kwargs` to generate cache keys for callable class UDF instances. That PR added [_CallableClassSpec.make_key()](https://github.com/ray-project/ray/blob/394cd2d5e0641d8ce4b44577da0f37dcedbac736/python/ray/data/expressions.py#L772), which produces hashable keys from constructor arguments so that Ray Data can deduplicate and reuse UDF instances with identical constructor arguments across actors.

However, we currently pass enum values ([vLLMTaskType](https://github.com/ray-project/ray/blob/6252a9dc51af2636a4f26c9cd4b0864e1e84a103/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py#L78)) as part of `fn_constructor_kwargs`. Hashing enum objects can lead to serialization inconsistencies across processes, since enum instances may serialize and deserialize differently. This causes cache key mismatches and ultimately results in KeyError when looking up cached UDF instances.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
