### PR TITLE
[Data] Make `StatefulShuffleAggregation.finalize` interface allow incremental streaming

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_aggregate.py
+++ b/python/ray/data/_internal/execution/operators/hash_aggregate.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
 
 from ray.data._internal.arrow_block import ArrowBlockAccessor
 from ray.data._internal.execution.interfaces import PhysicalOperator
@@ -69,11 +69,13 @@ class ReducingShuffleAggregation(StatefulShuffleAggregation):
             # TODO make aggregation async
             self._combine_aggregated_blocks(should_finalize=False)
 
-    def finalize(self, partition_id: int) -> Block:
+    def finalize(self, partition_id: int) -> Iterator[Block]:
         if len(self._aggregated_blocks) == 0:
-            return ArrowBlockAccessor._empty_table()
+            block = ArrowBlockAccessor._empty_table()
+        else:
+            block = self._combine_aggregated_blocks(should_finalize=True)
 
-        return self._combine_aggregated_blocks(should_finalize=True)
+        yield block
 
     def clear(self, partition_id: int):
         self._aggregated_blocks: List[Block] = []

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -16,6 +16,7 @@ from typing import (
     Deque,
     Dict,
     Generator,
+    Iterator,
     List,
     Optional,
     Set,
@@ -126,7 +127,7 @@ class StatefulShuffleAggregation(abc.ABC):
         """
         raise NotImplementedError()
 
-    def finalize(self, partition_id: int) -> Block:
+    def finalize(self, partition_id: int) -> Iterator[Block]:
         """Finalizes aggregation of partitions (identified by partition-id)
         from all input sequences returning resulting block.
         """
@@ -181,13 +182,13 @@ class Concat(StatefulShuffleAggregation):
 
         self._partition_block_builders[partition_id].add_block(partition_shard)
 
-    def finalize(self, partition_id: int) -> Block:
+    def finalize(self, partition_id: int) -> Iterator[Block]:
         block = self._partition_block_builders[partition_id].build()
 
         if self._should_sort and len(block) > 0:
             block = block.sort_by([(k, "ascending") for k in self._key_columns])
 
-        return block
+        yield block
 
     def clear(self, partition_id: int):
         self._partition_block_builders.pop(partition_id)
@@ -1565,31 +1566,46 @@ class HashShuffleAggregator:
 
         with self._lock:
             exec_stats_builder = BlockExecStats.builder()
+
             # Finalize given partition id
-            block = self._agg.finalize(partition_id)
-            exec_stats = exec_stats_builder.build()
+            blocks = self._agg.finalize(partition_id)
+
+            if self._target_max_block_size is not None:
+                blocks = _shape_blocks(blocks, self._target_max_block_size)
+
+            for block in blocks:
+                # Collect execution stats (and reset)
+                exec_stats = exec_stats_builder.build()
+                exec_stats_builder = BlockExecStats.builder()
+
+                yield block
+                yield BlockMetadataWithSchema.from_block(block, stats=exec_stats)
+
             # Clear any remaining state (to release resources)
             self._agg.clear(partition_id)
 
-        if self._target_max_block_size is None:
-            yield block
-            yield BlockMetadataWithSchema.from_block(block, stats=exec_stats)
-        else:
-            # Creating a block output buffer per partition finalize task because
-            # retrying finalize tasks cause stateful output_bufer to be
-            # fragmented (ie, adding duplicated blocks, calling finalize 2x)
-            output_buffer = BlockOutputBuffer(
-                output_block_size_option=OutputBlockSizeOption(
-                    target_max_block_size=self._target_max_block_size
-                )
-            )
 
-            output_buffer.add_block(block)
-            output_buffer.finalize()
-            while output_buffer.has_next():
-                block = output_buffer.next()
-                yield block
-                yield BlockMetadataWithSchema.from_block(block, stats=exec_stats)
+def _shape_blocks(
+    blocks: Iterator[Block], target_max_block_size: int
+) -> Iterator[Block]:
+    output_buffer = BlockOutputBuffer(
+        output_block_size_option=OutputBlockSizeOption(
+            target_max_block_size=target_max_block_size
+        )
+    )
+
+    for block in blocks:
+        output_buffer.add_block(block)
+
+        while output_buffer.has_next():
+            block = output_buffer.next()
+            yield block
+
+    output_buffer.finalize()
+
+    while output_buffer.has_next():
+        block = output_buffer.next()
+        yield block
 
 
 def _get_total_cluster_resources() -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Tuple, Type
 
 from ray._private.arrow_utils import get_pyarrow_version
 from ray.data._internal.arrow_block import ArrowBlockAccessor, ArrowBlockBuilder
@@ -111,7 +111,7 @@ class JoiningShuffleAggregation(StatefulShuffleAggregation):
         self._right_input_seq_partition_builders: Dict[int, ArrowBlockBuilder] = {
             partition_id: ArrowBlockBuilder() for partition_id in target_partition_ids
         }
-        self.data_context = data_context
+        self._data_context = data_context
 
     def accept(self, input_seq_id: int, partition_id: int, partition_shard: Block):
         assert 0 <= input_seq_id < 2
@@ -123,7 +123,7 @@ class JoiningShuffleAggregation(StatefulShuffleAggregation):
 
         partition_builder.add_block(partition_shard)
 
-    def finalize(self, partition_id: int) -> Block:
+    def finalize(self, partition_id: int) -> Iterator[Block]:
 
         left_on, right_on = list(self._left_key_col_names), list(
             self._right_key_col_names
@@ -153,7 +153,7 @@ class JoiningShuffleAggregation(StatefulShuffleAggregation):
             preprocess_result_r.unsupported_projection,
         )
 
-        return supported
+        yield supported
 
     def _preprocess(
         self,


### PR DESCRIPTION
## Description

This change makes `StatefulShuffleAggregation.finalize` interface allow incremental streaming to prepare it for future shift to streaming results incrementally.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
