### PR TITLE
feat: implement arrow string- and binary-view serialization

### DIFF
--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -4,6 +4,7 @@
 # see https://github.com/ray-project/ray/issues/30498 for more context.
 import logging
 import os
+import struct
 import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
@@ -312,6 +313,8 @@ def _array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
         return _primitive_array_to_array_payload(a)
     elif _is_binary(a.type):
         return _binary_array_to_array_payload(a)
+    elif _is_binary_view(a.type):
+        return _binary_view_array_to_array_payload(a)
     elif pa.types.is_list(a.type) or pa.types.is_large_list(a.type):
         return _list_array_to_array_payload(a)
     elif pa.types.is_fixed_size_list(a.type):
@@ -354,6 +357,16 @@ def _is_binary(type_: "pyarrow.DataType") -> bool:
         or pa.types.is_large_string(type_)
         or pa.types.is_binary(type_)
         or pa.types.is_large_binary(type_)
+    )
+
+
+def _is_binary_view(type_: "pyarrow.DataType") -> bool:
+    """Whether the provided Array type is a variable-sized binary view type."""
+    import pyarrow as pa
+
+    return (
+        pa.types.is_string_view(type_)
+        or pa.types.is_binary_view(type_)
     )
 
 
@@ -428,6 +441,84 @@ def _binary_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload
         length=len(a),
         buffers=[bitmap_buf, offset_buf, data_buf],
         null_count=a.null_count,
+        offset=0,
+        children=[],
+    )
+
+
+def _binary_view_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
+    """Serialize binary (variable-sized binary view, string view) arrays to
+    PicklableArrayPayload.
+    """
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    assert _is_binary_view(a.type), a.type
+    # Buffer scheme: [bitmap, views, data0, data1, ..., dataN]
+    #
+    # NB: In the C API there is a trailing buffer containing buffer lengths as 64-bit integers. This
+    # is not exposed in the Python interface (the buffer lengths are accessible, for example, via:
+    #
+    #     len(a.buffers()[1])
+    #
+    buffers = a.buffers()
+    assert len(buffers) >= 2, len(buffers)
+
+    # Copy bitmap buffer, if needed.
+    if a.null_count > 0:
+        bitmap_buf = _copy_bitpacked_buffer_if_needed(buffers[0], a.offset, len(a))
+    else:
+        bitmap_buf = None
+
+    # Copy view buffer, if needed.
+    #
+    # Views are defined in the spec as 16-bytes: https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-view-layout
+    view_buf = _copy_normal_buffer_if_needed(buffers[1], 16, a.offset, len(a))
+
+    # list[tuple[string_length, prefix, buffer_index, buffer_offset]]
+    views = [
+        struct.unpack("<iiii", view_buf[(index * 16):(index + 1)*16])
+        for index in range(len(a))
+    ]
+
+    bytes_allocated = sum(len(b) for b in a.buffers()[2:])
+
+    upper_bound_of_bytes_used = 0
+    seen_view_slices: set[tuple[int, int, int]] = set()
+    for string_length, _, buffer_index, buffer_offset in views:
+        if string_length <= 12:
+            continue
+
+        view_slice_key = (buffer_index, buffer_offset, string_length)
+        if view_slice_key in seen_view_slices:
+            continue
+
+        seen_view_slices.add(view_slice_key)
+        upper_bound_of_bytes_used += string_length
+
+    if upper_bound_of_bytes_used >= bytes_allocated // 2:
+        # If our best guess says we need most of the bytes, just pickle all the buffers:
+        return PicklableArrayPayload(
+            type=a.type,
+            length=len(a),
+            buffers=[bitmap_buf, view_buf, *a.buffers()[2:]],
+            null_count=a.null_count,
+            offset=0,
+            children=[],
+        )
+
+    # Otherwise, compact the array
+    if pa.types.is_string_view(a.type):
+        compacted = pc.cast(a, pa.large_string())
+        compacted_view = pc.cast(compacted, pa.string_view())
+    else:
+        compacted = pc.cast(a, pa.large_binary())
+        compacted_view = pc.cast(compacted, pa.binary_view())
+    return PicklableArrayPayload(
+        type=compacted_view.type,
+        length=len(compacted_view),
+        buffers=compacted_view.buffers(),
+        null_count=compacted_view.null_count,
         offset=0,
         children=[],
     )

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -482,7 +482,10 @@ def _binary_view_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPa
 
     upper_bound_of_bytes_used = 0
     seen_view_slices: set[tuple[int, int, int]] = set()
