### PR TITLE
[Data] speedup checkpoint filter 5x

### DIFF
--- a/python/ray/data/checkpoint/load_checkpoint_callback.py
+++ b/python/ray/data/checkpoint/load_checkpoint_callback.py
@@ -1,12 +1,13 @@
 import logging
 from typing import Optional
 
+import numpy
+
 from ray.data._internal.execution.execution_callback import (
     ExecutionCallback,
     remove_execution_callback,
 )
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
-from ray.data.block import Block
 from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_filter import BatchBasedCheckpointFilter
 from ray.types import ObjectRef
@@ -22,7 +23,7 @@ class LoadCheckpointCallback(ExecutionCallback):
         self._config = config
 
         self._ckpt_filter = self._create_checkpoint_filter(config)
-        self._checkpoint_ref: Optional[ObjectRef[Block]] = None
+        self._checkpoint_ref: Optional[ObjectRef[numpy.ndarray]] = None
 
     def _create_checkpoint_filter(
         self, config: CheckpointConfig
@@ -57,6 +58,6 @@ class LoadCheckpointCallback(ExecutionCallback):
         # Remove the callback from the DataContext.
         remove_execution_callback(self, executor._data_context)
 
-    def load_checkpoint(self) -> ObjectRef[Block]:
+    def load_checkpoint(self) -> ObjectRef[numpy.ndarray]:
         assert self._checkpoint_ref is not None
         return self._checkpoint_ref


### PR DESCRIPTION
## Modification
I'm using Ray Data's checkpoint. My data has 115 million records, with primary key {"id": str}. When I use Checkpoint to filter the input blocks, it takes several hours.

I checked the performance bottleneck and found it occurs in the `filter_with_ckpt_chunk `function in [checkpoint_filter.py](https://github.com/ray-project/ray/blob/master/python/ray/data/checkpoint/checkpoint_filter.py#L231). I add some logs:
```python
# Get all chunks of the checkpointed ID column.
ckpt_chunks = checkpointed_ids[self.id_column].chunks
# Convert the block's ID column to a numpy array for fast processing.
block_ids = block[self.id_column].to_numpy()

def filter_with_ckpt_chunk(ckpt_chunk: pyarrow.ChunkedArray) -> numpy.ndarray:
    t1 = time.time()
    ckpt_ids = transform_pyarrow.to_numpy(ckpt_chunk, zero_copy_only=False)
    print(f"ckpt_ids to numpy cost time {time.time()-t1}s")
   
    ...
    t2 = time.time()
    sorted_indices = numpy.searchsorted(ckpt_ids, block_ids)
    print(f"searchsorted costs {time.time()-t2}s")
```
the `ckpt_chunk` has shape (115022113), and block_ids has shape (14534). I got:
```
ckpt_ids to numpy cost time: 6.057122468948364s
searchsorted costs 0.11587834358215332s
```

We can see from the perf test that:
  1. `ckpt_chunks` has only one chunk because we has combined chunks [_combine_chunks](https://github.com/ray-project/ray/blob/c6b19e56613d8445e544e3321bc47c253ca32258/python/ray/data/checkpoint/checkpoint_filter.py#L38C5-L38C20)
  2. the  `ckpt_chunk` is a very large chunk that holds 115 millon ids, convert it from pyarrow to numpy will costs 6s
  3. For every input block, `ckpt_ids = transform_pyarrow.to_numpy(ckpt_chunk, zero_copy_only=False)` is executed once, causing a large time overhead.
  
This PR obtains the `ckpt_id` numpy array in advance, avoiding multiple calls. In my tests, this can reduce the filtering time from 5 hours to 40 minutes.

#### Notes:
In this PR, each read task needs to read the ckpt_ids(numpy.ndarray) from the object store, rather than Arrow format. This increases I/O and memory overhead because Arrow arrays usually costs less space. In my experiment, the pyarrow array(115 million rows, string-typed) used 1.7 GB of memory, while the numpy array used 9 GB. However, I this this memory overhead is acceptable because of the performance improvement.
