### PR TITLE
[Data] - Add warning for `udf_warning_row_count=False`

### DIFF
--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -589,11 +589,10 @@ def _generate_transform_fn_for_map_batches(
         ) -> Iterable[DataBatch]:
             for batch in batches:
                 try:
-                    is_empty_block = (
+                    if (
                         not isinstance(batch, collections.abc.Mapping)
                         and BlockAccessor.for_block(batch).num_rows() == 0
-                    )
-                    if is_empty_block:
+                    ):
                         # For empty input blocks, we directly output them without
                         # calling the UDF.
                         # TODO(hchen): This workaround is because some all-to-all
@@ -624,7 +623,8 @@ def _generate_transform_fn_for_map_batches(
                             "giving it to fn. To elide this copy, modify your mapper "
                             "function so it doesn't try to mutate its input."
                         ) from e
-                    raise e from None
+                    else:
+                        raise e from None
                 else:
                     output_num_rows = 0
                     for out_batch in res:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3,7 +3,6 @@ import copy
 import html
 import itertools
 import logging
-import sys
 import time
 import warnings
 from typing import (
@@ -150,19 +149,6 @@ if TYPE_CHECKING:
     from ray.data._internal.execution.streaming_executor import StreamingExecutor
     from ray.data.grouped_data import GroupedData
     from ray.data.stats import DatasetSummary
-
-
-class MapBatchesRowCountWarning(UserWarning):
-    """Warning issued when map_batches is called without explicitly specifying
-    udf_modifying_row_count."""
-
-    pass
-
-
-# By default, print the first occurrence of matching warnings for
-# each module where the warning is issued (regardless of line number)
-if not sys.warnoptions:
-    warnings.filterwarnings("once", category=MapBatchesRowCountWarning)
 
 
 logger = logging.getLogger(__name__)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3,6 +3,7 @@ import copy
 import html
 import itertools
 import logging
+import sys
 import time
 import warnings
 from typing import (
@@ -158,8 +159,10 @@ class MapBatchesRowCountWarning(UserWarning):
     pass
 
 
-# Ensure this warning is only shown once per session
-warnings.filterwarnings("once", category=MapBatchesRowCountWarning)
+# By default, print the first occurrence of matching warnings for
+# each module where the warning is issued (regardless of line number)
+if not sys.warnoptions:
+    warnings.filterwarnings("once", category=MapBatchesRowCountWarning)
 
 
 logger = logging.getLogger(__name__)
@@ -719,16 +722,6 @@ class Dataset:
                 Call this method to transform one record at time.
 
         """  # noqa: E501
-        if not udf_modifying_row_count:
-            warnings.warn(
-                "By default, `map_batches` assumes the provided function doesn't "
-                "modify the number of rows, enabling optimizations like limit pushdown. "
-                "If your function filters rows or generates additional rows, set "
-                "`udf_modifying_row_count=True` to disable these optimizations and "
-                "ensure correct results.",
-                category=MapBatchesRowCountWarning,
-                stacklevel=2,
-            )
         use_gpus = num_gpus is not None and num_gpus > 0
         if use_gpus and (batch_size is None or batch_size == "default"):
             raise ValueError(


### PR DESCRIPTION
## Description
`map_batches` assumes that the UDF doesn't modify the number of output rows which by default enables certain logical optimizations to take place. But if the user's UDF does modify the number of rows, then these optimizations (like limit pushdown) should not be enforced to guarantee correctness.

This change just adds a simple warning to convey the above message.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
