### PR TITLE
[core] Unbreak windows build by allowing long compile commands

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -84,6 +84,7 @@ build:windows --experimental_repository_cache_hardlinks
 # For colored output (seems necessary on Windows)
 build:windows --color=yes
 # For compiler colored output (seems necessary on Windows)
+build:windows --features=compiler_param_file
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fansi-escape-codes"
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fcolor-diagnostics"
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -86,7 +86,7 @@ build:windows --color=yes
 # For compiler colored output (seems necessary on Windows)
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fansi-escape-codes"
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fcolor-diagnostics"
-# For bypassing the command line length limit on Windows
+# For bypassing the command line length limit on Windows due to long depedency lists in GCS bazel build file
 build:windows --features=compiler_param_file
 
 # Debug build flags. Uncomment in '-c dbg' builds to enable checks in the C++ standard library:

--- a/.bazelrc
+++ b/.bazelrc
@@ -86,8 +86,6 @@ build:windows --color=yes
 # For compiler colored output (seems necessary on Windows)
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fansi-escape-codes"
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fcolor-diagnostics"
-# For bypassing the command line length limit on Windows due to long depedency lists in GCS bazel build file
-build:windows --features=compiler_param_file
 
 # Debug build flags. Uncomment in '-c dbg' builds to enable checks in the C++ standard library:
 build:linux-debug --config linux

--- a/.bazelrc
+++ b/.bazelrc
@@ -86,7 +86,8 @@ build:windows --color=yes
 # For compiler colored output (seems necessary on Windows)
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fansi-escape-codes"
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fcolor-diagnostics"
-
+# For bypassing the command line length limit on Windows
+build:windows --features=compiler_param_file
 
 # Debug build flags. Uncomment in '-c dbg' builds to enable checks in the C++ standard library:
 build:linux-debug --config linux

--- a/.bazelrc
+++ b/.bazelrc
@@ -84,7 +84,6 @@ build:windows --experimental_repository_cache_hardlinks
 # For colored output (seems necessary on Windows)
 build:windows --color=yes
 # For compiler colored output (seems necessary on Windows)
-build:windows --features=compiler_param_file
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fansi-escape-codes"
 build:clang-cl --per_file_copt="-\\.(asm|S)$@-fcolor-diagnostics"
 

--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -492,6 +492,10 @@ ray_cc_library(
     hdrs = [
         "gcs_server.h",
     ],
+    features = select({
+        "@platforms//os:windows": ["compiler_param_file"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":gcs_actor",
         ":gcs_actor_manager",
@@ -554,6 +558,10 @@ ray_cc_binary(
     srcs = [
         "gcs_server_main.cc",
     ],
+    features = select({
+        "@platforms//os:windows": ["compiler_param_file"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":gcs_server_lib",


### PR DESCRIPTION
It seems the windows build started breaking in between commits bfa6f0b and 9ce0cd0 due to the compile command for gcs_server_lib being too long. The only PR that went in that would've caused this is #59979 which used local_lease_manager instead of possibly using local_lease_manager_interface in the dependency list. However, #60121 was merged shortly after that removes this dependency entirely. I'm not sure if something else is potentially being drawn in transitively and if that contributes to the compile command used in windows? 

It does seem like we're on the knife's edge for the windows command line length limit 32768. A better long term fix would be to obviously revist the bazel file for these massives libs and try to prune them down/move them to smaller subtargets with interfaces and so on, but that's probably going to take a while so as a cheat in the bazel guide: https://bazel.build/configure/windows they mention that the flag "compiler_param_file" can bypass this so I added this and hoping it works. 
