### PR TITLE
[core] Use dedicated service account path for Ray auth tokens

### DIFF
--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -151,9 +151,10 @@ TokenLoadResult AuthenticationTokenLoader::TryLoadTokenFromSources() {
     }
   }
 
-  // Precedence 3 (ENABLE_K8S_TOKEN_AUTH only): Load Kubernetes service account token
+  // Precedence 3 (ENABLE_K8S_TOKEN_AUTH only): Load Ray service account token in
+  // /var/run/secrets/ray.io/serviceaccount/token
   if (IsK8sTokenAuthEnabled()) {
-    const std::string k8s_token_path(k8s::kK8sSaTokenPath);
+    const std::string k8s_token_path(k8s::kRaySaTokenPath);
     std::string token_str = TrimWhitespace(ReadTokenFromFile(k8s_token_path));
     if (!token_str.empty()) {
       RAY_LOG(DEBUG)

--- a/src/ray/rpc/authentication/k8s_constants.h
+++ b/src/ray/rpc/authentication/k8s_constants.h
@@ -23,6 +23,7 @@ constexpr char kK8sServicePortEnvVar[] = "KUBERNETES_SERVICE_PORT";
 
 constexpr char kK8sCaCertPath[] = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
 constexpr char kK8sSaTokenPath[] = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+constexpr char kRaySaTokenPath[] = "/var/run/secrets/ray.io/serviceaccount/token";
 
 constexpr char kRayClusterNameEnvVar[] = "RAY_CLUSTER_NAME";
 constexpr char kRayClusterNamespaceEnvVar[] = "RAY_CLUSTER_NAMESPACE";


### PR DESCRIPTION
## Description

This PR updates the default service account token path for Raylet from `/var/run/secrets/kubernetes.io/serviceaccount/token` to  `/var/run/secrets/ray.io/serviceaccount/token`. This is to avoid using the same token that would be used for Kubernetes API access.

Raylet pods can be configured with additional audience-specific tokens using a feature called [serviceAccountToken projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes/#serviceaccounttoken). E.g.:
```yaml
spec:
  containers:
  - name: ray-worker
    ...
    volumeMounts:
    - name: token-vol
      mountPath: "/var/run/secrets/ray.io/service-account"
      readOnly: true
  serviceAccountName: default
  volumes:
  - name: token-vol
    projected:
      sources:
      - serviceAccountToken:
          audience: ray.io
          expirationSeconds: 3600
          path: token
```

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
