### PR TITLE
[ci] port Buildkite Ray Images to Wanda

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -133,91 +133,261 @@ steps:
     depends_on: manylinux-x86_64
     job_env: manylinux-x86_64
 
-  - label: ":tapioca: build: ray py{{matrix}} docker (x86_64)"
-    key: ray_images
+  - name: ray-image-cpu-build
+    label: "wanda: ray py{{matrix}} cpu (x86_64)"
+    wanda: ci/docker/ray-image-cpu.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: ""
     tags:
       - python_dependencies
       - docker
       - oss
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
-        --platform cu11.7.1-cudnn8 --platform cu11.8.0-cudnn8
-        --platform cu12.1.1-cudnn8 --platform cu12.3.2-cudnn9
-        --platform cu12.4.1-cudnn --platform cu12.5.1-cudnn
-        --platform cu12.6.3-cudnn --platform cu12.8.1-cudnn
-        --platform cu12.9.1-cudnn
-        --platform cpu
-        --image-type ray --upload
     depends_on:
-      - manylinux-x86_64
-      - forge
-      - raycudabase
+      - ray-wheel-build
       - raycpubase
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
 
-  - label: ":tapioca: build: ray-extra py{{matrix}} docker (x86_64)"
-    key: ray_extra_images
+  - name: ray-image-cuda-build
+    label: "wanda: ray py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
+    wanda: ci/docker/ray-image-cuda.wanda.yaml
+    matrix:
+      setup:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+        cuda:
+          - "11.7.1-cudnn8"
+          - "11.8.0-cudnn8"
+          - "12.1.1-cudnn8"
+          - "12.3.2-cudnn9"
+          - "12.4.1-cudnn"
+          - "12.5.1-cudnn"
+          - "12.6.3-cudnn"
+          - "12.8.1-cudnn"
+          - "12.9.1-cudnn"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix.python}}"
+      CUDA_VERSION: "{{matrix.cuda}}"
+      ARCH_SUFFIX: ""
     tags:
       - python_dependencies
       - docker
       - oss
-    instance_type: medium
+    depends_on:
+      - ray-wheel-build
+      - raycudabase
+
+  - label: ":crane: publish: ray py{{matrix}} (x86_64)"
+    key: ray_images_push
+    instance_type: small
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
-        --platform cu11.7.1-cudnn8 --platform cu11.8.0-cudnn8
-        --platform cu12.1.1-cudnn8 --platform cu12.3.2-cudnn9
-        --platform cu12.4.1-cudnn --platform cu12.5.1-cudnn
-        --platform cu12.6.3-cudnn --platform cu12.8.1-cudnn
-        --platform cu12.9.1-cudnn
+      - bazel run //.buildkite:copy_files -- --destination docker_login
+      - bazel run //ci/ray_ci/automation:push_ray_image --
+        --python-version {{matrix}}
         --platform cpu
-        --image-type ray-extra --upload
-    depends_on:
-      - manylinux-x86_64
-      - forge
-      - raycpubaseextra
-      - raycudabaseextra
+        --platform cu11.7.1-cudnn8
+        --platform cu11.8.0-cudnn8
+        --platform cu12.1.1-cudnn8
+        --platform cu12.3.2-cudnn9
+        --platform cu12.4.1-cudnn
+        --platform cu12.5.1-cudnn
+        --platform cu12.6.3-cudnn
+        --platform cu12.8.1-cudnn
+        --platform cu12.9.1-cudnn
+        --image-type ray
+        --architecture x86_64
     matrix:
       - "3.10"
       - "3.11"
       - "3.12"
       - "3.13"
-
-  - label: ":tapioca: build: ray-llm py{{matrix}} docker (x86_64)"
+    depends_on:
+      - ray-image-cpu-build
+      - ray-image-cuda-build
     tags:
       - python_dependencies
       - docker
       - oss
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
-        --platform cu12.8.1-cudnn --image-type ray-llm --upload
+      - skip-on-premerge
+
+  - name: ray-extra-image-cpu-build
+    label: "wanda: ray-extra py{{matrix}} cpu (x86_64)"
+    wanda: ci/docker/ray-extra-image-cpu.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: ""
+    tags:
+      - python_dependencies
+      - docker
+      - oss
     depends_on:
