### PR TITLE
[core] Fix num retries left message

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -23,8 +23,6 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         int64_t raylet_client_connect_timeout_milliseconds() const
 
-        int64_t raylet_fetch_timeout_milliseconds() const
-
         int64_t kill_worker_timeout_milliseconds() const
 
         int64_t worker_register_timeout_seconds() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -33,11 +33,6 @@ cdef class Config:
                 .raylet_client_connect_timeout_milliseconds())
 
     @staticmethod
-    def raylet_fetch_timeout_milliseconds():
-        return (RayConfig.instance()
-                .raylet_fetch_timeout_milliseconds())
-
-    @staticmethod
     def kill_worker_timeout_milliseconds():
         return RayConfig.instance().kill_worker_timeout_milliseconds()
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -262,11 +262,6 @@ RAY_CONFIG(bool, yield_plasma_lock_workaround, true)
 RAY_CONFIG(int64_t, raylet_client_num_connect_attempts, 10)
 RAY_CONFIG(int64_t, raylet_client_connect_timeout_milliseconds, 1000)
 
-/// The duration that the raylet will wait before reinitiating a
-/// fetch request for a missing task dependency. This time may adapt based on
-/// the number of missing task dependencies.
-RAY_CONFIG(int64_t, raylet_fetch_timeout_milliseconds, 1000)
-
 /// The duration that we wait after sending a worker SIGTERM before sending
 /// the worker SIGKILL.
 RAY_CONFIG(int64_t, kill_worker_timeout_milliseconds, 5000)

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -3052,7 +3052,7 @@ TEST_F(TaskManagerTest, TestRetryErrorMessageSentToCallback) {
   // Verify that the expected retry message was sent to the callback
   EXPECT_THAT(captured_error_message,
               testing::HasSubstr(
-                  "There are 1 retries remaining, so the task will be retried. Error:"));
+                  "There are 2 retries remaining, so the task will be retried. Error:"));
   EXPECT_THAT(captured_error_message,
               testing::HasSubstr("Worker crashed during task execution"));
   EXPECT_EQ(captured_error_type, "WORKER_DIED");


### PR DESCRIPTION
## Description
Before you would get a message that looks like:
```
Task Actor.f failed. There are 0 retries remaining, so the task will be retried. Error: The actor is temporarily unavailable: IOError: The actor was restarted
```
when a task with 1 retry gets retried. Doesn't make sense to get retried when there's "0 retries". This is because we decrement before pushing this message. Fixing this with a +1 in the msg str. Also we'd print the same thing for preemptions which could possibly not make sense, e.g. 0 retries remaining but still retrying when node is preempted because it doesn't count against retries. So now it explicitly says that this retry is because of preemption and it won't count against retries.

Also removing an unused ray config - `raylet_fetch_timeout_milliseconds`.