### PR TITLE
[core] Unbreak gcs tests on Windows due to long command paths

### DIFF
--- a/src/ray/gcs/tests/BUILD.bazel
+++ b/src/ray/gcs/tests/BUILD.bazel
@@ -42,6 +42,10 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
+    features = select({
+        "@platforms//os:windows": ["compiler_param_file"],
+        "//conditions:default": [],
+    }),
     tags = [
         "no_tsan",
         "no_windows",

--- a/src/ray/gcs/tests/BUILD.bazel
+++ b/src/ray/gcs/tests/BUILD.bazel
@@ -42,10 +42,6 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
-    features = select({
-        "@platforms//os:windows": ["compiler_param_file"],
-        "//conditions:default": [],
-    }),
     tags = [
         "no_tsan",
         "no_windows",

--- a/src/ray/gcs_rpc_client/tests/BUILD.bazel
+++ b/src/ray/gcs_rpc_client/tests/BUILD.bazel
@@ -28,6 +28,10 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
+    features = select({
+        "@platforms//os:windows": ["compiler_param_file"],
+        "//conditions:default": [],
+    }),
     tags = ["team:core"],
     deps = [
         "//src/ray/common:test_utils",
@@ -55,6 +59,10 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
+    features = select({
+        "@platforms//os:windows": ["compiler_param_file"],
+        "//conditions:default": [],
+    }),
     tags = [
         "exclusive",
         "no_tsan",
@@ -85,6 +93,10 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
+    features = select({
+        "@platforms//os:windows": ["compiler_param_file"],
+        "//conditions:default": [],
+    }),
     tags = [
         "no_windows",
         "team:core",

--- a/src/ray/gcs_rpc_client/tests/BUILD.bazel
+++ b/src/ray/gcs_rpc_client/tests/BUILD.bazel
@@ -93,10 +93,6 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
-    features = select({
-        "@platforms//os:windows": ["compiler_param_file"],
-        "//conditions:default": [],
-    }),
     tags = [
         "no_windows",
         "team:core",


### PR DESCRIPTION
Seems like gcs_client_test is breaking on windows due to the same issue as #60213 and I think any test that uses gcs_server_lib probably has a high chance of running into this issue due to it's lengthy list of dependencies. Adding the compiler_param_file flag to any bazel target that depends on it. 
