### PR TITLE
[serve] Static Placement Group RFC Implementation

### DIFF
--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -44,6 +44,8 @@ class ReplicaContext:
         - servable_object: instance of the user class/function this replica is running.
         - rank: the rank of the replica.
         - world_size: the number of replicas in the deployment.
+        - bundle_indices: list of placement group bundle indices assigned to this
+            replica when using static placement. None if not using static placement.
     """
 
     replica_id: ReplicaID
@@ -52,6 +54,7 @@ class ReplicaContext:
     rank: ReplicaRank
     world_size: int
     _handle_registration_callback: Optional[Callable[[DeploymentID], None]] = None
+    bundle_indices: Optional[List[int]] = None
 
     @property
     def app_name(self) -> str:
@@ -117,6 +120,7 @@ def _set_internal_replica_context(
     rank: ReplicaRank,
     world_size: int,
     handle_registration_callback: Optional[Callable[[str, str], None]] = None,
+    bundle_indices: Optional[List[int]] = None,
 ):
     global _INTERNAL_REPLICA_CONTEXT
     _INTERNAL_REPLICA_CONTEXT = ReplicaContext(
@@ -126,6 +130,7 @@ def _set_internal_replica_context(
         rank=rank,
         world_size=world_size,
         _handle_registration_callback=handle_registration_callback,
+        bundle_indices=bundle_indices,
     )
 
 

--- a/python/ray/serve/tests/unit/test_static_placement_config.py
+++ b/python/ray/serve/tests/unit/test_static_placement_config.py
@@ -1,0 +1,177 @@
+"""Unit tests for StaticPlacementConfig."""
+import pytest
+
+from ray.serve.config import StaticPlacementConfig
+
+
+class FakePlacementGroup:
+    """Fake placement group for unit testing."""
+
+    def __init__(self, name="fake_pg"):
+        self.name = name
+
+
+class TestStaticPlacementConfig:
+    """Test suite for StaticPlacementConfig dataclass."""
+
+    def test_basic_creation(self):
+        """Test basic creation of StaticPlacementConfig."""
+        pg = FakePlacementGroup()
+        config = StaticPlacementConfig(
+            placement_group=pg,
+            replica_bundle_mapping={
+                0: [0],
+                1: [1],
+            },
+        )
+        assert config.placement_group == pg
+        assert config.num_replicas == 2
+        assert config.capture_child_tasks is True
+
+    def test_capture_child_tasks_false(self):
+        """Test capture_child_tasks can be set to False."""
+        pg = FakePlacementGroup()
+        config = StaticPlacementConfig(
+            placement_group=pg,
+            replica_bundle_mapping={0: [0]},
+            capture_child_tasks=False,
+        )
+        assert config.capture_child_tasks is False
+
+    def test_multiple_bundles_per_replica(self):
+        """Test that replicas can have multiple bundles."""
+        pg = FakePlacementGroup()
+        config = StaticPlacementConfig(
+            placement_group=pg,
+            replica_bundle_mapping={
+                0: [0, 1],
+                1: [2, 3],
+            },
+        )
+        assert config.num_replicas == 2
+        assert config.get_bundle_indices_for_replica(0) == [0, 1]
+        assert config.get_bundle_indices_for_replica(1) == [2, 3]
+        assert config.get_primary_bundle_index_for_replica(0) == 0
+        assert config.get_primary_bundle_index_for_replica(1) == 2
+
+    def test_empty_mapping_raises_error(self):
+        """Test that empty mapping raises ValueError."""
+        pg = FakePlacementGroup()
+        with pytest.raises(ValueError, match="replica_bundle_mapping cannot be empty"):
+            StaticPlacementConfig(
+                placement_group=pg,
+                replica_bundle_mapping={},
+            )
+
+    def test_non_contiguous_ranks_raises_error(self):
+        """Test that non-contiguous ranks raise ValueError."""
+        pg = FakePlacementGroup()
+        with pytest.raises(ValueError, match="Replica ranks must be contiguous"):
+            StaticPlacementConfig(
+                placement_group=pg,
+                replica_bundle_mapping={
+                    0: [0],
+                    2: [1],  # Missing rank 1
+                },
+            )
+
+    def test_non_zero_starting_rank_raises_error(self):
+        """Test that ranks not starting from 0 raise ValueError."""
+        pg = FakePlacementGroup()
+        with pytest.raises(ValueError, match="Replica ranks must be contiguous"):
+            StaticPlacementConfig(
+                placement_group=pg,
+                replica_bundle_mapping={
+                    1: [0],
+                    2: [1],
+                },
+            )
+
+    def test_empty_bundle_list_raises_error(self):
+        """Test that empty bundle list raises ValueError."""
+        pg = FakePlacementGroup()
+        with pytest.raises(
+            ValueError, match="must be mapped to at least one bundle index"
+        ):
+            StaticPlacementConfig(
+                placement_group=pg,
+                replica_bundle_mapping={
+                    0: [],  # Empty list
+                },
+            )
+
+    def test_negative_bundle_index_raises_error(self):
+        """Test that negative bundle indices raise ValueError."""
+        pg = FakePlacementGroup()
+        with pytest.raises(
+            ValueError, match="Bundle indices.*must be non-negative integers"
+        ):
+            StaticPlacementConfig(
+                placement_group=pg,
+                replica_bundle_mapping={
+                    0: [-1],
+                },
+            )
+
+    def test_non_integer_bundle_index_raises_error(self):
+        """Test that non-integer bundle indices raise ValueError."""
+        pg = FakePlacementGroup()
+        with pytest.raises(
+            ValueError, match="Bundle indices.*must be non-negative integers"
+        ):
+            StaticPlacementConfig(
+                placement_group=pg,
+                replica_bundle_mapping={
+                    0: ["invalid"],  # type: ignore
+                },
+            )
+
+    def test_duplicate_bundle_indices_raises_error(self):
+        """Test that duplicate bundle indices across replicas raise ValueError."""
+        pg = FakePlacementGroup()
+        with pytest.raises(ValueError, match="Bundle indices must be unique"):
+            StaticPlacementConfig(
+                placement_group=pg,
+                replica_bundle_mapping={
+                    0: [0, 1],
+                    1: [1, 2],  # Bundle 1 is duplicated
+                },
+            )
+
+    def test_get_bundle_indices_for_invalid_rank_raises_error(self):
+        """Test that getting bundle indices for invalid rank raises KeyError."""
+        pg = FakePlacementGroup()
+        config = StaticPlacementConfig(
+            placement_group=pg,
+            replica_bundle_mapping={0: [0]},
+        )
+        with pytest.raises(KeyError, match="Replica rank 1 not found in mapping"):
+            config.get_bundle_indices_for_replica(1)
+
+    def test_num_replicas_property(self):
+        """Test num_replicas property returns correct count."""
+        pg = FakePlacementGroup()
+        config = StaticPlacementConfig(
+            placement_group=pg,
+            replica_bundle_mapping={
+                0: [0],
+                1: [1],
+                2: [2],
+            },
+        )
+        assert config.num_replicas == 3
+
+    def test_single_replica_single_bundle(self):
+        """Test simple case of single replica with single bundle."""
+        pg = FakePlacementGroup()
+        config = StaticPlacementConfig(
+            placement_group=pg,
+            replica_bundle_mapping={0: [0]},
+        )
+        assert config.num_replicas == 1
+        assert config.get_bundle_indices_for_replica(0) == [0]
+        assert config.get_primary_bundle_index_for_replica(0) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements the Static Placement Group RFC ([#59857](https://github.com/ray-project/ray/issues/59857)) to enable external placement groups with explicit replica-to-bundle mapping for Ray Serve deployments.

**Key features:**
- New `StaticPlacementConfig` dataclass for external placement group configuration
- `_placement_info` parameter on `@serve.deployment` decorator
- `bundle_indices` exposed via `serve.get_replica_context()`
- Recovery support: replicas restart on identical bundles

**Use case:** GPU colocation between Serve deployments and other Ray components (e.g., RL training workflows requiring zero-copy weight sync via CUDA IPC).

### Example Usage
```python
from ray.util.placement_group import placement_group
from ray import serve
from ray.serve.config import StaticPlacementConfig

# Create external placement group
pg = placement_group([{"GPU": 1, "CPU": 1}] * 4)
ray.get(pg.ready())

@serve.deployment(
    _placement_info=StaticPlacementConfig(
        placement_group=pg,
        replica_bundle_mapping={
            0: [0, 1],  # Replica 0 uses bundles 0 and 1
            1: [2, 3],  # Replica 1 uses bundles 2 and 3
        },
    ),
)
class MyLLMServer:
    def __init__(self):
        ctx = serve.get_replica_context()
        print(f"Replica {ctx.rank} using bundles: {ctx.bundle_indices}")
```

## Test plan
- [ ] Unit tests for `StaticPlacementConfig` validation
- [ ] Integration tests with actual placement groups
- [ ] Recovery test: controller restart with live replicas
- [ ] Verify mutual exclusivity validation with autoscaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)