### PR TITLE
[Data] Fix unify_tensor_arrays

### DIFF
--- a/python/ray/data/_internal/tensor_extensions/arrow.py
+++ b/python/ray/data/_internal/tensor_extensions/arrow.py
@@ -1311,7 +1311,10 @@ class ArrowVariableShapedTensorArray(pa.ExtensionArray):
         #
         # TODO avoid python loop
         expanded_shapes_array = pa.array(
-            [_pad_shape_with_singleton_axes(s, ndim) for s in shapes_array.to_pylist()]
+            [
+                _pad_shape_with_singleton_axes(tuple(s), ndim)
+                for s in shapes_array.to_pylist()
+            ]
         )
 
         storage = pa.StructArray.from_arrays(
@@ -1327,7 +1330,7 @@ def _pad_shape_with_singleton_axes(
 ) -> Tuple[int, ...]:
     assert ndim >= len(shape)
 
-    return (1,) * (ndim - len(shape)) + tuple(shape)
+    return (1,) * (ndim - len(shape)) + shape
 
 
 def _ravel_tensors(

--- a/python/ray/data/_internal/tensor_extensions/arrow.py
+++ b/python/ray/data/_internal/tensor_extensions/arrow.py
@@ -1429,7 +1429,7 @@ def unify_tensor_arrays(
     # This is important because ArrowVariableShapedTensorType.__eq__ ignores
     # ndim, but PyArrow's chunked_array validation requires exact type match.
     # Using a dict with id() as key to track unique type instances.
-    distinct_types_by_id: Dict[int, Any] = {}
+    distinct_types_by_id: Dict[int, pa.ExtensionType] = {}
 
     for arr in arrs:
         if isinstance(arr.type, supported_tensor_types):

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -3280,12 +3280,12 @@ class TestUnifyTensorArrays:
             arrays.append(ArrowTensorArray.from_numpy(data))
 
         # Each array has its own type instance
-        assert len(set(id(arr.type) for arr in arrays)) == 5
+        assert len({id(arr.type) for arr in arrays}) == 5
 
         unified = unify_tensor_arrays(arrays)
 
         # All unified arrays share the same type instance
-        assert len(set(id(arr.type) for arr in unified)) == 1
+        assert len({id(arr.type) for arr in unified}) == 1
         # Type is still fixed-shape (not variable-shaped)
         fixed_types = get_arrow_extension_fixed_shape_tensor_types()
         assert isinstance(unified[0].type, fixed_types)
@@ -3302,12 +3302,12 @@ class TestUnifyTensorArrays:
             data = [np.ones((3 + i, 4 + i), dtype=np.float32) for _ in range(2)]
             arrays.append(ArrowVariableShapedTensorArray.from_numpy(data))
 
-        assert len(set(id(arr.type) for arr in arrays)) == 5
+        assert len({id(arr.type) for arr in arrays}) == 5
         assert all(arr.type.ndim == 2 for arr in arrays)
 
         unified = unify_tensor_arrays(arrays)
 
-        assert len(set(id(arr.type) for arr in unified)) == 1
+        assert len({id(arr.type) for arr in unified}) == 1
         assert isinstance(unified[0].type, ArrowVariableShapedTensorType)
         assert unified[0].type.ndim == 2
 
@@ -3323,7 +3323,7 @@ class TestUnifyTensorArrays:
 
         unified = unify_tensor_arrays(arrays)
 
-        assert len(set(id(arr.type) for arr in unified)) == 1
+        assert len({id(arr.type) for arr in unified}) == 1
         assert isinstance(unified[0].type, ArrowVariableShapedTensorType)
 
     def test_different_ndims_unify_with_padding(self):
@@ -3341,7 +3341,7 @@ class TestUnifyTensorArrays:
         unified = unify_tensor_arrays(arrays)
 
         # All share same type instance
-        assert len(set(id(arr.type) for arr in unified)) == 1
+        assert len({id(arr.type) for arr in unified}) == 1
         assert isinstance(unified[0].type, ArrowVariableShapedTensorType)
         assert unified[0].type.ndim == 3  # Unified to max ndim
 
@@ -3383,7 +3383,7 @@ class TestUnifyTensorArrays:
         unified = unify_tensor_arrays(arrays)
 
         # All share same type instance
-        assert len(set(id(arr.type) for arr in unified)) == 1
+        assert len({id(arr.type) for arr in unified}) == 1
         # Should be variable-shaped since shapes differ
         assert isinstance(unified[0].type, ArrowVariableShapedTensorType)
 

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -3322,13 +3322,18 @@ def test_concat_many_tensor_blocks_with_varying_ndim():
         all_arrays.extend(tensor_col.chunk(i).to_numpy())
     assert len(all_arrays) == 50
 
-    # Verify that the shapes of the tensors are correct after concatenation.
-    num_2d = sum(1 for arr in all_arrays if arr.ndim == 2 and arr.shape == (32, 32))
-    num_3d = sum(1 for arr in all_arrays if arr.ndim == 3 and arr.shape == (32, 32, 3))
+    # After unification, 2D tensors (32, 32) are padded to 3D as (1, 32, 32)
+    # to match the 3D tensors (32, 32, 3). All tensors become 3D.
+    num_padded_2d = sum(
+        1 for arr in all_arrays if arr.ndim == 3 and arr.shape == (1, 32, 32)
+    )
+    num_3d = sum(
+        1 for arr in all_arrays if arr.ndim == 3 and arr.shape == (32, 32, 3)
+    )
 
-    assert num_2d == 25, f"Expected 25 2D tensors, but found {num_2d}"
+    assert num_padded_2d == 25, f"Expected 25 padded 2D tensors, but found {num_padded_2d}"
     assert num_3d == 25, f"Expected 25 3D tensors, but found {num_3d}"
-    assert num_2d + num_3d == len(all_arrays), "Found tensors with unexpected dimensions"
+    assert num_padded_2d + num_3d == len(all_arrays), "Found tensors with unexpected shapes"
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -3322,6 +3322,14 @@ def test_concat_many_tensor_blocks_with_varying_ndim():
         all_arrays.extend(tensor_col.chunk(i).to_numpy())
     assert len(all_arrays) == 50
 
+    # Verify that the shapes of the tensors are correct after concatenation.
+    num_2d = sum(1 for arr in all_arrays if arr.ndim == 2 and arr.shape == (32, 32))
+    num_3d = sum(1 for arr in all_arrays if arr.ndim == 3 and arr.shape == (32, 32, 3))
+
+    assert num_2d == 25, f"Expected 25 2D tensors, but found {num_2d}"
+    assert num_3d == 25, f"Expected 25 3D tensors, but found {num_3d}"
+    assert num_2d + num_3d == len(all_arrays), "Found tensors with unexpected dimensions"
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

### [Data] Fix unify_tensor_arrays

**Problem**

When concatenating PyArrow tables containing tensor extension types with varying dimensions (e.g., mixing 2D grayscale and 3D RGB image tensors), PyArrow would fail with:
`ArrowTypeError: Array chunks must all be same type`

Discovered this issue with https://github.com/ray-project/ray/pull/59560

**Root Cause**

- Incorrect type deduplication: Using set() to collect distinct types relied on __eq__, but ArrowVariableShapedTensorType.__eq__ ignores ndim. This incorrectly merged types with different dimensions.
- Type identity mismatch: PyArrow's C++ validation compares extension types by object identity, not Python's __eq__. Each converted array created its own type instance, failing validation.


## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
