### PR TITLE
[Data][Docs] Split Input/Output API reference into Loading and Saving Data APIs

### DIFF
--- a/doc/source/data/api/api.rst
+++ b/doc/source/data/api/api.rst
@@ -6,7 +6,8 @@ Ray Data API
 .. toctree::
     :maxdepth: 2
 
-    input_output.rst
+    loading_data.rst
+    saving_data.rst
     dataset.rst
     data_iterator.rst
     execution_options.rst

--- a/doc/source/data/api/loading_data.rst
+++ b/doc/source/data/api/loading_data.rst
@@ -1,0 +1,368 @@
+.. _loading-data-api:
+
+Loading Data API
+================
+
+.. currentmodule:: ray.data
+
+Synthetic Data
+--------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   range
+   range_tensor
+
+Python Objects
+--------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_items
+
+Parquet
+-------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_parquet
+
+CSV
+---
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_csv
+
+JSON
+----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_json
+
+Text
+----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_text
+
+Audio
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_audio
+
+Avro
+----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_avro
+
+Images
+------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_images
+
+Binary
+------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_binary_files
+
+TFRecords
+---------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_tfrecords
+   TFXReadOptions
+
+Pandas
+------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_pandas
+   from_pandas_refs
+
+NumPy
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_numpy
+   from_numpy
+   from_numpy_refs
+
+Arrow
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_arrow
+   from_arrow_refs
+
+MongoDB
+-------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_mongo
+
+BigQuery
+--------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_bigquery
+
+SQL Databases
+-------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_sql
+
+Databricks
+----------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_databricks_tables
+
+Snowflake
+---------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_snowflake
+
+Unity Catalog
+-------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_unity_catalog
+
+Delta Sharing
+-------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_delta_sharing_tables
+
+Hudi
+----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_hudi
+
+Iceberg
+-------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_iceberg
+
+Delta Lake
+----------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_delta
+
+Lance
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_lance
+
+MCAP (Message Capture)
+----------------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_mcap
+
+ClickHouse
+----------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_clickhouse
+
+Daft
+----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_daft
+
+Dask
+----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_dask
+
+Spark
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_spark
+
+Modin
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_modin
+
+Mars
+----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_mars
+
+Torch
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_torch
+
+Hugging Face
+------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_huggingface
+
+TensorFlow
+----------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_tf
+
+Video
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_videos
+
+WebDataset
+----------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_webdataset
+
+Kafka
+-----
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_kafka
+
+.. _data_source_api:
+
+Datasource API
+--------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_datasource
+   Datasource
+   ReadTask
+   datasource.FilenameProvider

--- a/doc/source/data/api/loading_data.rst
+++ b/doc/source/data/api/loading_data.rst
@@ -366,3 +366,37 @@ Datasource API
    Datasource
    ReadTask
    datasource.FilenameProvider
+
+Partitioning API
+----------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   datasource.Partitioning
+   datasource.PartitionStyle
+   datasource.PathPartitionParser
+   datasource.PathPartitionFilter
+
+.. _metadata_provider:
+
+MetadataProvider API
+--------------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   datasource.FileMetadataProvider
+   datasource.BaseFileMetadataProvider
+   datasource.DefaultFileMetadataProvider
+
+Shuffling API
+-------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   FileShuffleConfig

--- a/doc/source/data/api/saving_data.rst
+++ b/doc/source/data/api/saving_data.rst
@@ -1,28 +1,9 @@
-.. _input-output:
+.. _saving-data-api:
 
-Input/Output
-============
+Saving Data API
+===============
 
 .. currentmodule:: ray.data
-
-Synthetic Data
---------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   range
-   range_tensor
-
-Python Objects
---------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   from_items
 
 Parquet
 -------
@@ -31,7 +12,6 @@ Parquet
    :nosignatures:
    :toctree: doc/
 
-   read_parquet
    Dataset.write_parquet
 
 CSV
@@ -41,7 +21,6 @@ CSV
    :nosignatures:
    :toctree: doc/
 
-   read_csv
    Dataset.write_csv
 
 JSON
@@ -51,35 +30,7 @@ JSON
    :nosignatures:
    :toctree: doc/
 
-   read_json
    Dataset.write_json
-
-Text
-----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_text
-
-Audio
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_audio
-
-Avro
-----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_avro
 
 Images
 ------
@@ -88,17 +39,7 @@ Images
    :nosignatures:
    :toctree: doc/
 
-   read_images
    Dataset.write_images
-
-Binary
-------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_binary_files
 
 TFRecords
 ---------
@@ -107,9 +48,7 @@ TFRecords
    :nosignatures:
    :toctree: doc/
 
-   read_tfrecords
    Dataset.write_tfrecords
-   TFXReadOptions
 
 Pandas
 ------
@@ -118,8 +57,6 @@ Pandas
    :nosignatures:
    :toctree: doc/
 
-   from_pandas
-   from_pandas_refs
    Dataset.to_pandas
    Dataset.to_pandas_refs
 
@@ -130,9 +67,6 @@ NumPy
    :nosignatures:
    :toctree: doc/
 
