### PR TITLE
[LLM] Fix NIXL port conflict in prefill-decode disaggregation test

### DIFF
--- a/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_multi_node_integration.py
@@ -154,6 +154,7 @@ def test_llm_serve_prefill_decode_with_data_parallelism():
         },
         experimental_configs={
             "dp_size_per_node": 4,
+            "NIXL_SIDE_CHANNEL_PORT_BASE": 40000,  # Prefill port range
         },
         runtime_env={"env_vars": {"VLLM_DISABLE_COMPILE_CACHE": "1"}},
     )
@@ -170,6 +171,7 @@ def test_llm_serve_prefill_decode_with_data_parallelism():
         },
         experimental_configs={
             "dp_size_per_node": 4,
+            "NIXL_SIDE_CHANNEL_PORT_BASE": 41000,  # Decode port range (different)
         },
         runtime_env={"env_vars": {"VLLM_DISABLE_COMPILE_CACHE": "1"}},
     )


### PR DESCRIPTION
## Summary

When running prefill-decode disaggregation with NixlConnector and data parallelism, both prefill and decode deployments were using the same port base for their ZMQ side channel. This caused "Address already in use" errors when both deployments had workers on the same node:

```
zmq.error.ZMQError: Address already in use (addr='tcp://10.0.75.118:40009')
Exception in thread nixl_handshake_listener
```

## Changes

Fix by setting different `NIXL_SIDE_CHANNEL_PORT_BASE` values for prefill (40000) and decode (41000) configs to ensure port isolation.

## Test plan

- Run `test_llm_serve_prefill_decode_with_data_parallelism` - should complete without timeout
- The test previously hung forever waiting for "READY message from DP Coordinator"