### PR TITLE
[macos] stop building python 3.9 wheels

### DIFF
--- a/ci/build/test-macos-wheels.sh
+++ b/ci/build/test-macos-wheels.sh
@@ -44,8 +44,8 @@ function retry {
 
 MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 
-PY_WHEEL_VERSIONS=("39" "310")
-PY_MMS=("3.9" "3.10")
+PY_WHEEL_VERSIONS=("310" "311" "312")
+PY_MMS=("3.10" "3.11" "3.12")
 
 for ((i=0; i<${#PY_MMS[@]}; ++i)); do
   PY_MM="${PY_MMS[i]}"

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -10,7 +10,7 @@ DOWNLOAD_DIR=python_downloads
 
 NODE_VERSION="14"
 
-PY_MMS=("3.9" "3.10" "3.11" "3.12" "3.13")
+PY_MMS=("3.10" "3.11" "3.12" "3.13")
 
 if [[ -n "${SKIP_DEP_RES}" ]]; then
   ./ci/env/install-bazel.sh


### PR DESCRIPTION
and remove python 3.9 related tests
