### PR TITLE
[train] Pass ray remote args to validation task

### DIFF
--- a/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
+++ b/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
@@ -132,9 +132,13 @@ class ValidationManager(ControllerCallback, ReportCallback, WorkerGroupCallback)
         for _ in range(num_validations_to_start):
             training_report = self._training_report_queue.popleft()
             # TODO: handle timeouts - ray.remote() does not have them
-            validate_task = run_validation_fn.options(
-                **training_report.validation.ray_remote_kwargs,
-            ).remote(
+            if isinstance(training_report.validation, ValidationTaskConfig):
+                run_validation_fn_with_options = run_validation_fn.options(
+                    **training_report.validation.ray_remote_kwargs,
+                )
+            else:
+                run_validation_fn_with_options = run_validation_fn
+            validate_task = run_validation_fn_with_options.remote(
                 self._validation_config,
                 training_report.validation,
                 training_report.checkpoint,

--- a/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
+++ b/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
@@ -131,7 +131,10 @@ class ValidationManager(ControllerCallback, ReportCallback, WorkerGroupCallback)
         )
         for _ in range(num_validations_to_start):
             training_report = self._training_report_queue.popleft()
-            validate_task = run_validation_fn.remote(
+            # TODO: handle timeouts - ray.remote() does not have them
+            validate_task = run_validation_fn.options(
+                **training_report.validation.ray_remote_kwargs,
+            ).remote(
                 self._validation_config,
                 training_report.validation,
                 training_report.checkpoint,
@@ -152,7 +155,6 @@ class ValidationManager(ControllerCallback, ReportCallback, WorkerGroupCallback)
         except (ray.exceptions.RayTaskError, ray.exceptions.TaskCancelledError):
             checkpoint_to_metrics[checkpoint] = {}
             logger.exception(f"Validation failed for checkpoint {checkpoint}")
-            # TODO: retry validations and time out appropriately.
             # TODO: track failed validations - see ed45912bb6ed435de06ac1cd58e9918e6825b4fe
         return checkpoint_to_metrics
 

--- a/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
+++ b/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
@@ -133,11 +133,13 @@ class ValidationManager(ControllerCallback, ReportCallback, WorkerGroupCallback)
             training_report = self._training_report_queue.popleft()
             # TODO: handle timeouts - ray.remote() does not have them
             if isinstance(training_report.validation, ValidationTaskConfig):
-                run_validation_fn_with_options = run_validation_fn.options(
+                merged_kwargs = {
+                    **self._validation_config.task_config.ray_remote_kwargs,
                     **training_report.validation.ray_remote_kwargs,
-                )
+                }
             else:
-                run_validation_fn_with_options = run_validation_fn
+                merged_kwargs = self._validation_config.task_config.ray_remote_kwargs
+            run_validation_fn_with_options = run_validation_fn.options(**merged_kwargs)
             validate_task = run_validation_fn_with_options.remote(
                 self._validation_config,
                 training_report.validation,

--- a/python/ray/train/v2/api/validation_config.py
+++ b/python/ray/train/v2/api/validation_config.py
@@ -24,13 +24,18 @@ class ValidationTaskConfig:
         fn_kwargs: json-serializable keyword arguments to pass to the validation function.
             Note that we always pass `checkpoint` as the first argument to the
             validation function.
+        ray_remote_kwargs: Keyword arguments to pass to `ray.remote()` for the validation task.
+            This can be used to specify resource requirements, number of retries, etc.
     """
 
     fn_kwargs: Optional[Dict[str, Any]] = None
+    ray_remote_kwargs: Optional[Dict[str, Any]] = None
 
     def __post_init__(self):
         if self.fn_kwargs is None:
             self.fn_kwargs = {}
+        if self.ray_remote_kwargs is None:
+            self.ray_remote_kwargs = {}
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/train/v2/tests/test_async_checkpointing_validation.py
+++ b/python/ray/train/v2/tests/test_async_checkpointing_validation.py
@@ -369,7 +369,7 @@ def test_report_validation_fn_error():
     assert len(result.best_checkpoints) == 2
 
 
-def test_report_validate_fn_success_after_retry():
+def test_report_validation_fn_success_after_retry():
     @ray.remote
     class Counter:
         def __init__(self):
@@ -381,7 +381,7 @@ def test_report_validate_fn_success_after_retry():
 
     counter = Counter.remote()
 
-    def validate_fn(checkpoint):
+    def validation_fn(checkpoint):
         if ray.get(counter.increment.remote()) < 2:
             raise ValueError("validation failed")
         return {"score": 100}
@@ -402,7 +402,7 @@ def test_report_validate_fn_success_after_retry():
     trainer = DataParallelTrainer(
         train_fn,
         scaling_config=ScalingConfig(num_workers=1),
-        validation_config=ValidationConfig(validate_fn=validate_fn),
+        validation_config=ValidationConfig(validation_fn=validation_fn),
     )
     result = trainer.fit()
     assert result.best_checkpoints[0][1] == {"score": 100}

--- a/python/ray/train/v2/tests/test_async_checkpointing_validation.py
+++ b/python/ray/train/v2/tests/test_async_checkpointing_validation.py
@@ -402,7 +402,7 @@ def test_report_validation_fn_success_after_retry():
     trainer = DataParallelTrainer(
         train_fn,
         scaling_config=ScalingConfig(num_workers=1),
-        validation_config=ValidationConfig(validation_fn=validation_fn),
+        validation_config=ValidationConfig(fn=validation_fn),
     )
     result = trainer.fit()
     assert result.best_checkpoints[0][1] == {"score": 100}

--- a/python/ray/train/v2/tests/test_async_checkpointing_validation.py
+++ b/python/ray/train/v2/tests/test_async_checkpointing_validation.py
@@ -369,6 +369,45 @@ def test_report_validation_fn_error():
     assert len(result.best_checkpoints) == 2
 
 
+def test_report_validate_fn_success_after_retry():
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.value = 0
+
+        def increment(self):
+            self.value += 1
+            return self.value
+
+    counter = Counter.remote()
+
+    def validate_fn(checkpoint):
+        if ray.get(counter.increment.remote()) < 2:
+            raise ValueError("validation failed")
+        return {"score": 100}
+
+    def train_fn():
+        with create_dict_checkpoint({}) as cp:
+            ray.train.report(
+                metrics={},
+                checkpoint=cp,
+                validation=ValidationTaskConfig(
+                    ray_remote_kwargs={
+                        "max_retries": 1,
+                        "retry_exceptions": [ValueError],
+                    },
+                ),
+            )
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        scaling_config=ScalingConfig(num_workers=1),
+        validation_config=ValidationConfig(validate_fn=validate_fn),
+    )
+    result = trainer.fit()
+    assert result.best_checkpoints[0][1] == {"score": 100}
+
+
 def test_report_checkpoint_upload_fn(tmp_path):
     def checkpoint_upload_fn(checkpoint, checkpoint_dir_name):
         full_checkpoint_path = (

--- a/python/ray/train/v2/tests/test_validation_manager.py
+++ b/python/ray/train/v2/tests/test_validation_manager.py
@@ -175,6 +175,64 @@ def test_checkpoint_validation_management_failure(tmp_path):
     )
 
 
+def test_checkpoint_validation_management_success_after_retry(tmp_path):
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.value = 0
+
+        def increment(self):
+            self.value += 1
+            return self.value
+
+    counter = Counter.remote()
+
+    def one_time_failing_validate_fn(checkpoint):
+        print("one_time_failing_validate_fn called")
+        if ray.get(counter.increment.remote()) < 2:
+            raise ValueError("Fail on first attempt")
+        return {"score": 100}
+
+    checkpoint_manager = create_autospec(CheckpointManager, instance=True)
+    vm = validation_manager.ValidationManager(
+        checkpoint_manager=checkpoint_manager,
+        validation_config=ValidationConfig(validate_fn=one_time_failing_validate_fn),
+    )
+    training_result = create_dummy_training_results(
+        num_results=1,
+        storage_context=StorageContext(
+            storage_path=tmp_path,
+            experiment_dir_name="checkpoint_validation_management_success_after_retry_experiment",
+        ),
+    )[0]
+
+    vm.after_report(
+        training_report=_TrainingReport(
+            metrics=training_result.metrics,
+            checkpoint=training_result.checkpoint,
+            validation=ValidationTaskConfig(
+                ray_remote_kwargs={
+                    "max_retries": 1,
+                    "retry_exceptions": [ValueError],
+                },
+            ),
+        ),
+        metrics={},
+    )
+    assert vm._poll_validations() == 0
+    assert vm._kick_off_validations() == 1
+    ray.wait(
+        list(vm._pending_validations.keys()),
+        num_returns=1,
+        timeout=100,
+    )
+    assert vm._poll_validations() == 0
+    assert vm._kick_off_validations() == 0
+    checkpoint_manager.update_checkpoints_with_metrics.assert_called_once_with(
+        {training_result.checkpoint: {"score": 100}}
+    )
+
+
 def test_checkpoint_validation_management_slow_validation_fn(tmp_path):
     checkpoint_manager = create_autospec(CheckpointManager, instance=True)
 

--- a/python/ray/train/v2/tests/test_validation_manager.py
+++ b/python/ray/train/v2/tests/test_validation_manager.py
@@ -187,8 +187,8 @@ def test_checkpoint_validation_management_success_after_retry(tmp_path):
 
     counter = Counter.remote()
 
-    def one_time_failing_validate_fn(checkpoint):
-        print("one_time_failing_validate_fn called")
+    def one_time_failing_validation_fn(checkpoint):
+        print("one_time_failing_validation_fn called")
         if ray.get(counter.increment.remote()) < 2:
             raise ValueError("Fail on first attempt")
         return {"score": 100}
@@ -196,7 +196,7 @@ def test_checkpoint_validation_management_success_after_retry(tmp_path):
     checkpoint_manager = create_autospec(CheckpointManager, instance=True)
     vm = validation_manager.ValidationManager(
         checkpoint_manager=checkpoint_manager,
-        validation_config=ValidationConfig(validate_fn=one_time_failing_validate_fn),
+        validation_config=ValidationConfig(validation_fn=one_time_failing_validation_fn),
     )
     training_result = create_dummy_training_results(
         num_results=1,

--- a/python/ray/train/v2/tests/test_validation_manager.py
+++ b/python/ray/train/v2/tests/test_validation_manager.py
@@ -196,7 +196,7 @@ def test_checkpoint_validation_management_success_after_retry(tmp_path):
     checkpoint_manager = create_autospec(CheckpointManager, instance=True)
     vm = validation_manager.ValidationManager(
         checkpoint_manager=checkpoint_manager,
-        validation_config=ValidationConfig(validation_fn=one_time_failing_validation_fn),
+        validation_config=ValidationConfig(fn=one_time_failing_validation_fn),
     )
     training_result = create_dummy_training_results(
         num_results=1,


### PR DESCRIPTION
# Summary

Allow users to configure ray remote args (such as number of retries) on the validation Ray task itself. Repurposed from https://github.com/ray-project/ray/pull/59165 since we decided to support all ray remote args as oppose to just retry/retry_exception.

# Testing

Unit tests pass retry + retry_exceptions through