### PR TITLE
[Data] Fix test_execution_optimizer_limit_pushdown determinism

### DIFF
--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -36,7 +36,8 @@ def _check_valid_plan_and_result(
 
 def test_limit_pushdown_basic_limit_fusion(ray_start_regular_shared_2_cpus):
     """Test basic Limit -> Limit fusion."""
-    ds = ray.data.range(100).limit(5).limit(100)
+    # Use override_num_blocks=1 for deterministic row ordering.
+    ds = ray.data.range(100, override_num_blocks=1).limit(5).limit(100)
     _check_valid_plan_and_result(
         ds,
         "Read[ReadRange] -> Limit[limit=5]",
@@ -47,7 +48,8 @@ def test_limit_pushdown_basic_limit_fusion(ray_start_regular_shared_2_cpus):
 
 def test_limit_pushdown_limit_fusion_reversed(ray_start_regular_shared_2_cpus):
     """Test Limit fusion with reversed order."""
-    ds = ray.data.range(100).limit(100).limit(5)
+    # Use override_num_blocks=1 for deterministic row ordering.
+    ds = ray.data.range(100, override_num_blocks=1).limit(100).limit(5)
     _check_valid_plan_and_result(
         ds,
         "Read[ReadRange] -> Limit[limit=5]",
@@ -58,7 +60,14 @@ def test_limit_pushdown_limit_fusion_reversed(ray_start_regular_shared_2_cpus):
 
 def test_limit_pushdown_multiple_limit_fusion(ray_start_regular_shared_2_cpus):
     """Test multiple Limit operations fusion."""
-    ds = ray.data.range(100).limit(50).limit(80).limit(5).limit(20)
+    # Use override_num_blocks=1 for deterministic row ordering.
+    ds = (
+        ray.data.range(100, override_num_blocks=1)
+        .limit(50)
+        .limit(80)
+        .limit(5)
+        .limit(20)
+    )
     _check_valid_plan_and_result(
         ds,
         "Read[ReadRange] -> Limit[limit=5]",


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.


**[Data] Fix test_execution_optimizer_limit_pushdown determinism**

Fix by adding `override_num_blocks=1`

```

[2026-01-08T00:20:42Z] =================================== FAILURES ===================================
--
[2026-01-08T00:20:42Z] ____________________ test_limit_pushdown_basic_limit_fusion ____________________
[2026-01-08T00:20:42Z]
[2026-01-08T00:20:42Z] ray_start_regular_shared_2_cpus = RayContext(dashboard_url='127.0.0.1:8265', python_version='3.10.19', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}')
[2026-01-08T00:20:42Z]
[2026-01-08T00:20:42Z]     def test_limit_pushdown_basic_limit_fusion(ray_start_regular_shared_2_cpus):
[2026-01-08T00:20:42Z]         """Test basic Limit -> Limit fusion."""
[2026-01-08T00:20:42Z]         ds = ray.data.range(100).limit(5).limit(100)
[2026-01-08T00:20:42Z] >       _check_valid_plan_and_result(
[2026-01-08T00:20:42Z]             ds,
[2026-01-08T00:20:42Z]             "Read[ReadRange] -> Limit[limit=5]",
[2026-01-08T00:20:42Z]             [{"id": i} for i in range(5)],
[2026-01-08T00:20:42Z]             check_ordering=False,
[2026-01-08T00:20:42Z]         )
[2026-01-08T00:20:42Z]
[2026-01-08T00:20:42Z] python/ray/data/tests/test_execution_optimizer_limit_pushdown.py:40:
[2026-01-08T00:20:42Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
[2026-01-08T00:20:42Z]
[2026-01-08T00:20:42Z] ds = limit=5
[2026-01-08T00:20:42Z] +- Dataset(num_rows=5, schema={id: int64})
[2026-01-08T00:20:42Z] expected_plan = 'Read[ReadRange] -> Limit[limit=5]'
[2026-01-08T00:20:42Z] expected_result = [{'id': 0}, {'id': 1}, {'id': 2}, {'id': 3}, {'id': 4}]
[2026-01-08T00:20:42Z] expected_physical_plan_ops = None, check_ordering = False
[2026-01-08T00:20:42Z]
[2026-01-08T00:20:42Z]     def _check_valid_plan_and_result(
[2026-01-08T00:20:42Z]         ds: Dataset,
[2026-01-08T00:20:42Z]         expected_plan: Plan,
[2026-01-08T00:20:42Z]         expected_result: List[Dict[str, Any]],
[2026-01-08T00:20:42Z]         expected_physical_plan_ops=None,
[2026-01-08T00:20:42Z]         check_ordering=True,
[2026-01-08T00:20:42Z]     ):
[2026-01-08T00:20:42Z]         actual_result = ds.take_all()
[2026-01-08T00:20:42Z]         if check_ordering:
[2026-01-08T00:20:42Z]             assert actual_result == expected_result
[2026-01-08T00:20:42Z]         else:
[2026-01-08T00:20:42Z] >           assert rows_same(pd.DataFrame(actual_result), pd.DataFrame(expected_result))
[2026-01-08T00:20:42Z] E           AssertionError: assert False
[2026-01-08T00:20:42Z] E            +  where False = rows_same(   id\n0  25\n1  26\n2  27\n3  28\n4  29,    id\n0   0\n1   1\n2   2\n3   3\n4   4)
[2026-01-08T00:20:42Z] E            +    where    id\n0  25\n1  26\n2  27\n3  28\n4  29 = <class 'pandas.core.frame.DataFrame'>([{'id': 25}, {'id': 26}, {'id': 27}, {'id': 28}, {'id': 29}])
[2026-01-08T00:20:42Z] E            +      where <class 'pandas.core.frame.DataFrame'> = pd.DataFrame
[2026-01-08T00:20:42Z] E            +    and      id\n0   0\n1   1\n2   2\n3   3\n4   4 = <class 'pandas.core.frame.DataFrame'>([{'id': 0}, {'id': 1}, {'id': 2}, {'id': 3}, {'id': 4}])
[2026-01-08T00:20:42Z] E            +      where <class 'pandas.core.frame.DataFrame'> = pd.DataFrame
 
```



## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
