### PR TITLE
[build] add local wheel build script

### DIFF
--- a/ci/build/Makefile
+++ b/ci/build/Makefile
@@ -1,0 +1,75 @@
+# Ray Wheel Build
+#
+# Usage:
+#   make wheel [PY] [TARGET]
+#   python build_wheel_local.py [OPTIONS] [PYTHON_VERSION] [TARGET]
+
+.PHONY: wheel wheel-test wheel-clean matrix-wheels clean help print-vars
+
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+BUILD_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+WHEEL_DIR := $(ROOT)/.whl
+
+# Defaults (overridable via vars or positionals)
+PY ?= 3.10
+TARGET ?= ray              # ray|cpp|all
+DRY_RUN ?=                 # set to any value for dry-run
+
+PY_VERS ?= 3.11 3.12
+
+# Extra "goals" after a target are treated as args.
+ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+$(eval $(ARGS):;@:)
+
+help:
+	@echo "Usage (vars or positional):"
+	@echo ""
+	@echo "  wheel:"
+	@echo "    make wheel                        # defaults: PY=3.10 TARGET=ray"
+	@echo "    make wheel 3.12                   # PY=3.12 TARGET=ray"
+	@echo "    make wheel 3.12 cpp               # PY=3.12 TARGET=cpp"
+	@echo "    make wheel PY=3.12 TARGET=cpp"
+	@echo ""
+	@echo "  matrix:"
+	@echo "    make matrix-wheels TARGET=all PY_VERS='3.11 3.12'"
+	@echo ""
+	@echo "Other:"
+	@echo "  make wheel-clean"
+	@echo "  make clean"
+	@echo ""
+	@echo "Notes:"
+	@echo "  - Wheels are extracted to $(WHEEL_DIR)/"
+
+print-vars:
+	@echo "ROOT=$(ROOT)"
+	@echo "BUILD_DIR=$(BUILD_DIR)"
+	@echo "PY=$(PY)"
+	@echo "TARGET=$(TARGET)"
+	@echo "ARGS=$(ARGS)"
+	@echo "PY_VERS=$(PY_VERS)"
+	@echo "WHEEL_DIR=$(WHEEL_DIR)"
+
+wheel:
+	@set -e; \
+	py="$(PY)"; target="$(TARGET)"; \
+	if [ "$(strip $(ARGS))" != "" ]; then \
+	  set -- $(ARGS); \
+	  case "$$1" in 3.*) ;; *) echo "Error: positional usage requires python first: make wheel <3.x> [ray|cpp|all]"; exit 1;; esac; \
+	  py="$$1"; \
+	  if [ $$# -ge 2 ]; then target="$$2"; fi; \
+	  if [ $$# -gt 2 ]; then echo "Error: too many args. Usage: make wheel <3.x> [ray|cpp|all]"; exit 1; fi; \
+	fi; \
+	echo "==> wheel: PY=$$py TARGET=$$target"; \
+	python3 $(BUILD_DIR)/build_wheel_local.py $$py $$target $(if $(DRY_RUN),--dry-run)
+
+wheel-clean:
+	rm -rf $(WHEEL_DIR)/
+
+matrix-wheels:
+	@set -e; \
+	for py in $(PY_VERS); do \
+	  echo "==> wheels: PY=$$py TARGET=$(TARGET)"; \
+	  $(MAKE) wheel $$py $(TARGET); \
+	done
+
+clean: wheel-clean

--- a/ci/build/Makefile
+++ b/ci/build/Makefile
@@ -13,7 +13,6 @@ WHEEL_DIR := $(ROOT)/.whl
 # Defaults (overridable via vars or positionals)
 PY ?= 3.10
 TARGET ?= ray              # ray|cpp|all
-DRY_RUN ?=                 # set to any value for dry-run
 
 PY_VERS ?= 3.11 3.12
 
@@ -60,7 +59,7 @@ wheel:
 	  if [ $$# -gt 2 ]; then echo "Error: too many args. Usage: make wheel <3.x> [ray|cpp|all]"; exit 1; fi; \
 	fi; \
 	echo "==> wheel: PY=$$py TARGET=$$target"; \
-	python3 $(BUILD_DIR)/build_wheel_local.py $$py $$target $(if $(DRY_RUN),--dry-run)
+	python3 $(BUILD_DIR)/build_wheel_local.py $$py $$target
 
 wheel-clean:
 	rm -rf $(WHEEL_DIR)/

--- a/ci/build/Makefile
+++ b/ci/build/Makefile
@@ -4,7 +4,7 @@
 #   make wheel [PY] [TARGET]
 #   python build_wheel_local.py [OPTIONS] [PYTHON_VERSION] [TARGET]
 
-.PHONY: wheel wheel-test wheel-clean matrix-wheels clean help print-vars
+.PHONY: wheel wheel-clean matrix-wheels clean help print-vars
 
 ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 BUILD_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/ci/build/build_wheel_local.py
+++ b/ci/build/build_wheel_local.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Build Ray wheel files locally.
+Usage:
+    python build_wheel_local.py [PYTHON_VERSION] [TARGET]
+Examples:
+    python build_wheel_local.py 3.11
+    python build_wheel_local.py 3.12 cpp
+    python build_wheel_local.py 3.11 all
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from wanda_targets import (
+    RayCppWheel,
+    RayWheel,
+    create_context,
+)
+
+
+def header(msg: str) -> None:
+    """Print a blue header."""
+    print(f"\n\033[34;1m===> {msg}\033[0m", file=sys.stderr)
+
+
+def extract_from_image(image: str, out_dir: Path) -> list[Path]:
+    """Extract .whl files from a docker image."""
+    header(f"Extracting wheels to {out_dir}...")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        ["docker", "create", image, "true"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    container_id = result.stdout.strip()
+
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            export = subprocess.Popen(
+                ["docker", "export", container_id], stdout=subprocess.PIPE
+            )
+            subprocess.run(["tar", "-x", "-C", tmpdir], stdin=export.stdout, check=True)
+            export.wait()
+
+            wheels = []
+            for whl in Path(tmpdir).rglob("*.whl"):
+                dest = out_dir / whl.name
+                shutil.copy2(whl, dest)
+                wheels.append(dest)
+            return wheels
+    finally:
+        subprocess.run(["docker", "rm", container_id], capture_output=True)
+
+
+def build_wheels(
+    python_version: str = "3.10",
+    manylinux_version: str = "",
+    arch_suffix: str = "",
+    hosttype: str = "",
+    target: str = "ray",
+) -> tuple[RayWheel, RayCppWheel]:
+    """Build Ray wheels and return the wheel targets."""
+    ctx = create_context(
+        python_version=python_version,
+        manylinux_version=manylinux_version,
+        arch_suffix=arch_suffix,
+        hosttype=hosttype,
+    )
+
+    ray_wheel = RayWheel(ctx)
+    cpp_wheel = RayCppWheel(ctx)
+
+    if target in ("ray", "all"):
+        ray_wheel.build()
+    if target in ("cpp", "all"):
+        cpp_wheel.build()
+
+    return ray_wheel, cpp_wheel
+
+
+def extract_wheels(
+    ray_wheel: RayWheel,
+    cpp_wheel: RayCppWheel,
+    target: str = "ray",
+    out_dir: Path | None = None,
+) -> list[Path]:
+    """Extract wheels from built images."""
+    if out_dir is None:
+        out_dir = ray_wheel.ctx.repo_root / ".whl"
+
+    wheels: list[Path] = []
+    if target in ("ray", "all"):
+        extracted = extract_from_image(ray_wheel.remote_image, out_dir)
+        for w in extracted:
+            print(f"  {w}")
+        wheels.extend(extracted)
+    if target in ("cpp", "all"):
+        extracted = extract_from_image(cpp_wheel.remote_image, out_dir)
+        for w in extracted:
+            print(f"  {w}")
+        wheels.extend(extracted)
+    return wheels
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build Ray wheels locally",
+        usage="%(prog)s [python_version] [target] [options]\n"
+        "       %(prog)s 3.11              # build ray wheel for py3.11\n"
+        "       %(prog)s 3.12 cpp          # build cpp wheel for py3.12",
+    )
+    parser.add_argument("python_version", nargs="?", default="3.10")
+    parser.add_argument(
+        "target", nargs="?", default="ray", choices=["ray", "cpp", "all"]
+    )
+    parser.add_argument("--manylinux-version", default="")
+    parser.add_argument("--arch-suffix", default="")
+    parser.add_argument("--hosttype", default="")
+    parser.add_argument("--out-dir", type=Path)
+    return parser.parse_args(args)
+
+
+def main(args: list[str] | None = None) -> int:
+    try:
+        p = parse_args(args)
+        py = p.python_version.lower().removeprefix("python").removeprefix("py")
+
+        ray_wheel, cpp_wheel = build_wheels(
+            python_version=py,
+            manylinux_version=p.manylinux_version,
+            arch_suffix=p.arch_suffix,
+            hosttype=p.hosttype,
+            target=p.target,
+        )
+
+        extract_wheels(ray_wheel, cpp_wheel, p.target, p.out_dir)
+
+        return 0
+    except KeyboardInterrupt:
+        return 130
+    except Exception as e:
+        print(f"\033[31;1mError: {e}\033[0m", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Developer tooling for building Ray wheels locally via Wanda.
- build_wheel_local.py: Python script for building wheels
- Makefile: Convenient targets (make wheel, make wheel-cpp, make wheel-all)

Usage:
    make wheel PY=3.11          # build ray wheel
    make wheel-cpp PY=3.12      # build cpp wheel
    make wheel-all              # build both

Extracts .whl files from built images to .whl/ directory.

Topic: wanda-ray-makefile
Relative: wanda-ray-wheel

Signed-off-by: andrew <andrew@anyscale.com>