-    for index in range(len(a)):
+    for index, is_valid in zip(range(len(a)), a.is_valid()):
+        if not is_valid:
+            continue
+
         view: tuple[int, int, int, int] = struct.unpack(
             "<iiii",
             view_buf[

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -364,7 +364,9 @@ def _is_binary_view(type_: "pyarrow.DataType") -> bool:
     """Whether the provided Array type is a variable-sized binary view type."""
     import pyarrow as pa
 
-    return pa.types.is_string_view(type_) or pa.types.is_binary_view(type_)
+    return (hasattr(pa.types, "is_string_view") and pa.types.is_string_view(type_)) or (
+        hasattr(pa.types, "is_binary_view") and pa.types.is_binary_view(type_)
+    )
 
 
 def _null_array_to_array_payload(a: "pyarrow.NullArray") -> "PicklableArrayPayload":
@@ -510,6 +512,7 @@ def _binary_view_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPa
         )
 
     # Otherwise, compact the array
+    assert hasattr(pa.types, "is_string_view")
     if pa.types.is_string_view(a.type):
         compacted = pc.cast(a, pa.large_string())
         compacted_view = pc.cast(compacted, pa.string_view())

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -456,7 +456,6 @@ def _binary_view_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPa
     import pyarrow as pa
     import pyarrow.compute as pc
 
-    assert _is_binary_view(a.type), a.type
     # Buffer scheme: [bitmap, views, data0, data1, ..., dataN]
     #
     # NB: In the C API there is a trailing buffer containing buffer lengths as 64-bit integers. This
@@ -515,7 +514,6 @@ def _binary_view_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPa
         )
 
     # Otherwise, compact the array
-    assert hasattr(pa.types, "is_string_view")
     if pa.types.is_string_view(a.type):
         compacted = pc.cast(a, pa.large_string())
         compacted_view = pc.cast(compacted, pa.string_view())

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -493,6 +493,15 @@ def _binary_view_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPa
         if not is_valid:
             continue
 
