### PR TITLE
[ci] fix dashboard test

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -6,7 +6,7 @@ import os
 import socket
 import sys
 import traceback
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional, Tuple
 
@@ -876,7 +876,7 @@ class ReporterAgent(
     def _get_disk_usage():
         if IN_KUBERNETES_POD and not ENABLE_K8S_DISK_USAGE:
             # If in a K8s pod, disable disk display by passing in dummy values.
-            sdiskusage = type(psutil.disk_usage("/"))
+            sdiskusage = namedtuple("sdiskusage", ["total", "used", "free", "percent"])
             return {"/": sdiskusage(total=1, used=0, free=1, percent=0.0)}
         if sys.platform == "win32":
             root = psutil.disk_partitions()[0].mountpoint


### PR DESCRIPTION
## Description
test_enable_k8s_disk_usage[False] can fail based on the version of psutil installed on the ci image
Newer versions of psutil will fail on the with the following error when psutil._common.sdiskusage() is called
`AttributeError: module 'psutil._common' has no attribute 'sdiskusage'`

Using an object with all of the expected disk usage attributes instead

BK failures: 
https://buildkite.com/ray-project/premerge/builds/56787#019b80f9-0d5c-4168-837a-40c18661a0da/L913
https://buildkite.com/ray-project/premerge/builds/56425#019b4f5d-ccd0-44e9-94fe-33b3e53017a2/L992
