### PR TITLE
[core] Add reserve() calls for vectors with known/estimable sizes

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3062,6 +3062,7 @@ void CoreWorker::TryDelPendingObjectRefStreams() {
   absl::MutexLock lock(&generator_ids_pending_deletion_mutex_);
 
   std::vector<ObjectID> deleted;
+  deleted.reserve(generator_ids_pending_deletion_.size());
   for (const auto &generator_id : generator_ids_pending_deletion_) {
     RAY_LOG(DEBUG).WithField(generator_id)
         << "TryDelObjectRefStream from generator_ids_pending_deletion_";
@@ -3267,6 +3268,7 @@ std::vector<rpc::ObjectReference> CoreWorker::ExecuteTaskLocalMode(
 
   std::vector<rpc::ObjectReference> returned_refs;
   size_t num_returns = task_spec.NumReturns();
+  returned_refs.reserve(num_returns);
   for (size_t i = 0; i < num_returns; i++) {
     if (!task_spec.IsActorCreationTask()) {
       reference_counter_->AddOwnedObject(task_spec.ReturnId(i),
@@ -3308,6 +3310,7 @@ Status CoreWorker::GetAndPinArgsForExecutor(const TaskSpecification &task,
   auto num_args = task.NumArgs();
   args->reserve(num_args);
   arg_refs->reserve(num_args);
+  borrowed_ids->reserve(num_args);
 
   absl::flat_hash_set<ObjectID> by_ref_ids;
   absl::flat_hash_map<ObjectID, std::vector<size_t>> by_ref_indices;
@@ -4219,6 +4222,7 @@ void CoreWorker::HandleDeleteObjects(rpc::DeleteObjectsRequest request,
                                      rpc::DeleteObjectsReply *reply,
                                      rpc::SendReplyCallback send_reply_callback) {
   std::vector<ObjectID> object_ids;
+  object_ids.reserve(request.object_ids_size());
   for (const auto &obj_id : request.object_ids()) {
     object_ids.push_back(ObjectID::FromBinary(obj_id));
   }
@@ -4537,6 +4541,7 @@ bool CoreWorker::IsIdle() const {
 
 Status CoreWorker::WaitForActorRegistered(const std::vector<ObjectID> &ids) {
   std::vector<ActorID> actor_ids;
+  actor_ids.reserve(ids.size());
   for (const auto &id : ids) {
     if (ObjectID::IsActorID(id)) {
       actor_ids.emplace_back(ObjectID::ToActorID(id));

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -688,6 +688,7 @@ std::vector<rpc::Address> ReferenceCounter::GetOwnerAddresses(
     const std::vector<ObjectID> &object_ids) const {
   absl::MutexLock lock(&mutex_);
   std::vector<rpc::Address> owner_addresses;
+  owner_addresses.reserve(object_ids.size());
   for (const auto &object_id : object_ids) {
     rpc::Address owner_addr;
     bool has_owner = GetOwnerInternal(object_id, &owner_addr);
@@ -1143,6 +1144,7 @@ void ReferenceCounter::MergeRemoteBorrowers(const ObjectID &object_id,
     it = object_id_refs_.emplace(object_id, Reference()).first;
   }
   std::vector<rpc::Address> new_borrowers;
+  new_borrowers.reserve(borrower_ref.borrow().borrowers.size() + 1);
 
   // The worker is still using the reference, so it is still a borrower.
   if (borrower_ref.RefCount() > 0) {

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -247,6 +247,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
 
   // Add references for the dependencies to the task.
   std::vector<ObjectID> task_deps;
+  task_deps.reserve(spec.NumArgs());
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
       task_deps.push_back(spec.ArgObjectId(i));
@@ -913,6 +914,8 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
   std::vector<ObjectID> dynamic_returns_in_plasma;
   std::vector<ObjectID> direct_return_ids;
   if (reply.dynamic_return_objects_size() > 0) {
+    dynamic_return_ids.reserve(reply.dynamic_return_objects_size());
+    dynamic_returns_in_plasma.reserve(reply.dynamic_return_objects_size());
     RAY_CHECK(reply.return_objects_size() == 1)
         << "Dynamic generators only supported for num_returns=1";
     const auto generator_id = ObjectID::FromBinary(reply.return_objects(0).object_id());
@@ -947,6 +950,7 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     }
   }
 
+  direct_return_ids.reserve(reply.return_objects_size());
   for (const auto &return_object : reply.return_objects()) {
     const auto object_id = ObjectID::FromBinary(return_object.object_id());
     StatusOr<bool> direct_or = HandleTaskReturn(object_id,
@@ -1822,6 +1826,7 @@ ObjectID TaskManager::TaskGeneratorId(const TaskID &task_id) const {
 
 std::vector<ObjectID> ExtractPlasmaDependencies(const TaskSpecification &spec) {
   std::vector<ObjectID> plasma_dependencies;
+  plasma_dependencies.reserve(spec.NumArgs());
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
       plasma_dependencies.push_back(spec.ArgObjectId(i));


### PR DESCRIPTION
## Description

Add reserve() calls for vectors with known/estimable sizes in src/ray/core_worker/ to reduce reallocations during push_back.

## Related issues

> Link related issues: "Fixes #59885", "Closes #59885", or "Related to #59885".

## Additional information

