### PR TITLE
[Core] Fix request_resources failures when autoscaler v2 is disabled

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -451,7 +451,7 @@ class StandardAutoscaler:
             self.load_metrics.get_resource_utilization(),
             self.load_metrics.get_pending_placement_groups(),
             self.load_metrics.get_static_node_resources_by_ip(),
-            ensure_min_cluster_size=self.load_metrics.get_resource_requests(),
+            ensure_min_cluster_size=self.load_metrics.get_resource_request_bundles(),
             node_availability_summary=self.node_provider_availability_tracker.summary(),
         )
         self._report_pending_infeasible(unfulfilled)
@@ -926,7 +926,7 @@ class StandardAutoscaler:
         resource_demands, strict_spreads = placement_groups_to_resource_demands(
             self.load_metrics.get_pending_placement_groups()
         )
-        resource_demands.extend(self.load_metrics.get_resource_requests())
+        resource_demands.extend(self.load_metrics.get_resource_request_bundles())
         if not resource_demands and not strict_spreads:
             return frozenset(nodes_not_allowed_to_terminate)
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -366,6 +366,22 @@ class LoadMetricsTest(unittest.TestCase):
             "1.05 GiB/2.1 GiB object_store_memory"
         ) in debug
 
+    def testRequestResourcesSummary(self):
+        lm = LoadMetrics()
+        request = {"resources": {"CPU": 1, "memory": 0}, "label_selector": {}}
+        lm.set_resource_requests([request])
+
+        summary = lm.summary()
+
+        assert summary.request_demand == [(request, 1)]
+
+    def testRequestResourcesBundles(self):
+        lm = LoadMetrics()
+        request = {"resources": {"CPU": 1}, "label_selector": {}}
+        lm.set_resource_requests([request, {"CPU": 2}])
+
+        assert lm.get_resource_request_bundles() == [{"CPU": 1}, {"CPU": 2}]
+
 
 class AutoscalingTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

**Fix autoscaler v1 crashes on nested request_resources requests**


With RAY_enable_autoscaler_v2=0, request_resources writes nested request objects (e.g. {"resources": {...}, "label_selector": {...}}). The v1 autoscaler hits two consecutive issues:

1. LoadMetrics.summary() calls freq_of_dicts with the default serializer (frozenset(d.items())), which fails on nested dicts and raises TypeError: unhashable type: 'dict'.
2. After `#1` is fixed, v1 passes the raw request objects into the demand scheduler, which expects plain resource dicts and crashes (Error: `TypeError: unsupported operand type(s) for +: 'int' and 'dict'`) when computing sum(demand.values()) . This second issue was previously masked by `#1`.




## Related issues
> Link related issues: "Fixes #59677 ", "Closes #59677 ", or "Related to #59677 ".



## Additional information

### Fix / Solution

- Make the default freq_of_dicts serializer recursively freeze nested dict/list/set/tuple structures and restore them on default deserialization.
- Add LoadMetrics.get_resource_request_bundles() to normalize request objects into plain resource dicts, and use it in v1 autoscaler paths.

### Tests
- python -m pytest python/ray/tests/test_autoscaler.py

- Local quick check (example):