-      - manylinux-x86_64
-      - forge
+      - ray-wheel-build
+      - raycpubaseextra
+
+  - name: ray-extra-image-cuda-build
+    label: "wanda: ray-extra py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
+    wanda: ci/docker/ray-extra-image-cuda.wanda.yaml
+    matrix:
+      setup:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+        cuda:
+          - "11.7.1-cudnn8"
+          - "11.8.0-cudnn8"
+          - "12.1.1-cudnn8"
+          - "12.3.2-cudnn9"
+          - "12.4.1-cudnn"
+          - "12.5.1-cudnn"
+          - "12.6.3-cudnn"
+          - "12.8.1-cudnn"
+          - "12.9.1-cudnn"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix.python}}"
+      CUDA_VERSION: "{{matrix.cuda}}"
+      ARCH_SUFFIX: ""
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+    depends_on:
+      - ray-wheel-build
+      - raycudabaseextra
+
+  - name: ray-llm-image-cuda-build
+    label: "wanda: ray-llm py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
+    wanda: ci/docker/ray-llm-image-cuda.wanda.yaml
+    matrix:
+      setup:
+        python:
+          - "3.11"
+        cuda:
+          - "12.8.1-cudnn"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix.python}}"
+      CUDA_VERSION: "{{matrix.cuda}}"
+      ARCH_SUFFIX: ""
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+    depends_on:
+      - ray-wheel-build
       - ray-llmbase
-    matrix:
-      - "3.11"
 
-  - label: ":tapioca: build: ray-llm-extra py{{matrix}} docker (x86_64)"
+  - name: ray-llm-extra-image-cuda-build
+    label: "wanda: ray-llm-extra py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
+    wanda: ci/docker/ray-llm-extra-image-cuda.wanda.yaml
+    matrix:
+      setup:
+        python:
+          - "3.11"
+        cuda:
+          - "12.8.1-cudnn"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix.python}}"
+      CUDA_VERSION: "{{matrix.cuda}}"
+      ARCH_SUFFIX: ""
     tags:
       - python_dependencies
       - docker
       - oss
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
-        --platform cu12.8.1-cudnn --image-type ray-llm-extra --upload
     depends_on:
-      - manylinux-x86_64
-      - forge
+      - ray-wheel-build
       - ray-llmbaseextra
+
+  - label: ":crane: publish: ray-extra py{{matrix}} (x86_64)"
+    key: ray_extra_images_push
+    instance_type: small
+    commands:
+      - bazel run //.buildkite:copy_files -- --destination docker_login
+      - bazel run //ci/ray_ci/automation:push_ray_image --
+        --python-version {{matrix}}
+        --platform cpu
+        --platform cu11.7.1-cudnn8
+        --platform cu11.8.0-cudnn8
+        --platform cu12.1.1-cudnn8
+        --platform cu12.3.2-cudnn9
+        --platform cu12.4.1-cudnn
+        --platform cu12.5.1-cudnn
+        --platform cu12.6.3-cudnn
+        --platform cu12.8.1-cudnn
+        --platform cu12.9.1-cudnn
+        --image-type ray-extra
+        --architecture x86_64
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    depends_on:
+      - ray-extra-image-cpu-build
+      - ray-extra-image-cuda-build
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+      - skip-on-premerge
+
+  - label: ":crane: publish: ray-llm py{{matrix}} (x86_64)"
+    key: ray_llm_images_cuda_push
+    instance_type: small
+    commands:
+      - bazel run //.buildkite:copy_files -- --destination docker_login
+      - bazel run //ci/ray_ci/automation:push_ray_image --
+        --python-version {{matrix}}
+        --platform cu12.8.1-cudnn
+        --image-type ray-llm
+        --architecture x86_64
     matrix:
       - "3.11"
+    depends_on:
+      - ray-llm-image-cuda-build
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+      - skip-on-premerge
+
+  - label: ":crane: publish: ray-llm-extra py{{matrix}} (x86_64)"
+    key: ray_llm_extra_images_cuda_push
+    instance_type: small
+    commands:
+      - bazel run //.buildkite:copy_files -- --destination docker_login
+      - bazel run //ci/ray_ci/automation:push_ray_image --
+        --python-version {{matrix}}
+        --platform cu12.8.1-cudnn
+        --image-type ray-llm-extra
+        --architecture x86_64
+    matrix:
+      - "3.11"
+    depends_on:
+      - ray-llm-extra-image-cuda-build
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+      - skip-on-premerge
 
   - label: ":tapioca: smoke test build-docker.sh"
     tags:
