### PR TITLE
[wheel] use latest manylinux build image

### DIFF
--- a/ci/docker/manylinux-cibase.wanda.yaml
+++ b/ci/docker/manylinux-cibase.wanda.yaml
@@ -1,6 +1,6 @@
 name: "manylinux-cibase$JDK_SUFFIX-$HOSTTYPE"
 froms:
-  - quay.io/pypa/manylinux2014_$HOSTTYPE:2024-07-02-9ac04ee
+  - quay.io/pypa/manylinux2014_$HOSTTYPE:2026.01.02-1
 srcs:
   - ci/build/build-manylinux-forge.sh
 build_args:

--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 
 ARG HOSTTYPE
-FROM quay.io/pypa/manylinux2014_${HOSTTYPE}:2024-07-02-9ac04ee
+FROM quay.io/pypa/manylinux2014_${HOSTTYPE}:2026.01.02-1
 
 ARG BUILDKITE_BAZEL_CACHE_URL
 ARG RAYCI_DISABLE_JAVA=false

--- a/python/README-building-wheels.md
+++ b/python/README-building-wheels.md
@@ -16,7 +16,7 @@ docker run -ti --rm \
     -e BUILD_ONE_PYTHON_ONLY=py39 \
     -w /ray -v "$(pwd)":/ray \
     -e HOME=/tmp \
-    quay.io/pypa/manylinux2014_x86_64:2024-07-02-9ac04ee \
+    quay.io/pypa/manylinux2014_x86_64:2026.01.02-1 \
     /ray/python/build-wheel-manylinux2014.sh
 ```
 
@@ -34,7 +34,7 @@ docker run -ti --rm \
     -e BUILDKITE_COMMIT="$(git rev-parse HEAD)" \
     -e BUILD_ONE_PYTHON_ONLY=py39 \
     -w /ray -v "$(pwd)":/ray \
-    quay.io/pypa/manylinux2014_aarch64:2024-07-02-9ac04ee \
+    quay.io/pypa/manylinux2014_aarch64:2026.01.02-1 \
     /ray/python/build-wheel-manylinux2014.sh
 ```
 


### PR DESCRIPTION
Contains py3.14. The manylinux project now uses a new format for tagging images of YYYY.MM.DD-<build_number>, hence why there is no commit hash on this.
