### PR TITLE
[Data] support checkpoint with string-typed id column

### DIFF
--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -224,9 +224,13 @@ class BatchBasedCheckpointFilter(CheckpointFilter):
         # Convert the block's ID column to a numpy array for fast processing.
         block_ids = block[self.id_column].to_numpy()
 
-        def filter_with_ckpt_chunk(ckpt_chunk: pyarrow.ChunkedArray) -> numpy.ndarray:
+        def filter_with_ckpt_chunk(ckpt_chunk: pyarrow.Array) -> numpy.ndarray:
             # Convert checkpoint chunk to numpy for fast search.
-            ckpt_ids = ckpt_chunk.to_numpy(zero_copy_only=True)
+            try:
+                ckpt_ids = ckpt_chunk.to_numpy(zero_copy_only=True)
+            except Exception:
+                # fallback to disable zero_copy
+                ckpt_ids = ckpt_chunk.to_numpy(zero_copy_only=False)
             # Start with a mask of all True (keep all rows).
             mask = numpy.ones(len(block_ids), dtype=bool)
             # Use binary search to find where block_ids would be in ckpt_ids.

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -228,7 +228,7 @@ class BatchBasedCheckpointFilter(CheckpointFilter):
             # Convert checkpoint chunk to numpy for fast search.
             try:
                 ckpt_ids = ckpt_chunk.to_numpy(zero_copy_only=True)
-            except Exception:
+            except pyarrow.lib.ArrowInvalid:
                 # fallback to disable zero_copy
                 ckpt_ids = ckpt_chunk.to_numpy(zero_copy_only=False)
             # Start with a mask of all True (keep all rows).


### PR DESCRIPTION
## Description
I am using Ray data checkpoint with the following code:
```python
import ray
import pandas as pd
from ray.data.checkpoint import CheckpointConfig
import os

# Setup paths
base_dir = "/tmp/ray_checkpoint_demo"
input_path = os.path.join(base_dir, "input")
output_path = os.path.join(base_dir, "output")
checkpoint_path = os.path.join(base_dir, "checkpoint")

# Create sample data (10 rows with unique IDs)
df = pd.DataFrame({"id": [str(i) for i in range(10)], "value": [f"row_{i}" for i in range(10)]})
df.to_parquet(os.path.join(input_path, "data.parquet"), index=False)
print(f"Created 10 rows of sample data")

def run_pipeline(fail_on_id_gt=None):
    """Run pipeline with optional simulated failure."""
    ctx = ray.data.DataContext.get_current()
    ctx.checkpoint_config = CheckpointConfig(
        id_column="id",
        checkpoint_path=checkpoint_path,
        delete_checkpoint_on_success=False,
    )

    def process_batch(batch):
        if fail_on_id_gt is not None and max(batch["id"]) > fail_on_id_gt:
            raise RuntimeError(f"Simulated failure at id > {fail_on_id_gt}")
        if fail_on_id_gt is not None:
            batch["info"] = ["checkpointed from first run"] * len(batch["id"])
        else:
            batch["info"] = ["not checkpointed from first run"] * len(batch["id"])
        return batch

    ds = ray.data.read_parquet(input_path)
    ds = ds.map_batches(process_batch, batch_size=5)
    ds.write_parquet(output_path)


# Run 1: Fail after processing some rows
print("\n=== Run 1: Pipeline with simulated failure ===")
try:
    run_pipeline(fail_on_id_gt="5")
except Exception as e:
    print(f"Failed as expected: {e}")

# Run 2: Resume from checkpoint
print("\n=== Run 2: Resume from checkpoint ===")
run_pipeline(fail_on_id_gt=None)  # No failure

# Verify results
print("\n=== Results ===")
result = ray.data.read_parquet(output_path)
print(f"Total rows in output: {result.count()}")
print(f"Result: {result.take_all()}")

```

and get the following error:
```
Traceback (most recent call last):
  File "/home/admin/workspace/aop_lab/qwen3-asr-aidata/omega_infer_ckpt.py", line 50, in <module>
    run_pipeline(fail_on_id_gt=None)  # No failure
  File "/home/admin/workspace/aop_lab/qwen3-asr-aidata/omega_infer_ckpt.py", line 38, in run_pipeline
    ds.write_parquet(output_path)
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/dataset.py", line 4091, in write_parquet
    self.write_datasink(
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/dataset.py", line 5369, in write_datasink
    self._write_ds = Dataset(plan, logical_plan).materialize()
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/dataset.py", line 6284, in materialize
    bundle: RefBundle = copy._plan.execute()
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/exceptions.py", line 89, in handle_trace
    raise e.with_traceback(None) from SystemException()
ray.exceptions.RayTaskError(ArrowInvalid): ray::ReadParquet->SplitBlocks(4)() (pid=105235, ip=33.64.55.169)
    for b_out in map_transformer.apply_transform(block_iter, ctx):
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 102, in __call__
    yield from self._post_process(results)
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 406, in _apply_transform
    yield from self._block_fn(blocks, ctx)
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/_internal/execution/operators/map_operator.py", line 1040, in _split_blocks
    for block in blocks:
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 102, in __call__
    yield from self._post_process(results)
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 84, in _shape_blocks
    for result in results:
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 406, in _apply_transform
    yield from self._block_fn(blocks, ctx)
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/checkpoint/util.py", line 38, in filter_checkpointed_rows_for_blocks
    filtered_block = filter_fn(block)
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/checkpoint/util.py", line 32, in filter_fn
    return ckpt_filter.filter_rows_for_block(
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/checkpoint/checkpoint_filter.py", line 249, in filter_rows_for_block
    masks = list(executor.map(filter_with_ckpt_chunk, ckpt_chunks))
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 621, in result_iterator
    yield _result_or_cancel(fs.pop())
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 319, in _result_or_cancel
    return fut.result(timeout)
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 458, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/admin/.local/lib/python3.10/site-packages/ray/data/checkpoint/checkpoint_filter.py", line 229, in filter_with_ckpt_chunk
    ckpt_ids = ckpt_chunk.to_numpy(zero_copy_only=True)
  File "pyarrow/array.pxi", line 1777, in pyarrow.lib.Array.to_numpy
  File "pyarrow/error.pxi", line 92, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: Needed to copy 1 chunks with 0 nulls, but zero_copy_only was True
```
This issue occurs because Ray attempts to call to_numpy(zero_copy_only=True) on a PyArrow Array of type string, the following code can reproduce: 

```python
import pyarrow as pa
x = pa.chunked_array([pa.array(['1', '2']), pa.array(['3', '4'])])
y = x.chunks
y[0].to_numpy(zero_copy_only=True)
```
