### PR TITLE
[Docs][Dev] `setup-dev.py` script might conflict due to `/tmp/ray`

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -118,7 +118,7 @@ RLlib, Tune, Autoscaler, and most Python files do not require you to build and c
     rm -rf <package path>/site-packages/ray # Path will be in the output of `setup-dev.py`.
     pip uninstall ray # or `pip install -U <wheel>`
 
-.. tip:: When running ``python python/ray/setup-dev.py`` again (or possibly multiple times due to script error), it is helpful to run ``rm -rf /tmp/ray`` to remove any temporary files that might cause conflicts.
+.. tip:: When re-running ``python python/ray/setup-dev.py``, especially after a failure, run ``rm -rf /tmp/ray`` to clear temporary files from previous runs and prevent potential conflicts.
 
 Preparing to build Ray on Linux
 -------------------------------

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -118,6 +118,8 @@ RLlib, Tune, Autoscaler, and most Python files do not require you to build and c
     rm -rf <package path>/site-packages/ray # Path will be in the output of `setup-dev.py`.
     pip uninstall ray # or `pip install -U <wheel>`
 
+.. tip:: When running ``python python/ray/setup-dev.py`` again (or possibly multiple times due to script error), it is helpful to run ``rm -rf /tmp/ray`` to remove any temporary files that might cause conflicts.
+
 Preparing to build Ray on Linux
 -------------------------------
 


### PR DESCRIPTION
## Description
I sometimes had situations where `setup-dev.py` fails to run (due to missing files, mismatched branch files and wheels, etc). When I fix and re-run `setup-dev.py`, some files are left over in `/tmp/ray` that prevents me from running `setup-dev.py` properly (I get `FileAlreadyExists` error).

This pr improves documentations to give users hints to remove that folder before proceeding.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
