### PR TITLE
[Core] Fix deadlock in garbage collection when holding lock

### DIFF
--- a/python/ray/tests/test_client_gc_deadlock.py
+++ b/python/ray/tests/test_client_gc_deadlock.py
@@ -1,0 +1,137 @@
+"""
+Test for Ray Client GC-related deadlock issue.
+
+This test reproduces the deadlock that occurs when ClientObjectRef.__del__
+is called during GC while DataClient.lock is held.
+"""
+
+import gc
+import logging
+import sys
+
+import pytest
+
+from ray.util.client.common import INT32_MAX
+from ray.util.client.dataclient import DataClient
+from ray.util.client.ray_client_helpers import ray_start_client_server
+
+logger = logging.getLogger(__name__)
+
+
+def _next_id_with_gc(self) -> int:
+    """
+    Modified _next_id that triggers GC while holding the lock.
+
+    This reproduces the deadlock scenario where GC triggers
+    ClientObjectRef.__del__, which tries to acquire the same lock.
+    """
+    assert self.lock.locked()
+    self._req_id += 1
+
+    # Force GC while holding the lock - this can trigger deadlock
+    gc.collect()
+
+    if self._req_id > INT32_MAX:
+        self._req_id = 1
+    assert self._req_id != 0
+
+    logger.info(f"req_id={self._req_id}")
+    return self._req_id
+
+
+@pytest.mark.timeout(30)  # 30 second timeout - test should fail if it times out
+def test_client_gc_deadlock(ray_start_regular):
+    """
+    Test that GC during DataClient lock acquisition doesn't cause deadlock.
+
+    This test:
+    1. Sets aggressive GC thresholds
+    2. Creates objects with circular references (require GC to collect)
+    3. Forces GC while DataClient.lock is held
+    4. Verifies the test completes without hanging (within 30 seconds)
+
+    If this test times out (30s), it means a deadlock occurred and the test FAILS.
+
+    Note: This test is expected to fail (timeout) when run against the unfixed
+    Ray Client code. After the fix (RLock + gc.disable or deferred release),
+    it should pass quickly (< 5 seconds).
+
+    Related: https://github.com/ray-project/ray/issues/59643
+    """
+    import threading
+    import time
+
+    start_time = time.time()
+    timeout_occurred = threading.Event()
+
+    def timeout_handler():
+        timeout_occurred.set()
+        pytest.fail("Test timed out after 30 seconds - deadlock detected!")
+
+    # Set up our own timeout to ensure test fails
+    timer = threading.Timer(25.0, timeout_handler)
+    timer.daemon = True
+    timer.start()
+
+    with ray_start_client_server() as ray_client:
+        # Set aggressive GC thresholds
+        old_thresholds = gc.get_threshold()
+        gc.set_threshold(1, 1, 1)
+
+        try:
+
+            @ray_client.remote
+            def foo(x):
+                return x
+
+            # Monkey-patch _next_id to trigger GC
+            original_next_id = DataClient._next_id
+            DataClient._next_id = _next_id_with_gc
+
+            try:
+                # Create objects with circular references
+                class SelfRef:
+                    def __init__(self, future):
+                        self.future = future
+                        self.self_ref = self  # Circular reference
+
+                results = []
+                loop_time = 2
+
+                for i in range(loop_time):
+                    future = foo.remote(i)
+                    self_ref = SelfRef(future)
+
+                    # Get result
+                    results.append(ray_client.get(future))
+
+                    # Delete references to trigger GC
+                    del self_ref
+                    del future
+
+                # Verify results
+                assert results == list(range(loop_time))
+
+                elapsed = time.time() - start_time
+                print(f"Test completed successfully in {elapsed:.2f} seconds")
+                print(f"Results: {results}")
+
+            finally:
+                # Restore original _next_id
+                DataClient._next_id = original_next_id
+
+        finally:
+            # Restore GC thresholds
+            gc.set_threshold(*old_thresholds)
+
+    # Cancel the timeout timer
+    timer.cancel()
+
+    # If we reach here, test passed (no deadlock)
+    elapsed = time.time() - start_time
+    assert not timeout_occurred.is_set(), "Test timed out - deadlock detected"
+    print(f"✓ Test passed in {elapsed:.2f}s - no deadlock detected")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 import os
+import queue
 import tempfile
 import threading
 import time
