### PR TITLE
[Core] Support concurrent pg scheduling

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -376,6 +376,8 @@ RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
 RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_min_interval_ms, 100)
 RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_max_interval_ms, 1000)
 RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5)
+/// Maximum number of placement groups that can be concurrently scheduled.
+RAY_CONFIG(size_t, gcs_max_concurrent_pg_scheduling, 50)
 /// Maximum number of destroyed actors in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)
 /// Maximum number of dead nodes in GCS server memory cache.

--- a/src/ray/gcs/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_placement_group_manager.cc
@@ -347,6 +347,11 @@ void GcsPlacementGroupManager::SchedulePendingPlacementGroups() {
       stats->set_scheduling_attempt(stats->scheduling_attempt() + 1);
       stats->set_scheduling_started_time_ns(absl::GetCurrentTimeNanos());
       MarkSchedulingStarted(placement_group_id);
+      RAY_LOG(INFO) << "[CONCURRENT_PG_DEBUG] GCS Manager: Starting to schedule PG "
+                    << placement_group_id << " (name=" << placement_group->GetName()
+                    << ")"
+                    << ", current in-flight count: " << scheduling_in_progress_ids_.size()
+                    << ", pending count: " << pending_placement_groups_.size();
       // We can't use designated initializers thanks to MSVC (error C7555).
       gcs_placement_group_scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
           /*placement_group=*/placement_group,

--- a/src/ray/gcs/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_placement_group_manager.cc
@@ -328,6 +328,9 @@ void GcsPlacementGroupManager::SchedulePendingPlacementGroups() {
     }
 
     const auto &pg_id_peek = iter->second.second->GetPlacementGroupID();
+    // ScheduleUnplacedBundles may synchronously call failure_callback (when nodes are
+    // releasing bundles, or resource scheduling fails), which re-adds the PGs to the
+    // pending queue. In this case, should handle them in the next round.
     if (scheduled_this_round.contains(pg_id_peek)) {
       break;
     }

--- a/src/ray/gcs/tests/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_manager_test.cc
@@ -1233,7 +1233,7 @@ TEST_F(GcsPlacementGroupManagerTest, TestGetAllPlacementGroupInfoLimit) {
                              ++registered_placement_group_count;
                            });
   }
-  ASSERT_EQ(mock_placement_group_scheduler_->GetPlacementGroupCount(), 1);
+  ASSERT_EQ(mock_placement_group_scheduler_->GetPlacementGroupCount(), num_pgs);
 
   {
     rpc::GetAllPlacementGroupRequest request;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1922,9 +1922,13 @@ void NodeManager::HandlePrepareBundleResources(
     bundle_specs.push_back(
         std::make_shared<const BundleSpecification>(std::move(bundle_spec)));
   }
-  RAY_LOG(DEBUG) << "Request to prepare resources for bundles: "
-                 << GetDebugStringForBundles(bundle_specs);
+  PlacementGroupID pg_id = bundle_specs.empty() ? PlacementGroupID::Nil()
+                                                : bundle_specs[0]->PlacementGroupId();
+  RAY_LOG(INFO) << "[CONCURRENT_PG_DEBUG] Raylet: Received Prepare request for PG "
+                << pg_id << ", bundles: " << GetDebugStringForBundles(bundle_specs);
   auto prepared = placement_group_resource_manager_.PrepareBundles(bundle_specs);
+  RAY_LOG(INFO) << "[CONCURRENT_PG_DEBUG] Raylet: Prepare result for PG " << pg_id << ": "
+                << (prepared ? "SUCCESS" : "FAILED");
   reply->set_success(prepared);
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }


### PR DESCRIPTION
##  Perf gain TODO


Test Configuration:
5 nodes, each with custom=100, total cluster resources custom=500
Each bundle requires only 0.001 custom resource
Strategy: SPREAD (distribute bundles across different nodes)



## Investigation Summary: Concurrent PG Scheduling Performance

After extensive analysis and testing, I found the root cause of the performance regression.

### Root Cause


The original benchmark creates a batch of PGs, removes them all, then repeats. The key issue is in the **PG removal flow**:

