### PR TITLE
[Core] Support `ALL` in exposable event config

### DIFF
--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -57,6 +57,7 @@ class PublisherClientInterface(ABC):
 
     def __init__(self):
         self._exposable_event_types_list: List[str] = []
+        self._allow_all_event_types: bool = False
 
     def count_num_events_in_batch(self, batch: PublishBatch) -> int:
         """Count the number of events in a given PublishBatch."""
@@ -66,8 +67,10 @@ class PublisherClientInterface(ABC):
         """
         Check if an event should be allowed to be published.
         """
-        if not self._exposable_event_types_list:
+        if self._allow_all_event_types:
             return True
+        if not self._exposable_event_types_list:
+            return False
 
         event_type_name = events_base_event_pb2.RayEvent.EventType.Name(
             event.event_type
@@ -102,11 +105,15 @@ class AsyncHttpPublisherClient(PublisherClientInterface):
         self._session = None
         self._preserve_proto_field_name = preserve_proto_field_name
 
-        self._exposable_event_types_list = [
-            event_type.strip()
-            for event_type in HTTP_EXPOSABLE_EVENT_TYPES.split(",")
-            if event_type.strip()
-        ]
+        if HTTP_EXPOSABLE_EVENT_TYPES.strip() == "ALL":
+            self._allow_all_event_types = True
+            self._exposable_event_types_list = []
+        else:
+            self._exposable_event_types_list = [
+                event_type.strip()
+                for event_type in HTTP_EXPOSABLE_EVENT_TYPES.split(",")
+                if event_type.strip()
+            ]
 
     async def publish(self, batch: PublishBatch) -> PublishStats:
         events_batch: list[events_base_event_pb2.RayEvent] = batch.events

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -105,7 +105,7 @@ class AsyncHttpPublisherClient(PublisherClientInterface):
         self._session = None
         self._preserve_proto_field_name = preserve_proto_field_name
 
-        if HTTP_EXPOSABLE_EVENT_TYPES.strip() == "ALL":
+        if HTTP_EXPOSABLE_EVENT_TYPES.strip().upper() == "ALL":
             self._allow_all_event_types = True
             self._exposable_event_types_list = []
         else:

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -27,7 +27,8 @@ PUBLISHER_MAX_BUFFER_SEND_INTERVAL_SECONDS = ray_constants.env_float(
 
 # HTTP Publisher specific configurations
 # Comma-separated list of event types that are allowed to be exposed to external HTTP services
-# Valid values: TASK_DEFINITION_EVENT, TASK_LIFECYCLE_EVENT, ACTOR_TASK_DEFINITION_EVENT
+# Valid values: TASK_DEFINITION_EVENT, TASK_LIFECYCLE_EVENT, ACTOR_TASK_DEFINITION_EVENT, etc.
+# Set to "ALL" to allow all event types.
 # The list of all supported event types can be found in src/ray/protobuf/public/events_base_event.proto (EventType enum)
 # By default TASK_PROFILE_EVENT is not exposed to external services
 DEFAULT_HTTP_EXPOSABLE_EVENT_TYPES = (

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -507,6 +507,69 @@ def test_aggregator_agent_profile_events_not_exposed(
         assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
 
 
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_env_vars",
+    [
+        {
+            "env_vars": generate_event_export_env_vars(
+                additional_env_vars={
+                    "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER_HTTP_ENDPOINT_EXPOSABLE_EVENT_TYPES": "ALL",
+                }
+            )
+        },
+    ],
+    indirect=True,
+)
+def test_aggregator_agent_all_event_types_exposed(
+    ray_start_cluster_head_with_env_vars,
+    httpserver,
+    fake_timestamp,
+):
+    """Test that setting EXPOSABLE_EVENT_TYPES to 'ALL' allows all event types including profile events."""
+    cluster = ray_start_cluster_head_with_env_vars
+    stub = get_event_aggregator_grpc_stub(
+        cluster.gcs_address, cluster.head_node.node_id
+    )
+
+    httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
+
+    # Send both a profile event (normally filtered) and a task definition event
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[
+                _create_profile_event_request(fake_timestamp[0]),
+                RayEvent(
+                    event_id=b"2",
+                    source_type=RayEvent.SourceType.CORE_WORKER,
+                    event_type=RayEvent.EventType.TASK_DEFINITION_EVENT,
+                    timestamp=fake_timestamp[0],
+                    severity=RayEvent.Severity.INFO,
+                    message="task_def_event",
+                ),
+            ],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[],
+            ),
+        )
+    )
+
+    stub.AddEvents(request)
+
+    # Wait for events to be received
+    wait_for_condition(lambda: len(httpserver.log) == 1)
+
+    req, _ = httpserver.log[0]
+    req_json = json.loads(req.data)
+
+    # With "ALL" config, both events should be published
+    assert len(req_json) == 2
+
+    # Verify both event types are present
+    event_types = {event["eventType"] for event in req_json}
+    assert "TASK_PROFILE_EVENT" in event_types
+    assert "TASK_DEFINITION_EVENT" in event_types
+
+
 def _create_task_definition_event_proto(timestamp):
     return RayEvent(
         event_id=b"1",


### PR DESCRIPTION
## Description
allow `RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER_HTTP_ENDPOINT_EXPOSABLE_EVENT_TYPES` to accept `ALL` so that all events are exported. will be used by history server. (without this config, kuberay needs to explicitly list each event type which is tedious as this list may grow in the future)

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