+        # https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-view-layout
+        #
+        # Each element of a string or binary view array is a 16-byte "view". The first four bytes
+        # are a signed 32-bit integer indicating the length of the string element. If the string
+        # element contains twelve or fewer bytes, it is stored in-line. Otherwise, the next 12 bytes
+        # comprise the string element's 4-byte prefix, the index of the buffer containing this
+        # string, and the offset within that buffer of this string.
+        #
+        # The buffer index and offset are also 32-bit signed integers.
         view: tuple[int, int, int, int] = struct.unpack(
             "<iiii",
             view_buf[

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -452,6 +452,14 @@ ARROW_VIEW_BYTE_SIZE = 16
 def _binary_view_array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
     """Serialize binary (variable-sized binary view, string view) arrays to
     PicklableArrayPayload.
+
+    Arrow arrays support zero-copy slices by storing an offset and length. Other serialization
+    functions in this file only serialize bytes referenced by the slice. Doing so for a binary or
+    string view is challenging because each view may refer to an arbitrary slice of an arbitrary
+    buffer. This function does a naive one-pass algorithm to overestimate the number of bytes
+    referenced by views in this array. If this estimate is less than half of the total bytes
+    allocated for this array, we compact the views (which requires copying data out of the buffers).
+
     """
     import pyarrow as pa
     import pyarrow.compute as pc

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -189,6 +189,11 @@ def string_array():
 
 
 @pytest.fixture
+def string_view_array():
+    return pa.array(["foo", "barbarbarbarbar", "bz", None, "quuxquuxquuxquux"] * 200, type=pa.string_view())
+
+
+@pytest.fixture
 def large_string_array():
     return pa.array(["foo", "bar", "bz", None, "quux"] * 200, type=pa.large_string())
 
@@ -196,6 +201,11 @@ def large_string_array():
 @pytest.fixture
 def binary_array():
     return pa.array([b"foo", b"bar", b"bz", None, b"quux"] * 200)
+
+
+@pytest.fixture
+def binary_view_array():
+    return pa.array([b"foo", b"barbarbarbarbar", b"bz", None, b"quuxquuxquuxquux"] * 200, type=pa.binary_view())
 
 
 @pytest.fixture
@@ -378,10 +388,14 @@ pytest_custom_serialization_arrays = [
     (lazy_fixture("boolean_array"), 0.8),
     # String array
     (lazy_fixture("string_array"), 0.1),
+    # String View array
+    (lazy_fixture("string_view_array"), 0.1),
     # Large string array
     (lazy_fixture("large_string_array"), 0.1),
     # Binary array
     (lazy_fixture("binary_array"), 0.1),
+    # Binary View array
+    (lazy_fixture("binary_view_array"), 0.1),
     # Fixed size binary array
     (lazy_fixture("fixed_size_binary_array"), 0.1),
     # Large binary array

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -190,7 +190,10 @@ def string_array():
 
 @pytest.fixture
 def string_view_array():
-    return pa.array(["foo", "barbarbarbarbar", "bz", None, "quuxquuxquuxquux"] * 200, type=pa.string_view())
+    return pa.array(
+        ["foo", "barbarbarbarbar", "bz", None, "quuxquuxquuxquux"] * 200,
+        type=pa.string_view(),
+    )
 
 
 @pytest.fixture
@@ -205,7 +208,10 @@ def binary_array():
 
 @pytest.fixture
 def binary_view_array():
-    return pa.array([b"foo", b"barbarbarbarbar", b"bz", None, b"quuxquuxquuxquux"] * 200, type=pa.binary_view())
+    return pa.array(
+        [b"foo", b"barbarbarbarbar", b"bz", None, b"quuxquuxquuxquux"] * 200,
+        type=pa.binary_view(),
+    )
 
 
 @pytest.fixture

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import random
+import string
 import sys
 import types
 from unittest import mock
@@ -18,6 +20,7 @@ import ray.train
 from ray._private.arrow_serialization import (
     PicklableArrayPayload,
     _align_bit_offset,
+    _binary_view_array_to_array_payload,
     _bytes_for_bits,
     _copy_bitpacked_buffer_if_needed,
     _copy_buffer_if_needed,
@@ -727,6 +730,41 @@ def test_variable_shape_tensor_serialization():
     payload = PicklableArrayPayload.from_array(ar)
     ar2 = payload.to_array()
     assert ar == ar2
+
+
+def test_binary_view_serialization_does_not_overestimate_nulls():
+    def random_string(length=15):
+        return "".join(random.choices(string.ascii_letters + string.digits, k=length))
+
+    all_out_of_line_strings = pa.array(
+        [random_string() for i in range(100)], type=pa.string_view()
+    )
+
+    # # PyArrow has no kernel for masking string_view arrays.
+    # mostly_null_strings = pc.replace_with_mask(
+    #     all_out_of_line_strings,
+    #     pa.array([False] * 250 + [None] * 750),
+    #     pa.scalar("dummy", type=pa.string_view()),
+    # )
+
+    # Replace 90% of the elements with null.
+    mostly_null_validity_buffer = pa.array([True] * 10 + [False] * 90).buffers()[1]
+    mostly_null_strings = pa.Array.from_buffers(
+        all_out_of_line_strings.type,
+        len(all_out_of_line_strings),
+        [mostly_null_validity_buffer, *all_out_of_line_strings.buffers()[1:]],
+    )
+    mostly_null_serialized = _binary_view_array_to_array_payload(mostly_null_strings)
+
+    mostly_null_serialized_byte_size = sum(
+        len(b) if b else 0 for b in mostly_null_serialized.buffers
+    )
+
+    # The minimum possible size is the sum of:
+    # - the views: 16 * 100
+    # - the null bits: (100 + 7)/8
+    # - the non-null out-of-line string values: 15 * 10
+    assert mostly_null_serialized_byte_size == 16 * 100 + (100 + 7) // 8 + 15 * 10
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Allow use of Arrow string-view and binary-view arrays. These were [added in Arrow 1.4](https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-view-layout) and, relevant to my interests, are the default string type in [Vortex](https://github.com/vortex-data/vortex), a new columnar file format.

## Related issues
Resolves https://github.com/ray-project/ray/issues/59951

## Additional information

I attempted to adhere to the spirit of this module: elide inaccessible memory. Views, however, make this rather complicated. The out-of-line views are just a buffer index, length, and buffer offset. In theory, multiple views could refer to the same slice of memory or even to overlapping slices. I wrote a naive one-pass algorithm that computes the sum of bytes of the out-of-line views, avoiding double counting when two views refer to the exact same slice. I then check if this estimate of bytes-used is more than half of the buffers' bytes. If it is not, I cast from view to large-(binary/string) and back to view which effectively compacts the buffers.

This might not be the best implementation of view serialization but it takes views from not working at all to working.