- **Create**: Sends **one RPC per node** (batches multiple bundles together)
- **Remove**: Sends **one RPC per bundle** (`CancelResourceReserve`)

For large PGs (40 bundles × 5 nodes), removing sends **200 RPCs per PG**. With 100 PGs, that's **20,000 RPCs** flooding the Raylet event queue.

### Why Degradation Happens

Under concurrent scheduling:
- 50 PGs scheduled simultaneously = 50 × 40 × 2 (Prepare + Commit) = **4,000 RPCs**
- Plus leftover `CancelResourceReserve` RPCs from the previous batch (fire-and-forget, not waited)
- Python starts the next iteration before cleanup completes
- Each iteration accumulates more backlog
- **P99 Raylet Queue Time grows from 150ms → 1200ms+**

### The Fix

I batched the remove operation to match the create pattern: **one RPC per node** (`CancelBundleResources`) instead of one RPC per bundle. This reduces RPC count by **8x** for 40-bundle PGs across 5 nodes.

---

## Results After Fix

### Throughput with Remove (Steady State Benchmark)

**Varying PG Count (1 bundle/PG)**

| PG Count | Concurrent (PG/s) | Serial (PG/s) | Improvement |
|----------|-------------------|---------------|-------------|
| 10 | 1,053 | 774 | **+36%** |
| 100 | 1,072 | 793 | **+35%** |
| 200 | 1,061 | 780 | **+36%** |
| 400 | 1,074 | 712 | **+51%** |
| 800 | 1,051 | 618 | **+70%** |
| 1600 | 989 | 465 | **+113%** |

**Varying Bundle Count (100 PGs)**

| Bundles | Concurrent (PG/s) | Serial (PG/s) | Improvement |
|---------|-------------------|---------------|-------------|
| 1 | 1,076 | 800 | **+34%** |
| 10 | 476 | 276 | **+73%** |
| 20 | 183 | 134 | **+37%** |
| 40 | 45 | 46 | ≈same |

### Pure Creation Throughput (No Remove Between Iterations)

**Varying PG Count (1 bundle/PG)**

| PG Count | Concurrent (PG/s) | Serial (PG/s) | Improvement |
|----------|-------------------|---------------|-------------|
| 10 | 1,429 | 882 | **+62%** |
| 100 | 1,523 | 888 | **+71%** |
| 200 | 1,519 | 766 | **+98%** |
| 400 | 1,485 | 634 | **+134%** |
| 800 | 1,358 | 442 | **+207%** |
| 1600 | 1,183 | 212 | **+458%** |

**Varying Bundle Count (100 PGs)**

| Bundles | Concurrent (PG/s) | Serial (PG/s) | Improvement |
|---------|-------------------|---------------|-------------|
| 10 | 396 | 213 | **+86%** |
| 20 | 87 | 61 | **+43%** |
| 40 | 19.7 | 15.3 | **+29%** |

---

## Key Findings

1. **Concurrent mode is faster in ALL configurations** — from +29% to +458%

2. **The more PGs, the bigger the advantage** — 1600 PGs: +113% (with remove), +458% (pure create)

3. **Serial mode degrades severely under sustained load** — throughput drops from 882 → 212 PG/s for 1600×1

**4. **Raylet Queue Time is the bottleneck for large PGs — this explains why concurrent advantage diminishes as bundle count increases**:
   - Concurrent: P50 Raylet Queue = 453ms (Prepare) + 411ms (Commit) = **864ms queue wait**
   - Serial: P50 Raylet Queue = 0.2ms + 0.2ms = **0.4ms queue wait**
   - As bundle count grows, queue contention dominates, eroding concurrent mode's parallelism advantage
   - This is why: **1 bundle → +34% faster, 10 bundles → +73%, 20 bundles → +37%, 40 bundles → ≈same****


## Description

