### PR TITLE
[LLM] Fix nested dict to Namespace conversion in vLLM engine initialization

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -62,8 +62,8 @@ vllm = try_import("vllm")
 logger = get_logger(__name__)
 
 
-def _dict_to_namespace(obj):
-    """Рекурсивно преобразует словари в argparse.Namespace"""
+def _dict_to_namespace(obj: Any) -> Any:
+    """Recursively converts dictionaries to argparse.Namespace."""
     if isinstance(obj, dict):
         return argparse.Namespace(**{k: _dict_to_namespace(v) for k, v in obj.items()})
     elif isinstance(obj, list):

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -267,13 +267,9 @@ class VLLMEngine(LLMEngine):
 
         state = State()
         # TODO (Kourosh): There might be some variables that needs protection?
-        args = argparse.Namespace(
-            **(vllm_frontend_args.__dict__ | vllm_engine_args.__dict__)
+        args = _dict_to_namespace(
+            vllm_frontend_args.__dict__ | vllm_engine_args.__dict__
         )
-        # Рекурсивно преобразуем вложенные dict в Namespace
-        for key, value in vars(args).items():
-            if isinstance(value, dict):
-                setattr(args, key, _dict_to_namespace(value))
 
         if "vllm_config" in inspect.signature(init_app_state).parameters:
             await init_app_state(


### PR DESCRIPTION
## Summary
  This PR fixes a bug in the vLLM engine initialization where nested dictionaries in engine arguments were not being converted to `argparse.Namespace` objects, causing `AttributeError` when accessing nested configuration attributes.

  ## Problem
  When merging `vllm_frontend_args` and `vllm_engine_args`, nested dictionary values remained as `dict` objects instead of being converted to `Namespace` objects. This caused issues when vLLM's initialization code attempted to access nested attributes using dot notation.

  **Example failing configuration:**
  When deploying a RayService with nested `structured_outputs_config`, the service would fail to initialize:

  ```yaml
  apiVersion: ray.io/v1
  kind: RayService
  metadata:
    name: qwen-thinking-service
  spec:
    serveConfigV2: |
      applications:
        - name: llms
          import_path: ray.serve.llm:build_openai_app
          route_prefix: "/"
          args:
            llm_configs:
              - model_loading_config:
                  model_id: qwen3-4b-thinking
                  model_source: /models/Qwen3-4B
                engine_kwargs:
                  tensor_parallel_size: 2
                  trust_remote_code: true
                  gpu_memory_utilization: 0.9
                  dtype: auto
                  max_model_len: 4096
                  structured_outputs_config:  # This nested dict caused the issue
                    backend: xgrammar
                    reasoning_parser: qwen3
                deployment_config:
                  autoscaling_config:
                    min_replicas: 1
                    max_replicas: 1
                    target_ongoing_requests: 32
                  max_ongoing_requests: 64
```
  The error occurred because structured_outputs_config was passed as a dict, but vLLM expected it as a Namespace object to access attributes like args.structured_outputs_config.backend.

  Solution

  - Added _dict_to_namespace() helper function that recursively converts dictionaries and lists of dictionaries to argparse.Namespace objects
  - Applied this conversion to all nested dictionary values in the merged args Namespace after initialization in VLLMEngine.__init__()

  Changes

  - Added _dict_to_namespace() function at python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py:65
  - Added recursive conversion logic in VLLMEngine.__init__() at python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py:273-276

  Testing

  - Tested with Kubernetes RayService deployment using nested structured_outputs_config
  - Verified that the vLLM engine initializes correctly with nested configuration parameters