### PR TITLE
[train] Cleanup Zombie RayTrainWorker Actors

### DIFF
--- a/python/ray/train/v2/_internal/execution/worker_group/state.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/state.py
@@ -106,25 +106,15 @@ class WorkerGroupStateBuilder:
 
 
 def _shutdown_workers(workers: List[Worker], patience_s: float = 5):
-    # Run the worker shutdown logic on each of the workers. This should
-    # be a non-blocking call to realize forceful shutdown after patience_s.
-    _ = [w.actor.shutdown.remote() for w in workers]
+    # Shuts down workers after allowing a maximum of patience_s seconds for shutdown hooks to run.
+    done_refs = [w.actor.shutdown.remote() for w in workers]
 
     logger.debug(f"Shutting down {len(workers)} workers.")
-    if patience_s <= 0:
-        for worker in workers:
-            ray.kill(worker.actor)
-    else:
-        done_refs = [w.actor.__ray_terminate__.remote() for w in workers]
-        # Wait for actors to die gracefully.
-        _, not_done = ray.wait(
-            done_refs, num_returns=len(done_refs), timeout=patience_s
-        )
-        if not_done:
-            logger.debug("Graceful termination failed. Falling back to force kill.")
-            # If all actors are not able to die gracefully, then kill them.
-            for worker in workers:
-                ray.kill(worker.actor)
+
+    ray.wait(done_refs, num_returns=len(done_refs), timeout=patience_s)
+
+    for worker in workers:
+        ray.kill(worker.actor)
 
 
 def _shutdown_sync_actor(sync_actor: SynchronizationActor):

--- a/python/ray/train/v2/_internal/execution/worker_group/state.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/state.py
@@ -107,11 +107,14 @@ class WorkerGroupStateBuilder:
 
 def _shutdown_workers(workers: List[Worker], patience_s: float = 5):
     """Shuts down workers after allowing a maximum of patience_s seconds for shutdown hooks to run."""
+    if patience_s < 0:
+        raise ValueError("Invalid patience_s: must be non-negative")
+
     done_refs = [w.actor.shutdown.remote() for w in workers]
 
     logger.debug(f"Shutting down {len(workers)} workers.")
 
-    ray.wait(done_refs, num_returns=len(done_refs), timeout=max(0, patience_s))
+    ray.wait(done_refs, num_returns=len(done_refs), timeout=patience_s)
 
     for worker in workers:
         ray.kill(worker.actor)

--- a/python/ray/train/v2/_internal/execution/worker_group/state.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/state.py
@@ -106,7 +106,7 @@ class WorkerGroupStateBuilder:
 
 
 def _shutdown_workers(workers: List[Worker], patience_s: float = 5):
-    # Shuts down workers after allowing a maximum of patience_s seconds for shutdown hooks to run.
+    """Shuts down workers after allowing a maximum of patience_s seconds for shutdown hooks to run."""
     done_refs = [w.actor.shutdown.remote() for w in workers]
 
     logger.debug(f"Shutting down {len(workers)} workers.")

--- a/python/ray/train/v2/_internal/execution/worker_group/state.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/state.py
@@ -111,7 +111,7 @@ def _shutdown_workers(workers: List[Worker], patience_s: float = 5):
 
     logger.debug(f"Shutting down {len(workers)} workers.")
 
-    ray.wait(done_refs, num_returns=len(done_refs), timeout=patience_s)
+    ray.wait(done_refs, num_returns=len(done_refs), timeout=max(0, patience_s))
 
     for worker in workers:
         ray.kill(worker.actor)

--- a/python/ray/train/v2/tests/test_worker_group.py
+++ b/python/ray/train/v2/tests/test_worker_group.py
@@ -30,8 +30,10 @@ from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupContext,
     WorkerGroupState,
 )
-from ray.train.v2.api.config import RunConfig
+from ray.train.v2._internal.util import ObjectRefWrapper
+from ray.train.v2.api.config import RunConfig, ScalingConfig
 from ray.train.v2.tests.util import DummyObjectRefWrapper, create_dummy_run_context
+from ray.util.state import list_actors
 
 pytestmark = pytest.mark.usefixtures("mock_runtime_context")
 
@@ -593,6 +595,75 @@ def test_shutdown_hook_with_dead_actors():
 
     # TODO: This test leaves the WorkerGroup in a bad state.
     # If more tests are added below this, they may not be able to run.
