### PR TITLE
[Train] Train Benchmark to include time to first batch

### DIFF
--- a/release/train_tests/benchmark/runner.py
+++ b/release/train_tests/benchmark/runner.py
@@ -343,8 +343,8 @@ class TrainLoopRunner:
         train_time = (
             metrics["train/dataset_creation_time"]
             + self._metrics["train/step"].get()
-            # Exclude the time it takes to get the first batch.
-            # + self._metrics["train/iter_first_batch"].get()
+            # Include the time it takes to get the first batch.
+            + self._metrics["train/iter_first_batch"].get()
             + self._metrics["train/iter_batch"].get()
         )
         if train_time > 0:
@@ -355,8 +355,8 @@ class TrainLoopRunner:
         validation_time = (
             metrics["validation/dataset_creation_time"]
             + self._metrics["validation/step"].get()
-            # Exclude the time it takes to get the first batch.
-            # + self._metrics["validation/iter_first_batch"].get()
+            # Include the time it takes to get the first batch.
+            + self._metrics["validation/iter_first_batch"].get()
             + self._metrics["validation/iter_batch"].get()
         )
         if validation_time > 0:


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

### [Train] Train Benchmark to include time to first batch

- In train benchmarks, include time to first batch while reporting Throughput.
- Without this, it's misleading because throughput with preserve-order looks better than without. 

For instance,

- In [skip train parquet benchmark](https://buildkite.com/ray-project/release/builds/74298#019b9a97-4087-4dbe-aec5-698a7953f6a4), iter_first_batch = 15 secs.

- In [skip train parquet benchmark with preserve-order](https://buildkite.com/ray-project/release/builds/74298#019b9a97-4088-4127-ba6c-37df618f7053), iter_first_batch = 67 secs.

- So excluding time to first batch would show preserve order producing better throughput.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
