### PR TITLE
[Serve] send requests to replica immediately when replicas are full and max_queued = -1 

### DIFF
--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -624,6 +624,15 @@ class RequestRouter(ABC):
             }
         )
 
+    def set_max_queued_requests(self, max_queued_requests: int) -> None:
+        """Set the max queued requests limit for optimistic routing decisions.
+
+        When max_queued_requests is -1 (disabled), optimistic routing to full
+        replicas is enabled for better performance. When set to a positive value,
+        optimistic routing is disabled to allow load shedding to work correctly.
+        """
+        self._max_queued_requests = max_queued_requests
+
     def _update_router_queue_len_gauge(
         self, replica_id: ReplicaID, queue_len: int, *, force: bool = False
     ) -> None:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -687,6 +687,8 @@ class AsyncioRouter:
             deployment_config,
             curr_num_replicas=len(self.request_router.curr_replicas),
         )
+        # Update max_queued_requests on the request router for optimistic routing.
+        self.request_router._max_queued_requests = deployment_config.max_queued_requests
 
     async def _resolve_request_arguments(
         self,

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -687,8 +687,10 @@ class AsyncioRouter:
             deployment_config,
             curr_num_replicas=len(self.request_router.curr_replicas),
         )
-        # Update max_queued_requests on the request router for optimistic routing.
-        self.request_router._max_queued_requests = deployment_config.max_queued_requests
+        # Update max_queued_requests for optimistic routing decision.
+        self.request_router.set_max_queued_requests(
+            deployment_config.max_queued_requests
+        )
 
     async def _resolve_request_arguments(
         self,

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -466,7 +466,6 @@ class RouterMetricsManager:
 
         if self.metrics_pusher:
             await self.metrics_pusher.graceful_shutdown()
-
         self._shutdown = True
 
 
@@ -925,6 +924,8 @@ class AsyncioRouter:
                 raise
 
     async def shutdown(self):
+        if self.request_router:
+            self.request_router.shutdown()
         await self._metrics_manager.shutdown()
 
 


### PR DESCRIPTION
Serve Application Architecture

```
                                          ┌──────────────────┐     ┌──────────────────┐
┌───────────────────────────┐             │ ParentDeployment │────▶│ ChildDeployment  │
│  Ray Task 1 (≤48 users)  │──handle───▶│    (1 CPU)       │     │    (1 CPU)       │
└───────────────────────────┘             └──────────────────┘     └──────────────────┘
┌───────────────────────────┐                    │                        │
│  Ray Task 2 (≤48 users)  │──handle───▶        ▼                        ▼
└───────────────────────────┘             Records: replica_id,      Records: replica_id,
             ...                          node_id, timestamp        node_id, request_count
┌───────────────────────────┐
│  Ray Task N (≤48 users)  │──handle───▶
└───────────────────────────┘
```

Cluster scales

- small: 8 replicas, 40 concurrent users
- medium: 32 replicas, 160 concurrent users
- large: 128 replicas, 640 concurrent users
- xlarge: 512 replicas, 2560 concurrent users

Workload: 0.01s sleep, exponential distribution

Hardware: m7i.2xlarge

utilization defined as

```python
# For each child replica:
total_work_time_ms = sum(simulated_latency_ms for all requests handled)
max_capacity_ms = duration_s * 1000 * max_ongoing_requests  # e.g., 60s * 1000 * 5 = 300,000ms
utilization = total_work_time_ms / max_capacity_ms
```

opt and opt_2 are from https://github.com/ray-project/ray/pull/60139, opt_3 are from this PR


<img width="2082" height="1031" alt="latency_by_scale" src="https://github.com/user-attachments/assets/2c8c26ea-1b5d-4227-99b5-8be2a9104833" />
<img width="2384" height="776" alt="load_balancing_comparison" src="https://github.com/user-attachments/assets/f81c7aef-70cb-4a0d-92ea-0e12da770683" />
<img width="2082" height="1031" alt="throughput_by_scale" src="https://github.com/user-attachments/assets/e8f62308-ebaa-400c-ab16-a819c6b8c0bf" />
<img width="2082" height="1180" alt="throughput_vs_latency" src="https://github.com/user-attachments/assets/fd0e269b-ffc3-4c1f-a79f-594b3961ba24" />
<img width="2382" height="1076" alt="utilization_boxplot" src="https://github.com/user-attachments/assets/d9c7b27a-4d64-41bc-89c5-2946482409c3" />

**Before:** When all cached replicas appeared full, the router did a **blocking probe** (RPC) before routing.

**After:** When load shedding is disabled (`max_queued_requests == -1`), optimistically route to the replica with **lowest queue length** without blocking.

Replaced individual `create_task()` calls with a **deduplicated background probe system**

**This change caused queued request metric to be broken:**
The issue is that with optimistic routing, requests are sent directly to replicas instead of being queued in the router. This changes the serve_deployment_queued_queries metric behavior. The metric tracks "queries waiting to be assigned to a replica" - with optimistic routing, requests are immediately assigned (not queued), so the metric shows 0.
