### PR TITLE
[train][release-test] Fix bool parsing for training benchmarks

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1634,7 +1634,7 @@
     - __suffix__: full_training.parquet.preserve_order
       run:
         timeout: 2000
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --image_classification_data_format=parquet --preserve_order
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --image_classification_data_format=parquet --preserve_order=True
 
     - __suffix__: full_training.parquet.torch_dataloader
       run:
@@ -1644,22 +1644,22 @@
     - __suffix__: skip_training.parquet
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet
 
     - __suffix__: skip_training.parquet.preserve_order
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --image_classification_data_format=parquet --preserve_order
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet --preserve_order=True
 
     - __suffix__: skip_training.parquet.torch_dataloader
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=torch --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=torch --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet
 
     - __suffix__: skip_training.parquet.fault_tolerance
       run:
         timeout: 2700
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --mock_gpu --skip_train_step --skip_validation_step --num_epochs=5 --max_failures=4 --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --mock_gpu=True --skip_train_step=True --skip_validation_step=True --num_epochs=5 --max_failures=4 --image_classification_data_format=parquet
         prepare: python setup_chaos.py --kill-interval 480 --max-to-kill 2 --kill-delay 360
       cluster:
         cluster_compute: compute_configs/compute_mock_gpu_4x4_aws.yaml
@@ -1667,7 +1667,7 @@
     - __suffix__: skip_training.parquet.fault_tolerance.preserve_order
       run:
         timeout: 2700
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --mock_gpu --skip_train_step --skip_validation_step --num_epochs=5 --max_failures=4 --image_classification_data_format=parquet --preserve_order
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --mock_gpu=True --skip_train_step=True --skip_validation_step=True --num_epochs=5 --max_failures=4 --image_classification_data_format=parquet --preserve_order=True
         prepare: python setup_chaos.py --kill-interval 480 --max-to-kill 2 --kill-delay 360
       cluster:
         cluster_compute: compute_configs/compute_mock_gpu_4x4_aws.yaml
@@ -1680,7 +1680,7 @@
     - __suffix__: full_training.jpeg.preserve_order
       run:
         timeout: 2000
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=ray_data --num_workers=16 --preserve_order
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=ray_data --num_workers=16 --preserve_order=True
 
     - __suffix__: full_training.jpeg.torch_dataloader
       run:
@@ -1690,57 +1690,57 @@
     - __suffix__: skip_training.jpeg
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True
 
     - __suffix__: skip_training.jpeg.preserve_order
       run:
         timeout: 2400
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --preserve_order
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --preserve_order=True
 
     - __suffix__: skip_training.jpeg.torch_dataloader
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=torch --num_workers=16 --num_torch_workers=16 --skip_train_step --skip_validation_at_epoch_end
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --dataloader_type=torch --num_workers=16 --num_torch_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True
 
     - __suffix__: skip_training.jpeg.local_fs
       run:
         timeout: 1200
-        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset --dataloader_type=ray_data --num_workers=1 --skip_train_step --skip_validation_at_epoch_end
+        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset=True --dataloader_type=ray_data --num_workers=1 --skip_train_step=True --skip_validation_at_epoch_end=True
       cluster:
         cluster_compute: compute_configs/compute_gpu_1x1_aws.yaml
 
     - __suffix__: skip_training.jpeg.local_fs.preserve_order
       run:
         timeout: 1200
-        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset --dataloader_type=ray_data --num_workers=1 --skip_train_step --skip_validation_at_epoch_end --preserve_order
+        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset=True --dataloader_type=ray_data --num_workers=1 --skip_train_step=True --skip_validation_at_epoch_end=True --preserve_order=True
       cluster:
         cluster_compute: compute_configs/compute_gpu_1x1_aws.yaml
 
     - __suffix__: skip_training.jpeg.local_fs.torch_dataloader
       run:
         timeout: 1200
-        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset --dataloader_type=torch --num_workers=1 --num_torch_workers=32 --skip_train_step --skip_validation_at_epoch_end
+        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset=True --dataloader_type=torch --num_workers=1 --num_torch_workers=32 --skip_train_step=True --skip_validation_at_epoch_end=True
       cluster:
         cluster_compute: compute_configs/compute_gpu_1x1_aws.yaml
 
     - __suffix__: skip_training.jpeg.local_fs_multi_gpus
       run:
         timeout: 1200
-        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset --dataloader_type=ray_data --num_workers=4 --skip_train_step --skip_validation_at_epoch_end
+        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset=True --dataloader_type=ray_data --num_workers=4 --skip_train_step=True --skip_validation_at_epoch_end=True
       cluster:
         cluster_compute: compute_configs/compute_gpu_1x1_multi_gpus_aws.yaml
 
     - __suffix__: skip_training.jpeg.local_fs_multi_gpus.preserve_order
       run:
         timeout: 1200
-        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset --dataloader_type=ray_data --num_workers=4 --skip_train_step --skip_validation_at_epoch_end --preserve_order
+        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset=True --dataloader_type=ray_data --num_workers=4 --skip_train_step=True --skip_validation_at_epoch_end=True --preserve_order=True
       cluster:
         cluster_compute: compute_configs/compute_gpu_1x1_multi_gpus_aws.yaml
 
     - __suffix__: skip_training.jpeg.local_fs_multi_gpus.torch_dataloader
       run:
         timeout: 1200
-        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset --dataloader_type=torch --num_workers=4 --num_torch_workers=9 --skip_train_step --skip_validation_at_epoch_end
+        script: bash image_classification/jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --image_classification_data_format=jpeg --image_classification_local_dataset=True --dataloader_type=torch --num_workers=4 --num_torch_workers=9 --skip_train_step=True --skip_validation_at_epoch_end=True
       cluster:
         cluster_compute: compute_configs/compute_gpu_1x1_multi_gpus_aws.yaml
 
