### PR TITLE
[Data] Info log cluster scale up decisions

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/__init__.py
+++ b/python/ray/data/_internal/cluster_autoscaler/__init__.py
@@ -40,8 +40,8 @@ def create_cluster_autoscaler(
     if selected_autoscaler == ClusterAutoscalerVersion.V2:
         return DefaultClusterAutoscalerV2(
             resource_manager,
-            resource_limits=resource_limits,
             execution_id=execution_id,
+            resource_limits=resource_limits,
         )
 
     elif selected_autoscaler == ClusterAutoscalerVersion.V1:

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -145,7 +145,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self,
         resource_manager: "ResourceManager",
         execution_id: str,
-        resource_limits: ExecutionResources = ExecutionResources.for_limits(),
+        resource_limits: ExecutionResources = ExecutionResources.inf(),
         resource_utilization_calculator: Optional[ResourceUtilizationGauge] = None,
         cluster_scaling_up_util_threshold: float = DEFAULT_CLUSTER_SCALING_UP_UTIL_THRESHOLD,  # noqa: E501
         cluster_scaling_up_delta: float = DEFAULT_CLUSTER_SCALING_UP_DELTA,

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -107,11 +107,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         "RAY_DATA_CLUSTER_SCALING_UP_UTIL_THRESHOLD",
         0.75,
     )
-    # Default interval in seconds to check cluster utilization.
-    DEFAULT_CLUSTER_UTIL_CHECK_INTERVAL_S: float = env_float(
-        "RAY_DATA_CLUSTER_UTIL_CHECK_INTERVAL_S",
-        0.25,
-    )
     # Default time window in seconds to calculate the average of cluster utilization.
     DEFAULT_CLUSTER_UTIL_AVG_WINDOW_S: int = env_integer(
         "RAY_DATA_CLUSTER_UTIL_AVG_WINDOW_S",

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -176,7 +176,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._resource_utilization_calculator = resource_utilization_calculator
         # Threshold of cluster utilization to trigger scaling up.
         self._cluster_scaling_up_util_threshold = cluster_scaling_up_util_threshold
-        self._cluster_scaling_up_delta = int(math.ceil(self._cluster_scaling_up_delta))
+        self._cluster_scaling_up_delta = int(math.ceil(cluster_scaling_up_delta))
         self._min_gap_between_autoscaling_requests_s = (
             min_gap_between_autoscaling_requests_s
         )

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -176,7 +176,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._resource_utilization_calculator = resource_utilization_calculator
         # Threshold of cluster utilization to trigger scaling up.
         self._cluster_scaling_up_util_threshold = cluster_scaling_up_util_threshold
-        self._cluster_scaling_up_delta = cluster_scaling_up_delta
+        self._cluster_scaling_up_delta = int(math.ceil(self._cluster_scaling_up_delta))
         self._min_gap_between_autoscaling_requests_s = (
             min_gap_between_autoscaling_requests_s
         )
@@ -228,8 +228,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             # Bundles for existing nodes -> active (must include)
             active_bundles.extend([bundle] * count)
             # Bundles for scale-up delta -> pending (best-effort)
-            delta_count = int(math.ceil(self._cluster_scaling_up_delta))
-            pending_bundles.extend([bundle] * delta_count)
+            pending_bundles.extend([bundle] * self._cluster_scaling_up_delta)
 
         # Cap the resource request to respect user-configured limits.
         # Active bundles (existing nodes) are always included; pending bundles
@@ -254,7 +253,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             f"specified threshold of {self._cluster_scaling_up_util_threshold:.0%}: "
             f"CPU={current_utilization.cpu:.0%}, GPU={current_utilization.gpu:.0%}, "
             f"object_store_memory={current_utilization.object_store_memory:.0%}. "
-            "Requesting one node of each shape:"
+            f"Requesting {self._cluster_scaling_up_delta} node(s) of each shape:"
         )
 
         current_node_counts = Counter(

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -143,14 +143,12 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         cluster_scaling_up_util_threshold: float = DEFAULT_CLUSTER_SCALING_UP_UTIL_THRESHOLD,  # noqa: E501
         cluster_scaling_up_delta: float = DEFAULT_CLUSTER_SCALING_UP_DELTA,
         cluster_util_avg_window_s: float = DEFAULT_CLUSTER_UTIL_AVG_WINDOW_S,
-        cluster_util_check_interval_s: float = DEFAULT_CLUSTER_UTIL_CHECK_INTERVAL_S,
         min_gap_between_autoscaling_requests_s: float = MIN_GAP_BETWEEN_AUTOSCALING_REQUESTS,  # noqa: E501
         autoscaling_coordinator: Optional[AutoscalingCoordinator] = None,
         get_node_counts: Callable[[], Dict[_NodeResourceSpec, int]] = (
             _get_node_resource_spec_and_count
         ),
     ):
-        assert cluster_util_check_interval_s >= 0, cluster_util_check_interval_s
         assert cluster_scaling_up_delta > 0
         assert cluster_util_avg_window_s > 0
         assert min_gap_between_autoscaling_requests_s >= 0
