### PR TITLE
[LLM] Fix shell injection vulnerability in lora_utils.py

### DIFF
--- a/python/ray/llm/_internal/common/utils/lora_utils.py
+++ b/python/ray/llm/_internal/common/utils/lora_utils.py
@@ -8,7 +8,7 @@ download primitives from download_utils.py.
 
 import json
 import os
-import subprocess
+import shutil
 import time
 from functools import wraps
 from typing import Any, Callable, List, Optional, TypeVar, Union
@@ -58,10 +58,7 @@ def clean_model_id(model_id: str) -> str:
 
 def clear_directory(dir: str) -> None:
     """Clear a directory recursively, ignoring missing directories."""
-    try:
-        subprocess.run(f"rm -r {dir}", shell=True, check=False)
-    except FileNotFoundError:
-        pass
+    shutil.rmtree(dir, ignore_errors=True)
 
 
 def retry_with_exponential_backoff(


### PR DESCRIPTION
## Summary
- Replace `subprocess.run(f"rm -r {dir}", shell=True)` with `shutil.rmtree()` to prevent potential command injection
- Removes unreachable `except FileNotFoundError` block (subprocess.run doesn't raise this exception)

## Why is this change needed?
The previous implementation used shell interpolation which could allow command injection if the directory path contained shell metacharacters. `shutil.rmtree()` is the standard library function for recursive directory deletion and handles edge cases correctly.

## Test plan
- Existing tests should pass
- The change is functionally equivalent but safer

🤖 Generated with [Claude Code](https://claude.com/code)