+
+
+def test_zombie_actor_termination(ray_start_4_cpus):
+    """This test checks that RayTrainWorker actors are terminated correctly even if python garbage collection hangs on actor shutdown."""
+    NUM_WORKERS = 4
+
+    def is_process_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        else:
+            return True
+
+    class Node:
+        def __init__(self, name):
+            self.name = name
+            self.other = None
+
+        def __del__(self):
+            # Simulate hang during garbage collection
+            while True:
+                time.sleep(1)
+
+    def train_fn():
+        # Create a circular reference to delay garbage collection
+        a, b = Node("a"), Node("b")
+        a.other = b
+        b.other = a
+
+    train_fn_ref = ObjectRefWrapper(train_fn)
+
+    train_run_context = create_dummy_run_context(
+        scaling_config=ScalingConfig(num_workers=NUM_WORKERS)
+    )
+    worker_group_context = _default_worker_group_context(
+        train_fn_ref=train_fn_ref,
+        num_workers=NUM_WORKERS,
+    )
+
+    # Starts the worker group and runs the train function
+    worker_group = WorkerGroup.create(
+        train_run_context=train_run_context,
+        worker_group_context=worker_group_context,
+        callbacks=[],
+    )
+
+    train_worker_pids = [
+        actor.pid
+        for actor in list_actors()
+        if actor.class_name == RayTrainWorker.__name__ and actor.state == "ALIVE"
+    ]
+
+    assert len(train_worker_pids) == NUM_WORKERS
+
+    worker_group.shutdown()
+
+    # ray.kill is async, allow some time for the processes to terminate
+    TIMEOUT_S = 5
+    deadline = time.monotonic() + TIMEOUT_S
+    remaining = set(train_worker_pids)
+    while remaining and time.monotonic() < deadline:
+        remaining = {pid for pid in remaining if is_process_alive(pid)}
+        if remaining:
+            time.sleep(0.1)
+
+    assert not remaining
 
 
 def test_check_cluster_resources_and_raise_if_insufficient(monkeypatch):

--- a/python/ray/train/v2/tests/test_worker_group.py
+++ b/python/ray/train/v2/tests/test_worker_group.py
@@ -163,6 +163,75 @@ def test_start_timeout(monkeypatch):
         wg._start()
 
 
