### PR TITLE
[Core] Bump up object fetch timeout in release test

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -719,6 +719,7 @@
         - RAY_health_check_timeout_ms=100000
         - RAY_health_check_failure_threshold=10
         - RAY_gcs_rpc_server_connect_timeout_s=60
+        - RAY_fetch_fail_timeout_milliseconds=1800000
     cluster_compute: dataset/cross_az_250_350_compute_gce.yaml
 
   run:


### PR DESCRIPTION
Object fetch's may take a while when in the presence of transient network errors due to long reconstruction chains + when push/pull fails we need to resend over all the chunks again. Hence we were seeing some ObjectFetchTimeout errors in the cross AZ transient network error release tests due to this, bumping up the timeout from 10 min to 30 min accordingly. 