### PR TITLE
[Data] Fix empty blocks accumulation in BlockRefBundler

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -808,6 +808,13 @@ class BlockRefBundler(BaseRefBundler):
         return self._bundle_buffer and (
             self._min_rows_per_bundle is None
             or self._bundle_buffer_size >= self._min_rows_per_bundle
+            # For empty blocks (0 rows), use bundle count instead of row count
+            # to avoid accumulating too many empty blocks.
+            # Only apply this fallback when all accumulated bundles are empty.
+            or (
+                self._bundle_buffer_size == 0
+                and len(self._bundle_buffer) >= self._min_rows_per_bundle
+            )
             or (self._finalized and self._bundle_buffer_size >= 0)
         )
 


### PR DESCRIPTION
## Description

Fixes empty blocks accumulation in `BlockRefBundler` when upstream produces empty blocks (e.g., after filter operations or checkpoint restarts).

## Problem

`BlockRefBundler` waits indefinitely for non-empty blocks to accumulate enough rows to reach `min_rows_per_bundle`. However, when upstream operators produce empty blocks (0 rows), `_bundle_buffer_size` remains 0, causing `has_bundle()` to always return `False`. This leads to empty blocks accumulating indefinitely in the driver, causing memory pressure and potential OOM issues.

**Common scenarios:**
- After filtering large datasets where many blocks become empty
- When restarting from checkpoints where checkpoint filtering produces empty blocks

```
2026-01-17 14:06:58,217	INFO progress_bar.py:215 -- MapBatches(LabelActor): Tasks: 0; Actors: 256; Queued blocks: 566 (0.0B); Resources: 512.0 CPU, 64.0 GPU, 0.0B object store; [all objects local]: Progress Completed 0 / ?
```

## Solution

Add a bundle count check in `BlockRefBundler.has_bundle()`: output bundles when `self._bundle_buffer_size == 0 and len(self._bundle_buffer) >= min_rows_per_bundle`, even if all bundles are empty (0 rows). This ensures empty blocks are batched and output promptly, preventing indefinite accumulation.