@@ -68,6 +69,7 @@ MAX_BLOCKING_OPERATION_TIME_S: float = env_float(
 # If the total size (bytes) of all outbound messages to schedule tasks since
 # the connection began exceeds this value, a warning should be raised
 MESSAGE_SIZE_THRESHOLD = 10 * 2**20  # 10 MB
+CLIENT_RELEASE_SERVER_OBJECT_BATCH = 1
 
 # Links to the Ray Design Pattern doc to use in the task overhead warning
 # message
@@ -162,6 +164,15 @@ class Worker:
         # Used to create unique IDs for RPCs to the RayletServicer
         self._req_id_lock = threading.Lock()
         self._req_id = 0
+
+        # Used to call ReleaseObject outside ClientObjectRef.__del__ to avoid
+        # holding lock which can cause deadlock.
+        # See https://github.com/ray-project/ray/issues/59643 for more details.
+        self._release_queue = queue.SimpleQueue()
+        self._release_thread = threading.Thread(
+            target=self._release_server_worker, daemon=True
+        )
+        self._release_thread.start()
 
     def _connect_channel(self, reconnecting=False) -> None:
         """
@@ -644,8 +655,32 @@ class Worker:
 
     def _release_server(self, id: bytes) -> None:
         if self.data_client is not None:
-            logger.debug(f"Releasing {id.hex()}")
-            self.data_client.ReleaseObject(ray_client_pb2.ReleaseRequest(ids=[id]))
+            logger.debug(f"Put {id.hex()} to release queue")
+            self._release_queue.put(id)
+
+    def _release_server_worker(self):
+        while not self.closed:
+            batch = []
+            try:
+                id = self._release_queue.get(timeout=0.1)
+                if id is None:  # Sentinel
+                    break
+                batch.append(id)
+
+                if (
+                    self.data_client is not None
+                    and len(batch) >= CLIENT_RELEASE_SERVER_OBJECT_BATCH
+                ):
+                    logger.debug(f"Releasing {[id.hex() for id in batch]}")
+                    self.data_client.ReleaseObject(
+                        ray_client_pb2.ReleaseRequest(ids=batch)
+                    )
+            except queue.Empty:
+                continue
+
+        if self.data_client is not None and len(batch) > 0:
+            logger.debug(f"Releasing {[id.hex() for id in batch]}")
+            self.data_client.ReleaseObject(ray_client_pb2.ReleaseRequest(ids=batch))
 
     def call_retain(self, id: bytes) -> None:
         logger.debug(f"Retaining {id.hex()}")
@@ -653,6 +688,11 @@ class Worker:
 
     def close(self):
         self._in_shutdown = True
+
+        self._release_queue.put(None)  # Sentinel
+        timeout = 5
+        self._release_thread.join(timeout=timeout)
+
         self.closed = True
         self.data_client.close()
         self.log_client.close()


### PR DESCRIPTION
## Description
This PR fixes a critical deadlock issue in Ray Client that occurs when garbage collection triggers `ClientObjectRef.__del__()` while the DataClient lock is held.

When using Ray Client, a deadlock can occur in the following scenario:

  1. Main thread acquires DataClient.lock (e.g., in _async_send())
  2. Garbage collection is triggered while holding the lock
  3. GC calls `ClientObjectRef.__del__()`
  4. `__del__()` attempts to call call_release() → _release_server() → DataClient.ReleaseObject()
  5. ReleaseObject() tries to acquire the same DataClient.lock
  6. Deadlock: The same thread tries to acquire a non-reentrant lock it already holds

## Related issues
> PR Closed 
> Related to 59643 

## Additional information
This PR implements a deferred release pattern that completely avoids the deadlock:

  1. Deferred Release Queue: Introduces _release_queue (a thread-safe queue.SimpleQueue) to collect object IDs that need to be released
  2. Background Release Thread: Adds _release_thread that processes the release queue asynchronously
  3. Non-blocking `__del__`: `ClientObjectRef.__del__()` now only puts IDs into the queue (no lock acquisition)
