### PR TITLE
[ci] bump gcloud-cli version, don't hardcode arch

### DIFF
--- a/release/gcloud_docker_login.sh
+++ b/release/gcloud_docker_login.sh
@@ -4,8 +4,21 @@
 
 set -euo pipefail
 
-curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-441.0.0-linux-arm.tar.gz
-tar -xf google-cloud-cli-441.0.0-linux-arm.tar.gz
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+    GCLOUD_ARCH="x86_64"
+elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+    GCLOUD_ARCH="arm"
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+GCLOUD_VERSION="550.0.0"
+GCLOUD_TARBALL="google-cloud-cli-${GCLOUD_VERSION}-linux-${GCLOUD_ARCH}.tar.gz"
+
+curl -fO "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TARBALL}"
+tar -xf "$GCLOUD_TARBALL"
 ./google-cloud-sdk/install.sh -q
 PATH="$(pwd)/google-cloud-sdk/bin:$PATH"
 export PATH

--- a/release/gcloud_docker_login.sh
+++ b/release/gcloud_docker_login.sh
@@ -5,14 +5,18 @@
 set -euo pipefail
 
 ARCH=$(uname -m)
-if [[ "$ARCH" == "x86_64" ]]; then
-    GCLOUD_ARCH="x86_64"
-elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
-    GCLOUD_ARCH="arm"
-else
-    echo "Unsupported architecture: $ARCH"
-    exit 1
-fi
+case "$ARCH" in
+    x86_64)
+        GCLOUD_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        GCLOUD_ARCH="arm"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
 
 GCLOUD_VERSION="550.0.0"
 GCLOUD_TARBALL="google-cloud-cli-${GCLOUD_VERSION}-linux-${GCLOUD_ARCH}.tar.gz"


### PR DESCRIPTION
As-is, this script installs for arm architecture, regardless of actual machine type. Also bumping version to unblock issue from running with newer
OpenSSL version--
```
[ERROR 2026-01-07 03:46:50,067] crane_lib.py: 70  Crane command `/home/forge/.cache/bazel/_bazel_forge/5fe90af4e7d1ed9fcf52f59e39e126f5/external/crane_linux_x86_64/crane copy 029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:d656a31a-ray-anyscale-py3.10-cpu us-west1-docker.pkg.dev/anyscale-oss-ci/anyscale/ray:pr-59902.3702b2-py310-cpu` failed with stderr:
--
2026/01/07 03:46:49 Copying from 029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:d656a31a-ray-anyscale-py3.10-cpu to us-west1-docker.pkg.dev/anyscale-oss-ci/anyscale/ray:pr-59902.3702b2-py310-cpu
ERROR: gcloud failed to load: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'
gcloud_main = _import_gcloud_main()
import googlecloudsdk.gcloud_main
from googlecloudsdk.calliope import cli
from googlecloudsdk.calliope import backend
from googlecloudsdk.calliope import parser_extensions
from googlecloudsdk.core.updater import update_manager
from googlecloudsdk.core.updater import installers
from googlecloudsdk.core.credentials import store
from googlecloudsdk.api_lib.auth import util as auth_util
from googlecloudsdk.core.credentials import google_auth_credentials as c_google_auth
from oauth2client import client as oauth2client_client
from oauth2client import crypt
from oauth2client import _openssl_crypt
from OpenSSL import crypto
from OpenSSL import SSL, crypto
from OpenSSL.crypto import (
class X509StoreFlags:
NOTIFY_POLICY: int = _lib.X509_V_FLAG_NOTIFY_POLICY
 
This usually indicates corruption in your gcloud installation or problems with your Python interpreter.

```
