### PR TITLE
[build] add ray-wheel and ray-cpp wheel build targets

### DIFF
--- a/ci/build/test_wanda_targets.py
+++ b/ci/build/test_wanda_targets.py
@@ -12,8 +12,11 @@ from wanda_targets import (
     TARGETS,
     BuildContext,
     RayCore,
+    RayCppCore,
+    RayCppWheel,
     RayDashboard,
     RayJava,
+    RayWheel,
     build_env,
     create_context,
     detect_target_platform,
@@ -174,6 +177,71 @@ class TestRayJava:
     def test_build(self, ctx):
         RayJava(ctx).build()
         assert any("ray-java.wanda.yaml" in str(c) for c in ctx._commands)
+
+
+class TestRayWheel:
+    def test_spec(self):
+        assert "ray-wheel.wanda.yaml" in RayWheel.SPEC
+
+    def test_deps(self):
+        assert RayCore in RayWheel.DEPS
+        assert RayDashboard in RayWheel.DEPS
+        assert RayJava in RayWheel.DEPS
+
+    def test_build_includes_deps(self, ctx):
+        RayWheel(ctx).build()
+        wanda_calls = [c for c in ctx._commands if "wanda" in str(c[0])]
+        # Should build: ray-core, ray-dashboard, ray-java, ray-wheel
+        assert len(wanda_calls) == 4
+        assert any("ray-core" in str(c) for c in wanda_calls)
+        assert any("ray-wheel" in str(c) for c in wanda_calls)
+
+    def test_remote_image(self, ctx):
+        name = RayWheel(ctx).remote_image
+        assert IMAGE_PREFIX in name
+        assert "ray-wheel-py3.11" in name
+
+
+class TestRayCppCore:
+    def test_spec(self):
+        assert "ray-cpp-core.wanda.yaml" in RayCppCore.SPEC
+
+    def test_no_deps(self):
+        # RayCppCore only depends on manylinux base, not other ray images
+        assert RayCppCore.DEPS == ()
+
+    def test_build(self, ctx):
+        RayCppCore(ctx).build()
+        wanda_calls = [c for c in ctx._commands if "wanda" in str(c[0])]
+        # Should only build ray-cpp-core (no deps)
+        assert len(wanda_calls) == 1
+        assert any("ray-cpp-core.wanda.yaml" in str(c) for c in ctx._commands)
+
+
+class TestRayCppWheel:
+    def test_spec(self):
+        assert "ray-cpp-wheel.wanda.yaml" in RayCppWheel.SPEC
+
+    def test_deps(self):
+        assert RayCore in RayCppWheel.DEPS
+        assert RayCppCore in RayCppWheel.DEPS
+        assert RayJava in RayCppWheel.DEPS
+        assert RayDashboard in RayCppWheel.DEPS
+
+    def test_build_includes_all_deps(self, ctx):
+        RayCppWheel(ctx).build()
+        wanda_calls = [c for c in ctx._commands if "wanda" in str(c[0])]
+        # Should build: ray-core, ray-dashboard, ray-java, ray-cpp-core, ray-cpp-wheel
+        assert len(wanda_calls) == 5
+        assert any("ray-core" in str(c) for c in wanda_calls)
+        assert any("ray-dashboard" in str(c) for c in wanda_calls)
+        assert any("ray-java" in str(c) for c in wanda_calls)
+        assert any("ray-cpp-core" in str(c) for c in wanda_calls)
+        assert any("ray-cpp-wheel" in str(c) for c in wanda_calls)
+
+    def test_remote_image(self, ctx):
+        name = RayCppWheel(ctx).remote_image
+        assert "ray-cpp-wheel-py3.11" in name
 
 
 class TestExpandEnvVars:
@@ -486,15 +554,20 @@ class TestCreateContext:
 
 
 class TestDependencyDeduplication:
-    def test_target_built_once(self, ctx):
-        """Building the same target twice should only build it once."""
-        RayCore(ctx).build()
-        RayCore(ctx).build()
+    def test_shared_deps_built_once(self, ctx):
+        """When building both RayWheel and RayCppWheel, shared deps are built once."""
+        RayWheel(ctx).build()
+        RayCppWheel(ctx).build()
 
         wanda_calls = [c for c in ctx._commands if "wanda" in str(c[0])]
-        # Should only build ray-core once, not twice
-        assert len(wanda_calls) == 1
-        assert "ray-core.wanda.yaml" in str(wanda_calls[0])
+        # Should build: ray-core, ray-dashboard, ray-java, ray-wheel, ray-cpp-core, ray-cpp-wheel
+        # Shared deps (core, dashboard, java) should NOT be duplicated
+        assert len(wanda_calls) == 6
+        # Each spec should appear exactly once
+        specs = [str(c[1]) for c in wanda_calls]
+        assert specs.count("ci/docker/ray-core.wanda.yaml") == 1
+        assert specs.count("ci/docker/ray-dashboard.wanda.yaml") == 1
+        assert specs.count("ci/docker/ray-java.wanda.yaml") == 1
 
 
 if __name__ == "__main__":

--- a/ci/build/test_wanda_targets.py
+++ b/ci/build/test_wanda_targets.py
@@ -194,6 +194,8 @@ class TestRayWheel:
         # Should build: ray-core, ray-dashboard, ray-java, ray-wheel
         assert len(wanda_calls) == 4
         assert any("ray-core" in str(c) for c in wanda_calls)
+        assert any("ray-dashboard" in str(c) for c in wanda_calls)
+        assert any("ray-java" in str(c) for c in wanda_calls)
         assert any("ray-wheel" in str(c) for c in wanda_calls)
 
     def test_remote_image(self, ctx):
@@ -241,6 +243,7 @@ class TestRayCppWheel:
 
     def test_remote_image(self, ctx):
         name = RayCppWheel(ctx).remote_image
+        assert IMAGE_PREFIX in name
         assert "ray-cpp-wheel-py3.11" in name
 
 

--- a/ci/build/wanda_targets.py
+++ b/ci/build/wanda_targets.py
@@ -219,10 +219,27 @@ class RayJava(WandaDockerTarget):
     SPEC = "ci/docker/ray-java.wanda.yaml"
 
 
+class RayWheel(WandaDockerTarget):
+    SPEC = "ci/docker/ray-wheel.wanda.yaml"
+    DEPS = (RayCore, RayDashboard, RayJava)
+
+
+class RayCppCore(WandaDockerTarget):
+    SPEC = "ci/docker/ray-cpp-core.wanda.yaml"
+
+
+class RayCppWheel(WandaDockerTarget):
+    SPEC = "ci/docker/ray-cpp-wheel.wanda.yaml"
+    DEPS = (RayCore, RayCppCore, RayJava, RayDashboard)
+
+
 TARGETS: Dict[str, Type[BuildTarget]] = {
     "ray-core": RayCore,
     "ray-dashboard": RayDashboard,
     "ray-java": RayJava,
+    "ray-wheel": RayWheel,
+    "ray-cpp-core": RayCppCore,
+    "ray-cpp-wheel": RayCppWheel,
 }
 
 

--- a/ci/build/wanda_targets.py
+++ b/ci/build/wanda_targets.py
@@ -230,7 +230,7 @@ class RayCppCore(WandaDockerTarget):
 
 class RayCppWheel(WandaDockerTarget):
     SPEC = "ci/docker/ray-cpp-wheel.wanda.yaml"
-    DEPS = (RayCore, RayCppCore, RayJava, RayDashboard)
+    DEPS = (RayCore, RayCppCore, RayDashboard, RayJava)
 
 
 TARGETS: Dict[str, Type[BuildTarget]] = {

--- a/ci/docker/ray-cpp-core.Dockerfile
+++ b/ci/docker/ray-cpp-core.Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.3-labs
+#
+# Ray C++ Core Artifacts Builder
+# ==============================
+# Builds ray_cpp_pkg.zip containing C++ headers, libraries, and examples.
+#
+ARG ARCH_SUFFIX=
+ARG HOSTTYPE=x86_64
+ARG MANYLINUX_VERSION=251216.3835fc5
+FROM rayproject/manylinux2014:${MANYLINUX_VERSION}-jdk-${HOSTTYPE} AS builder
+
+ARG PYTHON_VERSION=3.10
+ARG BUILDKITE_BAZEL_CACHE_URL
+ARG BUILDKITE_CACHE_READONLY
+ARG HOSTTYPE
+
+WORKDIR /home/forge/ray
+
+COPY . .
+
+# Mounting cache dir for faster local rebuilds (architecture-specific to avoid toolchain conflicts)
+RUN --mount=type=cache,target=/home/forge/.cache,uid=2000,gid=100,id=bazel-cache-${HOSTTYPE}-${PYTHON_VERSION} \
+    <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+PY_CODE="${PYTHON_VERSION//./}"
+PY_BIN="cp${PY_CODE}-cp${PY_CODE}"
+export RAY_BUILD_ENV="manylinux_py${PY_BIN}"
+
+sudo ln -sf "/opt/python/${PY_BIN}/bin/python3" /usr/local/bin/python3
+sudo ln -sf /usr/local/bin/python3 /usr/local/bin/python
+
+if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+  echo "build --remote_upload_local_results=false" >> "$HOME/.bazelrc"
+fi
+
+echo "build --repository_cache=/home/forge/.cache/bazel-repo" >> "$HOME/.bazelrc"
+
+bazelisk build --config=ci //cpp:ray_cpp_pkg_zip
+
+cp bazel-bin/cpp/ray_cpp_pkg.zip /home/forge/ray_cpp_pkg.zip
+
+EOF
+
+FROM scratch
+
+COPY --from=builder /home/forge/ray_cpp_pkg.zip /

--- a/ci/docker/ray-cpp-core.wanda.yaml
+++ b/ci/docker/ray-cpp-core.wanda.yaml
@@ -1,0 +1,30 @@
+name: "ray-cpp-core-py$PYTHON_VERSION$ARCH_SUFFIX"
+froms: ["rayproject/manylinux2014:$MANYLINUX_VERSION-jdk-$HOSTTYPE"]
+dockerfile: ci/docker/ray-cpp-core.Dockerfile
+srcs:
+  - .bazelversion
+  - .bazelrc
+  - WORKSPACE
+  - BUILD.bazel
+  - bazel/
+  - thirdparty/
+  - src/
+  - cpp/
+  - python/ray/__init__.py
+  - python/ray/_raylet.pxd
+  - python/ray/_raylet.pyi
+  - python/ray/_raylet.pyx
+  - python/ray/includes/
+  - java/BUILD.bazel
+  - java/dependencies.bzl
+  - release/BUILD.bazel
+  - release/requirements.txt
+  - release/requirements_py310.txt
+build_args:
+  - PYTHON_VERSION
+  - ARCH_SUFFIX
+  - HOSTTYPE
+  - MANYLINUX_VERSION
+  - BUILDKITE_BAZEL_CACHE_URL
+build_hint_args:
+  - BUILDKITE_CACHE_READONLY

--- a/ci/docker/ray-cpp-wheel.wanda.yaml
+++ b/ci/docker/ray-cpp-wheel.wanda.yaml
@@ -1,0 +1,26 @@
+name: "ray-cpp-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"
+disable_caching: true
+froms:
+  - "rayproject/manylinux2014:$MANYLINUX_VERSION-jdk-$HOSTTYPE"
+  - "@ray-core-py$PYTHON_VERSION$ARCH_SUFFIX"      # C++ binaries (ray_pkg.zip)
+  - "@ray-cpp-core-py$PYTHON_VERSION$ARCH_SUFFIX"  # C++ headers/libs (ray_cpp_pkg.zip)
+  - "@ray-java-build$ARCH_SUFFIX"                  # Java JARs
+  - "@ray-dashboard"                               # Dashboard
+dockerfile: ci/docker/ray-wheel.Dockerfile
+srcs:
+  - pyproject.toml
+  - README.rst
+  - ci/build/build-manylinux-wheel.sh
+  - python/
+  - rllib/
+build_args:
+  - PYTHON_VERSION
+  - MANYLINUX_VERSION
+  - HOSTTYPE
+  - BUILDKITE_COMMIT
+  - ARCH_SUFFIX
+  - WHEEL_TYPE=cpp
+  - RAY_CORE_IMAGE=ray-core-py$PYTHON_VERSION$ARCH_SUFFIX
+  - RAY_CPP_CORE_IMAGE=ray-cpp-core-py$PYTHON_VERSION$ARCH_SUFFIX
+  - RAY_JAVA_IMAGE=ray-java-build$ARCH_SUFFIX
+  - RAY_DASHBOARD_IMAGE=ray-dashboard

--- a/ci/docker/ray-wheel.Dockerfile
+++ b/ci/docker/ray-wheel.Dockerfile
@@ -1,0 +1,129 @@
+# syntax=docker/dockerfile:1.3-labs
+#
+# Ray Wheel Builder (Unified)
+# ===========================
+# Builds manylinux2014-compatible wheels using pre-built C++ artifacts from wanda cache.
+#
+# Build Types:
+#   - ray wheel:     WHEEL_TYPE=ray (default) - Standard Ray Python wheel
+#   - ray-cpp wheel: WHEEL_TYPE=cpp          - Ray C++ API wheel
+#
+# GLIBC Compatibility:
+# --------------------
+# manylinux2014 requires GLIBC <= 2.17 for broad Linux compatibility.
+# The pre-built _raylet.so is compiled inside manylinux2014 with GLIBC 2.17.
+#
+
+ARG RAY_CORE_IMAGE
+ARG RAY_CPP_CORE_IMAGE=scratch
+ARG RAY_JAVA_IMAGE
+ARG RAY_DASHBOARD_IMAGE
+ARG MANYLINUX_VERSION
+ARG HOSTTYPE
+
+FROM ${RAY_CORE_IMAGE} AS ray-core
+FROM ${RAY_CPP_CORE_IMAGE} AS ray-cpp-core
+FROM ${RAY_JAVA_IMAGE} AS ray-java
+FROM ${RAY_DASHBOARD_IMAGE} AS ray-dashboard
+
+# Main build stage - manylinux2014 provides GLIBC 2.17
+FROM rayproject/manylinux2014:${MANYLINUX_VERSION}-jdk-${HOSTTYPE} AS builder
+
+ARG PYTHON_VERSION=3.10
+ARG BUILDKITE_COMMIT
+ARG WHEEL_TYPE=ray
+
+# Set environment variables for the build
+# - BUILDKITE_COMMIT: Used for ray.__commit__. Defaults to "unknown" for local builds.
+# - SKIP_BAZEL_BUILD=1: Skip bazel build, use pre-built artifacts from ray-core/ray-java/ray-dashboard
+# - RAY_DISABLE_EXTRA_CPP: 1 for ray wheel only, 0 for ray-cpp wheel
+# - WHEEL_TYPE: "ray" or "cpp" - determines which wheel to build
+ENV BUILDKITE_COMMIT=${BUILDKITE_COMMIT:-unknown} \
+    PYTHON_VERSION=${PYTHON_VERSION} \
+    SKIP_BAZEL_BUILD=1 \
+    WHEEL_TYPE=${WHEEL_TYPE}
+
+WORKDIR /home/forge/ray
+
+# Copy artifacts from all stages
+COPY --from=ray-core /ray_pkg.zip /tmp/
+COPY --from=ray-core /ray_py_proto.zip /tmp/
+COPY --from=ray-java /ray_java_pkg.zip /tmp/
+COPY --from=ray-dashboard /dashboard.tar.gz /tmp/
+
+# Source files needed for wheel build
+COPY --chown=2000:100 ci/build/build-manylinux-wheel.sh ci/build/
+COPY --chown=2000:100 README.rst pyproject.toml ./
+COPY --chown=2000:100 rllib/ rllib/
+COPY --chown=2000:100 python/ python/
+
+USER forge
+# Note: ray-cpp-core may be "scratch" (empty) for ray-only builds
+RUN --mount=from=ray-cpp-core,source=/,target=/ray-cpp-core,ro \
+    <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+PY_VERSION="${PYTHON_VERSION//./}"
+PY_BIN="cp${PY_VERSION}-cp${PY_VERSION}"
+
+# Verify required artifacts exist before unpacking
+for f in /tmp/ray_pkg.zip /tmp/ray_py_proto.zip /tmp/ray_java_pkg.zip /tmp/dashboard.tar.gz; do
+  [[ -f "$f" ]] || { echo "ERROR: missing artifact: $f"; exit 1; }
+done
+
+# Clean extraction dirs to avoid stale leftovers
+rm -rf /tmp/ray_pkg /tmp/ray_java_pkg /tmp/ray_cpp_pkg
+mkdir -p /tmp/ray_pkg /tmp/ray_java_pkg
+
+# Unpack common pre-built artifacts
+unzip -o /tmp/ray_pkg.zip -d /tmp/ray_pkg
+unzip -o /tmp/ray_py_proto.zip -d python/
+unzip -o /tmp/ray_java_pkg.zip -d /tmp/ray_java_pkg
+mkdir -p python/ray/dashboard/client/build
+tar -xzf /tmp/dashboard.tar.gz -C python/ray/dashboard/client/build/
+
+# C++ core artifacts
+cp -r /tmp/ray_pkg/ray/* python/ray/
+
+# Java JARs
+cp -r /tmp/ray_java_pkg/ray/* python/ray/
+
+# Handle wheel type specific setup
+if [[ "$WHEEL_TYPE" == "cpp" ]]; then
+  # C++ API artifacts (headers, libs, examples)
+  if [[ -f /ray-cpp-core/ray_cpp_pkg.zip ]]; then
+    mkdir -p /tmp/ray_cpp_pkg
+    unzip -o /ray-cpp-core/ray_cpp_pkg.zip -d /tmp/ray_cpp_pkg
+    cp -r /tmp/ray_cpp_pkg/ray/cpp python/ray/
+  else
+    echo "ERROR: ray_cpp_pkg.zip not found for cpp wheel build"
+    exit 1
+  fi
+  export RAY_DISABLE_EXTRA_CPP=0
+else
+  export RAY_DISABLE_EXTRA_CPP=1
+fi
+
+# Build wheels
+./ci/build/build-manylinux-wheel.sh "$PY_BIN"
+
+# Filter output based on wheel type
+if [[ "$WHEEL_TYPE" == "cpp" ]]; then
+  # Keep only ray-cpp wheel
+  rm -f .whl/ray-[0-9]*.whl
+fi
+
+# Sanity check: ensure wheels exist
+shopt -s nullglob
+wheels=(.whl/*.whl)
+if (( ${#wheels[@]} == 0 )); then
+  echo "ERROR: No wheels produced in .whl/"
+  ls -la .whl || true
+  exit 1
+fi
+
+EOF
+
+FROM scratch
+COPY --from=builder /home/forge/ray/.whl/*.whl /

--- a/ci/docker/ray-wheel.wanda.yaml
+++ b/ci/docker/ray-wheel.wanda.yaml
@@ -1,0 +1,24 @@
+name: "ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"
+disable_caching: true
+froms:
+  - "rayproject/manylinux2014:$MANYLINUX_VERSION-jdk-$HOSTTYPE"
+  - "@ray-core-py$PYTHON_VERSION$ARCH_SUFFIX"    # C++ binaries (ray_pkg.zip)
+  - "@ray-java-build$ARCH_SUFFIX"                # Java JARs
+  - "@ray-dashboard"                             # Dashboard
+dockerfile: ci/docker/ray-wheel.Dockerfile
+srcs:
+  - pyproject.toml
+  - README.rst
+  - ci/build/build-manylinux-wheel.sh
+  - python/
+  - rllib/
+build_args:
+  - PYTHON_VERSION
+  - MANYLINUX_VERSION
+  - HOSTTYPE
+  - BUILDKITE_COMMIT
+  - ARCH_SUFFIX
+  - WHEEL_TYPE=ray
+  - RAY_CORE_IMAGE=ray-core-py$PYTHON_VERSION$ARCH_SUFFIX
+  - RAY_JAVA_IMAGE=ray-java-build$ARCH_SUFFIX
+  - RAY_DASHBOARD_IMAGE=ray-dashboard


### PR DESCRIPTION
Wanda specs and build targets for wheel image generation:
- ray-wheel.wanda.yaml: Ray Python wheel (depends on core, dashboard, java)
- ray-cpp-core.wanda.yaml: Ray C++ core build
- ray-cpp-wheel.wanda.yaml: Ray C++ wheel (depends on core, cpp-core, java, dashboard)

Includes corresponding Dockerfiles and test coverage.

Topic: wanda-ray-wheel
Relative: wanda-local-targets
Signed-off-by: andrew <andrew@anyscale.com>