### PR TITLE
[ci] remove python 3.9 references

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -38,9 +38,9 @@ while [[ $# -gt 0 ]]; do
             BUILD_ARGS+=("-q")
         ;;
         --python-version)
-            # Python version to install. e.g. 3.9
+            # Python version to install. e.g. 3.10
             # Changing python versions may require a different wheel.
-            # If not provided defaults to 3.9
+            # If not provided defaults to 3.10
             shift
             PYTHON_VERSION="$1"
         ;;

--- a/ci/ray_ci/test_builder_container.py
+++ b/ci/ray_ci/test_builder_container.py
@@ -33,11 +33,11 @@ def test_run() -> None:
         ]
 
         # test debug build
-        BuilderContainer("3.9", "debug", "x86_64").run()
+        BuilderContainer("3.10", "debug", "x86_64").run()
         assert cmds[-1] == [
             "export RAY_DEBUG_BUILD=debug",
             "./ci/build/build-manylinux-ray.sh",
-            "./ci/build/build-manylinux-wheel.sh cp39-cp39",
+            "./ci/build/build-manylinux-wheel.sh cp310-cp310",
             "chown -R 2000:100 /artifact-mount",
         ]
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -630,7 +630,7 @@ The ``runtime_env`` is a Python dictionary or a Python class :class:`ray.runtime
   - Example: ``{"stop-on-exit": "true", "t": "cuda,cublas,cudnn", "ftrace": ""}``
 
 - ``image_uri`` (dict): Require a given Docker image. The worker process runs in a container with this image.
-  - Example: ``{"image_uri": "anyscale/ray:2.31.0-py39-cpu"}``
+  - Example: ``{"image_uri": "anyscale/ray:2.53.0-py310-cpu"}``
 
   Note: ``image_uri`` is experimental. If you have some requirements or run into any problems, raise issues in `github <https://github.com/ray-project/ray/issues>`__.
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -421,7 +421,7 @@ Installed Python dependencies
 Our docker images are shipped with pre-installed Python dependencies
 required for Ray and its libraries.
 
-We publish the dependencies that are installed in our ``ray`` Docker images for Python 3.9.
+We publish the dependencies that are installed in our ``ray`` Docker images for Python 3.10.
 
 .. tab-set::
 


### PR DESCRIPTION
removes python 3.9 reference in CI scripts and docs; ray only supports python 3.10+ now