-   read_numpy
-   from_numpy
-   from_numpy_refs
    Dataset.write_numpy
    Dataset.to_numpy_refs
 
@@ -143,8 +77,6 @@ Arrow
    :nosignatures:
    :toctree: doc/
 
-   from_arrow
-   from_arrow_refs
    Dataset.to_arrow_refs
 
 MongoDB
@@ -154,16 +86,15 @@ MongoDB
    :nosignatures:
    :toctree: doc/
 
-   read_mongo
    Dataset.write_mongo
 
 BigQuery
 --------
 
 .. autosummary::
+   :nosignatures:
    :toctree: doc/
 
-   read_bigquery
    Dataset.write_bigquery
 
 SQL Databases
@@ -173,17 +104,7 @@ SQL Databases
    :nosignatures:
    :toctree: doc/
 
-   read_sql
    Dataset.write_sql
-
-Databricks
-----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_databricks_tables
 
 Snowflake
 ---------
@@ -192,35 +113,7 @@ Snowflake
    :nosignatures:
    :toctree: doc/
 
-   read_snowflake
    Dataset.write_snowflake
-
-Unity Catalog
--------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_unity_catalog
-
-Delta Sharing
--------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_delta_sharing_tables
-
-Hudi
-----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_hudi
 
 Iceberg
 -------
@@ -229,17 +122,7 @@ Iceberg
    :nosignatures:
    :toctree: doc/
 
-   read_iceberg
    Dataset.write_iceberg
-
-Delta Lake
-----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_delta
 
 Lance
 -----
@@ -248,17 +131,7 @@ Lance
    :nosignatures:
    :toctree: doc/
 
-   read_lance
    Dataset.write_lance
-
-MCAP (Message Capture)
-----------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_mcap
 
 ClickHouse
 ----------
@@ -267,7 +140,6 @@ ClickHouse
    :nosignatures:
    :toctree: doc/
 
-   read_clickhouse
    Dataset.write_clickhouse
 
 Daft
@@ -277,7 +149,6 @@ Daft
    :nosignatures:
    :toctree: doc/
 
-   from_daft
    Dataset.to_daft
 
 Dask
@@ -287,7 +158,6 @@ Dask
    :nosignatures:
    :toctree: doc/
 
-   from_dask
    Dataset.to_dask
 
 Spark
@@ -297,7 +167,6 @@ Spark
    :nosignatures:
    :toctree: doc/
 
-   from_spark
    Dataset.to_spark
 
 Modin
@@ -307,7 +176,6 @@ Modin
    :nosignatures:
    :toctree: doc/
 
-   from_modin
    Dataset.to_modin
 
 Mars
@@ -317,76 +185,7 @@ Mars
    :nosignatures:
    :toctree: doc/
 
-   from_mars
    Dataset.to_mars
-
-Torch
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   from_torch
-
-Hugging Face
-------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   from_huggingface
-
-TensorFlow
-----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   from_tf
-
-Video
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_videos
-
-WebDataset
-----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_webdataset
-
-.. _data_source_api:
-
-Kafka
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_kafka
-
-Datasource API
---------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_datasource
-   Datasource
-   ReadTask
-   datasource.FilenameProvider
 
 Datasink API
 ------------

--- a/doc/source/data/api/saving_data.rst
+++ b/doc/source/data/api/saving_data.rst
@@ -201,37 +201,3 @@ Datasink API
    datasource.FileBasedDatasource
    datasource.WriteResult
    datasource.WriteReturnType
-
-Partitioning API
-----------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   datasource.Partitioning
-   datasource.PartitionStyle
-   datasource.PathPartitionParser
-   datasource.PathPartitionFilter
-
-.. _metadata_provider:
-
-MetadataProvider API
---------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   datasource.FileMetadataProvider
-   datasource.BaseFileMetadataProvider
-   datasource.DefaultFileMetadataProvider
-
-Shuffling API
--------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   FileShuffleConfig

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -17,7 +17,7 @@ Reading files
 
 Ray Data reads files from local disk or cloud storage in a variety of file formats.
 To view the full list of supported file formats, see the
-:ref:`Input/Output reference <input-output>`.
+:ref:`Loading Data API <loading-data-api>`.
 
 .. tab-set::
 
@@ -157,7 +157,7 @@ Reading files from local disk
 To read files from local disk, call a function like :func:`~ray.data.read_parquet` and
 specify paths with the ``local://`` schema. Paths can point to files or directories.
 
-To read formats other than Parquet, see the :ref:`Input/Output reference <input-output>`.
+To read formats other than Parquet, see the :ref:`Loading Data API <loading-data-api>`.
 
 .. tip::
 
@@ -190,7 +190,7 @@ To read files in cloud storage, authenticate all nodes with your cloud service p
 Then, call a method like :func:`~ray.data.read_parquet` and specify URIs with the
 appropriate schema. URIs can point to buckets, folders, or objects.
 
-To read formats other than Parquet, see the :ref:`Input/Output reference <input-output>`.
+To read formats other than Parquet, see the :ref:`Loading Data API <loading-data-api>`.
 
 .. tab-set::
 
