### PR TITLE
[core][autoscaler] Fix invalid status transition from RAY_INSTALLING to RAY_STOP_REQUESTED

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -1186,7 +1186,10 @@ class Reconciler:
                     termination_request=terminate_request,
                     details=f"allocation canceled: {terminate_request.details}",
                 )
-            elif terminate_request.instance_status == IMInstance.ALLOCATED:
+            elif terminate_request.instance_status in (
+                IMInstance.ALLOCATED,
+                IMInstance.RAY_INSTALLING,
+            ):
                 # The instance is not yet running, so we can't request to stop/drain Ray.
                 # Therefore, we can skip the RAY_STOP_REQUESTED state and directly terminate the node.
                 im_instance_to_terminate = im_instances_by_instance_id[instance_id]

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -1877,6 +1877,93 @@ class TestReconciler:
         assert instances["i-0"].status == Instance.TERMINATED
         assert instances["i-1"].status == Instance.TERMINATED
 
+    @staticmethod
+    def test_terminate_ray_installing_instances_max_workers(setup):
+        instance_manager, instance_storage, _, cloud_resource_monitor = setup
+
+        instances = [
+            create_instance(
+                "head",
+                status=Instance.RAY_RUNNING,
+                node_kind=NodeKind.HEAD,
+                cloud_instance_id="c-head",
+                ray_node_id=binary_to_hex(b"r-head"),
+            ),
+            create_instance(
+                "i-0",
+                status=Instance.RAY_INSTALLING,
+                instance_type="type-1",
+                cloud_instance_id="c-0",
+            ),
+            create_instance(
+                "i-1",
+                status=Instance.RAY_INSTALLING,
+                instance_type="type-1",
+                cloud_instance_id="c-1",
+            ),
+        ]
+        TestReconciler._add_instances(instance_storage, instances)
+
+        # Empty list of Ray nodes - RAY_INSTALLING instances have not started ray yet
+        ray_nodes = []
+
+        # Cloud instances for head and installing workers
+        cloud_instances = {
+            "c-head": CloudInstance("c-head", "head", True, NodeKind.HEAD),
+            "c-0": CloudInstance("c-0", "type-1", True, NodeKind.WORKER),
+            "c-1": CloudInstance("c-1", "type-1", True, NodeKind.WORKER),
+        }
+
+        # Scheduler should terminate RAY_INSTALLING instances due to max_workers limit
+        mock_scheduler = MockScheduler(
+            to_launch=[],
+            to_terminate=[
+                TerminationRequest(
+                    id="t0",
+                    instance_id="i-0",
+                    instance_status=Instance.RAY_INSTALLING,
+                    cause=TerminationRequest.Cause.MAX_NUM_NODE_PER_TYPE,
+                ),
+                TerminationRequest(
+                    id="t1",
+                    instance_id="i-1",
+                    instance_status=Instance.RAY_INSTALLING,
+                    cause=TerminationRequest.Cause.MAX_NUM_NODE_PER_TYPE,
+                ),
+            ],
+        )
+
+        Reconciler.reconcile(
+            instance_manager=instance_manager,
+            scheduler=mock_scheduler,
+            cloud_provider=MagicMock(),
+            cloud_resource_monitor=cloud_resource_monitor,
+            ray_cluster_resource_state=ClusterResourceState(
+                node_states=ray_nodes,
+                cluster_resource_state_version=1,
+            ),
+            non_terminated_cloud_instances=cloud_instances,
+            cloud_provider_errors=[],
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(
+                configs={
+                    "node_type_configs": {
+                        "type-1": {
+                            "name": "type-1",
+                            "resources": {"CPU": 1},
+                            "min_worker_nodes": 0,
+                            "max_worker_nodes": 0,
+                        }
+                    },
+                }
+            ),
+        )
+
+        instances, _ = instance_storage.get_instances()
+
+        assert instances["i-0"].status == Instance.TERMINATING
+        assert instances["i-1"].status == Instance.TERMINATING
+
 
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):


### PR DESCRIPTION
## Description

When the autoscaler attempts to terminate instances in `RAY_INSTALLING` state (e.g., due to `max_num_nodes_per_type` limits being reduced), it crashes with an assertion error:

```
AssertionError: Invalid status transition from RAY_INSTALLING to RAY_STOP_REQUESTED
```

<details>
<summary>Full stacktrace</summary>

```
2026-01-22 17:49:33,055    ERROR autoscaler.py:222 -- Invalid status transition from RAY_INSTALLING to RAY_STOP_REQUESTED
Traceback (most recent call last):
  File "/virtualenv/lib/python3.12/site-packages/ray/autoscaler/v2/autoscaler.py", line 206, in update_autoscaling_state
    return Reconciler.reconcile(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/virtualenv/lib/python3.12/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 126, in reconcile
    Reconciler._step_next(
  File "/virtualenv/lib/python3.12/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 289, in _step_next
    Reconciler._scale_cluster(
  File "/virtualenv/lib/python3.12/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 1223, in _scale_cluster
    Reconciler._update_instance_manager(instance_manager, version, updates)
  File "/virtualenv/lib/python3.12/site-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 635, in _update_instance_manager
    reply = instance_manager.update_instance_manager_state(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/virtualenv/lib/python3.12/site-packages/ray/autoscaler/v2/instance_manager/instance_manager.py", line 94, in update_instance_manager_state
    instance = self._update_instance(
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/virtualenv/lib/python3.12/site-packages/ray/autoscaler/v2/instance_manager/instance_manager.py", line 264, in _update_instance
    assert InstanceUtil.set_status(instance, update.new_instance_status), (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Invalid status transition from RAY_INSTALLING to RAY_STOP_REQUESTED
```

</details>

The reconciler incorrectly tries to transition `RAY_INSTALLING` to `RAY_STOP_REQUESTED`, but the state machine doesn't allow this. Ray isn't running yet, so there's nothing to stop/drain.

This fix adds `RAY_INSTALLING` to the same condition as `ALLOCATED`. Both states have cloud instances allocated but Ray not yet running, so they should transition directly to `TERMINATING`.

## Related issues

Related to #59219 and #59550 (which fixed the same issue for `QUEUED` instances)

## Additional information

The valid transitions from `RAY_INSTALLING` are: `RAY_RUNNING`, `RAY_INSTALL_FAILED`, `RAY_STOPPED`, `TERMINATING`, `TERMINATED`. `RAY_STOP_REQUESTED` is not in this set.