### PR TITLE
Tseah/torchft prototype

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -101,6 +101,7 @@ steps:
         --platform cu12.1.1-cudnn8 --platform cu12.3.2-cudnn9
         --platform cu12.4.1-cudnn --platform cu12.5.1-cudnn
         --platform cu12.6.3-cudnn --platform cu12.8.1-cudnn
+        --platform cu12.9.1-cudnn
         --platform cpu
         --image-type ray-extra --upload
     depends_on:

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -19,7 +19,7 @@ from ray_release.test import Test, TestState
 GLOBAL_CONFIG_FILE = (
     os.environ.get("RAYCI_GLOBAL_CONFIG") or "ci/ray_ci/oss_config.yaml"
 )
-RAY_VERSION = "3.0.0.dev0"
+RAY_VERSION = "2.53.0"
 
 
 def ci_init() -> None:

--- a/copier.sh
+++ b/copier.sh
@@ -1,30 +1,107 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
+
+# Default source: ray's site-packages location
+DEFAULT_SRC=$(python -c "import ray; import os; print(os.path.dirname(ray.__path__[0]))")
+
+# Parse arguments - if none provided, use default
+if [[ $# -eq 0 ]]; then
+    FILES=("$DEFAULT_SRC")
+else
+    FILES=("$@")
+fi
 
 PORT=2222
-
-SRC="/home/ray/default/torchft/torchft/ddp.py"
-DST=$SRC
-
-IPS=(
-  10.0.2.189
-  10.0.9.110
-)
-
 SSH_OPTS=(-p "$PORT" -o StrictHostKeyChecking=accept-new)
 SCP_OPTS=(-P "$PORT" -o StrictHostKeyChecking=accept-new)
 
-for ip in "${IPS[@]}"; do
-  echo "==> Copying to $ip"
+echo "Files to copy:"
+for f in "${FILES[@]}"; do
+    echo "  - $f"
+done
+echo ""
 
-  # Make sure destination directory exists (on the remote)
-  ssh "${SSH_OPTS[@]}" "$ip" "mkdir -p '$(dirname "$DST")'"
+# Get node IPs using Python/Ray
+echo "==> Getting node IPs from Ray cluster..."
+NODE_INFO=$(python -c "
+import ray
+ray.init(ignore_reinit_error=True)
+nodes = ray.nodes()
+head_ip = None
+worker_ips = []
+for node in nodes:
+    if node['Alive']:
+        ip = node['NodeManagerAddress']
+        if node.get('Resources', {}).get('node:__internal_head__'):
+            head_ip = ip
+        else:
+            worker_ips.append(ip)
+# If no explicit head marker, use first node as head
+if head_ip is None and worker_ips:
+    head_ip = worker_ips.pop(0)
+print(f'HEAD:{head_ip or \"\"}')
+for ip in worker_ips:
+    print(f'WORKER:{ip}')
+" 2>/dev/null)
 
-  # Backup existing file if present
-  ssh "${SSH_OPTS[@]}" "$ip" "test -f '$DST' && cp '$DST' '${DST}.bak.$(date +%s)' || true"
+if [[ -z "$NODE_INFO" ]]; then
+    echo "Error: Could not get node info from Ray. Is Ray running?"
+    exit 1
+fi
 
-  # Copy
-  scp "${SCP_OPTS[@]}" "$SRC" "$ip:$DST"
+echo "$NODE_INFO"
+echo ""
+
+# Parse head and worker IPs
+HEAD_IP=$(echo "$NODE_INFO" | grep "^HEAD:" | cut -d: -f2)
+WORKER_IPS=()
+while IFS= read -r line; do
+    ip=$(echo "$line" | cut -d: -f2)
+    if [[ -n "$ip" ]]; then
+        WORKER_IPS+=("$ip")
+    fi
+done <<< "$(echo "$NODE_INFO" | grep "^WORKER:")"
+
+if [[ -z "$HEAD_IP" ]]; then
+    echo "Error: Could not determine head node IP"
+    exit 1
+fi
+
+echo "Head node IP: $HEAD_IP (this machine)"
+
+if [[ ${#WORKER_IPS[@]} -eq 0 ]]; then
+    echo "No worker nodes found. Nothing to copy."
+    exit 0
+fi
+
+echo "Worker node IPs: ${WORKER_IPS[*]}"
+echo ""
+
+# Re-enable exit on error for the copy operations
+set -e
+
+# Copy from this machine (head node) to each worker node
+for worker_ip in "${WORKER_IPS[@]}"; do
+    echo "==> Copying to worker ($worker_ip)"
+
+    for src in "${FILES[@]}"; do
+        dst="$src"  # Same path on destination
+        echo "    Copying: $src"
+
+        # Note: $dst expands locally (intentional - we pass the value to remote)
+        # shellcheck disable=SC2029
+        ssh "${SSH_OPTS[@]}" "$worker_ip" "mkdir -p '$(dirname "$dst")'"
+
+        # Note: $dst expands locally, \$(date +%s) expands on remote (intentional)
+        # shellcheck disable=SC2029
+        ssh "${SSH_OPTS[@]}" "$worker_ip" "test -e '$dst' && cp -r '$dst' '${dst}.bak.\$(date +%s)' || true"
+
+        # Copy from head (local) to worker
+        scp -r "${SCP_OPTS[@]}" "$src" "$worker_ip:$dst"
+    done
+
+    echo "    Done copying to $worker_ip"
 done
 
-echo "Done."
+echo ""
+echo "All copies complete."

--- a/copier.sh
+++ b/copier.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT=2222
+
+SRC="/home/ray/default/torchft/torchft/ddp.py"
+DST=$SRC
+
+IPS=(
+  10.0.2.189
+  10.0.9.110
+)
+
+SSH_OPTS=(-p "$PORT" -o StrictHostKeyChecking=accept-new)
+SCP_OPTS=(-P "$PORT" -o StrictHostKeyChecking=accept-new)
+
+for ip in "${IPS[@]}"; do
+  echo "==> Copying to $ip"
+
+  # Make sure destination directory exists (on the remote)
+  ssh "${SSH_OPTS[@]}" "$ip" "mkdir -p '$(dirname "$DST")'"
+
+  # Backup existing file if present
+  ssh "${SSH_OPTS[@]}" "$ip" "test -f '$DST' && cp '$DST' '${DST}.bak.$(date +%s)' || true"
+
+  # Copy
+  scp "${SCP_OPTS[@]}" "$SRC" "$ip:$DST"
+done
+
+echo "Done."

--- a/copier.sh
+++ b/copier.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# Default source: ray's site-packages location
-DEFAULT_SRC=$(python -c "import ray; import os; print(os.path.dirname(ray.__path__[0]))")
+# Source base: ray repo on head node
+SRC_BASE="/home/ray/default/ray/python"
 
-# Parse arguments - if none provided, use default
+# Destination base: ray's site-packages location
+DST_BASE=$(python -c "import ray; import os; print(os.path.dirname(ray.__path__[0]))")
+
+# Parse arguments - if none provided, copy entire directory
 if [[ $# -eq 0 ]]; then
-    FILES=("$DEFAULT_SRC")
+    FILES=("")  # Empty string means copy the whole SRC_BASE
 else
     FILES=("$@")
 fi
@@ -15,9 +18,15 @@ PORT=2222
 SSH_OPTS=(-p "$PORT" -o StrictHostKeyChecking=accept-new)
 SCP_OPTS=(-P "$PORT" -o StrictHostKeyChecking=accept-new)
 
+echo "Source base: $SRC_BASE"
+echo "Destination base: $DST_BASE"
 echo "Files to copy:"
 for f in "${FILES[@]}"; do
-    echo "  - $f"
+    if [[ -z "$f" ]]; then
+        echo "  - (entire directory)"
+    else
+        echo "  - $f"
+    fi
 done
 echo ""
 
@@ -42,7 +51,7 @@ if head_ip is None and worker_ips:
 print(f'HEAD:{head_ip or \"\"}')
 for ip in worker_ips:
     print(f'WORKER:{ip}')
-" 2>/dev/null)
+")
 
 if [[ -z "$NODE_INFO" ]]; then
     echo "Error: Could not get node info from Ray. Is Ray running?"
@@ -69,24 +78,44 @@ fi
 
 echo "Head node IP: $HEAD_IP (this machine)"
 
-if [[ ${#WORKER_IPS[@]} -eq 0 ]]; then
-    echo "No worker nodes found. Nothing to copy."
-    exit 0
-fi
-
-echo "Worker node IPs: ${WORKER_IPS[*]}"
+echo "Worker node IPs: ${WORKER_IPS[*]:-none}"
 echo ""
 
 # Re-enable exit on error for the copy operations
 set -e
 
-# Copy from this machine (head node) to each worker node
+# Copy from SRC to DST on head node (local)
+echo "==> Copying to head node (local)"
+for f in "${FILES[@]}"; do
+    if [[ -z "$f" ]]; then
+        src="$SRC_BASE"
+        dst="$DST_BASE"
+    else
+        src="$SRC_BASE/$f"
+        dst="$DST_BASE/$f"
+    fi
+    echo "    $src -> $dst"
+    if [[ -e "$dst" ]]; then
+        cp -r "$dst" "${dst}.bak.$(date +%s)"
+    fi
+    mkdir -p "$(dirname "$dst")"
+    cp -r "$src" "$dst"
+done
+echo "    Done copying to head node"
+
+# Copy from SRC to DST on each worker node
 for worker_ip in "${WORKER_IPS[@]}"; do
     echo "==> Copying to worker ($worker_ip)"
 
-    for src in "${FILES[@]}"; do
-        dst="$src"  # Same path on destination
-        echo "    Copying: $src"
+    for f in "${FILES[@]}"; do
+        if [[ -z "$f" ]]; then
+            src="$SRC_BASE"
+            dst="$DST_BASE"
+        else
+            src="$SRC_BASE/$f"
+            dst="$DST_BASE/$f"
+        fi
+        echo "    $src -> $worker_ip:$dst"
 
         # Note: $dst expands locally (intentional - we pass the value to remote)
         # shellcheck disable=SC2029

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -423,7 +423,7 @@ We publish the dependencies that are installed in our ``ray`` Docker images for 
     .. tab-item:: ray (Python 3.10)
         :sync: ray (Python 3.10)
 
-        Ray version: nightly (`ae94ff4 <https://github.com/ray-project/ray/commit/ae94ff496a308c52100cd99b1857836b739498e0>`_)
+        Ray version: 2.53.0 (`0de2118 <https://github.com/ray-project/ray/commit/0de211850589aea71f842873bc32574c702ab492>`_)
 
         .. literalinclude:: ./pip_freeze_ray-py310-cpu.txt
 

--- a/doc/source/ray-overview/pip_freeze_ray-py310-cpu.txt
+++ b/doc/source/ray-overview/pip_freeze_ray-py310-cpu.txt
@@ -4,6 +4,7 @@ aiohttp==3.11.16
 aiohttp-cors==0.7.0
 aiosignal==1.3.1
 amqp==5.3.1
+annotated-doc==0.0.4
 annotated-types==0.6.0
 anyio==3.7.1
 archspec @ file:///home/conda/feedstock_root/build_artifacts/archspec_1737352602016/work
@@ -18,11 +19,11 @@ billiard==4.2.1
 boltons @ file:///home/conda/feedstock_root/build_artifacts/boltons_1733827268945/work
 boto3==1.29.7
 botocore==1.32.7
-Brotli @ file:///home/conda/feedstock_root/build_artifacts/brotli-split_1761591974641/work
+Brotli @ file:///home/conda/feedstock_root/build_artifacts/brotli-split_1764016952863/work
 cachetools==5.5.2
 celery==5.5.3
 certifi==2025.1.31
-cffi==1.16.0
+cffi @ file:///home/conda/feedstock_root/build_artifacts/cffi_1725560520483/work
 charset-normalizer==3.3.2
 click==8.1.7
 click-didyoumean==0.3.1
@@ -31,20 +32,20 @@ click-repl==0.3.0
 cloudpickle==2.2.0
 colorama @ file:///home/conda/feedstock_root/build_artifacts/colorama_1733218098505/work
 colorful==0.5.5
-conda @ file:///home/conda/feedstock_root/build_artifacts/conda_1760108586898/work/conda-src
-conda-libmamba-solver @ file:///home/conda/feedstock_root/build_artifacts/conda-libmamba-solver_1745834476052/work/src
+conda @ file:///home/conda/feedstock_root/build_artifacts/conda_1765816446718/work/conda-src
+conda-libmamba-solver @ file:///home/conda/feedstock_root/build_artifacts/conda-libmamba-solver_1764081326783/work/src
 conda-package-handling @ file:///home/conda/feedstock_root/build_artifacts/conda-package-handling_1736345463896/work
 conda_package_streaming @ file:///home/conda/feedstock_root/build_artifacts/conda-package-streaming_1729004031731/work
 cryptography==44.0.3
-cupy-cuda12x==13.1.0
+cupy-cuda12x==13.4.0
 Cython==0.29.37
 distlib==0.3.7
 distro @ file:///home/conda/feedstock_root/build_artifacts/distro_1734729835256/work
 dm-tree==0.1.8
-exceptiongroup==1.3.0
+exceptiongroup==1.3.1
 Farama-Notifications==0.0.4
-fastapi==0.115.12
-fastrlock==0.8.2
+fastapi==0.121.0
+fastrlock==0.8.3
 filelock==3.17.0
 flatbuffers==23.5.26
 frozendict @ file:///home/conda/feedstock_root/build_artifacts/frozendict_1763082794572/work
@@ -74,17 +75,19 @@ isodate==0.6.1
 Jinja2==3.1.6
 jmespath==1.0.1
 jsonpatch @ file:///home/conda/feedstock_root/build_artifacts/jsonpatch_1733814567314/work
-jsonpointer @ file:///home/conda/feedstock_root/build_artifacts/jsonpointer_1756754132747/work
+jsonpointer @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_jsonpointer_1765026384/work
 jsonschema==4.23.0
 jsonschema-specifications==2024.10.1
 kombu==5.5.4
-libmambapy @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_libmambapy_1760729597/work/libmambapy
-lz4==4.3.3
+libmambapy @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_libmambapy_1764158555/work/libmambapy
+linkify-it-py==2.0.3
+lz4==4.4.5
 markdown-it-py==2.2.0
 MarkupSafe==2.1.3
+mdit-py-plugins==0.3.5
 mdurl==0.1.2
-memray==1.10.0
-menuinst @ file:///home/conda/feedstock_root/build_artifacts/menuinst_1761299740801/work
+memray==1.19.1
+menuinst @ file:///home/conda/feedstock_root/build_artifacts/menuinst_1765733081264/work
 msal==1.28.1
 msal-extensions==1.2.0b1
 msgpack==1.0.7
@@ -98,7 +101,7 @@ opentelemetry-proto==1.27.0
 opentelemetry-sdk==1.34.1
 opentelemetry-semantic-conventions==0.55b1
 ormsgpack==1.7.0
-packaging==23.0
+packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1733203243479/work
 pandas==1.5.3
 platformdirs==3.11.0
 pluggy @ file:///home/conda/feedstock_root/build_artifacts/pluggy_1733222765875/work
@@ -115,8 +118,8 @@ pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pycosat @ file:///home/conda/feedstock_root/build_artifacts/pycosat_1757744612102/work
 pycparser==2.21
-pydantic==2.11.7
-pydantic_core==2.33.2
+pydantic==2.12.4
+pydantic_core==2.41.5
 Pygments==2.18.0
 PyJWT==2.8.0
 pyOpenSSL==25.0.0
@@ -125,11 +128,11 @@ PySocks @ file:///home/conda/feedstock_root/build_artifacts/pysocks_173321723672
 python-dateutil==2.8.2
 python-dotenv==1.2.1
 pytz==2022.7.1
-PyYAML==6.0.1
-ray @ file:///home/ray/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl#sha256=c096db8428166779cf10817e3698d3fdf50e11e45911cc95f6feeb2b44cdc481
+PyYAML==6.0.3
+ray @ file:///home/ray/ray-2.53.0-cp310-cp310-manylinux2014_x86_64.whl#sha256=ec758f5aa71f01f090557a0fe8732689f7e2f8e49a1f39f4649ee9a7804c7514
 referencing==0.36.2
-requests @ file:///home/conda/feedstock_root/build_artifacts/requests_1733217035951/work
-rich==13.3.2
+requests==2.32.5
+rich==13.7.1
 rpds-py==0.22.3
 rsa==4.7.2
 ruamel.yaml @ file:///home/conda/feedstock_root/build_artifacts/ruamel.yaml_1761160605807/work
@@ -139,13 +142,15 @@ scipy==1.11.4
 six==1.16.0
 smart-open==6.2.0
 sniffio==1.3.1
-starlette==0.46.2
+starlette==0.49.1
 tensorboardX==2.6.2.2
+textual==4.0.0
 tqdm @ file:///home/conda/feedstock_root/build_artifacts/tqdm_1735661334605/work
 truststore @ file:///home/conda/feedstock_root/build_artifacts/truststore_1729762363021/work
-typing-inspection==0.4.1
-typing_extensions==4.12.2
+typing-inspection==0.4.2
+typing_extensions==4.15.0
 tzdata==2025.2
+uc-micro-py==1.0.3
 uritemplate==4.1.1
 urllib3==1.26.19
 uvicorn==0.22.0

--- a/driver.py
+++ b/driver.py
@@ -1,0 +1,88 @@
+import os
+import tempfile
+
+import torch
+from torch.nn import CrossEntropyLoss
+from torch.optim import Adam
+from torch.utils.data import DataLoader
+from torchvision.datasets import FashionMNIST
+from torchvision.models import resnet18
+from torchvision.transforms import Compose, Normalize, ToTensor
+
+import ray.train.torch
+
+
+def train_func():
+    # Model, Loss, Optimizer
+    model = resnet18(num_classes=10)
+    model.conv1 = torch.nn.Conv2d(
+        1, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False
+    )
+    # [1] Prepare model.
+    model = ray.train.torch.prepare_model(model)
+    # model.to("cuda")  # This is done by `prepare_model`
+    criterion = CrossEntropyLoss()
+    optimizer = Adam(model.parameters(), lr=0.001)
+
+    # Data
+    transform = Compose([ToTensor(), Normalize((0.28604,), (0.32025,))])
+    data_dir = os.path.join(tempfile.gettempdir(), "data")
+    train_data = FashionMNIST(
+        root=data_dir, train=True, download=True, transform=transform
+    )
+    train_loader = DataLoader(train_data, batch_size=128, shuffle=True)
+    # [2] Prepare dataloader.
+    train_loader = ray.train.torch.prepare_data_loader(train_loader)
+
+    # Training
+    for epoch in range(10):
+        if ray.train.get_context().get_world_size() > 1:
+            train_loader.sampler.set_epoch(epoch)
+
+        for images, labels in train_loader:
+            # This is done by `prepare_data_loader`!
+            # images, labels = images.to("cuda"), labels.to("cuda")
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        # [3] Report metrics and checkpoint.
+        metrics = {"loss": loss.item(), "epoch": epoch}
+        with tempfile.TemporaryDirectory() as temp_checkpoint_dir:
+            torch.save(
+                model.module.state_dict(), os.path.join(temp_checkpoint_dir, "model.pt")
+            )
+            ray.train.report(
+                metrics,
+                checkpoint=ray.train.Checkpoint.from_directory(temp_checkpoint_dir),
+            )
+        if ray.train.get_context().get_world_rank() == 0:
+            print(metrics)
+
+
+# [4] Configure scaling and resource requirements.
+scaling_config = ray.train.ScalingConfig(num_workers=2, use_gpu=True)
+
+# [5] Launch distributed training job.
+trainer = ray.train.torch.TorchTrainer(
+    train_func,
+    scaling_config=scaling_config,
+    # [5a] If running in a multi-node cluster, this is where you
+    # should configure the run's persistent storage that is accessible
+    # across all worker nodes.
+    run_config=ray.train.RunConfig(
+        storage_path="/mnt/cluster_storage", name="my_run_name"
+    ),
+)
+result = trainer.fit()
+
+# [6] Load the trained model.
+with result.checkpoint.as_directory() as checkpoint_dir:
+    model_state_dict = torch.load(os.path.join(checkpoint_dir, "model.pt"))
+    model = resnet18(num_classes=10)
+    model.conv1 = torch.nn.Conv2d(
+        1, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False
+    )
+    model.load_state_dict(model_state_dict)

--- a/driver.py
+++ b/driver.py
@@ -112,8 +112,7 @@ def train_func():
                     metrics,
                     checkpoint=ray.train.Checkpoint.from_directory(temp_checkpoint_dir),
                 )
-        if ray.train.get_context().get_world_rank() == 0:
-            print(metrics)
+        print(f"Rank {ray.train.get_context().get_world_rank()} metrics: {metrics}")
 
 
 # [4] Configure scaling and resource requirements.

--- a/driver.py
+++ b/driver.py
@@ -53,6 +53,10 @@ def train_func():
         min_replica_size=1,
         load_state_dict=load_state_dict,
         state_dict=state_dict,
+        # This is replica group world size. torchft example doesn't set this.
+        world_size=1,
+        # Always rank 0 per replica group.
+        rank=0,
         # example does REPLICA_GROUP_ID, but we will do N replica groups and 1 worker per replica group
         replica_id=f"train_ddp_{ray.train.get_context().get_world_rank()}",
         timeout=timedelta(seconds=30),

--- a/driver.py
+++ b/driver.py
@@ -103,7 +103,7 @@ def train_func():
 
         if manager.current_step() >= 200:
             # complete training
-            exit()
+            break
 
     # [3] Print metrics.
     metrics = {"loss": loss.item()}

--- a/driver.py
+++ b/driver.py
@@ -22,8 +22,6 @@ import ray.train.torch
 
 
 def train_func():
-    os.environ["TORCHFT_LIGHTHOUSE"] = "http://ip-10-0-50-13:29510"
-
     # Model, Loss, Optimizer
     model = resnet18(num_classes=10)
     model.conv1 = torch.nn.Conv2d(

--- a/driver.py
+++ b/driver.py
@@ -22,49 +22,6 @@ import ray.train.torch
 
 
 def train_func():
-    # Model, Loss, Optimizer
-    model = resnet18(num_classes=10)
-    model.conv1 = torch.nn.Conv2d(
-        1, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False
-    )
-    model.to("cuda")
-    criterion = CrossEntropyLoss()
-    optimizer = Adam(model.parameters(), lr=0.001)
-
-    # Wrap model and optimizer with torchft primitives
-    def load_state_dict(state_dict):
-        model.load_state_dict(state_dict["model"])
-        optimizer.load_state_dict(state_dict["optim"])
-
-    def state_dict():
-        return {
-            "model": model.state_dict(),
-            "optim": optimizer.state_dict(),
-        }
-
-    pg = ProcessGroupNCCL(timeout=timedelta(seconds=30))
-    transport = PGTransport(
-        pg,
-        timeout=timedelta(seconds=10),
-        device="cuda",
-    )
-    manager = Manager(
-        pg=pg,
-        min_replica_size=1,
-        load_state_dict=load_state_dict,
-        state_dict=state_dict,
-        # This is replica group world size. torchft example doesn't set this.
-        world_size=1,
-        # Always rank 0 per replica group.
-        rank=0,
-        # example does REPLICA_GROUP_ID, but we will do N replica groups and 1 worker per replica group
-        replica_id=f"train_ddp_{ray.train.get_context().get_world_rank()}",
-        timeout=timedelta(seconds=30),
-        checkpoint_transport=transport,
-    )
-    model = DistributedDataParallel(manager, model)
-    optimizer = Optimizer(manager, optimizer)
-
     # Data
     transform = Compose([ToTensor(), Normalize((0.28604,), (0.32025,))])
     data_dir = os.path.join(tempfile.gettempdir(), "data")
@@ -91,8 +48,53 @@ def train_func():
         train_data, batch_size=64, num_workers=2, sampler=sampler
     )
 
+    # Model, Loss, Optimizer
+    model = resnet18(num_classes=10)
+    model.conv1 = torch.nn.Conv2d(
+        1, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False
+    )
+    model.to("cuda")
+    criterion = CrossEntropyLoss()
+    optimizer = Adam(model.parameters(), lr=0.001)
+
+    # Wrap model and optimizer with torchft primitives
+    def load_state_dict(state_dict):
+        model.load_state_dict(state_dict["model"])
+        optimizer.load_state_dict(state_dict["optim"])
+        train_loader.load_state_dict(state_dict["dataloader"])
+
+    def state_dict():
+        return {
+            "model": model.state_dict(),
+            "optim": optimizer.state_dict(),
+            "dataloader": train_loader.state_dict(),
+        }
+
+    pg = ProcessGroupNCCL(timeout=timedelta(seconds=30))
+    transport = PGTransport(
+        pg,
+        timeout=timedelta(seconds=10),
+        device="cuda",
+    )
+    manager = Manager(
+        pg=pg,
+        min_replica_size=1,
+        load_state_dict=load_state_dict,
+        state_dict=state_dict,
+        # This is replica group world size. torchft example doesn't set this.
+        world_size=1,
+        # Always rank 0 per replica group.
+        rank=0,
+        # example does REPLICA_GROUP_ID, but we will do N replica groups and 1 worker per replica group
+        replica_id=f"train_ddp_{ray.train.get_context().get_world_rank()}",
+        timeout=timedelta(seconds=30),
+        checkpoint_transport=transport,
+    )
+    model = DistributedDataParallel(manager, model)
+    optimizer = Optimizer(manager, optimizer)
+
     # Training
-    for epoch in range(2):
+    for epoch in range(1):
         if ray.train.get_context().get_world_size() > 1:
             train_loader.sampler.set_epoch(epoch)
 

--- a/driver.py
+++ b/driver.py
@@ -92,15 +92,16 @@ def train_func():
     )
 
     # Training
-    for epoch in range(2):
+    for epoch in range(1):
         if ray.train.get_context().get_world_size() > 1:
             train_loader.sampler.set_epoch(epoch)
 
         for images, labels in train_loader:
             images, labels = images.to("cuda"), labels.to("cuda")
+            # Do zero_grad first to start quorum early as done in torchft train_ddp example
+            optimizer.zero_grad()
             outputs = model(images)
             loss = criterion(outputs, labels)
-            optimizer.zero_grad()
             loss.backward()
             optimizer.step()
 

--- a/java/api/pom_template.xml
+++ b/java/api/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.53.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/performance_test/pom_template.xml
+++ b/java/performance_test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.53.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.ray</groupId>
   <artifactId>ray-superpom</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.53.0</version>
   <packaging>pom</packaging>
   <name>Ray Project Parent POM</name>
   <description>An open source framework that provides a simple, universal API for building distributed applications.
@@ -63,7 +63,7 @@
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.version>2.0.0-SNAPSHOT</project.version>
+    <project.version>2.53.0</project.version>
   </properties>
 
   <dependencyManagement>

--- a/java/runtime/pom_template.xml
+++ b/java/runtime/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.53.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/serve/pom_template.xml
+++ b/java/serve/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.53.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/test/pom_template.xml
+++ b/java/test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.53.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/python/ray/_version.py
+++ b/python/ray/_version.py
@@ -1,6 +1,6 @@
 # Replaced with the current commit when building the wheels.
 commit = "{{RAY_COMMIT_SHA}}"
-version = "3.0.0.dev0"
+version = "2.53.0"
 
 if __name__ == "__main__":
     print("%s %s" % (version, commit))

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -352,7 +352,8 @@ class _AutoscalingCoordinatorActor:
         if any(res1.get(key, 0) < res2[key] for key in res2):
             return False
         for key in res2:
-            res1[key] -= res2[key]
+            if key in res1:
+                res1[key] -= res2[key]
         return True
 
     def _update_cluster_node_resources(self) -> bool:

--- a/python/ray/data/_internal/execution/backpressure_policy/concurrency_cap_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/concurrency_cap_backpressure_policy.py
@@ -41,18 +41,18 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
     """
 
     # Smoothing factor for the asymmetric EWMA (slow fall, faster rise).
-    EWMA_ALPHA = env_float("RAY_DATA_CONCURRENCY_CAP_EWMA_ALPHA", 0.2)
+    EWMA_ALPHA = env_float("RAY_DATA_CONCURRENCY_CAP_EWMA_ALPHA", 0.1)
     EWMA_ALPHA_UP = 1.0 - (1.0 - EWMA_ALPHA) ** 2  # fast rise
     # Deadband width in units of the EWMA absolute deviation estimate.
-    K_DEV = env_float("RAY_DATA_CONCURRENCY_CAP_K_DEV", 2.0)
+    K_DEV = env_float("RAY_DATA_CONCURRENCY_CAP_K_DEV", 1.0)
     # Factor to back off when the queue is too large.
     BACKOFF_FACTOR = env_float("RAY_DATA_CONCURRENCY_CAP_BACKOFF_FACTOR", 1)
     # Factor to ramp up when the queue is too small.
     RAMPUP_FACTOR = env_float("RAY_DATA_CONCURRENCY_CAP_RAMPUP_FACTOR", 1)
     # Threshold for per-Op object store budget (available) vs total
     # (available / total) ratio to enable dynamic output queue size backpressure.
-    OBJECT_STORE_BUDGET_RATIO = env_float(
-        "RAY_DATA_CONCURRENCY_CAP_OBJECT_STORE_BUDGET_RATIO", 0.1
+    AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD = env_float(
+        "RAY_DATA_CONCURRENCY_CAP_AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD", 0.1
     )
 
     def __init__(self, *args, **kwargs):
@@ -93,7 +93,7 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
             dynamic_output_queue_size_backpressure_configs = (
                 f", EWMA_ALPHA={self.EWMA_ALPHA}, K_DEV={self.K_DEV}, "
                 f"BACKOFF_FACTOR={self.BACKOFF_FACTOR}, RAMPUP_FACTOR={self.RAMPUP_FACTOR}, "
-                f"OBJECT_STORE_BUDGET_RATIO={self.OBJECT_STORE_BUDGET_RATIO}"
+                f"AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD={self.AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD}"
             )
         logger.debug(
             f"ConcurrencyCapBackpressurePolicy caps: {self._concurrency_caps}, "
@@ -141,10 +141,16 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
         """Return whether `op` may accept another input now."""
         num_tasks_running = op.metrics.num_tasks_running
 
-        # If not a MapOperator or feature disabled, just enforce configured cap.
+        # Skip dynamic backpressure if:
+        # - Not a MapOperator
+        # - Not eligible for Op for Backpressure
+        # - Dynamic backpressure based on output queue size is disabled
+        # - Downstream is a materializing op which requires full materialization
         if (
             not isinstance(op, MapOperator)
+            or not self._resource_manager.is_op_eligible(op)
             or not self.enable_dynamic_output_queue_size_backpressure
+            or self._resource_manager.has_materializing_downstream_op(op)
         ):
             return num_tasks_running < self._concurrency_caps[op]
 
@@ -156,7 +162,7 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
             total_mem = op_usage.object_store_memory + op_budget.object_store_memory
             if total_mem == 0 or (
                 op_budget.object_store_memory / total_mem
-                > self.OBJECT_STORE_BUDGET_RATIO
+                > self.AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD
             ):
                 # If the objectstore budget (available) to total
                 # ratio is above threshold (10%), skip dynamic output queue size
@@ -164,12 +170,9 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
                 return num_tasks_running < self._concurrency_caps[op]
 
         # Current total queued bytes (this op + downstream)
-        current_queue_size_bytes = (
-            self._resource_manager.get_op_internal_object_store_usage(op)
-            + self._resource_manager.get_op_outputs_object_store_usage_with_downstream(
-                op
-            )
-        )
+        current_queue_size_bytes = self._resource_manager.get_mem_op_internal(
+            op
+        ) + self._resource_manager.get_op_outputs_object_store_usage_with_downstream(op)
 
         # Update EWMA state (level & dev) and compute effective cap. Note that
         # we don't update the EWMA state if the objectstore budget (available) vs total

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -251,6 +251,7 @@ DEFAULT_ACTOR_POOL_MAX_UPSCALING_DELTA: int = env_integer(
 )
 
 
+# Dynamic output queue size backpressure disabled by default.
 DEFAULT_ENABLE_DYNAMIC_OUTPUT_QUEUE_SIZE_BACKPRESSURE: bool = env_bool(
     "RAY_DATA_ENABLE_DYNAMIC_OUTPUT_QUEUE_SIZE_BACKPRESSURE", False
 )

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -396,6 +396,20 @@ def test_request_resources_handles_timeout_error(teardown_autoscaling_coordinato
     )
 
 
+def test_coordinator_accepts_zero_resource_for_missing_resource_type(
+    teardown_autoscaling_coordinator,
+):
+    # This is a regression test for a bug where the coordinator crashes when you request
+    # a resource type (e.g., GPU: 0) that doesn't exist on the cluster.
+    coordinator = DefaultAutoscalingCoordinator()
+
+    coordinator.request_resources(
+        requester_id="spam", resources=[{"CPU": 1, "GPU": 0}], expire_after_s=1
+    )
+
+    assert coordinator.get_allocated_resources("spam") == [{"CPU": 1, "GPU": 0}]
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -60,10 +60,16 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
             map_op_no_concurrency: MagicMock(),
         }
 
+        mock_resource_manager = MagicMock()
+        # Return None to skip dynamic output queue size backpressure check
+        mock_resource_manager.get_op_usage.return_value = None
+        mock_resource_manager.get_budget.return_value = None
+        mock_resource_manager.is_op_eligible.return_value = False
+
         policy = ConcurrencyCapBackpressurePolicy(
             DataContext.get_current(),
             topology,
-            MagicMock(),
+            mock_resource_manager,
         )
 
         self.assertEqual(policy._concurrency_caps[map_op], concurrency)
@@ -177,6 +183,67 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
         # InputDataBuffer has infinite concurrency cap, so should always allow
         self.assertTrue(policy.can_add_input(input_op))
 
+    def test_can_add_input_with_ineligible_op(self):
+        """Test can_add_input when op is not eligible for backpressure."""
+        input_op = InputDataBuffer(DataContext.get_current(), input_data=[MagicMock()])
+        map_op = TaskPoolMapOperator(
+            map_transformer=MagicMock(),
+            data_context=DataContext.get_current(),
+            input_op=input_op,
+            max_concurrency=5,
+        )
+        map_op.metrics.num_tasks_running = 3
+
+        topology = {map_op: MagicMock(), input_op: MagicMock()}
+
+        mock_resource_manager = MagicMock()
+        # Op is not eligible for backpressure
+        mock_resource_manager.is_op_eligible.return_value = False
+
+        policy = ConcurrencyCapBackpressurePolicy(
+            DataContext.get_current(),
+            topology,
+            mock_resource_manager,
+        )
+        policy.enable_dynamic_output_queue_size_backpressure = True
+
+        # Should skip dynamic backpressure and use basic cap check
+        self.assertTrue(policy.can_add_input(map_op))  # 3 < 5
+
+        map_op.metrics.num_tasks_running = 5
+        self.assertFalse(policy.can_add_input(map_op))  # 5 >= 5
+
+    def test_can_add_input_with_materializing_downstream_op(self):
+        """Test can_add_input when downstream op is a materializing operator."""
+        input_op = InputDataBuffer(DataContext.get_current(), input_data=[MagicMock()])
+        map_op = TaskPoolMapOperator(
+            map_transformer=MagicMock(),
+            data_context=DataContext.get_current(),
+            input_op=input_op,
+            max_concurrency=5,
+        )
+        map_op.metrics.num_tasks_running = 3
+
+        topology = {map_op: MagicMock(), input_op: MagicMock()}
+
+        mock_resource_manager = MagicMock()
+        mock_resource_manager.is_op_eligible.return_value = True
+        mock_resource_manager.has_materializing_downstream_op.return_value = True
+
+        policy = ConcurrencyCapBackpressurePolicy(
+            DataContext.get_current(),
+            topology,
+            mock_resource_manager,
+        )
+        policy.enable_dynamic_output_queue_size_backpressure = True
+
+        # Should skip dynamic backpressure and use basic cap check
+        # to avoid starving materializing operators
+        self.assertTrue(policy.can_add_input(map_op))  # 3 < 5
+
+        map_op.metrics.num_tasks_running = 5
+        self.assertFalse(policy.can_add_input(map_op))  # 5 >= 5
+
     def test_can_add_input_with_object_store_memory_usage_ratio_above_threshold(self):
         """Test can_add_input when object store memory usage ratio is above threshold."""
         input_op = InputDataBuffer(DataContext.get_current(), input_data=[MagicMock()])
@@ -193,8 +260,10 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
         mock_resource_manager = MagicMock()
 
         # Mock object store memory usage ratio above threshold
-        # Ratio = budget / (usage + budget) > OBJECT_STORE_BUDGET_RATIO
-        threshold = ConcurrencyCapBackpressurePolicy.OBJECT_STORE_BUDGET_RATIO
+        # Ratio = budget / (usage + budget) > AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD
+        threshold = (
+            ConcurrencyCapBackpressurePolicy.AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD
+        )
         mock_usage = MagicMock()
         mock_usage.object_store_memory = 1000  # usage
         mock_budget = MagicMock()
@@ -207,6 +276,8 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
 
         mock_resource_manager.get_op_usage.return_value = mock_usage
         mock_resource_manager.get_budget.return_value = mock_budget
+        mock_resource_manager.is_op_eligible.return_value = True
+        mock_resource_manager.has_materializing_downstream_op.return_value = False
 
         policy = ConcurrencyCapBackpressurePolicy(
             DataContext.get_current(),
@@ -249,8 +320,10 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
         mock_resource_manager = MagicMock()
 
         # Mock object store memory usage ratio below threshold
-        # Ratio = budget / (usage + budget) < OBJECT_STORE_BUDGET_RATIO
-        threshold = ConcurrencyCapBackpressurePolicy.OBJECT_STORE_BUDGET_RATIO
+        # Ratio = budget / (usage + budget) < AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD
+        threshold = (
+            ConcurrencyCapBackpressurePolicy.AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD
+        )
         mock_usage = MagicMock()
         mock_usage.object_store_memory = 1000  # usage
         mock_budget = MagicMock()
@@ -263,9 +336,11 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
 
         mock_resource_manager.get_op_usage.return_value = mock_usage
         mock_resource_manager.get_budget.return_value = mock_budget
+        mock_resource_manager.is_op_eligible.return_value = True
+        mock_resource_manager.has_materializing_downstream_op.return_value = False
 
         # Mock queue size methods
-        mock_resource_manager.get_op_internal_object_store_usage.return_value = 100
+        mock_resource_manager.get_mem_op_internal.return_value = 100
         mock_resource_manager.get_op_outputs_object_store_usage_with_downstream.return_value = (
             200
         )
@@ -286,9 +361,10 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
         policy._q_level_dev[map_op] = initial_dev
 
         result = policy.can_add_input(map_op)
-        # With queue size 300, initial level=200, dev=50, bounds=[100, 300]
-        # Queue size 300 is at the upper bound, so should hold.
-        # running=3 < effective_cap=3 should be False
+        # With queue size 300, initial level=200, dev=50, bounds=[150, 250]
+        # Queue size 300 is above the upper bound, so should backoff.
+        # running=3, backoff by 1 -> effective_cap=2
+        # running=3 < effective_cap=2 should be False
         self.assertFalse(result)
         # EWMA state should be updated when ratio < threshold
         # Level should move toward 300 (queue size)
@@ -310,7 +386,9 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
         topology = {map_op: MagicMock(), input_op: MagicMock()}
 
         mock_resource_manager = MagicMock()
-        threshold = ConcurrencyCapBackpressurePolicy.OBJECT_STORE_BUDGET_RATIO
+        threshold = (
+            ConcurrencyCapBackpressurePolicy.AVAILABLE_OBJECT_STORE_BUDGET_THRESHOLD
+        )
         mock_usage = MagicMock()
         mock_usage.object_store_memory = 1000
         mock_budget = MagicMock()
@@ -323,6 +401,8 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
 
         mock_resource_manager.get_op_usage.return_value = mock_usage
         mock_resource_manager.get_budget.return_value = mock_budget
+        mock_resource_manager.is_op_eligible.return_value = True
+        mock_resource_manager.has_materializing_downstream_op.return_value = False
 
         policy = ConcurrencyCapBackpressurePolicy(
             DataContext.get_current(),
@@ -369,9 +449,7 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
             description,
         ) in test_cases:
             with self.subTest(description=description):
-                mock_resource_manager.get_op_internal_object_store_usage.return_value = (
-                    internal_usage
-                )
+                mock_resource_manager.get_mem_op_internal.return_value = internal_usage
                 mock_resource_manager.get_op_outputs_object_store_usage_with_downstream.return_value = (
                     downstream_usage
                 )

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -132,7 +132,8 @@ def _shutdown_torch(destroy_process_group=False):
     from ray.air._internal.torch_utils import get_devices
 
     devices = get_devices()
-    if destroy_process_group:
+    # Check dist.is_initialized() because torchft might already destroy process group.
+    if destroy_process_group and dist.is_initialized():
         dist.destroy_process_group()
     if torch.cuda.is_available():
         for device in devices:

--- a/python/ray/train/v2/_internal/constants.py
+++ b/python/ray/train/v2/_internal/constants.py
@@ -91,6 +91,8 @@ RAY_TRAIN_CALLBACKS_ENV_VAR = "RAY_TRAIN_CALLBACKS"
 # Ray Train does not warn by default when using blocking ray.get inside async actor.
 DEFAULT_RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_VALUE = "0"
 
+TORCHFT_LIGHTHOUSE_ENV_VAR = "TORCHFT_LIGHTHOUSE"
+
 # Environment variables to propagate from the driver to the controller,
 # and then from the controller to the workers.
 ENV_VARS_TO_PROPAGATE = {
@@ -106,6 +108,7 @@ ENV_VARS_TO_PROPAGATE = {
     ENABLE_STATE_ACTOR_RECONCILIATION_ENV_VAR,
     STATE_ACTOR_RECONCILIATION_INTERVAL_S_ENV_VAR,
     RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR,
+    TORCHFT_LIGHTHOUSE_ENV_VAR,
 }
 
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -464,7 +464,9 @@ class TrainController:
             )
         elif isinstance(controller_state, SchedulingState):
             assert isinstance(controller_state.scaling_decision, ResizeDecision)
-            return self._execute_resize_decision(controller_state.scaling_decision)
+            return await self._execute_resize_decision(
+                controller_state.scaling_decision
+            )
         elif isinstance(controller_state, RunningState):
             try:
                 worker_group_status: WorkerGroupPollStatus = await self._poll_workers()

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -85,6 +85,7 @@ class Worker:
     actor: ActorHandle
     metadata: ActorMetadata
     resources: Dict[str, float]
+    bundle_index: int
     distributed_context: Optional[DistributedContext] = None
     log_file_path: Optional[str] = None
 

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -670,12 +670,14 @@ class WorkerGroup(BaseWorkerGroup):
                     import os
 
                     # Capture all distributed training env vars
+                    # TODO: might not all be needed and have different usages in torchft Manager.
+                    # TODO: maybe even set these inside TorchConfig.on_start?
                     env_var_names = [
                         "MASTER_ADDR",
                         "MASTER_PORT",
-                        "WORLD_SIZE",
-                        "LOCAL_WORLD_SIZE",
-                        "NODE_RANK",
+                        # "WORLD_SIZE",
+                        # "LOCAL_WORLD_SIZE",
+                        # "NODE_RANK",
                     ]
                     return {k: os.environ.get(k, "") for k in env_var_names}
 
@@ -745,6 +747,7 @@ class WorkerGroup(BaseWorkerGroup):
                     if v:  # Only set non-empty values
                         os.environ[k] = v
                 # Set worker-specific env vars
+                # TODO: I don't think this is needed.
                 os.environ["RANK"] = str(rank)
                 os.environ["LOCAL_RANK"] = str(local_rank)
 

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -4,6 +4,8 @@ import sys
 import threading
 from typing import Any, Callable, Dict, List, Optional, Union
 
+from torchft.coordination import LighthouseServer
+
 import ray
 from ray._common.constants import RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR
 from ray._common.usage import usage_lib
@@ -44,6 +46,7 @@ from ray.train.v2._internal.callbacks.user_callback import UserCallbackHandler
 from ray.train.v2._internal.constants import (
     DEFAULT_RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_VALUE,
     METRICS_ENABLED_ENV_VAR,
+    TORCHFT_LIGHTHOUSE_ENV_VAR,
     V2_ENABLED_ENV_VAR,
     get_env_vars_to_propagate,
     is_v2_enabled,
@@ -259,6 +262,13 @@ class DataParallelTrainer:
         env_vars.setdefault(
             RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_ENV_VAR,
             DEFAULT_RAY_WARN_BLOCKING_GET_INSIDE_ASYNC_VALUE,
+        )
+        lighthouse = LighthouseServer(
+            bind="[::]:0", min_replicas=1, join_timeout_ms=60000
+        )
+        env_vars.setdefault(
+            TORCHFT_LIGHTHOUSE_ENV_VAR,
+            lighthouse.address(),
         )
 
         # Attach the controller to the node running the driver script.

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -104,6 +104,7 @@ def mock_worker():
         actor=actor,
         metadata=metadata,
         resources={"CPU": 1},
+        bundle_index=0,
         distributed_context=distributed_context,
         log_file_path="/tmp/ray/session_xxx/logs/train/ray-train-app-worker.log",
     )
@@ -479,6 +480,7 @@ def test_train_state_manager_run_attempt_lifecycle(ray_start_regular):
                 node_id="node_1", node_ip="127.0.0.1", pid=1000 + i, gpu_ids=[]
             ),
             resources={"CPU": 1},
+            bundle_index=i,
             distributed_context=MagicMock(world_rank=i, local_rank=i, node_rank=0),
             log_file_path="/tmp/ray/session_xxx/logs/train/ray-train-app-worker.log",
         )

--- a/python/ray/train/v2/tests/test_worker_group.py
+++ b/python/ray/train/v2/tests/test_worker_group.py
@@ -337,8 +337,9 @@ def test_group_workers_by_ip():
                     pid=0,
                 ),
                 resources={"CPU": 1},
+                bundle_index=i,
             )
-            for node_id in node_ids
+            for i, node_id in enumerate(node_ids)
         ]
 
     workers = create_workers(["2", "3", "1", "4", "2", "1", "3", "3", "4", "2"])
@@ -374,8 +375,9 @@ def test_local_rank_assignment():
                     pid=pid,
                 ),
                 resources={"CPU": 1},
+                bundle_index=i,
             )
-            for pid, node_id, gpu_id in zip(pids, node_ids, gpu_ids)
+            for i, (pid, node_id, gpu_id) in enumerate(zip(pids, node_ids, gpu_ids))
         ]
 
     def setup_and_check_worker_group(pids, node_ids, gpu_ids, expected_local_ranks):

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -67,7 +67,7 @@ constexpr int kMessagePackOffset = 9;
 constexpr char kSetupWorkerFilename[] = "setup_worker.py";
 
 /// The version of Ray
-constexpr char kRayVersion[] = "3.0.0.dev0";
+constexpr char kRayVersion[] = "2.53.0";
 
 /*****************************/
 /* ENV labels for autoscaler */


### PR DESCRIPTION
The description below is mostly accurate, but please look at https://github.com/ray-project/ray/pull/60820 instead, which correctly replaces replica groups instead of individual workers.

# Summary

This is a prototype not intended for submission. It does the following:
1) Modifies the [Ray Train PyTorch example](https://docs.ray.io/en/latest/train/getting-started-pytorch.html) to use the same torchft primitives as this [torchft example](https://github.com/meta-pytorch/torchft/blob/main/train_ddp.py). 
2) DataParallelTrainer creates a LighthouseServer and passes that information to the train controller and workers
3) When the Controller detects worker failures, it creates new workers with the same information (e.g. env vars, train context) and schedules them on the existing placement group.

# Testing

I tested this prototype by:
1) Running the driver script (2 workers)
2) Killing the rank 1 main RayTrainWorker process. Note that killing the rank 0 main RayTrainWorker process causes training to fail entirely because rank 0 contains the TCPStore (used by MASTER_ADDR).
3) Waiting for Ray Train to replace rank 1 and finish training.

Replacing a faulty worker takes ~5s:

```
2026-01-12 18:25:46.332 | Detected 1 bad/non-running workers. Replacing workers at world ranks: [1]
-- | --
I | 2026-01-12 18:25:46.334 | Replacing 1 workers at world ranks: [1]
I | 2026-01-12 18:25:46.336 | Retrieved distributed env vars from surviving worker: {'MASTER_ADDR': '10.0.105.178', 'MASTER_PORT': '46297'}
I | 2026-01-12 18:25:48.189 | Set distributed env vars on new workers: {'MASTER_ADDR': '10.0.105.178', 'MASTER_PORT': '46297'} (plus worker-specific RANK and LOCAL_RANK)
I | 2026-01-12 18:25:51.431 | Successfully replaced workers: - (ip=10.0.119.203, pid=39311) world_rank=1, local_rank=0, node_rank=1
I | 2026-01-12 18:25:51.432 | [State Transition] SCHEDULING -> RUNNING.
```

and the next step happens ~18s after that, but that number depends on checkpoint size.

```
2026-01-12T18:26:09.266 [INFO] [torchft::lighthouse] - Quorum! Quorum { quorum_id: 2, participants: [QuorumMember { replica_id: "train_ddp_0:983f2668-b891-44cc-9caf-28c29588352d", address: "http://ip-10-0-105-178:33689", store_address: "10.0.105.178:46297", step: 62, world_size: 1, shrink_only: false, commit_failures: 1, data: "" }, QuorumMember { replica_id: "train_ddp_1:b9c83efb-419b-4f22-a28c-170322b9d131", address: "http://ip-10-0-119-203:37793", store_address: "10.0.105.178:46297", step: 0, world_size: 1, shrink_only: false, commit_failures: 0, data: "" }], created: Some(Timestamp { seconds: 1768271169, nanos: 266410680 }) }
```

# Appendix

Note that the statefuldataloader state_dict looks like this

`{'_snapshot': {'_snapshot_step': 100, '_last_yielded_worker_id': 1, '_main_snapshot': {'_num_workers': 2, '_sampler_iter_state': {'samples_yielded': 6400}, '_index_sampler_state': None, '_sampler_iter_yielded': 100, '_IterableDataset_len_called': None, '_shared_seed': None, '_base_seed': 6301677103399260047}, '_worker_snapshots': {'worker_0': {'worker_id': 0, 'dataset_state': None, 'fetcher_state': None}, 'worker_1': {'worker_id': 1, 'dataset_state': None, 'fetcher_state': None}}}, '_steps_since_snapshot': 0, '_iterator_finished': False}
`