### PR TITLE
[core] Fix incorrect error handling in autoscaler for available_node_types when spawning on-prem cluster

### DIFF
--- a/python/ray/autoscaler/_private/local/config.py
+++ b/python/ray/autoscaler/_private/local/config.py
@@ -17,11 +17,13 @@ def prepare_local(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     config = copy.deepcopy(config)
     for field in "head_node", "worker_nodes", "available_node_types":
-        if field == "available_node_types" and LOCAL_CLUSTER_NODE_TYPE in config.get(
-            field, {}
-        ):
-            continue
         if config.get(field):
+            # If the config already contains the internal node type, it's been prepared already hence return as-is.
+            if (
+                field == "available_node_types"
+                and LOCAL_CLUSTER_NODE_TYPE in config.get(field, {})
+            ):
+                return config
             err_msg = unsupported_field_message.format(field)
             cli_logger.abort(err_msg)
     # We use a config with a single node type for on-prem clusters.

--- a/python/ray/autoscaler/_private/local/config.py
+++ b/python/ray/autoscaler/_private/local/config.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Tuple
 
 from ray._common.utils import get_default_ray_temp_dir
 from ray.autoscaler._private.cli_logger import cli_logger
@@ -10,7 +10,7 @@ unsupported_field_message = "The field {} is not supported for on-premise cluste
 LOCAL_CLUSTER_NODE_TYPE = "local.cluster.node"
 
 
-def prepare_local(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def prepare_local(config: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
     """
     Prepare local cluster config for ingestion by cluster launcher and
     autoscaler.
@@ -23,7 +23,7 @@ def prepare_local(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
                 field == "available_node_types"
                 and LOCAL_CLUSTER_NODE_TYPE in config.get(field, {})
             ):
-                return None
+                return config, True
             err_msg = unsupported_field_message.format(field)
             cli_logger.abort(err_msg)
     # We use a config with a single node type for on-prem clusters.
@@ -37,7 +37,7 @@ def prepare_local(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         config = prepare_coordinator(config)
     else:
         config = prepare_manual(config)
-    return config
+    return config, False
 
 
 def prepare_coordinator(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/ray/autoscaler/_private/local/config.py
+++ b/python/ray/autoscaler/_private/local/config.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from ray._common.utils import get_default_ray_temp_dir
 from ray.autoscaler._private.cli_logger import cli_logger
@@ -10,7 +10,7 @@ unsupported_field_message = "The field {} is not supported for on-premise cluste
 LOCAL_CLUSTER_NODE_TYPE = "local.cluster.node"
 
 
-def prepare_local(config: Dict[str, Any]) -> Dict[str, Any]:
+def prepare_local(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """
     Prepare local cluster config for ingestion by cluster launcher and
     autoscaler.
@@ -18,12 +18,12 @@ def prepare_local(config: Dict[str, Any]) -> Dict[str, Any]:
     config = copy.deepcopy(config)
     for field in "head_node", "worker_nodes", "available_node_types":
         if config.get(field):
-            # If the config already contains the internal node type, it's been prepared already hence return as-is.
+            # If the config already contains the internal node type, it's been prepared via ray up already hence return as-is.
             if (
                 field == "available_node_types"
                 and LOCAL_CLUSTER_NODE_TYPE in config.get(field, {})
             ):
-                return config
+                return None
             err_msg = unsupported_field_message.format(field)
             cli_logger.abort(err_msg)
     # We use a config with a single node type for on-prem clusters.

--- a/python/ray/autoscaler/_private/local/config.py
+++ b/python/ray/autoscaler/_private/local/config.py
@@ -17,6 +17,10 @@ def prepare_local(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     config = copy.deepcopy(config)
     for field in "head_node", "worker_nodes", "available_node_types":
+        if field == "available_node_types" and LOCAL_CLUSTER_NODE_TYPE in config.get(
+            field, {}
+        ):
+            continue
         if config.get(field):
             err_msg = unsupported_field_message.format(field)
             cli_logger.abort(err_msg)

--- a/python/ray/autoscaler/_private/local/config.py
+++ b/python/ray/autoscaler/_private/local/config.py
@@ -23,7 +23,7 @@ def prepare_local(config: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
                 field == "available_node_types"
                 and LOCAL_CLUSTER_NODE_TYPE in config.get(field, {})
             ):
-                return config, True
+                return config, False
             err_msg = unsupported_field_message.format(field)
             cli_logger.abort(err_msg)
     # We use a config with a single node type for on-prem clusters.
@@ -37,7 +37,7 @@ def prepare_local(config: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
         config = prepare_coordinator(config)
     else:
         config = prepare_manual(config)
-    return config, False
+    return config, True
 
 
 def prepare_coordinator(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -240,7 +240,11 @@ def prepare_config(config: Dict[str, Any]) -> Dict[str, Any]:
     is_local = config.get("provider", {}).get("type") == "local"
     is_kuberay = config.get("provider", {}).get("type") == "kuberay"
     if is_local:
-        config = prepare_local(config)
+        new_config = prepare_local(config)
+        # If the config is already prepared via ray up, return it as is.
+        if new_config is None:
+            return config
+        config = new_config
     elif is_kuberay:
         # With KubeRay, we don't need to do anything here since KubeRay
         # generate the autoscaler config from the RayCluster CR instead

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -241,10 +241,10 @@ def prepare_config(config: Dict[str, Any]) -> Dict[str, Any]:
     is_kuberay = config.get("provider", {}).get("type") == "kuberay"
     if is_local:
         prepared_config, already_prepared = prepare_local(config)
+        config = prepared_config
         # If the config is already prepared via ray up, return it as is.
         if already_prepared:
             return config
-        config = prepared_config
     elif is_kuberay:
         # With KubeRay, we don't need to do anything here since KubeRay
         # generate the autoscaler config from the RayCluster CR instead

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -240,10 +240,9 @@ def prepare_config(config: Dict[str, Any]) -> Dict[str, Any]:
     is_local = config.get("provider", {}).get("type") == "local"
     is_kuberay = config.get("provider", {}).get("type") == "kuberay"
     if is_local:
-        prepared_config, already_prepared = prepare_local(config)
-        config = prepared_config
+        config, modified = prepare_local(config)
         # If the config is already prepared via ray up, return it as is.
-        if already_prepared:
+        if not modified:
             return config
     elif is_kuberay:
         # With KubeRay, we don't need to do anything here since KubeRay

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -240,11 +240,11 @@ def prepare_config(config: Dict[str, Any]) -> Dict[str, Any]:
     is_local = config.get("provider", {}).get("type") == "local"
     is_kuberay = config.get("provider", {}).get("type") == "kuberay"
     if is_local:
-        new_config = prepare_local(config)
+        prepared_config, already_prepared = prepare_local(config)
         # If the config is already prepared via ray up, return it as is.
-        if new_config is None:
+        if already_prepared:
             return config
-        config = new_config
+        config = prepared_config
     elif is_kuberay:
         # With KubeRay, we don't need to do anything here since KubeRay
         # generate the autoscaler config from the RayCluster CR instead


### PR DESCRIPTION
From #59905 we're seeing an issue with launching an on-prem cluster using the ray up invocation. The logs provided have an interesting part which is that the command to start the head node contains this line:
ray start --head --port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml

Why does an on-prem cluster need an autoscaling config in ray up? The reason is that the we use the autoscaler monitor to start up all the worker nodes, ray up only explicitly starts the head node. The autoscaling config specified here is initially created where you run ray up -> create_or_update_cluster -> _boostrap_config -> prepare_local and here
https://github.com/ray-project/ray/blob/68050c41a609d20db83f6010f9a53dbe9403f05c/python/ray/autoscaler/_private/local/config.py#L26-L29
we do set available_node_types. When they created this function in https://github.com/ray-project/ray/pull/16202/files#diff-62543304b853c748b850947d1c146f5220d4b77b9ea93e2247f12bdb4d11d355R15 it seems they intentionally removed the default values from the config (maybe since it was always unchanging and potentially confusing to a user to leave these as default values?) but the code still access available_node_types repeatedly since the code for on-prem/normal clusters uses the same path in ray up. Hence rather than repeatedly checking for empty key errors, I think they just decided to insert a dummy value for available_node_types to make life easier. 

The error happens because once we call prepare_config in ray up and insert the dummy available_node_types, we store it as a file in /tmp, create a mapping to what it'll be stored to in the head node, then copy it over to the head node. However, when we spin up the autoscaler monitor on the head node we call prepare_config again here: https://github.com/ray-project/ray/blob/20d10ddcc151bd7d19e6ede3da04cff44d333ec2/python/ray/autoscaler/v2/instance_manager/config.py#L173
I don't see it being called in autoscaler v1 explicitly which is why the error wasn't being triggered then and only with v2. I do think it's correct to call prepare_config in the autoscaler as well and not just in ray up because https://docs.ray.io/en/latest/cluster/vms/user-guides/launching-clusters/on-premises.html
we can also just explicitly call ray start on the head and worker nodes. Hence I think the simplest fix is to allow setting available_node_types in the config file if it's the dummy values since we need to support both paths. 


