### PR TITLE
[Serve] Skip tracing test on Windows due to temp directory cleanup failure

### DIFF
--- a/python/ray/serve/tests/test_serve_with_tracing.py
+++ b/python/ray/serve/tests/test_serve_with_tracing.py
@@ -60,6 +60,9 @@ def get_span_list():
 
 
 @pytest.mark.skipif(
+    sys.platform == "win32", reason="Temp directory cleanup fails on Windows"
+)
+@pytest.mark.skipif(
     os.environ.get("RAY_SERVE_USE_GRPC_BY_DEFAULT", "0") == "1",
     reason="Tracing context propagation not yet supported in gRPC mode. "
     "See https://github.com/ray-project/ray/issues/60223",


### PR DESCRIPTION
## Why are these changes needed?

Skip `test_deployment_remote_calls_with_tracing` on Windows due to temp directory cleanup failures.

The test passes but the `cleanup_spans` fixture fails during teardown with:
```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: '/tmp/spans/XXXX.txt'
```

Windows doesn't release file handles immediately after process termination, causing `shutil.rmtree(spans_dir)` to fail even though the tracer provider shutdown is called.

This follows the same pattern from #60356 which skipped `test_grpc_e2e.py` tests on Windows for similar reasons.

## Related issue number

Fixes flaky test: `windows://python/ray/serve/tests:test_serve_with_tracing`
BK: https://buildkite.com/ray-project/postmerge/builds/15577#019be214-54c7-4056-af82-e955767e20b4

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests