### PR TITLE
[Runtime Env] Add bearer token support for remote URI downloads

### DIFF
--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -3,6 +3,7 @@ import os
 from urllib.parse import urlparse
 
 RAY_RUNTIME_ENV_HTTP_USER_AGENT_ENV_VAR = "RAY_RUNTIME_ENV_HTTP_USER_AGENT"
+RAY_RUNTIME_ENV_BEARER_TOKEN_ENV_VAR = "RAY_RUNTIME_ENV_BEARER_TOKEN"
 _DEFAULT_HTTP_USER_AGENT = "ray-runtime-env-curl/1.0"
 
 
@@ -202,12 +203,18 @@ class ProtocolsProvider:
 
     @classmethod
     def _http_headers(cls) -> dict:
-        return {
+        headers = {
             "User-Agent": os.environ.get(
                 RAY_RUNTIME_ENV_HTTP_USER_AGENT_ENV_VAR, _DEFAULT_HTTP_USER_AGENT
             ),
             "Accept": "*/*",
         }
+
+        bearer_token = os.environ.get(RAY_RUNTIME_ENV_BEARER_TOKEN_ENV_VAR)
+        if bearer_token:
+            headers["Authorization"] = f"Bearer {bearer_token}"
+
+        return headers
 
     @classmethod
     def _handle_https_protocol(cls):


### PR DESCRIPTION
## Description

Add support for authenticating HTTPS downloads in runtime environments using 
bearer tokens via the RAY_RUNTIME_ENV_BEARER_TOKEN environment variable.

## Related issues

Fixes [#46833](https://github.com/ray-project/ray/issues/46833)