### PR TITLE
[Core] Fix missing <cstdint> include for GCC 13+ compatibility

### DIFF
--- a/src/ray/observability/open_telemetry_metric_recorder.h
+++ b/src/ray/observability/open_telemetry_metric_recorder.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #pragma once
 
 #include <opentelemetry/metrics/meter.h>


### PR DESCRIPTION
This PR fixes a build failure encountered when building Ray from source on modern Linux environments (e.g., Fedora 42, Arch) using GCC 13/14.

Newer compilers no longer include `<cstdint>` transitively. This PR adds the explicit include to `src/ray/observability/open_telemetry_metric_recorder.h` to resolve `uint64_t` / `int64_t` "not declared in this scope" errors.