### PR TITLE
[Core] Support Alternative runtime_env packaging options

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -490,7 +490,7 @@ API Reference
 
 The ``runtime_env`` is a Python dictionary or a Python class :class:`ray.runtime_env.RuntimeEnv <ray.runtime_env.RuntimeEnv>` including one or more of the following fields:
 
-- ``working_dir`` (str): Specifies the working directory for the Ray workers. This must either be (1) an local existing directory with total size at most 500 MiB, (2) a local existing zipped file with total unzipped size at most 500 MiB (Note: ``excludes`` has no effect), or (3) a URI to a remotely-stored zip file containing the working directory for your job (no file size limit is enforced by Ray). See :ref:`remote-uris` for details.
+- ``working_dir`` (str): Specifies the working directory for the Ray workers. This must either be (1) an local existing directory with total size at most 500 MiB, (2) a local existing compressed archive (``.zip``, ``.tar``, ``.tar.gz``, ``.tgz``, ``.tar.zst``, ``.tzst``) with total uncompressed size at most 500 MiB (Note: ``excludes`` has no effect), or (3) a URI to a remotely-stored archive containing the working directory for your job (no file size limit is enforced by Ray). See :ref:`remote-uris` for details.
   The specified directory will be downloaded to each node on the cluster, and Ray workers will be started in their node's copy of this directory.
 
   - Examples
@@ -806,7 +806,7 @@ Remote URIs
 The ``working_dir`` and ``py_modules`` arguments in the ``runtime_env`` dictionary can specify either local path(s) or remote URI(s).
 
 A local path must be a directory path. The directory's contents will be directly accessed as the ``working_dir`` or a ``py_module``.
-A remote URI must be a link directly to a zip file or a wheel file (only for ``py_module``). **The zip file must contain only a single top-level directory.**
+A remote URI must be a link directly to a zip or tar archive (or a wheel file for ``py_module``). **The archive must contain only a single top-level directory.**
 The contents of this directory will be directly accessed as the ``working_dir`` or a ``py_module``.
 
 For example, suppose you want to use the contents in your local ``/some_path/example_dir`` directory as your ``working_dir``.
@@ -818,25 +818,31 @@ If you want to specify this directory as a local path, your ``runtime_env`` dict
   runtime_env = {..., "working_dir": "/some_path/example_dir", ...}
 
 Suppose instead you want to host your files in your ``/some_path/example_dir`` directory remotely and provide a remote URI.
-You would need to first compress the ``example_dir`` directory into a zip file.
+You would need to first compress the ``example_dir`` directory into a zip or tar archive.
 
-There should be no other files or directories at the top level of the zip file, other than ``example_dir``.
+There should be no other files or directories at the top level of the archive, other than ``example_dir``.
 You can use the following command in the Terminal to do this:
 
 .. code-block:: bash
 
     cd /some_path
     zip -r zip_file_name.zip example_dir
+    tar -cf tar_file_name.tar example_dir
+    tar -I zstd -cf tar_file_name.tar.zst example_dir
+    # If your tar does not support -I (GNU tar), use:
+    # tar -cf - example_dir | zstd > tar_file_name.tar.zst
 
-Note that this command must be run from the *parent directory* of the desired ``working_dir`` to ensure that the resulting zip file contains a single top-level directory.
-In general, the zip file's name and the top-level directory's name can be anything.
+Note that this command must be run from the *parent directory* of the desired ``working_dir`` to ensure that the resulting archive contains a single top-level directory.
+In general, the archive's name and the top-level directory's name can be anything.
 The top-level directory's contents will be used as the ``working_dir`` (or ``py_module``).
 
-You can check that the zip file contains a single top-level directory by running the following command in the Terminal:
+You can check that the archive contains a single top-level directory by running the following command in the Terminal:
 
 .. code-block:: bash
 
   zipinfo -1 zip_file_name.zip
