### PR TITLE
[Build] Patch vendored setproctitle for C23 compatibility

### DIFF
--- a/src/ray/thirdparty/setproctitle/c.h
+++ b/src/ray/thirdparty/setproctitle/c.h
@@ -12,9 +12,10 @@
 
 #include "spt_config.h"
 
-#ifndef __cplusplus
+#if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L)
 
 #ifndef bool
+/* Define bool, true, false for C before C23. C++ and C23+ have them built-in. */
 typedef char bool;
 #endif
 


### PR DESCRIPTION
This PR fixes a build failure encountered when building Ray from source on modern Linux environments (e.g., Fedora 42) using compilers that default to the C23 standard.

The `typedef char bool;` in the vendored `setproctitle` library conflicts with `bool` being a keyword in C23. This patch guards the typedef to prevent redefinition.