### PR TITLE
[docs] [devprod] add hook to automatically mark examples notebook as orphan

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -552,7 +552,6 @@ def setup(app):
     if os.getenv("READTHEDOCS") == "True":
         generate_versions_json()
 
-    # Pregenerate example RST files
     pregenerate_example_rsts(app)
 
     # NOTE: 'MOCK' is a custom option we introduced to illustrate mock outputs. Since

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,6 +27,7 @@ from custom_directives import (  # noqa
     setup_context,
     pregenerate_example_rsts,
     generate_versions_json,
+    collect_example_orphans,
 )
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -551,8 +552,8 @@ def setup(app):
     if os.getenv("READTHEDOCS") == "True":
         generate_versions_json()
 
-    # Pregenerate example RST files and collect example links
-    example_orphan_documents = pregenerate_example_rsts(app)
+    # Pregenerate example RST files
+    pregenerate_example_rsts(app)
 
     # NOTE: 'MOCK' is a custom option we introduced to illustrate mock outputs. Since
     # `doctest` doesn't support this flag by default, `sphinx.ext.doctest` raises
@@ -611,6 +612,7 @@ def setup(app):
     logging.getLogger("sphinx").addFilter(DuplicateObjectFilter())
     
     # Register hook to mark orphan documents
+    example_orphan_documents = collect_example_orphans(app.confdir, app.srcdir)
     def mark_orphans(app, docname, _source):
         if docname in example_orphan_documents:
             app.env.metadata.setdefault(docname, {})

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -754,7 +754,7 @@ os.environ["RAY_TRAIN_V2_ENABLED"] = "1"
 
 os.environ["RAY_DOC_BUILD"] = "1"
 
-def mark_documents_as_orphan(app, docname, source):
+def mark_documents_as_orphan(app, docname, _source):
     """
     Apply orphan metadata to documents referenced in examples.yml files.
     

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -609,6 +609,9 @@ def setup(app):
 
     logging.getLogger("sphinx").addFilter(DuplicateObjectFilter())
 
+    # Apply orphan metadata to documents from examples.yml files
+    app.connect('source-read', mark_documents_as_orphan)
+
 
 redoc = [
     {
@@ -750,3 +753,18 @@ assert (
 os.environ["RAY_TRAIN_V2_ENABLED"] = "1"
 
 os.environ["RAY_DOC_BUILD"] = "1"
+
+def mark_documents_as_orphan(app, docname, source):
+    """
+    Apply orphan metadata to documents referenced in examples.yml files.
+    
+    This function marks documents as orphan if they appear in any of the
+    examples.yml files processed during pregenerate_example_rsts().
+    This prevents Sphinx from warning about documents not included in any toctree.
+    """
+    # Check if this document is in our collected list from examples.yml
+    if docname in app._example_orphan_documents:
+        # (MyST-NB expects this to exist when it writes to it)
+        app.env.metadata.setdefault(docname, {})
+        app.env.metadata[docname]["orphan"] = True
+    

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -767,4 +767,3 @@ def mark_documents_as_orphan(app, docname, _source):
         # (MyST-NB expects this to exist when it writes to it)
         app.env.metadata.setdefault(docname, {})
         app.env.metadata[docname]["orphan"] = True
-    

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -763,7 +763,7 @@ def mark_documents_as_orphan(app, docname, _source):
     This prevents Sphinx from warning about documents not included in any toctree.
     """
     # Check if this document is in our collected list from examples.yml
-    if docname in app._example_orphan_documents:
+    if hasattr(app, "_example_orphan_documents") and docname in app._example_orphan_documents:
         # (MyST-NB expects this to exist when it writes to it)
         app.env.metadata.setdefault(docname, {})
         app.env.metadata[docname]["orphan"] = True

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1283,8 +1283,8 @@ def pregenerate_example_rsts(
                 "modify examples for this library."
             )
 
