### PR TITLE
Title: Add documentation for custom dependencies in RayService and LMCache+Mooncake on Kubernetes

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayserve-llm-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-llm-example.md
@@ -166,7 +166,7 @@ Once forwarded, navigate to the Serve tab on the dashboard to review application
 
 ## Add custom dependencies
 
-To install additional custom packages that are required by the LLM services that cannot be installed directly via `runtime_env` such as KV cache backends, see [Add custom dependencies](kuberay-rayservice-custom-deps) in the RayService user guide. For a complete example with LMCache and Mooncake for distributed KV cache, see [Deploy on Kubernetes with LMCache and Mooncake](kv-cache-offloading-guide).
+To install additional custom packages necessary for the LLM services that can't be directly installed through `runtime_env`, such as KV cache backends, see [Add custom dependencies](kuberay-rayservice-custom-deps) in the RayService user guide. For a complete example, refer to the LMCache and Mooncake integration for distributed KV cache at [Deploy on Kubernetes with LMCache and Mooncake](kv-cache-offloading-guide).
 
 Download a basic example:
 

--- a/doc/source/cluster/kubernetes/examples/rayserve-llm-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-llm-example.md
@@ -163,3 +163,13 @@ kubectl port-forward svc/ray-serve-llm-head-svc 8265
 
 Once forwarded, navigate to the Serve tab on the dashboard to review application status, deployments, routers, logs, and other relevant features.
 ![LLM Serve Application](../images/ray_dashboard_llm_application.png)
+
+## Add custom dependencies
+
+To install additional custom packages that are required by the LLM services that cannot be installed directly via `runtime_env` such as KV cache backends, see [Add custom dependencies](kuberay-rayservice-custom-deps) in the RayService user guide. For a complete example with LMCache and Mooncake for distributed KV cache, see [Deploy on Kubernetes with LMCache and Mooncake](kv-cache-offloading-guide).
+
+Download a basic example:
+
+```sh
+curl -o ray-serve.extra-dependency.yaml https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-serve.extra-dependency.yaml
+```

--- a/doc/source/cluster/kubernetes/examples/rayserve-llm-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-llm-example.md
@@ -171,5 +171,5 @@ To install additional custom packages necessary for the LLM services that can't 
 Download a basic example:
 
 ```sh
-curl -o ray-serve.extra-dependency.yaml https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-serve.extra-dependency.yaml
+curl -o ray-service.extra-dependency.yaml https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.extra-dependency.yaml
 ```

--- a/doc/source/cluster/kubernetes/user-guides/rayservice.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice.md
@@ -312,13 +312,13 @@ workerGroupSpecs:
       spec:
         containers:
           - name: ray-worker
-            image: rayproject/ray:2.53.0-py312-cu129-aarch64
+            image: rayproject/ray:2.53.0
             args:
               - |
                 sudo apt-get update && \
-                sudo apt-get install -y --no-install-recommends ffmpeg libsm6 libxext6 && \
+                sudo apt-get install -y --no-install-recommends curl && \
                 sudo rm -rf /var/lib/apt/lists/* && \
-                pip install opencv-python-headless pillow
+                pip install httpx \
 ```
 
 You can also install Python packages via `runtime_env`, but using `args` makes them available to all applications and avoids repeated installation.
@@ -330,24 +330,22 @@ For dependencies that only a specific application needs, use `runtime_env` in yo
 ```yaml
 serveConfigV2: |
   applications:
-  - name: ml_app
-    import_path: ml_module:app
+  - name: fruit_app
+    import_path: fruit.deployment_graph
     runtime_env:
       pip:
         - pandas
-        - scikit-learn
-  - name: nlp_app
-    import_path: nlp_module:app
+  - name: math_app
+    import_path: conditional_dag.serve_dag
     runtime_env:
       pip:
-        - transformers
-        - tokenizers
+        - numpy
 ```
 
 Download a complete example combining both approaches:
 
 ```sh
-curl -o ray-serve.extra-dependency.yaml https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-serve.extra-dependency.yaml
+curl -o ray-service.extra-dependency.yaml https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.extra-dependency.yaml
 ```
 
 :::{note}

--- a/doc/source/cluster/kubernetes/user-guides/rayservice.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice.md
@@ -354,7 +354,7 @@ curl -o ray-serve.extra-dependency.yaml https://raw.githubusercontent.com/ray-pr
 Packages installed via `args` install on every container restart. For production, consider building a custom image with shared dependencies pre-installed.
 :::
 
-For advanced container command customization, see [Specify container commands](kuberay-pod-command). For LLM-specific dependencies such as KV cache offloading with LMCache and Mooncake, see [KV cache offloading](kv-cache-offloading-guide).
+For advanced container command customization, see [Specify container commands](kuberay-pod-command).
 
 ## Next steps
 

--- a/doc/source/serve/llm/user-guides/kv-cache-offloading.md
+++ b/doc/source/serve/llm/user-guides/kv-cache-offloading.md
@@ -283,7 +283,7 @@ Mooncake requires system-level dependencies. Use the `args` field in your RaySer
         libgtest-dev libjsoncpp-dev libnuma-dev libunwind-dev \
         libpython3-dev libboost-all-dev libssl-dev pybind11-dev \
         libcurl4-openssl-dev libhiredis-dev pkg-config patchelf && \
-      sudo rm -rf /var/lib/apt/lists/*
+      sudo rm -rf /var/lib/apt/lists/* \
 ```
 
 For general Kubernetes dependency patterns, also see [Add custom dependencies](kuberay-rayservice-custom-deps) in the RayService user guide.

--- a/doc/source/serve/production-guide/handling-dependencies.md
+++ b/doc/source/serve/production-guide/handling-dependencies.md
@@ -59,3 +59,7 @@ Example:
 ```{literalinclude} ../doc_code/delayed_import.py
 :language: python
 ```
+
+## Handle dependencies on Kubernetes
+
+When deploying Ray Serve on Kubernetes with KubeRay, you can install packages at container startup using the `args` field or via `runtime_env` in your Serve config. See [Add custom dependencies](kuberay-rayservice-custom-deps) in the RayService user guide for details and examples.


### PR DESCRIPTION
## Description
Add documentation for installing custom dependencies in RayService deployments:
- rayservice.md: Add "Add custom dependencies" section explaining:
   - Shared dependencies via args (system packages + Python packages for all apps)
   - Application-specific dependencies via runtime_env
- rayserve-llm-example.md: Add section linking to custom dependencies guide and KV cache offloading
- kv-cache-offloading.md: Add "Deploy on Kubernetes with LMCache and Mooncake" section covering:
  - System package installation for Mooncake
  - LMCache + Mooncake pip packages via runtime_env
  - kv_transfer_config setup
  - Example lmcache-config.yaml for Mooncake backend
- handling-dependencies.md: Add Kubernetes cross-reference
