### PR TITLE
[Data] Avoid redundant reads in train_test_split

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2430,7 +2430,7 @@ class Dataset:
         if any(p <= 0 for p in proportions):
             raise ValueError("proportions must be bigger than 0")
 
-        ds, dataset_length = self._get_dataset_length_for_split(self)
+        ds, dataset_length = self._try_count_or_materialize(self)
         cumulative_proportions = np.cumsum(proportions)
         split_indices = [
             int(dataset_length * proportion) for proportion in cumulative_proportions
@@ -2517,11 +2517,11 @@ class Dataset:
             self._validate_test_size_float(test_size)
             return ds.split_proportionately([1 - test_size])
         else:
-            ds, ds_length = self._get_dataset_length_for_split(ds)
+            ds, ds_length = self._try_count_or_materialize(ds)
             ds_length = self._validate_test_size_int(test_size, ds, ds_length=ds_length)
             return ds.split_at_indices([ds_length - test_size])
 
-    def _get_dataset_length_for_split(self, ds: "Dataset") -> Tuple["Dataset", int]:
+    def _try_count_or_materialize(self, ds: "Dataset") -> Tuple["Dataset", int]:
         dataset_length = ds._meta_count()
         if dataset_length is None:
             # Materialize once so split_at_indices() can reuse the computed snapshot.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2435,8 +2435,8 @@ class Dataset:
         if dataset_length is None:
             ds = ds.materialize()
             dataset_length = ds._meta_count()
-        if dataset_length is None:
-            dataset_length = ds.count()
+            if dataset_length is None:
+                dataset_length = ds.count()
         cumulative_proportions = np.cumsum(proportions)
         split_indices = [
             int(dataset_length * proportion) for proportion in cumulative_proportions

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2433,6 +2433,9 @@ class Dataset:
         ds = self
         dataset_length = ds._meta_count()
         if dataset_length is None:
+            # Materialize once so split_at_indices() can reuse the computed snapshot.
+            # Calling count() first would execute the upstream pipeline for counting,
+            # then execute it again for the split.
             ds = ds.materialize()
             dataset_length = ds._meta_count()
             if dataset_length is None:
@@ -2525,6 +2528,8 @@ class Dataset:
         else:
             ds_length = ds._meta_count()
             if ds_length is None:
+                # Materialize once so split_at_indices() doesn't re-execute the
+                # upstream pipeline after a separate count() run.
                 ds = ds.materialize()
                 ds_length = ds._meta_count()
             ds_length = self._validate_test_size_int(test_size, ds, ds_length=ds_length)


### PR DESCRIPTION
## Description
This PR fixes train_test_split/split_proportionately reading the dataset twice in the example by avoiding redundant execution.

## Related issues
> Link related issues: "Fixes #51223 ", "Closes #51223 ", or "Related to #51223 ".

## Additional information

### implementation
- train_test_split(test_size=int) now tries _meta_count() first; if unknown, it materialize()s once and reuses the metadata row count, only falling back to count() if still unknown. It then splits on the (materialized) dataset to avoid re-reading.
- split_proportionately() uses the same pattern to avoid count() forcing an extra execution for float splits.
- _validate_test_size_int() now accepts an optional precomputed ds_length to avoid redundant count() calls.

### Local quick check

#### Reproduce script
`demo_torch_detection_like_issue.py` 

（based on Torch object detection example https://docs.ray.io/en/latest/train/examples/pytorch/torch_detection.html）
```python
import io
import os
import ray
import requests
import xmltodict
import numpy as np
from PIL import Image
from typing import Any, Dict, List, Tuple

CLASS_TO_LABEL = {"background": 0, "cat": 1, "dog": 2}

def decode_annotation(row: Dict[str, Any]) -> Dict[str, Any]:
    text = row["bytes"].decode("utf-8")
    annotation = xmltodict.parse(text)["annotation"]
    objects = annotation["object"]
    if isinstance(objects, dict):
        objects = [objects]
    boxes: List[Tuple] = []
    for obj in objects:
        x1 = float(obj["bndbox"]["xmin"])
        y1 = float(obj["bndbox"]["ymin"])
        x2 = float(obj["bndbox"]["xmax"])
        y2 = float(obj["bndbox"]["ymax"])
        boxes.append((x1, y1, x2, y2))
    labels = [CLASS_TO_LABEL[obj["name"]] for obj in objects]
    return {"boxes": boxes, "labels": labels, "filename": annotation["filename"]}


def read_images(row: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
    url = os.path.join("https://s3-us-west-2.amazonaws.com/air-example-data/AnimalDetection/JPEGImages",row["filename"],)
    response = requests.get(url)
    image = Image.open(io.BytesIO(response.content))
    row["image"] = np.array(image)
    return row

if __name__ == "__main__":
    ray.init()
    annotations = ray.data.read_binary_files("s3://anonymous@air-example-data/AnimalDetection/Annotations").map(decode_annotation)
    dataset = annotations.limit(20).map(read_images)
    train, test = dataset.train_test_split(test_size=0.2)
    print("train count:", train.count())
    print("test count:", test.count())
    ray.shutdown()
```
#### Before:
```bash
2026-01-19 02:12:40,039	INFO worker.py:2007 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265
/Users/xxx/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/_private/worker.py:2055: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
RayContext(dashboard_url='127.0.0.1:8265', python_version='3.10.19', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}')
2026-01-19 02:12:53,068	INFO logging.py:397 -- Registered dataset logger for dataset dataset_4_0
2026-01-19 02:12:53,091	INFO streaming_executor.py:182 -- Starting execution of Dataset dataset_4_0. Full logs are in /tmp/ray/session_2026-01-19_02-12-36_655885_24877/logs/ray-data
2026-01-19 02:12:53,091	INFO streaming_executor.py:183 -- Execution plan of Dataset dataset_4_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadBinary] -> LimitOperator[limit=20] -> TaskPoolMapOperator[Map(decode_annotation)->Map(read_images)->Project] -> AggregateNumRows[AggregateNumRows]
2026-01-19 02:12:53,108	WARNING resource_manager.py:134 -- ⚠️  Ray's object store is configured to use only 23.6% of available memory (2.0GiB out of 8.5GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.
2026-01-19 02:12:53,108	INFO streaming_executor.py:661 -- [dataset]: A new progress UI is available. To enable, set `ray.data.DataContext.get_current().enable_rich_progress_bars = True` and `ray.data.DataContext.get_current().use_ray_tqdm = False`.
Running Dataset dataset_4_0.: 0.00 row [00:00, ? row/s]                                                                                                 2026-01-19 02:12:53,144  WARNING resource_manager.py:791 -- Cluster resources are not enough to run any task from TaskPoolMapOperator[ReadBinary]. The job may hang forever unless the cluster scales up.                                                                            | 0.00/1.00 [00:00<?, ? row/s]
2026-01-19 02:12:53,156)WARNING utils.py:33 -- Truncating long operator name to 100 characters. To disable this behavior, set `ray.data.DataContext.get_current().DEFAULT_ENABLE_PROGRESS_BAR_NAME_TRUNCATION = False`.                                                             | 0.00/1.00 [00:00<?, ? row/s]
✔️  Dataset dataset_4_0 execution finished in 37.60 seconds: 100%|██████████████████████████████████████████████████| 1.00/1.00 [00:37<00:00, 37.6s/ row]
- ReadBinary: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: 100%|██████████████| 140/140 [00:37<00:00, 3.73 row/s]
- limit=20: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: 100%|██████████████| 20.0/20.0 [00:37<00:00, 1.88s/ row]
- Map(decode_annotation)->...->Project: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: 100%|█| 20.0/20.0 [00:37<00:
- AggregateNumRows: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 8.0B object store: 100%|██████| 1.00/1.00 [00:37<00:00, 37.6s/ row]
2026-01-19 02:13:30,695 INFO streaming_executor.py:302 -- ✔️  Dataset dataset_4_0 execution finished in 37.60 seconds
2026-01-19 02:13:30,703 INFO logging.py:397 -- Registered dataset logger for dataset dataset_3_0
2026-01-19 02:13:30,725 INFO streaming_executor.py:182 -- Starting execution of Dataset dataset_3_0. Full logs are in /tmp/ray/session_2026-01-19_02-12-36_655885_24877/logs/ray-data
2026-01-19 02:13:30,725	INFO streaming_executor.py:183 -- Execution plan of Dataset dataset_3_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadBinary] -> LimitOperator[limit=20] -> TaskPoolMapOperator[Map(decode_annotation)->Map(read_images)]
Running Dataset dataset_3_0.: 0.00 row [00:00, ? row/s]                                                                                                 2026-01-19 02:13:30,742  WARNING resource_manager.py:791 -- Cluster resources are not enough to run any task from TaskPoolMapOperator[ReadBinary]. The job may hang forever unless the cluster scales up.                                                                            | 0.00/1.00 [00:00<?, ? row/s]
✔️  Dataset dataset_3_0 execution finished in 36.65 seconds: 100%|██████████████████████████████████████████████████| 20.0/20.0 [00:36<00:00, 1.83s/ row]
- ReadBinary: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: 100%|██████████████| 140/140 [00:36<00:00, 3.82 row/s]
- limit=20: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: 100%|██████████████| 20.0/20.0 [00:36<00:00, 1.83s/ row]
- Map(decode_annotation)->Map(read_images): Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 10.5MiB object store: 100%|█| 20.0/20.0 [00
2026-01-19 02:14:07,383 INFO streaming_executor.py:302 -- ✔️  Dataset dataset_3_0 execution finished in 36.65 seconds
train count: 16
test count: 4
```

#### After:
```bash
2026-01-19 02:19:40,794	INFO worker.py:2007 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265
/Users/xxx/miniforge3/envs/clion-ray-ce/lib/python3.10/site-packages/ray/_private/worker.py:2055: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
RayContext(dashboard_url='127.0.0.1:8265', python_version='3.10.19', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}')
2026-01-19 02:19:49,261	INFO logging.py:397 -- Registered dataset logger for dataset dataset_4_0
2026-01-19 02:19:49,280	INFO streaming_executor.py:182 -- Starting execution of Dataset dataset_4_0. Full logs are in /tmp/ray/session_2026-01-19_02-19-37_385772_25956/logs/ray-data
2026-01-19 02:19:49,280	INFO streaming_executor.py:183 -- Execution plan of Dataset dataset_4_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadBinary] -> LimitOperator[limit=20] -> TaskPoolMapOperator[Map(decode_annotation)->Map(read_images)]
2026-01-19 02:19:49,288	WARNING resource_manager.py:134 -- ⚠️  Ray's object store is configured to use only 24.5% of available memory (2.0GiB out of 8.2GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.
2026-01-19 02:19:49,288	INFO streaming_executor.py:661 -- [dataset]: A new progress UI is available. To enable, set `ray.data.DataContext.get_current().enable_rich_progress_bars = True` and `ray.data.DataContext.get_current().use_ray_tqdm = False`.
Running Dataset dataset_4_0.: 0.00 row [00:00, ? row/s]                                                                                                 2026-01-19 02:19:49,318  WARNING resource_manager.py:791 -- Cluster resources are not enough to run any task from TaskPoolMapOperator[ReadBinary]. The job may hang forever unless the cluster scales up.                                                                            | 0.00/1.00 [00:00<?, ? row/s]
✔️  Dataset dataset_4_0 execution finished in 37.63 seconds: 100%|██████████████████████████████████████████████████| 20.0/20.0 [00:37<00:00, 1.88s/ row]
- ReadBinary: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: 100%|██████████████| 140/140 [00:37<00:00, 3.72 row/s]
- limit=20: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: 100%|██████████████| 20.0/20.0 [00:37<00:00, 1.88s/ row]
- Map(decode_annotation)->Map(read_images): Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 10.5MiB object store: 100%|█| 20.0/20.0 [00
2026-01-19 02:20:26,910 INFO streaming_executor.py:302 -- ✔️  Dataset dataset_4_0 execution finished in 37.63 seconds
train count: 16
test count: 4
```


