### PR TITLE
[CI][KubeRay] Update KubeRay CI Tests branch for KubeRay v1.5.1 release

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -66,7 +66,7 @@ steps:
     key: trigger-kuberay
     depends_on: check-ray-commit
     build:
-      branch: "release-1.4"
+      branch: "release-1.5"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
       env:
         # KubeRay CI will pull an image based on this commit and the current date


### PR DESCRIPTION
1. yesterday the Ray + KubeRay auto release pipeline is broken: https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/12548
2. after 
https://github.com/ray-project/kuberay/pull/4372 and this are merged, the pipeline will work again.
