### PR TITLE
[train] Add training failed error back to failure policy log

### DIFF
--- a/python/ray/train/v2/_internal/execution/failure_handling/default.py
+++ b/python/ray/train/v2/_internal/execution/failure_handling/default.py
@@ -44,7 +44,8 @@ class DefaultFailurePolicy(FailurePolicy):
         logger.info(
             f"[FailurePolicy] {decision.value}\n"
             f"  Source: {error_source}\n"
-            f"  Error count: {error_count} (max allowed: {retry_limit})\n\n",
+            f"  Error count: {error_count} (max allowed: {retry_limit})\n\n"
+            f"{training_failed_error}",
             exc_info=(
                 type(training_failed_error),
                 training_failed_error,

--- a/python/ray/train/v2/_internal/execution/failure_handling/default.py
+++ b/python/ray/train/v2/_internal/execution/failure_handling/default.py
@@ -44,8 +44,8 @@ class DefaultFailurePolicy(FailurePolicy):
         logger.info(
             f"[FailurePolicy] {decision.value}\n"
             f"  Source: {error_source}\n"
-            f"  Error count: {error_count} (max allowed: {retry_limit})\n\n"
-            f"{training_failed_error}",
+            f"  Error count: {error_count} (max allowed: {retry_limit})\n"
+            f"Error: {training_failed_error}",
             exc_info=(
                 type(training_failed_error),
                 training_failed_error,


### PR DESCRIPTION
# Summary

Before this PR, the training failed error was buried in the `exc_text` part of the log. After this PR it should also appear in the `message` part of the log. 

# Testing

Unit tests