### PR TITLE
[Train] Deprecate all Predictor APIs (#60266)

### DIFF
--- a/python/ray/train/_internal/dl_predictor.py
+++ b/python/ray/train/_internal/dl_predictor.py
@@ -10,13 +10,23 @@ from ray.air.util.data_batch_conversion import (
     _convert_pandas_to_batch_type,
 )
 from ray.train.predictor import Predictor
-from ray.util.annotations import DeveloperAPI
+from ray.util.annotations import Deprecated, DeveloperAPI
 
 TensorType = TypeVar("TensorType")
 TensorDtype = TypeVar("TensorDtype")
 
 
+@Deprecated(
+    message=(
+        "DLPredictor is deprecated and will be removed in a future version "
+        "of Ray. The Predictor API was part of the Ray AI Runtime, which has been "
+        "sunsetted. Users should migrate away from Predictor APIs."
+    ),
+    warning=True,
+)
 class DLPredictor(Predictor):
+    """Base class for deep learning framework predictors."""
+
     @abc.abstractmethod
     def _arrays_to_tensors(
         self,

--- a/python/ray/train/lightgbm/lightgbm_predictor.py
+++ b/python/ray/train/lightgbm/lightgbm_predictor.py
@@ -9,12 +9,20 @@ from ray.air.data_batch_type import DataBatchType
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
 from ray.train.lightgbm import LightGBMCheckpoint
 from ray.train.predictor import Predictor
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import Deprecated, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
 
 
+@Deprecated(
+    message=(
+        "LightGBMPredictor is deprecated and will be removed in a future version "
+        "of Ray. The Predictor API was part of the Ray AI Runtime, which has been "
+        "sunsetted. Users should migrate away from Predictor APIs."
+    ),
+    warning=True,
+)
 @PublicAPI(stability="beta")
 class LightGBMPredictor(Predictor):
     """A predictor for LightGBM models.

--- a/python/ray/train/predictor.py
+++ b/python/ray/train/predictor.py
@@ -12,7 +12,7 @@ from ray.air.util.data_batch_conversion import (
 )
 from ray.data import Preprocessor
 from ray.train import Checkpoint
-from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 
 try:
     import pyarrow
@@ -36,6 +36,14 @@ class PredictorNotSerializableException(RuntimeError):
     pass
 
 
+@Deprecated(
+    message=(
+        "The Predictor API is deprecated and will be removed in a future version "
+        "of Ray. The Predictor API was part of the Ray AI Runtime, which has been "
+        "sunsetted. Users should migrate away from Predictor APIs."
+    ),
+    warning=True,
+)
 @PublicAPI(stability="beta")
 class Predictor(abc.ABC):
     """Predictors load models from checkpoints to perform inference.

--- a/python/ray/train/tensorflow/tensorflow_predictor.py
+++ b/python/ray/train/tensorflow/tensorflow_predictor.py
@@ -9,7 +9,7 @@ from ray.train._internal.dl_predictor import DLPredictor
 from ray.train.predictor import DataBatchType
 from ray.train.tensorflow import TensorflowCheckpoint
 from ray.util import log_once
-from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@Deprecated(
+    message=(
+        "TensorflowPredictor is deprecated and will be removed in a future version "
+        "of Ray. The Predictor API was part of the Ray AI Runtime, which has been "
+        "sunsetted. Users should migrate away from Predictor APIs."
+    ),
+    warning=True,
+)
 @PublicAPI(stability="beta")
 class TensorflowPredictor(DLPredictor):
     """A predictor for TensorFlow models.

--- a/python/ray/train/torch/torch_detection_predictor.py
+++ b/python/ray/train/torch/torch_detection_predictor.py
@@ -6,9 +6,17 @@ import torch
 
 from ray.train._internal.dl_predictor import TensorDtype
 from ray.train.torch.torch_predictor import TorchPredictor
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import Deprecated, PublicAPI
 
 
+@Deprecated(
+    message=(
+        "TorchDetectionPredictor is deprecated and will be removed in a future version "
+        "of Ray. The Predictor API was part of the Ray AI Runtime, which has been "
+        "sunsetted. Users should migrate away from Predictor APIs."
+    ),
+    warning=True,
+)
 @PublicAPI(stability="alpha")
 class TorchDetectionPredictor(TorchPredictor):
     """A predictor for TorchVision detection models.

--- a/python/ray/train/torch/torch_predictor.py
+++ b/python/ray/train/torch/torch_predictor.py
@@ -9,7 +9,7 @@ from ray.train._internal.dl_predictor import DLPredictor
 from ray.train.predictor import DataBatchType
 from ray.train.torch import TorchCheckpoint
 from ray.util import log_once
-from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@Deprecated(
+    message=(
+        "TorchPredictor is deprecated and will be removed in a future version "
+        "of Ray. The Predictor API was part of the Ray AI Runtime, which has been "
+        "sunsetted. Users should migrate away from Predictor APIs."
+    ),
+    warning=True,
+)
 @PublicAPI(stability="beta")
 class TorchPredictor(DLPredictor):
     """A predictor for PyTorch models.

--- a/python/ray/train/xgboost/xgboost_predictor.py
+++ b/python/ray/train/xgboost/xgboost_predictor.py
@@ -8,12 +8,20 @@ from ray.air.data_batch_type import DataBatchType
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
 from ray.train.predictor import Predictor
 from ray.train.xgboost import XGBoostCheckpoint
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import Deprecated, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
 
 
+@Deprecated(
+    message=(
+        "XGBoostPredictor is deprecated and will be removed in a future version "
+        "of Ray. The Predictor API was part of the Ray AI Runtime, which has been "
+        "sunsetted. Users should migrate away from Predictor APIs."
+    ),
+    warning=True,
+)
 @PublicAPI(stability="beta")
 class XGBoostPredictor(Predictor):
     """A predictor for XGBoost models.


### PR DESCRIPTION
## Description
> Deprecate ray.train.Predictor and all concrete Predictor subclasses (TorchPredictor, TensorflowPredictor, XGBoostPredictor, LightGBMPredictor, TorchDetectionPredictor, DLPredictor) using the @Deprecated decorator.
The Predictor API was part of the Ray AI Runtime, which has been sunsetted. This change adds deprecation warnings when Predictor classes are instantiated, guiding users to migrate away from these APIs.
This is a deprecation-only change - no APIs are removed and backward compatibility is maintained.

## Related issues
> Fixes - #60266
