### PR TITLE
[build] add BuildKit cache mounts for Bazel builds in wheel wanda Dockerfiles

### DIFF
--- a/ci/docker/ray-core.Dockerfile
+++ b/ci/docker/ray-core.Dockerfile
@@ -7,15 +7,27 @@ FROM rayproject/manylinux2014:${MANYLINUX_VERSION}-jdk-${HOSTTYPE} AS builder
 ARG PYTHON_VERSION=3.10
 ARG BUILDKITE_BAZEL_CACHE_URL
 ARG BUILDKITE_CACHE_READONLY
+ARG HOSTTYPE
+ARG CACHE_DIR=/opt/cache
+
+ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
+ENV BUILDKITE_CACHE_READONLY=${BUILDKITE_CACHE_READONLY}
+ENV CACHE_DIR=${CACHE_DIR}
+ENV DOWNLOAD_CACHE=${CACHE_DIR}/downloads
+ENV BAZEL_CACHE=${CACHE_DIR}/bazel
 
 WORKDIR /home/forge/ray
 
 COPY . .
 
-RUN <<EOF
+RUN --mount=type=cache,target=${DOWNLOAD_CACHE},uid=2000,gid=100,id=ray-downloads-${HOSTTYPE} \
+    --mount=type=cache,target=${BAZEL_CACHE},uid=2000,gid=100,id=ray-bazel-${HOSTTYPE}-py${PYTHON_VERSION} \
+    <<'EOF'
 #!/bin/bash
-
 set -euo pipefail
+
+export BAZELISK_HOME=$DOWNLOAD_CACHE/bazelisk
+REPOSITORY_CACHE=$DOWNLOAD_CACHE/repo
 
 PY_CODE="${PYTHON_VERSION//./}"
 PY_BIN="cp${PY_CODE}-cp${PY_CODE}"
@@ -25,11 +37,19 @@ export RAY_BUILD_ENV="manylinux_py${PY_BIN}"
 sudo ln -sf "/opt/python/${PY_BIN}/bin/python3" /usr/local/bin/python3
 sudo ln -sf /usr/local/bin/python3 /usr/local/bin/python
 
