### PR TITLE
[core] Remove `actor_creation_task_done` callback from `TaskReceiver`

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -387,12 +387,11 @@ CoreWorker::CoreWorker(
           RAY_CHECK_OK(raylet_ipc_client_->WaitForActorCallArgs(args, tag))
               << "WaitForActorCallArgs IPC failed unexpectedly";
         });
-    task_receiver_ = std::make_unique<TaskReceiver>(
-        task_execution_service_,
-        *task_event_buffer_,
-        execute_task,
-        *actor_task_execution_arg_waiter_,
-        options_.initialize_thread_callback);
+    task_receiver_ = std::make_unique<TaskReceiver>(task_execution_service_,
+                                                    *task_event_buffer_,
+                                                    execute_task,
+                                                    *actor_task_execution_arg_waiter_,
+                                                    options_.initialize_thread_callback);
   }
 
   RegisterToGcs(options_.worker_launch_time_ms, options_.worker_launched_time_ms);
@@ -3015,7 +3014,8 @@ Status CoreWorker::ExecuteTask(
       << "Finished executing task, status=" << status;
 
   if (task_spec.IsActorCreationTask()) {
-    RAY_CHECK_OK(raylet_ipc_client_->ActorCreationTaskDone()) << "Unexpected error in IPC to the Raylet; the Raylet has most likely crashed.";
+    RAY_CHECK_OK(raylet_ipc_client_->ActorCreationTaskDone())
+        << "Unexpected error in IPC to the Raylet; the Raylet has most likely crashed.";
   }
 
   std::ostringstream stream;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -392,8 +392,7 @@ CoreWorker::CoreWorker(
         *task_event_buffer_,
         execute_task,
         *actor_task_execution_arg_waiter_,
-        options_.initialize_thread_callback,
-        [this] { return raylet_ipc_client_->ActorCreationTaskDone(); });
+        options_.initialize_thread_callback);
   }
 
   RegisterToGcs(options_.worker_launch_time_ms, options_.worker_launched_time_ms);
@@ -3014,6 +3013,10 @@ Status CoreWorker::ExecuteTask(
   }
   RAY_LOG(DEBUG).WithField(task_spec.TaskId())
       << "Finished executing task, status=" << status;
+
+  if (task_spec.IsActorCreationTask()) {
+    RAY_CHECK_OK(raylet_ipc_client_->ActorCreationTaskDone()) << "Unexpected error in IPC to the Raylet; the Raylet has most likely crashed.";
+  }
 
   std::ostringstream stream;
   if (status.IsCreationTaskError()) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3013,7 +3013,7 @@ Status CoreWorker::ExecuteTask(
   RAY_LOG(DEBUG).WithField(task_spec.TaskId())
       << "Finished executing task, status=" << status;
 
-  if (task_spec.IsActorCreationTask()) {
+  if (!options_.is_local_mode && task_spec.IsActorCreationTask()) {
     RAY_CHECK_OK(raylet_ipc_client_->ActorCreationTaskDone())
         << "Unexpected error in IPC to the Raylet; the Raylet has most likely crashed.";
   }

--- a/src/ray/core_worker/task_execution/task_receiver.cc
+++ b/src/ray/core_worker/task_execution/task_receiver.cc
@@ -129,7 +129,6 @@ void TaskReceiver::QueueTaskForExecution(rpc::PushTaskRequest request,
                 initialize_thread_callback_);
           }
 
-          RAY_CHECK_OK(actor_creation_task_done_());
           if (status.IsCreationTaskError()) {
             RAY_LOG(WARNING) << "Actor creation task finished with errors, task_id: "
                              << accepted_task_spec.TaskId()

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -63,7 +63,6 @@ class TaskReceiver {
         task_event_buffer_(task_event_buffer),
         waiter_(actor_task_execution_arg_waiter),
         initialize_thread_callback_(std::move(initialize_thread_callback)),
-        actor_creation_task_done_(std::move(actor_creation_task_done)),
         normal_task_execution_queue_(std::make_unique<NormalTaskExecutionQueue>()),
         pool_manager_(std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>()),
         fiber_state_manager_(nullptr) {}

--- a/src/ray/core_worker/task_execution/task_receiver.h
+++ b/src/ray/core_worker/task_execution/task_receiver.h
@@ -53,14 +53,11 @@ class TaskReceiver {
       bool *is_retryable_error,
       std::string *application_error)>;
 
-  using OnActorCreationTaskDone = std::function<Status()>;
-
   TaskReceiver(instrumented_io_context &task_execution_service,
                worker::TaskEventBuffer &task_event_buffer,
                TaskHandler task_handler,
                ActorTaskExecutionArgWaiter &actor_task_execution_arg_waiter,
-               std::function<std::function<void()>()> initialize_thread_callback,
-               OnActorCreationTaskDone actor_creation_task_done)
+               std::function<std::function<void()>()> initialize_thread_callback)
       : task_handler_(std::move(task_handler)),
         task_execution_service_(task_execution_service),
         task_event_buffer_(task_event_buffer),
@@ -130,9 +127,6 @@ class TaskReceiver {
 
   /// The language-specific callback function that initializes threads.
   std::function<std::function<void()>()> initialize_thread_callback_;
-
-  /// The callback function to be invoked when finishing a task.
-  OnActorCreationTaskDone actor_creation_task_done_;
 
   /// Queue of actor tasks waiting to execute, keyed on the ID of the worker that
   /// submitted the task.

--- a/src/ray/core_worker/task_execution/tests/task_receiver_test.cc
+++ b/src/ray/core_worker/task_execution/tests/task_receiver_test.cc
@@ -140,8 +140,7 @@ class TaskReceiverTest : public ::testing::Test {
         task_event_buffer_,
         execute_task,
         *actor_task_execution_arg_waiter_,
-        /* initialize_thread_callback= */ []() { return []() { return; }; },
-        /* actor_creation_task_done= */ []() { return Status::OK(); });
+        /* initialize_thread_callback= */ []() { return []() { return; }; });
   }
 
   Status MockExecuteTask(


### PR DESCRIPTION
There is no need for this callback to be nested so deeply inside of the `TaskReceiver`. We can instead call it from `CoreWorker::ExecuteTask` prior to returning.