### PR TITLE
fix: ecr login in extract_wanda_wheels

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -70,6 +70,7 @@ steps:
       - "3.13"
     depends_on:
       - ray-wheel-build
+      - forge
     tags:
       - release_wheels
       - skip-on-premerge
@@ -114,6 +115,7 @@ steps:
       - ./ci/build/copy_build_artifacts.sh wheel
     depends_on:
       - ray-cpp-wheel-build
+      - forge
     tags:
       - release_wheels
       - skip-on-premerge

--- a/ci/build/extract_wanda_wheels.sh
+++ b/ci/build/extract_wanda_wheels.sh
@@ -21,6 +21,13 @@ WANDA_IMAGE="${RAYCI_WORK_REPO}:${RAYCI_BUILD_ID}-${WANDA_IMAGE_NAME}"
 
 echo "Extracting wheels from: ${WANDA_IMAGE}"
 
+# Login to ECR if not already authenticated
+if ! crane manifest "${WANDA_IMAGE}" &>/dev/null; then
+  ECR_REGISTRY="$(echo "${RAYCI_WORK_REPO}" | cut -d'/' -f1)"
+  aws ecr get-login-password --region us-west-2 | \
+    crane auth login --username AWS --password-stdin "${ECR_REGISTRY}"
+fi
+
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir" || true' EXIT
 


### PR DESCRIPTION
Builds running into errors since we were not logged in.

https://buildkite.com/ray-project/postmerge/builds/15387/steps/canvas?jid=019bbaad-93e8-40e9-aeef-3592bd609f2d#019bbaad-93e8-40e[…]3592bd609f2d/L198

Topic: login-ecr-fix
Signed-off-by: andrew <andrew@anyscale.com>