### PR TITLE
[Serve] deflake gcs fail test

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1306,6 +1306,17 @@ class ProxyActor(ProxyActorInterface):
         _, handle, _ = self.http_proxy.proxy_router.match_route(route)
         return handle._router._asyncio_router._request_router._replica_id_set
 
+    def _dump_ingress_cache_for_testing(self, route: str) -> Set[ReplicaID]:
+        """Get replica IDs that have entries in the queue length cache (for testing)."""
+        _, handle, _ = self.http_proxy.proxy_router.match_route(route)
+        request_router = handle._router._asyncio_router._request_router
+        cache = request_router.replica_queue_len_cache
+        return {
+            replica_id
+            for replica_id in request_router._replica_id_set
+            if cache.get(replica_id) is not None
+        }
+
     async def ready(self) -> str:
         """Blocks until the proxy HTTP (and optionally gRPC) servers are running.
 


### PR DESCRIPTION
The test test_proxy_router_updated_replicas_then_gcs_failure was failing with httpx.ReadTimeout because it didn't ensure the proxy's replica queue length cache was populated before killing GCS. The equivalent handle test (test_handle_router_updated_replicas_then_gcs_failure) uses check_cache_populated=True to ensure the cache is populated, but the proxy test was missing this check.

https://buildkite.com/ray-project/postmerge/builds/15633#019becb0-fe62-4df7-b279-6e41f6cbd6c3/L1137
https://buildkite.com/ray-project/postmerge/builds/15625#019bebd9-ce8e-4cd0-bac9-c6659cb3c659/L1111
https://buildkite.com/ray-project/postmerge/builds/15625#019bebd9-ce85-48a0-84df-530baea6c481/L1111

I was not able to repro this locally since this is a timing issue between when the GCS is killed and new replica getting added + probe happening.

