### PR TITLE
[CORE] Add wait after killing redis process in test cleanup

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -38,6 +38,7 @@ from ray._private import (
     ray_constants,
 )
 from ray._private.internal_api import memory_summary
+from ray._private.services import ProcessInfo
 from ray._private.tls_utils import generate_self_signed_tls_certs
 from ray._private.worker import RayContext
 from ray._raylet import Config, GcsClient, GcsClientOptions, GlobalStateAccessor
@@ -496,6 +497,31 @@ def kill_process_by_name(name, SIGKILL=False):
                 p.kill()
             else:
                 p.terminate()
+
+
+def kill_processes(process_infos: List[ProcessInfo]):
+    """
+    Forcefully kills the list of given processes.
+    Ignores processes that are already dead.
+
+    Args:
+        process_infos: The list of ProcessInfo representing the processes to kill.
+
+    Raises:
+        TimeoutError: If the process did not exit within 5 seconds.
+    """
+    for process_info in process_infos:
+        try:
+            process_info.process.kill()
+            process_info.process.wait(timeout=5)
+        except ProcessLookupError:
+            # Process already dead
+            pass
+        except subprocess.TimeoutExpired as exception:
+            raise TimeoutError(
+                f"Process {process_info.process.pid} did not exit within 5 seconds "
+                "after SIGKILL"
+            ) from exception
 
 
 def run_string_as_driver(driver_script: str, env: Dict = None, encode: str = "utf-8"):

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -33,6 +33,7 @@ from ray._private.authentication_test_utils import (
 )
 from ray._private.conftest_utils import set_override_dashboard_url  # noqa: F401
 from ray._private.runtime_env import virtualenv_utils
+from ray._private.services import ProcessInfo
 from ray._private.test_utils import (
     RayletKiller,
     external_redis_test_enabled,
@@ -407,24 +408,55 @@ def start_redis(db_dir):
         return address_str, processes
 
 
-def kill_all_redis_server():
+def kill_all_redis_server(process_infos: List[ProcessInfo] = None):
+    """
+    Kill all given process infos if provided.
+    Otherwise, find all redis server processes running on this host via cmdline
+    and kill them.
+    Note: killed redis process not tracked by process_infos will
+          raise ResourceWarning when the python Subprocess tracking the
+          underlying process is garbage collected.
+
+    Args:
+        process_infos: The list of ProcessInfo objects to kill.
+    """
     import psutil
 
-    # Find Redis server processes
-    redis_procs = []
-    for proc in psutil.process_iter(["name", "cmdline"]):
-        try:
-            if proc.name() == "redis-server":
-                redis_procs.append(proc)
-        except psutil.NoSuchProcess:
-            pass
+    if process_infos is not None:
+        # Try gracefully killing the spawned subprocesses first
+        for process_info in process_infos:
+            try:
+                process_info.process.kill()
+                process_info.process.wait(timeout=5)
+            except OSError:
+                # Process already dead
+                pass
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    f"Redis server process {process_info.process.pid} did not exit within 5 seconds "
+                    "after SIGKILL during test cleanup"
+                )
+    else:
+        # Find and kill all Redis server processes on host
+        redis_procs = []
+        for proc in psutil.process_iter(["name", "cmdline"]):
+            try:
+                if proc.name() == "redis-server":
+                    redis_procs.append(proc)
+            except psutil.NoSuchProcess:
+                pass
 
-    # Kill Redis server processes
-    for proc in redis_procs:
-        try:
-            proc.kill()
-        except psutil.NoSuchProcess:
-            pass
+        for proc in redis_procs:
+            try:
+                proc.kill()
+                proc.wait(timeout=5)
+            except psutil.NoSuchProcess:
+                pass
+            except psutil.TimeoutExpired:
+                logger.warning(
+                    f"Redis server process {proc.pid} did not exit within 5 seconds "
+                    "after SIGKILL during test cleanup"
+                )
 
 
 @contextmanager
@@ -455,9 +487,7 @@ def _setup_redis(request, with_sentinel=False):
         else:
             del os.environ["RAY_external_storage_namespace"]
 
-        for proc in processes:
-            proc.process.kill()
-        kill_all_redis_server()
+        kill_all_redis_server(processes)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
The `python redis test` is failing with high probability in testing due to `test_network_partial_failures` catching a "subprocess is still running" resource warning when it expects no warnings to be thrown. 

Investigation showed that existing kill redis server logic during test cleanup does not wait for the redis server process to die before moving onto the next test, causing the resource warning we observed above. This PR addresses this issue by adding wait to ensure that the redis server is fully cleaned up before moving to the proceeding test during redis test cleanup step.

## Related issues
Fixes failing `test_network_partial_failures` in CI automated tests.

## Additional information
Example of the fix passing `test_network_partial_failures` in post merge: https://buildkite.com/ray-project/postmerge/builds/15416#_
