### PR TITLE
[Data] An option to add a per-file row number column

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -380,7 +380,11 @@ class ParquetDatasink(_FileDatasink):
         row_number_array = combined_pl[self.row_number_column_name].to_arrow()
 
         # Concatenate the original Arrow tables so all column types are preserved as-is.
-        arrow_combined = pa.concat_tables(tables, promote_options="default")
+        # Reuse the internal concat() which handles PyArrow version compatibility
+        # (promote_options vs promote kwarg) and extension type support.
+        from ray.data._internal.arrow_ops.transform_pyarrow import concat
+
+        arrow_combined = concat(tables, preserve_order=True)
 
         return arrow_combined.append_column(
             pa.field(self.row_number_column_name, pa.int64()),

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -119,6 +119,7 @@ class ParquetDatasink(_FileDatasink):
         filename_provider: Optional[FilenameProvider] = None,
         dataset_uuid: Optional[str] = None,
         mode: SaveMode = SaveMode.APPEND,
+        row_number_column_name: Optional[str] = None,
     ):
         if arrow_parquet_args_fn is None:
             arrow_parquet_args_fn = lambda: {}  # noqa: E731
@@ -131,6 +132,17 @@ class ParquetDatasink(_FileDatasink):
         self.min_rows_per_file = min_rows_per_file
         self.max_rows_per_file = max_rows_per_file
         self.partition_cols = partition_cols
+        self.row_number_column_name = row_number_column_name
+
+        if self.row_number_column_name is not None:
+            if (
+                not isinstance(self.row_number_column_name, str)
+                or not self.row_number_column_name
+            ):
+                raise ValueError(
+                    "row_number_column_name must be a non-empty string, got: "
+                    f"{self.row_number_column_name!r}"
+                )
 
         if self.min_rows_per_file is not None and self.max_rows_per_file is not None:
             if self.min_rows_per_file > self.max_rows_per_file:
@@ -268,7 +280,18 @@ class ParquetDatasink(_FileDatasink):
         write_kwargs: Dict[str, Any],
         partitioning_flavor: Optional[str],
     ) -> None:
+        import pyarrow as pa
         import pyarrow.dataset as ds
+
+        # Add row numbers if requested
+        if self.row_number_column_name is not None:
+            table = self._add_row_numbers(tables)
+            tables = [table]
+
+            # Update schema to include the row number column
+            if output_schema is not None:
+                row_number_field = pa.field(self.row_number_column_name, pa.int64())
+                output_schema = output_schema.append(row_number_field)
 
         # Make every incoming batch conform to the final schema *before* writing
         for idx, table in enumerate(tables):
@@ -314,3 +337,52 @@ class ParquetDatasink(_FileDatasink):
     @property
     def min_rows_per_write(self) -> Optional[int]:
         return self.min_rows_per_file
+
+    def _add_row_numbers(self, tables: List["pyarrow.Table"]) -> "pyarrow.Table":
+        """
+        This function logically concatenates the tables and appends a column of row numbers
+        to the logically concatenated table. When using partitioned writes, the row numbers
+        are reset for each partition. Since multiple write tasks can write to the same
+        partition, the row numbers are not guaranteed to be unique across all files
+        belonging to the same partition.
+        """
+        import pyarrow as pa
+
+        try:
+            import polars as pl
+        except ImportError:
+            raise ImportError(
+                "polars is required for adding per-file row numbers. Install with `pip install polars`"
+            )
+
+        assert (
+            self.row_number_column_name is not None
+        ), "row_number_column_name must be set"
+
+        # Zero-copy for arrow-polars conversion. Setting rechunk=False for logical concatenation.
+        dfs = [pl.DataFrame(t) for t in tables]
+        combined_pl = pl.concat(dfs, rechunk=False)
+
+        row_num_expr = pl.int_range(pl.len())
+
+        # If partitioning is used, use window functions to reset the row number for each partition
+        if self.partition_cols:
+            row_num_expr = row_num_expr.over(self.partition_cols)
+
+        combined_pl = combined_pl.with_columns(
+            row_num_expr.alias(self.row_number_column_name)
+        )
+
+        # Extract only the row number column from Polars to avoid type promotion of other
+        # columns. Polars's to_arrow() converts string->large_string, binary->large_binary,
+        # and list->large_list. Casting large_list back to list is not always supported by
+        # PyArrow and casting large_string back copies all string data unnecessarily.
+        row_number_array = combined_pl[self.row_number_column_name].to_arrow()
+
+        # Concatenate the original Arrow tables so all column types are preserved as-is.
+        arrow_combined = pa.concat_tables(tables, promote_options="default")
+
+        return arrow_combined.append_column(
+            pa.field(self.row_number_column_name, pa.int64()),
+            row_number_array,
+        )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4036,6 +4036,7 @@ class Dataset:
         concurrency: Optional[int] = None,
         num_rows_per_file: Optional[int] = None,
         mode: SaveMode = SaveMode.APPEND,