@@ -168,12 +166,9 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         # Threshold of cluster utilization to trigger scaling up.
         self._cluster_scaling_up_util_threshold = cluster_scaling_up_util_threshold
         self._cluster_scaling_up_delta = cluster_scaling_up_delta
-        self._cluster_util_check_interval_s = cluster_util_check_interval_s
         self._min_gap_between_autoscaling_requests_s = (
             min_gap_between_autoscaling_requests_s
         )
-        # Last time when the cluster utilization was checked.
-        self._last_cluster_util_check_time = 0
         # Last time when a request was sent to Ray's autoscaler.
         self._last_request_time = 0
         self._requester_id = f"data-{execution_id}"
@@ -187,17 +182,10 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
     def try_trigger_scaling(self):
         # Note, should call this method before checking `_last_request_time`,
         # in order to update the average cluster utilization.
-        now = time.time()
-        if (
-            now - self._last_cluster_util_check_time
-            >= self._cluster_util_check_interval_s
-        ):
-            # Update observed resource utilization
-            self._last_cluster_util_check_time = now
-
-            self._resource_utilization_calculator.observe()
+        self._resource_utilization_calculator.observe()
 
         # Limit the frequency of autoscaling requests.
+        now = time.time()
         if now - self._last_request_time < self._min_gap_between_autoscaling_requests_s:
             return
 

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -546,7 +546,7 @@ class TestClusterAutoscaling:
         expected_message = (
             "The utilization of one or more logical resource is higher than the "
             "specified threshold of 75%: CPU=100%, GPU=100%, object_store_memory=100%. "
-            "Requesting one node of each shape: "
+            "Requesting 1 node(s) of each shape: "
             "[{CPU: 1, GPU: 0, memory: 8.0GiB}: 1 -> 2]"
         )
         log_messages = [record.message for record in caplog.records]

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -546,7 +546,7 @@ class TestClusterAutoscaling:
         expected_message = (
             "Scaling up cluster. Current utilization: "
             "CPU=1.00, GPU=1.00, object_store_memory=1.00. "
-            "Requesting resources: [{CPU: 1, GPU: 0, memory: 8.0GiB}: +1]"
+            "Requesting resources: [{CPU: 1, GPU: 0, memory: 8.0GiB}: 1 -> 2]"
         )
         log_messages = [record.message for record in caplog.records]
         assert expected_message in log_messages, (

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -544,9 +544,10 @@ class TestClusterAutoscaling:
             autoscaler.try_trigger_scaling()
 
         expected_message = (
-            "Scaling up cluster. Current utilization: "
-            "CPU=1.00, GPU=1.00, object_store_memory=1.00. "
-            "Requesting resources: [{CPU: 1, GPU: 0, memory: 8.0GiB}: 1 -> 2]"
+            "The utilization of one or more logical resource is higher than the "
+            "specified threshold of 75%: CPU=100%, GPU=100%, object_store_memory=100%. "
+            "Requesting one node of each shape: "
+            "[{CPU: 1, GPU: 0, memory: 8.0GiB}: 1 -> 2]"
         )
         log_messages = [record.message for record in caplog.records]
         assert expected_message in log_messages, (

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -524,6 +525,34 @@ class TestClusterAutoscaling:
         assert resources_allocated.memory >= large_node_spec.mem, (
             f"Existing large node (mem={large_node_spec.mem}) should be included. "
             f"Got total memory={resources_allocated.memory}"
+        )
+
+    def test_try_scale_up_logs_info_message(self, propagate_logs, caplog):
+        fake_coordinator = FakeAutoscalingCoordinator()
+        node_spec = _NodeResourceSpec.of(cpu=1, gpu=0, mem=8 * 1024**3)
+        utilization = ExecutionResources(cpu=1, gpu=1, object_store_memory=1)
+        autoscaler = DefaultClusterAutoscalerV2(
+            resource_manager=MagicMock(),
+            execution_id="test_execution_id",
+            resource_utilization_calculator=StubUtilizationGauge(utilization),
+            min_gap_between_autoscaling_requests_s=0,
+            autoscaling_coordinator=fake_coordinator,
+            get_node_counts=lambda: {node_spec: 1},
+        )
+
+        with caplog.at_level(logging.INFO):
+            autoscaler.try_trigger_scaling()
+
+        expected_message = (
+            "Scaling up cluster. Current utilization: "
+            "CPU=1.00, GPU=1.00, object_store_memory=1.00. "
+            "Requesting resources: [{CPU: 1, GPU: 0, memory: 8.0GiB}: +1]"
+        )
+        log_messages = [record.message for record in caplog.records]
+        assert expected_message in log_messages, (
+            f"Expected log message not found.\n"
+            f"Expected: {expected_message}\n"
+            f"Actual logs: {log_messages}"
         )
 
 


### PR DESCRIPTION
> I am thinking there is very limited visibility into the autoscaling decisions, currently have to look through DEBUG logs FWICT.  Adding some visibility in terms of metrics and events would be nice, and promoting key action logs to INFO would be my high-level suggestion

This PR logs a message to STDOUT whenever the autoscaler decides to scale up the cluster.