### PR TITLE
[Data] Make logical operators frozen dataclasses with public attrs

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1128,28 +1128,6 @@ python/ray/data/_internal/logging.py
     DOC201: Function `register_dataset_logger` does not have a return section in docstring
     DOC201: Function `unregister_dataset_logger` does not have a return section in docstring
 --------------------
-python/ray/data/_internal/logical/operators/all_to_all_operator.py
-    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
-    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
-    DOC101: Method `AbstractAllToAll.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `AbstractAllToAll.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [input_op: LogicalOperator, name: str, num_outputs: Optional[int], ray_remote_args: Optional[Dict[str, Any]], sub_progress_bar_names: Optional[List[str]]].
---------------------
-python/ray/data/_internal/logical/operators/join_operator.py
-    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
-    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
-    DOC101: Method `Join.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `Join.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [aggregator_ray_remote_args: Optional[Dict[str, Any]], join_type: str, left_columns_suffix: Optional[str], left_input_op: LogicalOperator, left_key_columns: Tuple[str], num_partitions: int, partition_size_hint: Optional[int], right_columns_suffix: Optional[str], right_input_op: LogicalOperator, right_key_columns: Tuple[str]].
---------------------
-python/ray/data/_internal/logical/operators/map_operator.py
-    DOC101: Method `StreamingRepartition.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `StreamingRepartition.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [input_op: LogicalOperator].
---------------------
-python/ray/data/_internal/logical/operators/n_ary_operator.py
-    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
-    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
-    DOC101: Method `NAry.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `NAry.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*input_ops: LogicalOperator, num_outputs: Optional[int]].
---------------------
 python/ray/data/_internal/metadata_exporter.py
     DOC101: Method `Topology.create_topology_metadata`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `Topology.create_topology_metadata`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [op_to_id: Dict['PhysicalOperator', str]].

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -374,6 +374,10 @@ class PhysicalOperator(Operator):
     def input_dependencies(self) -> List["PhysicalOperator"]:
         return super().input_dependencies  # type: ignore
 
+    @input_dependencies.setter
+    def input_dependencies(self, value: List["PhysicalOperator"]) -> None:
+        self._input_dependencies = value
+
     @property
     def output_dependencies(self) -> List["PhysicalOperator"]:
         return super().output_dependencies  # type: ignore

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -42,6 +42,10 @@ class Operator:
         ), "Operator.__init__() was not called."
         return self._input_dependencies
 
+    @input_dependencies.setter
+    def input_dependencies(self, value: List["Operator"]) -> None:
+        self._input_dependencies = value
+
     @property
     def output_dependencies(self) -> List["Operator"]:
         """List of operators that consume outputs from this operator."""

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
@@ -12,213 +13,197 @@ from ray.data.aggregate import AggregateFn
 from ray.data.block import BlockMetadata
 
 if TYPE_CHECKING:
-
     from ray.data.block import Schema
 
 
+@dataclass(frozen=True, repr=False)
 class AbstractAllToAll(LogicalOperator):
     """Abstract class for logical operators should be converted to physical
     AllToAllOperator.
     """
 
-    def __init__(
-        self,
-        name: str,
-        input_op: LogicalOperator,
-        num_outputs: Optional[int] = None,
-        sub_progress_bar_names: Optional[List[str]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        """
-        Args:
-            name: Name for this operator. This is the name that will appear when
-                inspecting the logical plan of a Dataset.
-            input_op: The operator preceding this operator in the plan DAG. The outputs
-                of `input_op` will be the inputs to this operator.
-            num_outputs: The number of expected output bundles outputted by this
-                operator.
-            ray_remote_args: Args to provide to :func:`ray.remote`.
-        """
-        super().__init__(name, [input_op], num_outputs=num_outputs)
-        self._ray_remote_args = ray_remote_args or {}
-        self._sub_progress_bar_names = sub_progress_bar_names
+    input_op: Optional[LogicalOperator] = None
+    ray_remote_args: Optional[Dict[str, Any]] = None
+    sub_progress_bar_names: Optional[List[str]] = None
+
+    def __post_init__(self) -> None:
+        if not self.input_dependencies and self.input_op is not None:
+            object.__setattr__(self, "input_dependencies", (self.input_op,))
+        if self.ray_remote_args is None:
+            object.__setattr__(self, "ray_remote_args", {})
+        super().__post_init__()
+        assert self.name is not None
+        assert len(self.input_dependencies) == 1, self.input_dependencies
 
 
+@dataclass(frozen=True, repr=False)
 class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for randomize_block_order."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        seed: Optional[int] = None,
-    ):
-        super().__init__(
-            "RandomizeBlockOrder",
-            input_op,
-        )
-        self._seed = seed
+    seed: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.name is None:
+            object.__setattr__(self, "name", "RandomizeBlockOrder")
+        super().__post_init__()
 
     def infer_metadata(self) -> "BlockMetadata":
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata()
 
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Randomizing block order doesn't affect filtering correctness
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False)
 class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
-    """Logical operator for random_shuffle."""
+    """Logical operator for randomshuffle."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        name: str = "RandomShuffle",
-        seed: Optional[int] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            name,
-            input_op,
-            sub_progress_bar_names=[
-                ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
-                ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
-            ],
-            ray_remote_args=ray_remote_args,
-        )
-        self._seed = seed
+    seed: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.name is None:
+            object.__setattr__(self, "name", "RandomShuffle")
+        if self.sub_progress_bar_names is None:
+            object.__setattr__(
+                self,
+                "sub_progress_bar_names",
+                [
+                    ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
+                    ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
+                ],
+            )
+        super().__post_init__()
 
     def infer_metadata(self) -> "BlockMetadata":
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata()
 
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Random shuffle doesn't affect filtering correctness
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False)
 class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for repartition."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        num_outputs: int,
-        shuffle: bool,
-        keys: Optional[List[str]] = None,
-        sort: bool = False,
-    ):
-        if shuffle:
-            sub_progress_bar_names = [
-                ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
-                ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
-            ]
-        else:
-            sub_progress_bar_names = [
-                ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME,
-            ]
-        super().__init__(
-            "Repartition",
-            input_op,
-            num_outputs=num_outputs,
-            sub_progress_bar_names=sub_progress_bar_names,
-        )
-        self._shuffle = shuffle
-        self._keys = keys
-        self._sort = sort
+    shuffle: bool = False
+    keys: Optional[List[str]] = None
+    sort: bool = False
+
+    def __post_init__(self) -> None:
+        assert self.num_outputs is not None
+        if self.name is None:
+            object.__setattr__(self, "name", "Repartition")
+        if self.sub_progress_bar_names is None:
+            if self.shuffle:
+                sub_progress_bar_names = [
+                    ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
+                    ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
+                ]
+            else:
+                sub_progress_bar_names = [
+                    ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME,
+                ]
+            object.__setattr__(self, "sub_progress_bar_names", sub_progress_bar_names)
+        super().__post_init__()
 
     def infer_metadata(self) -> "BlockMetadata":
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata()
 
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Repartition doesn't affect filtering correctness
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False)
 class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for sort."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        sort_key: SortKey,
-        batch_format: Optional[str] = "default",
-    ):
-        super().__init__(
-            "Sort",
-            input_op,
-            sub_progress_bar_names=[
-                SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,
-                ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
-                ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
-            ],
-        )
-        self._sort_key = sort_key
-        self._batch_format = batch_format
+    sort_key: Optional[SortKey] = None
+    batch_format: Optional[str] = "default"
+
+    def __post_init__(self) -> None:
+        assert self.sort_key is not None
+        if self.name is None:
+            object.__setattr__(self, "name", "Sort")
+        if self.sub_progress_bar_names is None:
+            object.__setattr__(
+                self,
+                "sub_progress_bar_names",
+                [
+                    SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,
+                    ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
+                    ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
+                ],
+            )
+        super().__post_init__()
 
     def infer_metadata(self) -> "BlockMetadata":
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata()
 
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Sort doesn't affect filtering correctness
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False)
 class Aggregate(AbstractAllToAll):
     """Logical operator for aggregate."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        key: Optional[str],
-        aggs: List[AggregateFn],
-        num_partitions: Optional[int] = None,
-        batch_format: Optional[str] = "default",
-    ):
-        super().__init__(
-            "Aggregate",
-            input_op,
-            sub_progress_bar_names=[
-                SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,
-                ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
-                ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
-            ],
-        )
-        self._key = key
-        self._aggs = aggs
-        self._num_partitions = num_partitions
-        self._batch_format = batch_format
+    key: Optional[str] = None
+    aggs: List[AggregateFn] = None  # type: ignore[assignment]
+    num_partitions: Optional[int] = None
+    batch_format: Optional[str] = "default"
+
+    def __post_init__(self) -> None:
+        assert self.aggs is not None
+        if self.name is None:
+            object.__setattr__(self, "name", "Aggregate")
+        if self.sub_progress_bar_names is None:
+            object.__setattr__(
+                self,
+                "sub_progress_bar_names",
+                [
+                    SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,
+                    ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
+                    ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
+                ],
+            )
+        super().__post_init__()

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,6 +1,10 @@
+from dataclasses import dataclass
+from typing import Optional
+
 from ray.data._internal.logical.interfaces import LogicalOperator
 
 
+@dataclass(frozen=True, repr=False)
 class Count(LogicalOperator):
     """Logical operator that represents counting the number of rows in inputs.
 
@@ -11,8 +15,11 @@ class Count(LogicalOperator):
 
     COLUMN_NAME = "__num_rows"
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-    ):
-        super().__init__("Count", [input_op])
+    input_op: Optional[LogicalOperator] = None
+
+    def __post_init__(self) -> None:
+        if not self.input_dependencies and self.input_op is not None:
+            object.__setattr__(self, "input_dependencies", (self.input_op,))
+        if self.name is None:
+            object.__setattr__(self, "name", "Count")
+        super().__post_init__()

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -1,4 +1,5 @@
 import functools
+from dataclasses import dataclass
 from typing import List, Optional
 
 from ray.data._internal.execution.interfaces import RefBundle
@@ -7,18 +8,24 @@ from ray.data._internal.util import unify_schemas_with_validation
 from ray.data.block import BlockMetadata
 
 
+@dataclass(frozen=True, repr=False)
 class InputData(LogicalOperator, SourceOperator):
     """Logical operator for input data.
 
     This may hold cached blocks from a previous Dataset execution.
     """
 
-    def __init__(
-        self,
-        input_data: List[RefBundle],
-    ):
-        super().__init__("InputData", [], len(input_data))
-        self.input_data = input_data
+    input_data: List[RefBundle] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        assert self.input_data is not None
+        if self.name is None:
+            object.__setattr__(self, "name", "InputData")
+        if self.input_dependencies is None:
+            object.__setattr__(self, "input_dependencies", ())
+        if self.num_outputs is None:
+            object.__setattr__(self, "num_outputs", len(self.input_data))
+        super().__post_init__()
 
     def output_data(self) -> Optional[List[RefBundle]]:
         return self.input_data

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -1,11 +1,11 @@
 import functools
 import inspect
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Dict, Iterable, Optional
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.logical.interfaces import (
-    LogicalOperator,
     LogicalOperatorSupportsPredicatePassThrough,
     PredicatePassThroughBehavior,
 )
@@ -17,123 +17,49 @@ from ray.data.preprocessor import Preprocessor
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, repr=False)
 class AbstractMap(AbstractOneToOne):
     """Abstract class for logical operators that should be converted to physical
     MapOperator.
     """
 
-    def __init__(
-        self,
-        name: str,
-        input_op: Optional[LogicalOperator] = None,
-        num_outputs: Optional[int] = None,
-        *,
-        can_modify_num_rows: bool,
-        min_rows_per_bundled_input: Optional[int] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        compute: Optional[ComputeStrategy] = None,
-    ):
-        """Initialize an ``AbstractMap`` logical operator that will later
-        be converted into a physical ``MapOperator``.
+    min_rows_per_bundled_input: Optional[int] = None
+    ray_remote_args: Optional[Dict[str, Any]] = None
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
+    compute: Optional[ComputeStrategy] = None
+    per_block_limit: Optional[int] = None
 
