### PR TITLE
Fix test_metrics

### DIFF
--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -1045,7 +1045,13 @@ def test_queue_wait_time_metric(metrics_start_shutdown):
     )
 
 
-def test_router_queue_len_metric(metrics_start_shutdown):
+@pytest.fixture
+def disable_queue_len_throttle(monkeypatch):
+    """Disable throttling for router queue length gauge updates."""
+    monkeypatch.setenv("RAY_SERVE_ROUTER_QUEUE_LEN_GAUGE_THROTTLE_S", "0")
+
+
+def test_router_queue_len_metric(disable_queue_len_throttle, metrics_start_shutdown):
     """Test that router queue length metric is recorded correctly per replica."""
     signal = SignalActor.remote()
 


### PR DESCRIPTION
The test was flaky due to a race condition with the router queue length gauge throttling (0.1s default). When a replica is created, an initial probe sets the gauge to 0. If the test's request arrives within 0.1s, the gauge update to 1 is
  throttled, causing the test to fail.

**Fix:** Disable throttling for this test by setting `RAY_SERVE_ROUTER_QUEUE_LEN_GAUGE_THROTTLE_S` = 0 via a fixture that runs before Ray starts.