### PR TITLE
[Core] Deflake test_placement_group_reschedule_node_dead with ps wide output

### DIFF
--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -381,7 +381,7 @@ def test_placement_group_reschedule_node_dead(autoscaler_v2):
         wait_for_condition(lambda: verify_nodes(3, 1))
 
         def kill_node(node_id):
-            cmd = f"ps aux | grep {node_id} | grep -v grep | awk '{{print $2}}'"
+            cmd = f"ps auxww | grep {node_id} | grep -v grep | awk '{{print $2}}'"
             pids = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
             print(f"Killing pids {pids}")
             # kill the pids (handle multiple PIDs separated by newlines)


### PR DESCRIPTION

## Description

`test_placement_group_reschedule_node_dead` uses `ps aux | grep {node_id}` to find and kill a node.

Recently, I found it failed to kill the node because grep found nothing. The root cause is that ps aux truncates long command lines, causing the `--node_id` parameter to be cut off and grep to fail finding the process(maybe we have longer raylet command now or we changed terminal setting).

This PR use `ps auxww` which ensures unlimited output width (the ww option means "wide output, use twice for unlimited width")



See the CI failure: it checks after killing. It should have 3 − 1 = 2, but it always has 3 after the timeout.
https://buildkite.com/ray-project/microcheck/builds/35178/steps/canvas?jid=019ba263-a01d-4ef2-9d7e-d3bfb149e638#019ba263-a01d-4ef2-9d7e-d3bfb149e638/L191
https://buildkite.com/ray-project/microcheck/builds/35178/steps/canvas?jid=019ba332-55cb-4669-ae55-99572de4ffbf#019ba332-55cb-4669-ae55-99572de4ffbf/L1348

