### PR TITLE
[Docs] Fix incorrect code output in `writing-code-snippets` doc

### DIFF
--- a/doc/source/ray-contribute/writing-code-snippets.rst
+++ b/doc/source/ray-contribute/writing-code-snippets.rst
@@ -155,7 +155,7 @@ If you're writing a longer example, or if object representations aren't relevant
         def transform_batch(batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
             vec_a = batch["petal length (cm)"]
             vec_b = batch["petal width (cm)"]
-            batch["petal area (cm^2)"] = vec_a * vec_b
+            batch["petal area (cm^2)"] = np.round(vec_a * vec_b, 2)
             return batch
 
         transformed_ds = ds.map_batches(transform_batch)
@@ -163,18 +163,25 @@ If you're writing a longer example, or if object representations aren't relevant
 
     .. testoutput::
 
-        MaterializedDataset(
-           num_blocks=...,
-           num_rows=150,
-           schema={
-              sepal length (cm): double,
-              sepal width (cm): double,
-              petal length (cm): double,
-              petal width (cm): double,
-              target: int64,
-              petal area (cm^2): double
-           }
-        )
+        shape: (150, 6)
+        ╭───────────────────┬──────────────────┬───────────────────┬──────────────────┬────────┬───────────────────╮
+        │ sepal length (cm) ┆ sepal width (cm) ┆ petal length (cm) ┆ petal width (cm) ┆ target ┆ petal area (cm^2) │
+        │ ---               ┆ ---              ┆ ---               ┆ ---              ┆ ---    ┆ ---               │
+        │ double            ┆ double           ┆ double            ┆ double           ┆ int64  ┆ double            │
+        ╞═══════════════════╪══════════════════╪═══════════════════╪══════════════════╪════════╪═══════════════════╡
+        │ 5.1               ┆ 3.5              ┆ 1.4               ┆ 0.2              ┆ 0      ┆ 0.28              │
+        │ 4.9               ┆ 3.0              ┆ 1.4               ┆ 0.2              ┆ 0      ┆ 0.28              │
+        │ 4.7               ┆ 3.2              ┆ 1.3               ┆ 0.2              ┆ 0      ┆ 0.26              │
+        │ 4.6               ┆ 3.1              ┆ 1.5               ┆ 0.2              ┆ 0      ┆ 0.3               │
+        │ 5.0               ┆ 3.6              ┆ 1.4               ┆ 0.2              ┆ 0      ┆ 0.28              │
+        │ …                 ┆ …                ┆ …                 ┆ …                ┆ …      ┆ …                 │
+        │ 6.7               ┆ 3.0              ┆ 5.2               ┆ 2.3              ┆ 2      ┆ 11.96             │
+        │ 6.3               ┆ 2.5              ┆ 5.0               ┆ 1.9              ┆ 2      ┆ 9.5               │
+        │ 6.5               ┆ 3.0              ┆ 5.2               ┆ 2.0              ┆ 2      ┆ 10.4              │
+        │ 6.2               ┆ 3.4              ┆ 5.4               ┆ 2.3              ┆ 2      ┆ 12.42             │
+        │ 5.9               ┆ 3.0              ┆ 5.1               ┆ 1.8              ┆ 2      ┆ 9.18              │
+        ╰───────────────────┴──────────────────┴───────────────────┴──────────────────┴────────┴───────────────────╯
+        (Showing 10 of 150 rows)
 
 When to use *literalinclude*
 ============================


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/59631 changed the way the `Dataset` representations look, but CI didn't test `writing-code-snippet` in that PR's premerge CI. This PR fixes the incorrect output.