### PR TITLE
Update kubernetes token auth verb to ray:write 

### DIFF
--- a/src/ray/rpc/authentication/k8s_constants.h
+++ b/src/ray/rpc/authentication/k8s_constants.h
@@ -40,7 +40,7 @@ constexpr char kAuthorizationAPIVersion[] = "authorization.k8s.io/v1";
 
 constexpr char kRayResourceGroup[] = "ray.io";
 constexpr char kRayClusterResourceName[] = "rayclusters";
-constexpr char kRayClusterRayUserVerb[] = "ray-user";
+constexpr char kRayClusterRayUserVerb[] = "ray:write";
 
 }  // namespace k8s
 }  // namespace rpc


### PR DESCRIPTION
## Description

The current token auth integration with Kubernetes uses custom verb `ray-user`. Although there are no plans to add fine-grain access control, the existing verbs should be future-proof if we add it in the future. This PR updates the custom verb from `ray-user` to `ray:write`, which better describes the access provided and future proof when fine-grain access control is implemented. 

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
