### PR TITLE
[Data][LLM] Remove DataContext overrides in Ray Data LLM Processor

### DIFF
--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from pydantic import Field, field_validator, model_validator
 
-import ray
 from ray.data import Dataset
 from ray.data.block import UserDefinedFunction
 from ray.llm._internal.batch.stages import (
@@ -330,11 +329,6 @@ class Processor:
         self.preprocess_map_kwargs = preprocess_map_kwargs or {}
         self.postprocess_map_kwargs = postprocess_map_kwargs or {}
         self.stages: OrderedDict[str, StatefulStage] = OrderedDict()
-
-        # TODO: Remove this when https://github.com/ray-project/ray/issues/53169
-        # is fixed.
-        data_context = ray.data.DataContext.get_current()
-        data_context._enable_actor_pool_on_exit_hook = True
 
         # NOTE (Kourosh): If pre/postprocess is not provided, use the identity function.
         # Wrapping is required even if they are identity functions, b/c data_column

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -331,12 +331,9 @@ class Processor:
         self.postprocess_map_kwargs = postprocess_map_kwargs or {}
         self.stages: OrderedDict[str, StatefulStage] = OrderedDict()
 
-        # FIXES: https://github.com/ray-project/ray/issues/53124
-        # TODO (Kourosh): Remove this once the issue is fixed
-        data_context = ray.data.DataContext.get_current()
-        data_context.wait_for_min_actors_s = 600
         # TODO: Remove this when https://github.com/ray-project/ray/issues/53169
         # is fixed.
+        data_context = ray.data.DataContext.get_current()
         data_context._enable_actor_pool_on_exit_hook = True
 
         # NOTE (Kourosh): If pre/postprocess is not provided, use the identity function.

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_no_blocking.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_no_blocking.py
@@ -4,6 +4,8 @@ Test that Ray Data LLM does not override wait_for_min_actors_s.
 With default settings (wait_for_min_actors_s <= 0), processing starts
 as soon as any actor is ready, regardless of concurrency config.
 """
+import sys
+
 import pytest
 
 from ray.data import DataContext
@@ -90,3 +92,7 @@ class TestConcurrencyConfigPassthrough:
         assert (
             compute.max_size == expected_max_size
         ), f"Expected max_size={expected_max_size}, got {compute.max_size}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_no_blocking.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_no_blocking.py
@@ -1,0 +1,92 @@
+"""
+Test that Ray Data LLM does not override wait_for_min_actors_s.
+
+With default settings (wait_for_min_actors_s <= 0), processing starts
+as soon as any actor is ready, regardless of concurrency config.
+"""
+import pytest
+
+from ray.data import DataContext
+from ray.llm._internal.batch.processor import ProcessorBuilder
+from ray.llm._internal.batch.processor.vllm_engine_proc import vLLMEngineProcessorConfig
+
+
+@pytest.fixture(autouse=True)
+def reset_data_context():
+    """Reset DataContext before and after each test."""
+    ctx = DataContext.get_current()
+    original_value = ctx.wait_for_min_actors_s
+    ctx.wait_for_min_actors_s = -1
+    yield
+    ctx.wait_for_min_actors_s = original_value
+
+
+class TestWaitForMinActorsNotOverridden:
+    """Test that Processor does not override wait_for_min_actors_s."""
+
+    def test_processor_does_not_override_default(self):
+        """Processor should not change wait_for_min_actors_s from default."""
+        ctx = DataContext.get_current()
+        ctx.wait_for_min_actors_s = -1
+
+        config = vLLMEngineProcessorConfig(
+            model_source="facebook/opt-125m",
+            concurrency=4,
+        )
+        ProcessorBuilder.build(config)
+
+        assert ctx.wait_for_min_actors_s == -1
+
+    @pytest.mark.parametrize("user_value", [60, 600, 1800])
+    def test_processor_preserves_user_setting(self, user_value):
+        """Processor should preserve user-set wait_for_min_actors_s."""
+        ctx = DataContext.get_current()
+        ctx.wait_for_min_actors_s = user_value
+
+        config = vLLMEngineProcessorConfig(
+            model_source="facebook/opt-125m",
+            concurrency=4,
+        )
+        ProcessorBuilder.build(config)
+
+        assert ctx.wait_for_min_actors_s == user_value
+
+
+class TestConcurrencyConfigPassthrough:
+    """
+    Test that concurrency config correctly sets ActorPoolStrategy.
+
+    This determines blocking behavior when wait_for_min_actors_s > 0:
+    - concurrency=N → min_size=N → blocks for N actors
+    - concurrency=(1, N) → min_size=1 → blocks for 1 actor
+    """
+
+    @pytest.mark.parametrize(
+        "concurrency,expected_min_size,expected_max_size",
+        [
+            (4, 4, 4),  # int: fixed pool
+            ((1, 4), 1, 4),  # tuple: autoscaling pool
+            ((2, 8), 2, 8),  # tuple: custom min
+        ],
+        ids=["int_concurrency", "tuple_1_to_n", "tuple_custom_min"],
+    )
+    def test_concurrency_to_actor_pool_strategy(
+        self, concurrency, expected_min_size, expected_max_size
+    ):
+        """Verify concurrency config maps to correct ActorPoolStrategy."""
+        config = vLLMEngineProcessorConfig(
+            model_source="facebook/opt-125m",
+            concurrency=concurrency,
+        )
+        processor = ProcessorBuilder.build(config)
+
+        # Get the vLLM stage and check its compute strategy
+        stage = processor.get_stage_by_name("vLLMEngineStage")
+        compute = stage.map_batches_kwargs.get("compute")
+
+        assert (
+            compute.min_size == expected_min_size
+        ), f"Expected min_size={expected_min_size}, got {compute.min_size}"
+        assert (
+            compute.max_size == expected_max_size
+        ), f"Expected max_size={expected_max_size}, got {compute.max_size}"


### PR DESCRIPTION
## Summary

Remove two DataContext workarounds in Ray Data LLM that are no longer needed:

1. **Remove `wait_for_min_actors_s = 600` override** (issue #53124 closed)
2. **Remove `_enable_actor_pool_on_exit_hook = True` override** (issue #53169 closed)

## Behavior Change

Previously, Ray Data LLM hardcoded `wait_for_min_actors_s = 600`, which caused blocking behavior:
- `concurrency=N`: blocked until all N actors were ready
- `concurrency=(1, N)`: blocked until 1 actor was ready

After this change, `wait_for_min_actors_s` stays at default (-1), so:
- No blocking occurs regardless of concurrency config
- Processing starts as soon as any actor is ready
- Users can still set `wait_for_min_actors_s` manually if they want blocking/timeout behavior

Related
* https://github.com/ray-project/ray/pull/52754
* https://github.com/ray-project/ray/issues/59522
* https://github.com/ray-project/ray/issues/60124

## Reproduction / Proof

See: https://gist.github.com/nrghosh/68d63040e92b82987c67e4dee6c8f40f

## Test Plan

- Added tests verifying Processor does not override `wait_for_min_actors_s`
- Added tests verifying concurrency config correctly maps to ActorPoolStrategy