@@ -244,6 +414,6 @@ steps:
       - bazel run .buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:generate_index -- --prefix nightly
     depends_on:
-      - ray_images
-      - ray_images_aarch64
+      - ray_images_push
+      - ray_images_push_aarch64
       - forge

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -234,61 +234,181 @@ steps:
       - linux_wheels
       - oss
 
-  - label: ":tapioca: build: ray-extra py{{matrix}} docker (aarch64)"
-    key: ray_extra_images_aarch64
-    tags:
-      - python_dependencies
-      - docker
-      - oss
-    instance_type: medium-arm64
-    commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
-        --platform cu11.7.1-cudnn8 --platform cu11.8.0-cudnn8
-        --platform cu12.1.1-cudnn8 --platform cu12.3.2-cudnn9
-        --platform cu12.4.1-cudnn --platform cu12.5.1-cudnn
-        --platform cu12.6.3-cudnn --platform cu12.8.1-cudnn
-        --platform cu12.9.1-cudnn
-        --platform cpu
-        --image-type ray-extra --architecture aarch64 --upload
-    depends_on:
-      - manylinux-aarch64
-      - forge-aarch64
-      - raycudabaseextra-aarch64
-      - raycpubaseextra-aarch64
-    job_env: forge-aarch64
+  - name: ray-image-cpu-build-aarch64
+    label: "wanda: ray py{{matrix}} cpu (aarch64)"
+    wanda: ci/docker/ray-image-cpu.wanda.yaml
     matrix:
       - "3.10"
       - "3.11"
       - "3.12"
       - "3.13"
-
-  - label: ":tapioca: build: ray py{{matrix}} docker (aarch64)"
-    key: ray_images_aarch64
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
       - docker
       - oss
-    instance_type: medium-arm64
-    commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
-        --platform cu11.7.1-cudnn8 --platform cu11.8.0-cudnn8
-        --platform cu12.1.1-cudnn8 --platform cu12.3.2-cudnn9
-        --platform cu12.4.1-cudnn --platform cu12.5.1-cudnn
-        --platform cu12.6.3-cudnn --platform cu12.8.1-cudnn
-        --platform cu12.9.1-cudnn
-        --platform cpu
-        --image-type ray --architecture aarch64 --upload
     depends_on:
-      - manylinux-aarch64
-      - forge-aarch64
-      - raycudabase-aarch64
+      - ray-wheel-build-aarch64
       - raycpubase-aarch64
-    job_env: forge-aarch64
+    instance_type: builder-arm64
+
+  - name: ray-image-cuda-build-aarch64
+    label: "wanda: ray py{{matrix.python}} cu{{matrix.cuda}} (aarch64)"
+    wanda: ci/docker/ray-image-cuda.wanda.yaml
+    matrix:
+      setup:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+        cuda:
+          - "11.7.1-cudnn8"
+          - "11.8.0-cudnn8"
+          - "12.1.1-cudnn8"
+          - "12.3.2-cudnn9"
+          - "12.4.1-cudnn"
+          - "12.5.1-cudnn"
+          - "12.6.3-cudnn"
+          - "12.8.1-cudnn"
+          - "12.9.1-cudnn"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix.python}}"
+      CUDA_VERSION: "{{matrix.cuda}}"
+      ARCH_SUFFIX: "-aarch64"
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+    depends_on:
+      - ray-wheel-build-aarch64
+      - raycudabase-aarch64
+    instance_type: builder-arm64
+
+  - label: ":crane: publish: ray py{{matrix}} (aarch64)"
+    key: ray_images_push_aarch64
+    instance_type: small  # x86_64 instance since crane is currently only x86_64
+    commands:
+      - bazel run //.buildkite:copy_files -- --destination docker_login
+      - bazel run //ci/ray_ci/automation:push_ray_image --
+        --python-version {{matrix}}
+        --platform cpu
+        --platform cu11.7.1-cudnn8
+        --platform cu11.8.0-cudnn8
+        --platform cu12.1.1-cudnn8
+        --platform cu12.3.2-cudnn9
+        --platform cu12.4.1-cudnn
+        --platform cu12.5.1-cudnn
+        --platform cu12.6.3-cudnn
+        --platform cu12.8.1-cudnn
+        --platform cu12.9.1-cudnn
+        --image-type ray
+        --architecture aarch64
     matrix:
       - "3.10"
       - "3.11"
       - "3.12"
       - "3.13"
