### PR TITLE
[Core] Fix task stuck when worker registration failed multiple times.

### DIFF
--- a/python/ray/_private/custom_types.py
+++ b/python/ray/_private/custom_types.py
@@ -120,6 +120,7 @@ ERROR_TYPE = [
     "OBJECT_UNRECONSTRUCTABLE_REF_NOT_FOUND",
     "OBJECT_UNRECONSTRUCTABLE_TASK_CANCELLED",
     "OBJECT_UNRECONSTRUCTABLE_LINEAGE_DISABLED",
+    "WORKER_REGISTRATION_RETRY_EXHAUSTED",
 ]
 # The Language enum is used in the export API so it is public
 # and any modifications must be backward compatible.

--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -53,6 +53,7 @@ from ray.exceptions import (
     TaskPlacementGroupRemoved,
     TaskUnschedulableError,
     WorkerCrashedError,
+    WorkerRegistrationRetryExhaustedError,
 )
 from ray.experimental.compiled_dag_ref import CompiledDAGRef
 from ray.util import serialization_addons
@@ -534,6 +535,11 @@ class SerializationContext:
             elif error_type == ErrorType.Value("TASK_UNSCHEDULABLE_ERROR"):
                 error_info = self._deserialize_error_info(data, metadata_fields)
                 return TaskUnschedulableError(error_info.error_message)
+            elif error_type == ErrorType.Value("WORKER_REGISTRATION_RETRY_EXHAUSTED"):
+                error_info = self._deserialize_error_info(data, metadata_fields)
+                return WorkerRegistrationRetryExhaustedError(
+                    error_message=error_info.error_message
+                )
             elif error_type == ErrorType.Value("ACTOR_UNSCHEDULABLE_ERROR"):
                 error_info = self._deserialize_error_info(data, metadata_fields)
                 return ActorUnschedulableError(error_info.error_message)

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -903,6 +903,25 @@ class RuntimeEnvSetupError(RayError):
 
 
 @PublicAPI
+class WorkerRegistrationRetryExhaustedError(RayError):
+    """Raised when a worker registration timeout multiple times.
+
+    Args:
+        error_message: The error message that explains
+            why worker registration failed.
+    """
+
+    def __init__(self, error_message: str = None):
+        self.error_message = error_message
+
+    def __str__(self):
+        msgs = ["Worker registration timeout multiple times."]
+        if self.error_message:
+            msgs.append(self.error_message)
+        return "\n".join(msgs)
+
+
+@PublicAPI
 class TaskPlacementGroupRemoved(RayError):
     """Raised when the corresponding placement group was removed."""
 