Before this PR, the Placement Group Scheduling can only have one at a time:
- Prepare：Ask Nodes if can reserver resources
- Commit: ALL nodes reply yes
```
PG1: [====Prepare====][==Commit==]
PG2:                              [====Prepare====][==Commit==]
PG3:                                                            [====Prepare====][==Commit==]
```
After (Concurrent):
```
PG1: [====Prepare====][==Commit==]
PG2:  [====Prepare====][==Commit==]
PG3:    [====Prepare====][==Commit==]
```



And after this PR, concurrent PG scheduling overview is as follow:

Architecture:
- GCS and Raylet both use single-threaded event loops
- GCS maintains:
   - Pending PG Queue (ordered by rank = time + delay): PGs waiting to be scheduled (scheduling has not started yet).
      - For a new PG (`status = PENDING`), the rank is the current time.
      - For a failed retry, the rank is `current time + backoff_delay`.
      - For rescheduling caused by node failure (`status = RESCHEDULING`) , the rank is 0, giving it the highest scheduling priority.
   - In-Progress Set: PGs for which Prepare RPCs have already been sent and are currently waiting for responses.
- **A configurable limit (`gcs_max_concurrent_pg_scheduling`, default: 1) controls max in-flight PGs**

GCS Side - Scheduling Flow
1. Trigger: `SchedulePendingPlacementGroups()` is called when:
    - New PG is registered
    - Previous PG scheduling completes
    - Node joins/dies or Cluster resources change

2. Schedule Loop: **While `CanScheduleMore() `(in-progress < limit) and queue not empty**:
    - Pop PG from pending queue
    - **A PG may be encountered twice in one loop because, on failure, the rollback may re-add the PG to the pending queue. In this case, we break and wait for the next round of `SchedulePendingPlacementGroups()`**
    - Make scheduling decision using cluster resource view
    - Call `ScheduleUnplacedBundles` which send `PrepareBundleResources` RPC to selected nodes
    - Mark PG as in-progress
    - Return immediately (non-blocking) ← This enables concurrency


3. On Prepare Response (for any PG) from node raylet:
    - Record if this node's resource reservation succeeded or not
    - Check if all prepare requests have returned:
       - If all returned and all success → state changes to `PREPARED`, send Commit requests
       - If all returned but any failed → back to pending queue, MarkSchedulingDone，send `CancelResourceReserve`  to all nodes.

4. On Commit Response (for any PG) from node raylet:
   - Record if this node's commit succeeded or not  
   - Check if all commit requests have returned:
     - If all returned and all success → state changes to `CREATED`, MarkSchedulingDone
     - If all returned but any failed → state changes to `RESCHEDULING`, **only reschedule the failed bundles**（send `CancelResourceReserve`  to that failed node）MarkSchedulingDone

Raylet Side - Naturally Concurrent
- Single-threaded event loop processes RPCs sequentially
- Each `PrepareBundleResources` RPC immediately reserves resources and returns
- Resources are reserved in request arrival order



What if node died？
- For PGs already in CREATED status:
  -  GCS detects the node failure and calls `OnNodeDead()`, which handles PGs in the `CREATED` state by changing their status to `RESCHEDULING`, adding them to the pending queue, and calling `SchedulePendingPlacementGroups` again.
- For PGs that are still in progress:
  - The gRPC connection is closed, the RPC callback returns an error, and the PG is re-added to the pending queue with MarkSchedulingDone called.



For detail code change, this PR only changes`SchedulePendingPlacementGroups()` to schedule multiple PGs in a loop 
(up to `gcs_max_concurrent_pg_scheduling`, default 50), instead of just one. The existing 2PC protocol, callbacks, and pending queue mechanism automatically support this cocurrent change — no modifications needed there.










## concurrent scheduling Test
### Step 1: Verify concurrent PG scheduling works

In this test, the Raylet `PrepareBundleResources` RPC intentionally introduces a 2 second delay so that a placement group remains in progress state for a longer time while waiting for the Raylet to confirm resource reservation.
As shown in the test results, with one node with sufficient resources, scheduling 5 placement groups concurrently takes approximately 2.02 seconds in total. In contrast, scheduling them serially takes approximately 10.05 seconds (2 × 5 = 10).