-        Args:
-            name: Name for this operator. This is the name that will appear when
-                inspecting the logical plan of a Dataset.
-            input_op: The operator preceding this operator in the plan DAG. The
-                outputs of ``input_op`` will be the inputs to this operator.
-            num_outputs: Number of outputs for this operator.
-            can_modify_num_rows: Whether the operator can change the row count. False if
-                # of input rows = # of output rows. True otherwise.
-            min_rows_per_bundled_input: Minimum number of rows a single bundle of
-                blocks passed on to the task must possess.
-            ray_remote_args: Args to provide to :func:`ray.remote`.
-            ray_remote_args_fn: A function that returns a dictionary of remote
-                args passed to each map worker. The purpose of this argument is
-                to generate dynamic arguments for each actor/task, and it will
-                be called each time prior to initializing the worker. Args
-                returned from this dict always override the args in
-                ``ray_remote_args``. Note: this is an advanced, experimental
-                feature.
-            compute: The compute strategy, either ``TaskPoolStrategy`` (default)
-                to use Ray tasks, or ``ActorPoolStrategy`` to use an
-                autoscaling actor pool.
-        """
-        super().__init__(name, input_op, can_modify_num_rows, num_outputs)
-        self._min_rows_per_bundled_input = min_rows_per_bundled_input
-        self._ray_remote_args = ray_remote_args or {}
-        self._ray_remote_args_fn = ray_remote_args_fn
-        self._compute = compute or TaskPoolStrategy()
-        self._per_block_limit = None
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.ray_remote_args is None:
+            object.__setattr__(self, "ray_remote_args", {})
+        if self.compute is None:
+            object.__setattr__(self, "compute", TaskPoolStrategy())
 
-    def set_per_block_limit(self, per_block_limit: int):
-        self._per_block_limit = per_block_limit
+    def with_per_block_limit(self, per_block_limit: int) -> "AbstractMap":
+        return replace(self, per_block_limit=per_block_limit)
 
 
+@dataclass(frozen=True, repr=False)
 class AbstractUDFMap(AbstractMap):
     """Abstract class for logical operators performing a UDF that should be converted
     to physical MapOperator.
     """
 
-    def __init__(
-        self,
-        name: str,
-        input_op: LogicalOperator,
-        fn: UserDefinedFunction,
-        *,
-        can_modify_num_rows: bool,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        min_rows_per_bundled_input: Optional[int] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        """Initialize AbstractUDFMap.
+    fn: Optional[UserDefinedFunction] = None
+    fn_args: Optional[Iterable[Any]] = None
+    fn_kwargs: Optional[Dict[str, Any]] = None
+    fn_constructor_args: Optional[Iterable[Any]] = None
+    fn_constructor_kwargs: Optional[Dict[str, Any]] = None
 
-        Args:
-            name: Name for this operator. This is the name that will appear when
-                inspecting the logical plan of a Dataset.
-            input_op: The operator preceding this operator in the plan DAG. The outputs
-                of `input_op` will be the inputs to this operator.
-            fn: User-defined function to be called.
-            can_modify_num_rows: Whether the UDF can change the row count. False if
-                # of input rows = # of output rows. True otherwise.
-            fn_args: Arguments to `fn`.
-            fn_kwargs: Keyword arguments to `fn`.
-            fn_constructor_args: Arguments to provide to the initializor of `fn` if
-                `fn` is a callable class.
-            fn_constructor_kwargs: Keyword Arguments to provide to the initializor of
-                `fn` if `fn` is a callable class.
-            min_rows_per_bundled_input: The target number of rows to pass to
-                ``MapOperator._add_bundled_input()``.
-            compute: The compute strategy, either ``TaskPoolStrategy`` (default) to use
-                Ray tasks, or ``ActorPoolStrategy`` to use an autoscaling actor pool.
-            ray_remote_args_fn: A function that returns a dictionary of remote args
-                passed to each map worker. The purpose of this argument is to generate
-                dynamic arguments for each actor/task, and will be called each time
-                prior to initializing the worker. Args returned from this dict will
-                always override the args in ``ray_remote_args``. Note: this is an
-                advanced, experimental feature.
-            ray_remote_args: Args to provide to :func:`ray.remote`.
-        """
-        name = self._get_operator_name(name, fn)
-        super().__init__(
-            name,
-            input_op,
-            can_modify_num_rows=can_modify_num_rows,
-            min_rows_per_bundled_input=min_rows_per_bundled_input,
-            ray_remote_args=ray_remote_args,
-            compute=compute,
-        )
-        self._fn = fn
-        self._fn_args = fn_args
-        self._fn_kwargs = fn_kwargs
-        self._fn_constructor_args = fn_constructor_args
-        self._fn_constructor_kwargs = fn_constructor_kwargs
-        self._ray_remote_args_fn = ray_remote_args_fn
+    def __post_init__(self) -> None:
+        if self.name is None and self.fn is not None:
+            object.__setattr__(
+                self,
+                "name",
+                self._get_operator_name(self.__class__.__name__, self.fn),
+            )
+        super().__post_init__()
 
     def _get_operator_name(self, op_name: str, fn: UserDefinedFunction):
         """Gets the Operator name including the map `fn` UDF name."""
@@ -165,116 +91,56 @@ class AbstractUDFMap(AbstractMap):
             return "<unknown>"
 
 
+@dataclass(frozen=True, repr=False)
 class MapBatches(AbstractUDFMap):
     """Logical operator for map_batches."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        fn: UserDefinedFunction,
-        can_modify_num_rows: bool = False,
-        batch_size: Optional[int] = None,
-        batch_format: str = "default",
-        zero_copy_batch: bool = True,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        min_rows_per_bundled_input: Optional[int] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            "MapBatches",
-            input_op,
-            fn,
-            can_modify_num_rows=can_modify_num_rows,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-            fn_constructor_args=fn_constructor_args,
-            fn_constructor_kwargs=fn_constructor_kwargs,
-            min_rows_per_bundled_input=min_rows_per_bundled_input,
-            compute=compute,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
-        )
-        self._batch_size = batch_size
-        self._batch_format = batch_format
-        self._zero_copy_batch = zero_copy_batch
+    batch_size: Optional[int] = None
+    batch_format: str = "default"
+    zero_copy_batch: bool = True
+
+    def __post_init__(self) -> None:
+        if self.name is None and self.fn is None:
+            object.__setattr__(self, "name", "MapBatches")
+        super().__post_init__()
 
 
+@dataclass(frozen=True, repr=False)
 class MapRows(AbstractUDFMap):
     """Logical operator for map."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        fn: UserDefinedFunction,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            "Map",
-            input_op,
-            fn,
-            can_modify_num_rows=False,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-            fn_constructor_args=fn_constructor_args,
-            fn_constructor_kwargs=fn_constructor_kwargs,
-            compute=compute,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
-        )
+    def __post_init__(self) -> None:
+        if self.name is None and self.fn is not None:
+            object.__setattr__(self, "name", self._get_operator_name("Map", self.fn))
+        elif self.name is None:
+            object.__setattr__(self, "name", "Map")
+        super().__post_init__()
 
 
+@dataclass(frozen=True, repr=False)
 class Filter(AbstractUDFMap):
     """Logical operator for filter."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        predicate_expr: Optional[Expr] = None,
-        fn: Optional[UserDefinedFunction] = None,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        # Ensure exactly one of fn, or predicate_expr is provided
-        provided_params = sum([fn is not None, predicate_expr is not None])
+    predicate_expr: Optional[Expr] = None
+    can_modify_num_rows: bool = True
+
+    def __post_init__(self) -> None:
+        provided_params = sum([self.fn is not None, self.predicate_expr is not None])
         if provided_params != 1:
             raise ValueError(
-                f"Exactly one of 'fn', or 'predicate_expr' must be provided (received fn={fn}, predicate_expr={predicate_expr})"
+                "Exactly one of 'fn', or 'predicate_expr' must be provided "
+                f"(received fn={self.fn}, predicate_expr={self.predicate_expr})"
             )
-
-        self._predicate_expr = predicate_expr
-
-        super().__init__(
-            "Filter",
-            input_op,
-            can_modify_num_rows=True,
-            fn=fn,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-            fn_constructor_args=fn_constructor_args,
-            fn_constructor_kwargs=fn_constructor_kwargs,
-            compute=compute,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
-        )
+        if self.name is None:
+            object.__setattr__(
+                self,
+                "name",
+                self._get_operator_name(self.__class__.__name__, self.fn),
+            )
+        super().__post_init__()
 
     def is_expression_based(self) -> bool:
-        return self._predicate_expr is not None
+        return self.predicate_expr is not None
 
     def _get_operator_name(self, op_name: str, fn: UserDefinedFunction):
         if self.is_expression_based():
@@ -283,7 +149,7 @@ class Filter(AbstractUDFMap):
                 _InlineExprReprVisitor,
             )
 
-            expr_str = _InlineExprReprVisitor().visit(self._predicate_expr)
+            expr_str = _InlineExprReprVisitor().visit(self.predicate_expr)
 
             # Truncate only the final result if too long
             max_length = 60
@@ -294,33 +160,25 @@ class Filter(AbstractUDFMap):
         return super()._get_operator_name(op_name, fn)
 
 
+@dataclass(frozen=True, repr=False)
 class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for all Projection Operations."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        exprs: list["Expr"],
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        # Auto-select compute strategy based on whether expressions contain callable class UDFs
-        if compute is None:
-            compute = self._detect_and_get_compute_strategy(exprs)
+    exprs: list["Expr"] = None  # type: ignore[assignment]
+    batch_size: Optional[int] = None
+    batch_format: str = "pyarrow"
+    zero_copy_batch: bool = True
 
-        super().__init__(
-            "Project",
-            input_op=input_op,
-            can_modify_num_rows=False,
-            ray_remote_args=ray_remote_args,
-            compute=compute,
-        )
-        self._batch_size = None
-        self._exprs = exprs
-        self._batch_format = "pyarrow"
-        self._zero_copy_batch = True
-
-        for expr in self._exprs:
+    def __post_init__(self) -> None:
+        assert self.exprs is not None
+        if self.compute is None:
+            object.__setattr__(
+                self, "compute", self._detect_and_get_compute_strategy(self.exprs)
+            )
+        if self.name is None:
+            object.__setattr__(self, "name", "Project")
+        super().__post_init__()
+        for expr in self.exprs:
             if expr.name is None and not isinstance(expr, StarExpr):
                 raise TypeError(
                     "All Project expressions must be named (use .alias(name) or col(name)), "
@@ -357,15 +215,11 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
 
     def get_star_expr(self) -> Optional[StarExpr]:
         """Check if this projection contains a star() expression."""
-        for expr in self._exprs:
+        for expr in self.exprs:
             if isinstance(expr, StarExpr):
                 return expr
 
         return None
-
-    @property
-    def exprs(self) -> List["Expr"]:
-        return self._exprs
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         return PredicatePassThroughBehavior.PASSTHROUGH_WITH_SUBSTITUTION
@@ -381,59 +235,40 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
             _extract_input_columns_renaming_mapping,
         )
 
-        rename_map = _extract_input_columns_renaming_mapping(self._exprs)
+        rename_map = _extract_input_columns_renaming_mapping(self.exprs)
         return rename_map if rename_map else None
 
 
+@dataclass(frozen=True, repr=False)
 class FlatMap(AbstractUDFMap):
     """Logical operator for flat_map."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        fn: UserDefinedFunction,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            "FlatMap",
-            input_op,
-            fn,
-            can_modify_num_rows=True,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-            fn_constructor_args=fn_constructor_args,
-            fn_constructor_kwargs=fn_constructor_kwargs,
-            compute=compute,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
-        )
+    can_modify_num_rows: bool = True
+
+    def __post_init__(self) -> None:
+        if self.name is None and self.fn is None:
+            object.__setattr__(self, "name", "FlatMap")
+        super().__post_init__()
 
 
+@dataclass(frozen=True, repr=False)
 class StreamingRepartition(AbstractMap):
     """Logical operator for streaming repartition operation.
+
     Args:
+        input_op: Upstream logical operator.
         target_num_rows_per_block: The target number of rows per block granularity for
            streaming repartition.
+        **kwargs: Used by dataclasses.replace.
     """
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        target_num_rows_per_block: int,
-    ):
-        super().__init__(
-            f"StreamingRepartition[num_rows_per_block={target_num_rows_per_block}]",
-            input_op,
-            can_modify_num_rows=False,
-        )
-        self._target_num_rows_per_block = target_num_rows_per_block
+    target_num_rows_per_block: int = 0
 
-    @property
-    def target_num_rows_per_block(self) -> int:
-        return self._target_num_rows_per_block
+    def __post_init__(self) -> None:
+        if self.name is None:
+            object.__setattr__(
+                self,
+                "name",
+                f"StreamingRepartition[num_rows_per_block={self.target_num_rows_per_block}]",
+            )
+        super().__post_init__()

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from dataclasses import dataclass
+from typing import List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -7,33 +8,41 @@ from ray.data._internal.logical.interfaces import (
 )
 
 
+@dataclass(frozen=True, init=False, repr=False)
 class NAry(LogicalOperator):
     """Base class for n-ary operators, which take multiple input operators."""
 
     def __init__(
         self,
         *input_ops: LogicalOperator,
+        input_dependencies: Optional[List[LogicalOperator]] = None,
         num_outputs: Optional[int] = None,
+        name: Optional[str] = None,
     ):
-        """
+        """Initialize an n-ary logical operator.
+
         Args:
-            input_ops: The input operators.
+            *input_ops: The input operators.
+            input_dependencies: The input operators. If set, overrides input_ops.
+            num_outputs: The output number of blocks. None means unknown.
+            name: The operator name. Defaults to the class name.
         """
-        super().__init__(self.__class__.__name__, list(input_ops), num_outputs)
+        if name is None:
+            name = self.__class__.__name__
+        if input_dependencies is None:
+            input_dependencies = list(input_ops)
+        super().__init__(
+            name=name, input_dependencies=input_dependencies, num_outputs=num_outputs
+        )
 
 
+@dataclass(frozen=True, init=False, repr=False)
 class Zip(NAry):
     """Logical operator for zip."""
 
-    def __init__(
-        self,
-        *input_ops: LogicalOperator,
-    ):
-        super().__init__(*input_ops)
-
     def estimated_num_outputs(self):
         total_num_outputs = 0
-        for input in self._input_dependencies:
+        for input in self.input_dependencies:
             num_outputs = input.estimated_num_outputs()
             if num_outputs is None:
                 return None
@@ -41,18 +50,13 @@ class Zip(NAry):
         return total_num_outputs
 
 
+@dataclass(frozen=True, init=False, repr=False)
 class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for union."""
 
-    def __init__(
-        self,
-        *input_ops: LogicalOperator,
-    ):
-        super().__init__(*input_ops)
-
     def estimated_num_outputs(self):
         total_num_outputs = 0
-        for input in self._input_dependencies:
+        for input in self.input_dependencies:
             num_outputs = input.estimated_num_outputs()
             if num_outputs is None:
                 return None

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
@@ -12,60 +13,41 @@ if TYPE_CHECKING:
     from ray.data.block import Schema
 
 
+@dataclass(frozen=True, repr=False)
 class AbstractOneToOne(LogicalOperator):
     """Abstract class for one-to-one logical operators, which
     have one input and one output dependency.
     """
 
-    def __init__(
-        self,
-        name: str,
-        input_op: Optional[LogicalOperator],
-        can_modify_num_rows: bool,
-        num_outputs: Optional[int] = None,
-    ):
-        """Initialize an AbstractOneToOne operator.
+    input_op: Optional[LogicalOperator] = None
+    can_modify_num_rows: bool = False
 
-        Args:
-            name: Name for this operator. This is the name that will appear when
-                inspecting the logical plan of a Dataset.
-            input_op: The operator preceding this operator in the plan DAG. The outputs
-                of `input_op` will be the inputs to this operator.
-            can_modify_num_rows: Whether the UDF can change the row count. False if
-                # of input rows = # of output rows. True otherwise.
-            num_outputs: If known, the number of blocks produced by this operator.
-        """
-        super().__init__(
-            name=name,
-            input_dependencies=[input_op] if input_op else [],
-            num_outputs=num_outputs,
-        )
-        self._can_modify_num_rows = can_modify_num_rows
+    def __post_init__(self) -> None:
+        if not self.input_dependencies and self.input_op is not None:
+            object.__setattr__(self, "input_dependencies", (self.input_op,))
+        super().__post_init__()
+        assert self.name is not None
+        if self.input_dependencies:
+            assert len(self.input_dependencies) == 1, self.input_dependencies
+        else:
+            assert self.input_op is None
 
     @property
     def input_dependency(self) -> LogicalOperator:
-        return self._input_dependencies[0]
-
-    def can_modify_num_rows(self) -> bool:
-        """Whether this operator can modify the number of rows,
-        i.e. number of input rows != number of output rows."""
-        return self._can_modify_num_rows
+        return self.input_dependencies[0]
 
 
+@dataclass(frozen=True, repr=False)
 class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for limit."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        limit: int,
-    ):
-        super().__init__(
-            f"limit={limit}",
-            input_op=input_op,
-            can_modify_num_rows=True,
-        )
-        self._limit = limit
+    limit: int = 0
+    can_modify_num_rows: bool = True
+
+    def __post_init__(self) -> None:
+        if self.name is None:
+            object.__setattr__(self, "name", f"limit={self.limit}")
+        super().__post_init__()
 
     def infer_metadata(self) -> BlockMetadata:
         return BlockMetadata(
@@ -78,23 +60,23 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def _num_rows(self):
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        input_rows = self._input_dependencies[0].infer_metadata().num_rows
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        input_rows = self.input_dependencies[0].infer_metadata().num_rows
         if input_rows is not None:
-            return min(input_rows, self._limit)
+            return min(input_rows, self.limit)
         else:
             return None
 
     def _input_files(self):
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata().input_files
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata().input_files
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Pushing filter through limit is safe: Filter(Limit(data, n), pred)
@@ -102,37 +84,27 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False)
 class Download(AbstractOneToOne):
     """Logical operator for download operation.
 
     Supports downloading from multiple URI columns in a single operation.
     """
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        uri_column_names: List[str],
-        output_bytes_column_names: List[str],
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__("Download", input_op, can_modify_num_rows=False)
-        if len(uri_column_names) != len(output_bytes_column_names):
+    uri_column_names: Optional[List[str]] = None
+    output_bytes_column_names: Optional[List[str]] = None
+    ray_remote_args: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        if self.name is None:
+            object.__setattr__(self, "name", "Download")
+        super().__post_init__()
+        assert self.uri_column_names is not None
+        assert self.output_bytes_column_names is not None
+        if len(self.uri_column_names) != len(self.output_bytes_column_names):
             raise ValueError(
-                f"Number of URI columns ({len(uri_column_names)}) must match "
-                f"number of output columns ({len(output_bytes_column_names)})"
+                f"Number of URI columns ({len(self.uri_column_names)}) must match "
+                f"number of output columns ({len(self.output_bytes_column_names)})"
             )
-        self._uri_column_names = uri_column_names
-        self._output_bytes_column_names = output_bytes_column_names
-        self._ray_remote_args = ray_remote_args or {}
-
-    @property
-    def uri_column_names(self) -> List[str]:
-        return self._uri_column_names
-
-    @property
-    def output_bytes_column_names(self) -> List[str]:
-        return self._output_bytes_column_names
-
-    @property
-    def ray_remote_args(self) -> Dict[str, Any]:
-        return self._ray_remote_args
+        if self.ray_remote_args is None:
+            object.__setattr__(self, "ray_remote_args", {})

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,10 +1,11 @@
-import copy
 import functools
 import math
-from typing import Any, Dict, Optional, Union
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.logical.interfaces import (
+    LogicalOperator,
     LogicalOperatorSupportsPredicatePushdown,
     LogicalOperatorSupportsProjectionPushdown,
     SourceOperator,
@@ -19,6 +20,7 @@ from ray.data.datasource.datasource import Datasource, Reader
 from ray.data.expressions import Expr
 
 
+@dataclass(frozen=True, init=False, repr=False)
 class Read(
     AbstractMap,
     SourceOperator,
@@ -27,47 +29,73 @@ class Read(
 ):
     """Logical operator for read."""
 
-    # TODO: make this a frozen dataclass. https://github.com/ray-project/ray/issues/55747
+    datasource: Datasource
+    datasource_or_legacy_reader: Union[Datasource, Reader]
+    parallelism: int
+    detected_parallelism: Optional[int]
+
     def __init__(
         self,
-        datasource: Datasource,
-        datasource_or_legacy_reader: Union[Datasource, Reader],
-        parallelism: int,
+        input_op: Optional[LogicalOperator] = None,
+        datasource: Optional[Datasource] = None,
+        datasource_or_legacy_reader: Optional[Union[Datasource, Reader]] = None,
+        parallelism: Optional[int] = None,
         num_outputs: Optional[int] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         compute: Optional[ComputeStrategy] = None,
+        name: Optional[str] = None,
+        min_rows_per_bundled_input: Optional[int] = None,
+        per_block_limit: Optional[int] = None,
+        detected_parallelism: Optional[int] = None,
+        can_modify_num_rows: bool = True,
+        input_dependencies: Optional[List[LogicalOperator]] = None,
     ):
+        assert datasource is not None
+        assert datasource_or_legacy_reader is not None
+        assert parallelism is not None
+        assert input_op is None
+        if name is None:
+            name = f"Read{datasource.get_name()}"
+        if input_dependencies is None:
+            input_dependencies = []
         super().__init__(
-            name=f"Read{datasource.get_name()}",
+            name=name,
             input_op=None,
-            can_modify_num_rows=True,
+            input_dependencies=input_dependencies,
+            can_modify_num_rows=can_modify_num_rows,
             num_outputs=num_outputs,
+            min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
+            ray_remote_args_fn=ray_remote_args_fn,
             compute=compute,
+            per_block_limit=per_block_limit,
         )
-        self._datasource = datasource
-        self._datasource_or_legacy_reader = datasource_or_legacy_reader
-        self._parallelism = parallelism
-        self._detected_parallelism = None
+        object.__setattr__(self, "datasource", datasource)
+        object.__setattr__(
+            self, "datasource_or_legacy_reader", datasource_or_legacy_reader
+        )
+        object.__setattr__(self, "parallelism", parallelism)
+        object.__setattr__(self, "detected_parallelism", detected_parallelism)
 
     def output_data(self):
         return None
 
-    def set_detected_parallelism(self, parallelism: int):
+    def with_detected_parallelism(self, parallelism: int) -> "Read":
         """
         Set the true parallelism that should be used during execution. This
         should be specified by the user or detected by the optimizer.
         """
-        self._detected_parallelism = parallelism
+        return replace(self, detected_parallelism=parallelism)
 
-    def get_detected_parallelism(self) -> int:
+    def get_detected_parallelism(self) -> Optional[int]:
         """
         Get the true parallelism that should be used during execution.
         """
-        return self._detected_parallelism
+        return self.detected_parallelism
 
     def estimated_num_outputs(self) -> Optional[int]:
-        return self._num_outputs or self._estimate_num_outputs()
+        return self.num_outputs or self._estimate_num_outputs()
 
     def infer_metadata(self) -> BlockMetadata:
         """A ``BlockMetadata`` that represents the aggregate metadata of the outputs.
@@ -104,12 +132,12 @@ class Read(
     @functools.cached_property
     def _cached_output_metadata(self) -> "BlockMetadataWithSchema":
         # Legacy datasources might not implement `get_read_tasks`.
-        if self._datasource.should_create_reader:
+        if self.datasource.should_create_reader:
             empty_meta = BlockMetadata(None, None, None, None)
             return BlockMetadataWithSchema(metadata=empty_meta, schema=None)
 
         # HACK: Try to get a single read task to get the metadata.
-        read_tasks = self._datasource.get_read_tasks(1)
+        read_tasks = self.datasource.get_read_tasks(1)
         if len(read_tasks) == 0:
             # If there are no read tasks, the dataset is probably empty.
             empty_meta = BlockMetadata(None, None, None, None)
@@ -122,8 +150,8 @@ class Read(
             num_rows = sum(meta.num_rows for meta in metadata)
             original_num_rows = num_rows
             # Apply per-block limit if set
-            if self._per_block_limit is not None:
-                num_rows = min(num_rows, self._per_block_limit)
+            if self.per_block_limit is not None:
+                num_rows = min(num_rows, self.per_block_limit)
         else:
             num_rows = None
             original_num_rows = None
@@ -132,7 +160,7 @@ class Read(
             size_bytes = sum(meta.size_bytes for meta in metadata)
             # Pro-rate the byte size if we applied a row limit
             if (
-                self._per_block_limit is not None
+                self.per_block_limit is not None
                 and original_num_rows is not None
                 and original_num_rows > 0
             ):
@@ -162,37 +190,35 @@ class Read(
         return BlockMetadataWithSchema(metadata=meta, schema=schema)
 
     def supports_projection_pushdown(self) -> bool:
-        return self._datasource.supports_projection_pushdown()
+        return self.datasource.supports_projection_pushdown()
 
     def get_projection_map(self) -> Optional[Dict[str, str]]:
-        return self._datasource.get_projection_map()
+        return self.datasource.get_projection_map()
 
     def apply_projection(
         self,
         projection_map: Optional[Dict[str, str]],
     ) -> "Read":
-        clone = copy.copy(self)
-
-        projected_datasource = self._datasource.apply_projection(projection_map)
-        clone._datasource = projected_datasource
-        clone._datasource_or_legacy_reader = projected_datasource
-
-        return clone
+        projected_datasource = self.datasource.apply_projection(projection_map)
+        return replace(
+            self,
+            datasource=projected_datasource,
+            datasource_or_legacy_reader=projected_datasource,
+        )
 
     def get_column_renames(self) -> Optional[Dict[str, str]]:
-        return self._datasource.get_column_renames()
+        return self.datasource.get_column_renames()
 
     def supports_predicate_pushdown(self) -> bool:
-        return self._datasource.supports_predicate_pushdown()
+        return self.datasource.supports_predicate_pushdown()
 
     def get_current_predicate(self) -> Optional[Expr]:
-        return self._datasource.get_current_predicate()
+        return self.datasource.get_current_predicate()
 
     def apply_predicate(self, predicate_expr: Expr) -> "Read":
-        predicated_datasource = self._datasource.apply_predicate(predicate_expr)
-
-        clone = copy.copy(self)
-        clone._datasource = predicated_datasource
-        clone._datasource_or_legacy_reader = predicated_datasource
-
-        return clone
+        predicated_datasource = self.datasource.apply_predicate(predicate_expr)
+        return replace(
+            self,
+            datasource=predicated_datasource,
+            datasource_or_legacy_reader=predicated_datasource,
+        )

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
@@ -6,17 +7,34 @@ if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces import NodeIdStr
 
 
+@dataclass(frozen=True, init=False, repr=False)
 class StreamingSplit(LogicalOperator):
     """Logical operator that represents splitting the input data to `n` splits."""
 
+    num_splits: int
+    equal: bool
+    locality_hints: Optional[List["NodeIdStr"]]
+
     def __init__(
         self,
-        input_op: LogicalOperator,
-        num_splits: int,
-        equal: bool,
+        input_op: Optional[LogicalOperator] = None,
+        input_dependencies: Optional[List[LogicalOperator]] = None,
+        num_splits: Optional[int] = None,
+        equal: Optional[bool] = None,
         locality_hints: Optional[List["NodeIdStr"]] = None,
+        name: Optional[str] = None,
+        num_outputs: Optional[int] = None,
     ):
-        super().__init__("StreamingSplit", [input_op])
-        self._num_splits = num_splits
-        self._equal = equal
-        self._locality_hints = locality_hints
+        assert num_splits is not None
+        assert equal is not None
+        if input_dependencies is None:
+            assert input_op is not None
+            input_dependencies = [input_op]
+        if name is None:
+            name = "StreamingSplit"
+        super().__init__(
+            name=name, input_dependencies=input_dependencies, num_outputs=num_outputs
+        )
+        object.__setattr__(self, "num_splits", num_splits)
+        object.__setattr__(self, "equal", equal)
+        object.__setattr__(self, "locality_hints", locality_hints)

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional, Union
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.logical.interfaces import LogicalOperator
@@ -7,17 +8,33 @@ from ray.data.datasource.datasink import Datasink
 from ray.data.datasource.datasource import Datasource
 
 
+@dataclass(frozen=True, init=False, repr=False)
 class Write(AbstractMap):
     """Logical operator for write."""
 
+    datasink_or_legacy_datasource: Union[Datasink, Datasource]
+    write_args: Dict[str, Any]
+
     def __init__(
         self,
-        input_op: LogicalOperator,
-        datasink_or_legacy_datasource: Union[Datasink, Datasource],
+        input_op: Optional[LogicalOperator] = None,
+        datasink_or_legacy_datasource: Optional[Union[Datasink, Datasource]] = None,
+        input_dependencies: Optional[List[LogicalOperator]] = None,
+        num_outputs: Optional[int] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
         compute: Optional[ComputeStrategy] = None,
-        **write_args,
+        name: Optional[str] = None,
+        per_block_limit: Optional[int] = None,
+        write_args: Optional[Dict[str, Any]] = None,
+        **extra_write_args,
     ):
+        assert datasink_or_legacy_datasource is not None
+        if name is None:
+            name = "Write"
+        if write_args is None:
+            write_args = extra_write_args
+        elif extra_write_args:
+            write_args = {**write_args, **extra_write_args}
         if isinstance(datasink_or_legacy_datasource, Datasink):
             min_rows_per_bundled_input = (
                 datasink_or_legacy_datasource.min_rows_per_write
@@ -25,13 +42,21 @@ class Write(AbstractMap):
         else:
             min_rows_per_bundled_input = None
 
+        if input_dependencies is None:
+            assert input_op is not None
+            input_dependencies = [input_op]
         super().__init__(
-            "Write",
-            input_op,
+            name=name,
+            input_op=input_op,
+            input_dependencies=input_dependencies,
             can_modify_num_rows=True,
+            num_outputs=num_outputs,
             min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
             compute=compute,
+            per_block_limit=per_block_limit,
         )
-        self._datasink_or_legacy_datasource = datasink_or_legacy_datasource
-        self._write_args = write_args
+        object.__setattr__(
+            self, "datasink_or_legacy_datasource", datasink_or_legacy_datasource
+        )
+        object.__setattr__(self, "write_args", write_args)

--- a/python/ray/data/_internal/logical/rules/combine_shuffles.py
+++ b/python/ray/data/_internal/logical/rules/combine_shuffles.py
@@ -45,42 +45,42 @@ class CombineShuffles(Rule):
         input_op = op.input_dependencies[0]
 
         if isinstance(input_op, Repartition) and isinstance(op, Repartition):
-            shuffle = input_op._shuffle or op._shuffle
+            shuffle = input_op.shuffle or op.shuffle
             return Repartition(
-                input_op.input_dependencies[0],
-                num_outputs=op._num_outputs,
+                input_op=input_op.input_dependencies[0],
+                num_outputs=op.num_outputs,
                 shuffle=shuffle,
-                keys=op._keys,
-                sort=op._sort,
+                keys=op.keys,
+                sort=op.sort,
             )
         elif isinstance(input_op, StreamingRepartition) and isinstance(
             op, StreamingRepartition
         ):
             return StreamingRepartition(
-                input_op.input_dependencies[0],
+                input_op=input_op.input_dependencies[0],
                 target_num_rows_per_block=op.target_num_rows_per_block,
             )
         elif isinstance(input_op, Repartition) and isinstance(op, Aggregate):
             return Aggregate(
                 input_op=input_op.input_dependencies[0],
-                key=op._key,
-                aggs=op._aggs,
-                num_partitions=op._num_partitions,
-                batch_format=op._batch_format,
+                key=op.key,
+                aggs=op.aggs,
+                num_partitions=op.num_partitions,
+                batch_format=op.batch_format,
             )
         elif isinstance(input_op, StreamingRepartition) and isinstance(op, Repartition):
             return Repartition(
-                input_op.input_dependencies[0],
-                num_outputs=op._num_outputs,
-                shuffle=op._shuffle,
-                keys=op._keys,
-                sort=op._sort,
+                input_op=input_op.input_dependencies[0],
+                num_outputs=op.num_outputs,
+                shuffle=op.shuffle,
+                keys=op.keys,
+                sort=op.sort,
             )
         elif isinstance(input_op, Sort) and isinstance(op, Sort):
             return Sort(
-                input_op.input_dependencies[0],
-                sort_key=op._sort_key,
-                batch_format=op._batch_format,
+                input_op=input_op.input_dependencies[0],
+                sort_key=op.sort_key,
+                batch_format=op.batch_format,
             )
 
         return op

--- a/python/ray/data/_internal/logical/rules/inherit_batch_format.py
+++ b/python/ray/data/_internal/logical/rules/inherit_batch_format.py
@@ -1,4 +1,4 @@
-import copy
+from dataclasses import fields, replace
 
 from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule
 from ray.data._internal.logical.operators import AbstractAllToAll, MapBatches
@@ -22,16 +22,15 @@ class InheritBatchFormatRule(Rule):
         def transform(node: LogicalOperator) -> LogicalOperator:
             if not isinstance(node, AbstractAllToAll):
                 return node
+            if "batch_format" not in {field.name for field in fields(node)}:
+                return node
 
             # traversal up the DAG until we find MapBatches with batch_format
             # or we reach to source op and do nothing
             upstream_op = node.input_dependencies[0]
             while upstream_op.input_dependencies:
-                if isinstance(upstream_op, MapBatches) and upstream_op._batch_format:
-                    new_op = copy.copy(node)
-                    new_op._batch_format = upstream_op._batch_format
-                    new_op._output_dependencies = []
-                    return new_op
+                if isinstance(upstream_op, MapBatches) and upstream_op.batch_format:
+                    return replace(node, batch_format=upstream_op.batch_format)
                 upstream_op = upstream_op.input_dependencies[0]
 
             return node

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -1,5 +1,5 @@
-import copy
 import logging
+from dataclasses import replace
 from typing import List
 
 from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule
@@ -46,8 +46,8 @@ class LimitPushdownRule(Rule):
                 upstream_op = node.input_dependency
                 if isinstance(upstream_op, Limit):
                     # Fuse consecutive Limits: Limit[n] -> Limit[m] becomes Limit[min(n,m)]
-                    new_limit = min(node._limit, upstream_op._limit)
-                    return Limit(upstream_op.input_dependency, new_limit)
+                    new_limit = min(node.limit, upstream_op.limit)
+                    return Limit(input_op=upstream_op.input_dependency, limit=new_limit)
 
                 # If no fusion, apply pushdown logic
                 if isinstance(upstream_op, Union):
@@ -105,25 +105,25 @@ class LimitPushdownRule(Rule):
             current = op
             while (
                 isinstance(current, AbstractOneToOne)
-                and not current.can_modify_num_rows()
+                and not current.can_modify_num_rows
                 and current.input_dependencies
             ):
                 if isinstance(current, Limit):
-                    return current._limit == limit
+                    return current.limit == limit
                 # Safe to use input_dependency: current is an AbstractOneToOne here.
                 current = current.input_dependency
 
-            return isinstance(current, Limit) and current._limit == limit
+            return isinstance(current, Limit) and current.limit == limit
 
         # Insert a branch-local Limit and push it further upstream.
         branch_tails: List[LogicalOperator] = []
         for child in union_op.input_dependencies:
             # Avoid inserting a duplicate Limit on a branch that already has the same
             # limit upstream of row-preserving ops.
-            if _branch_has_limit(child, limit_op._limit):
+            if _branch_has_limit(child, limit_op.limit):
                 branch_tails.append(child)
                 continue
-            raw_limit = Limit(child, limit_op._limit)  # child → limit
+            raw_limit = Limit(input_op=child, limit=limit_op.limit)  # child → limit
 
             if isinstance(raw_limit.input_dependency, Union):
                 # This represents the limit operator appended after the union.
@@ -134,7 +134,7 @@ class LimitPushdownRule(Rule):
             branch_tails.append(pushed_tail)
 
         new_union = Union(*branch_tails)
-        return Limit(new_union, limit_op._limit)
+        return Limit(input_op=new_union, limit=limit_op.limit)
 
     def _push_limit_down(self, limit_op: Limit) -> LogicalOperator:
         """Push a single limit down through compatible operators conservatively.
@@ -147,15 +147,15 @@ class LimitPushdownRule(Rule):
         num_rows_preserving_ops: List[LogicalOperator] = []
         while (
             isinstance(current_op, AbstractOneToOne)
-            and not current_op.can_modify_num_rows()
+            and not current_op.can_modify_num_rows
         ):
             if isinstance(current_op, AbstractMap):
-                min_rows = current_op._min_rows_per_bundled_input
-                if min_rows is not None and min_rows > limit_op._limit:
+                min_rows = current_op.min_rows_per_bundled_input
+                if min_rows is not None and min_rows > limit_op.limit:
                     # Avoid pushing the limit past batch-based maps that require more
                     # rows than the limit to produce stable outputs (e.g. schema).
                     logger.info(
-                        f"Skipping push down of limit {limit_op._limit} through map {current_op} because it requires {min_rows} rows to produce stable outputs"
+                        f"Skipping push down of limit {limit_op.limit} through map {current_op} because it requires {min_rows} rows to produce stable outputs"
                     )
                     break
             num_rows_preserving_ops.append(current_op)
@@ -166,11 +166,11 @@ class LimitPushdownRule(Rule):
             return limit_op
         # Apply per-block limit to the deepest operator if it supports it
         limit_input = self._apply_per_block_limit_if_supported(
-            current_op, limit_op._limit
+            current_op, limit_op.limit
         )
 
         # Build the new operator chain: Chain non-preserving number of rows -> Limit -> Operators preserving number of rows
-        new_limit = Limit(limit_input, limit_op._limit)
+        new_limit = Limit(input_op=limit_input, limit=limit_op.limit)
         result_op = new_limit
 
         # Recreate the intermediate operators and apply per-block limits
@@ -187,9 +187,7 @@ class LimitPushdownRule(Rule):
     ) -> LogicalOperator:
         """Apply per-block limit to operators that support it."""
         if isinstance(op, AbstractMap):
-            new_op = copy.copy(op)
-            new_op.set_per_block_limit(limit)
-            return new_op
+            return op.with_per_block_limit(limit)
         return op
 
     def _recreate_operator_with_new_input(
@@ -198,11 +196,6 @@ class LimitPushdownRule(Rule):
         """Create a new operator of the same type as original_op but with new_input as its input."""
 
         if isinstance(original_op, Limit):
-            return Limit(new_input, original_op._limit)
+            return Limit(input_op=new_input, limit=original_op.limit)
 
-        # Use copy and replace input dependencies approach
-        new_op = copy.copy(original_op)
-        new_op._input_dependencies = [new_input]
-        new_op._output_dependencies = []
-
-        return new_op
+        return replace(original_op, input_dependencies=(new_input,))

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -78,12 +78,12 @@ class FuseOperators(Rule):
         return new_plan
 
     def _remove_output_deps(self, op: PhysicalOperator) -> None:
-        for input in op._input_dependencies:
+        for input in op.input_dependencies:
             input._output_dependencies = []
             self._remove_output_deps(input)
 
     def _update_output_deps(self, op: PhysicalOperator) -> None:
-        for input in op._input_dependencies:
+        for input in op.input_dependencies:
             input._output_dependencies.append(op)
             self._update_output_deps(input)
 
@@ -129,7 +129,7 @@ class FuseOperators(Rule):
             dag = self._get_fused_streaming_repartition_operator(dag, upstream_ops[0])
             upstream_ops = dag.input_dependencies
 
-        dag._input_dependencies = [
+        dag.input_dependencies = [
             self._fuse_streaming_repartition_operators_in_dag(upstream_op)
             for upstream_op in upstream_ops
         ]
@@ -153,7 +153,7 @@ class FuseOperators(Rule):
 
         # Done fusing back-to-back map operators together here,
         # move up the DAG to find the next map operators to fuse.
-        dag._input_dependencies = [
+        dag.input_dependencies = [
             self._fuse_map_operators_in_dag(upstream_op) for upstream_op in upstream_ops
         ]
         return dag
@@ -183,7 +183,7 @@ class FuseOperators(Rule):
 
         # Done fusing MapOperator -> AllToAllOperator together here,
         # move up the DAG to find the next pair of operators to fuse.
-        dag._input_dependencies = [
+        dag.input_dependencies = [
             self._fuse_all_to_all_operators_in_dag(upstream_op)
             for upstream_op in upstream_ops
         ]
@@ -229,7 +229,7 @@ class FuseOperators(Rule):
 
         # If the downstream operator takes no input, it cannot be fused with
         # the upstream operator.
-        if not down_logical_op._input_dependencies:
+        if not down_logical_op.input_dependencies:
             return False
 
         # We currently only support fusing for the following cases:
@@ -251,22 +251,22 @@ class FuseOperators(Rule):
             or (
                 isinstance(up_logical_op, AbstractMap)
                 and isinstance(down_logical_op, Repartition)
-                and down_logical_op._shuffle
+                and down_logical_op.shuffle
             )
         ):
             return False
 
         # Only fuse if the ops' remote arguments are compatible.
         if not are_remote_args_compatible(
-            getattr(up_logical_op, "_ray_remote_args", {}),
-            getattr(down_logical_op, "_ray_remote_args", {}),
+            getattr(up_logical_op, "ray_remote_args", {}),
+            getattr(down_logical_op, "ray_remote_args", {}),
         ):
             return False
 
-        # Do not fuse if either op specifies a `_ray_remote_args_fn`,
+        # Do not fuse if either op specifies a `ray_remote_args_fn`,
         # since it is not known whether the generated args will be compatible.
-        if getattr(up_logical_op, "_ray_remote_args_fn", None) or getattr(
-            down_logical_op, "_ray_remote_args_fn", None
+        if getattr(up_logical_op, "ray_remote_args_fn", None) or getattr(
+            down_logical_op, "ray_remote_args_fn", None
         ):
             return False
 
@@ -280,7 +280,7 @@ class FuseOperators(Rule):
         if isinstance(down_logical_op, StreamingRepartition):
             return (
                 isinstance(up_logical_op, MapBatches)
-                and up_logical_op._batch_size is not None
+                and up_logical_op.batch_size is not None
                 and down_logical_op.target_num_rows_per_block is not None
                 and down_logical_op.target_num_rows_per_block > 0
                 # When the batch_size is a multiple of target_num_rows_per_block, fusing would still produce exactly identical sequence of blocks.
@@ -288,8 +288,7 @@ class FuseOperators(Rule):
                 # TODO: when the StreamingRepartition supports none_strict_mode, we can fuse
                 # `MapBatches -> StreamingRepartition` no matter what the `batch_size` and `target_num_rows` are.
                 # https://anyscale1.atlassian.net/browse/DATA-1731
-                and up_logical_op._batch_size
-                % down_logical_op.target_num_rows_per_block
+                and up_logical_op.batch_size % down_logical_op.target_num_rows_per_block
                 == 0
             )
         # Other operators cannot fuse with StreamingRepartition.
@@ -313,21 +312,19 @@ class FuseOperators(Rule):
         up_logical_op = self._op_map.pop(up_op)
         assert isinstance(up_logical_op, MapBatches)
         assert isinstance(down_logical_op, StreamingRepartition)
-        assert (
-            up_logical_op._batch_size % down_logical_op.target_num_rows_per_block == 0
-        )
-        batch_size = up_logical_op._batch_size
+        assert up_logical_op.batch_size % down_logical_op.target_num_rows_per_block == 0
+        batch_size = up_logical_op.batch_size
 
         compute = self._fuse_compute_strategy(
-            up_logical_op._compute, down_logical_op._compute
+            up_logical_op.compute, down_logical_op.compute
         )
         assert compute is not None
 
         map_task_kwargs = {**up_op._map_task_kwargs, **down_op._map_task_kwargs}
 
-        ray_remote_args = up_logical_op._ray_remote_args
+        ray_remote_args = up_logical_op.ray_remote_args
         ray_remote_args_fn = (
-            up_logical_op._ray_remote_args_fn or down_logical_op._ray_remote_args_fn
+            up_logical_op.ray_remote_args_fn or down_logical_op.ray_remote_args_fn
         )
         input_deps = up_op.input_dependencies
         assert len(input_deps) == 1
@@ -356,14 +353,14 @@ class FuseOperators(Rule):
 
         input_op = up_logical_op.input_dependency
         logical_op = AbstractUDFMap(
-            name,
-            input_op,
-            up_logical_op._fn,
-            can_modify_num_rows=up_logical_op.can_modify_num_rows(),
-            fn_args=up_logical_op._fn_args,
-            fn_kwargs=up_logical_op._fn_kwargs,
-            fn_constructor_args=up_logical_op._fn_constructor_args,
-            fn_constructor_kwargs=up_logical_op._fn_constructor_kwargs,
+            name=name,
+            input_op=input_op,
+            fn=up_logical_op.fn,
+            can_modify_num_rows=up_logical_op.can_modify_num_rows,
+            fn_args=up_logical_op.fn_args,
+            fn_kwargs=up_logical_op.fn_kwargs,
+            fn_constructor_args=up_logical_op.fn_constructor_args,
+            fn_constructor_kwargs=up_logical_op.fn_constructor_kwargs,
             min_rows_per_bundled_input=batch_size,
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
@@ -449,16 +446,16 @@ class FuseOperators(Rule):
         )
 
         compute = self._fuse_compute_strategy(
-            up_logical_op._compute, down_logical_op._compute
+            up_logical_op.compute, down_logical_op.compute
         )
         assert compute is not None
 
         # Merge map task kwargs
         map_task_kwargs = {**up_op._map_task_kwargs, **down_op._map_task_kwargs}
 
-        ray_remote_args = up_logical_op._ray_remote_args
+        ray_remote_args = up_logical_op.ray_remote_args
         ray_remote_args_fn = (
-            up_logical_op._ray_remote_args_fn or down_logical_op._ray_remote_args_fn
+            up_logical_op.ray_remote_args_fn or down_logical_op.ray_remote_args_fn
         )
         # Make the upstream operator's inputs the new, fused operator's inputs.
         input_deps = up_op.input_dependencies
@@ -510,17 +507,17 @@ class FuseOperators(Rule):
             input_op = up_logical_op
 
         can_modify_num_rows = (
-            up_logical_op.can_modify_num_rows() or down_logical_op.can_modify_num_rows()
+            up_logical_op.can_modify_num_rows or down_logical_op.can_modify_num_rows
         )
         if isinstance(down_logical_op, AbstractUDFMap):
             logical_op = AbstractUDFMap(
-                name,
-                input_op,
-                down_logical_op._fn,
-                fn_args=down_logical_op._fn_args,
-                fn_kwargs=down_logical_op._fn_kwargs,
-                fn_constructor_args=down_logical_op._fn_constructor_args,
-                fn_constructor_kwargs=down_logical_op._fn_constructor_kwargs,
+                name=name,
+                input_op=input_op,
+                fn=down_logical_op.fn,
+                fn_args=down_logical_op.fn_args,
+                fn_kwargs=down_logical_op.fn_kwargs,
+                fn_constructor_args=down_logical_op.fn_constructor_args,
+                fn_constructor_kwargs=down_logical_op.fn_constructor_kwargs,
                 min_rows_per_bundled_input=min_rows_per_bundled_input,
                 compute=compute,
                 can_modify_num_rows=can_modify_num_rows,
@@ -530,8 +527,8 @@ class FuseOperators(Rule):
         else:
             # The downstream op is AbstractMap instead of AbstractUDFMap.
             logical_op = AbstractMap(
-                name,
-                input_op,
+                name=name,
+                input_op=input_op,
                 can_modify_num_rows=can_modify_num_rows,
                 min_rows_per_bundled_input=min_rows_per_bundled_input,
                 ray_remote_args_fn=ray_remote_args_fn,
@@ -547,8 +544,8 @@ class FuseOperators(Rule):
         down_logical_op: AbstractMap,
         up_logical_op: AbstractMap,
     ) -> Optional[int]:
-        us_bundle_min_rows_req = up_logical_op._min_rows_per_bundled_input
-        ds_bundle_min_rows_req = down_logical_op._min_rows_per_bundled_input
+        us_bundle_min_rows_req = up_logical_op.min_rows_per_bundled_input
+        ds_bundle_min_rows_req = down_logical_op.min_rows_per_bundled_input
 
         # In case neither of the ops specify `min_rows_per_bundled_input`,
         # return None
@@ -579,7 +576,7 @@ class FuseOperators(Rule):
         assert isinstance(up_logical_op, AbstractMap)
 
         # Fuse transformation functions.
-        ray_remote_args = up_logical_op._ray_remote_args
+        ray_remote_args = up_logical_op.ray_remote_args
         down_transform_fn = down_op.get_transformation_fn()
         up_map_transformer = up_op.get_map_transformer()
 
@@ -612,7 +609,7 @@ class FuseOperators(Rule):
             num_outputs=down_op._num_outputs,
             # Transfer over the existing sub-progress bars from
             # the AllToAllOperator (if any) into the fused operator.
-            sub_progress_bar_names=down_op._sub_progress_bar_names,
+            sub_progress_bar_names=down_op.get_sub_progress_bar_names(),
             name=name,
         )
         # Bottom out at the source logical op (e.g. Read()).
@@ -620,15 +617,15 @@ class FuseOperators(Rule):
 
         if isinstance(down_logical_op, RandomShuffle):
             logical_op = RandomShuffle(
-                input_op,
+                input_op=input_op,
                 name=name,
                 ray_remote_args=ray_remote_args,
             )
         elif isinstance(down_logical_op, Repartition):
             logical_op = Repartition(
-                input_op,
-                num_outputs=down_logical_op._num_outputs,
-                shuffle=down_logical_op._shuffle,
+                input_op=input_op,
+                num_outputs=down_logical_op.num_outputs,
+                shuffle=down_logical_op.shuffle,
             )
         self._op_map[op] = logical_op
         # Return the fused physical operator.
@@ -642,8 +639,8 @@ class FuseOperators(Rule):
     ) -> bool:
         if (
             cls._fuse_compute_strategy(
-                upstream_op._compute,
-                downstream_op._compute,
+                upstream_op.compute,
+                downstream_op.compute,
             )
             is None
         ):
@@ -664,13 +661,13 @@ class FuseOperators(Rule):
         #   ``Filter->MapBatches(batch_size=...)``
         #
         if (
-            upstream_op.can_modify_num_rows()
-            and downstream_op._min_rows_per_bundled_input is not None
+            upstream_op.can_modify_num_rows
+            and downstream_op.min_rows_per_bundled_input is not None
         ):
             logger.debug(
                 f"Upstream operator '{upstream_op}' could be modifying # of input "
                 f"rows, while downstream operator '{downstream_op}' expects at least "
-                f"{downstream_op._min_rows_per_bundled_input} rows in a batch. "
+                f"{downstream_op.min_rows_per_bundled_input} rows in a batch. "
                 f"Skipping fusion"
             )
 

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -319,8 +319,6 @@ class PredicatePushdown(Rule):
         """
         new_op = copy.copy(op)
         new_op._input_dependencies = new_inputs
-        # Clear and re-wire dependencies for the new operator.
-        # The output dependencies will be wired by the parent transform's traversal.
         new_op._output_dependencies = []
         new_op._wire_output_deps(new_inputs)
         return new_op

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -145,15 +145,15 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
 
     # Check if remote args (num_cpus, num_gpus, etc.) are compatible
     if not are_remote_args_compatible(
-        upstream_project._ray_remote_args or {},
-        downstream_project._ray_remote_args or {},
+        upstream_project.ray_remote_args or {},
+        downstream_project.ray_remote_args or {},
     ):
         # Resources don't match - cannot fuse
         return downstream_project
 
     # Check if compute strategies are compatible
     fused_compute = FuseOperators._fuse_compute_strategy(
-        upstream_project._compute, downstream_project._compute
+        upstream_project.compute, downstream_project.compute
     )
     if fused_compute is None:
         # Compute strategies incompatible - cannot fuse
@@ -261,10 +261,10 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
         new_exprs = projected_upstream_output_col_exprs + rebound_downstream_exprs
 
     return Project(
-        upstream_project.input_dependency,
+        input_op=upstream_project.input_dependency,
         exprs=new_exprs,
         compute=fused_compute,
-        ray_remote_args=downstream_project._ray_remote_args,
+        ray_remote_args=downstream_project.ray_remote_args,
     )
 
 
@@ -404,10 +404,10 @@ class ProjectionPushdown(Rule):
 
                 # Has transformations: Keep Project on top of optimized Read
                 return Project(
-                    projected_input_op,
+                    input_op=projected_input_op,
                     exprs=current_project.exprs,
-                    compute=current_project._compute,
-                    ray_remote_args=current_project._ray_remote_args,
+                    compute=current_project.compute,
+                    ray_remote_args=current_project.ray_remote_args,
                 )
 
         return current_project

--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -6,16 +6,11 @@ from ray import available_resources as ray_available_resources
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.logical.interfaces import PhysicalPlan, Rule
-from ray.data._internal.logical.operators import Read
+from ray.data._internal.logical.operators.read_operator import Read
+from ray.data._internal.planner.plan_read_op import _make_input_data_factory
 from ray.data._internal.util import _autodetect_parallelism
 from ray.data.context import WARN_PREFIX, DataContext
 from ray.data.datasource.datasource import Datasource, Reader
-
-__all__ = [
-    "SetReadParallelismRule",
-    "compute_additional_split_factor",
-]
-
 
 logger = logging.getLogger(__name__)
 
@@ -107,12 +102,12 @@ class SetReadParallelismRule(Rule):
                 continue
             logical_op = plan.op_map[op]
             if isinstance(logical_op, Read):
-                self._apply(op, logical_op)
+                self._apply(plan, op, logical_op)
             ops += op.input_dependencies
 
         return plan
 
-    def _apply(self, op: PhysicalOperator, logical_op: Read):
+    def _apply(self, plan: PhysicalPlan, op: PhysicalOperator, logical_op: Read):
         estimated_in_mem_bytes = logical_op.infer_metadata().size_bytes
 
         (
@@ -121,20 +116,30 @@ class SetReadParallelismRule(Rule):
             estimated_num_blocks,
             k,
         ) = compute_additional_split_factor(
-            logical_op._datasource_or_legacy_reader,
-            logical_op._parallelism,
+            logical_op.datasource_or_legacy_reader,
+            logical_op.parallelism,
             estimated_in_mem_bytes,
             op.target_max_block_size_override or op.data_context.target_max_block_size,
             op._additional_split_factor,
         )
 
-        if logical_op._parallelism == -1:
+        if logical_op.parallelism == -1:
             assert reason != ""
             logger.debug(
                 f"Using autodetected parallelism={detected_parallelism} "
                 f"for operator {logical_op.name} to satisfy {reason}."
             )
-        logical_op.set_detected_parallelism(detected_parallelism)
+        updated_logical_op = logical_op.with_detected_parallelism(detected_parallelism)
+        # Update the physical InputDataBuffer to avoid mutating the logical op.
+        if op.input_dependencies and isinstance(
+            op.input_dependencies[0], InputDataBuffer
+        ):
+            op.input_dependencies[0]._input_data_factory = _make_input_data_factory(
+                updated_logical_op,
+                op.data_context,
+                detected_parallelism,
+            )
+        plan.op_map[op] = updated_logical_op
 
         if k is not None:
             logger.debug(

--- a/python/ray/data/_internal/logical/util.py
+++ b/python/ray/data/_internal/logical/util.py
@@ -92,11 +92,11 @@ def _collect_operators_to_dict(op: LogicalOperator, ops_dict: Dict[str, int]):
 
     # Check read and write operator, and anonymize user-defined data source.
     if isinstance(op, Read):
-        op_name = f"Read{op._datasource.get_name()}"
+        op_name = f"Read{op.datasource.get_name()}"
         if op_name not in _op_name_white_list:
             op_name = "ReadCustom"
     elif isinstance(op, Write):
-        op_name = f"Write{op._datasink_or_legacy_datasource.get_name()}"
+        op_name = f"Write{op.datasink_or_legacy_datasource.get_name()}"
         if op_name not in _op_name_white_list:
             op_name = "WriteCustom"
     elif isinstance(op, AbstractUDFMap):

--- a/python/ray/data/_internal/metadata_exporter.py
+++ b/python/ray/data/_internal/metadata_exporter.py
@@ -157,8 +157,15 @@ class Topology:
             )
 
             # Add sub-stages if they exist
-            if hasattr(op, "_sub_progress_bar_names") and op._sub_progress_bar_names:
-                for j, sub_name in enumerate(op._sub_progress_bar_names):
+            sub_stage_names = None
+            if hasattr(op, "get_sub_progress_bar_names"):
+                sub_stage_names = op.get_sub_progress_bar_names()
+            elif hasattr(op, "sub_progress_bar_names"):
+                sub_stage_names = op.sub_progress_bar_names
+            elif hasattr(op, "_sub_progress_bar_names"):
+                sub_stage_names = op._sub_progress_bar_names
+            if sub_stage_names:
+                for j, sub_name in enumerate(sub_stage_names):
                     sub_stage_id = f"{op_id}_sub_{j}"
                     operator.sub_stages.append(SubStage(name=sub_name, id=sub_stage_id))
 

--- a/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
@@ -46,7 +46,7 @@ def plan_write_op_with_checkpoint_writer(
 def _generate_checkpoint_writing_transform(
     data_context: DataContext, logical_op: Write
 ) -> BlockMapTransformFn:
-    datasink = logical_op._datasink_or_legacy_datasource
+    datasink = logical_op.datasink_or_legacy_datasource
     if not isinstance(datasink, Datasink):
         raise InvalidCheckpointingOperators(
             f"To enable checkpointing, Write operation must use a "

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Iterable, List
+from typing import Callable, Iterable, List, Optional
 
 import ray
 from ray import ObjectRef
@@ -53,28 +53,16 @@ def _derive_metadata(read_task: ReadTask, read_task_ref: ObjectRef) -> BlockMeta
     )
 
 
-def plan_read_op(
+def _make_input_data_factory(
     op: Read,
-    physical_children: List[PhysicalOperator],
     data_context: DataContext,
-) -> PhysicalOperator:
-    """Get the corresponding DAG of physical operators for Read.
-
-    Note this method only converts the given `op`, but not its input dependencies.
-    See Planner.plan() for more details.
-    """
-    assert len(physical_children) == 0
-
+    parallelism: int,
+) -> Callable[[int], List[RefBundle]]:
     def get_input_data(target_max_block_size) -> List[RefBundle]:
-        parallelism = op.get_detected_parallelism()
-        assert (
-            parallelism is not None
-        ), "Read parallelism must be set by the optimizer before execution"
-
         # Get the original read tasks
-        read_tasks = op._datasource_or_legacy_reader.get_read_tasks(
+        read_tasks = op.datasource_or_legacy_reader.get_read_tasks(
             parallelism,
-            per_task_row_limit=op._per_block_limit,
+            per_task_row_limit=op.per_block_limit,
             data_context=data_context,
         )
 
@@ -101,7 +89,38 @@ def plan_read_op(
             ret.append(ref_bundle)
         return ret
 
-    inputs = InputDataBuffer(data_context, input_data_factory=get_input_data)
+    return get_input_data
+
+
+def plan_read_op(
+    op: Read,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
+) -> PhysicalOperator:
+    """Get the corresponding DAG of physical operators for Read.
+
+    Note this method only converts the given `op`, but not its input dependencies.
+    See Planner.plan() for more details.
+    """
+    assert len(physical_children) == 0
+
+    detected_parallelism: Optional[int] = op.get_detected_parallelism()
+    if detected_parallelism is None:
+
+        def get_input_data(_target_max_block_size) -> List[RefBundle]:
+            raise AssertionError(
+                "Read parallelism must be set by the optimizer before execution"
+            )
+
+        input_data_factory = get_input_data
+    else:
+        input_data_factory = _make_input_data_factory(
+            op,
+            data_context,
+            detected_parallelism,
+        )
+
+    inputs = InputDataBuffer(data_context, input_data_factory=input_data_factory)
 
     def do_read(blocks: Iterable[ReadTask], _: TaskContext) -> Iterable[Block]:
         for read_task in blocks:
@@ -125,6 +144,6 @@ def plan_read_op(
         inputs,
         data_context,
         name=op.name,
-        compute_strategy=op._compute,
-        ray_remote_args=op._ray_remote_args,
+        compute_strategy=op.compute,
+        ray_remote_args=op.ray_remote_args,
     )

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -140,7 +140,7 @@ def plan_project_op(
     # datasources with weak references, e.g., PyIceberg tables)
     projection_exprs = op.exprs
 
-    compute = get_compute(op._compute)
+    compute = get_compute(op.compute)
 
     # Create init_fn to initialize all callable class UDFs at actor startup
     from ray.data.util.expression_utils import (
@@ -174,8 +174,8 @@ def plan_project_op(
         data_context,
         name=op.name,
         compute_strategy=compute,
-        ray_remote_args=op._ray_remote_args,
-        ray_remote_args_fn=op._ray_remote_args_fn,
+        ray_remote_args=op.ray_remote_args,
+        ray_remote_args_fn=op.ray_remote_args_fn,
     )
 
 
@@ -186,7 +186,7 @@ def plan_streaming_repartition_op(
 ) -> MapOperator:
     assert len(physical_children) == 1
     input_physical_dag = physical_children[0]
-    compute = get_compute(op._compute)
+    compute = get_compute(op.compute)
     transform_fn = BlockMapTransformFn(
         lambda blocks, ctx: blocks,
         output_block_size_option=OutputBlockSizeOption.of(
@@ -203,8 +203,8 @@ def plan_streaming_repartition_op(
         name=op.name,
         compute_strategy=compute,
         ref_bundler=StreamingRepartitionRefBundler(op.target_num_rows_per_block),
-        ray_remote_args=op._ray_remote_args,
-        ray_remote_args_fn=op._ray_remote_args_fn,
+        ray_remote_args=op.ray_remote_args,
+        ray_remote_args_fn=op.ray_remote_args_fn,
     )
 
     return operator
@@ -222,8 +222,8 @@ def plan_filter_op(
         target_max_block_size=data_context.target_max_block_size,
     )
 
-    predicate_expr = op._predicate_expr
-    compute = get_compute(op._compute)
+    predicate_expr = op.predicate_expr
+    compute = get_compute(op.compute)
     if predicate_expr is not None:
 
         def filter_block_fn(
@@ -241,13 +241,13 @@ def plan_filter_op(
             output_block_size_option=output_block_size_option,
         )
     else:
-        udf_is_callable_class = isinstance(op._fn, CallableClass)
+        udf_is_callable_class = isinstance(op.fn, CallableClass)
         filter_fn, init_fn = _get_udf(
-            op._fn,
-            op._fn_args,
-            op._fn_kwargs,
-            op._fn_constructor_args if udf_is_callable_class else None,
-            op._fn_constructor_kwargs if udf_is_callable_class else None,
+            op.fn,
+            op.fn_args,
+            op.fn_kwargs,
+            op.fn_constructor_args if udf_is_callable_class else None,
+            op.fn_constructor_kwargs if udf_is_callable_class else None,
             compute=compute,
         )
 
@@ -265,8 +265,8 @@ def plan_filter_op(
         data_context,
         name=op.name,
         compute_strategy=compute,
-        ray_remote_args=op._ray_remote_args,
-        ray_remote_args_fn=op._ray_remote_args_fn,
+        ray_remote_args=op.ray_remote_args,
+        ray_remote_args_fn=op.ray_remote_args_fn,
     )
 
 
@@ -287,23 +287,23 @@ def plan_udf_map_op(
         target_max_block_size=data_context.target_max_block_size,
     )
 
-    compute = get_compute(op._compute)
-    udf_is_callable_class = isinstance(op._fn, CallableClass)
+    compute = get_compute(op.compute)
+    udf_is_callable_class = isinstance(op.fn, CallableClass)
     fn, init_fn = _get_udf(
-        op._fn,
-        op._fn_args,
-        op._fn_kwargs,
-        op._fn_constructor_args if udf_is_callable_class else None,
-        op._fn_constructor_kwargs if udf_is_callable_class else None,
+        op.fn,
+        op.fn_args,
+        op.fn_kwargs,
+        op.fn_constructor_args if udf_is_callable_class else None,
+        op.fn_constructor_kwargs if udf_is_callable_class else None,
         compute=compute,
     )
 
     if isinstance(op, MapBatches):
         transform_fn = BatchMapTransformFn(
             _generate_transform_fn_for_map_batches(fn),
-            batch_size=op._batch_size,
-            batch_format=op._batch_format,
-            zero_copy_batch=op._zero_copy_batch,
+            batch_size=op.batch_size,
+            batch_format=op.batch_format,
+            zero_copy_batch=op.zero_copy_batch,
             is_udf=True,
             output_block_size_option=output_block_size_option,
         )
@@ -330,10 +330,10 @@ def plan_udf_map_op(
         data_context,
         name=op.name,
         compute_strategy=compute,
-        min_rows_per_bundle=op._min_rows_per_bundled_input,
-        ray_remote_args_fn=op._ray_remote_args_fn,
-        ray_remote_args=op._ray_remote_args,
-        per_block_limit=op._per_block_limit,
+        min_rows_per_bundle=op.min_rows_per_bundled_input,
+        ray_remote_args_fn=op.ray_remote_args_fn,
+        ray_remote_args=op.ray_remote_args,
+        per_block_limit=op.per_block_limit,
     )
 
 

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -91,8 +91,8 @@ def _plan_write_op_internal(
     assert len(physical_children) == 1
     input_physical_dag = physical_children[0]
 
-    datasink = op._datasink_or_legacy_datasource
-    write_fn = generate_write_fn(datasink, **op._write_args)
+    datasink = op.datasink_or_legacy_datasource
+    write_fn = generate_write_fn(datasink, **op.write_args)
 
     # Create a MapTransformer for a write operator
     transform_fns = [
@@ -121,9 +121,9 @@ def _plan_write_op_internal(
         # Add a UUID to write tasks to prevent filename collisions. This a UUID for the
         # overall write operation, not the individual write tasks.
         map_task_kwargs={WRITE_UUID_KWARG_NAME: uuid.uuid4().hex},
-        ray_remote_args=op._ray_remote_args,
-        min_rows_per_bundle=op._min_rows_per_bundled_input,
-        compute_strategy=op._compute,
+        ray_remote_args=op.ray_remote_args,
+        min_rows_per_bundle=op.min_rows_per_bundled_input,
+        compute_strategy=op.compute,
         on_start=on_start,
     )
 

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -97,7 +97,7 @@ def plan_union_op(_, physical_children, data_context):
 
 def plan_limit_op(logical_op, physical_children, data_context):
     assert len(physical_children) == 1
-    return LimitOperator(logical_op._limit, physical_children[0], data_context)
+    return LimitOperator(logical_op.limit, physical_children[0], data_context)
 
 
 def plan_count_op(logical_op, physical_children, data_context):
@@ -117,14 +117,14 @@ def plan_join_op(
         data_context=data_context,
         left_input_op=physical_children[0],
         right_input_op=physical_children[1],
-        join_type=logical_op._join_type,
-        left_key_columns=logical_op._left_key_columns,
-        right_key_columns=logical_op._right_key_columns,
-        left_columns_suffix=logical_op._left_columns_suffix,
-        right_columns_suffix=logical_op._right_columns_suffix,
-        num_partitions=logical_op._num_outputs,
-        partition_size_hint=logical_op._partition_size_hint,
-        aggregator_ray_remote_args_override=logical_op._aggregator_ray_remote_args,
+        join_type=logical_op.join_type,
+        left_key_columns=logical_op.left_key_columns,
+        right_key_columns=logical_op.right_key_columns,
+        left_columns_suffix=logical_op.left_columns_suffix,
+        right_columns_suffix=logical_op.right_columns_suffix,
+        num_partitions=logical_op.num_outputs,
+        partition_size_hint=logical_op.partition_size_hint,
+        aggregator_ray_remote_args_override=logical_op.aggregator_ray_remote_args,
     )
 
 
@@ -136,10 +136,10 @@ def plan_streaming_split_op(
     assert len(physical_children) == 1
     return OutputSplitter(
         physical_children[0],
-        n=logical_op._num_splits,
-        equal=logical_op._equal,
+        n=logical_op.num_splits,
+        equal=logical_op.equal,
         data_context=data_context,
-        locality_hints=logical_op._locality_hints,
+        locality_hints=logical_op.locality_hints,
     )
 
 

--- a/python/ray/data/_internal/planner/randomize_blocks.py
+++ b/python/ray/data/_internal/planner/randomize_blocks.py
@@ -32,10 +32,10 @@ def generate_randomize_blocks_fn(
             )
 
         if len(blocks_with_metadata) == 0:
-            return refs, {op._name: []}
+            return refs, {op.name: []}
         else:
-            if op._seed is not None:
-                random.seed(op._seed)
+            if op.seed is not None:
+                random.seed(op.seed)
             input_owned = all(b.owns_blocks for b in refs)
             random.shuffle(blocks_with_metadata)
             output = []
@@ -54,6 +54,6 @@ def generate_randomize_blocks_fn(
                         schema=index_to_schema[i],
                     )
                 )
-            return output, {op._name: stats_list}
+            return output, {op.name: stats_list}
 
     return fn

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -435,8 +435,8 @@ class Dataset:
 
         plan = self._plan.copy()
         map_op = MapRows(
-            self._logical_plan.dag,
-            fn,
+            input_op=self._logical_plan.dag,
+            fn=fn,
             fn_args=fn_args,
             fn_kwargs=fn_kwargs,
             fn_constructor_args=fn_constructor_args,
@@ -799,8 +799,8 @@ class Dataset:
 
         plan = self._plan.copy()
         map_batches_op = MapBatches(
-            self._logical_plan.dag,
-            fn,
+            input_op=self._logical_plan.dag,
+            fn=fn,
             batch_size=batch_size,
             can_modify_num_rows=udf_modifying_row_count,
             batch_format=batch_format,
@@ -901,7 +901,7 @@ class Dataset:
         plan = self._plan.copy()
         if isinstance(expr, DownloadExpr):
             download_op = Download(
-                self._logical_plan.dag,
+                input_op=self._logical_plan.dag,
                 uri_column_names=[expr.uri_column_name],
                 output_bytes_column_names=[column_name],
                 ray_remote_args=ray_remote_args,
@@ -909,7 +909,7 @@ class Dataset:
             logical_plan = LogicalPlan(download_op, self.context)
         else:
             project_op = Project(
-                self._logical_plan.dag,
+                input_op=self._logical_plan.dag,
                 exprs=[StarExpr(), expr.alias(column_name)],
                 compute=compute,
                 ray_remote_args=ray_remote_args,
@@ -1162,7 +1162,7 @@ class Dataset:
 
         plan = self._plan.copy()
         select_op = Project(
-            self._logical_plan.dag,
+            input_op=self._logical_plan.dag,
             exprs=exprs,
             compute=compute,
             ray_remote_args=ray_remote_args,
@@ -1287,7 +1287,7 @@ class Dataset:
 
         plan = self._plan.copy()
         select_op = Project(
-            self._logical_plan.dag,
+            input_op=self._logical_plan.dag,
             exprs=[StarExpr(), *exprs],
             compute=compute,
             ray_remote_args=ray_remote_args,
@@ -1744,12 +1744,12 @@ class Dataset:
         plan = self._plan.copy()
         if target_num_rows_per_block is not None:
             op = StreamingRepartition(
-                self._logical_plan.dag,
+                input_op=self._logical_plan.dag,
                 target_num_rows_per_block=target_num_rows_per_block,
             )
         else:
             op = Repartition(
-                self._logical_plan.dag,
+                input_op=self._logical_plan.dag,
                 num_outputs=num_blocks,
                 shuffle=shuffle,
                 keys=keys,
@@ -1802,7 +1802,7 @@ class Dataset:
             )
         plan = self._plan.copy()
         op = RandomShuffle(
-            self._logical_plan.dag,
+            input_op=self._logical_plan.dag,
             seed=seed,
             ray_remote_args=ray_remote_args,
         )
@@ -1839,10 +1839,7 @@ class Dataset:
         """  # noqa: E501
 
         plan = self._plan.copy()
-        op = RandomizeBlocks(
-            self._logical_plan.dag,
-            seed=seed,
-        )
+        op = RandomizeBlocks(input_op=self._logical_plan.dag, seed=seed)
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
 
@@ -2007,7 +2004,7 @@ class Dataset:
         """
         plan = self._plan.copy()
         op = StreamingSplit(
-            self._logical_plan.dag,
+            input_op=self._logical_plan.dag,
             num_splits=n,
             equal=equal,
             locality_hints=locality_hints,
@@ -3505,10 +3502,7 @@ class Dataset:
             raise ValueError("The 'key' parameter cannot be None for sorting.")
         sort_key = SortKey(key, descending, boundaries)
         plan = self._plan.copy()
-        op = Sort(
-            self._logical_plan.dag,
-            sort_key=sort_key,
-        )
+        op = Sort(input_op=self._logical_plan.dag, sort_key=sort_key)
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
 
@@ -3577,7 +3571,7 @@ class Dataset:
             The truncated dataset.
         """
         plan = self._plan.copy()
-        op = Limit(self._logical_plan.dag, limit=limit)
+        op = Limit(input_op=self._logical_plan.dag, limit=limit)
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
 
@@ -3798,7 +3792,7 @@ class Dataset:
 
         # NOTE: Project the dataset to avoid the need to carry actual
         #       data when we're only interested in the total count
-        count_op = Count(Project(self._logical_plan.dag, exprs=[]))
+        count_op = Count(input_op=Project(input_op=self._logical_plan.dag, exprs=[]))
         logical_plan = LogicalPlan(count_op, self.context)
         count_ds = Dataset(plan, logical_plan)
 
@@ -5356,8 +5350,8 @@ class Dataset:
 
         plan = self._plan.copy()
         write_op = Write(
-            self._logical_plan.dag,
-            datasink,
+            input_op=self._logical_plan.dag,
+            datasink_or_legacy_datasource=datasink,
             ray_remote_args=ray_remote_args,
             compute=TaskPoolStrategy(concurrency),
         )

--- a/python/ray/data/datasource/partitioning.py
+++ b/python/ray/data/datasource/partitioning.py
@@ -310,7 +310,9 @@ class PathPartitionParser:
 
             # Extract boolean result from array-like types
             # Check for specific array types to avoid issues with strings (which are iterable)
-            if isinstance(result, (pa.Array, pa.ChunkedArray, np.ndarray)):
+            if isinstance(result, (pa.Array, pa.ChunkedArray)):
+                return bool(result[0].as_py())
+            if isinstance(result, np.ndarray):
                 return bool(result[0])
 
             # Import pandas here to avoid circular dependencies

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -65,7 +65,7 @@ class GroupedData:
 
         plan = self._dataset._plan.copy()
         op = Aggregate(
-            self._dataset._logical_plan.dag,
+            input_op=self._dataset._logical_plan.dag,
             key=self._key,
             aggs=aggs,
             num_partitions=self._num_partitions,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -462,8 +462,8 @@ def read_datasource(
         parent=None,
     )
     read_op = Read(
-        datasource,
-        datasource_or_legacy_reader,
+        datasource=datasource,
+        datasource_or_legacy_reader=datasource_or_legacy_reader,
         parallelism=parallelism,
         num_outputs=len(read_tasks) if read_tasks else 0,
         ray_remote_args=ray_remote_args,

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -103,9 +103,16 @@ def generate_sample_physical_plan(generate_sample_data_csv, tmp_path):
 
     datasource = CSVDatasource(generate_sample_data_csv())
 
-    read_op = Read(datasource, datasource, -1, None)
+    read_op = Read(
+        datasource=datasource,
+        datasource_or_legacy_reader=datasource,
+        parallelism=-1,
+        num_outputs=None,
+    )
     write_path = os.path.join(tmp_path, "output")
-    write_op = Write(read_op, ParquetDatasink(write_path))
+    write_op = Write(
+        input_op=read_op, datasink_or_legacy_datasource=ParquetDatasink(write_path)
+    )
     logical_plan = LogicalPlan(write_op, ctx)
     physical_plan = get_execution_plan(logical_plan)
     yield physical_plan

--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -47,10 +47,7 @@ def test_random_shuffle_operator(ray_start_regular_shared_2_cpus):
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = RandomShuffle(
-        read_op,
-        seed=0,
-    )
+    op = RandomShuffle(input_op=read_op, seed=0)
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
 
@@ -82,7 +79,7 @@ def test_repartition_operator(ray_start_regular_shared_2_cpus, shuffle):
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = Repartition(read_op, num_outputs=5, shuffle=shuffle)
+    op = Repartition(input_op=read_op, num_outputs=5, shuffle=shuffle)
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
 
@@ -155,8 +152,8 @@ def test_write_operator(ray_start_regular_shared_2_cpus, tmp_path):
     datasink = ParquetDatasink(tmp_path)
     read_op = get_parquet_read_logical_op()
     op = Write(
-        read_op,
-        datasink,
+        input_op=read_op,
+        datasink_or_legacy_datasource=datasink,
         compute=TaskPoolStrategy(concurrency),
     )
     plan = LogicalPlan(op, ctx)
@@ -179,10 +176,7 @@ def test_sort_operator(
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = Sort(
-        read_op,
-        sort_key=SortKey("col1"),
-    )
+    op = Sort(input_op=read_op, sort_key=SortKey("col1"))
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
 
@@ -248,14 +242,14 @@ def test_inherit_batch_format_rule():
     ctx = DataContext.get_current()
 
     operator1 = get_parquet_read_logical_op()
-    operator2 = MapBatches(operator1, fn=lambda g: g, batch_format="pandas")
+    operator2 = MapBatches(input_op=operator1, fn=lambda g: g, batch_format="pandas")
     sort_key = SortKey("number", descending=True)
-    operator3 = Sort(operator2, sort_key)
+    operator3 = Sort(input_op=operator2, sort_key=sort_key)
     original_plan = LogicalPlan(dag=operator3, context=ctx)
 
     rule = InheritBatchFormatRule()
     optimized_plan = rule.apply(original_plan)
-    assert optimized_plan.dag._batch_format == "pandas"
+    assert optimized_plan.dag.batch_format == "pandas"
 
 
 def test_batch_format_on_sort(ray_start_regular_shared_2_cpus):

--- a/python/ray/data/tests/test_execution_optimizer_basic.py
+++ b/python/ray/data/tests/test_execution_optimizer_basic.py
@@ -103,10 +103,7 @@ def test_split_blocks_operator(ray_start_regular_shared_2_cpus):
     assert physical_op._additional_split_factor == 10
 
     # Test that split blocks prevents fusion.
-    op = MapBatches(
-        op,
-        lambda x: x,
-    )
+    op = MapBatches(input_op=op, fn=lambda x: x)
     logical_plan = LogicalPlan(op, ctx)
     physical_plan = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -189,10 +186,7 @@ def test_map_operator_udf_name(ray_start_regular_shared_2_cpus):
     ]
 
     for udf, expected_name in zip(udf_list, expected_names):
-        op = MapRows(
-            get_parquet_read_logical_op(),
-            udf,
-        )
+        op = MapRows(input_op=get_parquet_read_logical_op(), fn=udf)
         assert op.name == f"Map({expected_name})"
 
 
@@ -201,10 +195,7 @@ def test_map_batches_operator(ray_start_regular_shared_2_cpus):
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = MapBatches(
-        read_op,
-        lambda x: x,
-    )
+    op = MapBatches(input_op=read_op, fn=lambda x: x)
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
 
@@ -229,10 +220,7 @@ def test_map_rows_operator(ray_start_regular_shared_2_cpus):
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = MapRows(
-        read_op,
-        lambda x: x,
-    )
+    op = MapRows(input_op=read_op, fn=lambda x: x)
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
 
@@ -256,10 +244,7 @@ def test_filter_operator(ray_start_regular_shared_2_cpus):
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = Filter(
-        read_op,
-        fn=lambda x: x,
-    )
+    op = Filter(input_op=read_op, fn=lambda x: x)
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
 
@@ -332,10 +317,7 @@ def test_flat_map(ray_start_regular_shared_2_cpus):
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = FlatMap(
-        read_op,
-        lambda x: x,
-    )
+    op = FlatMap(input_op=read_op, fn=lambda x: x)
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
 

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -39,10 +39,7 @@ def test_read_map_batches_operator_fusion(ray_start_regular_shared_2_cpus):
     # Test that Read is fused with MapBatches.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    op = MapBatches(
-        read_op,
-        lambda x: x,
-    )
+    op = MapBatches(input_op=read_op, fn=lambda x: x)
     logical_plan = LogicalPlan(op, ctx)
     physical_plan = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -64,10 +61,10 @@ def test_read_map_chain_operator_fusion(ray_start_regular_shared_2_cpus):
     # Test that a chain of different map operators are fused.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    map1 = MapRows(read_op, lambda x: x)
-    map2 = MapBatches(map1, lambda x: x)
-    map3 = FlatMap(map2, lambda x: x)
-    map4 = Filter(map3, fn=lambda x: x)
+    map1 = MapRows(input_op=read_op, fn=lambda x: x)
+    map2 = MapBatches(input_op=map1, fn=lambda x: x)
+    map3 = FlatMap(input_op=map2, fn=lambda x: x)
+    map4 = Filter(input_op=map3, fn=lambda x: x)
     logical_plan = LogicalPlan(map4, ctx)
     physical_plan = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -113,8 +110,10 @@ def test_read_map_batches_operator_fusion_compatible_remote_args(
             ray_remote_args={"resources": {"non-existent": 1}},
             parallelism=1,
         )
-        op = MapBatches(read_op, lambda x: x, ray_remote_args=up_remote_args)
-        op = MapBatches(op, lambda x: x, ray_remote_args=down_remote_args)
+        op = MapBatches(
+            input_op=read_op, fn=lambda x: x, ray_remote_args=up_remote_args
+        )
+        op = MapBatches(input_op=op, fn=lambda x: x, ray_remote_args=down_remote_args)
         logical_plan = LogicalPlan(op, ctx)
 
         physical_plan = planner.plan(logical_plan)
@@ -159,8 +158,10 @@ def test_read_map_batches_operator_fusion_incompatible_remote_args(
         read_op = get_parquet_read_logical_op(
             ray_remote_args={"resources": {"non-existent": 1}}
         )
-        op = MapBatches(read_op, lambda x: x, ray_remote_args=up_remote_args)
-        op = MapBatches(op, lambda x: x, ray_remote_args=down_remote_args)
+        op = MapBatches(
+            input_op=read_op, fn=lambda x: x, ray_remote_args=up_remote_args
+        )
+        op = MapBatches(input_op=op, fn=lambda x: x, ray_remote_args=down_remote_args)
         logical_plan = LogicalPlan(op, ctx)
         physical_plan = planner.plan(logical_plan)
         physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -191,8 +192,8 @@ def test_read_map_batches_operator_fusion_compute_tasks_to_actors(
     # the former comes before the latter.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    op = MapBatches(read_op, lambda x: x)
-    op = MapBatches(op, lambda x: x, compute=ray.data.ActorPoolStrategy())
+    op = MapBatches(input_op=read_op, fn=lambda x: x)
+    op = MapBatches(input_op=op, fn=lambda x: x, compute=ray.data.ActorPoolStrategy())
     logical_plan = LogicalPlan(op, ctx)
     physical_plan = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -213,7 +214,9 @@ def test_read_map_batches_operator_fusion_compute_read_to_actors(
     # Test that reads fuse into an actor-based map operator.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    op = MapBatches(read_op, lambda x: x, compute=ray.data.ActorPoolStrategy())
+    op = MapBatches(
+        input_op=read_op, fn=lambda x: x, compute=ray.data.ActorPoolStrategy()
+    )
     logical_plan = LogicalPlan(op, ctx)
     physical_plan = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -234,8 +237,10 @@ def test_read_map_batches_operator_fusion_incompatible_compute(
     # Test that map operators are not fused when compute strategies are incompatible.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    op = MapBatches(read_op, lambda x: x, compute=ray.data.ActorPoolStrategy())
-    op = MapBatches(op, lambda x: x)
+    op = MapBatches(
+        input_op=read_op, fn=lambda x: x, compute=ray.data.ActorPoolStrategy()
+    )
+    op = MapBatches(input_op=op, fn=lambda x: x)
     logical_plan = LogicalPlan(op, ctx)
     physical_plan = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -298,27 +303,27 @@ def test_read_with_map_batches_fused_successfully(
         ),
         (
             # No fusion (could drastically reduce dataset)
-            Filter(InputData([]), fn=lambda x: False),
+            Filter(input_op=InputData(input_data=[]), fn=lambda x: False),
             False,
         ),
         (
             # No fusion (could drastically expand/reduce dataset)
-            FlatMap(InputData([]), lambda x: x),
+            FlatMap(input_op=InputData(input_data=[]), fn=lambda x: x),
             False,
         ),
         (
             # Fusion
-            MapBatches(InputData([]), lambda x: x),
+            MapBatches(input_op=InputData(input_data=[]), fn=lambda x: x),
             True,
         ),
         (
             # Fusion
-            MapRows(InputData([]), lambda x: x),
+            MapRows(input_op=InputData(input_data=[]), fn=lambda x: x),
             True,
         ),
         (
             # Fusion
-            Project(InputData([]), exprs=[star()]),
+            Project(input_op=InputData(input_data=[]), exprs=[star()]),
             True,
         ),
     ],
@@ -707,7 +712,7 @@ def test_zero_copy_fusion_eliminate_build_output_blocks(
     # Test the EliminateBuildOutputBlocks optimization rule.
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = MapBatches(read_op, lambda x: x)
+    op = MapBatches(input_op=read_op, fn=lambda x: x)
     logical_plan = LogicalPlan(op, ctx)
     physical_plan = planner.plan(logical_plan)
 

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -210,7 +210,7 @@ def test_spread_hint_inherit(ray_start_regular_shared):
 
     shuffle_op = ds._plan._logical_plan.dag
     read_op = shuffle_op.input_dependencies[0].input_dependencies[0]
-    assert read_op._ray_remote_args == {"scheduling_strategy": "SPREAD"}
+    assert read_op.ray_remote_args == {"scheduling_strategy": "SPREAD"}
 
 
 def test_optimize_randomize_block_order(ray_start_regular_shared):

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -123,7 +123,11 @@ class TestProjectionFusion:
                 named_expr = expr.alias(name)
                 exprs.append(named_expr)
 
-            current_op = Project(current_op, exprs=[star()] + exprs, ray_remote_args={})
+            current_op = Project(
+                input_op=current_op,
+                exprs=[star()] + exprs,
+                ray_remote_args={},
+            )
 
         return current_op
 

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -16,10 +16,7 @@ def test_randomize_blocks_operator(ray_start_regular_shared):
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = RandomizeBlocks(
-        read_op,
-        seed=0,
-    )
+    op = RandomizeBlocks(input_op=read_op, seed=0)
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1039,15 +1039,15 @@ def test_execution_callbacks_executor_arg(tmp_path, restore_data_context):
 
     assert len(logical_ops) == 3
     assert isinstance(logical_ops[0], Read)
-    datasource = logical_ops[0]._datasource
+    datasource = logical_ops[0].datasource
     assert isinstance(datasource, ParquetDatasource)
     assert datasource._source_paths == input_path
 
     assert isinstance(logical_ops[1], MapRows)
-    assert logical_ops[1]._fn == udf
+    assert logical_ops[1].fn == udf
 
     assert isinstance(logical_ops[2], Write)
-    datasink = logical_ops[2]._datasink_or_legacy_datasource
+    datasink = logical_ops[2].datasink_or_legacy_datasource
     assert isinstance(datasink, ParquetDatasink)
     assert datasink.unresolved_path == output_path
 


### PR DESCRIPTION
## Description
> PR2: Make logical operators frozen dataclasses
#### Issue goal: 
Make LogicalOperator immutable and comparable to avoid cross-dataset contamination.

The issue is split into two PRs for easier review. 
#### This PR focuses on: 
converting the LogicalOperator hierarchy to frozen dataclasses and making updates immutable via dataclasses.replace.

## Related issues
> Link related issues: "Fixes #60312 ", "Closes #60312 ", or "Related to #60312 ".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
#### Implementation details
- all logical operators are now `@dataclass(frozen=True)`; 
- setters/in-place updates become “return-new” methods (e.g., `with_per_block_limit`, `with_detected_parallelism`); 
- DAG transforms use `dataclasses.replace`; 
- `__repr__/dag_str` are preserved to keep explain output stable;
- inherit_batch_format only applies replace on ops that actually define `_batch_format`; `Read.detected_parallelism` is propagated immutably and the physical planning stage sets the input factory without mutating the logical op.
#### API changes
logical operators are now immutable; external behavior unchanged; logical layer no longer maintains `_output_dependencies`.
#### Tests: 
logical optimization, planning, and operator-fusion related tests were exercised (see test notes).
