### PR TITLE
[release test] stop fetching cloud provider via sdk

### DIFF
--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -8,7 +8,6 @@ from ray_release.aws import (
     add_tags_to_aws_config,
 )
 from ray_release.config import DEFAULT_AUTOSUSPEND_MINS, DEFAULT_MAXIMUM_UPTIME_MINS
-from ray_release.exception import CloudInfoError
 from ray_release.test import Test
 from ray_release.util import dict_hash, get_anyscale_sdk
 
@@ -45,7 +44,7 @@ class ClusterManager(abc.ABC):
         self.cluster_compute = None
         self.cluster_compute_name = None
         self.cluster_compute_id = None
-        self.cloud_provider = None
+        self.cloud_provider = test.get_cloud_env()
 
         self.autosuspend_minutes = DEFAULT_AUTOSUSPEND_MINS
         self.maximum_uptime_minutes = DEFAULT_MAXIMUM_UPTIME_MINS
@@ -75,10 +74,8 @@ class ClusterManager(abc.ABC):
         self.cluster_compute.setdefault(
             "maximum_uptime_minutes", self.maximum_uptime_minutes
         )
-        self.cloud_provider = self._get_cloud_provider(cluster_compute)
         self.cluster_compute = self._annotate_cluster_compute(
             self.cluster_compute,
-            cloud_provider=self.cloud_provider,
             extra_tags=extra_tags,
         )
 
@@ -88,21 +85,12 @@ class ClusterManager(abc.ABC):
             f"{dict_hash(self.cluster_compute)}"
         )
 
-    def _get_cloud_provider(self, cluster_compute: Dict[str, Any]) -> Optional[str]:
-        if not cluster_compute or "cloud_id" not in cluster_compute:
-            return None
-        try:
-            return self.sdk.get_cloud(cluster_compute["cloud_id"]).result.provider
-        except Exception as e:
-            raise CloudInfoError(f"Could not obtain cloud information: {e}") from e
-
     def _annotate_cluster_compute(
         self,
         cluster_compute: Dict[str, Any],
-        cloud_provider: str,
         extra_tags: Dict[str, str],
     ) -> Dict[str, Any]:
-        if not extra_tags or cloud_provider != "AWS":
+        if not extra_tags or self.cloud_provider != "aws":
             return cluster_compute
 
         cluster_compute = cluster_compute.copy()

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -379,23 +379,21 @@ class Test(dict):
         """
         return self.get("stable", True)
 
+    def get_cloud_env(self) -> str:
+        """Returns the cloud environment of the test."""
+        return self.get("env", "aws").lower()
+
     def is_gce(self) -> bool:
-        """
-        Returns whether this test is running on GCE.
-        """
-        return self.get("env") == "gce"
+        """Returns whether this test is running on GCE."""
+        return self.get_cloud_env() == "gce"
 
     def is_kuberay(self) -> bool:
-        """
-        Returns whether this test is running on KubeRay.
-        """
-        return self.get("env") == "kuberay"
+        """Returns whether this test is running on KubeRay."""
+        return self.get_cloud_env() == "kuberay"
 
     def is_azure(self) -> bool:
-        """
-        Returns whether this test is running on Azure.
-        """
-        return self.get("env") == "azure"
+        """Returns whether this test is running on Azure."""
+        return self.get_cloud_env() == "azure"
 
     def is_high_impact(self) -> bool:
         # a test is high impact if it catches regressions frequently, this field is


### PR DESCRIPTION
we already know the cloud provider / type via test definition, so there is no need to fetch it via sdk.
