### PR TITLE
Expose available_resources_per_node as public api

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -110,6 +110,7 @@ from ray._private.state import (  # noqa: E402,F401
     timeline,
     cluster_resources,
     available_resources,
+    available_resources_per_node,
 )
 from ray._private.worker import (  # noqa: E402,F401
     LOCAL_MODE,
@@ -179,6 +180,7 @@ __all__ = [
     "get_runtime_context",
     "autoscaler",
     "available_resources",
+    "available_resources_per_node",
     "cancel",
     "client",
     "ClientBuilder",
@@ -229,6 +231,7 @@ NON_AUTO_INIT_APIS = {
     "_config",
     "autoscaler",
     "available_resources",
+    "available_resources_per_node",
     "client",
     "cluster_resources",
     "cpp_function",

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -1089,6 +1089,7 @@ def available_resources():
 
 
 @DeveloperAPI
+@client_mode_hook
 def available_resources_per_node():
     """Get the current available resources of each live node.
 

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -30,6 +30,7 @@ def test_api_functions():
         "timeline",
         "cluster_resources",
         "available_resources",
+        "available_resources_per_node",
         "java_function",
         "java_actor_class",
         "client",

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -277,6 +277,22 @@ class _ClientAPI:
             ray_client_pb2.ClusterInfoType.AVAILABLE_RESOURCES
         )
 
+    def available_resources_per_node(self):
+        """Get available resources per node in the cluster.
+
+        Returns:
+            A mapping from node id to a resources dict describing the available
+            resources on that node.
+        """
+        # This should be imported here, otherwise, it will error doc build.
+        import ray.core.generated.ray_client_pb2 as ray_client_pb2
+
+        try:
+            typ = ray_client_pb2.ClusterInfoType.AVAILABLE_RESOURCES_PER_NODE
+        except AttributeError:
+            typ = 8
+        return self.worker.get_cluster_info(typ)
+
     def get_runtime_context(self):
         """Return a Ray RuntimeContext describing the state on the server
 

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -258,6 +258,12 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             resp.resource_table.CopyFrom(
                 ray_client_pb2.ClusterInfoResponse.ResourceTable(table=float_resources)
             )
+        elif (
+            request.type == ray_client_pb2.ClusterInfoType.AVAILABLE_RESOURCES_PER_NODE
+        ):
+            with disable_client_hook():
+                resources = ray._private.state.available_resources_per_node()
+            resp.json = json.dumps(resources)
         elif request.type == ray_client_pb2.ClusterInfoType.RUNTIME_CONTEXT:
             ctx = ray_client_pb2.ClusterInfoResponse.RuntimeContext()
             with disable_client_hook():

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -186,6 +186,7 @@ message ClusterInfoType {
     TIMELINE = 5;
     PING = 6;
     DASHBOARD_URL = 7;
+    AVAILABLE_RESOURCES_PER_NODE = 8;
   }
 }
 


### PR DESCRIPTION
## Description
Today it's impossible to get availability from ray cluster. This is problematic especially if you want to write some tooling or monitoring for multi-cluster environment

Let's make `available_resources_per_node` part of public API to fix this.

## Related issues
#60134 