+        include_row_number: bool = False,
         **arrow_parquet_args,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to parquet files under the provided ``path``.
@@ -4118,6 +4119,17 @@ class Dataset:
                 "ignore", "append". Defaults to "append".
                 NOTE: This method isn't atomic. "Overwrite" first deletes all the data
                 before writing to `path`.
+            include_row_number: [Experimental] The `polars` package is required to use this option.
+                If True, adds a ``_row_num`` column containing
+                row numbers (0-indexed). If ``partition_cols`` is specified, the row
+                numbering is reset for each partition. The row number is not
+                guaranteed to be unique across all files belonging to the same partition.
+                NOTE: When using this option with ``min_rows_per_file`` and
+                ``max_rows_per_file``, a partition may be split into multiple files.
+                In this case, the row number sequence will be contiguous across those
+                files that are generated from the same block and partition (e.g., file 1 has rows 0-99,
+                file 2 has rows 100-199).
+                Use ``Dataset.repartition()`` to control the number of output files instead.
             **arrow_parquet_args: Options to pass to
                 `pyarrow.parquet.ParquetWriter() <https:/\
                     /arrow.apache.org/docs/python/generated/\
@@ -4149,6 +4161,36 @@ class Dataset:
             max_rows_per_file=max_rows_per_file,
         )
 
+        # Validate include_row_number parameter
+        if include_row_number:
+            try:
+                import polars  # noqa: F401
+            except ImportError:
+                raise ImportError(
+                    "polars is required for adding per-file row numbers. Install with `pip install polars`"
+                )
+
+            row_number_column_name = "_row_num"
+
+            columns = self.columns()
+            if columns and row_number_column_name in columns:
+                raise ValueError(
+                    f"The column name '{row_number_column_name}' conflicts with an existing "
+                    f"column in the dataset. To use `include_row_number=True`, please remove "
+                    f"or rename the existing column."
+                )
+
+            if effective_min_rows is not None or effective_max_rows is not None:
+                warnings.warn(
+                    "When min_rows_per_file or max_rows_per_file are set, row numbers are "
+                    "consecutive within each file but may not start from 0 in each file. This is "
+                    "expected because row numbers are assigned sequentially (0..N-1) before the "
+                    "table is split into multiple files. Use Dataset.repartition() to control "
+                    "the number of output files instead."
+                )
+        else:
+            row_number_column_name = None
+
         datasink = ParquetDatasink(
             path,
             partition_cols=partition_cols,
@@ -4162,6 +4204,7 @@ class Dataset:
             filename_provider=filename_provider,
             dataset_uuid=self._uuid,
             mode=mode,
+            row_number_column_name=row_number_column_name,
         )
         self.write_datasink(
             datasink,

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -2670,6 +2670,115 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     assert actual_data == expected_data, (actual_data, expected_data)
 
 
+@pytest.mark.parametrize(
+    "max_rows_per_file,expected_num_files",
+    [(None, 10), (50, 20)],
+)
+def test_write_parquet_include_row_number(
+    max_rows_per_file, expected_num_files, ray_start_regular_shared, tmp_path
+):
+    ds = ray.data.range(1000, override_num_blocks=10)
+    ds.write_parquet(
+        tmp_path, include_row_number=True, max_rows_per_file=max_rows_per_file
+    )
+    result = ray.data.read_parquet(tmp_path)
+    assert result.count() == 1000
+    assert set(result.schema().names) == {"id", "_row_num"}
+
+    assert len(result.input_files()) == expected_num_files
+
+
+@pytest.mark.parametrize(
+    "max_rows_per_file",
+    [None, 50],
+)
+def test_write_parquet_include_row_number_with_partitioning(
+    max_rows_per_file, ray_start_regular_shared, tmp_path
+):
+    # Use a partition column that groups many rows (id % 10) so we get multiple
+    # rows per file and can meaningfully verify _row_num is unique per file.
+    # Partitioning by "id" alone would give 1 row per partition (trivial).
+    from ray.data.expressions import col
+
+    ds = ray.data.range(1000).with_column("part", col("id") % 10)
+    ds.write_parquet(
+        tmp_path,
+        partition_cols=["part"],
+        include_row_number=True,
+        max_rows_per_file=max_rows_per_file,
+    )
+    result = ray.data.read_parquet(tmp_path)
+    assert result.count() == 1000
+    assert set(result.schema().names) == {"id", "part", "_row_num"}
+
+    import polars as pl
+
+    df = pl.read_parquet(tmp_path, include_file_paths="path")
+
+    # Verify that the row numbers are unique within each file
+    assert (
+        df.group_by("path")
+        .agg(
+            pl.col("_row_num").n_unique().alias("num_unique_row_nums"),
+            pl.len().alias("num_rows"),
+        )
+        .select(pl.col("num_unique_row_nums") == pl.col("num_rows"))
+        .to_series()
+        .all()
+    )
+
+
+@pytest.mark.parametrize("partition_cols", [None, ["part"]])
+def test_add_row_numbers_preserves_arrow_types(tmp_path, partition_cols):
+    """Polars's to_arrow() promotes string->large_string, binary->large_binary,
+    list->large_list. _add_row_numbers must not let those promotions leak into
+    the returned table because the downstream cast (large_list->list) is not
+    reliably supported by PyArrow and the large_string->string cast copies all
+    string data unnecessarily."""
+    from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
+
+    pytest.importorskip("polars")
+
+    # Build tables that contain every type Polars would silently promote.
+    t1 = pa.table(
+        {
+            "str_col": pa.array(["a", "b"], pa.utf8()),
+            "bin_col": pa.array([b"x", b"y"], pa.binary()),
+            "list_col": pa.array([[1, 2], [3]], pa.list_(pa.int32())),
+            "part": pa.array([0, 1], pa.int32()),
+        }
+    )
+    t2 = pa.table(
+        {
+            "str_col": pa.array(["c", "d"], pa.utf8()),
+            "bin_col": pa.array([b"z", b"w"], pa.binary()),
+            "list_col": pa.array([[4], [5, 6]], pa.list_(pa.int32())),
+            "part": pa.array([0, 1], pa.int32()),
+        }
+    )
+
+    sink = ParquetDatasink(
+        str(tmp_path),
+        row_number_column_name="_row_num",
+        partition_cols=partition_cols,
+    )
+    result = sink._add_row_numbers([t1, t2])
+
+    # The row-number column is appended; all pre-existing columns must keep
+    # their original Arrow types (no large_string / large_binary / large_list).
+    assert (
+        result.schema.field("str_col").type == pa.utf8()
+    ), f"Expected utf8, got {result.schema.field('str_col').type}"
+    assert (
+        result.schema.field("bin_col").type == pa.binary()
+    ), f"Expected binary, got {result.schema.field('bin_col').type}"
+    assert result.schema.field("list_col").type == pa.list_(
+        pa.int32()
+    ), f"Expected list<int32>, got {result.schema.field('list_col').type}"
+    assert result.schema.field("_row_num").type == pa.int64()
+    assert len(result) == len(t1) + len(t2)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description
This is a new option to `write_parquet` for adding a per-file row number column.

### Motivation
A row number column is very useful for bookkeeping during ETL and checkpointing during model training. Combining row_number and the file name (e.g., enabled by include_paths during read), the tuple (path, row_number) is unique for each row. Since they are generated during write, they are permanent and part of the output. This makes it easier to use than other non-reproducible per-row unique IDs (uuid etc).

## Related issues
Closes #60255

## Additional information
### Implementation
The per-file row_number column is easier to implement, which only requires adding the column to the tables right before writing them by pyarrow. No parallelism or communication needs to be handled within a single Ray Task.

It does require an external `polars` package for a simple and efficient implementation. I think it's not worth reinventing the wheel for a specific and non-distributed case.

### Limitations
* When using partitioned writes, different writers will write the files to the same partition. So it's expected that row number is not unique per partition, but unique per file.
* When using min_rows_per_files etc, the splits happen after assign the row number column. A warning is given but it does not raise an error. The rationale for this is that per-file row number are still unique, so users can still use this for checkponting. The only non-ideal consequence is the row number may not start from 0 for some files.

I think both points are minor. So I have documented them in the docstring and raise warning (but not prevent users from using them).