### PR TITLE
[Dashboard] update total for dark mode color

### DIFF
--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
@@ -135,7 +135,7 @@ export const ProgressBar = ({
                     height: 16,
                     borderRadius: "4px",
                     marginRight: 1,
-                    backgroundColor: "black",
+                    backgroundColor: "text.primary",
                   }}
                 />
                 <Typography>Total: {finalTotal}</Typography>
@@ -293,7 +293,7 @@ const LegendTooltip = ({
                   height: 16,
                   borderRadius: "4px",
                   marginRight: 1,
-                  backgroundColor: "black",
+                  backgroundColor: "text.primary",
                 }}
               />
               <Typography>Total: {total}</Typography>


### PR DESCRIPTION
## Description
This updates the "total" color in the legend so it is visible in dark mode by using `text.primary` which will correctly apply the dark or light text color

## Related issues
Follow up to dark mode PR: https://github.com/ray-project/ray/pull/58768

## Additional information
Before:
<img width="244" height="204" alt="Screenshot 2026-01-13 at 10 05 17 AM" src="https://github.com/user-attachments/assets/a1928ae8-3f5d-48a4-b157-e9fc9d2483f1" />
<img width="291" height="139" alt="Screenshot 2026-01-13 at 6 11 50 PM" src="https://github.com/user-attachments/assets/01e18c0e-033d-4a64-a853-c330f86c4e69" />

After:
<img width="261" height="127" alt="Screenshot 2026-01-13 at 6 14 46 PM" src="https://github.com/user-attachments/assets/af31b7aa-d375-4214-9d45-f250bb722a1b" />
<img width="151" height="149" alt="Screenshot 2026-01-13 at 6 15 01 PM" src="https://github.com/user-attachments/assets/25186aa8-fd2b-41b2-adc3-76e43169e674" />