This indicates several things:
- **Raylet does not block the execution of one placement group while other placement groups are in progress**; otherwise, we would not observe this time difference. Raylet naturally supports concurrent placement group scheduling.
- Basic placement group scheduling works as expected.

The delay does not block the raylet. After receiving the request from the GCS, the raylet sets a 2-second timer and continues processing. When the timer expires, the RPC is handled. This also shows that the raylet is inherently concurrent: the 5 placement groups are processed almost simultaneously after the timer, which is why scheduling them takes about 2.02 seconds.

```python
"""
Usage:
  python test_step1_concurrent_timing.py --concurrent=50 --delay=2   # Concurrent
  python test_step1_concurrent_timing.py --concurrent=1 --delay=2    # Sequential

  --concurrent: max number of PGs that can be scheduled concurrently
  --delay: artificial delay (seconds) injected into Raylet's PrepareBundleResources RPC
"""

import ray
from ray.util.placement_group import placement_group, remove_placement_group
from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
import subprocess
import sys
import time
import os


def start_cluster(max_concurrent: int, delay_us: int):
    subprocess.run(["ray", "stop", "--force"], capture_output=True)
    time.sleep(2)
    
    env = os.environ.copy()
    env["RAY_testing_asio_delay_us"] = f"NodeManagerService.grpc_server.PrepareBundleResources={delay_us}:{delay_us}"
    env["RAY_gcs_max_concurrent_pg_scheduling"] = str(max_concurrent)
    
    subprocess.run(["ray", "start", "--head", "--num-cpus=8"], env=env, capture_output=True)
    time.sleep(3)


def main():
    # Parse: --concurrent=N --delay=N
    args = {a.split("=")[0]: int(a.split("=")[1]) for a in sys.argv[1:] if "=" in a}
    max_concurrent = args["--concurrent"]
    delay_s = args["--delay"]
    num_pgs = 5
    
    print(f"max_concurrent={max_concurrent}, delay={delay_s}s, num_pgs={num_pgs}")
    print(f"Expected: {'~' + str(num_pgs * delay_s) + 's' if max_concurrent == 1 else '~' + str(delay_s) + 's'}")
    
    start_cluster(max_concurrent, delay_s * 1000000)
    ray.init(address="auto")
    
    start = time.time()
    pgs = [placement_group([{"CPU": 0.1}], strategy="SPREAD", name=f"pg_{i}") for i in range(num_pgs)]
    
    for pg in pgs:
        pg.wait(timeout_seconds=60)
    
    total = time.time() - start
    print(f"Total time: {total:.2f}s")

    @ray.remote(num_cpus=0.1)
    def ping():
        return "pong"
    result = ray.get(ping.options(scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pgs[0])).remote())
    print(f"Task result: {result}")
    
    for pg in pgs:
        remove_placement_group(pg)
    ray.shutdown()
    subprocess.run(["ray", "stop", "--force"], capture_output=True)


if __name__ == "__main__":
    main()



```

```shell
(docs) ubuntu@devbox:~/ray$ python test_step1_concurrent_timing.py --concurrent=50 --delay=2 2>&1
max_concurrent=50, delay=2s, num_pgs=5
Expected: ~2s
2026-01-15 06:05:06,743 INFO worker.py:1826 -- Connecting to existing Ray cluster at address: 172.31.5.171:6379...
2026-01-15 06:05:06,783 INFO worker.py:2006 -- Connected to Ray cluster. View the dashboard at http://127.0.0.1:8265 
/home/ubuntu/ray/python/ray/_private/worker.py:2054: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
(raylet) [2026-01-15 06:05:07,399 E 2052135 2052186] (raylet) asio_chaos.cc:58: [1] Delaying method NodeManagerService.grpc_server.PrepareBundleResources for 2000000us
Total time: 2.02s
Task result: pong
(docs) ubuntu@devbox:~/ray$ python test_step1_concurrent_timing.py --concurrent=1 --delay=2 2>&1
max_concurrent=1, delay=2s, num_pgs=5
Expected: ~10s
2026-01-15 06:05:32,181 INFO worker.py:1826 -- Connecting to existing Ray cluster at address: 172.31.5.171:6379...
2026-01-15 06:05:32,220 INFO worker.py:2006 -- Connected to Ray cluster. View the dashboard at http://127.0.0.1:8265 
/home/ubuntu/ray/python/ray/_private/worker.py:2054: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
(raylet) [2026-01-15 06:05:32,834 E 2053825 2053876] (raylet) asio_chaos.cc:58: [1] Delaying method NodeManagerService.grpc_server.PrepareBundleResources for 2000000us
Total time: 10.05s
Task result: pong
```


