### PR TITLE
[Rllib] Modify `StatelessCartPole` APPO example to use new APPO attributes

### DIFF
--- a/rllib/examples/algorithms/appo/stateless_cartpole_appo.py
+++ b/rllib/examples/algorithms/appo/stateless_cartpole_appo.py
@@ -1,4 +1,5 @@
 from ray.rllib.algorithms.appo import APPOConfig
+from ray.rllib.connectors.env_to_module.mean_std_filter import MeanStdFilter
 from ray.rllib.core.rl_module.default_model_config import DefaultModelConfig
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
 from ray.rllib.examples.utils import (
@@ -23,14 +24,16 @@ config = (
     .environment(StatelessCartPole)
     # TODO (sven): Need to fix the MeanStdFilter(). It seems to cause NaNs when
     #  training.
-    # .env_runners(
-    #    env_to_module_connector=lambda env, spaces, device: MeanStdFilter(),
-    # )
+    .env_runners(
+        env_to_module_connector=lambda env, spaces, device: MeanStdFilter(),
+    )
     .training(
         lr=0.0005 * ((args.num_learners or 1) ** 0.5),
         num_epochs=1,
         vf_loss_coeff=0.05,
         entropy_coeff=0.005,
+        use_circular_buffer=False,
+        broadcast_interval=10,
     )
     .rl_module(
         model_config=DefaultModelConfig(

--- a/rllib/examples/algorithms/appo/stateless_cartpole_appo.py
+++ b/rllib/examples/algorithms/appo/stateless_cartpole_appo.py
@@ -22,8 +22,6 @@ args = parser.parse_args()
 config = (
     APPOConfig()
     .environment(StatelessCartPole)
-    # TODO (sven): Need to fix the MeanStdFilter(). It seems to cause NaNs when
-    #  training.
     .env_runners(
         env_to_module_connector=lambda env, spaces, device: MeanStdFilter(),
     )


### PR DESCRIPTION
## Description
The `StatelessCartPole` example form APPO is timing out. This could be due to the latest changes in the APPO data pipeline. This PR modifies the setup of the example by using the new APPO attributes.

## Related issues
Fixes https://buildkite.com/ray-project/postmerge/builds/15188#019b8f6e-2850-465e-a98c-63c29fbf98f7/L4702

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
