### PR TITLE
fix: crane_lib raises exceptions on failure

### DIFF
--- a/ci/ray_ci/automation/copy_wanda_image.py
+++ b/ci/ray_ci/automation/copy_wanda_image.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone as tz
 import click
 
 from ci.ray_ci.automation.crane_lib import (
+    CraneError,
     call_crane_copy,
     call_crane_manifest,
 )
@@ -55,8 +56,11 @@ def _generate_destination_tag(commit: str, tag_suffix: str) -> str:
 
 def _image_exists(tag: str) -> bool:
     """Check if a container image manifest exists using crane."""
-    return_code, _ = call_crane_manifest(tag)
-    return return_code == 0
+    try:
+        call_crane_manifest(tag)
+        return True
+    except CraneError:
+        return False
 
 
 def _copy_image(source: str, destination: str, dry_run: bool = False) -> None:
@@ -66,9 +70,7 @@ def _copy_image(source: str, destination: str, dry_run: bool = False) -> None:
         return
 
     logger.info(f"Copying {source} -> {destination}")
-    return_code, output = call_crane_copy(source, destination)
-    if return_code != 0:
-        raise CopyWandaImageError(f"Crane copy failed: {output}")
+    call_crane_copy(source, destination)
     logger.info(f"Successfully copied to {destination}")
 
 

--- a/ci/ray_ci/automation/extract_wanda_wheels.py
+++ b/ci/ray_ci/automation/extract_wanda_wheels.py
@@ -71,10 +71,7 @@ def main(
     ecr_docker_login(ecr_registry)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        rc, output = call_crane_export(wanda_image, tmpdir)
-        if rc != 0:
-            raise ExtractWandaWheelsError(f"Crane export failed: {output}")
-
+        call_crane_export(wanda_image, tmpdir)
         wheels = list(Path(tmpdir).rglob("*.whl"))
         for wheel in wheels:
             shutil.move(wheel, output_path / wheel.name)

--- a/ci/ray_ci/automation/test_docker_tags_lib.py
+++ b/ci/ray_ci/automation/test_docker_tags_lib.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 import requests
 
-from ci.ray_ci.automation.crane_lib import call_crane_copy
+from ci.ray_ci.automation.crane_lib import CraneError, call_crane_copy
 from ci.ray_ci.automation.docker_tags_lib import (
     AuthTokenException,
     DockerHubRateLimitException,
@@ -251,10 +251,7 @@ def test_is_release_tag(tag, release_versions, expected_value):
 @mock.patch("ci.ray_ci.automation.docker_tags_lib.call_crane_copy")
 def test_copy_tag_to_aws_ecr(mock_call_crane_cp):
     tag = "test_namespace/test_repository:test_tag"
-    mock_call_crane_cp.return_value = (
-        0,
-        "aws-ecr/name/repo:test_tag: digest: sha256:sample-sha256 size: 1788",
-    )
+    mock_call_crane_cp.return_value = None  # Success (no exception)
 
     is_copied = copy_tag_to_aws_ecr(tag, "aws-ecr/name/repo")
     mock_call_crane_cp.assert_called_once_with(
@@ -267,7 +264,7 @@ def test_copy_tag_to_aws_ecr(mock_call_crane_cp):
 @mock.patch("ci.ray_ci.automation.docker_tags_lib.call_crane_copy")
 def test_copy_tag_to_aws_ecr_failure(mock_call_crane_cp):
     tag = "test_namespace/test_repository:test_tag"
-    mock_call_crane_cp.return_value = (1, "Error: Failed to copy tag.")
+    mock_call_crane_cp.side_effect = CraneError("Failed to copy tag.")
 
     is_copied = copy_tag_to_aws_ecr(tag, "aws-ecr/name/repo")
     mock_call_crane_cp.assert_called_once_with(


### PR DESCRIPTION
Move away from go-approach and into Pythonic
exception-raise approach

Topic: refactor-crane-lib
Relative: port-extract-wheel

Signed-off-by: andrew <andrew@anyscale.com>