### PR TITLE
[Scripts] Fix ray start --no-redirect-output crash and honor expected behavior

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -845,8 +845,8 @@ class Node:
             # Fall back to stderr redirect environment variable.
         return (
             os.environ.get(ray_constants.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE)
-                != "1"
-            )
+            != "1"
+        )
 
     # TODO(hjiang): Re-implement the logic in C++, and expose via cython.
     def get_log_file_names(

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -832,16 +832,21 @@ class Node:
         raise FileExistsError(errno.EEXIST, "No usable temporary filename found")
 
     def should_redirect_logs(self):
+        # Preferred: thread the setting explicitly via RayParams.log_to_stderr.
+        # This avoids relying on process-global environment variables.
+        if getattr(self._ray_params, "log_to_stderr", None) is not None:
+            return not self._ray_params.log_to_stderr
+
+        # Deprecated (kept for backward compatibility): RayParams.redirect_output.
         redirect_output = self._ray_params.redirect_output
-        if redirect_output is None:
+        if redirect_output is not None:
+            return redirect_output
+
             # Fall back to stderr redirect environment variable.
-            redirect_output = (
-                os.environ.get(
-                    ray_constants.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE
-                )
+        return (
+            os.environ.get(ray_constants.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE)
                 != "1"
             )
-        return redirect_output
 
     # TODO(hjiang): Re-implement the logic in C++, and expose via cython.
     def get_log_file_names(

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -49,6 +49,9 @@ class RayParams:
             be started.
         redirect_output: True if stdout and stderr for non-worker
             processes should be redirected to files and false otherwise.
+        log_to_stderr: If set, controls whether non-worker stdout/stderr should be
+            written to stderr (True) or redirected to log files (False). This is the
+            preferred replacement for the deprecated `redirect_output` field.
         external_addresses: The address of external Redis server to
             connect to, in format of "ip1:port1,ip2:port2,...".  If this
             address is provided, then ray won't start Redis instances in the
@@ -143,6 +146,7 @@ class RayParams:
         ray_client_server_port: Optional[int] = None,
         driver_mode=None,
         redirect_output: Optional[bool] = None,
+        log_to_stderr: Optional[bool] = None,
         external_addresses: Optional[List[str]] = None,
         num_redis_shards: Optional[int] = None,
         redis_max_clients: Optional[int] = None,
@@ -200,6 +204,7 @@ class RayParams:
         self.ray_client_server_port = ray_client_server_port
         self.driver_mode = driver_mode
         self.redirect_output = redirect_output
+        self.log_to_stderr = log_to_stderr
         self.external_addresses = external_addresses
         self.num_redis_shards = num_redis_shards
         self.redis_max_clients = redis_max_clients

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -779,7 +779,18 @@ def start(
         system_reserved_memory=system_reserved_memory,
     )
 
-    redirect_output = None if not no_redirect_output else True
+    # - For non-worker processes, thread the behavior explicitly via RayParams.log_to_stderr.
+    # - For worker processes, stdout/stderr redirection is controlled in C++ via
+    #   `RAY_LOG_TO_STDERR`, so we pass it to the raylet/worker subprocess env via
+    #   RayParams.env_vars (without touching os.environ).
+    if no_redirect_output:
+        log_to_stderr = True
+        env_vars = {
+            ray_constants.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE: "1",
+        }
+    else:
+        log_to_stderr = None
+        env_vars = None
 
     # no  client, no  port -> ok
     # no  port, has client -> default to 10001
@@ -802,7 +813,7 @@ def start(
         object_store_memory=object_store_memory,
         redis_username=redis_username,
         redis_password=redis_password,
-        redirect_output=redirect_output,
+        log_to_stderr=log_to_stderr,
         num_cpus=num_cpus,
         num_gpus=num_gpus,
         resources=resources,
@@ -826,6 +837,7 @@ def start(
         ray_debugger_external=ray_debugger_external,
         include_log_monitor=include_log_monitor,
         resource_isolation_config=resource_isolation_config,
+        env_vars=env_vars,
     )
 
     if ray_constants.RAY_START_HOOK in os.environ:
@@ -849,7 +861,8 @@ def start(
 
         if os.environ.get("RAY_FAKE_CLUSTER"):
             ray_params.env_vars = {
-                "RAY_OVERRIDE_NODE_ID_FOR_TESTING": FAKE_HEAD_NODE_ID
+                **(ray_params.env_vars or {}),
+                "RAY_OVERRIDE_NODE_ID_FOR_TESTING": FAKE_HEAD_NODE_ID,
             }
 
         if (


### PR DESCRIPTION
## Summary

This PR fixes a startup crash when running `ray start --head --no-redirect-output` (and the same flag in KubeRay-generated `ray start` commands). The CLI previously routed this option through a deprecated `RayParams.redirect_output` parameter, which raises a `DeprecationWarning` as an exception and prevents Ray from starting. The PR also corrects the effective behavior of `--no-redirect-output` by using the supported mechanism (`RAY_LOG_TO_STDERR=1`) to disable log redirection.

## Description

### What happened 

- The CLI option `--no-redirect-output` was mapped to `RayParams.redirect_output`.
- `RayParams._check_usage()` raises `DeprecationWarning("The redirect_output argument is deprecated.")` whenever `redirect_output` is not `None`, which terminates `ray start`.
- Additionally, the previous mapping effectively inverted intent by setting `redirect_output=True` when `--no-redirect-output` was provided.

### What was expected to happen

- `ray start --no-redirect-output` should **not crash**.
- It should disable redirecting non-worker stdout/stderr into `.out/.err` files (i.e., logs should go to stderr/console), consistent with the flag name and help text.

### What this PR changes

- Stop passing the deprecated `redirect_output` argument into `RayParams` from the `ray start` CLI.
- When `--no-redirect-output` is set, configure the supported behavior by setting:`RAY_LOG_TO_STDERR=1`
- This leverages the existing fallback logic in `Node.should_redirect_logs()` which checks `RAY_LOG_TO_STDERR` when `RayParams.redirect_output` is `None`.

### Testing
<img width="1280" height="468" alt="image" src="https://github.com/user-attachments/assets/6eb32b2e-80fa-4c05-b308-1700e92b1efb" />


## Related issues
Closes #60367