-        # Store `orphan_documents` to be used by mark_documents_as_orphan hook
-        app._example_orphan_documents = orphan_documents
+    # Store `orphan_documents` to be used by mark_documents_as_orphan hook
+    app._example_orphan_documents = orphan_documents
 
 def generate_version_url(version):
     return f"https://docs.ray.io/en/{version}/"

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1241,6 +1241,9 @@ def pregenerate_example_rsts(
     See `add_custom_assets` for more information about the custom template
     that gets rendered from these configuration files.
 
+    Additionally, this function collects all example document paths from the
+    examples.yml files to mark them as orphan documents during the build.
+
     Parameters
     ----------
     *example_configs : Optional[List[str]]
@@ -1249,6 +1252,9 @@ def pregenerate_example_rsts(
     if not example_configs:
         example_configs = EXAMPLE_GALLERY_CONFIGS
 
+    # Collect all example links to mark as orphan
+    orphan_documents = set()
+
     for config in example_configs:
         # Depending on where the sphinx build command is run from, the path to the
         # target config file can change. Handle these paths manually to ensure it
@@ -1256,6 +1262,18 @@ def pregenerate_example_rsts(
         config_path = pathlib.Path(app.confdir) / pathlib.Path(config).relative_to(
             "source"
         )
+
+        # Parse the examples.yml to extract links
+        example_config = ExampleConfig(config_path, app.srcdir)
+        for example in example_config:
+            if not example.link.startswith("http"):
+                normalized_path = os.path.normpath(example.link) # (resolves . and ..)
+                normalized_path = pathlib.PurePosixPath(normalized_path)
+                if normalized_path.suffix:
+                    normalized_path = normalized_path.with_suffix('')
+                orphan_documents.add(str(normalized_path))
+
+        # Generate the examples.rst file
         page_title = "Examples"
         title_decoration = "=" * len(page_title)
         with open(config_path.with_suffix(".rst"), "w") as f:
@@ -1265,6 +1283,8 @@ def pregenerate_example_rsts(
                 "modify examples for this library."
             )
 
+        # Store `orphan_documents` to be used by mark_documents_as_orphan hook
+        app._example_orphan_documents = orphan_documents
 
 def generate_version_url(version):
     return f"https://docs.ray.io/en/{version}/"

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1302,8 +1302,6 @@ def pregenerate_example_rsts(
         config_path = pathlib.Path(app.confdir) / pathlib.Path(config).relative_to(
             "source"
         )
-
-        # Generate the examples.rst file
         page_title = "Examples"
         title_decoration = "=" * len(page_title)
         with open(config_path.with_suffix(".rst"), "w") as f:
@@ -1312,6 +1310,7 @@ def pregenerate_example_rsts(
                 "  .. this file is pregenerated; please edit ./examples.yml to "
                 "modify examples for this library."
             )
+
 
 def generate_version_url(version):
     return f"https://docs.ray.io/en/{version}/"


### PR DESCRIPTION
If publishers follow the example publishing pattern for ray data/serve/train, they should end up with a structure like:

```
doc/source/{path-to-examples}/my-example/
  └─ content/
     ├─ notebook.ipynb
     ├─ README.md
     └─ …
```
with path-to-examples any of "serve/tutorials/" | "data/examples/" | "train/examples/"

In the `examples.yml`, publishers link to `notebook.ipynb`.

### Issue

* `examples.rst` is dynamically created by custom scripts in `custom_directives.py`. The script reads each `examples.yml` file and create the html for the examples index page in ray docs.
* Because `examples.rst` is initially empty, Sphinx considers all notebooks as "orphan" documents and emits warnings, which fail CI because ReadTheDocs is configured to fail on warnings
* To silence the warning, publishers must manually add a `orphan: True` to the metadata of the notebook
* This adds unnecessary overhead for publishers unfamiliar with Sphinx. They should only worry about their content, not what an "orphan" document is

### Solution

This PR automatically adds the `orphan: True` metadata to any files listed in any of the `examples.yml` for ray data/serve/train. This ensures:

* Using examples.yml as source of truth so only impacted files are impacted. No side effect on unrelated files. 
* Publisher can focus on its content, doesn't have to worry about sphinx