### Step 2: Verify no deadlock with resource contention

In this test, with two nodes each having one “slot” custom resource and two PGs each requiring two slots (STRICT_SPREAD), subtest 1 intentionally introduces a 5-second delay in the Raylet PrepareBundleResources RPC so that, when the later PG is being scheduled, the first PG is still in progress. This confirms that no deadlock occurs (one PG succeeds while the other waits). Subtest 2 then confirms that after removing the successful PG, the pending PG can acquire the released resources and succeed.

This indicated：
- **When a PG is being scheduled, if other PGs are still in-flight, the GCS resource view correctly pre-allocates the resources. In other words, resource scheduling and deduction are atomic.**

```python
import ray, subprocess, time, os
from ray.util.placement_group import placement_group, remove_placement_group
from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy

subprocess.run(["ray", "stop", "-f"], capture_output=True)
time.sleep(1)

env = os.environ.copy()
env["RAY_gcs_max_concurrent_pg_scheduling"] = "50"
# 5 second delay on Raylet's PrepareBundleResources RPC
env["RAY_testing_asio_delay_us"] = "NodeManagerService.grpc_server.PrepareBundleResources=5000000:5000000"

subprocess.run(["ray", "start", "--head", "--num-cpus=2", '--resources={"slot":1}'], env=env, capture_output=True)
subprocess.run(["ray", "start", "--address=localhost:6379", "--num-cpus=2", '--resources={"slot":1}'], env=env, capture_output=True)
time.sleep(2)

ray.init(address="auto")

@ray.remote(num_cpus=0, resources={"slot": 1})
def ping():
    return "pong"

# Test 1: Create 2 competing PGs
pgs = [placement_group([{"slot":1},{"slot":1}], strategy="STRICT_SPREAD", name=f"pg_{i}") for i in range(2)]
results = [pg.wait(timeout_seconds=10) for pg in pgs]

print(f"Test 1: Results: {sum(results)} succeeded, {len(results)-sum(results)} pending")

# Verify pg_0 works
result = ray.get(ping.options(
    scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pgs[0], placement_group_bundle_index=0)
).remote())
print(f"Test 1: task on pg_0 = {result}")

# Test 2: Remove PG_0, verify PG_1 can succeed
remove_placement_group(pgs[0])
time.sleep(1)

# Now PG_1 should be able to succeed
ready = pgs[1].wait(timeout_seconds=15)
print(f"test2: PG_1 {ready}")

# Verify pg_1 works
result = ray.get(ping.options(
    scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pgs[1], placement_group_bundle_index=0)
).remote())
print(f"Test 2: task on pg_1 = {result}")

ray.shutdown()
subprocess.run(["ray", "stop", "-f"], capture_output=True)
```
Log evidence: PG_0 is still in-flight when PG_1 is being scheduled.
```
03:57:38.348  pg_0: Starting to schedule, in-flight count: 1
03:57:38.354  pg_0: Sending Prepare RPC to node c5f2... (bundle 1)
03:57:38.355  pg_0: Sending Prepare RPC to node ee5a... (bundle 0)
03:57:38.355  pg_1: Starting to schedule, in-flight count: 2  ← pg_0 still in progress!
03:57:43.357  pg_0: Finished leasing (pg_0 done)
```
```
[2026-01-15 03:57:38,354 I 2027574 2027574] (gcs_server) gcs_placement_group_scheduler.cc:207: [CONCURRENT_PG_DEBUG] GCS Scheduler: Sending Prepare RPC to node c5f243d52060acc53dc90d975f93b6de70a57d6d4cc7071707acb4e1 for PG 13b30bd5c8ef11171676be84c64d01000000, bundles: {placement group id={13b30bd5c8ef11171676be84c64d01000000}, bundle index={1}},
[2026-01-15 03:57:38,355 I 2027574 2027574] (gcs_server) gcs_placement_group_scheduler.cc:207: [CONCURRENT_PG_DEBUG] GCS Scheduler: Sending Prepare RPC to node ee5a9763a91c649ca996d5ddbc23224194ef4a1584052f97fb33dc7e for PG 13b30bd5c8ef11171676be84c64d01000000, bundles: {placement group id={13b30bd5c8ef11171676be84c64d01000000}, bundle index={0}},

[2026-01-15 03:57:42,862 I 2027574 2027574] (gcs_server) gcs_placement_group_manager.cc:350: [CONCURRENT_PG_DEBUG] GCS Manager: Starting to schedule PG f72a817b053232fa4dbc4ac90f4e01000000 (name=pg_1), current in-flight count: 2, pending count: 0


[2026-01-15 03:57:43,357 I 2027574 2027574] (gcs_server) gcs_placement_group_scheduler.cc:218: Finished leasing resource from c5f243d52060acc53dc90d975f93b6de70a57d6d4cc7071707acb4e1 for bundles: {placement group id={13b30bd5c8ef11171676be84c64d01000000}, bundle index={1}},
[2026-01-15 03:57:43,357 I 2027574 2027574] (gcs_server) gcs_placement_group_scheduler.cc:218: Finished leasing resource from ee5a9763a91c649ca996d5ddbc23224194ef4a1584052f97fb33dc7e for bundles: {placement group id={13b30bd5c8ef11171676be84c64d01000000}, bundle index={0}},
```



