### PR TITLE
[Data][Serialization] - Use Arrow IPC for Arrow Schema Serdes

### DIFF
--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 from ray._private.utils import is_in_test
 
@@ -111,7 +111,9 @@ def _register_arrow_data_serializer(serialization_context):
     serialization_context._register_cloudpickle_reducer(pa.Schema, _arrow_schema_reduce)
 
 
-def _arrow_schema_reduce(schema: "pyarrow.Schema"):
+def _arrow_schema_reduce(
+    schema: "pyarrow.Schema",
+) -> Tuple[Callable[["bytes"], "pyarrow.Schema"], Tuple[bytes]]:
     """Custom reducer for Arrow Schema that uses IPC serialization for performance.
 
     Arrow's native IPC serialization for schemas is significantly faster than


### PR DESCRIPTION
## Description
Ray Core was using `cloudpickle` instead of `Arrow IPC` as the serialization mechanism, and that takes a toll on Ray Data since Ray Data keeps track of the materialized `BlockMetadata` on the driver. 


Benchmark Results:

```
============================================================
Schema: Large Schema (100 fields, mixed types) (100 fields)
Iterations: 10,000
============================================================
```

| Method | Serialize (ms) | Deserialize (ms) | Size (bytes) |
|--------|----------------|------------------|--------------|
| Arrow IPC | 238.65 | 667.79 | 6856 |
| cloudpickle | 5985.70 | 1633.24  | 4710 |
| ray.cloudpickle (with Cloudpickle) | 6036.41 | 1623.84  | 4710 |
| ray.cloudpickle (with Arrow IPC) | 308.53 | 706.48 | 6942 |

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
