### PR TITLE
[Serve] Add max_queued_requests and max_ongoing_requests metrics #59698

### DIFF
--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -623,6 +623,8 @@ These metrics track request routing and queueing behavior.
 | `ray_serve_request_router_queue_len` **[H][D]** | Gauge | `deployment`, `replica_id`, `actor_id`, `application`, `handle_source` | Current number of requests running on a replica as tracked by the router's queue length cache. |
 | `ray_serve_num_scheduling_tasks` **[H][†]** | Gauge | `deployment`, `actor_id` | Current number of request scheduling tasks in the router. |
 | `ray_serve_num_scheduling_tasks_in_backoff` **[H][†]** | Gauge | `deployment`, `actor_id` | Current number of scheduling tasks in exponential backoff (waiting before retry). |
+| `ray_serve_deployment_max_queued_requests` **[H][†]** | Gauge | `deployment`, `application`, `handle`, `actor_id` | The configured maximum number of requests that can be queued for the deployment. |
+| `ray_serve_deployment_max_ongoing_requests` **[H][†]** | Gauge | `deployment`, `application`, `handle`, `actor_id` | The configured maximum number of ongoing requests allowed for the deployment. |
 
 ### Request processing metrics
 

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_deployment_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_deployment_dashboard_panels.py
@@ -236,6 +236,36 @@ SERVE_DEPLOYMENT_GRAFANA_PANELS = [
         ],
         grid_pos=GridPos(0, 5, 8, 8),
     ),
+    Panel(
+        id=16,
+        title="Max Queued Requests",
+        description="Configured maximum number of requests that can be queued per deployment. -1 indicates no limit and is not displayed.",
+        unit="requests",
+        targets=[
+            Target(
+                expr="sum(ray_serve_deployment_max_queued_requests{{{global_filters}}} != -1) by (application, deployment)",
+                legend="{{application}}#{{deployment}}",
+            ),
+        ],
+        fill=0,
+        stack=False,
+        grid_pos=GridPos(8, 5, 8, 8),
+    ),
+    Panel(
+        id=17,
+        title="Max Ongoing Requests",
+        description="Configured maximum number of ongoing requests allowed per replica.",
+        unit="requests",
+        targets=[
+            Target(
+                expr="sum(ray_serve_deployment_max_ongoing_requests{{{global_filters}}}) by (application, deployment)",
+                legend="{{application}}#{{deployment}}",
+            ),
+        ],
+        fill=0,
+        stack=False,
+        grid_pos=GridPos(16, 5, 8, 8),
+    ),
 ]
 
 ids = []

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -84,6 +84,8 @@ class RouterMetricsManager:
         router_requests_counter: metrics.Counter,
         queued_requests_gauge: metrics.Gauge,
         running_requests_gauge: metrics.Gauge,
+        max_queued_requests_gauge: metrics.Gauge,
+        max_ongoing_requests_gauge: metrics.Gauge,
         event_loop: asyncio.BaseEventLoop,
     ):
         self._handle_id = handle_id
@@ -128,6 +130,28 @@ class RouterMetricsManager:
                 "actor_id": self._self_actor_id,
             }
         )
+
+        # Gauges for max configured values
+        self.max_queued_requests_gauge = max_queued_requests_gauge
+        self.max_queued_requests_gauge.set_default_tags(
+            {
+                "deployment": deployment_id.name,
+                "application": deployment_id.app_name,
+                "handle": self._handle_id,
+                "actor_id": self._self_actor_id,
+            }
+        )
+
+        self.max_ongoing_requests_gauge = max_ongoing_requests_gauge
+        self.max_ongoing_requests_gauge.set_default_tags(
+            {
+                "deployment": deployment_id.name,
+                "application": deployment_id.app_name,
+                "handle": self._handle_id,
+                "actor_id": self._self_actor_id,
+            }
+        )
+
         # We use Ray object ref callbacks to update state when tracking
         # number of requests running on replicas. The callbacks will be
         # called from a C++ thread into the router's async event loop,
@@ -251,6 +275,10 @@ class RouterMetricsManager:
             return
 
         self._deployment_config = deployment_config
+
+        # Update max config value metrics
+        self.max_queued_requests_gauge.set(deployment_config.max_queued_requests)
+        self.max_ongoing_requests_gauge.set(deployment_config.max_ongoing_requests)
 
         # Start the metrics pusher if autoscaling is enabled.
         autoscaling_config = self.autoscaling_config
@@ -580,6 +608,22 @@ class AsyncioRouter:
                 description=(
                     "The current number of requests to this deployment that "
                     "have been submitted to a replica."
+                ),
+                tag_keys=("deployment", "application", "handle", "actor_id"),
+            ),
+            metrics.Gauge(
+                "serve_deployment_max_queued_requests",
+                description=(
+                    "The configured maximum number of requests that can be queued "
+                    "for this deployment. -1 indicates no limit."
+                ),
+                tag_keys=("deployment", "application", "handle", "actor_id"),
+            ),
+            metrics.Gauge(
+                "serve_deployment_max_ongoing_requests",
+                description=(
+                    "The configured maximum number of ongoing requests allowed "
+                    "per replica for this deployment."
                 ),
                 tag_keys=("deployment", "application", "handle", "actor_id"),
             ),


### PR DESCRIPTION
## Description
Exposes deployment limits as Prometheus metrics to help understand queue and replica saturation in monitoring dashboards.
Two metrics are added:

- ray_serve_deployment_max_queued_requests
- ray_serve_deployment_max_ongoing_requests

## Related issues
#59698

## Additional information

