### PR TITLE
[core] Add repr_name to actor_lifecycle_event

### DIFF
--- a/src/ray/observability/ray_actor_lifecycle_event.cc
+++ b/src/ray/observability/ray_actor_lifecycle_event.cc
@@ -31,6 +31,7 @@ RayActorLifecycleEvent::RayActorLifecycleEvent(
   state_transition.set_state(state);
   state_transition.mutable_timestamp()->CopyFrom(AbslTimeNanosToProtoTimestamp(
       absl::ToInt64Nanoseconds(absl::Now() - absl::UnixEpoch())));
+  state_transition.set_repr_name(data.repr_name());
 
   // Set state specific fields
   if (state == rpc::events::ActorLifecycleEvent::ALIVE) {

--- a/src/ray/observability/tests/ray_actor_lifecycle_event_test.cc
+++ b/src/ray/observability/tests/ray_actor_lifecycle_event_test.cc
@@ -33,6 +33,9 @@ TEST_F(RayActorLifecycleEventTest, TestMergeAndSerialize) {
 
   auto event1 = std::make_unique<RayActorLifecycleEvent>(
       data, rpc::events::ActorLifecycleEvent::DEPENDENCIES_UNREADY, "sess1");
+
+  // repr_name is only available after the actor creation.
+  data.set_repr_name("MyActor(id=123)");
   auto event2 = std::make_unique<RayActorLifecycleEvent>(
       data, rpc::events::ActorLifecycleEvent::ALIVE, "sess1");
 
@@ -54,6 +57,8 @@ TEST_F(RayActorLifecycleEventTest, TestMergeAndSerialize) {
             rpc::events::ActorLifecycleEvent::ALIVE);
   ASSERT_EQ(actor_life.state_transitions(1).node_id(), "node-1");
   ASSERT_EQ(actor_life.state_transitions(1).worker_id(), "worker-123");
+  ASSERT_EQ(actor_life.state_transitions(0).repr_name(), "");
+  ASSERT_EQ(actor_life.state_transitions(1).repr_name(), "MyActor(id=123)");
 }
 
 }  // namespace observability

--- a/src/ray/observability/tests/ray_actor_lifecycle_event_test.cc
+++ b/src/ray/observability/tests/ray_actor_lifecycle_event_test.cc
@@ -34,7 +34,7 @@ TEST_F(RayActorLifecycleEventTest, TestMergeAndSerialize) {
   auto event1 = std::make_unique<RayActorLifecycleEvent>(
       data, rpc::events::ActorLifecycleEvent::DEPENDENCIES_UNREADY, "sess1");
 
-  // repr_name is only available after the actor creation.
+  // repr_name is only available after actor creation.
   data.set_repr_name("MyActor(id=123)");
   auto event2 = std::make_unique<RayActorLifecycleEvent>(
       data, rpc::events::ActorLifecycleEvent::ALIVE, "sess1");

--- a/src/ray/protobuf/public/events_actor_lifecycle_event.proto
+++ b/src/ray/protobuf/public/events_actor_lifecycle_event.proto
@@ -43,6 +43,11 @@ message ActorLifecycleEvent {
     // The worker id of the worker on which this actor is running. available when state is ALIVE.
     // The worker id can change when the actor is restarted.
     bytes worker_id = 4;
+    // The repr name of the actor if specified with a customized repr method, e.g. __repr__
+    // This field is only available after the actor creation task has been run since it
+    // might depend on actor fields to be initialized in __init__.
+    // Default to empty string if no customized repr is defined.
+    string repr_name = 5;
     // Contains metadata about why the actor is dead. available when state is DEAD.
     ActorDeathCause death_cause = 6;
   }


### PR DESCRIPTION
## Description
Adds repr_name field to actor_lifecycle_event schema and populates it when available.

## Related issues
Closes https://github.com/ray-project/ray/issues/59813

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
