### PR TITLE
[wheel] remove oss tag from wheel build

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -50,7 +50,6 @@ steps:
     tags:
       - release_wheels
       - linux_wheels
-      - oss
     depends_on:
       - ray-core-build
       - ray-java-build


### PR DESCRIPTION
as it is build the artifact generically, not running oss specific logic (e.g. uploading to ray wheels s3)