@@ -1763,12 +1763,12 @@
     - __suffix__: skip_training.mock_dataloader
       run:
         timeout: 600
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=recsys --dataloader_type=mock --num_workers=8 --train_batch_size=8192 --num_epochs=1 --skip_train_step --skip_validation_at_epoch_end
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=recsys --dataloader_type=mock --num_workers=8 --train_batch_size=8192 --num_epochs=1 --skip_train_step=True --skip_validation_at_epoch_end=True
 
     - __suffix__: skip_training.ray_data
       run:
         timeout: 600
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=recsys --dataloader_type=ray_data --num_workers=8 --train_batch_size=8192 --num_epochs=1 --skip_train_step --skip_validation_at_epoch_end
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=recsys --dataloader_type=ray_data --num_workers=8 --train_batch_size=8192 --num_epochs=1 --skip_train_step=True --skip_validation_at_epoch_end=True
 
     - __suffix__: full_training.mock_dataloader
       run:

--- a/release/train_tests/benchmark/config.py
+++ b/release/train_tests/benchmark/config.py
@@ -100,14 +100,19 @@ def _is_pydantic_model(field_type) -> bool:
     return isinstance(field_type, type) and issubclass(field_type, BaseModel)
 
 
+def _str_to_bool(value: str) -> bool:
+    """Convert a string to a boolean value."""
+    if value.lower() == "true":
+        return True
+    elif value.lower() == "false":
+        return False
+    raise argparse.ArgumentTypeError(f"'True' or 'False' expected, got '{value}'")
+
+
 def _add_field_to_parser(parser: argparse.ArgumentParser, field: str, field_info):
     field_type = field_info.annotation
     if field_type is bool:
-        parser.add_argument(
-            f"--{field}",
-            action="store_true",
-            help=f"Enable {field} (default: {field_info.default})",
-        )
+        parser.add_argument(f"--{field}", type=_str_to_bool, default=field_info.default)
     else:
         parser.add_argument(f"--{field}", type=field_type, default=field_info.default)
 
@@ -151,3 +156,8 @@ def cli_to_config(benchmark_config_cls=BenchmarkConfig) -> BenchmarkConfig:
         nested_configs[nested_field] = nested_config_cls(**vars(args))
 
     return benchmark_config_cls(**vars(top_level_args), **nested_configs)
+
+
+if __name__ == "__main__":
+    config = cli_to_config()
+    print(config)


### PR DESCRIPTION
## Description

This PR changes the bool parsing from `store_true` to parsing an input `True/False` string.

This fixes an issue where default bool values are always set to `False` unless they're explicitly included as a CLI flag.
* **The problem:** `action="store_true"` always defaults to False and ignores any `default=` parameter.  Fields with `default=True` (like `enable_operator_progress_bars`, `actor_locality_enabled`, `enable_shard_locality`) would incorrectly default to False when parsed through the CLI, completely ignoring the Pydantic model's default.

Also updates the release test commands from `--bool_flag` -> `--bool_flag=True`

## Additional information

Before PR:
```python
❯ python config.py --mock_gpu
{ 'checkpoint_every_n_steps': -1,
  'dataloader_config': RayDataConfig(train_batch_size=32, limit_training_rows=1000000, validation_batch_size=256, limit_validation_rows=50000, local_buffer_shuffle_size=-1, enable_operator_progress_bars=False, ray_data_prefetch_batches=4, ray_data_override_num_blocks=-1,
  locality_with_output=False,      # <-- Wrong default! should be True
  actor_locality_enabled=False,  # <-- Wrong default! should be True
  enable_shard_locality=False,
  preserve_order=False,
  ray_data_pin_memory=False),
  'dataloader_type': <DataloaderType.RAY_DATA: 'ray_data'>,
  'log_metrics_every_n_steps': 512,
  'max_failures': 0,
  'mock_gpu': True,    # <-- bool configs are only True when you explicitly pass them in the CLI
  'num_epochs': 1,
  'num_workers': 1,
  'skip_train_step': False,
  'skip_validation_at_epoch_end': False,
  'skip_validation_step': False,
  'task': 'image_classification',
  'task_config': ImageClassificationConfig(image_classification_local_dataset=False, image_classification_data_format=<ImageFormat.PARQUET: 'parquet'>),
  'validate_every_n_steps': -1}
```

After PR:

```python
❯ python config.py --mock_gpu=True
{ 'checkpoint_every_n_steps': -1,
  'dataloader_config': RayDataConfig(train_batch_size=32, limit_training_rows=1000000, validation_batch_size=256, limit_validation_rows=50000, local_buffer_shuffle_size=-1, enable_operator_progress_bars=True, ray_data_prefetch_batches=4, ray_data_override_num_blocks=-1, locality_with_output=False,
   actor_locality_enabled=True,  # <-- These default values now reflect the actual defaults in the default configs.
   enable_shard_locality=True,   # <-- 
   preserve_order=False,
   ray_data_pin_memory=False),
  'dataloader_type': <DataloaderType.RAY_DATA: 'ray_data'>,
  'log_metrics_every_n_steps': 512,
  'max_failures': 0,
  'mock_gpu': True,   # <-- Still able to configure other bools properly
  'num_epochs': 1,
  'num_workers': 1,
  'skip_train_step': False,
  'skip_validation_at_epoch_end': False,
  'skip_validation_step': False,
  'task': 'image_classification',
  'task_config': ImageClassificationConfig(image_classification_local_dataset=False, image_classification_data_format=<ImageFormat.PARQUET: 'parquet'>),
  'validate_every_n_steps': -1}
```