+
+For tar archives, you can use ``tar -tf archive.tar`` (or ``tar -tf archive.tar.gz`` / ``archive.tar.zst``) to inspect the top-level entries.
   # example_dir/
   # example_dir/my_file_1.txt
   # example_dir/subdir/my_file_2.txt

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -1205,6 +1205,16 @@ def _safe_extract_tar(
         if not _is_within_directory(target_dir, member_path):
             logger.warning(f"Skipping unsafe path in tar: {member.name}")
             continue
+        if member.issym() or member.islnk():
+            link_target = os.path.join(os.path.dirname(member_path), member.linkname)
+            if not _is_within_directory(target_dir, link_target):
+                logger.warning(
+                    f"Skipping unsafe symlink in tar: {member.name} -> {member.linkname}"
+                )
+                continue
+        elif member.isdev():
+            logger.warning(f"Skipping device file in tar: {member.name}")
+            continue
         tar.extract(member, _to_extended_length_path(target_dir))
 
 

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -1205,11 +1205,18 @@ def _safe_extract_tar(
         if not _is_within_directory(target_dir, member_path):
             logger.warning(f"Skipping unsafe path in tar: {member.name}")
             continue
-        if member.issym() or member.islnk():
+        if member.issym():
             link_target = os.path.join(os.path.dirname(member_path), member.linkname)
             if not _is_within_directory(target_dir, link_target):
                 logger.warning(
                     f"Skipping unsafe symlink in tar: {member.name} -> {member.linkname}"
+                )
+                continue
+        elif member.islnk():
+            link_target = os.path.join(target_dir, member.linkname)
+            if not _is_within_directory(target_dir, link_target):
+                logger.warning(
+                    f"Skipping unsafe hard link in tar: {member.name} -> {member.linkname}"
                 )
                 continue
         elif member.isdev():

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -832,7 +832,11 @@ def upload_package_if_needed(
 def get_local_dir_from_uri(uri: str, base_directory: str) -> Path:
     """Return the local directory corresponding to this URI."""
     pkg_file = Path(_get_local_path(base_directory, uri))
-    local_dir = pkg_file.with_suffix("")
+    extension = _get_package_extension(pkg_file)
+    if extension:
+        local_dir = pkg_file.with_name(pkg_file.name[: -len(extension)])
+    else:
+        local_dir = pkg_file.with_suffix("")
     return local_dir
 
 

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -1175,10 +1175,16 @@ def get_top_level_dir_from_tar(package_path: str):
             if not name or name == ".":
                 continue
             parts = name.split("/", 1)
-            if len(parts) == 1:
-                return None
             dir_name = parts[0]
             if dir_name == MAC_OS_ZIP_HIDDEN_DIR_NAME:
+                continue
+            if len(parts) == 1:
+                if not member.isdir():
+                    return None
+                if top_level_directory is None:
+                    top_level_directory = dir_name
+                elif dir_name != top_level_directory:
+                    return None
                 continue
             if top_level_directory is None:
                 top_level_directory = dir_name
@@ -1203,7 +1209,7 @@ def _safe_extract_tar(
 ) -> None:
     for member in tar.getmembers():
         name = _normalize_tar_member_name(member.name)
-        if not name:
+        if not name or name == ".":
             continue
         member_path = os.path.join(target_dir, name)
         if not _is_within_directory(target_dir, member_path):

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -430,7 +430,13 @@ def test_http_bad_request(job_sdk_client):
 
 def test_invalid_runtime_env(job_sdk_client):
     client = job_sdk_client
-    with pytest.raises(ValueError, match="Only .zip files supported"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Only .zip, .tar, .tar.gz, .tgz, .tar.zst, or .tzst files "
+            "supported for remote URIs."
+        ),
+    ):
         client.submit_job(
             entrypoint="echo hello", runtime_env={"working_dir": "s3://not_a_zip"}
         )

--- a/python/ray/tests/unit/test_runtime_env_validation.py
+++ b/python/ray/tests/unit/test_runtime_env_validation.py
@@ -86,7 +86,11 @@ class TestValidateWorkingDir:
             "gs://bucket/file",
         ]:
             with pytest.raises(
-                ValueError, match="Only .zip or .whl files supported for remote URIs."
+                ValueError,
+                match=(
+                    "Only .zip, .tar, .tar.gz, .tgz, .tar.zst, or .tzst files "
+                    "supported for remote URIs."
+                ),
             ):
                 parse_and_validate_working_dir(uri)
 
@@ -95,6 +99,9 @@ class TestValidateWorkingDir:
             "https://some_domain.com/path/file.zip",
             "s3://bucket/file.zip",
             "gs://bucket/file.zip",
+            "https://some_domain.com/path/file.tar",
+            "s3://bucket/file.tar.zst",
+            "gs://bucket/file.tgz",
         ]:
             working_dir = parse_and_validate_working_dir(uri)
             assert working_dir == uri