@@ -1089,6 +1108,7 @@ RAY_EXCEPTION_TYPES = [
     GetTimeoutError,
     AsyncioActorExit,
     RuntimeEnvSetupError,
+    WorkerRegistrationRetryExhaustedError,
     TaskPlacementGroupRemoved,
     ActorPlacementGroupRemoved,
     PendingCallsLimitExceeded,

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -280,6 +280,13 @@ RAY_CONFIG(int64_t, worker_register_timeout_seconds, 60)
 /// 0 means it will use the default (number of CPUs).
 RAY_CONFIG(int64_t, worker_maximum_startup_concurrency, 0)
 
+/// Maximum number of retries for worker register timeout.
+/// When a worker fails to start (e.g., due to runtime environment issues),
+/// the task will be retried up to this many times before being cancelled.
+/// 0 means no retry (fail immediately), default is 3.
+/// Retries indefinitely if the value is -1.
+RAY_CONFIG(int32_t, worker_register_timeout_max_retries, 3)
+
 /// The maximum number of workers to iterate whenever we analyze the resources usage.
 RAY_CONFIG(uint32_t, worker_max_resource_analysis_iteration, 128)
 

--- a/src/ray/core_worker/task_submission/normal_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.cc
@@ -359,7 +359,10 @@ void NormalTaskSubmitter::RequestNewWorkerIfNeeded(const SchedulingKey &scheduli
                       rpc::RequestWorkerLeaseReply::
                           SCHEDULING_CANCELLED_PLACEMENT_GROUP_REMOVED ||
                   reply.failure_type() ==
-                      rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_UNSCHEDULABLE) {
+                      rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_UNSCHEDULABLE ||
+                  reply.failure_type() ==
+                      rpc::RequestWorkerLeaseReply::
+                          SCHEDULING_CANCELLED_WORKER_REGISTRATION_RETRY_EXHAUSTED) {
                 // We need to actively fail all of the pending tasks in the queue when the
                 // placement group was removed or the runtime env failed to be set up.
                 // Such an operation is straightforward for the scenario of placement
@@ -377,6 +380,10 @@ void NormalTaskSubmitter::RequestNewWorkerIfNeeded(const SchedulingKey &scheduli
                            rpc::RequestWorkerLeaseReply::
                                SCHEDULING_CANCELLED_UNSCHEDULABLE) {
                   error_type = rpc::ErrorType::TASK_UNSCHEDULABLE_ERROR;
+                } else if (reply.failure_type() ==
+                           rpc::RequestWorkerLeaseReply::
+                               SCHEDULING_CANCELLED_WORKER_REGISTRATION_RETRY_EXHAUSTED) {
+                  error_type = rpc::ErrorType::WORKER_REGISTRATION_RETRY_EXHAUSTED;
                 } else {
                   error_type = rpc::ErrorType::TASK_PLACEMENT_GROUP_REMOVED;
                 }

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -279,6 +279,8 @@ enum ErrorType {
   // The object cannot be reconstructed because lineage reconstruction is
   // disabled system-wide (lineage_pinning_enabled=false).
   OBJECT_UNRECONSTRUCTABLE_LINEAGE_DISABLED = 33;
+  // Indicates that a worker failed to register after multiple retry attempts.
+  WORKER_REGISTRATION_RETRY_EXHAUSTED = 34;
 }
 
 // The user error information.

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -69,6 +69,9 @@ message RequestWorkerLeaseReply {
     SCHEDULING_CANCELLED_INTENDED = 4;
     // Scheduling is cancelled because the task/actor is no longer schedulable.
     SCHEDULING_CANCELLED_UNSCHEDULABLE = 5;
+    // Scheduling is cancelled because worker register repeatedly failed after max
+    // retries.
+    SCHEDULING_CANCELLED_WORKER_REGISTRATION_RETRY_EXHAUSTED = 6;
   }
 
   // Address of the leased worker. If this is empty, then the request should be

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -73,6 +73,10 @@ enum PopWorkerStatus {
   // The lease's job has finished.
   // A nullptr worker will be returned with callback.
   JobFinished = 5,
+  // Worker process has been started, but the worker did not register at the raylet within
+  // the timeout after retrying max times.
+  // A nullptr worker will be returned with callback.
+  WorkerRegistrationRetryExhausted = 6,
 };
 
 /// \param[in] worker The started worker instance. Nullptr if worker is not started.
@@ -905,6 +909,9 @@ class WorkerPool : public WorkerPoolInterface {
   /// A map of idle workers that are pending exit.
   absl::flat_hash_map<WorkerID, std::shared_ptr<WorkerInterface>>
       pending_exit_idle_workers_;
+
+  /// A map of worker registration timeout retry counts per PopWorkerRequest.
+  absl::flat_hash_map<const PopWorkerRequest *, int> worker_register_timeout_retries_;
 
   /// The runner to run function periodically.
   std::shared_ptr<PeriodicalRunner> periodical_runner_;


### PR DESCRIPTION
## Description
This PR fixes a issue where tasks could become stuck indefinitely when worker registration repeatedly fails. Previously, when a worker process failed to register within the timeout period (e.g., due to dependency conflicts or environment setup failures), Ray would retry indefinitely without ever reporting the failure to the user, causing tasks to hang permanently.

  The fix introduces a configurable retry mechanism that limits the number of worker registration attempts and properly propagates errors to the user when retries are exhausted.

## Related issues
> Fixes #59342 

## Additional information
### Key Changes:

  1. **New Exception Type**: Added `WorkerRegistrationRetryExhaustedError` exception to explicitly signal when worker registration has failed after exhausting all retries
  2. **Retry Configuration**: Introduced `worker_register_timeout_max_retries` config (default: 3 retries, -1 for infinite retries, 0 to fail immediately)
  3. **Retry Tracking**: Implemented per-PopWorkerRequest retry counting in `WorkerPool` to track registration timeout attempts
  4. **Error Propagation**: Full error propagation path from raylet through core worker to Python, ensuring users receive clear error messages
  5. **Task Cancellation**: Automatically cancels pending tasks when retry limit is exceeded, preventing indefinite hangs
