### PR TITLE
[data][llm] Use numpy arrays for embeddings to avoid torch.Tensor serialization overhead

### DIFF
--- a/python/ray/llm/_internal/batch/benchmark/benchmark_processor.py
+++ b/python/ray/llm/_internal/batch/benchmark/benchmark_processor.py
@@ -13,11 +13,15 @@ from dataclasses import dataclass
 from enum import Enum
 from time import perf_counter, sleep
 
+from dataset import ShareGPTDataset
+
 import ray
-from .dataset import ShareGPTDataset
 from ray import data, serve
 from ray.data.llm import (
+    ChatTemplateStageConfig,
+    DetokenizeStageConfig,
     ServeDeploymentProcessorConfig,
+    TokenizerStageConfig,
     build_processor,
     vLLMEngineProcessorConfig,
 )
@@ -36,6 +40,7 @@ class Mode(Enum):
     SHARED_VLLM_ENGINE = "shared_vllm_engine"
     SERVE_DEPLOYMENT = "serve_deployment"
     SHARED_SERVE_DEPLOYMENT = "shared_serve_deployment"
+    CLASSIFY = "classify"
 
 
 # Default sampling parameters -- ensure a fair comparison by omitting sampling-induced variance
@@ -53,6 +58,11 @@ VLLM_ENGINE_KWARGS = {
     "max_num_batched_tokens": 4096,
 }
 
+# Default pooling parameters for classification
+CLASSIFY_POOLING_PARAMS = {
+    "truncate_prompt_tokens": -1,
+}
+
 
 def build_vllm_engine_kwargs(**kwargs) -> dict:
     """Build vLLM engine kwargs from command line arguments."""
@@ -68,21 +78,32 @@ def _build_vllm_engine_config(
     pipeline_parallel_size: int = None,
     tensor_parallel_size: int = None,
     distributed_executor_backend: str = None,
+    task_type: str = None,
+    max_model_len: int = None,
 ) -> vLLMEngineProcessorConfig:
     """Helper to create vLLMEngineProcessorConfig."""
-    return vLLMEngineProcessorConfig(
+    engine_kwargs = build_vllm_engine_kwargs(
+        pipeline_parallel_size=pipeline_parallel_size,
+        tensor_parallel_size=tensor_parallel_size,
+        distributed_executor_backend=distributed_executor_backend,
+    )
+    if max_model_len is not None:
+        engine_kwargs["max_model_len"] = max_model_len
+
+    config = vLLMEngineProcessorConfig(
         model_source=model,
         batch_size=batch_size,
         concurrency=concurrency,
         apply_chat_template=False,
         tokenize=False,
         detokenize=False,
-        engine_kwargs=build_vllm_engine_kwargs(
-            pipeline_parallel_size=pipeline_parallel_size,
-            tensor_parallel_size=tensor_parallel_size,
-            distributed_executor_backend=distributed_executor_backend,
-        ),
+        engine_kwargs=engine_kwargs,
     )
+
+    if task_type is not None:
+        config.task_type = task_type
+
+    return config
 
 
 def _build_serve_deployment_config(
@@ -200,6 +221,42 @@ def build_shared_vllm_engine_processor(
         return processor2(processor1(dataset))
 
     return multi_turn_processor
+
+
+def build_classify_processor(
+    batch_size: int,
+    concurrency: int,
+    model: str,
+    pooling_params: dict = CLASSIFY_POOLING_PARAMS,
+    max_model_len: int = 512,
+):
+    """Build vLLM engine processor for classification benchmark."""
+
+    config = vLLMEngineProcessorConfig(
+        model_source=model,
+        task_type="classify",
+        batch_size=batch_size,
+        concurrency=concurrency,
+        chat_template_stage=ChatTemplateStageConfig(enabled=False),
+        tokenize_stage=TokenizerStageConfig(enabled=True),
+        detokenize_stage=DetokenizeStageConfig(enabled=False),
+        engine_kwargs={
+            "enforce_eager": True,
+            "max_model_len": max_model_len,
+        },
+    )
+    return build_processor(
+        config,
+        preprocess=lambda row: dict(
+            prompt=row["prompt"],
+            pooling_params=pooling_params,
+        ),
+        postprocess=lambda row: {
+            "probs": float(row["embeddings"][0])
+            if row.get("embeddings") is not None and len(row["embeddings"]) > 0
+            else None,
+        },
+    )
 
 
 def setup_serve_deployment(model: str, concurrency: int) -> tuple[str, str]:
@@ -399,6 +456,7 @@ def benchmark(
         Mode.SHARED_VLLM_ENGINE: build_shared_vllm_engine_processor,
         Mode.SERVE_DEPLOYMENT: build_single_serve_deployment_processor,
         Mode.SHARED_SERVE_DEPLOYMENT: build_shared_serve_deployment_processor,
+        Mode.CLASSIFY: build_classify_processor,
     }
 
     if mode not in mode_to_builder:
@@ -422,6 +480,16 @@ def benchmark(
             )
         finally:
             serve.delete(app_name)
+    elif mode == Mode.CLASSIFY:
+        return run_processor(
+            mode,
+            dataset,
+            builder,
+            batch_size=batch_size,
+            concurrency=concurrency,
+            model=model,
+            pooling_params=CLASSIFY_POOLING_PARAMS,
+        )
     else:
         return run_processor(
             mode,
@@ -479,7 +547,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--truncate-prompt",
         type=int,
-        default=2048,
+        default=512,
         help="Maximum prompt length",
     )
     # Engine configuration

--- a/python/ray/llm/_internal/batch/benchmark/benchmark_processor.py
+++ b/python/ray/llm/_internal/batch/benchmark/benchmark_processor.py
@@ -13,9 +13,8 @@ from dataclasses import dataclass
 from enum import Enum
 from time import perf_counter, sleep
 
-from dataset import ShareGPTDataset
-
 import ray
+from .dataset import ShareGPTDataset
 from ray import data, serve
 from ray.data.llm import (
     ChatTemplateStageConfig,

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -190,6 +190,7 @@ class vLLMOutputData(BaseModel):
                 and data.embeddings.dtype == torch.bfloat16
             ):
                 data.embeddings = data.embeddings.to(torch.float32)
+            data.embeddings = data.embeddings.numpy()
         else:
             raise ValueError(f"Unknown output type: {type(output)}")
 


### PR DESCRIPTION
## Description
Currently, Ray Data LLM uses torch.Tensor to store embeddings from pooling tasks (e.g., classify) in Ray dataset columns. This causes redundant copies during serialization and deserialization. Using NumPy arrays is better because they support zero-copy deserialization via Ray's shared memory object store.

When embeddings are stored in Ray Data columns:
- `np.array`: Data stored once in shared memory → multiple workers read via pointers (zero-copy)
- `torch.Tensor`: Data copied into pickle stream → copied again on deserialize (2x copies)


### Benchmark Result
Using `np.array`, classification tasks with vLLMEngineStage show a ~9% throughput improvement.

| Metric | torch.Tensor | np.array |
|---|---|---|
| Throughput (row/s) | 953 | 1038 |

- Hardware: L4
- Repro command:
```
python benchmark_processor.py --mode classify --batch-size 2048 --concurrency 1 --num-prompts 102400 --model HuggingFaceTB/fineweb-edu-classifier
```

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
