### PR TITLE
[Serve] Optimize replica routing request data structures

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -26,6 +26,25 @@ class DeploymentID:
     name: str
     app_name: str = SERVE_DEFAULT_APP_NAME
 
+    def __hash__(self):
+        # Lazy hash caching: compute on first access, cache for subsequent calls.
+        # The _hash attribute is excluded from pickling via __getstate__, so after
+        # deserialization it gets recomputed with the correct per-process hash seed.
+        try:
+            return self._hash
+        except AttributeError:
+            h = hash((self.name, self.app_name))
+            object.__setattr__(self, "_hash", h)
+            return h
+
+    def __getstate__(self):
+        # Exclude _hash from pickling - it must be recomputed per-process
+        return {"name": self.name, "app_name": self.app_name}
+
+    def __setstate__(self, state):
+        object.__setattr__(self, "name", state["name"])
+        object.__setattr__(self, "app_name", state["app_name"])
+
     def to_replica_actor_class_name(self):
         return f"ServeReplica:{self.app_name}:{self.name}"
 
@@ -46,6 +65,25 @@ class ReplicaID:
 
     deployment_id: DeploymentID
     """The deployment this replica belongs to."""
+
+    def __hash__(self):
+        # Lazy hash caching: compute on first access, cache for subsequent calls.
+        # The _hash attribute is excluded from pickling via __getstate__, so after
+        # deserialization it gets recomputed with the correct per-process hash seed.
+        try:
+            return self._hash
+        except AttributeError:
+            h = hash((self.unique_id, self.deployment_id))
+            object.__setattr__(self, "_hash", h)
+            return h
+
+    def __getstate__(self):
+        # Exclude _hash from pickling - it must be recomputed per-process
+        return {"unique_id": self.unique_id, "deployment_id": self.deployment_id}
+
+    def __setstate__(self, state):
+        object.__setattr__(self, "unique_id", state["unique_id"])
+        object.__setattr__(self, "deployment_id", state["deployment_id"])
 
     def to_full_id_str(self) -> str:
         s = f"{self.deployment_id.name}#{self.unique_id}"

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -409,6 +409,12 @@ RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S = get_env_float_non_negative(
     "RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S", 10.0
 )
 
+# Minimum interval between router queue length gauge updates per replica.
+# Throttling reduces metrics overhead on the hot path. Set to 0 to disable throttling.
+RAY_SERVE_ROUTER_QUEUE_LEN_GAUGE_THROTTLE_S = get_env_float_non_negative(
+    "RAY_SERVE_ROUTER_QUEUE_LEN_GAUGE_THROTTLE_S", 0.1
+)
+
 # Backoff seconds when choosing router failed, backoff time is calculated as
 # initial_backoff_s * backoff_multiplier ** attempt.
 # The default backoff time is [0, 0.025, 0.05, 0.1, 0.2, 0.4, 0.5, 0.5 ... ].

