### PR TITLE
[core] Fix missing comment updates to RAY_testing_rpc_failure

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -694,7 +694,7 @@
  #         # 10% request failures, 10% response failures, 1 guaranteed request failure and 1 guaranteed response failure.
  #         # RAY_testing_rpc_failure_avoid_intra_node_failures=1 is used to avoid injecting RPC failures within the same node.
  #         runtime_env:
- #           - RAY_testing_rpc_failure="*=-1:10:10:1:1"
+ #           - RAY_testing_rpc_failure='{"*":{"num_failures":-1,"req_failure_prob":10,"resp_failure_prob":10,"in_flight_failure_prob":0,"num_lower_bound_req_failures":1,"num_lower_bound_resp_failures":1}}'
  #           - RAY_testing_rpc_failure_avoid_intra_node_failures=1
  #       cluster_compute: cross_az_250_350_compute_gce.yaml
  #   - __suffix__: aws_failure_injection
@@ -702,7 +702,7 @@
  #     cluster:
  #       byod:
  #         runtime_env:
- #           - RAY_testing_rpc_failure="*=-1:10:10:1:1"
+ #           - RAY_testing_rpc_failure='{"*":{"num_failures":-1,"req_failure_prob":10,"resp_failure_prob":10,"in_flight_failure_prob":0,"num_lower_bound_req_failures":1,"num_lower_bound_resp_failures":1}}'
  #           - RAY_testing_rpc_failure_avoid_intra_node_failures=1
  #       cluster_compute: cross_az_250_350_compute_aws.yaml
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -854,9 +854,9 @@ RAY_CONFIG(std::string, testing_asio_delay_us, "")
 /// Ex. unlimited failures for all RPCs with 25% request failures, 50% response
 /// failures, and 10% in-flight failures.
 ///     export
-///     RAY_testing_rpc_failure='{"*":{"num_failures":-1,"req_failure_prob":10,"resp_failure_prob":25,"in_flight_failure_prob":50}}'
-/// This will set the probabilities for all RPCs to 10% for request failures, 25% for
-/// response failures, and 50% for in-flight failures.
+///     RAY_testing_rpc_failure='{"*":{"num_failures":-1,"req_failure_prob":25,"resp_failure_prob":50,"in_flight_failure_prob":10}}'
+/// This will set the probabilities for all RPCs to 25% for request failures, 50% for
+/// response failures, and 10% for in-flight failures.
 /// NOTE: Setting the wildcard will override any configuration for other methods.
 ///
 /// You can also provide an optional fifth, sixth, and/or seventh parameter to specify

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -846,13 +846,17 @@ RAY_CONFIG(std::string, REDIS_SERVER_NAME, "")
 RAY_CONFIG(std::string, testing_asio_delay_us, "")
 
 /// To use this,
-///  export
-///  RAY_testing_rpc_failure="method1=max_num_failures:req_failure_prob:resp_failure_prob:in_flight_failure_prob,method2=max_num_failures:req_failure_prob:resp_failure_prob:in_flight_failure_prob"
-/// If you want to test all rpc failures you can use * as the method name and you can set
-/// -1 max_num_failures to have unlimited failures.
-/// Ex. unlimited failures for all rpc's with 25% request failures, 50% response
+///     export
+///     RAY_testing_rpc_failure='{"method1":{"num_failures":X,"req_failure_prob":Y,"resp_failure_prob":Z,"in_flight_failure_prob":W}}'
+///
+/// If you want to test all RPC failures you can use * as the method name and you can set
+/// -1 num_failures to have unlimited failures.
+/// Ex. unlimited failures for all RPCs with 25% request failures, 50% response
 /// failures, and 10% in-flight failures.
-///     export RAY_testing_rpc_failure="*=-1:25:50:10"
+///     export
+///     RAY_testing_rpc_failure='{"*":{"num_failures":-1,"req_failure_prob":10,"resp_failure_prob":25,"in_flight_failure_prob":50}}'
+/// This will set the probabilities for all RPCs to 10% for request failures, 25% for
+/// response failures, and 50% for in-flight failures.
 /// NOTE: Setting the wildcard will override any configuration for other methods.
 ///
 /// You can also provide an optional fifth, sixth, and/or seventh parameter to specify
@@ -866,10 +870,11 @@ RAY_CONFIG(std::string, testing_asio_delay_us, "")
 /// Afterwards, it will revert to the probabilistic failures. You can combine this with
 /// the wildcard so that each RPC method will have the same lower bounds applied.
 ///
-/// Ex. unlimited failures for all rpc's with 25% request failures, 50% response failures,
+/// Ex. unlimited failures for all RPCs with 25% request failures, 50% response failures,
 /// and 10% in-flight failures with at least 2 request failures, 3 response failures, and
-/// 1 in-flight failure.
-///     export RAY_testing_rpc_failure="*=-1:25:50:10:2:3:1"
+/// 1 in-flight failure:
+///     export
+///     RAY_testing_rpc_failure='{"*":{"num_failures":-1,"req_failure_prob":25,"resp_failure_prob":50,"in_flight_failure_prob":10,"num_lower_bound_req_failures":2,"num_lower_bound_resp_failures":3,"num_lower_bound_in_flight_failures":1}}'
 RAY_CONFIG(std::string, testing_rpc_failure, "")
 /// If this is set, when injecting RPC failures, we'll check if the server and client have
 /// the same address. If they do, we won't inject the failure.


### PR DESCRIPTION
There were a couple missing updates to RAY_testing_rpc_failure when we moved to a json format from here #58886 
that I noticed.
