### PR TITLE
[Core] Skip reporter and event aggregator client creation in minimal …

### DIFF
--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -222,14 +222,11 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
 
   // Create EventAggregatorClient. Use deferred connection if port is invalid
   // (minimal install writes -1 to indicate metrics agent not available).
-  std::unique_ptr<rpc::EventAggregatorClient> event_aggregator_client;
-  if (options.metrics_agent_port > 0) {
-    event_aggregator_client = std::make_unique<rpc::EventAggregatorClientImpl>(
-        options.metrics_agent_port, *client_call_manager_);
-  } else {
-    event_aggregator_client =
-        std::make_unique<rpc::EventAggregatorClientImpl>(*client_call_manager_);
-  }
+  auto event_aggregator_client =
+      (options.metrics_agent_port > 0)
+          ? std::make_unique<rpc::EventAggregatorClientImpl>(options.metrics_agent_port,
+                                                             *client_call_manager_)
+          : std::make_unique<rpc::EventAggregatorClientImpl>(*client_call_manager_);
   auto task_event_buffer = std::make_unique<worker::TaskEventBufferImpl>(
       std::make_unique<gcs::GcsClient>(options.gcs_options, options.node_ip_address),
       std::move(event_aggregator_client),

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -851,8 +851,8 @@ void GcsServer::InstallEventListeners() {
           if (actual_port > 0) {
             InitMetricsExporter(actual_port);
           } else {
-            RAY_LOG(WARNING) << "Metrics agent may not be started or configured. "
-                             << "metrics_agent_port=" << actual_port;
+            RAY_LOG(INFO) << "Metrics agent not available. To enable metrics, install "
+                             "Ray with dashboard support: `pip install 'ray[default]'`.";
           }
         }
         auto remote_address = rpc::RayletClientPool::GenerateRayletAddress(

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -1038,18 +1038,18 @@ int main(int argc, char *argv[]) {
     if (actual_metrics_agent_port > 0) {
       metrics_agent_client = std::make_unique<ray::rpc::MetricsAgentClientImpl>(
           "127.0.0.1", actual_metrics_agent_port, main_service, *client_call_manager);
-      metrics_agent_client->WaitForServerReady([actual_metrics_agent_port](
-                                                   const ray::Status &server_status) {
-        if (server_status.ok()) {
-          ray::stats::ConnectOpenCensusExporter(actual_metrics_agent_port);
-          ray::stats::InitOpenTelemetryExporter(actual_metrics_agent_port);
-        } else {
-          RAY_LOG(ERROR)
-              << "Failed to establish connection to the metrics exporter agent. "
-                 "Metrics will not be exported. "
-              << "Exporter agent status: " << server_status.ToString();
-        }
-      });
+      metrics_agent_client->WaitForServerReady(
+          [actual_metrics_agent_port](const ray::Status &server_status) {
+            if (server_status.ok()) {
+              ray::stats::ConnectOpenCensusExporter(actual_metrics_agent_port);
+              ray::stats::InitOpenTelemetryExporter(actual_metrics_agent_port);
+            } else {
+              RAY_LOG(ERROR)
+                  << "Failed to establish connection to the metrics exporter agent. "
+                     "Metrics will not be exported. "
+                  << "Exporter agent status: " << server_status.ToString();
+            }
+          });
     } else {
       RAY_LOG(INFO) << "Metrics agent not available. To enable metrics, install Ray "
                        "with dashboard support: `pip install 'ray[default]'`.";

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -1033,20 +1033,27 @@ int main(int argc, char *argv[]) {
     ray::stats::Init(global_tags, ray::WorkerID::Nil());
     // Use the actual bound port returned by the node manager.
     // config.metrics_agent_port can be 0 (dynamic port assignment).
+    // -1 means metrics agent is not available (minimal install).
     int actual_metrics_agent_port = node_manager->GetMetricsAgentPort();
-    metrics_agent_client = std::make_unique<ray::rpc::MetricsAgentClientImpl>(
-        "127.0.0.1", actual_metrics_agent_port, main_service, *client_call_manager);
-    metrics_agent_client->WaitForServerReady([actual_metrics_agent_port](
-                                                 const ray::Status &server_status) {
-      if (server_status.ok()) {
-        ray::stats::ConnectOpenCensusExporter(actual_metrics_agent_port);
-        ray::stats::InitOpenTelemetryExporter(actual_metrics_agent_port);
-      } else {
-        RAY_LOG(ERROR) << "Failed to establish connection to the metrics exporter agent. "
-                          "Metrics will not be exported. "
-                       << "Exporter agent status: " << server_status.ToString();
-      }
-    });
+    if (actual_metrics_agent_port > 0) {
+      metrics_agent_client = std::make_unique<ray::rpc::MetricsAgentClientImpl>(
+          "127.0.0.1", actual_metrics_agent_port, main_service, *client_call_manager);
+      metrics_agent_client->WaitForServerReady([actual_metrics_agent_port](
+                                                   const ray::Status &server_status) {
+        if (server_status.ok()) {
+          ray::stats::ConnectOpenCensusExporter(actual_metrics_agent_port);
+          ray::stats::InitOpenTelemetryExporter(actual_metrics_agent_port);
+        } else {
+          RAY_LOG(ERROR)
+              << "Failed to establish connection to the metrics exporter agent. "
+                 "Metrics will not be exported. "
+              << "Exporter agent status: " << server_status.ToString();
+        }
+      });
+    } else {
+      RAY_LOG(INFO) << "Metrics agent not available. To enable metrics, install Ray "
+                       "with dashboard support: `pip install 'ray[default]'`.";
+    }
 
     // Initialize event framework. This should be done after the node manager is
     // initialized.

--- a/src/ray/rpc/metrics_agent_client.h
+++ b/src/ray/rpc/metrics_agent_client.h
@@ -115,6 +115,7 @@ class MetricsAgentClientImpl : public MetricsAgentClient {
   FRIEND_TEST(MetricsAgentClientTest, WaitForServerReadyWithRetrySuccess);
   FRIEND_TEST(MetricsAgentClientTest, WaitForServerReadyWithRetryFailure);
   FRIEND_TEST(MetricsAgentClientTest, ConcurrentCallbacksCallInitExporterFnOnlyOnce);
+  FRIEND_TEST(MetricsAgentClientTest, ExhaustedRetriesReturnsFailure);
 };
 
 }  // namespace rpc


### PR DESCRIPTION

## Description
dashboard agent services such as reporter agent and event aggregator agent do not run in minimal ray installs (`pip install ray`). this pr skips client creation (and adds a info log to guide users) when using minimal installs.

## Related issues
Fixes https://github.com/ray-project/ray/issues/59665

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
