### PR TITLE
[data][llm] Prefer uniproc executor over mp executor when world_size==1

### DIFF
--- a/python/ray/llm/_internal/batch/benchmark/benchmark_processor.py
+++ b/python/ray/llm/_internal/batch/benchmark/benchmark_processor.py
@@ -44,17 +44,16 @@ class Mode(Enum):
 
 # Default sampling parameters -- ensure a fair comparison by omitting sampling-induced variance
 VLLM_SAMPLING_PARAMS = {
+    "top_p": 1.0,
     "temperature": 1.0,
     "max_tokens": 100,
-    "top_p": 1.0,
     "ignore_eos": True,
 }
 
 # Default vLLM engine kwargs
 VLLM_ENGINE_KWARGS = {
-    "enable_prefix_caching": True,
-    "enable_chunked_prefill": True,
-    "max_num_batched_tokens": 4096,
+    "enforce_eager": True,
+    "max_model_len": 512,
 }
 
 # Default pooling parameters for classification
@@ -228,8 +227,16 @@ def build_classify_processor(
     model: str,
     pooling_params: dict = CLASSIFY_POOLING_PARAMS,
     max_model_len: int = 512,
+    distributed_executor_backend: str = None,
 ):
     """Build vLLM engine processor for classification benchmark."""
+
+    engine_kwargs = {
+        "enforce_eager": True,
+        "max_model_len": max_model_len,
+    }
+    if distributed_executor_backend is not None:
+        engine_kwargs["distributed_executor_backend"] = distributed_executor_backend
 
     config = vLLMEngineProcessorConfig(
         model_source=model,
@@ -239,10 +246,7 @@ def build_classify_processor(
         chat_template_stage=ChatTemplateStageConfig(enabled=False),
         tokenize_stage=TokenizerStageConfig(enabled=True),
         detokenize_stage=DetokenizeStageConfig(enabled=False),
-        engine_kwargs={
-            "enforce_eager": True,
-            "max_model_len": max_model_len,
-        },
+        engine_kwargs=engine_kwargs,
     )
     return build_processor(
         config,
@@ -488,6 +492,7 @@ def benchmark(
             concurrency=concurrency,
             model=model,
             pooling_params=CLASSIFY_POOLING_PARAMS,
+            distributed_executor_backend=distributed_executor_backend,
         )
     else:
         return run_processor(
@@ -571,9 +576,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--distributed-executor-backend",
         type=str,
-        default="mp",
-        choices=["ray", "mp"],
+        default=None,
+        choices=["ray", "mp", "uni"],
         help="Distributed executor backend for vLLM engine",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=None,
+        help="Maximum number of tokens to generate per request (default: 100)",
     )
     # Ray Data worker configuration
     parser.add_argument(
@@ -603,13 +614,18 @@ def main() -> None:
         prompts = dataset.sample(args.num_prompts)
 
         dataset = data.from_items(prompts)
+
+        sampling_params = VLLM_SAMPLING_PARAMS.copy()
+        if args.max_tokens is not None:
+            sampling_params["max_tokens"] = args.max_tokens
+
         result = benchmark(
             Mode(args.mode),
             dataset,
             batch_size=args.batch_size,
             concurrency=args.concurrency,
             model=args.model,
-            sampling_params=VLLM_SAMPLING_PARAMS,
+            sampling_params=sampling_params,
             pipeline_parallel_size=args.pipeline_parallel_size,
             tensor_parallel_size=args.tensor_parallel_size,
             distributed_executor_backend=args.distributed_executor_backend,

--- a/python/ray/llm/_internal/batch/benchmark/benchmark_processor.py
+++ b/python/ray/llm/_internal/batch/benchmark/benchmark_processor.py
@@ -52,8 +52,7 @@ VLLM_SAMPLING_PARAMS = {
 
 # Default vLLM engine kwargs
 VLLM_ENGINE_KWARGS = {
-    "enforce_eager": True,
-    "max_model_len": 512,
+    "max_num_batched_tokens": 4096,
 }
 
 # Default pooling parameters for classification
@@ -231,10 +230,7 @@ def build_classify_processor(
 ):
     """Build vLLM engine processor for classification benchmark."""
 
-    engine_kwargs = {
-        "enforce_eager": True,
-        "max_model_len": max_model_len,
-    }
+    engine_kwargs = VLLM_ENGINE_KWARGS.copy()
     if distributed_executor_backend is not None:
         engine_kwargs["distributed_executor_backend"] = distributed_executor_backend
 

--- a/python/ray/llm/_internal/batch/benchmark/dataset.py
+++ b/python/ray/llm/_internal/batch/benchmark/dataset.py
@@ -93,11 +93,7 @@ class ShareGPTDataset(BenchmarkDataset):
             self._data = self._load_dataset_data()
 
     def sample(self, num_requests: int) -> List[Dict]:
-        """Sample prompts from the loaded dataset.
-
-        If num_requests exceeds the number of available samples, the samples
-        are replicated to meet the requested count.
-        """
+        """Sample prompts from the loaded dataset."""
         if self._data is None:
             self.load_data()
 

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -18,11 +18,21 @@ from ray.llm._internal.batch.stages.configs import (
 )
 
 
-def test_vllm_engine_processor(gpu_type, model_opt_125m):
+@pytest.mark.parametrize(
+    "tensor_parallel_size, expected_distributed_executor_backend",
+    [(1, "uni"), (2, "ray")],
+)
+def test_vllm_engine_processor(
+    gpu_type,
+    model_opt_125m,
+    tensor_parallel_size,
+    expected_distributed_executor_backend,
+):
     config = vLLMEngineProcessorConfig(
         model_source=model_opt_125m,
         engine_kwargs=dict(
             max_model_len=8192,
+            tensor_parallel_size=tensor_parallel_size,
         ),
         runtime_env=dict(
             env_vars=dict(
@@ -52,7 +62,8 @@ def test_vllm_engine_processor(gpu_type, model_opt_125m):
         "model": model_opt_125m,
         "engine_kwargs": {
             "max_model_len": 8192,
-            "distributed_executor_backend": "mp",
+            "distributed_executor_backend": expected_distributed_executor_backend,
+            "tensor_parallel_size": tensor_parallel_size,
             "task_type": vLLMTaskType.GENERATE,
         },
         "task_type": vLLMTaskType.GENERATE,
@@ -68,12 +79,24 @@ def test_vllm_engine_processor(gpu_type, model_opt_125m):
     assert runtime_env["env_vars"]["RANDOM_ENV_VAR"] == "12345"
     compute = stage.map_batches_kwargs.pop("compute")
     assert isinstance(compute, ray.data._internal.compute.ActorPoolStrategy)
-    assert stage.map_batches_kwargs == {
-        "zero_copy_batch": True,
-        "max_concurrency": 8,
-        "accelerator_type": gpu_type,
-        "num_gpus": 1,
-    }
+
+    if expected_distributed_executor_backend == "ray":
+        ray_remote_args_fn = stage.map_batches_kwargs.pop("ray_remote_args_fn")
+        assert ray_remote_args_fn is not None
+        assert stage.map_batches_kwargs == {
+            "zero_copy_batch": True,
+            "max_concurrency": 8,
+            "accelerator_type": gpu_type,
+            "num_gpus": 0,
+        }
+    else:
+        assert "ray_remote_args_fn" not in stage.map_batches_kwargs
+        assert stage.map_batches_kwargs == {
+            "zero_copy_batch": True,
+            "max_concurrency": 8,
+            "accelerator_type": gpu_type,
+            "num_gpus": 1,
+        }
 
 
 def test_vllm_engine_processor_task_override(model_opt_125m):
@@ -175,7 +198,7 @@ def test_prepare_multimodal_stage_vllm_engine_processor(gpu_type, model_smolvlm_
     assert model_config_kwargs["model"] == model_smolvlm_256m
 
 
-@pytest.mark.parametrize("backend", ["mp", "ray"])
+@pytest.mark.parametrize("backend", ["uni", "mp", "ray"])
 def test_generation_model(gpu_type, model_opt_125m, backend):
     # OPT models don't have chat template, so we use ChatML template
     # here to demonstrate the usage of custom chat template.


### PR DESCRIPTION
## Description
### Why are these changes needed?
We observed suboptimal performance when using `mp` as the distributed executor backend.

### Changes
1. When the world size is 1, use `uni` (uniproc executor) by default to avoid spawning additional processes and IPC overhead.
2. When the world size is greater than 1, prefer `ray` over `mp` as the distributed executor backend for the following reasons:
  a. **Improved resource cleanup**: Using `mp` as the vLLM backend is known to leave dangling processes during engine shutdown, whereas `ray` provides more reliable lifecycle management.
  b. **Unified execution path**: Cross-node PP requires `ray` as the distributed backend. To maintain a consistent code path across different TP/PP configurations, we standardize on `ray`, which supports all TP/PP combinations.
  c. **Advanced placement control**: With `ray` as the distributed backend, users can explicitly control placement via `vLLMEngineProcessorConfig.placement_group_config`, allowing fine-grained scheduling of Ray Data actors.
3. Adapted tests and benchmark script.

## Related issues
N/A

## Additional information
### Classification workload benchmark results
- Setup
  - Model: `HuggingFaceTB/fineweb-edu-classifier`
  - Repro script: `python benchmark_processor.py --mode classify --batch-size 2048 --concurrency 1 --num-prompts 102400 --model HuggingFaceTB/fineweb-edu-classifier`

- Results

| Distributed executor backend | Throughput (rows/s) | Δ vs. uni |
|-----------------------------|---------------------|-----------|
| uni                         | 1361.45             | —         |
| mp                          | 1144.76             | -15.9%    |

Note: With the changes in this PR, the uniproc executor backend is now used by default, whereas mp was the default prior to these changes. Therefore, run the repro script with and without these changes to obtain the results above.

### Generation workload benchmark results
- Purpose: Observe the throughput difference when using different executor backend under different model size / decode length.
- Setup
  - Model: `facebook/opt-1.3b` or `facebook/opt-350m`
  - Repro script
    - uniproc executor backend (default): `python benchmark_processor.py --mode vllm_engine --batch-size 512 --concurrency 1 --num-prompts 2560 --model facebook/opt-350m --max-tokens 1`
    - mp/ray executor backend: `python benchmark_processor.py --mode vllm_engine --batch-size 512 --concurrency 1 --num-prompts 2560 --model facebook/opt-350m --max-tokens 1 --distributed-executor-backend mp`
  - Note: Vary the decode length by adjusting the max-tokens CLI argument.
- Results (Model: `facebook/opt-1.3b`)

| Decode Length | Distributed Executor Backend | Throughput (rows/s) | Δ vs. uni |
|---------------|------------------------------|---------------------|-----------|
| 1             | uni                          | 62.84               | 0.0%      |
| 1             | mp                           | 53.41               | -15.0%    |
| 1             | ray                          | 52.68               | -16.2%    |
| 50            | uni                          | 33.23               | 0.0%      |
| 50            | mp                           | 32.54              | -2.1%    |
| 50            | ray                          | 32.31              | -2.8%    |

- Results (Model: `facebook/opt-350m`)

| Decode Length | Distributed Executor Backend | Throughput (rows/s) | Δ vs. uni |
|---------------|------------------------------|---------------------|-----------|
| 1             | uni                          | 80.38               | 0.0%      |
| 1             | mp                           | 65.78               | -18.2%    |
| 1             | ray                          | 64.68               | -19.5%    |
| 50            | uni                          | 56.84               | 0.0%      |
| 50            | mp                           | 49.34              | -13.2%    |
| 50            | ray                          | 47.80               | -15.9%    |

### Observations
1. When model size and decode length shrink, the gap between `mp` and `uni` becomes more evident.
2. Regardless of workload type, `uni` consistently outperforms `mp` because it avoids spawning additional processes and the associated IPC overhead, even though the data crossing process boundaries is relatively small (limited to sampled tokens and scheduler metadata).

### Conclusions
When GPU work is small, IPC overhead becomes more pronounced, leading to degraded performance when using the `mp` backend. In contrast, as model size and decode length increase, the relative overhead diminishes and the performance gap between `uni` and `mp` narrows.
