### PR TITLE
[release test] remove `save_metrics` method in runner

### DIFF
--- a/release/ray_release/command_runner/anyscale_job_runner.py
+++ b/release/ray_release/command_runner/anyscale_job_runner.py
@@ -139,10 +139,6 @@ class AnyscaleJobRunner(CommandRunner):
             f"python wait_cluster.py {num_nodes} {timeout}", timeout=timeout + 30
         )
 
-    def save_metrics(self, start_time: float, timeout: float = 900):
-        # Handled in run_command
-        return
-
     def _handle_command_output(
         self, job_status_code: int, error: str, raise_on_timeout: bool = True
     ):

--- a/release/ray_release/command_runner/command_runner.py
+++ b/release/ray_release/command_runner/command_runner.py
@@ -77,19 +77,6 @@ class CommandRunner(abc.ABC):
         """
         raise NotImplementedError
 
-    def save_metrics(self, start_time: float, timeout: float = 900.0):
-        """Obtains Prometheus metrics from head node and saves them
-        to ``self.metrics_output_json``.
-
-        Args:
-            start_time: From which UNIX timestamp to start the query.
-            timeout: Timeout in seconds.
-
-        Returns:
-            None
-        """
-        raise NotImplementedError
-
     def run_command(
         self,
         command: str,

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -359,12 +359,6 @@ def _fetching_results(
         )
 
     try:
-        # Logic duplicated in ray_release/command_runner/_anyscale_job_wrapper.py
-        # Timeout is the time the test took divided by 200
-        # (~7 minutes for a 24h test) but no less than 30s
-        # and no more than 900s
-        metrics_timeout = max(30, min((time.time() - start_time_unix) / 200, 900))
-        command_runner.save_metrics(start_time_unix, timeout=metrics_timeout)
         metrics = command_runner.fetch_metrics()
     except Exception as e:
         logger.exception(f"Could not fetch metrics for test command: {e}")


### PR DESCRIPTION
metrics saving is handled in job wrapper
