### PR TITLE
[Data] Add heterogeneous cluster release tests for image classification

### DIFF
--- a/release/nightly_tests/dataset/autoscaling_gpu_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/autoscaling_gpu_cpu_compute.yaml
@@ -1,0 +1,27 @@
+# Heterogeneous autoscaling cluster with both GPU and CPU worker nodes.
+# GPU nodes are used for inference, CPU nodes are used for preprocessing.
+# Both node types autoscale from 0 to max.
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+advanced_configurations_json:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node_type:
+    name: head-node
+    instance_type: m5.2xlarge
+    resources:
+      cpu: 0
+
+worker_node_types:
+    - name: gpu-worker-node
+      instance_type: g4dn.2xlarge
+      min_workers: 0
+      max_workers: 10
+      use_spot: false
+    - name: cpu-worker-node
+      # 16 cores, 128GB memory - good memory/core ratio for preprocessing
+      instance_type: r6i.4xlarge
+      min_workers: 0
+      max_workers: 10
+      use_spot: false

--- a/release/nightly_tests/dataset/heterogeneous_gpu_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/heterogeneous_gpu_cpu_compute.yaml
@@ -1,0 +1,26 @@
+# Heterogeneous cluster with both GPU and CPU worker nodes.
+# GPU nodes are used for inference, CPU nodes are used for preprocessing.
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+advanced_configurations_json:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node_type:
+    name: head-node
+    instance_type: m5.2xlarge
+    resources:
+      cpu: 0
+
+worker_node_types:
+    - name: gpu-worker-node
+      instance_type: g4dn.2xlarge
+      min_workers: 5
+      max_workers: 5
+      use_spot: false
+    - name: cpu-worker-node
+      # 16 cores, 128GB memory - good memory/core ratio for preprocessing
+      instance_type: r6i.4xlarge
+      min_workers: 5
+      max_workers: 5
+      use_spot: false

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -528,6 +528,38 @@
       python dataset/gpu_batch_inference.py
       --data-directory 300G-image-data-synthetic-raw-parquet --data-format parquet --chaos-test
 
+# Heterogeneous cluster with both GPU and CPU worker nodes (fixed size)
+- name: image_classification_heterogeneous
+  python: "3.10"
+  group: data-batch-inference
+
+  cluster:
+    byod:
+      python_depset: image_classification_py3.10.lock
+    cluster_compute: heterogeneous_gpu_cpu_compute.yaml
+
+  run:
+    timeout: 1800
+    script: >
+      python gpu_batch_inference.py
+      --data-directory 300G-image-data-synthetic-raw-parquet --data-format parquet
+
+# Heterogeneous autoscaling cluster with both GPU and CPU worker nodes
+- name: image_classification_heterogeneous_autoscaling
+  python: "3.10"
+  group: data-batch-inference
+
+  cluster:
+    byod:
+      python_depset: image_classification_py3.10.lock
+    cluster_compute: autoscaling_gpu_cpu_compute.yaml
+
+  run:
+    timeout: 1800
+    script: >
+      python gpu_batch_inference.py
+      --data-directory 300G-image-data-synthetic-raw-parquet --data-format parquet
+
 
 - name: image_embedding_from_uris_{{case}}
   python: "3.10"


### PR DESCRIPTION
## Summary
- Add release tests for image classification with heterogeneous clusters (mixed GPU + CPU nodes)
- Two new test configurations: fixed-size and autoscaling heterogeneous clusters
- GPU nodes (g4dn.2xlarge) handle inference, CPU nodes (r6i.4xlarge) handle preprocessing

## New Tests
| Test Name | Cluster Config | Description |
|-----------|----------------|-------------|
| `image_classification_heterogeneous` | `heterogeneous_gpu_cpu_compute.yaml` | Fixed 5 GPU + 5 CPU nodes |
| `image_classification_heterogeneous_autoscaling` | `autoscaling_gpu_cpu_compute.yaml` | Autoscaling 0-10 GPU + 0-10 CPU nodes |

## New Files
- `release/nightly_tests/dataset/heterogeneous_gpu_cpu_compute.yaml`
- `release/nightly_tests/dataset/autoscaling_gpu_cpu_compute.yaml`