### PR TITLE
[Data] Restoring `ray.air.util.tensor_extensions.arrow` class aliases to fix deserialization of existing datasets

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -405,11 +405,6 @@ python/ray/air/integrations/wandb.py
 python/ray/air/result.py
     DOC201: Method `Result._read_file_as_str` does not have a return section in docstring
 --------------------
-python/ray/air/util/tensor_extensions/arrow.py
-    DOC101: Function `pyarrow_table_from_pydict`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `pyarrow_table_from_pydict`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [pydict: Dict[str, Union[List[Any], pa.Array]]].
-    DOC201: Function `pyarrow_table_from_pydict` does not have a return section in docstring
---------------------
 python/ray/air/util/tensor_extensions/pandas.py
     DOC101: Method `TensorDtype.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `TensorDtype.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dtype: np.dtype, shape: Tuple[Optional[int], ...]].

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1,0 +1,10 @@
+
+# NOTE: We provide these as aliases to maintain compatibility with older version
+#       of Arrow `PyExtensionType` that relies on picked class references that
+#       reference `ray.air.util.tensor_extensions.arrow.*` classes
+
+from ray.data._internal.tensor_extensions.arrow import (
+    ArrowTensorType,    # noqa: F401
+    ArrowTensorTypeV2,  # noqa: F401
+    ArrowVariableShapedTensorType  # noqa: F401
+)

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1,10 +1,9 @@
-
 # NOTE: We provide these as aliases to maintain compatibility with older version
 #       of Arrow `PyExtensionType` that relies on picked class references that
 #       reference `ray.air.util.tensor_extensions.arrow.*` classes
 
 from ray.data._internal.tensor_extensions.arrow import (
-    ArrowTensorType,    # noqa: F401
+    ArrowTensorType,  # noqa: F401
     ArrowTensorTypeV2,  # noqa: F401
-    ArrowVariableShapedTensorType  # noqa: F401
+    ArrowVariableShapedTensorType,  # noqa: F401
 )

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -164,7 +164,7 @@ def check_for_legacy_tensor_type(schema):
                 f"to read data written with an older version of Ray. Reading data "
                 f"written with older versions of Ray might expose you to arbitrary code "
                 f"execution. To try reading the data anyway, "
-                f"set `RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE=1` on *all* nodes."
+                f"preset `RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE=1` on *all* nodes."
                 "To learn more, see https://github.com/ray-project/ray/issues/41314."
             )
 

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -158,11 +158,13 @@ def check_for_legacy_tensor_type(schema):
             type, pa.PyExtensionType
         ):
             raise RuntimeError(
-                f"Ray Data couldn't infer the type of column '{name}'. This might mean "
-                "you're trying to read data written with an older version of Ray. "
-                "Reading data written with older versions of Ray might expose you to "
-                "arbitrary code execution. To try reading the data anyway, set "
-                "`RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE=1` on *all* nodes."
+                f"Ray Data couldn't infer the type of column '{name}' (got "
+                f"`UnknownExtensionType` with pickled class ref "
+                f"'{type.__arrow_ext_serialize__()}'). This might mean you're trying "
+                f"to read data written with an older version of Ray. Reading data "
+                f"written with older versions of Ray might expose you to arbitrary code "
+                f"execution. To try reading the data anyway, "
+                f"set `RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE=1` on *all* nodes."
                 "To learn more, see https://github.com/ray-project/ray/issues/41314."
             )
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -500,6 +500,11 @@
   group: data-batch-inference
 
   cluster:
+    byod:
+      # NOTE: Image classification have to pin Pyarrow to 19.0 due to dataset using
+      #       previous tensor extension type inheriting from ``pyarrow.PyExtensionType``
+      #       that is removed in Pyarrow 21.0
+      python_depset: image_classification_py3.10.lock
     cluster_compute: "{{scaling}}_gpu_compute.yaml"
 
   matrix:
@@ -521,6 +526,11 @@
   group: data-batch-inference
 
   cluster:
+    byod:
+      # NOTE: Image classification have to pin Pyarrow to 19.0 due to dataset using
+      #       previous tensor extension type inheriting from ``pyarrow.PyExtensionType``
+      #       that is removed in Pyarrow 21.0
+      python_depset: image_classification_py3.10.lock
     cluster_compute: dataset/autoscaling_gpu_compute.yaml
 
   run:

--- a/release/release_multimodal_inference_benchmarks_tests.yaml
+++ b/release/release_multimodal_inference_benchmarks_tests.yaml
@@ -1,6 +1,6 @@
 - name: DEFAULTS
   python: "3.10"
-  group: multimodal-inference-benchmarks
+  group: data-multimodal-inference-benchmarks
   working_dir: nightly_tests/multimodal_inference_benchmarks
 
   frequency: manual


### PR DESCRIPTION
## Description

Context: [Slack](https://anyscaleteam.slack.com/archives/C04FMM4NPQ9/p1767322231131189)

#59420 moved Ray Data's Arrow tensor extensions from `ray.air.util.tensor_extensions` to `ray.data._internal.tensor_extensions`.

That actually broke deserialization of the datasets written with older Ray Data implementation of these extensions inheriting from `pyarrow.PyExtensionType`:

1. `PyEtensionType` pickles class-ref into the metadata when writing the data (in that case it's `ray.air.util.tensor_extensions.arrow.ArrowTensorType` for ex)
2. Upon reading the data it tries to unpickle it and now fails b/c these classes were moved.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