#### Before:
```shell
(clion-ray-ce) ➜  ray git:(master-current) export RAY_enable_autoscaler_v2=0
(clion-ray-ce) ➜  ray git:(master-current) python - <<'PY'                                           
import time
import ray
from ray.autoscaler.sdk import request_resources

print("ray version:", ray.__version__)
ray.init()
request_resources(bundles=[{'GPU': 0, 'CPU': 1, 'memory': 0}])
time.sleep(5) 
PY
ray version: 3.0.0.dev0
2026-01-12 03:40:21,260 INFO worker.py:2007 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265 
/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/_private/worker.py:2055: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
(clion-ray-ce) ➜  ray git:(master-current) cat /tmp/ray/session_latest/logs/monitor.log | tail -n 200
2026-01-12 03:40:17,597 INFO monitor.py:722 -- Starting monitor using ray installation: /Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/__init__.py
2026-01-12 03:40:17,597 INFO monitor.py:723 -- Ray version: 3.0.0.dev0
2026-01-12 03:40:17,597 INFO monitor.py:724 -- Ray commit: {{RAY_COMMIT_SHA}}
2026-01-12 03:40:17,597 INFO monitor.py:725 -- Monitor started with command: ['/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/autoscaler/_private/monitor.py', '--logs-dir=/tmp/ray/session_2026-01-12_03-40-16_658269_54522/logs', '--logging-rotate-bytes=536870912', '--logging-rotate-backup-count=5', '--gcs-address=127.0.0.1:63519', '--stdout-filepath=/tmp/ray/session_2026-01-12_03-40-16_658269_54522/logs/monitor.out', '--stderr-filepath=/tmp/ray/session_2026-01-12_03-40-16_658269_54522/logs/monitor.err', '--monitor-ip=127.0.0.1']
2026-01-12 03:40:17,599 INFO monitor.py:166 -- session_name: session_2026-01-12_03-40-16_658269_54522
2026-01-12 03:40:17,599 INFO monitor.py:198 -- Starting autoscaler metrics server on port 44217
2026-01-12 03:40:17,601 INFO monitor.py:225 -- Monitor: Started
2026-01-12 03:40:17,606 INFO autoscaler.py:280 -- disable_node_updaters:False
2026-01-12 03:40:17,606 INFO autoscaler.py:289 -- disable_launch_config_check:True
2026-01-12 03:40:17,606 INFO autoscaler.py:301 -- foreground_node_launch:False
2026-01-12 03:40:17,606 INFO autoscaler.py:311 -- worker_liveness_check:True
2026-01-12 03:40:17,606 INFO autoscaler.py:361 -- StandardAutoscaler: {'cluster_name': 'default', 'max_workers': 0, 'upscaling_speed': 1.0, 'docker': {}, 'idle_timeout_minutes': 0, 'provider': {'type': 'readonly', 'use_node_id_as_ip': True, 'disable_launch_config_check': True}, 'auth': {}, 'available_node_types': {'ray.head.default': {'resources': {}, 'node_config': {}, 'max_workers': 0}}, 'head_node_type': 'ray.head.default', 'file_mounts': {}, 'cluster_synced_files': [], 'file_mounts_sync_continuously': False, 'rsync_exclude': [], 'rsync_filter': [], 'initialization_commands': [], 'setup_commands': [], 'head_setup_commands': [], 'worker_setup_commands': [], 'head_start_ray_commands': [], 'worker_start_ray_commands': []}
2026-01-12 03:40:17,607 INFO monitor.py:400 -- Autoscaler has not yet received load metrics. Waiting.
2026-01-12 03:40:22,614 ERROR monitor.py:449 -- Monitor: Execution exception. Trying again...
Traceback (most recent call last):
  File "/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/autoscaler/_private/monitor.py", line 387, in _run
    load_metrics_summary = self.load_metrics.summary()
  File "/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/autoscaler/_private/load_metrics.py", line 268, in summary
    summarized_resource_requests = freq_of_dicts(self.get_resource_requests())
  File "/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/autoscaler/_private/load_metrics.py", line 57, in freq_of_dicts
    freqs = Counter(serializer(d) for d in dicts)
  File "/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/collections/__init__.py", line 577, in __init__
    self.update(iterable, **kwds)
  File "/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/collections/__init__.py", line 670, in update
    _count_elements(self, iterable)
  File "/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/autoscaler/_private/load_metrics.py", line 57, in <genexpr>
    freqs = Counter(serializer(d) for d in dicts)
  File "/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/autoscaler/_private/load_metrics.py", line 55, in <lambda>
    serializer = lambda d: frozenset(d.items())  # noqa: E731
TypeError: unhashable type: 'dict'
```

