### PR TITLE
[Data] Use metrics from `OpRuntimeMetrics` for Progress

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -202,8 +202,6 @@ class OpState:
         self._scheduling_status = OpSchedulingStatus()
         self._schema: Optional["Schema"] = None
         self._warned_on_schema_divergence: bool = False
-        # Progress Manager
-        self.output_row_count: int = 0
 
     def __repr__(self):
         return f"OpState({self.op.name})"
@@ -253,8 +251,6 @@ class OpState:
         self.num_completed_tasks += 1
 
         actor_info = self.op.get_actor_info()
-        if ref.num_rows() is not None:
-            self.output_row_count += ref.num_rows()
 
         self.op.metrics.num_alive_actors = actor_info.running
         self.op.metrics.num_restarting_actors = actor_info.restarting

--- a/python/ray/data/_internal/progress/logging_progress.py
+++ b/python/ray/data/_internal/progress/logging_progress.py
@@ -207,7 +207,7 @@ class LoggingExecutionProgressManager(BaseExecutionProgressManager):
     ):
         op_metrics = self._op_progress_metrics.get(opstate)
         if op_metrics is not None:
-            op_metrics.completed = opstate.output_row_count
+            op_metrics.completed = opstate.op.metrics.row_outputs_taken
             total = opstate.op.num_output_rows_total()
             if total is not None:
                 op_metrics.total = total

--- a/python/ray/data/_internal/progress/rich_progress.py
+++ b/python/ray/data/_internal/progress/rich_progress.py
@@ -334,7 +334,7 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
         tid, progress, stats = self._op_display[op_state]
 
         # progress
-        current_rows = op_state.output_row_count
+        current_rows = op_state.op.metrics.row_outputs_taken
         total_rows = op_state.op.num_output_rows_total()
         metrics = _get_progress_metrics(self._start_time, current_rows, total_rows)
         _update_with_conditional_rate(progress, tid, metrics)

--- a/python/ray/data/_internal/progress/tqdm_progress.py
+++ b/python/ray/data/_internal/progress/tqdm_progress.py
@@ -153,6 +153,6 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
         pg = self._op_display.get(opstate)
         if pg is not None:
             pg.update_absolute(
-                opstate.output_row_count, opstate.op.num_output_rows_total()
+                opstate.op.metrics.row_outputs_taken, opstate.op.num_output_rows_total()
             )
             pg.set_description(opstate.summary_str(resource_manager))


### PR DESCRIPTION
## Description
We had a separate field in `OpState` to keep track of outputted rows. `OpRuntimeMetrics` exist per `PhysicalOperator`, and also has a field to keep track of outputted rows, so there is no need to keep track of a duplicate in OpState.

## Related issues
N/A

## Additional information
N/A
