### PR TITLE
[core] bugfix - uv_runtime_env_hook.py

### DIFF
--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -319,11 +319,15 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     parser = _create_uv_run_parser()
     (options, command) = _parse_args(parser, cmdline[2:])
 
-    if cmdline[-len(command) :] != command:
+    # `command` can be empty when uv is invoked with options that consume all arguments.
+    # For example, `uv run -m module_name` has no positional command -- the parser
+    # treats `-m module_name` as an option, not as a command to execute.
+    # NOTE: The empty list is a suffix of any list.
+    if len(command) > 0 and cmdline[-len(command) :] != command:
         raise AssertionError(
             f"uv run command {command} is not a suffix of command line {cmdline}"
         )
-    uv_run_args = cmdline[: -len(command)]
+    uv_run_args = cmdline[: len(cmdline) - len(command)]
 
     # Remove the "--directory" argument since it has already been taken into
     # account when setting the current working directory of the current process.

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -297,6 +297,23 @@ def test_uv_run_runtime_env_hook():
     )
 
     # Check in the case that a module is use for "uv run" and there is
+    # no argument behind it
+    check_uv_run(
+        cmd=[
+            find_uv_bin(),
+            "run",
+            "--no-project",
+            "-m",
+            "ray._private.runtime_env.uv_runtime_env_hook",
+        ],
+        runtime_env={},
+        expected_output={
+            "py_executable": f"{find_uv_bin()} run --no-project",
+            "working_dir": os.getcwd(),
+        },
+    )
+
+    # Check in the case that a module is use for "uv run" and there is
     # an argument immediately behind it
     check_uv_run(
         cmd=[


### PR DESCRIPTION
## Description
The following demo breaks using current ray codebase.
```bash
uv init --package bugdemo && cd bugdemo && uv add ray && cat > src/bugdemo/main.py << EOF
import ray
def main():
    ray.init()
if __name__ == '__main__':
    main()
EOF && uv pip install -e . && uv run -m bugdemo.main
```

This PR fixes it. (same as https://github.com/ray-project/ray/pull/59567)

## Related issues
N/A