### PR TITLE
[Train][Data] Add heterogeneous cluster configurations for training ingest benchmarks

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1790,7 +1790,7 @@
     - __suffix__: skip_training.parquet
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet
 
 - name: training_ingest_benchmark-task=recsys
   python: "3.10"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1766,7 +1766,7 @@
     - __suffix__: skip_training.parquet
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step True --skip_validation_at_epoch_end True --image_classification_data_format=parquet
 
 - name: training_ingest_benchmark-task=image_classification-heterogenous_autoscaling
   python: "3.10"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1790,7 +1790,7 @@
     - __suffix__: skip_training.parquet
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step True --skip_validation_at_epoch_end True --image_classification_data_format=parquet
 
 - name: training_ingest_benchmark-task=recsys
   python: "3.10"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1744,6 +1744,54 @@
       cluster:
         cluster_compute: compute_configs/compute_gpu_1x1_multi_gpus_aws.yaml
 
+- name: training_ingest_benchmark-task=image_classification-heterogenous_fixed_size
+  python: "3.10"
+  group: Train tests
+  working_dir: train_tests/benchmark
+
+  frequency: nightly
+  team: ml
+
+  cluster:
+    byod:
+      runtime_env:
+        # Enable verbose stats for resource manager
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+
+      # 'type: gpu' means: use the 'ray-ml' image.
+      type: gpu
+    cluster_compute: compute_configs/heterogenous_fixed_size_gpu_4x4_aws.yaml
+
+  variations:
+    - __suffix__: skip_training.parquet
+      run:
+        timeout: 1200
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --image_classification_data_format=parquet
+
+- name: training_ingest_benchmark-task=image_classification-heterogenous_autoscaling
+  python: "3.10"
+  group: Train tests
+  working_dir: train_tests/benchmark
+
+  frequency: nightly
+  team: ml
+
+  cluster:
+    byod:
+      runtime_env:
+        # Enable verbose stats for resource manager
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+
+      # 'type: gpu' means: use the 'ray-ml' image.
+      type: gpu
+    cluster_compute: compute_configs/heterogenous_autoscaling_gpu_4x4_aws.yaml
+
+  variations:
+    - __suffix__: skip_training.parquet
+      run:
+        timeout: 1200
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --image_classification_data_format=parquet
+
 - name: training_ingest_benchmark-task=recsys
   python: "3.10"
   group: Train tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1766,7 +1766,7 @@
     - __suffix__: skip_training.parquet
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step --skip_validation_at_epoch_end --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet
 
 - name: training_ingest_benchmark-task=image_classification-heterogenous_autoscaling
   python: "3.10"

--- a/release/train_tests/benchmark/compute_configs/heterogenous_autoscaling_gpu_4x4_aws.yaml
+++ b/release/train_tests/benchmark/compute_configs/heterogenous_autoscaling_gpu_4x4_aws.yaml
@@ -1,0 +1,20 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+head_node_type:
+    name: head_node
+    instance_type: m5.4xlarge
+    resources:
+        cpu: 0
+
+worker_node_types:
+    - name: gpu-worker-node
+      instance_type: g4dn.12xlarge
+      max_workers: 4
+      min_workers: 4
+      use_spot: false
+    - name: cpu-worker-node
+      instance_type: r6i.4xlarge
+      max_workers: 4
+      min_workers: 0
+      use_spot: false

--- a/release/train_tests/benchmark/compute_configs/heterogenous_fixed_size_gpu_4x4_aws.yaml
+++ b/release/train_tests/benchmark/compute_configs/heterogenous_fixed_size_gpu_4x4_aws.yaml
@@ -1,0 +1,20 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+head_node_type:
+    name: head_node
+    instance_type: m5.4xlarge
+    resources:
+        cpu: 0
+
+worker_node_types:
+    - name: gpu-worker-node
+      instance_type: g4dn.12xlarge
+      max_workers: 4
+      min_workers: 4
+      use_spot: false
+    - name: cpu-worker-node
+      instance_type: r6i.4xlarge
+      max_workers: 4
+      min_workers: 4
+      use_spot: false


### PR DESCRIPTION
## Summary
- Add heterogeneous cluster configurations with dedicated CPU worker nodes for Ray Data operations alongside GPU worker nodes for training
- Include both fixed-size and autoscaling variants for benchmarking different scaling behaviors

## Cluster Configurations

**Fixed-size** (`heterogenous_fixed_size_gpu_4x4_aws.yaml`):
- 4x GPU workers (g4dn.12xlarge) - always running
- 4x CPU workers (r6i.4xlarge) - always running

**Autoscaling** (`heterogenous_autoscaling_gpu_4x4_aws.yaml`):
- 4x GPU workers (g4dn.12xlarge) - always running  
- 0-4x CPU workers (r6i.4xlarge) - scales based on demand

### Release test

| Test | Global throughput |
|---|---:|
| skip_training.parquet | 9717 |
| heterogenous_fixed_size.skip_training.parquet | 10893 |
| heterogenous_autoscaling.skip_training.parquet | 9986 |