+def test_zombie_actor_termination(ray_start_4_cpus):
+    """This test checks that RayTrainWorker actors are terminated correctly even if python garbage collection hangs on actor shutdown."""
+    NUM_WORKERS = 4
+
+    def is_process_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        else:
+            return True
+
+    class Node:
+        def __init__(self, name):
+            self.name = name
+            self.other = None
+
+        def __del__(self):
+            # Simulate hang during garbage collection
+            while True:
+                time.sleep(1)
+
+    def train_fn():
+        # Create a circular reference to delay garbage collection
+        a, b = Node("a"), Node("b")
+        a.other = b
+        b.other = a
+
+    train_fn_ref = ObjectRefWrapper(train_fn)
+
+    train_run_context = create_dummy_run_context(
+        scaling_config=ScalingConfig(num_workers=NUM_WORKERS)
+    )
+    worker_group_context = _default_worker_group_context(
+        train_fn_ref=train_fn_ref,
+        num_workers=NUM_WORKERS,
+    )
+
+    # Starts the worker group and runs the train function
+    worker_group = WorkerGroup.create(
+        train_run_context=train_run_context,
+        worker_group_context=worker_group_context,
+        callbacks=[],
+    )
+
+    train_worker_pids = [
+        actor.pid
+        for actor in list_actors()
+        if actor.class_name == RayTrainWorker.__name__ and actor.state == "ALIVE"
+    ]
+
+    assert len(train_worker_pids) == NUM_WORKERS
+
+    worker_group.shutdown()
+
+    # ray.kill is async, allow some time for the processes to terminate
+    TIMEOUT_S = 5
+    deadline = time.monotonic() + TIMEOUT_S
+    remaining = set(train_worker_pids)
+    while remaining and time.monotonic() < deadline:
+        remaining = {pid for pid in remaining if is_process_alive(pid)}
+        if remaining:
+            time.sleep(0.1)
+
+    assert not remaining
+
+
 def test_insufficient_cluster_resources_startup_failure(monkeypatch):
     """Test that WorkerGroup startup fails when cluster has insufficient resources.
 
@@ -595,75 +664,6 @@ def test_shutdown_hook_with_dead_actors():
 
     # TODO: This test leaves the WorkerGroup in a bad state.
     # If more tests are added below this, they may not be able to run.
-
-
-def test_zombie_actor_termination(ray_start_4_cpus):
-    """This test checks that RayTrainWorker actors are terminated correctly even if python garbage collection hangs on actor shutdown."""
-    NUM_WORKERS = 4
-
-    def is_process_alive(pid: int) -> bool:
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            return True
-        else:
-            return True
-
-    class Node:
-        def __init__(self, name):
-            self.name = name
-            self.other = None
-
-        def __del__(self):
-            # Simulate hang during garbage collection
-            while True:
-                time.sleep(1)
-
-    def train_fn():
-        # Create a circular reference to delay garbage collection
-        a, b = Node("a"), Node("b")
-        a.other = b
-        b.other = a
-
-    train_fn_ref = ObjectRefWrapper(train_fn)
-
-    train_run_context = create_dummy_run_context(
-        scaling_config=ScalingConfig(num_workers=NUM_WORKERS)
-    )
-    worker_group_context = _default_worker_group_context(
-        train_fn_ref=train_fn_ref,
-        num_workers=NUM_WORKERS,
-    )
-
-    # Starts the worker group and runs the train function
-    worker_group = WorkerGroup.create(
-        train_run_context=train_run_context,
-        worker_group_context=worker_group_context,
-        callbacks=[],
-    )
-
-    train_worker_pids = [
-        actor.pid
-        for actor in list_actors()
-        if actor.class_name == RayTrainWorker.__name__ and actor.state == "ALIVE"
-    ]
-
-    assert len(train_worker_pids) == NUM_WORKERS
-
-    worker_group.shutdown()
-
-    # ray.kill is async, allow some time for the processes to terminate
-    TIMEOUT_S = 5
-    deadline = time.monotonic() + TIMEOUT_S
-    remaining = set(train_worker_pids)
-    while remaining and time.monotonic() < deadline:
-        remaining = {pid for pid in remaining if is_process_alive(pid)}
-        if remaining:
-            time.sleep(0.1)
-
-    assert not remaining
 
 
 def test_check_cluster_resources_and_raise_if_insufficient(monkeypatch):


### PR DESCRIPTION
## Background
Leaking Ray Train actors have been observed occupying GPU memory following Train run termination, causing training failures/OOMs in subsequent train runs. Despite the train actors being marked DEAD by Ray Core, we find that upon ssh-ing into nodes, that the actor processes are still alive and occupying valuable GPU memory:

<p align="center">
  <img
    width="512"
    height="213"
    alt="unnamed"
    src="https://github.com/user-attachments/assets/749e973c-bff6-4a66-8541-a3857a1fdd5a"
  />
</p>

Upon further investigation, we find that the actor process is hanging on Python garbage collection following termination via `__ray_terminate__`. `__ray_terminate__` marks the actor as DEAD but does not guarantee the termination of the actor process. And following `__ray_terminate__` when circular references are cleaned during Python interpreter teardown/garbage collection, the execution of object finalizers hang if the worker state is unstable- preventing the actor from ever exiting. 

### Previous User Workaround
We find that if garbage collection is performed earlier via `gc.collect()` while the worker state is more stable prior to shutdown (e.g. at the end of user train_func), there are no zombie actors- a mitigation leveraged by users prior to this stable fix. 

## Changes 

This PR: 
- Replaces `__ray_terminate__` with `ray.kill` in Train run shutdown and abort paths to guarantee the termination of train actors

With the changes, the same train job as above no longer has Zombie train actors:

<p align="center">
<img width="943" height="205" alt="Screenshot 2026-01-06 at 5 15 17 PM" src="https://github.com/user-attachments/assets/2f046e95-c436-4b4a-ba90-852cd358fc74" />
</p>


### `ray.kill` preserves shutdown patience
Previously, `__ray_terminate__` was used for "graceful" termination of actors, scheduling the termination task with a timeout of 5 seconds to allow for pending tasks to complete, following which `ray.kill` would be called for non-terminated actors. While this PR does not schedule a termination task, it allows the worker shutdown hooks a (default) timeout of 5 seconds- preserving the amount of time shutdown hooks and other pending tasks have to complete. The difference is that after those 5 seconds,`ray.kill` is called to terminate _every_ actor. 

### Reliability of `ray.kill` vs `__ray_terminate__`  Shutdown
`ray.kill` performs a forceful out-of-band shutdown of an actor process, bypassing atexit handlers and python shutdown hooks- similar in nature to a SIGKILL- whereas `__ray_terminate__` raises an exception, allowing python shutdown hooks to run and allowing the opportunity for Train actors to hang. Because Train actors do not rely on said hooks or atexit handlers for functionality, `ray.kill` is more fitting for our use case. 