### PR TITLE
[Data][Docs] Sort references in Loading data and Saving data references (#60084)

### DIFF
--- a/doc/source/data/api/loading_data.rst
+++ b/doc/source/data/api/loading_data.rst
@@ -353,6 +353,27 @@ WebDataset
 
    read_webdataset
 
+Partitioning API
+^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   datasource.Partitioning
+   datasource.PartitionStyle
+   datasource.PathPartitionFilter
+   datasource.PathPartitionParser
+
+Shuffling API
+^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   FileShuffleConfig
+
 Developer APIs
 --------------
 
@@ -407,25 +428,3 @@ Pandas refs
    :toctree: doc/
 
    from_pandas_refs
-
-Partitioning API
-^^^^^^^^^^^^^^^^
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   datasource.Partitioning
-   datasource.PartitionStyle
-   datasource.PathPartitionFilter
-   datasource.PathPartitionParser
-
-Shuffling API
-^^^^^^^^^^^^^
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   FileShuffleConfig
-

--- a/doc/source/data/api/loading_data.rst
+++ b/doc/source/data/api/loading_data.rst
@@ -5,63 +5,20 @@ Loading Data API
 
 .. currentmodule:: ray.data
 
-Synthetic Data
---------------
+Public APIs
+-----------
+
+Arrow
+^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   range
-   range_tensor
-
-Python Objects
---------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   from_items
-
-Parquet
--------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_parquet
-
-CSV
----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_csv
-
-JSON
-----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_json
-
-Text
-----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_text
+   from_arrow
 
 Audio
------
+^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -70,7 +27,7 @@ Audio
    read_audio
 
 Avro
-----
+^^^^
 
 .. autosummary::
    :nosignatures:
@@ -78,76 +35,8 @@ Avro
 
    read_avro
 
-Images
-------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_images
-
-Binary
-------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_binary_files
-
-TFRecords
----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_tfrecords
-   TFXReadOptions
-
-Pandas
-------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   from_pandas
-   from_pandas_refs
-
-NumPy
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_numpy
-   from_numpy
-   from_numpy_refs
-
-Arrow
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   from_arrow
-   from_arrow_refs
-
-MongoDB
--------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_mongo
-
 BigQuery
---------
+^^^^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -155,98 +44,26 @@ BigQuery
 
    read_bigquery
 
-SQL Databases
--------------
+Binary
+^^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   read_sql
+   read_binary_files
 
-Databricks
-----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_databricks_tables
-
-Snowflake
----------
+CSV
+^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   read_snowflake
-
-Unity Catalog
--------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_unity_catalog
-
-Delta Sharing
--------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_delta_sharing_tables
-
-Hudi
-----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_hudi
-
-Iceberg
--------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_iceberg
-
-Delta Lake
-----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_delta
-
-Lance
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_lance
-
-MCAP (Message Capture)
-----------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_mcap
+   read_csv
 
 ClickHouse
-----------
+^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -255,7 +72,7 @@ ClickHouse
    read_clickhouse
 
 Daft
-----
+^^^^
 
 .. autosummary::
    :nosignatures:
@@ -264,7 +81,7 @@ Daft
    from_daft
 
 Dask
-----
+^^^^
 
 .. autosummary::
    :nosignatures:
@@ -272,44 +89,44 @@ Dask
 
    from_dask
 
-Spark
------
+Databricks
+^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   from_spark
+   read_databricks_tables
 
-Modin
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   from_modin
-
-Mars
-----
+Delta Lake
+^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   from_mars
+   read_delta
 
-Torch
------
+Delta Sharing
+^^^^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   from_torch
+   read_delta_sharing_tables
+
+Hudi
+^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_hudi
 
 Hugging Face
-------------
+^^^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -317,8 +134,173 @@ Hugging Face
 
    from_huggingface
 
+Iceberg
+^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_iceberg
+
+Images
+^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_images
+
+JSON
+^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_json
+
+Kafka
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_kafka
+
+Lance
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_lance
+
+MCAP (Message Capture)
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_mcap
+
+Mars
+^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_mars
+
+Modin
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_modin
+
+MongoDB
+^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_mongo
+
+NumPy
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_numpy
+   read_numpy
+
+Pandas
+^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_pandas
+
+Parquet
+^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_parquet
+
+Python Objects
+^^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_items
+
+SQL Databases
+^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_sql
+
+Snowflake
+^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_snowflake
+
+Spark
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_spark
+
+Synthetic Data
+^^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   range
+   range_tensor
+
+TFRecords
+^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_tfrecords
+   TFXReadOptions
+
 TensorFlow
-----------
+^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -326,8 +308,35 @@ TensorFlow
 
    from_tf
 
+Text
+^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_text
+
+Torch
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_torch
+
+Unity Catalog
+^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_unity_catalog
+
 Video
------
+^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -336,7 +345,7 @@ Video
    read_videos
 
 WebDataset
-----------
+^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -344,31 +353,63 @@ WebDataset
 
    read_webdataset
 
-Kafka
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   read_kafka
-
-.. _data_source_api:
-
-Datasource API
+Developer APIs
 --------------
 
+Arrow refs
+^^^^^^^^^^
+
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   read_datasource
+   from_arrow_refs
+
+Datasource API
+^^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
    Datasource
+   datasource.FileBasedDatasource
+   read_datasource
    ReadTask
-   datasource.FilenameProvider
+
+.. _metadata_provider:
+
+MetadataProvider API
+^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   datasource.BaseFileMetadataProvider
+   datasource.DefaultFileMetadataProvider
+   datasource.FileMetadataProvider
+
+NumPy refs
+^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_numpy_refs
+
+Pandas refs
+^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   from_pandas_refs
 
 Partitioning API
-----------------
+^^^^^^^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -376,27 +417,15 @@ Partitioning API
 
    datasource.Partitioning
    datasource.PartitionStyle
-   datasource.PathPartitionParser
    datasource.PathPartitionFilter
-
-.. _metadata_provider:
-
-MetadataProvider API
---------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   datasource.FileMetadataProvider
-   datasource.BaseFileMetadataProvider
-   datasource.DefaultFileMetadataProvider
+   datasource.PathPartitionParser
 
 Shuffling API
--------------
+^^^^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
    FileShuffleConfig
+

--- a/doc/source/data/api/saving_data.rst
+++ b/doc/source/data/api/saving_data.rst
@@ -5,91 +5,11 @@ Saving Data API
 
 .. currentmodule:: ray.data
 
-Parquet
--------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_parquet
-
-CSV
----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_csv
-
-JSON
-----
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_json
-
-Images
-------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_images
-
-TFRecords
----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_tfrecords
-
-Pandas
-------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.to_pandas
-   Dataset.to_pandas_refs
-
-NumPy
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_numpy
-   Dataset.to_numpy_refs
-
-Arrow
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.to_arrow_refs
-
-MongoDB
--------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_mongo
+Public APIs
+-----------
 
 BigQuery
---------
+^^^^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -97,44 +17,17 @@ BigQuery
 
    Dataset.write_bigquery
 
-SQL Databases
--------------
+CSV
+^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   Dataset.write_sql
-
-Snowflake
----------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_snowflake
-
-Iceberg
--------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_iceberg
-
-Lance
------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.write_lance
+   Dataset.write_csv
 
 ClickHouse
-----------
+^^^^^^^^^^
 
 .. autosummary::
    :nosignatures:
@@ -143,7 +36,7 @@ ClickHouse
    Dataset.write_clickhouse
 
 Daft
-----
+^^^^
 
 .. autosummary::
    :nosignatures:
@@ -152,7 +45,7 @@ Daft
    Dataset.to_daft
 
 Dask
-----
+^^^^
 
 .. autosummary::
    :nosignatures:
@@ -160,26 +53,44 @@ Dask
 
    Dataset.to_dask
 
-Spark
------
+Iceberg
+^^^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   Dataset.to_spark
+   Dataset.write_iceberg
 
-Modin
------
+Images
+^^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   Dataset.to_modin
+   Dataset.write_images
+
+JSON
+^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.write_json
+
+Lance
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.write_lance
 
 Mars
-----
+^^^^
 
 .. autosummary::
    :nosignatures:
@@ -187,17 +98,137 @@ Mars
 
    Dataset.to_mars
 
-Datasink API
-------------
+Modin
+^^^^^
 
 .. autosummary::
    :nosignatures:
    :toctree: doc/
 
-   Dataset.write_datasink
+   Dataset.to_modin
+
+MongoDB
+^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.write_mongo
+
+NumPy
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.write_numpy
+
+Pandas
+^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.to_pandas
+
+Parquet
+^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.write_parquet
+
+SQL Databases
+^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.write_sql
+
+Snowflake
+^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.write_snowflake
+
+Spark
+^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.to_spark
+
+TFRecords
+^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.write_tfrecords
+
+Developer APIs
+--------------
+
+Arrow refs
+^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.to_arrow_refs
+
+Datasink API
+^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
    Datasink
+   Dataset.write_datasink
    datasource.RowBasedFileDatasink
    datasource.BlockBasedFileDatasink
-   datasource.FileBasedDatasource
    datasource.WriteResult
    datasource.WriteReturnType
+
+FilenameProvider
+^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   datasource.FilenameProvider
+
+NumPy refs
+^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.to_numpy_refs
+
+Pandas refs
+^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Dataset.to_pandas_refs
+


### PR DESCRIPTION
Categorize APIs into Public APIs and Developer APIs, and sort them alphabetically by service name.

Changes:
- Reorganized loading_data.rst and saving_data.rst with Public APIs first, then Developer APIs
- Sorted all APIs alphabetically by service name within each section
- Sections that originally had APIs for both Public and Developer APIs were divided to respective sections
- Removed datasource.FastFileMetadataProvider API that has been removed ([reference](https://github.com/ray-project/ray/pull/59027))

Fixes #60084

Signed-off-by: mgchoi239 <mg.choi.239@gmail.com>