### PR TITLE
[windows] add `compiler_param_file` everywhere for windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -49,6 +49,8 @@ test --test_env=RAY_USAGE_STATS_REPORT_URL="http://127.0.0.1:8000"
 test --test_env=RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER="1"
 # This is needed for some core tests to run correctly
 build:windows --enable_runfiles
+# To prevent command line limit issue
+build:windows --features=compiler_param_file
 # TODO(mehrdadn): Revert the "-\\.(asm|S)$" exclusion when this Bazel bug
 #                 for compiling assembly files is fixed on Windows:
 #                 https://github.com/bazelbuild/bazel/issues/8924

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,8 +166,6 @@ pyx_library(
         srcs = PYX_SRCS,
         # cython code is auto-generated, which is out of our control.
         copts = COPTS + PYX_COPTS,
-        # This is needed since Windows has long file path issues and command length limits
-        features = ["compiler_param_file"],
         # see https://github.com/tensorflow/tensorflow/blob/r2.1/tensorflow/lite/BUILD#L444
         linkopts = select({
             "@platforms//os:osx": [

--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -402,10 +402,6 @@ ray_cc_library(
     hdrs = [
         "gcs_server.h",
     ],
-    features = select({
-        "@platforms//os:windows": ["compiler_param_file"],
-        "//conditions:default": [],
-    }),
     deps = [
         "//src/ray/gcs/actor:gcs_actor",
         "//src/ray/gcs/actor:gcs_actor_manager",
@@ -468,10 +464,6 @@ ray_cc_binary(
     srcs = [
         "gcs_server_main.cc",
     ],
-    features = select({
-        "@platforms//os:windows": ["compiler_param_file"],
-        "//conditions:default": [],
-    }),
     visibility = ["//visibility:public"],
     deps = [
         ":gcs_server_lib",

--- a/src/ray/gcs_rpc_client/tests/BUILD.bazel
+++ b/src/ray/gcs_rpc_client/tests/BUILD.bazel
@@ -28,10 +28,6 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
-    features = select({
-        "@platforms//os:windows": ["compiler_param_file"],
-        "//conditions:default": [],
-    }),
     tags = ["team:core"],
     deps = [
         "//src/ray/common:test_utils",
@@ -59,10 +55,6 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
-    features = select({
-        "@platforms//os:windows": ["compiler_param_file"],
-        "//conditions:default": [],
-    }),
     tags = [
         "exclusive",
         "no_tsan",


### PR DESCRIPTION
so that it does not trigger command line length limit