### PR TITLE
[Data] DefaultClusterAutoscalerV2 raises KeyError: 'CPU' Fix

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -72,9 +72,10 @@ def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
         for node in ray.nodes()
         if node["Alive"] and "node:__internal_head__" not in node["Resources"]
     ]
+
     for r in node_resources:
         node_resource_spec = _NodeResourceSpec.of(
-            cpu=r.get("CPU", 0), gpu=r.get("GPU", 0), mem=r["memory"]
+            cpu=r.get("CPU", 0), gpu=r.get("GPU", 0), mem=r.get("memory", 0)
         )
         nodes_resource_spec_count[node_resource_spec] += 1
 

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -74,7 +74,7 @@ def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
     ]
     for r in node_resources:
         node_resource_spec = _NodeResourceSpec.of(
-            cpu=r["CPU"], gpu=r.get("GPU", 0), mem=r["memory"]
+            cpu=r.get("CPU", 0), gpu=r.get("GPU", 0), mem=r["memory"]
         )
         nodes_resource_spec_count[node_resource_spec] += 1
 


### PR DESCRIPTION
This PR updates DefaultClusterAutoscalerV2 to safely handle nodes with 0 logical CPUs by replacing direct dictionary access (r["CPU"]) with r.get("CPU", 0), preventing crashes on dedicated GPU nodes.
This fix has been discussed firsthand with @bveeramani.

"Fixes #60166"