### PR TITLE
[release test] removes logs streaming limit

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -127,8 +127,6 @@ def get_step(
     cmd = [
         "./release/run_release_test.sh",
         shlex.quote(test["name"]),
-        "--log-streaming-limit",
-        "100",
     ]
 
     for file in test_collection_file or []:

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -2,7 +2,7 @@ import abc
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from ray_release.anyscale_util import LAST_LOGS_LENGTH, get_project_name
+from ray_release.anyscale_util import get_project_name
 from ray_release.aws import (
     RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
     add_tags_to_aws_config,
@@ -22,7 +22,6 @@ class ClusterManager(abc.ABC):
         project_id: str,
         sdk: Optional["AnyscaleSDK"] = None,
         smoke_test: bool = False,
-        log_streaming_limit: int = LAST_LOGS_LENGTH,
     ):
         self.sdk = sdk or get_anyscale_sdk()
 
@@ -30,7 +29,6 @@ class ClusterManager(abc.ABC):
         self.smoke_test = smoke_test
         self.project_id = project_id
         self.project_name = get_project_name(self.project_id, self.sdk)
-        self.log_streaming_limit = log_streaming_limit
 
         self.cluster_name = (
             f"{test.get_name()}{'-smoke-test' if smoke_test else ''}_{int(time.time())}"

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -9,7 +9,6 @@ from google.cloud import storage as gcs_storage
 
 from ray_release.alerts.handle import handle_result, require_result
 from ray_release.anyscale_util import (
-    LAST_LOGS_LENGTH,
     create_cluster_env_from_image,
     get_custom_cluster_env_name,
 )
@@ -81,7 +80,6 @@ def _load_test_configuration(
     anyscale_project: str,
     result: Result,
     smoke_test: bool = False,
-    log_streaming_limit: int = LAST_LOGS_LENGTH,
 ) -> Tuple[ClusterManager, CommandRunner, str]:
     logger.info(f"Test config: {test}")
 
@@ -128,7 +126,6 @@ def _load_test_configuration(
             test,
             anyscale_project,
             smoke_test=smoke_test,
-            log_streaming_limit=log_streaming_limit,
         )
         command_runner = command_runner_cls(
             cluster_manager,
@@ -386,7 +383,6 @@ def run_release_test(
     reporters: Optional[List[Reporter]] = None,
     smoke_test: bool = False,
     test_definition_root: Optional[str] = None,
-    log_streaming_limit: int = LAST_LOGS_LENGTH,
     image: Optional[str] = None,
 ) -> Result:
     if test.is_kuberay():
@@ -403,7 +399,6 @@ def run_release_test(
         reporters=reporters,
         smoke_test=smoke_test,
         test_definition_root=test_definition_root,
-        log_streaming_limit=log_streaming_limit,
         image=image,
     )
 
@@ -470,7 +465,6 @@ def run_release_test_anyscale(
     reporters: Optional[List[Reporter]] = None,
     smoke_test: bool = False,
     test_definition_root: Optional[str] = None,
-    log_streaming_limit: int = LAST_LOGS_LENGTH,
     image: Optional[str] = None,
 ) -> Result:
     old_wd = os.getcwd()
@@ -488,7 +482,6 @@ def run_release_test_anyscale(
             anyscale_project,
             result,
             smoke_test,
-            log_streaming_limit,
         )
         buildkite_group(":nut_and_bolt: Setting up cluster environment")
 

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -9,6 +9,7 @@ from anyscale.sdk.anyscale_client.models import (
     HaJobStates,
 )
 
+from ray_release.anyscale_util import LAST_LOGS_LENGTH
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.exception import (
     CommandTimeout,
@@ -258,14 +259,8 @@ class AnyscaleJobManager:
         return self._wait_job(timeout)
 
     def _get_ray_logs(self) -> str:
-        """
-        Obtain the last few logs
-        """
-        if self.cluster_manager.log_streaming_limit == -1:
-            return anyscale.job.get_logs(id=self.job_id)
-        return anyscale.job.get_logs(
-            id=self.job_id, max_lines=self.cluster_manager.log_streaming_limit
-        )
+        """Obtain the last few log"""
+        return anyscale.job.get_logs(id=self.job_id, max_lines=LAST_LOGS_LENGTH)
 
     def get_last_logs(self):
         if not self.job_id:

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -5,7 +5,6 @@ from typing import Optional, Tuple
 
 import click
 
-from ray_release.anyscale_util import LAST_LOGS_LENGTH
 from ray_release.aws import maybe_fetch_api_token
 from ray_release.config import (
     RELEASE_TEST_CONFIG_FILES,
@@ -71,12 +70,6 @@ from ray_release.result import Result
     help="Root of the test definition files. Default is the root of the repo.",
 )
 @click.option(
-    "--log-streaming-limit",
-    default=LAST_LOGS_LENGTH,
-    type=int,
-    help="Limit of log streaming in number of lines. Set to -1 to stream all logs.",
-)
-@click.option(
     "--image",
     default=None,
     type=str,
@@ -90,7 +83,6 @@ def main(
     env: Optional[str] = None,
     global_config: str = "oss_config.yaml",
     test_definition_root: Optional[str] = None,
-    log_streaming_limit: int = LAST_LOGS_LENGTH,
     image: Optional[str] = None,
 ):
     global_config_file = os.path.join(
@@ -146,7 +138,6 @@ def main(
             reporters=reporters,
             smoke_test=smoke_test,
             test_definition_root=test_definition_root,
-            log_streaming_limit=log_streaming_limit,
             image=image,
         )
         return_code = result.return_code

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -112,14 +112,12 @@ class GlueTest(unittest.TestCase):
                 project_id: str,
                 sdk=None,
                 smoke_test: bool = False,
-                log_streaming_limit: int = 100,
             ):
                 super(MockClusterManager, self).__init__(
                     test_name,
                     project_id,
                     this_sdk,
                     smoke_test=smoke_test,
-                    log_streaming_limit=log_streaming_limit,
                 )
                 self.return_dict = this_cluster_manager_return
                 this_instances["cluster_manager"] = self
@@ -261,18 +259,12 @@ class GlueTest(unittest.TestCase):
 
     def _run(self, result: Result, kuberay: bool = False, **kwargs):
         if kuberay:
-            run_release_test(
-                test=self.kuberay_test,
-                result=result,
-                log_streaming_limit=1000,
-                **kwargs
-            )
+            run_release_test(test=self.kuberay_test, result=result, **kwargs)
         else:
             run_release_test(
                 test=self.test,
                 anyscale_project=self.anyscale_project,
                 result=result,
-                log_streaming_limit=1000,
                 **kwargs
             )
 
@@ -427,7 +419,6 @@ class GlueTest(unittest.TestCase):
 
         self.assertEqual(result.return_code, ExitCode.COMMAND_ALERT.value)
         self.assertEqual(result.status, "error")
-        self.assertEqual(self.instances["cluster_manager"].log_streaming_limit, 1000)
 
     def testReportFails(self):
         result = Result()

--- a/release/ray_release/tests/test_step.py
+++ b/release/ray_release/tests/test_step.py
@@ -43,8 +43,6 @@ def test_get_step(mock):
     first_command = shlex.split(step["commands"][0])
     assert first_command[0] == "./release/run_release_test.sh"
     assert first_command[1] == "test with spaces"
-    assert first_command[2] == "--log-streaming-limit"
-    assert first_command[3] == "100"
 
 
 @patch("ray_release.test.Test.update_from_s3", return_value=None)


### PR DESCRIPTION
we have always been using a constant. if one needs more logs, they can go to anyscale's UI and view logs there.
