### PR TITLE
[release test] rename build_dir to context_dir in fill_build_context_dir

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -34,7 +34,7 @@ def build_anyscale_custom_byod_image(
             release_byod_dir = os.path.join(RELEASE_PACKAGE_DIR, "ray_release/byod")
 
     with tempfile.TemporaryDirectory() as build_dir:
-        fill_build_context_dir(build_context, build_dir, release_byod_dir)
+        fill_build_context_dir(build_context, release_byod_dir, build_dir)
 
         docker_build_cmd = "docker build --progress=plain .".split()
         docker_build_cmd += ["--build-arg", f"BASE_IMAGE={base_image}"]

--- a/release/ray_release/byod/build_context.py
+++ b/release/ray_release/byod/build_context.py
@@ -83,16 +83,16 @@ def build_context_digest(ctx: BuildContext) -> str:
 
 def fill_build_context_dir(
     ctx: BuildContext,
-    build_dir: str,
     source_dir: str,
+    context_dir: str,
 ) -> None:
     """
     Generate Dockerfile and copy source files to the build directory.
 
     Args:
         ctx: The BuildContext specifying what to include.
-        build_dir: Target directory for the generated Dockerfile and copied files.
         source_dir: Source directory containing the original files.
+        context_dir: Target directory for the generated Dockerfile and copied files.
     """
     dockerfile: List[str] = ["# syntax=docker/dockerfile:1.3-labs"]
     dockerfile.append("ARG BASE_IMAGE")
@@ -106,11 +106,11 @@ def fill_build_context_dir(
     if "python_depset" in ctx:
         shutil.copy(
             os.path.join(source_dir, ctx["python_depset"]),
-            os.path.join(build_dir, "python_depset.lock"),
+            os.path.join(context_dir, "python_depset.lock"),
         )
         shutil.copy(
             os.path.join(source_dir, "install_python_deps.sh"),
-            os.path.join(build_dir, "install_python_deps.sh"),
+            os.path.join(context_dir, "install_python_deps.sh"),
         )
         dockerfile.append("COPY install_python_deps.sh /tmp/install_python_deps.sh")
         dockerfile.append("COPY python_depset.lock python_depset.lock")
@@ -119,12 +119,12 @@ def fill_build_context_dir(
     if "post_build_script" in ctx:
         shutil.copy(
             os.path.join(source_dir, ctx["post_build_script"]),
-            os.path.join(build_dir, "post_build_script.sh"),
+            os.path.join(context_dir, "post_build_script.sh"),
         )
         dockerfile.append("COPY post_build_script.sh /tmp/post_build_script.sh")
         dockerfile.append("RUN bash /tmp/post_build_script.sh")
 
-    dockerfile_path = os.path.join(build_dir, "Dockerfile")
+    dockerfile_path = os.path.join(context_dir, "Dockerfile")
     with open(dockerfile_path, "w") as f:
         f.write("\n".join(dockerfile) + "\n")
 

--- a/release/ray_release/tests/test_byod_build_context.py
+++ b/release/ray_release/tests/test_byod_build_context.py
@@ -159,7 +159,7 @@ def test_fill_build_context_dir_empty() -> None:
     ):
         ctx = make_build_context(base_dir=source_dir)
 
-        fill_build_context_dir(ctx, build_dir, source_dir)
+        fill_build_context_dir(ctx, source_dir, build_dir)
 
         # Check Dockerfile
         with open(os.path.join(build_dir, "Dockerfile")) as f:
@@ -200,7 +200,7 @@ def test_fill_build_context_dir() -> None:
             python_depset="deps.lock",
         )
 
-        fill_build_context_dir(ctx, build_dir, source_dir)
+        fill_build_context_dir(ctx, source_dir, build_dir)
 
         # Check Dockerfile
         with open(os.path.join(build_dir, "Dockerfile")) as f:


### PR DESCRIPTION
Rename build_dir parameter to context_dir and move it to the last argument position for better API consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
