### PR TITLE
[4/n] remove env var - ray serve proxy always on head node

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -437,11 +437,6 @@ RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S = get_env_float_non_negative(
     "RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S", 10.0
 )
 
-# Feature flag to always run a proxy on the head node even if it has no replicas.
-RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE = get_env_bool(
-    "RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE", "1"
-)
-
 # Default is 2GiB, the max for a signed int.
 RAY_SERVE_GRPC_MAX_MESSAGE_SIZE = get_env_int(
     "RAY_SERVE_GRPC_MAX_MESSAGE_SIZE", (2 * 1024 * 1024 * 1024) - 1

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -508,7 +508,7 @@ class ServeController:
                 )
             self.control_loop_duration_gauge_s.set(loop_duration)
 
-            num_loops += 2
+            num_loops += 1
             self.num_control_loops_gauge.set(num_loops)
 
             sleep_start_time = time.time()

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -508,7 +508,7 @@ class ServeController:
                 )
             self.control_loop_duration_gauge_s.set(loop_duration)
 
-            num_loops += 1
+            num_loops += 2
             self.num_control_loops_gauge.set(num_loops)
 
             sleep_start_time = time.time()

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -21,7 +21,6 @@ from ray.serve._private.constants import (
     PROXY_HEALTH_CHECK_TIMEOUT_S,
     PROXY_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
     PROXY_READY_CHECK_TIMEOUT_S,
-    RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE,
     RAY_SERVE_ENABLE_TASK_EVENTS,
     REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
     SERVE_LOGGER_NAME,
@@ -690,10 +689,6 @@ class ProxyStateManager:
         """
         if proxy_nodes is None:
             proxy_nodes = set()
-
-        # Ensure head node always has a proxy (unless FF'd off).
-        if RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE:
-            proxy_nodes.add(self._head_node_id)
 
         target_nodes = self._get_target_nodes(proxy_nodes)
         target_node_ids = {node_id for node_id, _, _ in target_nodes}

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -690,6 +690,8 @@ class ProxyStateManager:
         if proxy_nodes is None:
             proxy_nodes = set()
 
+        proxy_nodes.add(self._head_node_id)
+
         target_nodes = self._get_target_nodes(proxy_nodes)
         target_node_ids = {node_id for node_id, _, _ in target_nodes}
 

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -690,8 +690,6 @@ class ProxyStateManager:
         if proxy_nodes is None:
             proxy_nodes = set()
 
-        proxy_nodes.add(self._head_node_id)
-
         target_nodes = self._get_target_nodes(proxy_nodes)
         target_node_ids = {node_id for node_id, _, _ in target_nodes}
 

--- a/python/ray/serve/tests/unit/test_proxy_state.py
+++ b/python/ray/serve/tests/unit/test_proxy_state.py
@@ -203,7 +203,7 @@ def test_proxy_state_manager_restarts_unhealthy_proxies(all_nodes):
 
     cluster_node_info_cache.alive_nodes = all_nodes
     # First iteration, refresh state
-    proxy_state_manager.update()
+    proxy_state_manager.update(proxy_nodes={HEAD_NODE_ID})
 
     prev_proxy_state = proxy_state_manager._proxy_states[HEAD_NODE_ID]
     # Mark existing head-node proxy UNHEALTHY
@@ -212,7 +212,7 @@ def test_proxy_state_manager_restarts_unhealthy_proxies(all_nodes):
 
     # Continuously trigger update and wait for status to be changed to HEALTHY.
     for _ in range(1):
-        proxy_state_manager.update(proxy_nodes=set(HEAD_NODE_ID))
+        proxy_state_manager.update(proxy_nodes={HEAD_NODE_ID})
         # Advance timer by 5 (to perform a health-check)
         timer.advance(5)
 
@@ -415,7 +415,7 @@ def test_proxy_manager_update_proxies_states(all_nodes, number_of_worker_nodes):
     node_ids = [node_id for node_id, _, _ in all_nodes]
 
     # No target proxy nodes
-    proxy_nodes = set()
+    proxy_nodes = {HEAD_NODE_ID}
 
     # Head node proxy should continue to be HEALTHY.
     # Worker node proxy should turn DRAINING.
@@ -533,7 +533,7 @@ def test_proxy_actor_manager_removing_proxies(all_nodes, number_of_worker_nodes)
     N = 10
     for _ in range(N):
         manager.update(
-            proxy_nodes=set(),
+            proxy_nodes={HEAD_NODE_ID},
         )
         timer.advance(5)
         # Assert that
@@ -550,7 +550,7 @@ def test_proxy_actor_manager_removing_proxies(all_nodes, number_of_worker_nodes)
     # Reconcile proxies with empty set of target nodes (worker node proxy
     # will be shutdown by now)
     manager.update(
-        proxy_nodes=set(),
+        proxy_nodes={HEAD_NODE_ID},
     )
 
     assert len(manager._proxy_states) == 1


### PR DESCRIPTION
### Summary
This PR removes the `RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE` environment variable as it has no practical effect in production.

### Why this env var is redundant
The env var was intended to "always run a proxy on the head node even if it has no replicas." However, the controller already unconditionally ensures the head node is included in the proxy nodes set, making this flag ineffective.

### Code flow analysis
#### In `controller.py` `_update_proxy_nodes()` (lines 419-430):
```python
def _update_proxy_nodes(self):
    new_proxy_nodes = self.deployment_state_manager.get_active_node_ids()
    new_proxy_nodes = new_proxy_nodes - set(
        self.cluster_node_info_cache.get_draining_nodes()
    )
    new_proxy_nodes.add(self._controller_node_id)  # <-- UNCONDITIONAL
    self._proxy_nodes = new_proxy_nodes
```

The head node (`_controller_node_id`) is **always** added to `_proxy_nodes` unconditionally.
#### In `proxy_state.py` `update()` (where the env var was checked):
```python
if RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE:
    proxy_nodes.add(self._head_node_id)
```

This check happens **after** the controller already added the head node. Since proxy_nodes is a set, adding the same node again is a no-op.

### Consequence
- Setting `RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE=0` had no effect because the controller adds the head node regardless.
- Setting `RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE=1` (the default) was also a no-op since the head node was already present.

### Changes
- Removed `RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE` definition from `constants.py`
- Removed the import and usage in `proxy_state.py`