### PR TITLE
[Data] Streamline `HashShuffleAggregator` protocol

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -650,6 +650,20 @@ py_test(
 )
 
 py_test(
+    name = "test_hash_shuffle_aggregator",
+    size = "medium",
+    srcs = ["tests/test_hash_shuffle_aggregator.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_hudi",
     size = "medium",
     srcs = ["tests/test_hudi.py"],

--- a/python/ray/data/_internal/execution/operators/hash_aggregate.py
+++ b/python/ray/data/_internal/execution/operators/hash_aggregate.py
@@ -108,6 +108,7 @@ class HashAggregateOperator(HashShufflingOperatorBase):
             input_ops=[input_op],
             data_context=data_context,
             key_columns=[key_columns],
+            num_input_seqs=1,
             num_partitions=(
                 # NOTE: In case of global aggregations (ie with no key columns specified),
                 #       we override number of partitions to 1, since the whole dataset

--- a/python/ray/data/_internal/execution/operators/hash_aggregate.py
+++ b/python/ray/data/_internal/execution/operators/hash_aggregate.py
@@ -7,7 +7,7 @@ from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.hash_shuffle import (
     BlockTransformer,
     HashShufflingOperatorBase,
-    StatefulShuffleAggregation,
+    ShuffleAggregation,
 )
 from ray.data._internal.util import GiB, MiB
 from ray.data.aggregate import AggregateFn
@@ -21,85 +21,59 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class ReducingShuffleAggregation(StatefulShuffleAggregation):
-    """Aggregation performing reduction of the shuffled sequence using provided
-    list of aggregating functions.
+class ReducingAggregation(ShuffleAggregation):
+    """Stateless aggregation that reduces blocks using aggregation functions.
 
-    NOTE: That reductions are performed incrementally in a streaming fashion upon
-          accumulation of pre-configured buffer of rows to run aggregation on."""
-
-    _DEFAULT_BLOCKS_BUFFER_LIMIT = 1000
+    This implementation performs incremental reduction during compaction,
+    combining multiple partially-aggregated blocks into one. The final
+    aggregation is performed during finalization.
+    """
 
     def __init__(
         self,
-        aggregator_id: int,
-        key_columns: Optional[Tuple[str]],
-        aggregation_fns: Tuple[AggregateFn],
+        key_columns: Tuple[str, ...],
+        aggregation_fns: Tuple[AggregateFn, ...],
     ):
+        self._sort_key: "SortKey" = self._get_sort_key(key_columns)
+        self._aggregation_fns: Tuple[AggregateFn, ...] = aggregation_fns
 
-        super().__init__(aggregator_id)
+    @classmethod
+    def is_compacting(cls):
+        return True
 
-        assert key_columns is not None, "Shuffle aggregation requires key columns"
+    def compact(self, partition_shards: List[Block]) -> Block:
+        assert len(partition_shards) > 0, "Provided sequence must be non-empty"
 
-        self._sort_key: "SortKey" = ReducingShuffleAggregation._get_sort_key(
-            key_columns
-        )
-        self._aggregation_fns: Tuple[AggregateFn] = aggregation_fns
+        return self._combine(partition_shards, finalize=False)
 
-        self._aggregated_blocks: List[Block] = []
-
-    def accept(self, input_seq_id: int, partition_id: int, partition_shard: Block):
+    def finalize(self, partition_shards_map: Dict[int, List[Block]]) -> Iterator[Block]:
         assert (
-            input_seq_id == 0
-        ), f"Single sequence is expected (got seq-id {input_seq_id})"
+            len(partition_shards_map) == 1
+        ), f"Single input-sequence is expected (got {len(partition_shards_map)})"
 
-        # Received partition shard is already partially aggregated, hence
-        # we simply add it to the list of aggregated blocks
-        #
-        # NOTE: We're not separating blocks by partition as it's ultimately not
-        #       relevant for the aggregations performed
-        self._aggregated_blocks.append(partition_shard)
+        blocks = partition_shards_map[0]
 
-        # Aggregation is performed incrementally, rather
-        # than being deferred to the finalization stage
-        if len(self._aggregated_blocks) > self._DEFAULT_BLOCKS_BUFFER_LIMIT:
-            # NOTE: This method will reset partially aggregated blocks to hold
-            #       the new combined one
-            #
-            # TODO make aggregation async
-            self._combine_aggregated_blocks(should_finalize=False)
+        if not blocks:
+            return
 
-    def finalize(self, partition_id: int) -> Iterator[Block]:
-        if len(self._aggregated_blocks) == 0:
-            block = ArrowBlockAccessor._empty_table()
-        else:
-            block = self._combine_aggregated_blocks(should_finalize=True)
+        yield self._combine(blocks, finalize=True)
 
-        yield block
+    def _combine(self, blocks: List[Block], *, finalize: bool) -> Block:
+        """Internal method to combine blocks with optional finalization."""
+        assert len(blocks) > 0
 
-    def clear(self, partition_id: int):
-        self._aggregated_blocks: List[Block] = []
-
-    def _combine_aggregated_blocks(self, *, should_finalize: bool) -> Block:
-        assert len(self._aggregated_blocks) > 0
-
-        block_accessor = BlockAccessor.for_block(self._aggregated_blocks[0])
+        block_accessor = BlockAccessor.for_block(blocks[0])
         combined_block, _ = block_accessor._combine_aggregated_blocks(
-            self._aggregated_blocks,
+            blocks,
             sort_key=self._sort_key,
             aggs=self._aggregation_fns,
-            finalize=should_finalize,
+            finalize=finalize,
         )
-
-        # For combined block that's not yet finalized reset cached aggregated
-        # blocks to only hold newly combined one
-        if not should_finalize:
-            self._aggregated_blocks = [combined_block]
 
         return combined_block
 
     @staticmethod
-    def _get_sort_key(key_columns: Tuple[str]):
+    def _get_sort_key(key_columns: Tuple[str, ...]) -> "SortKey":
         from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 
         return SortKey(key=list(key_columns), descending=False)
@@ -116,6 +90,13 @@ class HashAggregateOperator(HashShufflingOperatorBase):
         num_partitions: Optional[int] = None,
         aggregator_ray_remote_args_override: Optional[Dict[str, Any]] = None,
     ):
+        # Use new stateless ReducingAggregation factory
+        def _create_reducing_aggregation() -> ReducingAggregation:
+            return ReducingAggregation(
+                key_columns=key_columns,
+                aggregation_fns=aggregation_fns,
+            )
+
         super().__init__(
             name_factory=(
                 lambda num_partitions: f"HashAggregate(key_columns={key_columns}, "
@@ -132,13 +113,7 @@ class HashAggregateOperator(HashShufflingOperatorBase):
                 if len(key_columns) > 0
                 else 1
             ),
-            partition_aggregation_factory=(
-                lambda aggregator_id, target_partition_ids: ReducingShuffleAggregation(
-                    aggregator_id,
-                    key_columns,
-                    aggregation_fns,
-                )
-            ),
+            partition_aggregation_factory=_create_reducing_aggregation,
             input_block_transformer=_create_aggregating_transformer(
                 key_columns, aggregation_fns
             ),
@@ -198,7 +173,7 @@ def _create_aggregating_transformer(
     """Method creates input block transformer performing partial aggregation of
     the block applied prior to block being shuffled (to reduce amount of bytes shuffled)"""
 
-    sort_key = ReducingShuffleAggregation._get_sort_key(key_columns)
+    sort_key = ReducingAggregation._get_sort_key(key_columns)
 
     def _aggregate(block: Block) -> Block:
         from ray.data._internal.planner.exchange.aggregate_task_spec import (

--- a/python/ray/data/_internal/execution/operators/hash_aggregate.py
+++ b/python/ray/data/_internal/execution/operators/hash_aggregate.py
@@ -2,7 +2,6 @@ import logging
 import math
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
 
-from ray.data._internal.arrow_block import ArrowBlockAccessor
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.hash_shuffle import (
     BlockTransformer,
@@ -171,7 +170,9 @@ class HashAggregateOperator(HashShufflingOperatorBase):
         return aggregator_total_memory_required
 
     @classmethod
-    def _get_min_max_partition_shards_compaction_thresholds(cls) -> Optional[Tuple[int, int]]:
+    def _get_min_max_partition_shards_compaction_thresholds(
+        cls,
+    ) -> Optional[Tuple[int, int]]:
         return (
             cls._DEFAULT_MIN_NUM_SHARDS_COMPACTION_THRESHOLD,
             cls._DEFAULT_MAX_NUM_SHARDS_COMPACTION_THRESHOLD,

--- a/python/ray/data/_internal/execution/operators/hash_aggregate.py
+++ b/python/ray/data/_internal/execution/operators/hash_aggregate.py
@@ -80,6 +80,10 @@ class ReducingAggregation(ShuffleAggregation):
 
 
 class HashAggregateOperator(HashShufflingOperatorBase):
+
+    _DEFAULT_MIN_NUM_SHARDS_COMPACTION_THRESHOLD = 100
+    _DEFAULT_MAX_NUM_SHARDS_COMPACTION_THRESHOLD = 2000
+
     def __init__(
         self,
         data_context: DataContext,
@@ -165,6 +169,13 @@ class HashAggregateOperator(HashShufflingOperatorBase):
         )
 
         return aggregator_total_memory_required
+
+    @classmethod
+    def _get_min_max_partition_shards_compaction_thresholds(cls) -> Optional[Tuple[int, int]]:
+        return (
+            cls._DEFAULT_MIN_NUM_SHARDS_COMPACTION_THRESHOLD,
+            cls._DEFAULT_MAX_NUM_SHARDS_COMPACTION_THRESHOLD,
+        )
 
 
 def _create_aggregating_transformer(

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -521,6 +521,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
         *,
         key_columns: List[Tuple[str]],
         partition_aggregation_factory: ShuffleAggregationFactory,
+        num_input_seqs: int,
         num_partitions: Optional[int] = None,
         partition_size_hint: Optional[int] = None,
         input_block_transformer: Optional[BlockTransformer] = None,
@@ -604,6 +605,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
             ray_remote_args.update(aggregator_ray_remote_args_override)
 
         self._aggregator_pool: AggregatorPool = AggregatorPool(
+            num_input_seqs=num_input_seqs,
             num_partitions=target_num_partitions,
             num_aggregators=num_aggregators,
             aggregation_factory=partition_aggregation_factory,
@@ -1272,6 +1274,7 @@ class HashShuffleOperator(HashShufflingOperatorBase):
             input_ops=[input_op],
             data_context=data_context,
             key_columns=[key_columns],
+            num_input_seqs=1,
             num_partitions=num_partitions,
             aggregator_ray_remote_args_override=aggregator_ray_remote_args_override,
             partition_aggregation_factory=_create_concat_aggregation,

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1778,9 +1778,7 @@ class HashShuffleAggregator:
                     result[f"seq_{seq_id}"][f"partition_{partition_id}"] = {
                         # NOTE: qsize() is approximate but sufficient for debug logging
                         "num_blocks": partition.queue.qsize(),
-                        "compaction_threshold": self._current_compaction_thresholds[
-                            partition_id
-                        ],
+                        "compaction_threshold": partition.compaction_threshold,
                     }
 
             logger.debug(

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -727,13 +727,14 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
             #   - Block is first hash-partitioned into N partitions
             #   - Individual partitions then are submitted to the corresponding
             #     aggregators
+            #
+            # TODO HSA needs to be idempotent for _shuffle_block to be retriable
+            #      https://anyscale1.atlassian.net/browse/DATA-1763
             input_block_partition_shards_metadata_tuple_ref: ObjectRef[
                 Tuple[BlockMetadata, Dict[int, _PartitionStats]]
             ] = _shuffle_block.options(
                 **shuffle_task_resource_bundle,
                 num_returns=1,
-                # Make sure tasks are retried indefinitely
-                max_retries=-1,
             ).remote(
                 block_ref,
                 input_index,

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1728,7 +1728,7 @@ class HashShuffleAggregator:
                 #       compaction to amortize the cost of compaction.
                 self._current_compaction_thresholds[partition_id] = min(
                     self._current_compaction_thresholds[partition_id] * 2,
-                    self._max_num_blocks_compaction_threshold
+                    self._max_num_blocks_compaction_threshold,
                 )
 
     def finalize(

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -517,6 +517,8 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
           simultaneously (as required by Join operator for ex).
     """
 
+    _DEFAULT_SHUFFLE_BLOCK_NUM_CPUS = 1.0
+
     def __init__(
         self,
         name_factory: Callable[[int], str],
@@ -704,7 +706,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
             input_key_column_names = self._key_column_names[input_index]
             # Compose shuffling task resource bundle
             shuffle_task_resource_bundle = {
-                "num_cpus": 1.0,
+                "num_cpus": self._DEFAULT_SHUFFLE_BLOCK_NUM_CPUS,
                 "memory": self._estimate_shuffling_memory_req(
                     block_metadata,
                     target_max_block_size=(
@@ -1060,9 +1062,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
 
     def incremental_resource_usage(self) -> ExecutionResources:
         return ExecutionResources(
-            # TODO fix (this hack is currently to force Ray to spin up more tasks when
-            #      shuffling to autoscale hardware capacity)
-            cpu=0.01,
+            cpu=self._DEFAULT_SHUFFLE_BLOCK_NUM_CPUS,
             # cpu=self._shuffle_block_ray_remote_args.get("num_cpus", 0),
             # TODO estimate (twice avg block size)
             object_store_memory=0,

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1711,7 +1711,9 @@ class HashShuffleAggregator:
                 # Drain the queue to perform compaction
                 to_compact = bucket.drain_queue()
                 # We revise up compaction thresholds for partition after every
-                # compaction to amortize the cost of compaction.
+                # compaction so that for "non-compacting" aggregations (like
+                # `Unique`) we amortize the cost of compaction processing the same
+                # elements multiple times.
                 bucket.compaction_threshold = min(
                     bucket.compaction_threshold * 2,
                     self._max_num_blocks_compaction_threshold,

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1703,9 +1703,7 @@ class HashShuffleAggregator:
             with bucket.lock:
                 # Check queue size again to avoid running compaction after
                 # another one just drained the queue
-                if (
-                    bucket.queue.qsize() < bucket.compaction_threshold
-                ):
+                if bucket.queue.qsize() < bucket.compaction_threshold:
                     return
 
                 # Drain the queue to perform compaction
@@ -1799,7 +1797,9 @@ class HashShuffleAggregator:
 
         for seq_id in range(num_input_seqs):
             for part_id in target_partition_ids:
-                partition_buckets[seq_id][part_id] = PartitionBucket.create(compaction_threshold)
+                partition_buckets[seq_id][part_id] = PartitionBucket.create(
+                    compaction_threshold
+                )
 
         return partition_buckets
 

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -609,9 +609,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
             aggregation_factory=partition_aggregation_factory,
             aggregator_ray_remote_args=ray_remote_args,
             target_max_block_size=(
-                None
-                if disallow_block_splitting
-                else data_context.target_max_block_size
+                None if disallow_block_splitting else data_context.target_max_block_size
             ),
             min_max_shards_compaction_thresholds=(
                 self._get_min_max_partition_shards_compaction_thresholds()
@@ -1240,7 +1238,9 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
         raise NotImplementedError()
 
     @classmethod
-    def _get_min_max_partition_shards_compaction_thresholds(cls) -> Optional[Tuple[int, int]]:
+    def _get_min_max_partition_shards_compaction_thresholds(
+        cls,
+    ) -> Optional[Tuple[int, int]]:
         return None
 
 
@@ -1383,7 +1383,9 @@ class AggregatorPool:
             self._aggregator_partition_map,
         )
 
-        self._min_max_shards_compaction_thresholds = min_max_shards_compaction_thresholds
+        self._min_max_shards_compaction_thresholds = (
+            min_max_shards_compaction_thresholds
+        )
 
     def start(self):
         # Check cluster resources before starting aggregators

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1709,9 +1709,9 @@ class HashShuffleAggregator:
                 # Drain the queue to perform compaction
                 to_compact = bucket.drain_queue()
                 # We revise up compaction thresholds for partition after every
-                # compaction so that for "non-compacting" aggregations (like
-                # `Unique`) we amortize the cost of compaction processing the same
-                # elements multiple times.
+                # compaction so that for "non-reducing" aggregations (like
+                # `Unique`, `AsList`) we amortize the cost of compaction processing
+                # the same elements multiple times.
                 bucket.compaction_threshold = min(
                     bucket.compaction_threshold * 2,
                     self._max_num_blocks_compaction_threshold,

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -142,12 +142,10 @@ class ShuffleAggregation:
         is perfectly fine to return provided partition shards as they are.
 
         Args:
-            partial_partition_shards: partial (incomplete) list of
-            partition shards
+            partial_partition_shards: Partial (incomplete) list of partition shards.
 
         Returns:
-            Potentially "compacted" list of partition shards (if it's advantageous
-            to do so)
+            Potentially "compacted" block (if it's advantageous to do so).
         """
         raise NotImplementedError()
 

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1684,7 +1684,7 @@ class HashShuffleAggregator:
         Uses per-(sequence, partition) locking to avoid cross-partition contention.
         Performs incremental compaction when the block count exceeds threshold.
         """
-        bucket = self._get_or_create_partition_bucket(input_seq_id, partition_id)
+        bucket = self._input_seq_partition_buckets[input_seq_id][partition_id]
 
         # Add partition shard into the queue
         bucket.queue.put(partition_shard)

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1643,12 +1643,12 @@ class HashShuffleAggregator:
         self._min_num_blocks_compaction_threshold = (
             min_max_shards_compaction_thresholds[0]
             if min_max_shards_compaction_thresholds is not None
-            else self._DEFAULT_MIN_NUM_SHARDS_COMPACTION_THRESHOLD
+            else None
         )
         self._max_num_blocks_compaction_threshold = (
             min_max_shards_compaction_thresholds[1]
             if min_max_shards_compaction_thresholds is not None
-            else self._DEFAULT_MAX_NUM_SHARDS_COMPACTION_THRESHOLD
+            else None
         )
 
         self._current_compaction_thresholds: Dict[int, int] = defaultdict(
@@ -1728,7 +1728,7 @@ class HashShuffleAggregator:
                 #       compaction to amortize the cost of compaction.
                 self._current_compaction_thresholds[partition_id] = min(
                     self._current_compaction_thresholds[partition_id] * 2,
-                    self._DEFAULT_MAX_NUM_SHARDS_COMPACTION_THRESHOLD,
+                    self._max_num_blocks_compaction_threshold
                 )
 
     def finalize(

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1666,9 +1666,9 @@ class HashShuffleAggregator:
 
         # Per-sequence mapping of partition-id to `PartitionState` with individual
         # locks for thread-safe block accumulation
-        self._input_seq_partition_buckets: Dict[int, Dict[int, PartitionBucket]] = (
-            self._allocate_partition_buckets(num_input_seqs, target_partition_ids)
-        )
+        self._input_seq_partition_buckets: Dict[
+            int, Dict[int, PartitionBucket]
+        ] = self._allocate_partition_buckets(num_input_seqs, target_partition_ids)
         self._partitions_lock = threading.Lock()  # For lazy state creation
 
         self._bg_thread = threading.Thread(
@@ -1767,7 +1767,9 @@ class HashShuffleAggregator:
 
             result = defaultdict(defaultdict)
 
-            for seq_id, partition_map in list(self._input_seq_partition_buckets.items()):
+            for seq_id, partition_map in list(
+                self._input_seq_partition_buckets.items()
+            ):
                 for partition_id, partition in list(partition_map.items()):
                     result[f"seq_{seq_id}"][f"partition_{partition_id}"] = {
                         # NOTE: qsize() is approximate but sufficient for debug logging

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -700,7 +700,7 @@ class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
             input_key_column_names = self._key_column_names[input_index]
             # Compose shuffling task resource bundle
             shuffle_task_resource_bundle = {
-                "num_cpus": 0.5,
+                "num_cpus": 1.0,
                 "memory": self._estimate_shuffling_memory_req(
                     block_metadata,
                     target_max_block_size=(

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -385,6 +385,7 @@ class JoinOperator(HashShufflingOperatorBase):
             input_ops=[left_input_op, right_input_op],
             data_context=data_context,
             key_columns=[left_key_columns, right_key_columns],
+            num_input_seqs=2,
             num_partitions=num_partitions,
             partition_size_hint=partition_size_hint,
             partition_aggregation_factory=_create_joining_aggregation,

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Tuple, Type
 
 from ray._private.arrow_utils import get_pyarrow_version
-from ray.data._internal.arrow_block import ArrowBlockAccessor, ArrowBlockBuilder
+from ray.data._internal.arrow_block import ArrowBlockAccessor
 from ray.data._internal.arrow_ops.transform_pyarrow import (
     MIN_PYARROW_VERSION_RUN_END_ENCODED_TYPES,
     MIN_PYARROW_VERSION_VIEW_TYPES,
@@ -12,7 +12,8 @@ from ray.data._internal.arrow_ops.transform_pyarrow import (
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.hash_shuffle import (
     HashShufflingOperatorBase,
-    StatefulShuffleAggregation,
+    ShuffleAggregation,
+    _combine,
 )
 from ray.data._internal.logical.operators.join_operator import JoinType
 from ray.data._internal.util import GiB, MiB
@@ -51,92 +52,69 @@ _JOIN_TYPE_TO_ARROW_JOIN_VERB_MAP = {
 logger = logging.getLogger(__name__)
 
 
-class JoiningShuffleAggregation(StatefulShuffleAggregation):
-    """Aggregation performing distributed joining of the 2 sequences,
-    by utilising hash-based shuffling.
+class JoiningAggregation(ShuffleAggregation):
+    """Stateless aggregation for distributed joining of 2 sequences.
 
-    Hash-based shuffling applied to 2 input sequences and employing the same
-    partitioning scheme allows to
+    This implementation performs hash-based distributed joining by:
+        - Accumulating identical keys from both sequences into the same partition
+        - Performing join on individual partitions independently
 
-        - Accumulate identical keys from both sequences into the same
-        (numerical) partition. In other words, all keys such that
-
-            hash(key) % num_partitions = partition_id
-
-        - Perform join on individual partitions independently (from other partitions)
-
-    For actual joining Pyarrow native joining functionality is utilised, providing
-    incredible performance while allowing keep the data from being deserialized.
+    For actual joining, Pyarrow native joining functionality is utilised.
     """
 
     def __init__(
         self,
         *,
-        aggregator_id: int,
         join_type: JoinType,
-        left_key_col_names: Tuple[str],
-        right_key_col_names: Tuple[str],
-        target_partition_ids: List[int],
-        data_context: DataContext,
+        left_key_col_names: Tuple[str, ...],
+        right_key_col_names: Tuple[str, ...],
         left_columns_suffix: Optional[str] = None,
         right_columns_suffix: Optional[str] = None,
+        data_context: DataContext,
     ):
-        super().__init__(aggregator_id)
-
         assert (
             len(left_key_col_names) > 0
         ), "At least 1 column to join on has to be provided"
         assert len(right_key_col_names) == len(
             left_key_col_names
-        ), "Number of column for both left and right join operands has to match"
+        ), "Number of columns for both left and right join operands has to match"
 
         assert join_type in _JOIN_TYPE_TO_ARROW_JOIN_VERB_MAP, (
             f"Join type is not currently supported (got: {join_type}; "  # noqa: C416
             f"supported: {[jt for jt in JoinType]})"  # noqa: C416
         )
 
-        self._left_key_col_names: Tuple[str] = left_key_col_names
-        self._right_key_col_names: Tuple[str] = right_key_col_names
+        self._left_key_col_names: Tuple[str, ...] = left_key_col_names
+        self._right_key_col_names: Tuple[str, ...] = right_key_col_names
         self._join_type: JoinType = join_type
 
         self._left_columns_suffix: Optional[str] = left_columns_suffix
         self._right_columns_suffix: Optional[str] = right_columns_suffix
 
-        # Partition builders for the partition corresponding to
-        # left and right input sequences respectively
-        self._left_input_seq_partition_builders: Dict[int, ArrowBlockBuilder] = {
-            partition_id: ArrowBlockBuilder() for partition_id in target_partition_ids
-        }
+    def finalize(self, partition_shards_map: Dict[int, List[Block]]) -> Iterator[Block]:
+        """Performs join on blocks from left (seq 0) and right (seq 1) sequences."""
 
-        self._right_input_seq_partition_builders: Dict[int, ArrowBlockBuilder] = {
-            partition_id: ArrowBlockBuilder() for partition_id in target_partition_ids
-        }
-        self._data_context = data_context
+        assert (
+            len(partition_shards_map) == 2
+        ), f"Two input-sequences are expected (got {len(partition_shards_map)})"
 
-    def accept(self, input_seq_id: int, partition_id: int, partition_shard: Block):
-        assert 0 <= input_seq_id < 2
+        left_partition_shards = partition_shards_map[0]
+        right_partition_shards = partition_shards_map[1]
 
-        partition_builder = self._get_partition_builder(
-            input_seq_id=input_seq_id,
-            partition_id=partition_id,
-        )
+        left_table = _combine(left_partition_shards)
+        right_table = _combine(right_partition_shards)
 
-        partition_builder.add_block(partition_shard)
+        left_on = list(self._left_key_col_names)
+        right_on = list(self._right_key_col_names)
 
-    def finalize(self, partition_id: int) -> Iterator[Block]:
-
-        left_on, right_on = list(self._left_key_col_names), list(
-            self._right_key_col_names
-        )
-
+        # Preprocess: split unsupported columns and add index columns if needed
         preprocess_result_l, preprocess_result_r = self._preprocess(
-            left_on, right_on, partition_id
+            left_table, right_table, left_on, right_on
         )
 
         # Perform the join on supported columns
         arrow_join_type = _JOIN_TYPE_TO_ARROW_JOIN_VERB_MAP[self._join_type]
 
-        # Perform the join on supported columns
         supported = preprocess_result_l.supported_projection.join(
             preprocess_result_r.supported_projection,
             join_type=arrow_join_type,
@@ -146,36 +124,26 @@ class JoiningShuffleAggregation(StatefulShuffleAggregation):
             right_suffix=self._right_columns_suffix,
         )
 
-        # Add back unsupported columns (join type logic is in should_index_* variables)
-        supported = self._postprocess(
+        # Add back unsupported columns
+        result = self._postprocess(
             supported,
             preprocess_result_l.unsupported_projection,
             preprocess_result_r.unsupported_projection,
         )
 
-        yield supported
+        yield result
 
     def _preprocess(
         self,
+        left_table: "pa.Table",
+        right_table: "pa.Table",
         left_on: List[str],
         right_on: List[str],
-        partition_id: int,
     ) -> Tuple[_DatasetPreprocessingResult, _DatasetPreprocessingResult]:
-        import pyarrow as pa
-
-        left_seq_partition: pa.Table = self._get_partition_builder(
-            input_seq_id=0, partition_id=partition_id
-        ).build()
-
-        right_seq_partition: pa.Table = self._get_partition_builder(
-            input_seq_id=1, partition_id=partition_id
-        ).build()
-
+        """Preprocesses tables by splitting unsupported columns and adding indices."""
         # Get supported columns
-        supported_l, unsupported_l = self._split_unsupported_columns(left_seq_partition)
-        supported_r, unsupported_r = self._split_unsupported_columns(
-            right_seq_partition
-        )
+        supported_l, unsupported_l = self._split_unsupported_columns(left_table)
+        supported_r, unsupported_r = self._split_unsupported_columns(right_table)
 
         # Handle joins on unsupported columns
         conflicting_columns: Set[str] = set(unsupported_l.column_names) & set(left_on)
@@ -247,21 +215,6 @@ class JoiningShuffleAggregation(StatefulShuffleAggregation):
 
     def _index_name(self, suffix: str) -> str:
         return f"__rd_index_level_{suffix}__"
-
-    def clear(self, partition_id: int):
-        self._left_input_seq_partition_builders.pop(partition_id)
-        self._right_input_seq_partition_builders.pop(partition_id)
-
-    def _get_partition_builder(self, *, input_seq_id: int, partition_id: int):
-        if input_seq_id == 0:
-            partition_builder = self._left_input_seq_partition_builders[partition_id]
-        elif input_seq_id == 1:
-            partition_builder = self._right_input_seq_partition_builders[partition_id]
-        else:
-            raise ValueError(
-                f"Unexpected inpt sequence id of '{input_seq_id}' (expected 0 or 1)"
-            )
-        return partition_builder
 
     def _should_index_side(
         self, side: str, supported_table: "pa.Table", unsupported_table: "pa.Table"
@@ -403,16 +356,28 @@ class JoinOperator(HashShufflingOperatorBase):
         right_columns_suffix: Optional[str] = None,
         partition_size_hint: Optional[int] = None,
         aggregator_ray_remote_args_override: Optional[Dict[str, Any]] = None,
-        shuffle_aggregation_type: Optional[Type[StatefulShuffleAggregation]] = None,
+        shuffle_aggregation_type: Optional[Type[ShuffleAggregation]] = None,
     ):
-        if shuffle_aggregation_type is not None:
-            if not issubclass(shuffle_aggregation_type, StatefulShuffleAggregation):
-                raise TypeError(
-                    f"shuffle_aggregation_type must be a subclass of StatefulShuffleAggregation, "
-                    f"got {shuffle_aggregation_type}"
-                )
+        # Use new stateless JoiningAggregation factory
+        def _create_joining_aggregation() -> JoiningAggregation:
+            if shuffle_aggregation_type is not None:
+                if not issubclass(shuffle_aggregation_type, ShuffleAggregation):
+                    raise TypeError(
+                        f"shuffle_aggregation_type must be a subclass of {ShuffleAggregation.__class__}, "
+                        f"got {shuffle_aggregation_type}"
+                    )
 
-        aggregation_class = shuffle_aggregation_type or JoiningShuffleAggregation
+            aggregation_class = shuffle_aggregation_type or JoiningAggregation
+
+            return aggregation_class(
+                join_type=join_type,
+                left_key_col_names=left_key_columns,
+                right_key_col_names=right_key_columns,
+                left_columns_suffix=left_columns_suffix,
+                right_columns_suffix=right_columns_suffix,
+                data_context=data_context,
+            )
+
         super().__init__(
             name_factory=(
                 lambda num_partitions: f"Join(num_partitions={num_partitions})"
@@ -422,18 +387,7 @@ class JoinOperator(HashShufflingOperatorBase):
             key_columns=[left_key_columns, right_key_columns],
             num_partitions=num_partitions,
             partition_size_hint=partition_size_hint,
-            partition_aggregation_factory=(
-                lambda aggregator_id, target_partition_ids: aggregation_class(
-                    aggregator_id=aggregator_id,
-                    join_type=join_type,
-                    left_key_col_names=left_key_columns,
-                    right_key_col_names=right_key_columns,
-                    target_partition_ids=target_partition_ids,
-                    data_context=data_context,
-                    left_columns_suffix=left_columns_suffix,
-                    right_columns_suffix=right_columns_suffix,
-                )
-            ),
+            partition_aggregation_factory=_create_joining_aggregation,
             aggregator_ray_remote_args_override=aggregator_ray_remote_args_override,
             shuffle_progress_bar_name="Shuffle",
             finalize_progress_bar_name="Join",

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -363,7 +363,7 @@ class JoinOperator(HashShufflingOperatorBase):
             if shuffle_aggregation_type is not None:
                 if not issubclass(shuffle_aggregation_type, ShuffleAggregation):
                     raise TypeError(
-                        f"shuffle_aggregation_type must be a subclass of {ShuffleAggregation.__class__}, "
+                        f"shuffle_aggregation_type must be a subclass of {ShuffleAggregation}, "
                         f"got {shuffle_aggregation_type}"
                     )
 

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -148,7 +148,7 @@ class TableBlockBuilder(BlockBuilder):
     def num_rows(self) -> int:
         return self._num_rows
 
-    def nun_blocks(self) -> int:
+    def num_blocks(self) -> int:
         return len(self._tables)
 
     def get_estimated_memory_usage(self) -> int:

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -148,6 +148,9 @@ class TableBlockBuilder(BlockBuilder):
     def num_rows(self) -> int:
         return self._num_rows
 
+    def nun_blocks(self) -> int:
+        return len(self._tables)
+
     def get_estimated_memory_usage(self) -> int:
         if self._num_rows == 0:
             return 0

--- a/python/ray/data/tests/test_hash_shuffle_aggregator.py
+++ b/python/ray/data/tests/test_hash_shuffle_aggregator.py
@@ -88,7 +88,9 @@ class TestHashShuffleAggregator:
             # Thresholds are now per-partition in PartitionBucket
             return {
                 part_id: bucket.compaction_threshold
-                for part_id, bucket in aggregator._input_seq_partition_buckets[0].items()
+                for part_id, bucket in aggregator._input_seq_partition_buckets[
+                    0
+                ].items()
                 if bucket.compaction_threshold is not None
             }
 

--- a/python/ray/data/tests/test_hash_shuffle_aggregator.py
+++ b/python/ray/data/tests/test_hash_shuffle_aggregator.py
@@ -72,10 +72,11 @@ class TestHashShuffleAggregator:
         agg = MockCompactingAggregation()
         aggregator = _HashShuffleAggregatorClass(
             aggregator_id=0,
+            num_input_seqs=2,
             target_partition_ids=[0, 1, 2],
             agg_factory=lambda: agg,
             target_max_block_size=None,
-            min_max_num_blocks_compaction_thresholds=(3, 2000),
+            min_max_shards_compaction_thresholds=(3, 2000),
         )
 
         # Pre-generate blocks: split a 100-row block into 10 chunks of 10 rows
@@ -136,6 +137,7 @@ class TestHashShuffleAggregator:
 
         aggregator = _HashShuffleAggregatorClass(
             aggregator_id=1,
+            num_input_seqs=1,
             target_partition_ids=[0],
             agg_factory=MockNonCompactingAggregation,
             target_max_block_size=None,
@@ -153,6 +155,7 @@ class TestHashShuffleAggregator:
 
         aggregator = _HashShuffleAggregatorClass(
             aggregator_id=2,
+            num_input_seqs=1,
             target_partition_ids=[0],
             agg_factory=MockNonCompactingAggregation,
             target_max_block_size=50,

--- a/python/ray/data/tests/test_hash_shuffle_aggregator.py
+++ b/python/ray/data/tests/test_hash_shuffle_aggregator.py
@@ -1,0 +1,171 @@
+"""Unit tests for HashShuffleAggregator."""
+
+from typing import Dict, Iterator, List
+
+import pyarrow as pa
+import pytest
+
+from ray.data._internal.arrow_ops import transform_pyarrow
+from ray.data._internal.execution.operators.hash_shuffle import (
+    HashShuffleAggregator,
+    ShuffleAggregation,
+)
+from ray.data._internal.planner.exchange.sort_task_spec import SortKey
+from ray.data.block import Block
+
+# Access underlying class for direct instantiation (bypassing Ray actor)
+_HashShuffleAggregatorClass = HashShuffleAggregator.__ray_actor_class__
+
+
+def make_block(n: int = 10, offset: int = 0) -> pa.Table:
+    return pa.table({"x": list(range(offset, offset + n))})
+
+
+def split_block(block: pa.Table, chunk_size: int) -> List[pa.Table]:
+    """Split block into chunks of given size."""
+    return [block.slice(i, chunk_size) for i in range(0, block.num_rows, chunk_size)]
+
+
+class MockCompactingAggregation(ShuffleAggregation):
+    """Tracks compact/finalize calls and input blocks."""
+
+    def __init__(self):
+        self.compact_calls: List[int] = []
+        self.finalize_input: Dict[int, List[Block]] = {}
+
+    @classmethod
+    def is_compacting(cls):
+        return True
+
+    def compact(self, shards: List[Block]) -> Block:
+        self.compact_calls.append(len(shards))
+        return pa.concat_tables(shards) if shards else make_block(0)
+
+    def finalize(self, shards: Dict[int, List[Block]]) -> Iterator[Block]:
+        self.finalize_input = dict(shards)
+        blocks = [b for bs in shards.values() for b in bs]
+        yield pa.concat_tables(blocks) if blocks else make_block(0)
+
+
+class MockNonCompactingAggregation(ShuffleAggregation):
+    """Tracks finalize input blocks."""
+
+    def __init__(self):
+        self.finalize_input: Dict[int, List[Block]] = {}
+
+    @classmethod
+    def is_compacting(cls):
+        return False
+
+    def compact(self, shards: List[Block]) -> Block:
+        raise RuntimeError("Should not be called")
+
+    def finalize(self, shards: Dict[int, List[Block]]) -> Iterator[Block]:
+        self.finalize_input = dict(shards)
+        blocks = [b for bs in shards.values() for b in bs]
+        yield pa.concat_tables(blocks) if blocks else make_block(0)
+
+
+class TestHashShuffleAggregator:
+    def test_compacting_workflow(self, ray_start_regular_shared):
+        """Tests compaction triggers, threshold doubling, multi-partition/sequence."""
+        agg = MockCompactingAggregation()
+        aggregator = _HashShuffleAggregatorClass(
+            aggregator_id=0,
+            target_partition_ids=[0, 1, 2],
+            agg_factory=lambda: agg,
+            target_max_block_size=None,
+            min_max_num_blocks_compaction_thresholds=(3, 2000),
+        )
+
+        # Pre-generate blocks: split a 100-row block into 10 chunks of 10 rows
+        full_block = make_block(80)
+        input_seq0_part0 = split_block(full_block, 10)
+
+        # Submit 2 blocks (below threshold=3) - no compaction
+        for b in input_seq0_part0[:2]:
+            aggregator.submit(0, 0, b)
+        assert agg.compact_calls == []
+        assert dict(aggregator._current_compaction_thresholds) == {0: 3}
+
+        # Submit 3rd block - triggers compaction, threshold doubles
+        aggregator.submit(0, 0, input_seq0_part0[2])
+        assert agg.compact_calls == [3]
+        assert dict(aggregator._current_compaction_thresholds) == {0: 6}
+
+        # Submit 5 more (queue: 1+5=6) - triggers at new threshold
+        for b in input_seq0_part0[3:8]:
+            aggregator.submit(0, 0, b)
+
+        assert agg.compact_calls == [3, 6]
+        assert dict(aggregator._current_compaction_thresholds) == {0: 12}
+
+        # Partition 1 has independent threshold (starts at 3)
+        for b in split_block(make_block(30, offset=1000), 10):
+            aggregator.submit(0, 1, b)
+
+        assert agg.compact_calls == [3, 6, 3]
+        assert dict(aggregator._current_compaction_thresholds) == {0: 12, 1: 6}
+
+        # Multiple sequences (join scenario) - seq_id=1 for partition 0
+        input_seq1_part0 = split_block(make_block(20, offset=2000), 10)
+        for b in input_seq1_part0:
+            aggregator.submit(1, 0, b)
+
+        # Finalize partition 0 - receives blocks from both sequences
+        results = list(aggregator.finalize(0))
+        block, metadata = results
+        assert len(agg.finalize_input) == 2  # dict with 2 sequences
+
+        # Verify output equals concatenation of seq0 (first 8 chunks) + seq1
+        expected = transform_pyarrow.sort(
+            pa.concat_tables(tables=[*input_seq0_part0, *input_seq1_part0]),
+            sort_key=SortKey("x"),
+        )
+        assert transform_pyarrow.sort(block, sort_key=SortKey("x")) == expected
+
+        # Empty partition
+        results = list(aggregator.finalize(2))
+        assert results[0] == make_block(0)
+
+    def test_non_compacting_workflow(self, ray_start_regular_shared):
+        """Tests non-compacting aggregation with and without block splitting."""
+        # Without splitting
+        full_block = make_block(50)
+        input_seq = split_block(full_block, 10)
+
+        aggregator = _HashShuffleAggregatorClass(
+            aggregator_id=1,
+            target_partition_ids=[0],
+            agg_factory=MockNonCompactingAggregation,
+            target_max_block_size=None,
+        )
+        for b in input_seq:
+            aggregator.submit(0, 0, b)
+
+        results = list(aggregator.finalize(0))
+        block, metadata = results
+        assert block == full_block
+
+        # With splitting - output blocks should reconstruct to original
+        full_block = make_block(500)
+        input_seq = split_block(full_block, 100)
+
+        aggregator = _HashShuffleAggregatorClass(
+            aggregator_id=2,
+            target_partition_ids=[0],
+            agg_factory=MockNonCompactingAggregation,
+            target_max_block_size=50,
+        )
+        for b in input_seq:
+            aggregator.submit(0, 0, b)
+
+        results = list(aggregator.finalize(0))
+        output_blocks = [results[i] for i in range(0, len(results), 2)]
+        assert pa.concat_tables(output_blocks) == full_block
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Context
---
This change aims at revisiting of the `HashShuffleAggregator` protocol by 

 - Removing global lock (per aggregator)
 - Making shard accepting flow lock-free
 - Relocating all state from `ShuffleAggregation` into Aggregator itself
 - Adding dynamic compaction (exponentially increasing compaction period) to amortize compaction costs
 - Adding debugging state dumps

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
