### PR TITLE
Revert "[Core] Introduce node specific temp-dir specification. (#57735)"

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -192,6 +192,8 @@ python/ray/_private/services.py
     DOC101: Function `start_raylet`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `start_raylet`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
     DOC103: Function `start_raylet`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cluster_id: str, socket_to_use: Optional[int]].
+    DOC101: Function `determine_plasma_store_config`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `determine_plasma_store_config`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [temp_dir: str].
     DOC101: Function `start_monitor`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `start_monitor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [autoscaler_v2: bool, fate_share: Optional[bool]].
     DOC101: Function `start_ray_client_server`: Docstring contains fewer arguments than in function signature.

--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -114,11 +114,15 @@ void ProcessHelper::RayStart(CoreWorkerOptions::TaskExecutionCallback callback) 
     ConfigInternal::Instance().plasma_store_socket_name =
         node_info.object_store_socket_name();
     ConfigInternal::Instance().node_manager_port = node_info.node_manager_port();
-    ConfigInternal::Instance().UpdateSessionDir(node_info.session_dir());
   }
   RAY_CHECK(!ConfigInternal::Instance().raylet_socket_name.empty());
   RAY_CHECK(!ConfigInternal::Instance().plasma_store_socket_name.empty());
   RAY_CHECK(ConfigInternal::Instance().node_manager_port > 0);
+
+  if (ConfigInternal::Instance().worker_type == WorkerType::DRIVER) {
+    auto session_dir = *global_state_accessor->GetInternalKV("session", "session_dir");
+    ConfigInternal::Instance().UpdateSessionDir(session_dir);
+  }
 
   gcs::GcsClientOptions gcs_options =
       gcs::GcsClientOptions(bootstrap_ip,

--- a/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
@@ -55,6 +55,13 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
     super(rayConfig);
   }
 
+  private void updateSessionDir() {
+    // Fetch session dir from GCS.
+    final String sessionDir = getGcsClient().getInternalKV("session", "session_dir");
+    Preconditions.checkNotNull(sessionDir);
+    rayConfig.setSessionDir(sessionDir);
+  }
+
   @Override
   public void start() {
     try {
@@ -66,29 +73,26 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
       }
       Preconditions.checkNotNull(rayConfig.getBootstrapAddress());
 
+      // In order to remove redis dependency in Java lang, we use a temp dir to load library
+      // instead of getting session dir from redis.
       if (rayConfig.workerMode == WorkerType.DRIVER) {
-        // In order to remove redis dependency in Java lang, we use a temp dir to load library
-        // instead of getting session dir from redis.
         String tmpDir = "/tmp/ray/".concat(String.valueOf(System.currentTimeMillis()));
         JniUtils.loadLibrary(tmpDir, BinaryFileUtil.CORE_WORKER_JAVA_LIBRARY, true);
-
-        GcsNodeInfo nodeInfo = getGcsClient().getNodeToConnectForDriver(rayConfig.nodeIp);
-
-        // Update session dir.
-        final String sessionDir = nodeInfo.getSessionDir();
-        Preconditions.checkNotNull(sessionDir, "Session dir not found in node info");
-        rayConfig.setSessionDir(sessionDir);
+        updateSessionDir();
         Preconditions.checkNotNull(rayConfig.sessionDir);
-
-        rayConfig.rayletSocketName = nodeInfo.getRayletSocketName();
-        rayConfig.objectStoreSocketName = nodeInfo.getObjectStoreSocketName();
-        rayConfig.nodeManagerPort = nodeInfo.getNodeManagerPort();
       } else {
         // Expose ray ABI symbols which may be depended by other shared
         // libraries such as libstreaming_java.so.
         // See BUILD.bazel:libcore_worker_library_java.so
         Preconditions.checkNotNull(rayConfig.sessionDir);
         JniUtils.loadLibrary(rayConfig.sessionDir, BinaryFileUtil.CORE_WORKER_JAVA_LIBRARY, true);
+      }
+
+      if (rayConfig.workerMode == WorkerType.DRIVER) {
+        GcsNodeInfo nodeInfo = getGcsClient().getNodeToConnectForDriver(rayConfig.nodeIp);
+        rayConfig.rayletSocketName = nodeInfo.getRayletSocketName();
+        rayConfig.objectStoreSocketName = nodeInfo.getObjectStoreSocketName();
+        rayConfig.nodeManagerPort = nodeInfo.getNodeManagerPort();
       }
 
       if (rayConfig.workerMode == WorkerType.DRIVER && rayConfig.getJobId() == JobId.NIL) {

--- a/python/ray/_common/usage/usage_lib.py
+++ b/python/ray/_common/usage/usage_lib.py
@@ -60,8 +60,7 @@ import ray
 import ray._common.usage.usage_constants as usage_constant
 import ray._private.ray_constants as ray_constants
 from ray._raylet import GcsClient
-from ray.core.generated import usage_pb2
-from ray.core.generated.gcs_pb2 import GcsNodeInfo
+from ray.core.generated import gcs_pb2, usage_pb2
 from ray.experimental.internal_kv import (
     _internal_kv_initialized,
     _internal_kv_put,
@@ -566,8 +565,7 @@ def get_total_num_alive_nodes_to_report(gcs_client, timeout=None) -> Optional[in
     """Return the total number of alive nodes in the cluster"""
     try:
         result = gcs_client.get_all_node_info(
-            timeout=timeout,
-            state_filter=GcsNodeInfo.GcsNodeState.ALIVE,
+            timeout=timeout, state_filter=gcs_pb2.GcsNodeInfo.GcsNodeState.ALIVE
         )
         return len(result.items())
     except Exception as e:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -523,13 +523,8 @@ def get_node_to_connect_for_driver(
     filtered_node_to_connect_infos = []
     for node_info in node_to_connect_infos:
         if (
-            (
-                node_ip_address is None
-                or node_info.node_manager_address == node_ip_address
-            )
-            and (node_name is None or node_info.node_name == node_name)
-            and (temp_dir is None or node_info.temp_dir == temp_dir)
-        ):
+            node_ip_address is None or node_info.node_manager_address == node_ip_address
+        ) and (node_name is None or node_info.node_name == node_name):
             filtered_node_to_connect_infos.append(node_info)
 
     if not filtered_node_to_connect_infos:
@@ -939,7 +934,7 @@ def start_ray_process(
 
         # TODO(suquark): Any better temp file creation here?
         gdb_init_path = os.path.join(
-            ray._common.utils.get_default_ray_temp_dir(),
+            ray._common.utils.get_ray_temp_dir(),
             f"gdb_init_{process_type}_{time.time()}",
         )
         ray_process_path = command[0]
@@ -2125,7 +2120,6 @@ def determine_plasma_store_config(
 
     Args:
         object_store_memory: The object store memory to use.
-        temp_dir: The user-specified temp directory parameter (defaults to <system_temp_dir>/ray).
         plasma_directory: The user-specified plasma directory parameter.
         fallback_directory: The path extracted from the object_spilling_config when the
                             object spilling config is set and the spilling type is to
@@ -2170,7 +2164,7 @@ def determine_plasma_store_config(
                     )
                 )
             else:
-                plasma_directory = temp_dir
+                plasma_directory = ray._common.utils.get_user_temp_dir()
                 logger.warning(
                     "WARNING: The object store is using {} instead of "
                     "/dev/shm because /dev/shm has only {} bytes available. "
@@ -2180,13 +2174,13 @@ def determine_plasma_store_config(
                     "passing '--shm-size={:.2f}gb' to 'docker run' (or add it "
                     "to the run_options list in a Ray cluster config). Make "
                     "sure to set this to more than 30% of available RAM.".format(
-                        temp_dir,
+                        ray._common.utils.get_user_temp_dir(),
                         shm_avail,
                         object_store_memory * (1.1) / (2**30),
                     )
                 )
         else:
-            plasma_directory = temp_dir
+            plasma_directory = ray._common.utils.get_user_temp_dir()
 
         # Do some sanity checks.
         if object_store_memory > system_memory:

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -1024,14 +1024,7 @@ def timeline(filename=None):
     Returns:
         If filename is not provided, this returns a list of profiling events.
             Each profile event is a dictionary.
-
-    Raises:
-        RuntimeError: An exception is raised if ray.init() has not been called yet.
     """
-    if not ray.is_initialized():
-        raise RuntimeError(
-            "Ray has not been started yet. Timeline requires Ray to be initialized first."
-        )
     return state.chrome_tracing_dump(filename=filename)
 
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -580,11 +580,6 @@ class Worker:
         return self.core_worker.get_current_node_id()
 
     @property
-    def current_temp_dir(self):
-        self.check_connected()
-        return self.node.temp_dir
-
-    @property
     def task_depth(self):
         return self.core_worker.get_task_depth()
 
@@ -1545,9 +1540,7 @@ def init(
         runtime_env: The runtime environment to use
             for this job (see :ref:`runtime-environments` for details).
         object_spilling_directory: The path to spill objects to. The same path will
-            be used as the object store fallback directory as well. Defaults to the node's session dir.
-            If head node specifies an object spilling directory, and this node doesn't specify one,
-            use the head node's object spilling directory.
+            be used as the object store fallback directory as well.
         enable_resource_isolation: Enable resource isolation through cgroupv2 by reserving
             memory and cpu resources for ray system processes. To use, only cgroupv2 (not cgroupv1)
             must be enabled with read and write permissions for the raylet. Cgroup memory and
@@ -1583,8 +1576,7 @@ def init(
             from connecting to Redis if provided.
         _temp_dir: If provided, specifies the root temporary
             directory for the Ray process. Must be an absolute path. Defaults to an
-            OS-specific conventional location, e.g., "/tmp/ray" for head node, and
-            head node's temp dir for worker node.
+            OS-specific conventional location, e.g., "/tmp/ray".
         _metrics_export_port: Port number Ray exposes system metrics
             through a Prometheus endpoint. It is currently under active
             development, and the API is subject to change.

--- a/python/ray/air/_internal/filelock.py
+++ b/python/ray/air/_internal/filelock.py
@@ -25,7 +25,7 @@ class TempFileLock:
 
     def __init__(self, path: str, **kwargs):
         self.path = path
-        temp_dir = Path(ray._common.utils.get_default_system_temp_dir()).resolve()
+        temp_dir = Path(ray._common.utils.get_user_temp_dir()).resolve()
         self._lock_dir = temp_dir / RAY_LOCKFILE_DIR
         self._path_hash = hashlib.sha1(
             str(Path(self.path).resolve()).encode("utf-8")

--- a/python/ray/air/tests/test_utils.py
+++ b/python/ray/air/tests/test_utils.py
@@ -12,7 +12,7 @@ def test_temp_file_lock(tmp_path, monkeypatch):
     """Test that the directory where temp file locks are saved can be configured
     via the env variable that configures the global Ray temp dir."""
     monkeypatch.setenv("RAY_TMPDIR", str(tmp_path))
-    assert str(tmp_path) in ray._common.utils.get_default_system_temp_dir()
+    assert str(tmp_path) in ray._common.utils.get_user_temp_dir()
     with TempFileLock(path="abc.txt"):
         assert RAY_LOCKFILE_DIR in os.listdir(tmp_path)
         assert os.listdir(tmp_path / RAY_LOCKFILE_DIR)

--- a/python/ray/autoscaler/_private/local/config.py
+++ b/python/ray/autoscaler/_private/local/config.py
@@ -2,7 +2,7 @@ import copy
 import os
 from typing import Any, Dict
 
-from ray._common.utils import get_default_ray_temp_dir
+from ray._common.utils import get_ray_temp_dir
 from ray.autoscaler._private.cli_logger import cli_logger
 
 unsupported_field_message = "The field {} is not supported for on-premise clusters."
@@ -110,15 +110,11 @@ def prepare_manual(config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def get_lock_path(cluster_name: str) -> str:
-    return os.path.join(
-        get_default_ray_temp_dir(), "cluster-{}.lock".format(cluster_name)
-    )
+    return os.path.join(get_ray_temp_dir(), "cluster-{}.lock".format(cluster_name))
 
 
 def get_state_path(cluster_name: str) -> str:
-    return os.path.join(
-        get_default_ray_temp_dir(), "cluster-{}.state".format(cluster_name)
-    )
+    return os.path.join(get_ray_temp_dir(), "cluster-{}.state".format(cluster_name))
 
 
 def bootstrap_local(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -27,6 +27,7 @@ import ray.dashboard.modules.reporter.reporter_consts as reporter_consts
 import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import (
     get_or_create_event_loop,
+    get_user_temp_dir,
 )
 from ray._private import utils
 from ray._private.metrics_agent import Gauge, MetricsAgent, Record
@@ -869,7 +870,7 @@ class ReporterAgent(
         return total, available, percent, used
 
     @staticmethod
-    def _get_disk_usage(temp_dir: str):
+    def _get_disk_usage():
         if IN_KUBERNETES_POD and not ENABLE_K8S_DISK_USAGE:
             # If in a K8s pod, disable disk display by passing in dummy values.
             sdiskusage = namedtuple("sdiskusage", ["total", "used", "free", "percent"])
@@ -879,9 +880,10 @@ class ReporterAgent(
             root = psutil.disk_partitions()[0].mountpoint
         else:
             root = os.sep
+        tmp = get_user_temp_dir()
         return {
             "/": psutil.disk_usage(root),
-            temp_dir: psutil.disk_usage(temp_dir),
+            tmp: psutil.disk_usage(tmp),
         }
 
     @staticmethod
@@ -1124,7 +1126,7 @@ class ReporterAgent(
             "agent": self._get_agent(),
             "bootTime": self._get_boot_time(),
             "loadAvg": self._get_load_avg(),
-            "disk": self._get_disk_usage(self._dashboard_agent.temp_dir),
+            "disk": self._get_disk_usage(),
             "disk_io": disk_stats,
             "disk_io_speed": disk_speed_stats,
             "gpus": gpus,

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -852,9 +852,7 @@ def test_enable_k8s_disk_usage(enable_k8s_disk_usage: bool):
         IN_KUBERNETES_POD=True,
         ENABLE_K8S_DISK_USAGE=enable_k8s_disk_usage,
     ):
-        root_usage = ReporterAgent._get_disk_usage(
-            ray._common.utils.get_default_ray_temp_dir()
-        )["/"]
+        root_usage = ReporterAgent._get_disk_usage()["/"]
         if enable_k8s_disk_usage:
             # Since K8s disk usage is enabled, we shouuld get non-dummy values.
             assert root_usage.total != 1

--- a/python/ray/experimental/raysort/tracing_utils.py
+++ b/python/ray/experimental/raysort/tracing_utils.py
@@ -1,7 +1,6 @@
 import datetime
 import functools
 import logging
-import os
 import time
 from typing import List, Tuple
 
@@ -112,9 +111,6 @@ class ProgressTracker:
 
 def export_timeline():
     timestr = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    filename = f"ray-timeline-{timestr}.json"
-
-    temp_dir = ray.get_runtime_context().get_temp_dir()
-    filepath = os.path.join(temp_dir, filename)
-    ray.timeline(filename=filepath)
-    logging.info(f"Exported Ray timeline to {filepath}")
+    filename = f"/tmp/ray-timeline-{timestr}.json"
+    ray.timeline(filename=filename)
+    logging.info(f"Exported Ray timeline to {filename}")

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -115,17 +115,6 @@ class RuntimeContext(object):
         node_id = self.worker.current_node_id
         return node_id.hex()
 
-    def get_temp_dir(self) -> str:
-        """Get the temp directory for the current node.
-
-        Returns:
-            The temp directory for the current node.
-        """
-        assert (
-            ray.is_initialized()
-        ), "Temp directory is not available because Ray has not been initialized."
-        return self.worker.current_temp_dir
-
     def get_session_name(self) -> str:
         """Get the session name for the Ray cluster this process is connected to.
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -558,8 +558,8 @@ Windows powershell users need additional escaping:
 @click.option(
     "--temp-dir",
     default=None,
-    help="manually specify the root temporary dir of the Ray process. Can be "
-    "specified per node.",
+    help="manually specify the root temporary dir of the Ray process, only "
+    "works when --head is specified",
 )
 @click.option(
     "--system-config",
@@ -771,6 +771,14 @@ def start(
                 cf.bold('--labels="key1=val1,key2=val2"'),
             )
     labels_dict = {**labels_from_file, **labels_from_string}
+    if temp_dir and not head:
+        cli_logger.warning(
+            f"`--temp-dir={temp_dir}` option will be ignored. "
+            "`--head` is a required flag to use `--temp-dir`. "
+            "temp_dir is only configurable from a head node. "
+            "All the worker nodes will use the same temp_dir as a head node. "
+        )
+        temp_dir = None
 
     resource_isolation_config = ResourceIsolationConfig(
         enable_resource_isolation=enable_resource_isolation,
@@ -2065,10 +2073,11 @@ def timeline(address):
     ray.init(address=address)
     time = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
     filename = os.path.join(
-        ray.get_runtime_context().get_temp_dir(), f"ray-timeline-{time}.json"
+        ray._common.utils.get_user_temp_dir(), f"ray-timeline-{time}.json"
     )
     ray.timeline(filename=filename)
-    logger.info(f"Trace file written to {filename} in the ray temp directory.")
+    size = os.path.getsize(filename)
+    logger.info(f"Trace file written to {filename} ({size} bytes).")
     logger.info("You can open this with chrome://tracing in the Chrome browser.")
 
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -291,7 +291,7 @@ def _find_available_ports(start: int, end: int, *, num: int = 1) -> List[int]:
 
 
 def start_redis_with_sentinel(db_dir):
-    temp_dir = ray._common.utils.get_default_ray_temp_dir()
+    temp_dir = ray._common.utils.get_ray_temp_dir()
 
     redis_ports = _find_available_ports(49159, 55535, num=redis_sentinel_replicas() + 1)
     sentinel_port = redis_ports[0]
@@ -328,7 +328,7 @@ def start_redis(db_dir):
         leader_id = None
         redis_ports = []
         while len(redis_ports) != redis_replicas():
-            temp_dir = ray._common.utils.get_default_ray_temp_dir()
+            temp_dir = ray._common.utils.get_ray_temp_dir()
             port, free_port = _find_available_ports(49159, 55535, num=2)
             try:
                 node_id = None

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -8,7 +8,7 @@ import unittest
 import pytest
 
 from ray._common.network_utils import build_address
-from ray._common.utils import get_default_ray_temp_dir
+from ray._common.utils import get_ray_temp_dir
 from ray.autoscaler._private.local import config as local_config
 from ray.autoscaler._private.local.coordinator_node_provider import (
     CoordinatorSenderNodeProvider,
@@ -75,7 +75,7 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
         # second time.)
         self._monkeypatch.setenv("RAY_TMPDIR", self._tmpdir)
         # ensure that a new cluster can start up if RAY_TMPDIR doesn't exist yet
-        assert not os.path.exists(get_default_ray_temp_dir())
+        assert not os.path.exists(get_ray_temp_dir())
         head_ip = ".".join(str(random.randint(0, 255)) for _ in range(4))
         cluster_config = {
             "cluster_name": "random_name",
@@ -92,7 +92,7 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
         node_provider = _get_node_provider(
             provider_config, cluster_config["cluster_name"], use_cache=False
         )
-        assert os.path.exists(get_default_ray_temp_dir())
+        assert os.path.exists(get_ray_temp_dir())
         assert node_provider.external_ip(head_ip) == "0.0.0.0.3"
         assert isinstance(node_provider, LocalNodeProvider)
         expected_workers = {}

--- a/python/ray/tests/test_metrics_head.py
+++ b/python/ray/tests/test_metrics_head.py
@@ -7,7 +7,7 @@ import tempfile
 
 import pytest
 
-from ray._common.utils import get_default_ray_temp_dir
+from ray._common.utils import get_ray_temp_dir
 from ray._private.ray_constants import SESSION_LATEST
 from ray.dashboard.modules.metrics.dashboards.default_dashboard_panels import (
     DEFAULT_GRAFANA_ROWS,
@@ -45,7 +45,7 @@ def test_metrics_folder_and_content(is_temp_dir_set, temp_dir_val):
         include_dashboard=True, _temp_dir=temp_dir_val if is_temp_dir_set else None
     ) as context:
         session_dir = context["session_dir"]
-        temp_dir = temp_dir_val if is_temp_dir_set else get_default_ray_temp_dir()
+        temp_dir = temp_dir_val if is_temp_dir_set else get_ray_temp_dir()
         assert os.path.exists(
             f"{session_dir}/metrics/grafana/provisioning/dashboards/default.yml"
         )

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -129,7 +129,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
     )
     check_call_ray(["stop"])
 
-    temp_dir = ray._common.utils.get_default_ray_temp_dir()
+    temp_dir = ray._common.utils.get_ray_temp_dir()
 
     # Test starting Ray with RAY_REDIS_ADDRESS env.
     _, proc = start_redis_instance(

--- a/python/ray/tests/test_tempdir.py
+++ b/python/ray/tests/test_tempdir.py
@@ -7,18 +7,13 @@ import uuid
 import pytest
 
 import ray
-import ray._private.ray_constants as ray_constants
 from ray._common.test_utils import wait_for_condition
 from ray._private.test_utils import check_call_ray
 
 
 def unix_socket_create_path(name):
     unix = sys.platform != "win32"
-    return (
-        os.path.join(ray._common.utils.get_default_ray_temp_dir(), name)
-        if unix
-        else None
-    )
+    return os.path.join(ray._common.utils.get_user_temp_dir(), name) if unix else None
 
 
 def unix_socket_verify(unix_socket):
@@ -34,29 +29,25 @@ def unix_socket_delete(unix_socket):
 @pytest.fixture
 def delete_default_temp_dir():
     def delete_default_temp_dir_once():
-        shutil.rmtree(ray._common.utils.get_default_ray_temp_dir(), ignore_errors=True)
-        return not os.path.exists(ray._common.utils.get_default_ray_temp_dir())
+        shutil.rmtree(ray._common.utils.get_ray_temp_dir(), ignore_errors=True)
+        return not os.path.exists(ray._common.utils.get_ray_temp_dir())
 
     wait_for_condition(delete_default_temp_dir_once)
     yield
 
 
 def test_tempdir_created_successfully(delete_default_temp_dir, shutdown_only):
-    temp_dir = os.path.join(
-        "/tmp/test", uuid.uuid4().hex[:-10]
-    )  # truncate the uuid to avoid the socket path length limit
+    temp_dir = os.path.join(ray._common.utils.get_user_temp_dir(), uuid.uuid4().hex)
     ray.init(_temp_dir=temp_dir)
     assert os.path.exists(temp_dir), "Specified temp dir not found."
     assert not os.path.exists(
-        ray._common.utils.get_default_ray_temp_dir()
+        ray._common.utils.get_ray_temp_dir()
     ), "Default temp dir should not exist."
     shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 def test_tempdir_commandline(delete_default_temp_dir):
-    temp_dir = os.path.join(
-        "/tmp/test", uuid.uuid4().hex[:-10]
-    )  # truncate the uuid to avoid the socket path length limit
+    temp_dir = os.path.join(ray._common.utils.get_user_temp_dir(), uuid.uuid4().hex)
     check_call_ray(
         [
             "start",
@@ -68,7 +59,7 @@ def test_tempdir_commandline(delete_default_temp_dir):
     )
     assert os.path.exists(temp_dir), "Specified temp dir not found."
     assert not os.path.exists(
-        ray._common.utils.get_default_ray_temp_dir()
+        ray._common.utils.get_ray_temp_dir()
     ), "Default temp dir should not exist."
     check_call_ray(["stop"])
     shutil.rmtree(
@@ -81,9 +72,7 @@ def test_tempdir_long_path():
     if sys.platform != "win32":
         # Test AF_UNIX limits for sockaddr_un->sun_path on POSIX OSes
         maxlen = 104 if sys.platform.startswith("darwin") else 108
-        temp_dir = os.path.join(
-            ray._common.utils.get_default_ray_temp_dir(), "z" * maxlen
-        )
+        temp_dir = os.path.join(ray._common.utils.get_user_temp_dir(), "z" * maxlen)
         with pytest.raises(OSError):
             ray.init(_temp_dir=temp_dir)  # path should be too long
 
@@ -143,7 +132,7 @@ def test_raylet_tempfiles(shutdown_only):
 
 
 def test_tempdir_privilege(shutdown_only):
-    tmp_dir = ray._common.utils.get_default_ray_temp_dir()
+    tmp_dir = ray._common.utils.get_ray_temp_dir()
     os.makedirs(tmp_dir, exist_ok=True)
     os.chmod(tmp_dir, 0o000)
     ray.init(num_cpus=1)
@@ -158,261 +147,6 @@ def test_session_dir_uniqueness():
         session_dirs.add(ray._private.worker._global_node.get_session_dir_path)
         ray.shutdown()
     assert len(session_dirs) == 2
-
-
-def test_head_temp_dir_shared_with_worker(delete_default_temp_dir):
-    """Test that head node temp_dir is shared with worker node when only head temp_dir is specified."""
-    head_temp_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(),
-        uuid.uuid4().hex[
-            :-10
-        ],  # truncate the uuid to avoid the socket path length limit
-    )
-
-    # Start head node with temp-dir specified
-    check_call_ray(
-        [
-            "start",
-            "--head",
-            f"--temp-dir={head_temp_dir}",
-            "--port",
-            str(ray_constants.DEFAULT_PORT),
-        ]
-    )
-
-    # Start worker node without specifying temp-dir
-    check_call_ray(
-        [
-            "start",
-            f"--address=127.0.0.1:{ray_constants.DEFAULT_PORT}",
-        ]
-    )
-
-    try:
-        # Connect to the cluster
-        ray.init(address="auto")
-
-        # Verify both head and worker nodes exist
-        wait_for_condition(lambda: len(ray.nodes()) == 2, timeout=10)
-        nodes = ray.nodes()
-        assert len(nodes) == 2, "Expected 2 nodes in the cluster"
-
-        # Check that both nodes' temp directories are under the head's temp_dir
-        # The session_latest should exist in head_temp_dir
-        assert os.path.isdir(
-            os.path.join(head_temp_dir, "session_latest")
-        ), "Head node session directory not found in specified temp_dir"
-
-        # Both nodes should be using the same temp directory (head's temp_dir)
-        assert os.path.isfile(
-            os.path.join(head_temp_dir, "ray_current_cluster")
-        ), "Cluster info file not found in head temp_dir"
-
-        ray.shutdown()
-    finally:
-        check_call_ray(["stop"])
-        shutil.rmtree(head_temp_dir, ignore_errors=True)
-
-
-def test_worker_temp_dir_different_from_head(delete_default_temp_dir):
-    """Test that worker node can have a different temp_dir when only worker temp_dir is specified."""
-    worker_temp_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(),
-        uuid.uuid4().hex[
-            :-10
-        ],  # truncate the uuid to avoid the socket path length limit
-    )
-
-    # Start head node without specifying temp-dir
-    check_call_ray(
-        [
-            "start",
-            "--head",
-            "--port",
-            str(ray_constants.DEFAULT_PORT),
-        ]
-    )
-
-    # Start worker node with temp-dir specified
-    check_call_ray(
-        [
-            "start",
-            f"--address=127.0.0.1:{ray_constants.DEFAULT_PORT}",
-            f"--temp-dir={worker_temp_dir}",
-        ]
-    )
-
-    try:
-        # Connect to the cluster
-        ray.init(address="auto")
-
-        # Verify both head and worker nodes exist
-        wait_for_condition(lambda: len(ray.nodes()) == 2, timeout=10)
-        nodes = ray.nodes()
-        assert len(nodes) == 2, "Expected 2 nodes in the cluster"
-
-        # Verify worker temp-dir was created at the specified location
-        assert os.path.isfile(
-            os.path.join(worker_temp_dir, "ray_current_cluster")
-        ), "Worker cluster info file not found in specified temp_dir"
-        assert os.path.isdir(
-            os.path.join(worker_temp_dir, "session_latest")
-        ), "Worker session directory not found in specified temp_dir"
-
-        # Verify head node is using default temp_dir (different from worker)
-        default_head_temp_dir = ray._common.utils.get_default_ray_temp_dir()
-        assert os.path.exists(
-            default_head_temp_dir
-        ), "Head node should be using default temp_dir"
-
-        # Ensure they are different directories
-        assert (
-            worker_temp_dir != default_head_temp_dir
-        ), "Worker temp_dir should be different from head node's default temp_dir"
-
-        ray.shutdown()
-    finally:
-        check_call_ray(["stop"])
-        shutil.rmtree(worker_temp_dir, ignore_errors=True)
-
-
-def test_both_nodes_different_temp_dirs(delete_default_temp_dir):
-    """Test that head and worker can have different temp_dirs when both are specified."""
-    head_temp_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(),
-        uuid.uuid4().hex[
-            :-10
-        ],  # truncate the uuid to avoid the socket path length limit
-    )
-    worker_temp_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(),
-        uuid.uuid4().hex[
-            :-10
-        ],  # truncate the uuid to avoid the socket path length limit
-    )
-
-    # Ensure directories are different
-    assert (
-        head_temp_dir != worker_temp_dir
-    ), "Test setup error: directories should be different"
-
-    # Start head node with temp-dir specified
-    check_call_ray(
-        [
-            "start",
-            "--head",
-            f"--temp-dir={head_temp_dir}",
-            "--port",
-            str(ray_constants.DEFAULT_PORT),
-        ]
-    )
-
-    # Start worker node with a different temp-dir specified
-    check_call_ray(
-        [
-            "start",
-            f"--address=127.0.0.1:{ray_constants.DEFAULT_PORT}",
-            f"--temp-dir={worker_temp_dir}",
-        ]
-    )
-
-    try:
-        # Connect to the cluster
-        ray.init(address="auto")
-
-        # Verify both head and worker nodes exist
-        wait_for_condition(lambda: len(ray.nodes()) == 2, timeout=10)
-        nodes = ray.nodes()
-        assert len(nodes) == 2, "Expected 2 nodes in the cluster"
-
-        # Verify head temp-dir was created at the specified location
-        assert os.path.isfile(
-            os.path.join(head_temp_dir, "ray_current_cluster")
-        ), "Head cluster info file not found in specified temp_dir"
-        assert os.path.isdir(
-            os.path.join(head_temp_dir, "session_latest")
-        ), "Head session directory not found in specified temp_dir"
-
-        # Verify worker temp-dir was created at the specified location
-        assert os.path.isfile(
-            os.path.join(worker_temp_dir, "ray_current_cluster")
-        ), "Worker cluster info file not found in specified temp_dir"
-        assert os.path.isdir(
-            os.path.join(worker_temp_dir, "session_latest")
-        ), "Worker session directory not found in specified temp_dir"
-
-        # Verify both directories exist and are different
-        assert (
-            head_temp_dir != worker_temp_dir
-        ), "Head and worker temp_dirs should be different"
-        assert os.path.exists(head_temp_dir), "Head temp_dir should exist"
-        assert os.path.exists(worker_temp_dir), "Worker temp_dir should exist"
-
-        ray.shutdown()
-    finally:
-        check_call_ray(["stop"])
-        shutil.rmtree(head_temp_dir, ignore_errors=True)
-        shutil.rmtree(worker_temp_dir, ignore_errors=True)
-
-
-def test_resolve_user_ray_temp_dir_from_gcs(delete_default_temp_dir):
-    """Test that resolve_user_ray_temp_dir correctly retrieves temp_dir from GCS.
-
-    This test verifies that resolve_user_ray_temp_dir can correctly fetch temp_dir
-    from GCS node info both before and after ray.init() is called.
-    """
-    import ray._common.utils
-
-    head_temp_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(),
-        uuid.uuid4().hex[
-            :-10
-        ],  # truncate the uuid to avoid the socket path length limit
-    )
-
-    # Start head node with temp-dir specified
-    check_call_ray(
-        [
-            "start",
-            "--head",
-            f"--temp-dir={head_temp_dir}",
-            "--port",
-            str(ray_constants.DEFAULT_PORT),
-        ]
-    )
-
-    try:
-        ray.init(address="auto")
-        wait_for_condition(lambda: len(ray.nodes()) == 1, timeout=10)
-        nodes = ray.nodes()
-        assert len(nodes) == 1, "Expected 1 node in the cluster"
-        node_id = nodes[0]["NodeID"]
-        gcs_client = ray._private.worker.global_worker.gcs_client
-        ray.shutdown()
-
-        # test WITHOUT ray.init() (fetch temp_dir from GCS)
-        resolved_temp_dir = ray._common.utils.resolve_user_ray_temp_dir(
-            gcs_client, node_id=node_id
-        )
-        assert resolved_temp_dir == head_temp_dir, (
-            f"Expected temp_dir from GCS to be {head_temp_dir}, "
-            f"but got {resolved_temp_dir}"
-        )
-
-        # test WITH ray.init() (fetch temp_dir from runtime context)
-        ray.init(address="auto")
-        resolved_temp_dir = ray._common.utils.resolve_user_ray_temp_dir(
-            gcs_client, node_id=node_id
-        )
-        assert resolved_temp_dir == head_temp_dir, (
-            f"Expected temp_dir from runtime context to be {head_temp_dir}, "
-            f"but got {resolved_temp_dir}"
-        )
-
-        ray.shutdown()
-    finally:
-        check_call_ray(["stop"])
-        shutil.rmtree(head_temp_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -702,7 +702,7 @@ class ProgressReporterTest(unittest.TestCase):
                 assert EXPECTED_END_TO_END_END in output
                 for line in output.splitlines():
                     if "(raylet)" in line:
-                        assert "Setting" in line, "Unexpected raylet log messages"
+                        assert "cluster ID" in line, "Unexpected raylet log messages"
             except Exception:
                 print("*** BEGIN OUTPUT ***")
                 print(output)

--- a/rllib/algorithms/tests/test_algorithm_export_checkpoint.py
+++ b/rllib/algorithms/tests/test_algorithm_export_checkpoint.py
@@ -53,8 +53,7 @@ def save_test(alg_name, framework="tf", multi_agent=False):
     test_obs = np.array([[0.1, 0.2, 0.3, 0.4]])
 
     export_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(),
-        "export_dir_%s" % alg_name,
+        ray._common.utils.get_user_temp_dir(), "export_dir_%s" % alg_name
     )
 
     algo.train()

--- a/rllib/examples/_old_api_stack/checkpoints/cartpole_dqn_export.py
+++ b/rllib/examples/_old_api_stack/checkpoints/cartpole_dqn_export.py
@@ -71,12 +71,8 @@ def restore_policy_from_checkpoint(export_dir):
 
 if __name__ == "__main__":
     algo = "PPO"
-    model_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(), "model_export_dir"
-    )
-    ckpt_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(), "ckpt_export_dir"
-    )
+    model_dir = os.path.join(ray._common.utils.get_user_temp_dir(), "model_export_dir")
+    ckpt_dir = os.path.join(ray._common.utils.get_user_temp_dir(), "ckpt_export_dir")
     num_steps = 1
     train_and_export_policy_and_model(algo, num_steps, model_dir, ckpt_dir)
     restore_saved_model(model_dir)

--- a/rllib/examples/_old_api_stack/offline_rl/saving_experiences.py
+++ b/rllib/examples/_old_api_stack/offline_rl/saving_experiences.py
@@ -8,14 +8,14 @@ import os
 import gymnasium as gym
 import numpy as np
 
-from ray._common.utils import get_default_ray_temp_dir
+from ray._common.utils import get_user_temp_dir
 from ray.rllib.evaluation.sample_batch_builder import SampleBatchBuilder
 from ray.rllib.models.preprocessors import get_preprocessor
 from ray.rllib.offline.json_writer import JsonWriter
 
 if __name__ == "__main__":
     batch_builder = SampleBatchBuilder()  # or MultiAgentSampleBatchBuilder
-    writer = JsonWriter(os.path.join(get_default_ray_temp_dir(), "demo-out"))
+    writer = JsonWriter(os.path.join(get_user_temp_dir(), "demo-out"))
 
     # You normally wouldn't want to manually create sample batches if a
     # simulator is available, but let's do it anyways for example purposes:

--- a/rllib/policy/tests/test_export_checkpoint_and_model.py
+++ b/rllib/policy/tests/test_export_checkpoint_and_model.py
@@ -49,8 +49,7 @@ def export_test(
         test_obs = np.array([[0.1, 0.2, 0.3, 0.4]])
 
     export_dir = os.path.join(
-        ray._common.utils.get_default_ray_temp_dir(),
-        "export_dir_%s" % alg_name,
+        ray._common.utils.get_user_temp_dir(), "export_dir_%s" % alg_name
     )
 
     print("Exporting policy checkpoint", alg_name, export_dir)

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -356,12 +356,6 @@ message GcsNodeInfo {
 
   // The death info of this node.
   NodeDeathInfo death_info = 29;
-
-  // Temporary directory of this node.
-  string temp_dir = 32;
-
-  // Session directory of this node.
-  string session_dir = 33;
 }
 
 // A lighter version of GcsNodeInfo containing only essential fields.


### PR DESCRIPTION
## Description
The PR to introduce node specific `temp-dir` specification capabilities introduced a number of tests that fails on the Windows environment in post merge. To prevent these tests from blocking other PRs, we will be reverting the PR until the tests has been fixed.

This reverts PR "[Core] Introduce node specific temp-dir specification. (#57735)".

## Related issues
N/A

## Additional information
Temp dir PR: https://github.com/ray-project/ray/pull/57735