### PR TITLE
[deps] upgrade jaxlib and jax from 0.4.13 -> 0.4.22

### DIFF
--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -29,5 +29,5 @@ torch-geometric==2.5.3
 cupy-cuda12x>=13.4.0; sys_platform != 'darwin'
 
 # Keep JAX version consistent with dl-gpu-requirements.txt
-jax==0.4.13; python_version < '3.12' and sys_platform != 'darwin'
-jaxlib==0.4.13; python_version < '3.12' and sys_platform != 'darwin'
+jax==0.4.22; python_version < '3.12' and sys_platform != 'darwin'
+jaxlib==0.4.22; python_version < '3.12' and sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -19,5 +19,4 @@ cupy-cuda12x>=13.4.0; sys_platform != 'darwin'
 nixl==0.4.0; sys_platform != 'darwin'
 
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-# Downgrading to JAX 0.4.13 to be compatible with CUDA 12.1
-jaxlib==0.4.13+cuda12.cudnn89; python_version < '3.12' and sys_platform != 'darwin'
+jaxlib==0.4.22+cuda12.cudnn89; python_version < '3.12' and sys_platform != 'darwin'

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -850,9 +850,9 @@ isoduration==20.11.0
     # via jsonschema
 itsdangerous==2.1.2
     # via flask
-jax==0.4.13 ; python_version < "3.12" and sys_platform != "darwin"
+jax==0.4.22 ; python_version < "3.12" and sys_platform != "darwin"
     # via -r python/requirements/ml/dl-cpu-requirements.txt
-jaxlib==0.4.13 ; python_version < "3.12" and sys_platform != "darwin"
+jaxlib==0.4.22 ; python_version < "3.12" and sys_platform != "darwin"
     # via -r python/requirements/ml/dl-cpu-requirements.txt
 jedi==0.19.1
     # via ipython


### PR DESCRIPTION
upgrade jaxlib and jax from 0.4.13 -> 0.4.22 due to missing version on pypi [index](https://pypi.org/project/jaxlib/#history)

oldest version available is 0.4.17