### PR TITLE
[Data] Export dataset operator output schema to event logger

### DIFF
--- a/python/ray/_private/event/export_event_logger.py
+++ b/python/ray/_private/event/export_event_logger.py
@@ -16,6 +16,9 @@ from ray.core.generated.export_dataset_metadata_pb2 import (
 from ray.core.generated.export_dataset_operator_event_pb2 import (
     ExportDatasetOperatorEventData,
 )
+from ray.core.generated.export_dataset_operator_schema_pb2 import (
+    ExportDatasetOperatorSchema,
+)
 from ray.core.generated.export_event_pb2 import ExportEvent
 from ray.core.generated.export_submission_job_event_pb2 import (
     ExportSubmissionJobEventData,
@@ -35,6 +38,7 @@ ExportEventDataType = Union[
     ExportTrainRunAttemptEventData,
     ExportDatasetMetadata,
     ExportDatasetOperatorEventData,
+    ExportDatasetOperatorSchema,
 ]
 
 
@@ -48,6 +52,7 @@ class EventLogType(Enum):
         SUBMISSION_JOB: Export events related to job submissions.
         DATASET_METADATA: Export events related to dataset metadata.
         DATASET_OPERATOR_EVENT: Export events related to Ray Data operator.
+        DATASET_OPERATOR_SCHEMA: Export schema related to Ray Data operator.
     """
 
     TRAIN_STATE = (
@@ -59,6 +64,10 @@ class EventLogType(Enum):
     DATASET_OPERATOR_EVENT = (
         "EXPORT_DATASET_OPERATOR_EVENT",
         {ExportDatasetOperatorEventData},
+    )
+    DATASET_OPERATOR_SCHEMA = (
+        "EXPORT_DATASET_OPERATOR_SCHEMA",
+        {ExportDatasetOperatorSchema},
     )
 
     def __init__(self, log_type_name: str, event_types: set[ExportEventDataType]):
@@ -131,6 +140,9 @@ class ExportEventLoggerAdapter:
         elif isinstance(event_data, ExportDatasetOperatorEventData):
             event.dataset_operator_event_data.CopyFrom(event_data)
             event.source_type = ExportEvent.SourceType.EXPORT_DATASET_OPERATOR_EVENT
+        elif isinstance(event_data, ExportDatasetOperatorSchema):
+            event.dataset_operator_schema.CopyFrom(event_data)
+            event.source_type = ExportEvent.SourceType.EXPORT_DATASET_OPERATOR_SCHEMA
         else:
             raise TypeError(f"Invalid event_data type: {type(event_data)}")
         if not self.log_type.supports_event_type(event_data):

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1932,6 +1932,20 @@ py_test(
 )
 
 py_test(
+    name = "test_operator_schema_export",
+    size = "small",
+    srcs = ["tests/test_operator_schema_export.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_delta",
     size = "small",
     srcs = ["tests/datasource/test_delta.py"],

--- a/python/ray/data/_internal/operator_schema_exporter.py
+++ b/python/ray/data/_internal/operator_schema_exporter.py
@@ -1,0 +1,142 @@
+"""Exporter API for Ray Data operator schema."""
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import ray
+from ray._private.event.export_event_logger import (
+    EventLogType,
+    check_export_api_enabled,
+    get_export_event_logger,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OperatorSchema:
+    """Represents a Ray Data operator schema
+
+    Attributes:
+        operator_uuid: The uuid of the operator.
+        schema_fields: The schema fields of the operator.
+    """
+
+    operator_uuid: str
+    schema_fields: Dict[str, str]  # Mapping from name to type
+
+
+def operator_schema_to_proto(operator_schema: OperatorSchema) -> Any:
+    """Convert the operator schema to a protobuf message.
+
+    Args:
+        operator_schema: OperatorSchema object containing the schema details
+
+    Returns:
+        The protobuf message representing the operator schema.
+    """
+
+    from ray.core.generated.export_dataset_operator_schema_pb2 import (
+        ExportDatasetOperatorSchema as ProtoOperatorSchema,
+    )
+
+    # Create the protobuf message
+    proto_operator_schema = ProtoOperatorSchema(
+        operator_uuid=operator_schema.operator_uuid,
+        schema_fields=operator_schema.schema_fields,
+    )
+
+    return proto_operator_schema
+
+
+def get_operator_schema_exporter() -> Optional["LoggerOperatorSchemaExporter"]:
+    """Get the operator schema exporter instance.
+
+    Returns:
+        The operator schema exporter instance.
+    """
+    return LoggerOperatorSchemaExporter.create_if_enabled()
+
+
+class OperatorSchemaExporter(ABC):
+    """Abstract base class for operator schema exporters.
+
+    Implementations of this interface can export Ray Data operator schema to various
+    destinations like log files, databases, or monitoring systems.
+    """
+
+    @abstractmethod
+    def export_operator_schema(self, operator_schema: OperatorSchema) -> None:
+        """Export operator schema to the destination.
+
+        Args:
+            operator_schema: OperatorSchema object containing operator schema details.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def create_if_enabled(cls) -> Optional["OperatorSchemaExporter"]:
+        """Create a schema exporter instance if the export functionality is enabled.
+
+        Returns:
+            A schema exporter instance if enabled, none otherwise.
+        """
+        pass
+
+
+class LoggerOperatorSchemaExporter(OperatorSchemaExporter):
+    """Operator schema exporter implementation that uses the Ray export event logger.
+
+    This exporter writes operator schema to log files using Ray's export event system.
+    """
+
+    def __init__(self, logger: logging.Logger):
+        """Initialize with a configured export event logger.
+
+        Args:
+            logger: The export event logger to use for writing events.
+        """
+        self._export_logger = logger
+
+    def export_operator_schema(self, operator_schema: OperatorSchema) -> None:
+        """Export operator schema using the export event logger.
+
+        Args:
+            operator_schema: OperatorSchema object containing operator event details.
+        """
+        operator_schema_proto = operator_schema_to_proto(operator_schema)
+        self._export_logger.send_event(operator_schema_proto)
+
+    @classmethod
+    def create_if_enabled(cls) -> Optional["LoggerOperatorSchemaExporter"]:
+        """Create a logger-based exporter if the export API is enabled.
+
+        Returns:
+            A LoggerOperatorSchemaExporter instance, none otherwise.
+        """
+        from ray.core.generated.export_event_pb2 import ExportEvent
+
+        is_operator_schema_export_api_enabled = check_export_api_enabled(
+            ExportEvent.SourceType.EXPORT_DATASET_OPERATOR_SCHEMA
+        )
+        if not is_operator_schema_export_api_enabled:
+            # The export API is not enabled, so we shouldn't create an exporter
+            return None
+
+        log_directory = ray._private.worker._global_node.get_logs_dir_path()
+
+        try:
+            export_logger = get_export_event_logger(
+                EventLogType.DATASET_OPERATOR_SCHEMA,
+                log_directory,
+            )
+            return LoggerOperatorSchemaExporter(export_logger)
+        except Exception:
+            logger.exception(
+                "Unable to initialize the export event logger, so no operator export "
+                "schema will be written."
+            )
+            return None

--- a/python/ray/data/tests/test_operator_schema_export.py
+++ b/python/ray/data/tests/test_operator_schema_export.py
@@ -1,0 +1,75 @@
+import json
+import os
+import sys
+
+import pyarrow as pa
+import pytest
+
+import ray
+from ray._private import ray_constants
+from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.streaming_executor import StreamingExecutor
+from ray.data.context import DataContext
+
+
+def _get_exported_data():
+    exported_file = os.path.join(
+        ray._private.worker._global_node.get_session_dir_path(),
+        "logs",
+        "export_events",
+        "event_EXPORT_DATASET_OPERATOR_SCHEMA.log",
+    )
+    assert os.path.isfile(exported_file)
+
+    with open(exported_file, "r") as f:
+        data = f.readlines()
+
+    return [json.loads(line) for line in data]
+
+
+def test_export_operator_schema():
+    ray.init()
+    ray_constants.RAY_ENABLE_EXPORT_API_WRITE = True
+    ctx = DataContext.get_current()
+
+    op = InputDataBuffer(ctx, [])
+    executor = StreamingExecutor(ctx)
+
+    # Do not export schema if it's None
+    executor._export_operator_schema(op)
+    data = _get_exported_data()
+    assert len(data) == 0
+
+    # Export if it's a valid schema
+    schema = pa.schema([pa.field("id", pa.int32()), pa.field("name", pa.string())])
+    executor._op_schema[op] = schema
+    executor._export_operator_schema(op)
+    data = _get_exported_data()
+    assert len(data) == 1
+    assert data[0]["event_data"]["schema_fields"] == {"name": "string", "id": "int32"}
+
+    # Export updated schema of the same operator
+    schema2 = pa.schema(
+        [
+            pa.field("id", pa.int32()),
+            pa.field("name", pa.string()),
+            pa.field("age", pa.int32()),
+        ]
+    )
+    executor._op_schema[op] = schema2
+    executor._export_operator_schema(op)
+    data = _get_exported_data()
+    assert len(data) == 2
+    assert (
+        data[0]["event_data"]["operator_uuid"] == data[1]["event_data"]["operator_uuid"]
+    )
+    assert data[0]["event_data"]["schema_fields"] == {"name": "string", "id": "int32"}
+    assert data[1]["event_data"]["schema_fields"] == {
+        "name": "string",
+        "id": "int32",
+        "age": "int32",
+    }
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/protobuf/BUILD.bazel
+++ b/src/ray/protobuf/BUILD.bazel
@@ -262,6 +262,7 @@ proto_library(
         ":export_actor_event_proto",
         ":export_dataset_metadata_proto",
         ":export_dataset_operator_event_proto",
+        ":export_dataset_operator_schema_proto",
         ":export_driver_job_event_proto",
         ":export_node_event_proto",
         ":export_submission_job_event_proto",
@@ -363,6 +364,16 @@ proto_library(
 cc_proto_library(
     name = "export_dataset_operator_event_cc_proto",
     deps = [":export_dataset_operator_event_proto"],
+)
+
+proto_library(
+    name = "export_dataset_operator_schema_proto",
+    srcs = ["export_dataset_operator_schema.proto"],
+)
+
+cc_proto_library(
+    name = "export_dataset_operator_schema_cc_proto",
+    deps = [":export_dataset_operator_schema_proto"],
 )
 
 proto_library(

--- a/src/ray/protobuf/export_dataset_operator_schema.proto
+++ b/src/ray/protobuf/export_dataset_operator_schema.proto
@@ -1,0 +1,28 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option cc_enable_arenas = true;
+package ray.rpc;
+
+// This message defines the event_data stored by the export API for
+// EXPORT_DATASET_OPERATOR_SCHEMA type events from Ray Data operators.
+message ExportDatasetOperatorSchema {
+  // The operator UUID
+  string operator_uuid = 1;
+
+  // Schema as a dictionary mapping field names to their types (both strings)
+  map<string, string> schema_fields = 2;
+}

--- a/src/ray/protobuf/export_event.proto
+++ b/src/ray/protobuf/export_event.proto
@@ -24,6 +24,7 @@ import "src/ray/protobuf/export_submission_job_event.proto";
 
 import "src/ray/protobuf/export_train_state.proto";
 import "src/ray/protobuf/export_dataset_operator_event.proto";
+import "src/ray/protobuf/export_dataset_operator_schema.proto";
 import "src/ray/protobuf/export_dataset_metadata.proto";
 
 // ExportEvent defines events stored by the export API. This
@@ -39,6 +40,7 @@ message ExportEvent {
     EXPORT_TRAIN_RUN_ATTEMPT = 6;
     EXPORT_DATASET_METADATA = 7;
     EXPORT_DATASET_OPERATOR_EVENT = 8;
+    EXPORT_DATASET_OPERATOR_SCHEMA = 9;
   }
 
   // event_id is the unique ID of this event
@@ -59,5 +61,6 @@ message ExportEvent {
     ExportTrainRunAttemptEventData train_run_attempt_event_data = 10;
     ExportDatasetMetadata dataset_metadata = 11;
     ExportDatasetOperatorEventData dataset_operator_event_data = 12;
+    ExportDatasetOperatorSchema dataset_operator_schema = 13;
   }
 }


### PR DESCRIPTION
## Description
In this PR, we export the output schema of dataset operators so that we can check the output field names and their data types for better observability.

If `DataContext.enforce_schemas` is set to False, the schema will only be export once for each operator; and if it is set to True, the schema will be exported whenever the fields get updated.

Example export event:
```
{
  "event_id": "83b3A80eAa283CFFBf",
  "timestamp": 1769111404,
  "source_type": "EXPORT_DATASET_OPERATOR_SCHEMA",
  "event_data": {
    "operator_uuid": "a76411d1-5d28-4027-ad19-56cdcb073410",
    "schema_fields": {
      "int_field": "int64",
      "bool_field": "bool",
      "bytes_field": "binary",
      "string_field": "string",
      "date_field": "date32[day]",
      "datetime_field": "timestamp[us]",
      "numpy_int_field": "int32",
      "numpy_float_field": "double",
      "numpy_array_field": "ArrowTensorType(shape=(3,), dtype=int64)",
      "list_float_field": "list<item: double>",
      "list_list_field": "list<item: list<item: double>>",
      "nested_dict_field": "struct<a: struct<b: string>>",
      "none_field": "null",
    }
  }
}
```