--- a/python/ray/serve/_private/request_router/pow_2_router.py
+++ b/python/ray/serve/_private/request_router/pow_2_router.py
@@ -79,8 +79,24 @@ class PowerOfTwoChoicesRequestRouter(
         if not candidate_replica_ids:
             return []
 
-        chosen_ids = random.sample(
-            list(candidate_replica_ids),
-            k=min(2, len(candidate_replica_ids)),
-        )
+        # Optimized selection: use direct randrange for k=2 instead of random.sample.
+        # This is ~1.9x faster for the common case of selecting 2 replicas.
+        #
+        # Correctness proof: We pick i uniformly from [0, n), then j uniformly from
+        # [0, n-1) and shift j up if j >= i. Every ordered pair (i, j) with i != j
+        # has probability: Pr(i,j) = 1/n * 1/(n-1) = 1/(n(n-1))
+        # This matches random.sample(k=2): uniform among all 2-permutations.
+        candidates = tuple(candidate_replica_ids)
+        n = len(candidates)
+        if n == 1:
+            chosen_ids = [candidates[0]]
+        elif n == 2:
+            chosen_ids = list(candidates)
+        else:
+            i = random.randrange(n)
+            j = random.randrange(n - 1)
+            if j >= i:
+                j += 1
+            chosen_ids = [candidates[i], candidates[j]]
+
         return [[self._replicas[chosen_id] for chosen_id in chosen_ids]]

--- a/python/ray/serve/_private/request_router/pow_2_router.py
+++ b/python/ray/serve/_private/request_router/pow_2_router.py
@@ -92,7 +92,7 @@ class PowerOfTwoChoicesRequestRouter(
             chosen_ids = [candidates[0]]
         elif n == 2:
             # Randomize order to ensure fair selection when queue lengths are equal
-            if random.randint(0, 1):
+            if random.getrandbits(1):
                 chosen_ids = [candidates[0], candidates[1]]
             else:
                 chosen_ids = [candidates[1], candidates[0]]

--- a/python/ray/serve/_private/request_router/pow_2_router.py
+++ b/python/ray/serve/_private/request_router/pow_2_router.py
@@ -91,7 +91,11 @@ class PowerOfTwoChoicesRequestRouter(
         if n == 1:
             chosen_ids = [candidates[0]]
         elif n == 2:
-            chosen_ids = list(candidates)
+            # Randomize order to ensure fair selection when queue lengths are equal
+            if random.randint(0, 1):
+                chosen_ids = [candidates[0], candidates[1]]
+            else:
+                chosen_ids = [candidates[1], candidates[0]]
         else:
             i = random.randrange(n)
             j = random.randrange(n - 1)

--- a/python/ray/serve/_private/request_router/pow_2_router.py
+++ b/python/ray/serve/_private/request_router/pow_2_router.py
@@ -83,7 +83,4 @@ class PowerOfTwoChoicesRequestRouter(
             list(candidate_replica_ids),
             k=min(2, len(candidate_replica_ids)),
         )
-        replica_id_to_replica_map = {
-            replica.replica_id: replica for replica in candidate_replicas
-        }
-        return [[replica_id_to_replica_map[chosen_id] for chosen_id in chosen_ids]]
+        return [[self._replicas[chosen_id] for chosen_id in chosen_ids]]

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -654,8 +654,17 @@ class RequestRouter(ABC):
 
     @property
     def num_pending_requests(self) -> int:
-        """Current number of requests pending assignment."""
-        return len(self._pending_requests_by_id)
+        """Current number of requests pending assignment.
+
+        This uses the deque length rather than the dict length because the deque
+        uses lazy cleanup - fulfilled requests are only removed from the front
+        of the deque, not immediately when fulfilled. This intentionally keeps
+        the count higher, which keeps routing tasks alive longer to handle
+        incoming requests without the overhead of constantly stopping/restarting
+        tasks. Maybe it is possible to use the dict length instead, but it would
+        require rethinking the routing task termination logic.
+        """
+        return len(self._pending_requests_to_fulfill)
 
     @property
     def curr_num_routing_tasks(self) -> int:

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -1247,7 +1247,6 @@ class RequestRouter(ABC):
             if not is_retry:
                 self._pending_requests_to_fulfill.append(pending_request)
                 self._pending_requests_to_route.append(pending_request)
-                self._add_pending_request_to_indices(pending_request)
             else:
                 # Retry path: insert at correct position to maintain sorted order by
                 # created_at. Uses optimized helper that is O(1) for common case (recent
@@ -1259,8 +1258,8 @@ class RequestRouter(ABC):
                 self._insert_pending_request_sorted(
                     self._pending_requests_to_route, pending_request
                 )
-                self._add_pending_request_to_indices(pending_request)
 
+            self._add_pending_request_to_indices(pending_request)
             self._maybe_start_routing_tasks()
             replica = await pending_request.future
         except asyncio.CancelledError as e:

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -733,12 +733,14 @@ class RequestRouter(ABC):
         self._replicas.pop(replica_id, None)
         self._replicas_list = list(self._replicas.values())
         self._replica_id_set.discard(replica_id)
+        self._queue_len_gauge_last_update.pop(replica_id, None)
         if hasattr(self, "_discard_colocated_replica_ids_on_replica_actor_died"):
             self._discard_colocated_replica_ids_on_replica_actor_died(replica_id)
 
     def on_replica_actor_unavailable(self, replica_id: ReplicaID):
         """Invalidate cache entry so active probing is required for the next request."""
         self._replica_queue_len_cache.invalidate_key(replica_id)
+        self._queue_len_gauge_last_update.pop(replica_id, None)
 
     def _add_pending_request_to_indices(self, pending_request: PendingRequest):
         """Add a pending request to the dict indices for O(1) lookups."""

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -732,6 +732,9 @@ class RequestRouter(ABC):
     def _add_pending_request_to_indices(self, pending_request: PendingRequest):
         """Add a pending request to the dict indices for O(1) lookups."""
         internal_id = pending_request.metadata.internal_request_id
+        if internal_id in self._pending_requests_by_id:
+            # Retry path: avoid duplicating entries (especially for model_id lists).
+            return
         self._pending_requests_by_id[internal_id] = pending_request
         model_id = pending_request.metadata.multiplexed_model_id
         if model_id:

--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -1864,10 +1864,6 @@ async def test_locality_aware_backoff_skips_sleeps(pow_2_router):
     the same zone, it should not sleep before retrying and add additional latency.
     """
     s = pow_2_router
-
-    # Track the candidate replicas returned by apply_locality_routing at each step.
-    # We wrap apply_locality_routing instead of random.sample because the pow_2_router
-    # uses optimized random selection that doesn't call random.sample.
     original_apply_locality_routing = s.apply_locality_routing
     chosen_replicas = []
 


### PR DESCRIPTION
1. **O(1) Pending Request Lookups**
   - Added dict indices (`_pending_requests_by_id` and `_pending_requests_by_model_id`) for fast lookups
   - Replaced O(n) linear scans with O(1) dict lookups when finding requests by ID or multiplexed model

2. **Cached Replica List**
   - Added `_replicas_list` cache to avoid O(n) dict-to-list conversion on every routing iteration
   - List updated only when replicas change via `update_replicas()` or `on_replica_actor_died()`

3. **Lazy Cleanup Strategy**
   - Done futures are lazily cleaned from `_pending_requests_by_model_id` during lookups using O(1) `popleft()` 
   - Avoids expensive O(n) removal from deques

4. **Optimized Retry Insertion**
   - Extracted sorted insertion logic into `_insert_pending_request_sorted()` helper
   - O(1) fast path for common case (recent retries append to end)

5. **Simplified `pow_2_router`**
   - Removed redundant dict creation per routing call
   - Direct lookup via `self._replicas[chosen_id]` instead of building temporary map



<img width="1281" height="790" alt="image" src="https://github.com/user-attachments/assets/065102e7-739e-47ad-b3cc-60651f455611" />


1. **`random.sample` → Direct Selection**
2. **Lazy Hash Caching** (`common.py`)
3. **Metrics Throttling** (`request_router.py`, `constants.py`)

<img width="1246" height="698" alt="image" src="https://github.com/user-attachments/assets/6b21a7e4-0c3e-42b5-80bb-5e20cc8acc61" />

flamegraph of the router after all the optimization
<img width="3015" height="457" alt="image" src="https://github.com/user-attachments/assets/0f8cf8ec-caf6-420d-bc8c-a8fcdca0c56a" />
