### PR TITLE
[Core] Disable per-task proctitle on macOS by default to avoid freezes

### DIFF
--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -283,9 +283,12 @@ def test_ray_task_generator_setproctitle(ray_start_2_cpus):
 @pytest.mark.skipif(
     sys.platform != "darwin", reason="macOS-specific proctitle behavior."
 )
-def test_ray_setproctitle_disabled_on_darwin(ray_start_2_cpus, monkeypatch):
-    monkeypatch.delenv("RAY_ENABLE_TASK_PROCTITLE_ON_DARWIN", raising=False)
-
+@pytest.mark.parametrize(
+    "ray_start_2_cpus",
+    [{"runtime_env": {"env_vars": {"RAY_ENABLE_TASK_PROCTITLE_ON_DARWIN": "0"}}}],
+    indirect=True,
+)
+def test_ray_setproctitle_disabled_on_darwin(ray_start_2_cpus):
     @ray.remote
     def unique_task():
         return psutil.Process().cmdline()[0]


### PR DESCRIPTION
## Description
Since Ray 2.48, macOS shows a performance regression (#59663): many short tasks (e.g., 10k) can stall/freeze the system.

### Possible regression source
- PR #53471 
- It vendored setproctitle and enabled ray._raylet.setproctitle() in python/ray/_raylet.pyx.

### Why it happens
- Task execution hot path wraps each task with _changeproctitle(...) ⇒ every task entry/exit calls setproctitle.
- On macOS, this goes through LaunchServices / CFBundle (darwin_set_process_name.c) and is expensive with no caching.
- On Linux, it typically uses prctl / argv updates and is cheap.
- So per‑task updates are negligible on Linux but become costly on macOS with many short tasks.

## Related issues
> Link related issues: "Fixes #59663 ", "Closes #59663 ", or "Related to #59663 ".

## Additional information

### Implemention details
- Skip per‑task _changeproctitle on macOS by default.
- Keep behavior unchanged on other platforms.
- Allow opt‑in via RAY_ENABLE_TASK_PROCTITLE_ON_DARWIN=1.



### Testing
- pytest python/ray/tests/test_advanced_3.py -k proctitle
- Local quick check

#### Reproduction script: **local_test.py**
```python
from collections import Counter
import socket
import time

import ray

ray.init()

print(
    """This cluster consists of
    nodes: {} 
    resources: {}
""".format(
        len(ray.nodes()), ray.cluster_resources()
    )
)


@ray.remote
def f():
    time.sleep(0.001)
    # Return IP address.
    return socket.gethostbyname("localhost")


start = time.time()

object_ids = [f.remote() for _ in range(10_000)]
object_ids = ray.get(object_ids)

print("Tasks executed")
for ip_address, num_tasks in Counter(object_ids).items():
    print("    {} tasks on {}".format(num_tasks, ip_address))

print("Time taken: {:.2f} seconds".format(time.time() - start))
```
#### Before:
```shell
(clion-ray-ce) ➜  ray git:(avoid-macos-freeze) ✗ python local_test.py
2026-01-13 00:45:28,197	INFO worker.py:2006 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265
/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/_private/worker.py:2054: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
This cluster consists of
    nodes: 1
    resources: {'CPU': 10.0, 'memory': 8587526144.0, 'node:127.0.0.1': 1.0, 'node:__internal_head__': 1.0, 'object_store_memory': 2147483648.0}

Tasks executed
    10000 tasks on 127.0.0.1
Time taken: 18.30 seconds
```


#### After:
```shell
(clion-ray-ce) ➜  ray git:(avoid-macos-freeze) ✗ python local_test.py
2026-01-13 00:45:28,197	INFO worker.py:2006 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265
/Users/XXX/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/_private/worker.py:2054: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
This cluster consists of
    nodes: 1
    resources: {'CPU': 10.0, 'memory': 8587526144.0, 'node:127.0.0.1': 1.0, 'node:__internal_head__': 1.0, 'object_store_memory': 2147483648.0}

Tasks executed
    10000 tasks on 127.0.0.1
Time taken: 2.49 seconds
```



### Alternative approach (Not Taken)
- Cache darwin_set_process_title plumbing (LaunchServices/CFBundle handles).
- Not chosen here to keep the change minimal, avoid extra complexity/lifecycle risks, and provide a quick mitigation.
- If needed later, This preserves functionality while significantly reducing per‑call overhead to a tolerable level..
