### PR TITLE
fix(data): default Ray Data log encoding to UTF-8 on Windows

### DIFF
--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -110,11 +110,13 @@ class SessionFileHandler(logging.Handler):
     Args:
         filename: The name of the log file. The file is created in the 'logs' directory
             of the Ray session directory.
+        encoding: Optional file encoding. Defaults to UTF-8 on Windows.
     """
 
-    def __init__(self, filename: str):
+    def __init__(self, filename: str, encoding: Optional[str] = None):
         super().__init__()
         self._filename = filename
+        self._encoding = encoding
         self._handler = None
         self._formatter = None
         self._path = None
@@ -140,7 +142,10 @@ class SessionFileHandler(logging.Handler):
         os.makedirs(log_directory, exist_ok=True)
 
         self._path = os.path.join(log_directory, self._filename)
-        self._handler = logging.FileHandler(self._path)
+        encoding = self._encoding
+        if encoding is None and os.name == "nt":
+            encoding = "utf-8"
+        self._handler = logging.FileHandler(self._path, encoding=encoding)
         if self._formatter is not None:
             self._handler.setFormatter(self._formatter)
 

--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -142,10 +142,10 @@ class SessionFileHandler(logging.Handler):
         os.makedirs(log_directory, exist_ok=True)
 
         self._path = os.path.join(log_directory, self._filename)
-        encoding = self._encoding
-        if encoding is None and os.name == "nt":
-            encoding = "utf-8"
-        self._handler = logging.FileHandler(self._path, encoding=encoding)
+        effective_encoding = self._encoding
+        if effective_encoding is None and os.name == "nt":
+            effective_encoding = "utf-8"
+        self._handler = logging.FileHandler(self._path, encoding=effective_encoding)
         if self._formatter is not None:
             self._handler.setFormatter(self._formatter)
 


### PR DESCRIPTION
## Issue
- https://github.com/ray-project/ray/issues/59967

## Summary
- Default Ray Data session log files to UTF-8 on Windows when no encoding is provided.
- Add a Windows-only test to verify the FileHandler encoding.

## Motivation
- Prevent UnicodeEncodeError on Windows when Ray Data logs contain non-cp1252 characters.

## Validation
- python -m pytest python/ray/data/tests/test_logging.py -k file_handler_uses_utf8_on_windows