### PR TITLE
[Data] Refactor logical optimization rules to avoid in-place mutation

### DIFF
--- a/python/ray/data/_internal/logical/rules/inherit_batch_format.py
+++ b/python/ray/data/_internal/logical/rules/inherit_batch_format.py
@@ -1,5 +1,4 @@
-from collections import deque
-from typing import Iterable
+import copy
 
 from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule
 from ray.data._internal.logical.operators.all_to_all_operator import AbstractAllToAll
@@ -17,26 +16,21 @@ class InheritBatchFormatRule(Rule):
         return new_plan
 
     def _apply(self, op: LogicalOperator):
-        # Post-order traversal.
-        nodes: Iterable[LogicalOperator] = deque()
-        for node in op.post_order_iter():
-            nodes.appendleft(node)
+        def transform(node: LogicalOperator) -> LogicalOperator:
+            if not isinstance(node, AbstractAllToAll):
+                return node
 
-        while len(nodes) > 0:
-            current_op = nodes.pop()
+            # traversal up the DAG until we find MapBatches with batch_format
+            # or we reach to source op and do nothing
+            upstream_op = node.input_dependencies[0]
+            while upstream_op.input_dependencies:
+                if isinstance(upstream_op, MapBatches) and upstream_op._batch_format:
+                    new_op = copy.copy(node)
+                    new_op._batch_format = upstream_op._batch_format
+                    new_op._output_dependencies = []
+                    return new_op
+                upstream_op = upstream_op.input_dependencies[0]
 
-            if isinstance(current_op, AbstractAllToAll):
-                # traversal up the DAG until we find MapBatches with batch_format
-                # or we reach to source op and do nothing
-                upstream_op = current_op.input_dependencies[0]
-                while upstream_op.input_dependencies:
-                    if (
-                        isinstance(upstream_op, MapBatches)
-                        and upstream_op._batch_format
-                    ):
-                        current_op._batch_format = upstream_op._batch_format
-                        break
-                    upstream_op = upstream_op.input_dependencies[0]
+            return node
 
-        # just return the default op
-        return op
+        return op._apply_transform(transform)

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -86,21 +86,40 @@ class LimitPushdownRule(Rule):
             child₂ -> Limit ->┤ Union ──► Limit   (original)
                                │
             …    -> Limit  ->│
+
+        Example (skip duplicate limit on a branch that already has it):
+            before:
+                child -> Limit(n) -> Union -> Limit(n)
+            after:
+                child -> Limit(n) -> Union -> Limit(n)   (no extra branch limit inserted)
         """
         union_op = limit_op.input_dependency
         assert isinstance(union_op, Union)
 
-        # 1. Detach the original Union from its children.
-        original_children = list(union_op.input_dependencies)
-        for child in original_children:
-            if union_op in child._output_dependencies:
-                child._output_dependencies.remove(union_op)
+        def _branch_has_limit(op: LogicalOperator, limit: int) -> bool:
+            current = op
+            while (
+                isinstance(current, AbstractOneToOne)
+                and not current.can_modify_num_rows()
+                and current.input_dependencies
+            ):
+                if isinstance(current, Limit) and current._limit == limit:
+                    return True
+                # Safe to use input_dependency: current is an AbstractOneToOne here.
+                current = current.input_dependency
+            return False
 
-        # 2. Insert a branch-local Limit and push it further upstream.
+        # Insert a branch-local Limit and push it further upstream.
         branch_tails: List[LogicalOperator] = []
-        for child in original_children:
+        for child in union_op.input_dependencies:
+            # Avoid inserting a duplicate Limit on a branch that already has the same
+            # limit upstream of row-preserving ops.
+            if _branch_has_limit(child, limit_op._limit):
+                branch_tails.append(child)
+                continue
             raw_limit = Limit(child, limit_op._limit)  # child → limit
-            if isinstance(child, Union):
+
+            if isinstance(raw_limit.input_dependency, Union):
                 # This represents the limit operator appended after the union.
                 pushed_tail = self._push_limit_into_union(raw_limit)
             else:
@@ -108,16 +127,8 @@ class LimitPushdownRule(Rule):
                 pushed_tail = self._push_limit_down(raw_limit)
             branch_tails.append(pushed_tail)
 
-        # 3. Re-attach the Union so that it consumes the *tails*.
         new_union = Union(*branch_tails)
-        for tail in branch_tails:
-            tail._output_dependencies.append(new_union)
-
-        # 4. Re-wire the original (global) Limit to consume the *new* Union.
-        limit_op._input_dependencies = [new_union]
-        new_union._output_dependencies = [limit_op]
-
-        return limit_op
+        return Limit(new_union, limit_op._limit)
 
     def _push_limit_down(self, limit_op: Limit) -> LogicalOperator:
         """Push a single limit down through compatible operators conservatively.

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -103,11 +103,12 @@ class LimitPushdownRule(Rule):
                 and not current.can_modify_num_rows()
                 and current.input_dependencies
             ):
-                if isinstance(current, Limit) and current._limit == limit:
-                    return True
+                if isinstance(current, Limit):
+                    return current._limit == limit
                 # Safe to use input_dependency: current is an AbstractOneToOne here.
                 current = current.input_dependency
-            return False
+
+            return isinstance(current, Limit) and current._limit == limit
 
         # Insert a branch-local Limit and push it further upstream.
         branch_tails: List[LogicalOperator] = []

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -316,4 +316,5 @@ class PredicatePushdown(Rule):
         new_op = copy.copy(op)
         new_op._input_dependencies = new_inputs
         new_op._output_dependencies = []
+        new_op._wire_output_deps(new_inputs)
         return new_op

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -315,8 +315,5 @@ class PredicatePushdown(Rule):
         """
         new_op = copy.copy(op)
         new_op._input_dependencies = new_inputs
-        # Clear and re-wire dependencies for the new operator.
-        # The output dependencies will be wired by the parent transform's traversal.
         new_op._output_dependencies = []
-        new_op._wire_output_deps(new_inputs)
         return new_op


### PR DESCRIPTION
## Description
> PR1: Remove in‑place mutations in logical rules

#### Issue goal: 
Make LogicalOperator immutable and comparable to prevent in-place mutations during optimization.

The issue is split into two PRs for easier review. 
#### This PR focuses on: 
changing logical optimization rules from in-place edits to copy/rebuild the DAG, as a precursor to immutability.


## Related issues
> Link related issues: "Fixes #60312", "Closes #60312", or "Related to #60312".

## Additional information
#### Implementation details
update limit_pushdown, predicate_pushdown, and inherit_batch_format to rebuild nodes and rewire inputs instead of mutating dependencies; optimization semantics are unchanged—only construction changes.
#### API changes
none externally; internal logic switches from in-place mutation to rebuilding.