@@ -302,7 +302,7 @@ Reading files from NFS
 To read files from NFS filesystems, call a function like :func:`~ray.data.read_parquet`
 and specify files on the mounted filesystem. Paths can point to files or directories.
 
-To read formats other than Parquet, see the :ref:`Input/Output reference <input-output>`.
+To read formats other than Parquet, see the :ref:`Loading Data API <loading-data-api>`.
 
 .. testcode::
     :skipif: True

--- a/doc/source/data/performance-tips.rst
+++ b/doc/source/data/performance-tips.rst
@@ -25,7 +25,7 @@ Tuning output blocks for read
 
 By default, Ray Data automatically selects the number of output blocks for read according to the following procedure:
 
-- The ``override_num_blocks`` parameter passed to Ray Data's :ref:`read APIs <input-output>` specifies the number of output blocks, which is equivalent to the number of read tasks to create.
+- The ``override_num_blocks`` parameter passed to Ray Data's :ref:`read APIs <loading-data-api>` specifies the number of output blocks, which is equivalent to the number of read tasks to create.
 - Usually, if the read is followed by a :func:`~ray.data.Dataset.map` or :func:`~ray.data.Dataset.map_batches`, the map is fused with the read; therefore ``override_num_blocks`` also determines the number of map tasks.
 
 Ray Data decides the default value for number of output blocks based on the following heuristics, applied in order:

--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -36,8 +36,8 @@ directory with the `local://` scheme.
 
     ds.write_parquet("local:///tmp/iris/")
 
-To write data to formats other than Parquet, read the
-:ref:`Input/Output reference <input-output>`.
+To write data to formats other than Parquet, see the
+:ref:`Saving Data API <saving-data-api>`.
 
 Writing data to cloud storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -47,7 +47,7 @@ with your cloud service provider. Then, call a method like
 :meth:`Dataset.write_parquet <ray.data.Dataset.write_parquet>` and specify a URI with
 the appropriate scheme. URI can point to buckets or folders.
 
-To write data to formats other than Parquet, read the :ref:`Input/Output reference <input-output>`.
+To write data to formats other than Parquet, see the :ref:`Saving Data API <saving-data-api>`.
 
 .. tab-set::
 
@@ -134,8 +134,8 @@ mounted directory.
 
     ds.write_parquet("/mnt/cluster_storage/iris")
 
-To write data to formats other than Parquet, read the
-:ref:`Input/Output reference <input-output>`.
+To write data to formats other than Parquet, see the
+:ref:`Saving Data API <saving-data-api>`.
 
 .. _changing-number-output-files:
 

--- a/doc/source/data/shuffling-data.rst
+++ b/doc/source/data/shuffling-data.rst
@@ -20,7 +20,7 @@ resource consumption and runtime. Choose the most appropriate method for your us
 Shuffle the ordering of files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To randomly shuffle the ordering of input files before reading, call a :ref:`read function <input-output>` function that supports shuffling, such as
+To randomly shuffle the ordering of input files before reading, call a :ref:`read function <loading-data-api>` function that supports shuffling, such as
 :func:`~ray.data.read_images`, and use the ``shuffle="files"`` parameter. This randomly assigns
 input files to workers for reading.
 

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -20,7 +20,7 @@ Reading images
 Ray Data can read images from a variety of formats.
 
 To view the full list of supported file formats, see the
-:ref:`Input/Output reference <input-output>`.
+:ref:`Loading Data API <loading-data-api>`.
 
 .. tab-set::
 
@@ -272,7 +272,7 @@ Saving images
 -------------
 
 Save images with formats like PNG, Parquet, and NumPy. To view all supported formats,
-see the :ref:`Input/Output reference <input-output>`.
+see the :ref:`Saving Data API <saving-data-api>`.
 
 .. tab-set::
 

--- a/doc/source/data/working-with-tensors.rst
+++ b/doc/source/data/working-with-tensors.rst
@@ -105,7 +105,7 @@ Saving tensor data
 ------------------
 
 Save tensor data with formats like Parquet, NumPy, and JSON. To view all supported
-formats, see the :ref:`Input/Output reference <input-output>`.
+formats, see the :ref:`Saving Data API <saving-data-api>`.
 
 .. tab-set::
 

--- a/doc/source/data/working-with-text.rst
+++ b/doc/source/data/working-with-text.rst
@@ -182,7 +182,7 @@ To save text, call a method like :meth:`~ray.data.Dataset.write_parquet`. Ray Da
 save text in many formats.
 
 To view the full list of supported file formats, see the
-:ref:`Input/Output reference <input-output>`.
+:ref:`Saving Data API <saving-data-api>`.
 
 .. testcode::
 


### PR DESCRIPTION
This PR splits the Input/Output API reference page into two separate pages to improve organization and mirror the structure of the user guides.

## Changes
- Renamed `input_output.rst` to `loading_data.rst`
- Created `saving_data.rst` with all saving/writing APIs
- Updated `api.rst` to reference both new files
- Updated all references from `input-output` to `loading-data-api`/`saving-data-api`
- Standardized section header formatting with dashes matching title length

Fixes #59301