### PR DESCRIPTION
## Description
  - runtime_env.working_dir only accepts .zip or directories, which is slow and inefficient for large dependencies.
  - This change allows .tar/.tar.gz/.tgz/.tar.zst/.tzst for working_dir, reducing packaging/unpacking time for large environments.

## Related issues
> Link related issues: "Fixes #56987", "Closes #56987", or "Related to #56987".

## Additional information
### Implementation details
  - python/ray/_private/runtime_env/packaging.py
      - Add a tar unpack path alongside the existing zip path; add untar_package() in parallel with unzip_package().
      - Preserve multi-suffix extensions in parse_uri() (e.g., .tar.zst, .tar.gz, .tar) so remote URIs aren’t misidentified.
  - python/ray/_private/runtime_env/working_dir.py / python/ray/_private/runtime_env/validation.py
      - Extend the working_dir whitelist to include tar-based extensions.

### Tests
#### UT
      - python/ray/tests/test_runtime_env_working_dir.py adds local .tar / .tar.zst cases (skips tar.zst if zstandard isn’t installed).
      - python/ray/tests/unit/test_runtime_env_validation.py updates allowed extensions.
      - python/ray/dashboard/modules/job/tests/test_http_job_server.py updates error message matching.
#### Local quick checks
##### Step 1: Prepare a working_dir
```
mkdir -p /tmp/ray_wd_demo/test_module
cat >/tmp/ray_wd_demo/test_module/__init__.py <<'PY'
def one():
    return 1
PY
echo "world" >/tmp/ray_wd_demo/hello
```
##### Step 2: Create tar / tar.zst archives
```
tar -cf /tmp/ray_wd_demo.tar -C /tmp/ray_wd_demo .
tar -cf - -C /tmp/ray_wd_demo . | zstd > /tmp/ray_wd_demo.tar.zst
```
##### Step 3: Run the demo
```
python - <<'PY'
import ray

ray.init(runtime_env={"working_dir": "/tmp/ray_wd_demo.tar.zst"})

@ray.remote
def f():
    import test_module
    return test_module.one(), open("hello").read()

print(ray.get(f.remote()))
ray.shutdown()
PY
```
##### Step 4: Output:

```
2026-01-15 16:21:34,699	INFO worker.py:2007 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265
2026-01-15 16:21:34,706	INFO packaging.py:522 -- Pushing file package 'gcs://_ray_pkg_c371bb3f534f5e156a27062b243ea07d0abeefe5.tar.zst' (0.00MiB) to Ray cluster...
2026-01-15 16:21:34,707	INFO packaging.py:535 -- Successfully pushed file package 'gcs://_ray_pkg_c371bb3f534f5e156a27062b243ea07d0abeefe5.tar.zst'.
/Users/xxx/work/community/ray/python/ray/_private/worker.py:2055: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
(1, 'world\n')
```
