### PR TITLE
ci: install crane in forge image

### DIFF
--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -100,6 +100,25 @@ if [[ "$(uname -i)" == "x86_64" ]]; then
   bash install-k8s-tools.sh
 fi
 
+# Install crane (container registry tool)
+CRANE_VERSION=0.19.0
+case "$(uname -m)" in
+  x86_64|amd64)
+    CRANE_ARCH="x86_64"
+    ;;
+  aarch64|arm64)
+    CRANE_ARCH="arm64"
+    ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" \
+  | tar -xzf - -C /usr/local/bin crane
+
+chmod +x /usr/local/bin/crane
 EOF
 
 USER forge
@@ -120,4 +139,4 @@ EOF
 CMD ["echo", "ray forge"]
 
 
-# last update: 2025-11-12
+# last update: 2026-01-13


### PR DESCRIPTION
Currently seeing issues of crane not available in the uploading
environment. Default to Docker if crane is not available

https://buildkite.com/ray-project/postmerge/builds/15375/steps/canvas?jid=019bb99d-6f9e-45fa-92e3-a5a1d9373e8d#019bb99d-6f9e-45fa-92e3-a5a1d9373e8d/L198

Topic: crane-fix

Signed-off-by: andrew <andrew@anyscale.com>