### PR TITLE
[Core] Add Auth to Dashboard http agent + client

### DIFF
--- a/python/ray/dashboard/modules/event/event_agent.py
+++ b/python/ray/dashboard/modules/event/event_agent.py
@@ -8,6 +8,9 @@ from typing import Union
 import ray._private.ray_constants as ray_constants
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils
+from ray._private.authentication.http_token_authentication import (
+    get_auth_headers_if_auth_enabled,
+)
 from ray.dashboard.modules.event import event_consts
 from ray.dashboard.modules.event.event_utils import monitor_events
 from ray.dashboard.utils import async_loop_forever, create_task
@@ -86,6 +89,7 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
                 async with self._dashboard_agent.http_session.post(
                     f"{dashboard_http_address}/report_events",
                     json=data,
+                    headers=get_auth_headers_if_auth_enabled({}),
                 ) as response:
                     response.raise_for_status()
                 self.total_request_sent += 1

--- a/python/ray/tests/test_token_auth_integration.py
+++ b/python/ray/tests/test_token_auth_integration.py
@@ -9,6 +9,7 @@ from typing import Optional
 import pytest
 
 import ray
+import ray.dashboard.consts as dashboard_consts
 from ray._common.network_utils import build_address
 from ray._private.test_utils import (
     PrometheusTimeseries,
@@ -715,7 +716,7 @@ def _get_dashboard_agent_address(cluster_info):
 
     # Get agent address from internal KV
     node_id = ray.nodes()[0]["NodeID"]
-    key = f"DASHBOARD_AGENT_ADDR_{node_id}"
+    key = f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{node_id}"
     agent_addr = ray.experimental.internal_kv._internal_kv_get(
         key, namespace=ray._private.ray_constants.KV_NAMESPACE_DASHBOARD
     )

--- a/python/ray/tests/test_token_auth_integration.py
+++ b/python/ray/tests/test_token_auth_integration.py
@@ -725,6 +725,16 @@ def _get_dashboard_agent_address(cluster_info):
     return None
 
 
+def _wait_and_get_dashboard_agent_address(cluster_info, timeout=30):
+    """Waits for the dashboard agent address to become available and returns it."""
+
+    def agent_address_is_available():
+        return _get_dashboard_agent_address(cluster_info) is not None
+
+    wait_for_condition(agent_address_is_available, timeout=timeout)
+    return _get_dashboard_agent_address(cluster_info)
+
+
 @pytest.mark.parametrize(
     "token_type,expected_status",
     [
@@ -742,13 +752,7 @@ def test_dashboard_agent_auth(
 
     cluster_info = setup_cluster_with_token_auth
 
-    # Wait for agent address to be available
-    def get_agent_address():
-        addr = _get_dashboard_agent_address(cluster_info)
-        return addr is not None
-
-    wait_for_condition(get_agent_address, timeout=30)
-    agent_address = _get_dashboard_agent_address(cluster_info)
+    agent_address = _wait_and_get_dashboard_agent_address(cluster_info)
 
     # Build headers based on token type
     headers = {}
@@ -787,13 +791,7 @@ def test_dashboard_agent_health_check_public(endpoint, setup_cluster_with_token_
 
     cluster_info = setup_cluster_with_token_auth
 
-    # Wait for agent address to be available
-    def get_agent_address():
-        addr = _get_dashboard_agent_address(cluster_info)
-        return addr is not None
-
-    wait_for_condition(get_agent_address, timeout=30)
-    agent_address = _get_dashboard_agent_address(cluster_info)
+    agent_address = _wait_and_get_dashboard_agent_address(cluster_info)
 
     # Health check endpoints should be accessible without auth
     response = requests.get(f"{agent_address}{endpoint}", timeout=5)


### PR DESCRIPTION
## Description
this pr adds auth middleware to dashboard http agent service and  configures clients to include token headers in their requests. Pr also covers passing auth headers in state_manager runtime env agent api call which was previously missed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
