### PR TITLE
[docs][serve] Add guide and docstrings for custom check_health hooks

### DIFF
--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -73,10 +73,10 @@ class Deployment:
 
     User-defined Methods:
         check_health():
-            [Optional] Define this method to implement custom application-level 
-            health checks. Ray Serve calls this periodically (default 10s). 
-            If it raises an exception, the replica is marked as UNHEALTHY 
-            and restarted. Useful for detecting internal engine crashes 
+            [Optional] Define this method to implement custom application-level
+            health checks. Ray Serve calls this periodically (default 10s).
+            If it raises an exception, the replica is marked as UNHEALTHY
+            and restarted. Useful for detecting internal engine crashes
             (like vLLM AsyncEngineDeadError) that leave the actor process alive.
 
     Example:

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -71,6 +71,14 @@ class Deployment:
     One or more deployments can be composed together into an `Application` which is
     then run via `serve.run` or a config file.
 
+    User-defined Methods:
+        check_health():
+            [Optional] Define this method to implement custom application-level 
+            health checks. Ray Serve calls this periodically (default 10s). 
+            If it raises an exception, the replica is marked as UNHEALTHY 
+            and restarted. Useful for detecting internal engine crashes 
+            (like vLLM AsyncEngineDeadError) that leave the actor process alive.
+
     Example:
 
     .. code-block:: python


### PR DESCRIPTION
## Description

This documentation change helps users implement "Logic-level" monitoring instead of just "Process-level" monitoring.
### Context/Background
Users deploying heavy-compute models (specifically vLLM for LLMs) often encounter "zombie replicas." This occurs when the application's internal engine (e.g., the vLLM background loop) crashes with an AsyncEngineDeadError, but the Ray Actor process remains alive. Because the process is alive, the default Ray Serve health check remains green, and the Ray Head node continues to route traffic to the broken replica, resulting in a series of 5xx errors for the end user.

Currently, the documentation for implementing a custom check_health hook to solve this is fragmented and not easily discoverable in the core monitoring or API guides.

### Changes
This PR improves the discoverability of application-level health checks in two ways:
1. `doc/source/serve/monitoring.md`: Added a new section, "Application-level Health Checks (Custom Health Checks)," including a clear code example and a real-world scenario (engine crashes vs. process health).
2. `python/ray/serve/deployment.py`: Updated the Deployment class docstring to explicitly list check_health() as an optional user-defined hook. This ensures that developers using IDEs can discover the feature via hover-over or code completion.