-if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-  echo "build --remote_upload_local_results=false" >> "$HOME/.bazelrc"
+BAZEL_CACHE_ARGS=""
+if [[ -z "${BUILDKITE_BAZEL_CACHE_URL:-}" ]]; then
+  # Disable remote cache for local builds (no credentials)
+  BAZEL_CACHE_ARGS="--remote_cache="
+elif [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+  # Read-only mode: disable uploads only
+  BAZEL_CACHE_ARGS="--remote_upload_local_results=false"
 fi
 
-bazelisk build --config=ci //:ray_pkg_zip //:ray_py_proto_zip
+bazelisk --output_base=$BAZEL_CACHE build --config=ci \
+    --repository_cache=$REPOSITORY_CACHE \
+    $BAZEL_CACHE_ARGS \
+    //:ray_pkg_zip //:ray_py_proto_zip
 
 cp bazel-bin/ray_pkg.zip /home/forge/ray_pkg.zip
 cp bazel-bin/ray_py_proto.zip /home/forge/ray_py_proto.zip

--- a/ci/docker/ray-cpp-core.Dockerfile
+++ b/ci/docker/ray-cpp-core.Dockerfile
@@ -13,16 +13,26 @@ ARG PYTHON_VERSION=3.10
 ARG BUILDKITE_BAZEL_CACHE_URL
 ARG BUILDKITE_CACHE_READONLY
 ARG HOSTTYPE
+ARG CACHE_DIR=/opt/cache
+
+ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
+ENV BUILDKITE_CACHE_READONLY=${BUILDKITE_CACHE_READONLY}
+ENV CACHE_DIR=${CACHE_DIR}
+ENV DOWNLOAD_CACHE=${CACHE_DIR}/downloads
+ENV BAZEL_CACHE=${CACHE_DIR}/bazel
 
 WORKDIR /home/forge/ray
 
 COPY . .
 
-# Mounting cache dir for faster local rebuilds (architecture-specific to avoid toolchain conflicts)
-RUN --mount=type=cache,target=/home/forge/.cache,uid=2000,gid=100,id=bazel-cache-${HOSTTYPE}-${PYTHON_VERSION} \
+RUN --mount=type=cache,target=${DOWNLOAD_CACHE},uid=2000,gid=100,id=ray-downloads-${HOSTTYPE} \
+    --mount=type=cache,target=${BAZEL_CACHE},uid=2000,gid=100,id=ray-bazel-${HOSTTYPE}-py${PYTHON_VERSION} \
     <<'EOF'
 #!/bin/bash
 set -euo pipefail
+
+export BAZELISK_HOME=$DOWNLOAD_CACHE/bazelisk
+REPOSITORY_CACHE=$DOWNLOAD_CACHE/repo
 
 PY_CODE="${PYTHON_VERSION//./}"
 PY_BIN="cp${PY_CODE}-cp${PY_CODE}"
@@ -31,13 +41,19 @@ export RAY_BUILD_ENV="manylinux_py${PY_BIN}"
 sudo ln -sf "/opt/python/${PY_BIN}/bin/python3" /usr/local/bin/python3
 sudo ln -sf /usr/local/bin/python3 /usr/local/bin/python
 
-if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-  echo "build --remote_upload_local_results=false" >> "$HOME/.bazelrc"
+BAZEL_CACHE_ARGS=""
+if [[ -z "${BUILDKITE_BAZEL_CACHE_URL:-}" ]]; then
+  # Disable remote cache for local builds (no credentials)
+  BAZEL_CACHE_ARGS="--remote_cache="
+elif [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+  # Read-only mode: disable uploads only
+  BAZEL_CACHE_ARGS="--remote_upload_local_results=false"
 fi
 
-echo "build --repository_cache=/home/forge/.cache/bazel-repo" >> "$HOME/.bazelrc"
-
-bazelisk build --config=ci //cpp:ray_cpp_pkg_zip
+bazelisk --output_base=$BAZEL_CACHE build --config=ci \
+    --repository_cache=$REPOSITORY_CACHE \
+    $BAZEL_CACHE_ARGS \
+    //cpp:ray_cpp_pkg_zip
 
 cp bazel-bin/cpp/ray_cpp_pkg.zip /home/forge/ray_cpp_pkg.zip
 

--- a/ci/docker/ray-java.Dockerfile
+++ b/ci/docker/ray-java.Dockerfile
@@ -1,28 +1,49 @@
 # syntax=docker/dockerfile:1.3-labs
-ARG HOSTTYPE=x86_64
 ARG ARCH_SUFFIX
+ARG HOSTTYPE=x86_64
 ARG MANYLINUX_VERSION
 FROM rayproject/manylinux2014:${MANYLINUX_VERSION}-jdk-${HOSTTYPE} AS builder
 
 ARG BUILDKITE_BAZEL_CACHE_URL
 ARG BUILDKITE_CACHE_READONLY
+ARG HOSTTYPE
+ARG CACHE_DIR=/opt/cache
+
+ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
+ENV BUILDKITE_CACHE_READONLY=${BUILDKITE_CACHE_READONLY}
+ENV CACHE_DIR=${CACHE_DIR}
+ENV DOWNLOAD_CACHE=${CACHE_DIR}/downloads
+ENV BAZEL_CACHE=${CACHE_DIR}/bazel
 
 WORKDIR /home/forge/ray
 
 COPY . .
 
-RUN <<EOF
+RUN --mount=type=cache,target=${DOWNLOAD_CACHE},uid=2000,gid=100,id=ray-downloads-${HOSTTYPE} \
+    --mount=type=cache,target=${BAZEL_CACHE},uid=2000,gid=100,id=ray-bazel-${HOSTTYPE} \
+    <<'EOF'
 #!/bin/bash
-
 set -euo pipefail
+
+export BAZELISK_HOME=$DOWNLOAD_CACHE/bazelisk
+export COURSIER_CACHE=$DOWNLOAD_CACHE/coursier
+REPOSITORY_CACHE=$DOWNLOAD_CACHE/repo
 
 export RAY_BUILD_ENV="manylinux"
 
-if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-  echo "build --remote_upload_local_results=false" >> "$HOME/.bazelrc"
+BAZEL_CACHE_ARGS=""
+if [[ -z "${BUILDKITE_BAZEL_CACHE_URL:-}" ]]; then
+  # Disable remote cache for local builds (no credentials)
+  BAZEL_CACHE_ARGS="--remote_cache="
+elif [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+  # Read-only mode: disable uploads only
+  BAZEL_CACHE_ARGS="--remote_upload_local_results=false"
 fi
 
-bazelisk run --config=ci //java:gen_ray_java_pkg
+bazelisk --output_base=$BAZEL_CACHE run --config=ci \
+    --repository_cache=$REPOSITORY_CACHE \
+    $BAZEL_CACHE_ARGS \
+    //java:gen_ray_java_pkg
 
 cp bazel-bin/java/ray_java_pkg.zip /home/forge/ray_java_pkg.zip
 


### PR DESCRIPTION
- Add --mount=type=cache to ray-core and ray-java Dockerfiles
- Update ray-cpp-core to use shared cache ID (ray-bazel-cache-${HOSTTYPE})
- Configure Bazel repository cache inside the mount for faster dependency resolution
- Auto-disable remote cache uploads when BUILDKITE_BAZEL_CACHE_URL is empty,  preventing 403 errors on local builds without AWS credentials

All python-agnostic images now share the same Bazel cache per architecture, maximizing cache reuse while preventing cross-architecture toolchain conflicts.

Topic: wanda-bazel-cache

Signed-off-by: andrew <andrew@anyscale.com>