+    depends_on:
+      - ray-image-cpu-build-aarch64
+      - ray-image-cuda-build-aarch64
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+      - skip-on-premerge
+
+  - name: ray-extra-image-cpu-build-aarch64
+    label: "wanda: ray-extra py{{matrix}} cpu (aarch64)"
+    wanda: ci/docker/ray-extra-image-cpu.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: "-aarch64"
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+    depends_on:
+      - ray-wheel-build-aarch64
+      - raycpubaseextra-aarch64
+    instance_type: builder-arm64
+
+  - name: ray-extra-image-cuda-build-aarch64
+    label: "wanda: ray-extra py{{matrix.python}} cu{{matrix.cuda}} (aarch64)"
+    wanda: ci/docker/ray-extra-image-cuda.wanda.yaml
+    matrix:
+      setup:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+        cuda:
+          - "11.7.1-cudnn8"
+          - "11.8.0-cudnn8"
+          - "12.1.1-cudnn8"
+          - "12.3.2-cudnn9"
+          - "12.4.1-cudnn"
+          - "12.5.1-cudnn"
+          - "12.6.3-cudnn"
+          - "12.8.1-cudnn"
+          - "12.9.1-cudnn"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix.python}}"
+      CUDA_VERSION: "{{matrix.cuda}}"
+      ARCH_SUFFIX: "-aarch64"
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+    depends_on:
+      - ray-wheel-build-aarch64
+      - raycudabaseextra-aarch64
+    instance_type: builder-arm64
+
+  - label: ":crane: publish: ray-extra py{{matrix}} (aarch64)"
+    key: ray_extra_images_push_aarch64
+    instance_type: small
+    commands:
+      - bazel run //.buildkite:copy_files -- --destination docker_login
+      - bazel run //ci/ray_ci/automation:push_ray_image --
+        --python-version {{matrix}}
+        --platform cpu
+        --platform cu11.7.1-cudnn8
+        --platform cu11.8.0-cudnn8
+        --platform cu12.1.1-cudnn8
+        --platform cu12.3.2-cudnn9
+        --platform cu12.4.1-cudnn
+        --platform cu12.5.1-cudnn
+        --platform cu12.6.3-cudnn
+        --platform cu12.8.1-cudnn
+        --platform cu12.9.1-cudnn
+        --image-type ray-extra
+        --architecture aarch64
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    depends_on:
+      - ray-extra-image-cpu-build-aarch64
+      - ray-extra-image-cuda-build-aarch64
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+      - skip-on-premerge
 
   - label: ":ray: core: wheel-aarch64 tests"
     tags: linux_wheels

--- a/ci/ray_ci/automation/test_update_version_lib.py
+++ b/ci/ray_ci/automation/test_update_version_lib.py
@@ -104,6 +104,7 @@ def test_update_file_version(main_version, java_version, new_version):
         non_java_file_paths = [
             "ci/ray_ci/utils.py",
             "python/ray/_version.py",
+            "rayci.env",
             "src/ray/common/constants.h",
         ]
         select_java_file_paths = [
@@ -193,6 +194,7 @@ def test_update_file_version_fail_no_java_file():
         non_java_file_paths = [
             "ci/ray_ci/utils.py",
             "python/ray/_version.py",
+            "rayci.env",
             "src/ray/common/constants.h",
         ]
         for file_path in non_java_file_paths:

--- a/ci/ray_ci/automation/update_version_lib.py
+++ b/ci/ray_ci/automation/update_version_lib.py
@@ -55,6 +55,7 @@ def update_file_version(
     non_java_files = [
         "ci/ray_ci/utils.py",
         "python/ray/_version.py",
+        "rayci.env",
         "src/ray/common/constants.h",
     ]
     non_java_files.sort()

--- a/rayci.env
+++ b/rayci.env
@@ -1,2 +1,3 @@
 # Common variable defaults used in rayci.
 MANYLINUX_VERSION=260128.221a193
+RAY_VERSION=3.0.0.dev0


### PR DESCRIPTION
Updates buildkite steps to use Wanda+Dockerfile, including both build and upload steps.
For now, missing parity on uploading pip-freeze to Buildkite Artifacts. To be done in subsequent Wanda feature

Topic: wanda-image-upload
Relative: multiplat-support
Signed-off-by: andrew <andrew@anyscale.com>