### PR TITLE
[train][jax] Skip multislice jax tests for py3.12+

### DIFF
--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -292,6 +292,10 @@ def test_tpu_single_slice_multi_host(ray_tpu_multi_host, tmp_path):
         assert r.get("MEGASCALE_COORDINATOR_ADDRESS") is None
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Current jax version is not supported in python 3.12+",
+)
 def test_tpu_multi_slice_multi_host(ray_tpu_multi_host, tmp_path):
     """
     Tests execution of TPU workers across multiple multi-host slices. The
@@ -348,6 +352,10 @@ def test_tpu_multi_slice_multi_host(ray_tpu_multi_host, tmp_path):
     assert list({r["MEGASCALE_SLICE_ID"] for r in slice_b_reports}) == ["1"]
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Current jax version is not supported in python 3.12+",
+)
 def test_multi_slice_manual_resources(ray_tpu_multi_host, tmp_path):
     """
     Tests execution of TPU workers across multiple multi-host slices when
@@ -405,6 +413,10 @@ def test_multi_slice_manual_resources(ray_tpu_multi_host, tmp_path):
     assert list({r["MEGASCALE_SLICE_ID"] for r in slice_b_reports}) == ["1"]
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Current jax version is not supported in python 3.12+",
+)
 def test_tpu_multi_slice_uneven_workers(ray_tpu_multi_host, tmp_path):
     """
     Tests that ScalingConfig raises a ValueError if the requested num_workers

--- a/python/ray/train/v2/tests/test_jax_trainer.py
+++ b/python/ray/train/v2/tests/test_jax_trainer.py
@@ -199,7 +199,7 @@ class VerificationActor:
 
 @pytest.mark.skipif(
     sys.version_info >= (3, 12),
-    reason="Current jax version is not supported in python 3.12+",
+    reason="Current jax version (0.4.13) is not supported in python 3.12+",
 )
 def test_tpu_single_host(ray_tpu_single_host, tmp_path):
     """
@@ -244,7 +244,7 @@ def test_tpu_single_host(ray_tpu_single_host, tmp_path):
 
 @pytest.mark.skipif(
     sys.version_info >= (3, 12),
-    reason="Current jax version is not supported in python 3.12+",
+    reason="Current jax version (0.4.13) is not supported in python 3.12+",
 )
 def test_tpu_single_slice_multi_host(ray_tpu_multi_host, tmp_path):
     """
@@ -294,7 +294,7 @@ def test_tpu_single_slice_multi_host(ray_tpu_multi_host, tmp_path):
 
 @pytest.mark.skipif(
     sys.version_info >= (3, 12),
-    reason="Current jax version is not supported in python 3.12+",
+    reason="Current jax version (0.4.13) is not supported in python 3.12+",
 )
 def test_tpu_multi_slice_multi_host(ray_tpu_multi_host, tmp_path):
     """
@@ -354,7 +354,7 @@ def test_tpu_multi_slice_multi_host(ray_tpu_multi_host, tmp_path):
 
 @pytest.mark.skipif(
     sys.version_info >= (3, 12),
-    reason="Current jax version is not supported in python 3.12+",
+    reason="Current jax version (0.4.13) is not supported in python 3.12+",
 )
 def test_multi_slice_manual_resources(ray_tpu_multi_host, tmp_path):
     """
@@ -415,7 +415,7 @@ def test_multi_slice_manual_resources(ray_tpu_multi_host, tmp_path):
 
 @pytest.mark.skipif(
     sys.version_info >= (3, 12),
-    reason="Current jax version is not supported in python 3.12+",
+    reason="Current jax version (0.4.13) is not supported in python 3.12+",
 )
 def test_tpu_multi_slice_uneven_workers(ray_tpu_multi_host, tmp_path):
     """


### PR DESCRIPTION
## Description
1. Jax dependency is introduced in
https://github.com/ray-project/ray/pull/58322
2. The current test environment is for CUDA 12.1, which limit jax
version below 0.4.14.
3. jax <= 0.4.14 does not support py 3.12.
4. skip jax test if it runs against py3.12+.