#### After:
```shell
(clion-ray-ce) ➜  ray git:(master-current) export RAY_enable_autoscaler_v2=0
(clion-ray-ce) ➜  ray git:(master-current) python - <<'PY'           
import time
import ray
from ray.autoscaler.sdk import request_resources

print("ray version:", ray.__version__)
ray.init()
request_resources(bundles=[{'GPU': 0, 'CPU': 1, 'memory': 0}])
time.sleep(5) 
PY
ray version: 3.0.0.dev0
2026-01-12 03:46:30,407 INFO worker.py:2007 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265 
/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/_private/worker.py:2055: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
(clion-ray-ce) ➜  ray git:(master-current) cat /tmp/ray/session_latest/logs/monitor.log | tail -n 200
2026-01-12 03:46:26,713 INFO monitor.py:722 -- Starting monitor using ray installation: /Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/__init__.py
2026-01-12 03:46:26,713 INFO monitor.py:723 -- Ray version: 3.0.0.dev0
2026-01-12 03:46:26,713 INFO monitor.py:724 -- Ray commit: {{RAY_COMMIT_SHA}}
2026-01-12 03:46:26,713 INFO monitor.py:725 -- Monitor started with command: ['/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/autoscaler/_private/monitor.py', '--logs-dir=/tmp/ray/session_2026-01-12_03-46-25_900078_55478/logs', '--logging-rotate-bytes=536870912', '--logging-rotate-backup-count=5', '--gcs-address=127.0.0.1:56444', '--stdout-filepath=/tmp/ray/session_2026-01-12_03-46-25_900078_55478/logs/monitor.out', '--stderr-filepath=/tmp/ray/session_2026-01-12_03-46-25_900078_55478/logs/monitor.err', '--monitor-ip=127.0.0.1']
2026-01-12 03:46:26,714 INFO monitor.py:166 -- session_name: session_2026-01-12_03-46-25_900078_55478
2026-01-12 03:46:26,715 INFO monitor.py:198 -- Starting autoscaler metrics server on port 44217
2026-01-12 03:46:26,716 INFO monitor.py:225 -- Monitor: Started
2026-01-12 03:46:26,720 INFO autoscaler.py:280 -- disable_node_updaters:False
2026-01-12 03:46:26,720 INFO autoscaler.py:289 -- disable_launch_config_check:True
2026-01-12 03:46:26,720 INFO autoscaler.py:301 -- foreground_node_launch:False
2026-01-12 03:46:26,720 INFO autoscaler.py:311 -- worker_liveness_check:True
2026-01-12 03:46:26,720 INFO autoscaler.py:361 -- StandardAutoscaler: {'cluster_name': 'default', 'max_workers': 0, 'upscaling_speed': 1.0, 'docker': {}, 'idle_timeout_minutes': 0, 'provider': {'type': 'readonly', 'use_node_id_as_ip': True, 'disable_launch_config_check': True}, 'auth': {}, 'available_node_types': {'ray.head.default': {'resources': {}, 'node_config': {}, 'max_workers': 0}}, 'head_node_type': 'ray.head.default', 'file_mounts': {}, 'cluster_synced_files': [], 'file_mounts_sync_continuously': False, 'rsync_exclude': [], 'rsync_filter': [], 'initialization_commands': [], 'setup_commands': [], 'head_setup_commands': [], 'worker_setup_commands': [], 'head_start_ray_commands': [], 'worker_start_ray_commands': []}
2026-01-12 03:46:26,721 INFO monitor.py:400 -- Autoscaler has not yet received load metrics. Waiting.
2026-01-12 03:46:31,729 INFO autoscaler.py:147 -- The autoscaler took 0.0 seconds to fetch the list of non-terminated nodes.
2026-01-12 03:46:31,730 INFO autoscaler.py:408 -- 
======== Autoscaler status: 2026-01-12 03:46:31.730219 ========
Node status
---------------------------------------------------------------
Active:
 1 node_3cb93e2da9d0cac129b0c9ab4b51dcde4dcd38be11ab668dda5552d2
Pending:
 (no pending nodes)
Recent failures:
 (no failures)

Resources
---------------------------------------------------------------
Total Usage:
 0.0/10.0 CPU
 0B/6.68GiB memory
 0B/2.00GiB object_store_memory

From request_resources:
 {'label_selector': {}, 'resources': {'CPU': 1, 'GPU': 0, 'memory': 0}}: 1 from request_resources()
Pending Demands:
 (no resource demands)
2026-01-12 03:46:31,731 INFO autoscaler.py:469 -- The autoscaler took 0.001 seconds to complete the update iteration.
```




