### PR TITLE
[core] Fix event exporter init ray check

### DIFF
--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -846,7 +846,7 @@ void GcsServer::InstallEventListeners() {
         // Initialize the metrics exporter when the head node registers,
         // but only if we haven't already initialized it (i.e., when using
         // dynamic port assignment where config_.metrics_agent_port was 0).
-        if (node->is_head_node() && !metrics_exporter_initialized_) {
+        if (node->is_head_node() && !metrics_exporter_initialized_.load()) {
           int actual_port = node->metrics_agent_port();
           if (actual_port > 0) {
             InitMetricsExporter(actual_port);

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -984,10 +984,10 @@ RedisClientOptions GcsServer::GetRedisClientOptions() {
 }
 
 void GcsServer::InitMetricsExporter(int metrics_agent_port) {
-  RAY_CHECK(!metrics_exporter_initialized_)
-      << "InitMetricsExporter should only be called once.";
-  metrics_exporter_initialized_ = true;
-
+  if (metrics_exporter_initialized_.exchange(true, std::memory_order_acquire)) {
+    // Exit early as exporter has been initialized
+    return;
+  }
   event_aggregator_client_->Connect(metrics_agent_port);
 
   metrics_agent_client_ = std::make_unique<rpc::MetricsAgentClientImpl>(

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -325,7 +325,7 @@ class GcsServer {
   std::atomic<bool> is_started_;
   std::atomic<bool> is_stopped_;
   /// Flag to ensure InitMetricsExporter is only called once.
-  bool metrics_exporter_initialized_ = false;
+  std::atomic<bool> metrics_exporter_initialized_ = false;
   int task_pending_schedule_detected_ = 0;
   // Invoked when the RPC server has bound to a port.
   std::function<void(int)> port_ready_callback_;

--- a/src/ray/observability/ray_event_recorder.cc
+++ b/src/ray/observability/ray_event_recorder.cc
@@ -42,8 +42,9 @@ void RayEventRecorder::StartExportingEvents() {
     RAY_LOG(INFO) << "Ray event recording is disabled. Skipping start exporting events.";
     return;
   }
-  RAY_CHECK(!exporting_started_)
-      << "RayEventRecorder::StartExportingEvents() should be called only once.";
+  if (exporting_started_) {
+    return;
+  }
   exporting_started_ = true;
   periodical_runner_->RunFnPeriodically(
       [this]() { ExportEvents(); },


### PR DESCRIPTION
## Description

There isn't really a need to have a ray check on the event exporter as there isn't really an important correctness invariant here. One call will succeed.  We already take some measure of caution here with a mutex in the event recorder.  But ray checking right after the mutex is just asking for trouble.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
