### PR TITLE
[train] only run gpu train tests on air/train/tune changes

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -261,6 +261,7 @@ steps:
       - python
       - dashboard
       - oss
+      - min_build
     instance_type: medium
     commands:
       # validate minimal installation

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -74,7 +74,7 @@ steps:
 
   - label: ":bullettrain_front: ml: train v2 gpu tests"
     tags:
-      - train
+      - train_gpu
       - gpu
     instance_type: gpu-large
     commands:
@@ -107,7 +107,7 @@ steps:
 
   - label: ":train: ml: train v1 gpu tests"
     tags:
-      - train
+      - train_gpu
       - gpu
     instance_type: gpu-large
     parallelism: 2
@@ -121,7 +121,7 @@ steps:
   - label: ":train: ml: train gpu {{matrix.python}} tests ({{matrix.worker_id}})"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
-      - train
+      - train_gpu
       - gpu
     instance_type: gpu-large
     commands:
@@ -224,7 +224,9 @@ steps:
     depends_on: [ "mlbuild-multipy", "forge" ]
 
   - label: ":train: ml: train minimal"
-    tags: train
+    tags:
+      - train
+      - min_build
     instance_type: small
     commands:
       - python ./ci/env/check_minimal_install.py
@@ -260,7 +262,7 @@ steps:
 
   - label: ":train: ml: train gpu lightning 2.0 tests"
     tags:
-      - train
+      - train_gpu
       - gpu
     instance_type: gpu-large
     commands:

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -152,7 +152,10 @@ steps:
     depends_on: servebuild-multipy
 
   - label: ":ray-serve: serve: default minimal"
-    tags: python
+    tags:
+      - python
+      - serve
+      - min_build
     instance_type: small
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/dashboard/... serve
@@ -165,8 +168,9 @@ steps:
 
   - label: ":ray-serve: serve: serve minimal"
     tags:
-      - serve
       - python
+      - serve
+      - min_build
     instance_type: small
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests/... serve

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -10,11 +10,11 @@ ci/pipeline/test_conditional_testing.py: tools
 # === Ray Libraries ===
 
 python/ray/data/__init__.py: data ml train
-python/ray/air/__init__.py: ml train tune data linux_wheels
+python/ray/air/__init__.py: ml train train_gpu tune data linux_wheels
 python/ray/llm/llm.py: llm
 python/ray/workflow/workflow.py: workflow
 python/ray/tune/tune.py: ml train tune linux_wheels
-python/ray/train/train.py: ml train linux_wheels
+python/ray/train/train.py: ml train train_gpu linux_wheels
 python/ray/serve/serve.py: serve linux_wheels java
 python/ray/dashboard/dashboard.py: dashboard linux_wheels python
 
@@ -31,18 +31,23 @@ rllib/rllib.py: rllib rllib_gpu rllib_directly
 # === Python Core ===
 
 python/core.py: ml tune train data python dashboard linux_wheels macos_wheels java
-python/setup.py: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies
-python/requirements/test-requirements.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies
+python/setup.py: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
+python/requirements/test-requirements.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
 python/_raylet.pyx: ml tune train data python dashboard linux_wheels macos_wheels java
 
 # === Buildkite Configs ===
 
-.buildkite/ml.rayci.yml: ml train tune
+.buildkite/ml.rayci.yml: ml train train_gpu tune
 .buildkite/core.rayci.yml: python core_cpp
 .buildkite/others.rayci.yml: java
 .buildkite/lint.rayci.yml: tools
 .buildkite/macos.rayci.yml: macos_wheels
 .buildkite/base.rayci.yml: docker linux_wheels tools
+
+# === Min installation ===
+
+ci/docker/min.build.Dockerfile: min_build
+ci/docker/min.build.wanda.yaml: min_build
 
 # === Java/C++ ===
 

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -16,12 +16,12 @@
 ! always lint
 ! python cpp core_cpp java workflow cgraphs_direct_transport dashboard
 ! ray_client runtime_env_container
-! data dask serve ml tune train llm rllib rllib_gpu rllib_directly
-! linux_wheels macos_wheels docker doc python_dependencies tools
+! data dask serve ml tune train train_gpu llm rllib rllib_gpu rllib_directly
+! linux_wheels macos_wheels docker doc python_dependencies min_build tools
 ! release_tests spark_on_ray
 
 python/ray/air/
-@ ml train tune data linux_wheels
+@ ml train train_gpu tune data linux_wheels
 ;
 
 python/ray/llm/
@@ -51,19 +51,20 @@ python/ray/tune/
 ;
 
 python/ray/train/
-@ ml train linux_wheels
+@ ml train train_gpu linux_wheels
 ;
 
 .buildkite/ml.rayci.yml
-.buildkite/pipeline.test.yml
-ci/docker/ml.build.Dockerfile
-.buildkite/pipeline.gpu.yml
-.buildkite/pipeline.gpu_large.yml
 ci/docker/ml.build.wanda.yaml
+ci/docker/mllightning2gpu.build.wanda.yaml
+ci/docker/ml.build.Dockerfile
 ci/ray_ci/ml.tests.yml
+@ ml train train_gpu tune
+;
+
 ci/docker/min.build.Dockerfile
 ci/docker/min.build.wanda.yaml
-@ ml train tune
+@ min_build
 ;
 
 rllib/
@@ -87,7 +88,7 @@ python/setup.py
 python/requirements.txt
 python/requirements_compiled.txt
 python/requirements/
-@ ml tune train serve workflow data
+@ ml tune train serve workflow data min_build
 @ python dashboard linux_wheels macos_wheels java
 @ python_dependencies
 ;


### PR DESCRIPTION
so that generic changes to ray python code will not trigger expensive GPU tests

also separates out min-build as its own tag.