### PR TITLE
bumped packages to support vllm 0.12.0 and updated checkpoint path to match train v2 updates

### DIFF
--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
@@ -77,11 +77,13 @@
     "%%bash\n",
     "# Install dependencies\n",
     "pip install -q \\\n",
-    "    \"xgrammar==0.1.11\" \\\n",
+    "    \"xgrammar==0.1.27\" \\\n",
     "    \"pynvml==12.0.0\" \\\n",
     "    \"hf_transfer==0.1.9\" \\\n",
     "    \"tensorboard==2.19.0\" \\\n",
-    "    \"llamafactory@git+https://github.com/hiyouga/LLaMA-Factory.git@ac8c6fdd3ab7fb6372f231f238e6b8ba6a17eb16#egg=llamafactory\""
+    "    \"llamafactory==0.9.4\" \\\n",
+    "    \"transformers>=4.52.0\" \\\n",
+    "    \"pydantic>=2.12.0\""
    ]
   },
   {
@@ -1102,9 +1104,9 @@
    "source": [
     "# LoRA paths.\n",
     "save_dir = Path(\"/mnt/cluster_storage/viggo/saves/lora_sft_ray\")\n",
-    "trainer_dirs = [d for d in save_dir.iterdir() if d.name.startswith(\"TorchTrainer_\") and d.is_dir()]\n",
-    "latest_trainer = max(trainer_dirs, key=lambda d: d.stat().st_mtime, default=None)\n",
-    "lora_path = f\"{latest_trainer}/checkpoint_000000/checkpoint\"\n",
+    "checkpoint_dirs = [d for d in save_dir.iterdir() if d.name.startswith(\"checkpoint_\") and d.is_dir()]\n",
+    "checkpoint_dir = max(checkpoint_dirs, key=lambda d: d.stat().st_mtime, default=None)\n",
+    "lora_path = f\"{checkpoint_dir}/checkpoint\"\n",
     "cloud_lora_path = os.path.join(os.getenv(\"ANYSCALE_ARTIFACT_STORAGE\"), lora_path.split(\"/mnt/cluster_storage/\")[-1])\n",
     "dynamic_lora_path, lora_id = cloud_lora_path.rsplit(\"/\", 1)\n",
     "print (lora_path)\n",
@@ -1694,7 +1696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
Bumped the example's required packages to support vllm 0.12.0 (mainly transformers) and updated checkpoint path to match train v2 updates (it now starts with checkpoint_ rather than TorchTrainer_)