Log evidence: The Resource View correctly pre-allocated the slot resources - PG_1 see no "slot" resources.
```
Head node (id: -4395486834454304393):
total: {slot: 10000, CPU: 20000, ...}
available: {CPU: 20000, memory: ..., ...} — no slot
Worker node (id: -396737239669800612):
total: {slot: 10000, CPU: 20000, ...}
available: {CPU: 20000, memory: ..., ...} — No slot
```
```
[2026-01-15 03:57:38,356 I 2027574 2027574] (gcs_server) gcs_placement_group_scheduler.cc:90: [CONCURRENT_PG_DEBUG] SCHEDULING FAILED for PG pg_1, id: f72a817b053232fa4dbc4ac90f4e01000000, IsFailed: 1, IsInfeasible: 0, Required: bundle[0]={{slot: 1}} bundle[1]={{slot: 1}} , Cluster resource view:
Local id: 2335963631619537928 Local resources: {"total":{}}, "available": {}}, "labels":{} is_draining: 0 is_idle: 1 Cluster resources (at most 20 nodes are shown): node id: 2335963631619537928{"total":{}}, "available": {}}, "labels":{}, "is_draining": 0, "draining_deadline_timestamp_ms": -1}node id: -4395486834454304393{"total":{node:172.31.5.171: 10000, slot: 10000, node:__internal_head__: 10000, CPU: 20000, object_store_memory: 267941646330000, memory: 625197174790000}}, "available": {memory: 625197174790000, object_store_memory: 267941646330000, node:__internal_head__: 10000, CPU: 20000, node:172.31.5.171: 10000}}, "labels":{"ray.io/node-id":"ee5a9763a91c649ca996d5ddbc23224194ef4a1584052f97fb33dc7e",}, "is_draining": 0, "draining_deadline_timestamp_ms": -1}node id: -396737239669800612{"total":{node:172.31.5.171: 10000, memory: 623837175810000, slot: 10000, object_store_memory: 267358789630000, CPU: 20000}}, "available": {node:172.31.5.171: 10000, memory: 623837175810000, object_store_memory: 267358789630000, CPU: 20000}}, "labels":{"ray.io/node-id":"c5f243d52060acc53dc90d975f93b6de70a57d6d4cc7071707acb4e1",}, "is_draining": 0, "draining_deadline_timestamp_ms": -1} { "placement group locations": [], "node to bundles": []}
```


