### PR TITLE
[release test] remove stable field handling

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -182,16 +182,10 @@ def get_step(
     if test.get("run", {}).get("type") == "client":
         step["agents"]["queue"] = str(RELEASE_QUEUE_CLIENT)
 
-    # If a test is not stable, allow to soft fail
-    stable = test.get("stable", True)
     clone_test = copy.deepcopy(test)  # avoid modifying the original test
     clone_test.update_from_s3()
     jailed = clone_test.get_state() == TestState.JAILED
     full_label = ""
-    if not stable:
-        step["soft_fail"] = True
-    if not stable:
-        full_label += "[unstable]"
     if jailed:
         full_label += "[jailed]"
 

--- a/release/ray_release/test_automation/release_state_machine.py
+++ b/release/ray_release/test_automation/release_state_machine.py
@@ -5,7 +5,6 @@ from ray_release.test_automation.state_machine import (
 )
 
 CONTINUOUS_FAILURE_TO_JAIL = 3  # Number of continuous failures before jailing
-UNSTABLE_RELEASE_TEST_TAG = "unstable-release-test"
 
 
 class ReleaseTestStateMachine(TestStateMachine):
@@ -67,10 +66,7 @@ class ReleaseTestStateMachine(TestStateMachine):
             "triage",
             self.test.get_oncall(),
         ]
-        if not self.test.is_stable():
-            labels.append(UNSTABLE_RELEASE_TEST_TAG)
-        else:
-            labels.append(WEEKLY_RELEASE_BLOCKER_TAG)
+        labels.append(WEEKLY_RELEASE_BLOCKER_TAG)
         issue_number = self.ray_repo.create_issue(
             title=f"Release test {self.test.get_name()} failed",
             body=(

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -247,7 +247,7 @@ def test_release_move_from_passing_to_failing():
 
 
 def test_release_move_from_failing_to_consisently_failing():
-    test = Test(name="test", team="ci", stable=False)
+    test = Test(name="test", team="ci")
     test[Test.KEY_BISECT_BUILD_NUMBER] = 1
     test.test_results = [
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
@@ -264,7 +264,6 @@ def test_release_move_from_failing_to_consisently_failing():
     assert "Blamed commit: 1234567890" in issue.comments[0]
     labels = [label.name for label in issue.get_labels()]
     assert "ci" in labels
-    assert "unstable-release-test" in labels
 
 
 def test_release_move_from_failing_to_passing():

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -435,7 +435,6 @@
 - name: random_shuffle_chaos
   python: "3.10"
   working_dir: nightly_tests
-  stable: False
 
   cluster:
     byod:
@@ -473,7 +472,6 @@
 - name: sort_chaos
   python: "3.10"
   working_dir: nightly_tests
-  stable: False
 
   cluster:
     byod:
@@ -519,7 +517,6 @@
 
 - name: image_classification_chaos
   python: "3.10"
-  stable: False
   # Don't use 'nightly_tests/dataset' as the working directory because we need to run
   # the 'setup_chaos.py' script.
   working_dir: nightly_tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -280,8 +280,6 @@
   frequency: manual
   team: ml
 
-  stable: false
-
   cluster:
     byod:
       type: gpu
@@ -330,8 +328,6 @@
   group: AIR examples
   working_dir: air_examples/dreambooth
 
-  stable: false
-
   # https://github.com/ray-project/ray/issues/49847
   frequency: manual
   team: ml
@@ -352,8 +348,6 @@
   python: "3.10"
   group: AIR examples
   working_dir: air_examples/dreambooth
-
-  stable: false
 
   # https://github.com/ray-project/ray/issues/49846
   frequency: manual
@@ -756,8 +750,6 @@
   group: Tune fault tolerance tests
   working_dir: tune_tests/fault_tolerance_tests
 
-  stable: true
-
   frequency: nightly-3x
   team: ml
 
@@ -947,8 +939,6 @@
   python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
-
-  stable: false
 
   frequency: weekly
   team: ml
@@ -1148,8 +1138,6 @@
   group: Long running tests
   working_dir: long_running_tests
 
-  stable: true
-
   frequency: weekly
   team: serve
 
@@ -1188,8 +1176,6 @@
   python: "3.10"
   group: Long running tests
   working_dir: long_running_tests
-
-  stable: true
 
   frequency: weekly
   team: serve
@@ -3017,8 +3003,6 @@
 #       num_nodes: 32
 #       timeout: 600
 
-#   stable: false
-
 # - name: scheduling_test_many_5s_tasks_many_nodes
 #   group: core-scalability-test
 #   working_dir: benchmarks
@@ -3036,8 +3020,6 @@
 #     wait_for_nodes:
 #       num_nodes: 32
 #       timeout: 600
-
-#   stable: false
 
 
 ##################
@@ -3539,8 +3521,6 @@
   group: k8s-test
   working_dir: k8s_tests
 
-  stable: false
-
   # Failing since Oct 2024.
   # https://github.com/ray-project/ray/issues/36190
   frequency: manual
@@ -3716,8 +3696,6 @@
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
-  stable: true
-
   env: gce
   frequency: nightly
   team: clusters
@@ -3741,8 +3719,6 @@
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
-  stable: true
-
   env: gce
   frequency: nightly
   team: clusters
@@ -3764,8 +3740,6 @@
 - name: gcp_cluster_launcher_latest_image
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
-
-  stable: true
 
   env: gce
   frequency: manual
@@ -3790,8 +3764,6 @@
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
-  stable: true
-
   env: gce
   frequency: manual
   team: clusters
@@ -3815,8 +3787,6 @@
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
-  stable: true
-
   env: gce
   frequency: manual
   team: clusters
@@ -3839,8 +3809,6 @@
   python: "3.10"
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
-
-  stable: true
 
   env: gce
   frequency: weekly


### PR DESCRIPTION
if a test is not stable, it should be on manual frequency. we will no longer treat unstable tests differently.