### PR TITLE
[core][rdt] Synchronize cuda stream before registering for nixl

### DIFF
--- a/python/ray/experimental/gpu_object_manager/nixl_tensor_transport.py
+++ b/python/ray/experimental/gpu_object_manager/nixl_tensor_transport.py
@@ -102,6 +102,8 @@ class NixlTensorTransport(TensorTransportManager):
         obj_id: str,
         gpu_object: List["torch.Tensor"],
     ) -> NixlTransportMetadata:
+        import torch
+
         from ray._private.worker import global_worker
 
         gpu_object_store = global_worker.gpu_object_manager.gpu_object_store
@@ -114,18 +116,22 @@ class NixlTensorTransport(TensorTransportManager):
             return duplicate_meta
 
         if gpu_object:
-            nixl_agent = self.get_nixl_agent()
-            reg_descs = nixl_agent.register_memory(gpu_object)
-            serialized_descs = nixl_agent.get_serialized_descs(reg_descs.trim())
-            agent_meta = nixl_agent.get_agent_metadata()
-            # We assume all tensors in one GPU object have the same device type.
-            device = gpu_object[0].device
             for t in gpu_object:
                 if t.device.type != device.type:
                     raise ValueError(
                         "All tensors in an RDT object must have the same device type."
                     )
                 tensor_meta.append((t.shape, t.dtype))
+            if device.type == "cuda":
+                # We have to synchronize before memory registration to assure the object
+                # has been created because nixl doesn't guarantee it will.
+                torch.cuda.synchronize()
+            nixl_agent = self.get_nixl_agent()
+            reg_descs = nixl_agent.register_memory(gpu_object)
+            serialized_descs = nixl_agent.get_serialized_descs(reg_descs.trim())
+            agent_meta = nixl_agent.get_agent_metadata()
+            # We assume all tensors in one GPU object have the same device type.
+            device = gpu_object[0].device
         else:
             reg_descs, serialized_descs, agent_meta = None, None, None
 

--- a/python/ray/experimental/gpu_object_manager/nixl_tensor_transport.py
+++ b/python/ray/experimental/gpu_object_manager/nixl_tensor_transport.py
@@ -130,8 +130,8 @@ class NixlTensorTransport(TensorTransportManager):
             if device.type == "cuda":
                 # We have to synchronize before memory registration to assure the object
                 # has been created because nixl doesn't guarantee it will.
-                for device in devices:
-                    torch.cuda.synchronize(device)
+                for dev in devices:
+                    torch.cuda.synchronize(dev)
             nixl_agent = self.get_nixl_agent()
             reg_descs = nixl_agent.register_memory(gpu_object)
             serialized_descs = nixl_agent.get_serialized_descs(reg_descs.trim())


### PR DESCRIPTION
## Description
After talking to some people working on NIXL, they recommended synchronizing before memory registration because they don't do any checks on their end to see if the object is actually ready.

So now doing a synchronize on every device with one of the tensors before registering the memory.