### PR TITLE
[Core] Replace read-only string parameters with string_view on critical path

### DIFF
--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -131,7 +131,7 @@ class TaskSpecBuilder {
   /// \return Reference to the builder object itself.
   TaskSpecBuilder &SetCommonTaskSpec(
       const TaskID &task_id,
-      const std::string name,
+      std::string_view name,
       const Language &language,
       const ray::FunctionDescriptor &function_descriptor,
       const JobID &job_id,
@@ -146,12 +146,12 @@ class TaskSpecBuilder {
       int64_t generator_backpressure_num_objects,
       const std::unordered_map<std::string, double> &required_resources,
       const std::unordered_map<std::string, double> &required_placement_resources,
-      const std::string &debugger_breakpoint,
+      std::string_view debugger_breakpoint,
       int64_t depth,
       const TaskID &submitter_task_id,
-      const std::string &call_site,
+      std::string_view call_site,
       const std::shared_ptr<rpc::RuntimeEnvInfo> runtime_env_info = nullptr,
-      const std::string &concurrency_group_name = "",
+      std::string_view concurrency_group_name = "",
       bool enable_task_events = true,
       const std::unordered_map<std::string, std::string> &labels = {},
       const LabelSelector &label_selector = {},
@@ -196,7 +196,7 @@ class TaskSpecBuilder {
   TaskSpecBuilder &SetNormalTaskSpec(
       int max_retries,
       bool retry_exceptions,
-      const std::string &serialized_retry_exception_allowlist,
+      std::string_view serialized_retry_exception_allowlist,
       const rpc::SchedulingStrategy &scheduling_strategy,
       const ActorID root_detached_actor_id) {
     message_->set_max_retries(max_retries);
@@ -247,7 +247,7 @@ class TaskSpecBuilder {
   /// \return Reference to the builder object itself.
   TaskSpecBuilder &SetActorCreationTaskSpec(
       const ActorID &actor_id,
-      const std::string &serialized_actor_handle,
+      std::string_view serialized_actor_handle,
       const rpc::SchedulingStrategy &scheduling_strategy,
       int64_t max_restarts = 0,
       int64_t max_task_retries = 0,
@@ -258,7 +258,7 @@ class TaskSpecBuilder {
       std::string ray_namespace = "",
       bool is_asyncio = false,
       const std::vector<ConcurrencyGroup> &concurrency_groups = {},
-      const std::string &extension_data = "",
+      std::string_view extension_data = "",
       bool allow_out_of_order_execution = false,
       ActorID root_detached_actor_id = ActorID::Nil()) {
     message_->set_type(TaskType::ACTOR_CREATION_TASK);
@@ -298,14 +298,13 @@ class TaskSpecBuilder {
   /// See `common.proto` for meaning of the arguments.
   ///
   /// \return Reference to the builder object itself.
-  TaskSpecBuilder &SetActorTaskSpec(
-      const ActorID &actor_id,
-      const ObjectID &actor_creation_dummy_object_id,
-      int max_retries,
-      bool retry_exceptions,
-      const std::string &serialized_retry_exception_allowlist,
-      uint64_t sequence_number,
-      const std::optional<std::string> &tensor_transport) {
+  TaskSpecBuilder &SetActorTaskSpec(const ActorID &actor_id,
+                                    const ObjectID &actor_creation_dummy_object_id,
+                                    int max_retries,
+                                    bool retry_exceptions,
+                                    std::string_view serialized_retry_exception_allowlist,
+                                    uint64_t sequence_number,
+                                    const std::optional<std::string> &tensor_transport) {
     message_->set_type(TaskType::ACTOR_TASK);
     message_->set_max_retries(max_retries);
     message_->set_retry_exceptions(retry_exceptions);

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -29,10 +29,10 @@ rpc::ActorHandle CreateInnerActorHandle(
     const ObjectID &initial_cursor,
     const Language actor_language,
     const FunctionDescriptor &actor_creation_task_function_descriptor,
-    const std::string &extension_data,
+    std::string_view extension_data,
     int64_t max_task_retries,
-    const std::string &name,
-    const std::string &ray_namespace,
+    std::string_view name,
+    std::string_view ray_namespace,
     int32_t max_pending_calls,
     bool allow_out_of_order_execution,
     bool enable_tensor_transport,
@@ -61,9 +61,9 @@ rpc::ActorHandle CreateInnerActorHandle(
   return inner;
 }
 
-rpc::ActorHandle CreateInnerActorHandleFromString(const std::string &serialized) {
+rpc::ActorHandle CreateInnerActorHandleFromString(std::string_view serialized) {
   rpc::ActorHandle inner;
-  inner.ParseFromString(serialized);
+  inner.ParseFromString(std::string(serialized));
   return inner;
 }
 
@@ -104,10 +104,10 @@ ActorHandle::ActorHandle(
     const ObjectID &initial_cursor,
     const Language actor_language,
     const FunctionDescriptor &actor_creation_task_function_descriptor,
-    const std::string &extension_data,
+    std::string_view extension_data,
     int64_t max_task_retries,
-    const std::string &name,
-    const std::string &ray_namespace,
+    std::string_view name,
+    std::string_view ray_namespace,
     int32_t max_pending_calls,
     bool allow_out_of_order_execution,
     bool enable_tensor_transport,
@@ -132,20 +132,19 @@ ActorHandle::ActorHandle(
                                          labels,
                                          is_detached)) {}
 
-ActorHandle::ActorHandle(const std::string &serialized)
+ActorHandle::ActorHandle(std::string_view serialized)
     : ActorHandle(CreateInnerActorHandleFromString(serialized)) {}
 
 ActorHandle::ActorHandle(const rpc::ActorTableData &actor_table_data,
                          const rpc::TaskSpec &task_spec)
     : ActorHandle(CreateInnerActorHandleFromActorData(actor_table_data, task_spec)) {}
 
-void ActorHandle::SetActorTaskSpec(
-    TaskSpecBuilder &builder,
-    const ObjectID new_cursor,
-    int max_retries,
-    bool retry_exceptions,
-    const std::string &serialized_retry_exception_allowlist,
-    const std::optional<std::string> &tensor_transport) {
+void ActorHandle::SetActorTaskSpec(TaskSpecBuilder &builder,
+                                   const ObjectID new_cursor,
+                                   int max_retries,
+                                   bool retry_exceptions,
+                                   std::string_view serialized_retry_exception_allowlist,
+                                   const std::optional<std::string> &tensor_transport) {
   absl::MutexLock guard(&mutex_);
   // Build actor task spec.
   const TaskID actor_creation_task_id = TaskID::ForActorCreationTask(GetActorID());

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -43,10 +43,10 @@ class ActorHandle {
               const ObjectID &initial_cursor,
               const Language actor_language,
               const FunctionDescriptor &actor_creation_task_function_descriptor,
-              const std::string &extension_data,
+              std::string_view extension_data,
               int64_t max_task_retries,
-              const std::string &name,
-              const std::string &ray_namespace,
+              std::string_view name,
+              std::string_view ray_namespace,
               int32_t max_pending_calls,
               bool allow_out_of_order_execution = false,
               bool enable_tensor_transport = false,
@@ -55,7 +55,7 @@ class ActorHandle {
               bool is_detached = false);
 
   /// Constructs an ActorHandle from a serialized string.
-  explicit ActorHandle(const std::string &serialized);
+  explicit ActorHandle(std::string_view serialized);
 
   /// Constructs an ActorHandle from a rpc::ActorTableData and a rpc::TaskSpec message.
   ActorHandle(const rpc::ActorTableData &actor_table_data,
@@ -90,7 +90,7 @@ class ActorHandle {
                         const ObjectID new_cursor,
                         int max_retries,
                         bool retry_exceptions,
-                        const std::string &serialized_retry_exception_allowlist,
+                        std::string_view serialized_retry_exception_allowlist,
                         const std::optional<std::string> &tensor_transport);
 
   /// Reset the actor task spec fields of an existing task so that the task can

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -647,7 +647,7 @@ void CoreWorker::KillChildProcs() {
 
 void CoreWorker::Exit(
     const rpc::WorkerExitType exit_type,
-    const std::string &detail,
+    std::string_view detail,
     const std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb_bytes) {
   // Preserve actor creation failure details by marking a distinct shutdown reason
   // when initialization raised an exception. An exception payload is provided.
@@ -662,8 +662,7 @@ void CoreWorker::Exit(
                                          creation_task_exception_pb_bytes);
 }
 
-void CoreWorker::ForceExit(const rpc::WorkerExitType exit_type,
-                           const std::string &detail) {
+void CoreWorker::ForceExit(const rpc::WorkerExitType exit_type, std::string_view detail) {
   RAY_LOG(DEBUG) << "ForceExit called: exit_type=" << static_cast<int>(exit_type)
                  << ", detail=" << detail;
 
@@ -1865,7 +1864,7 @@ void CoreWorker::BuildCommonTaskSpec(
     TaskSpecBuilder &builder,
     const JobID &job_id,
     const TaskID &task_id,
-    const std::string &name,
+    std::string_view name,
     const TaskID &current_task_id,
     uint64_t task_index,
     const TaskID &caller_id,
@@ -1875,12 +1874,12 @@ void CoreWorker::BuildCommonTaskSpec(
     int64_t num_returns,
     const std::unordered_map<std::string, double> &required_resources,
     const std::unordered_map<std::string, double> &required_placement_resources,
-    const std::string &debugger_breakpoint,
+    std::string_view debugger_breakpoint,
     int64_t depth,
     const std::string &serialized_runtime_env_info,
-    const std::string &call_site,
+    std::string_view call_site,
     const TaskID &main_thread_current_task_id,
-    const std::string &concurrency_group_name,
+    std::string_view concurrency_group_name,
     bool include_job_config,
     int64_t generator_backpressure_num_objects,
     bool enable_task_events,
@@ -1968,9 +1967,9 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
     int max_retries,
     bool retry_exceptions,
     const rpc::SchedulingStrategy &scheduling_strategy,
-    const std::string &debugger_breakpoint,
-    const std::string &serialized_retry_exception_allowlist,
-    const std::string &call_site,
+    std::string_view debugger_breakpoint,
+    std::string_view serialized_retry_exception_allowlist,
+    std::string_view call_site,
     const TaskID current_task_id) {
   SubscribeToNodeChanges();
   RAY_CHECK(scheduling_strategy.scheduling_strategy_case() !=
@@ -2048,8 +2047,8 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
 Status CoreWorker::CreateActor(const RayFunction &function,
                                const std::vector<std::unique_ptr<TaskArg>> &args,
                                const ActorCreationOptions &actor_creation_options,
-                               const std::string &extension_data,
-                               const std::string &call_site,
+                               std::string_view extension_data,
+                               std::string_view call_site,
                                ActorID *return_actor_id) {
   SubscribeToNodeChanges();
   RAY_CHECK(actor_creation_options.scheduling_strategy.scheduling_strategy_case() !=
@@ -2341,17 +2340,16 @@ Status CoreWorker::WaitPlacementGroupReady(const PlacementGroupID &placement_gro
   return status;
 }
 
-Status CoreWorker::SubmitActorTask(
-    const ActorID &actor_id,
-    const RayFunction &function,
-    const std::vector<std::unique_ptr<TaskArg>> &args,
-    const TaskOptions &task_options,
-    int max_retries,
-    bool retry_exceptions,
-    const std::string &serialized_retry_exception_allowlist,
-    const std::string &call_site,
-    std::vector<rpc::ObjectReference> &task_returns,
-    const TaskID current_task_id) {
+Status CoreWorker::SubmitActorTask(const ActorID &actor_id,
+                                   const RayFunction &function,
+                                   const std::vector<std::unique_ptr<TaskArg>> &args,
+                                   const TaskOptions &task_options,
+                                   int max_retries,
+                                   bool retry_exceptions,
+                                   std::string_view serialized_retry_exception_allowlist,
+                                   std::string_view call_site,
+                                   std::vector<rpc::ObjectReference> &task_returns,
+                                   const TaskID current_task_id) {
   SubscribeToNodeChanges();
   absl::ReleasableMutexLock lock(&actor_task_mutex_);
   task_returns.clear();
@@ -2596,7 +2594,7 @@ std::optional<rpc::ActorTableData::ActorState> CoreWorker::GetLocalActorState(
   return actor_task_submitter_->GetLocalActorState(actor_id);
 }
 
-ActorID CoreWorker::DeserializeAndRegisterActorHandle(const std::string &serialized,
+ActorID CoreWorker::DeserializeAndRegisterActorHandle(std::string_view serialized,
                                                       const ObjectID &outer_object_id,
                                                       bool add_local_ref) {
   auto actor_handle = std::make_unique<ActorHandle>(serialized);
@@ -4601,8 +4599,8 @@ std::vector<ObjectID> CoreWorker::GetCurrentReturnIds(int num_returns,
 
 void CoreWorker::RecordTaskLogStart(const TaskID &task_id,
                                     int32_t attempt_number,
-                                    const std::string &stdout_path,
-                                    const std::string &stderr_path,
+                                    std::string_view stdout_path,
+                                    std::string_view stderr_path,
                                     int64_t stdout_start_offset,
                                     int64_t stderr_start_offset) const {
   if (options_.is_local_mode) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -858,9 +858,9 @@ class CoreWorker {
       int max_retries,
       bool retry_exceptions,
       const rpc::SchedulingStrategy &scheduling_strategy,
-      const std::string &debugger_breakpoint,
-      const std::string &serialized_retry_exception_allowlist = "",
-      const std::string &call_site = "",
+      std::string_view debugger_breakpoint,
+      std::string_view serialized_retry_exception_allowlist = "",
+      std::string_view call_site = "",
       const TaskID current_task_id = TaskID::Nil());
 
   /// Create an actor.
@@ -882,8 +882,8 @@ class CoreWorker {
   Status CreateActor(const RayFunction &function,
                      const std::vector<std::unique_ptr<TaskArg>> &args,
                      const ActorCreationOptions &actor_creation_options,
-                     const std::string &extension_data,
-                     const std::string &call_site,
+                     std::string_view extension_data,
+                     std::string_view call_site,
                      ActorID *actor_id);
 
   /// Create a placement group.
@@ -942,8 +942,8 @@ class CoreWorker {
                          const TaskOptions &task_options,
                          int max_retries,
                          bool retry_exceptions,
-                         const std::string &serialized_retry_exception_allowlist,
-                         const std::string &call_site,
+                         std::string_view serialized_retry_exception_allowlist,
+                         std::string_view call_site,
                          std::vector<rpc::ObjectReference> &task_returns,
                          const TaskID current_task_id = TaskID::Nil());
 
@@ -995,7 +995,7 @@ class CoreWorker {
   /// because the distributed reference counting protocol does not ensure that
   /// the owner will learn of this reference.
   /// \return The ActorID of the deserialized handle.
-  ActorID DeserializeAndRegisterActorHandle(const std::string &serialized,
+  ActorID DeserializeAndRegisterActorHandle(std::string_view serialized,
                                             const ObjectID &outer_object_id,
                                             bool add_local_ref);
 
@@ -1318,8 +1318,8 @@ class CoreWorker {
   /// \param stderr_start_offset Start offset of the stderr for this task.
   void RecordTaskLogStart(const TaskID &task_id,
                           int32_t attempt_number,
-                          const std::string &stdout_path,
-                          const std::string &stderr_path,
+                          std::string_view stdout_path,
+                          std::string_view stderr_path,
                           int64_t stdout_start_offset,
                           int64_t stderr_start_offset) const;
 
@@ -1344,7 +1344,7 @@ class CoreWorker {
   /// \param creation_task_exception_pb_bytes It is given when the worker is
   /// disconnected because the actor is failed due to its exception in its init method.
   void Exit(const rpc::WorkerExitType exit_type,
-            const std::string &detail,
+            std::string_view detail,
             const std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb_bytes =
                 nullptr);
 
@@ -1378,7 +1378,7 @@ class CoreWorker {
       TaskSpecBuilder &builder,
       const JobID &job_id,
       const TaskID &task_id,
-      const std::string &name,
+      std::string_view name,
       const TaskID &current_task_id,
       uint64_t task_index,
       const TaskID &caller_id,
@@ -1388,12 +1388,12 @@ class CoreWorker {
       int64_t num_returns,
       const std::unordered_map<std::string, double> &required_resources,
       const std::unordered_map<std::string, double> &required_placement_resources,
-      const std::string &debugger_breakpoint,
+      std::string_view debugger_breakpoint,
       int64_t depth,
       const std::string &serialized_runtime_env_info,
-      const std::string &call_site,
+      std::string_view call_site,
       const TaskID &main_thread_current_task_id,
-      const std::string &concurrency_group_name = "",
+      std::string_view concurrency_group_name = "",
       bool include_job_config = false,
       int64_t generator_backpressure_num_objects = -1,
       bool enable_task_events = true,
@@ -1411,7 +1411,7 @@ class CoreWorker {
   /// or cleaning any resources.
   /// \param exit_type The reason why this worker process is disconnected.
   /// \param exit_detail The detailed reason for a given exit.
-  void ForceExit(const rpc::WorkerExitType exit_type, const std::string &detail);
+  void ForceExit(const rpc::WorkerExitType exit_type, std::string_view detail);
 
   /// Forcefully kill child processes. User code running in actors or tasks
   /// can spawn processes that don't get terminated. If those processes


### PR DESCRIPTION
## Description
Replace `const std::string &` with `std::string_view` to avoid temporary string for a string literal or substring

## Related issues
Closes #59887 

## Additional information
protobuf `ParseFromString` only accepts std::string.

https://github.com/ray-project/ray/blob/c49b66692eb9c48254a6bba74de20cb1380928e7/src/ray/core_worker/actor_handle.cc#L64-L68