### PR TITLE
[Data] Isolate `summary_str`

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -35,6 +35,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     OpState,
     Topology,
     build_streaming_topology,
+    format_op_state_summary,
     process_completed_tasks,
     select_operator_to_run,
     update_operator_states,
@@ -703,8 +704,9 @@ def _debug_dump_topology(topology: Topology, resource_manager: ResourceManager) 
     """
     logger.debug("Execution Progress:")
     for i, (op, state) in enumerate(topology.items()):
+        summary_str = format_op_state_summary(state, resource_manager, verbose=True)
         logger.debug(
-            f"{i}: {state.summary_str(resource_manager, verbose=True)}, "
+            f"{i}: {op.name} - {summary_str}, "
             f"Blocks Outputted: {state.num_completed_tasks}/{op.num_outputs_total()}"
         )
 

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -265,46 +265,6 @@ class OpState:
         self.op.metrics.num_external_outqueue_blocks += len(ref.blocks)
         self.op.metrics.num_external_outqueue_bytes += ref.size_bytes()
 
-    def summary_str_raw(
-        self, resource_manager: ResourceManager, verbose: bool = False
-    ) -> str:
-        # Active tasks
-        active = self.op.num_active_tasks()
-        desc = f"Tasks: {active}"
-        if (
-            self.op._in_task_submission_backpressure
-            or self.op._in_task_output_backpressure
-        ):
-            backpressure_types = []
-            if self.op._in_task_submission_backpressure:
-                # The op is backpressured from submitting new tasks.
-                policy = self.op._task_submission_backpressure_policy or ""
-                backpressure_types.append(f"tasks({policy})")
-            if self.op._in_task_output_backpressure:
-                # The op is backpressured from producing new outputs.
-                policy = self.op._task_output_backpressure_policy or ""
-                backpressure_types.append(f"outputs({policy})")
-            desc += f" [backpressured:{','.join(backpressure_types)}]"
-
-        # Actors info
-        desc += f"; {_actor_info_summary_str(self.op.get_actor_info())}"
-
-        # Queued blocks
-        desc += f"; Queued blocks: {self.total_enqueued_input_blocks()} ({memory_string(self.total_enqueued_input_blocks_bytes())})"
-        desc += f"; Resources: {resource_manager.get_op_usage_str(self.op, verbose=verbose)}"
-
-        # Any additional operator specific information.
-        suffix = self.op.progress_str()
-        if suffix:
-            desc += f"; {suffix}"
-
-        return desc
-
-    def summary_str(
-        self, resource_manager: ResourceManager, verbose: bool = False
-    ) -> str:
-        return f"- {self.op.name}: {self.summary_str_raw(resource_manager, verbose)}"
-
     def dispatch_next_task(self) -> None:
         """Move a bundle from the operator inqueue to the operator itself."""
         for i, inqueue in enumerate(self.input_queues):
@@ -740,3 +700,40 @@ def dedupe_schemas_with_validation(
         ),
         diverged,
     )
+
+
+def format_op_state_summary(
+    op_state: OpState, resource_manager: ResourceManager, verbose: bool
+) -> str:
+    """Get a formatted summary of the OpState for progress reporting."""
+    # Active tasks
+    active = op_state.op.num_active_tasks()
+    desc = f"Tasks: {active}"
+    if (
+        op_state.op._in_task_submission_backpressure
+        or op_state.op._in_task_output_backpressure
+    ):
+        backpressure_types = []
+        if op_state.op._in_task_submission_backpressure:
+            # The op is backpressured from submitting new tasks.
+            policy = op_state.op._task_submission_backpressure_policy or ""
+            backpressure_types.append(f"tasks({policy})")
+        if op_state.op._in_task_output_backpressure:
+            # The op is backpressured from producing new outputs.
+            policy = op_state.op._task_output_backpressure_policy or ""
+            backpressure_types.append(f"outputs({policy})")
+        desc += f" [backpressured:{','.join(backpressure_types)}]"
+
+    # Actors info
+    desc += f"; {_actor_info_summary_str(op_state.op.get_actor_info())}"
+
+    # Queued blocks
+    desc += f"; Queued blocks: {op_state.total_enqueued_input_blocks()} ({memory_string(op_state.total_enqueued_input_blocks_bytes())})"
+    desc += f"; Resources: {resource_manager.get_op_usage_str(op_state.op, verbose=verbose)}"
+
+    # Any additional operator specific information.
+    suffix = op_state.op.progress_str()
+    if suffix:
+        desc += f"; {suffix}"
+
+    return desc

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -703,7 +703,7 @@ def dedupe_schemas_with_validation(
 
 
 def format_op_state_summary(
-    op_state: OpState, resource_manager: ResourceManager, verbose: bool
+    op_state: OpState, resource_manager: ResourceManager, verbose: bool = False
 ) -> str:
     """Get a formatted summary of the OpState for progress reporting."""
     # Active tasks

--- a/python/ray/data/_internal/progress/logging_progress.py
+++ b/python/ray/data/_internal/progress/logging_progress.py
@@ -8,6 +8,9 @@ from typing import Callable, Dict, List, Optional
 from ray._private.ray_constants import env_integer
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.streaming_executor_state import (
+    format_op_state_summary,
+)
 from ray.data._internal.progress.base_progress import (
     BaseExecutionProgressManager,
     BaseProgressBar,
@@ -211,7 +214,7 @@ class LoggingExecutionProgressManager(BaseExecutionProgressManager):
             total = opstate.op.num_output_rows_total()
             if total is not None:
                 op_metrics.total = total
-            op_metrics.desc = opstate.summary_str_raw(resource_manager)
+            op_metrics.desc = format_op_state_summary(opstate, resource_manager)
 
 
 def _format_progress(m: _LoggingMetrics) -> str:

--- a/python/ray/data/_internal/progress/rich_progress.py
+++ b/python/ray/data/_internal/progress/rich_progress.py
@@ -21,6 +21,9 @@ from rich.text import Text
 
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.streaming_executor_state import (
+    format_op_state_summary,
+)
 from ray.data._internal.progress.base_progress import (
     BaseExecutionProgressManager,
     BaseProgressBar,
@@ -339,7 +342,7 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
         metrics = _get_progress_metrics(self._start_time, current_rows, total_rows)
         _update_with_conditional_rate(progress, tid, metrics)
         # stats
-        stats_str = op_state.summary_str_raw(resource_manager)
+        stats_str = format_op_state_summary(op_state, resource_manager)
         stats.plain = f"{_TREE_VERTICAL_INDENT}{stats_str}"
 
 

--- a/python/ray/data/_internal/progress/tqdm_progress.py
+++ b/python/ray/data/_internal/progress/tqdm_progress.py
@@ -4,6 +4,9 @@ from typing import Dict, List, Optional
 
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.streaming_executor_state import (
+    format_op_state_summary,
+)
 from ray.data._internal.progress.base_progress import (
     BaseExecutionProgressManager,
     BaseProgressBar,
@@ -155,4 +158,5 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
             pg.update_absolute(
                 opstate.output_row_count, opstate.op.num_output_rows_total()
             )
-            pg.set_description(opstate.summary_str(resource_manager))
+            summary_str = format_op_state_summary(opstate, resource_manager)
+            pg.set_description(f"- {opstate.op.name}: {summary_str}")

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -52,6 +52,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     OpBufferQueue,
     OpState,
     build_streaming_topology,
+    format_op_state_summary,
     get_eligible_operators,
     process_completed_tasks,
     select_operator_to_run,
@@ -510,19 +511,19 @@ def test_summary_str_backpressure_policies(ray_start_regular_shared):
     resource_manager = mock_resource_manager()
 
     # Test with no backpressure
-    summary = topo[o2].summary_str_raw(resource_manager)
+    summary = format_op_state_summary(topo[o2], resource_manager)
     assert "backpressured" not in summary
 
     # Set task submission backpressure with policy (using UX name)
     o2._in_task_submission_backpressure = True
     o2._task_submission_backpressure_policy = "ConcurrencyCap"
-    summary = topo[o2].summary_str_raw(resource_manager)
+    summary = format_op_state_summary(topo[o2], resource_manager)
     assert "tasks(ConcurrencyCap)" in summary
 
     # Set output backpressure with policy (using UX name)
     o2._in_task_output_backpressure = True
     o2._task_output_backpressure_policy = "ResourceBudget"
-    summary = topo[o2].summary_str_raw(resource_manager)
+    summary = format_op_state_summary(topo[o2], resource_manager)
     assert "tasks(ConcurrencyCap)" in summary
     assert "outputs(ResourceBudget)" in summary
 
@@ -531,7 +532,7 @@ def test_summary_str_backpressure_policies(ray_start_regular_shared):
     o2._task_submission_backpressure_policy = None
     o2._in_task_output_backpressure = False
     o2._task_output_backpressure_policy = None
-    summary = topo[o2].summary_str_raw(resource_manager)
+    summary = format_op_state_summary(topo[o2], resource_manager)
     assert "backpressured" not in summary
 
 


### PR DESCRIPTION
## Description
Currently, `summary_str` functionality (which is used by progress rendering) was located in `OpState`, violating SRP. This PR isolates the function into a utility function.

## Related issues
N/A

## Additional information
N/A
