### PR TITLE
[Data][Docs](draft): Document job-level checkpointing

### DIFF
--- a/doc/source/data/batch_inference.rst
+++ b/doc/source/data/batch_inference.rst
@@ -236,6 +236,25 @@ Configuration and troubleshooting
 
 .. _batch_inference_gpu:
 
+Job-level Checkpointing
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Job-level checkpointing can be used to make offline batch inference jobs
+resilient to failures such as node restarts or transient execution errors.
+
+When enabled, Ray Data records progress during execution. If a batch inference
+job fails partway through processing, rerunning the same pipeline with the same
+checkpoint configuration will resume from the last completed checkpoint instead
+of reprocessing all records.
+
+This is especially useful for large batch inference workloads where restarting
+from the beginning would be expensive.
+
+To enable job-level checkpointing, configure a
+:class:`~ray.data.checkpoint.CheckpointConfig` on the current
+:class:`~ray.data.DataContext`. See the
+:ref:`Execution Configurations <execution_configurations>` guide for details.
+
 Using GPUs for inference
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/data/execution-configurations.rst
+++ b/doc/source/data/execution-configurations.rst
@@ -67,3 +67,32 @@ and most users shouldn't need to modify them. However, some of the most importan
 * `raise_original_map_exception`: Whether to raise the original exception encountered in map UDF instead of wrapping it in a `UserCodeException`.
 
 For more details on each of the preceding options, see :class:`~ray.data.DataContext`.
+
+Job-level Checkpointing
+-----------------------
+
+Ray Data supports job-level checkpointing to improve fault tolerance for
+long-running batch pipelines. When enabled, Ray Data can resume a failed job
+from the last successfully processed records instead of restarting from the
+beginning.
+
+Job-level checkpointing is configured through the
+:class:`~ray.data.checkpoint.CheckpointConfig` and is set on the current
+:class:`~ray.data.DataContext`.
+
+**Example configuration:**
+
+.. code-block:: python
+
+    import ray
+    from ray.data.checkpoint import CheckpointConfig
+
+    ctx = ray.data.DataContext.get_current()
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column="id",
+        checkpoint_path="s3://my-bucket/ray-data-checkpoints", 
+        delete_checkpoint_on_success=False,
+    ) 
+
+.. The checkpoint path must be accessible by all nodes in the Ray cluster.
+.. delete_checkpoint_on_success=False preserves checkpoints after successful runs.


### PR DESCRIPTION
This draft PR documents Ray Data job-level checkpointing that was added in #59409.

The documentation adds a short explanation of job-level checkpointing and how it
applies to offline batch inference, with a small configuration example.

Sections touched:
- Execution Configurations
- End-to-end: Offline Batch Inference

Feedback welcome.

Fixes https://github.com/ray-project/ray/issues/60250