### PR TITLE
[core] Removing exception for using old-style Python 2.1 classes.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2398,14 +2398,6 @@ def _modify_class(cls):
     if hasattr(cls, "__ray_actor_class__"):
         return cls
 
-    # Give an error if cls is an old-style class.
-    if not issubclass(cls, object):
-        raise TypeError(
-            "The @ray.remote decorator cannot be applied to old-style "
-            "classes. In Python 2, you must declare the class with "
-            "'class ClassName(object):' instead of 'class ClassName:'."
-        )
-
     # Modify the class to have additional default methods.
     class Class(cls):
         __ray_actor_class__ = cls  # The original actor class


### PR DESCRIPTION
This was from 7 years ago. We really truly don't support Python 2 anymore.