### PR TITLE
[Data] DownstreamCapacityBackpressure - Handle preserve_order

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
@@ -90,7 +90,13 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
     # Threshold for per-Op object store budget utilization vs total
     # (utilization / total) ratio to enable downstream capacity backpressure.
     OBJECT_STORE_BUDGET_UTIL_THRESHOLD = env_float(
-        "RAY_DATA_DOWNSTREAM_CAPACITY_OBJECT_STORE_BUDGET_UTIL_THRESHOLD", 0.9
+        "RAY_DATA_DOWNSTREAM_CAPACITY_OBJECT_STORE_BUDGET_UTIL_THRESHOLD", 0.75
+    )
+
+    # Threshold for per-Op object store budget utilization vs total
+    # (utilization / total) ratio to record baseline task index gap.
+    OBJECT_STORE_BUDGET_UTIL_BASELINE_THRESHOLD = env_float(
+        "RAY_DATA_DOWNSTREAM_CAPACITY_OBJECT_STORE_BUDGET_UTIL_BASELINE_THRESHOLD", 0.1
     )
 
     # Threshold for per-Op object store budget utilization vs total

--- a/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
@@ -115,7 +115,7 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
         )
         self._preserve_order = self._data_context.execution_options.preserve_order
         # Per-operator baseline task index gap recorded when budget threshold first hit
-        self._baseline_task_index_gap: dict["PhysicalOperator", int] = {}
+        self._baseline_task_index_gap: Dict["PhysicalOperator", int] = {}
         if self._backpressure_capacity_ratio is not None:
             logger.debug(
                 f"DownstreamCapacityBackpressurePolicy enabled with backpressure capacity ratio: {self._backpressure_capacity_ratio}"
@@ -201,7 +201,7 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
         if self._preserve_order:
             gap = self._get_task_index_gap(op)
             baseline = self._baseline_task_index_gap.get(op, 0)
-            if gap > baseline and baseline >= 0:
+            if gap > baseline:
                 # Gap has grown beyond baseline: reduce threshold exponentially
                 # gap_growth=1: threshold / 2, gap_growth=2: threshold / 4, etc.
                 gap_growth = gap - baseline
@@ -287,11 +287,11 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
                 gap = self._get_task_index_gap(op)
                 baseline = self._baseline_task_index_gap.get(op, 0)
                 gap_growth = max(0, gap - baseline)
-                if gap_growth > 0 and downstream_capacity > 0:
+                if gap_growth > 0:
                     # Reduce capacity exponentially: growth=1 → 50%, growth=2 → 25%
                     return int(max(1, downstream_capacity // (2 ** gap_growth)))
                 # No gap growth or no capacity info: allow full downstream capacity
-                return int(downstream_capacity) if downstream_capacity > 0 else None
+                return int(downstream_capacity)
             else:
                 # No backpressure: still limit to downstream capacity
                 if downstream_capacity > 0:

--- a/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
@@ -99,12 +99,6 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
         "RAY_DATA_DOWNSTREAM_CAPACITY_OBJECT_STORE_BUDGET_UTIL_BASELINE_THRESHOLD", 0.1
     )
 
-    # Threshold for per-Op object store budget utilization vs total
-    # (utilization / total) ratio to record baseline task index gap.
-    OBJECT_STORE_BUDGET_UTIL_BASELINE_THRESHOLD = env_float(
-        "RAY_DATA_DOWNSTREAM_CAPACITY_OBJECT_STORE_BUDGET_UTIL_BASELINE_THRESHOLD", 0.1
-    )
-
     @property
     def name(self) -> str:
         return "DownstreamCapacity"


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.


### [Data] DownstreamCapacityBackpressure - Handle preserve_order

In `max_task_output_bytes_to_read`, when preserve_order is enabled and backpressure is applied, returns a reduced bytes to read to allow earlier tasks to make progress. Earlier tasks must complete for their outputs to be consumed, so blocking completely would prevent progress.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
