### PR TITLE
[Data] Clean Outdated `ray.air` comments

### DIFF
--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -49,11 +49,6 @@ DEFAULT_CONFIG = {
             "handlers": ["file", "console"],
             "propagate": False,
         },
-        "ray.air.util.tensor_extensions": {
-            "level": "DEBUG",
-            "handlers": ["file", "console"],
-            "propagate": False,
-        },
     },
 }
 

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -575,7 +575,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         # extension columns separately.
         memory_usage = self._table.memory_usage(index=True, deep=False)
 
-        # TensorDtype for ray.air.util.tensor_extensions.pandas.TensorDtype
+        # TensorDtype for ray.data._internal.tensor_extensions.pandas.TensorDtype
         object_need_check = (TensorDtype,)
         max_sample_count = _PANDAS_SIZE_BYTES_MAX_SAMPLE_COUNT
 

--- a/python/ray/data/_internal/tensor_extensions/utils.py
+++ b/python/ray/data/_internal/tensor_extensions/utils.py
@@ -179,7 +179,7 @@ def create_ragged_ndarray(values: Sequence[Any]) -> np.ndarray:
         .. testsetup::
 
             import numpy as np
-            from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
+            from ray.data._internal.tensor_extensions.utils import create_ragged_ndarray
 
         .. doctest::
 

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -344,7 +344,6 @@ class Preprocessor(abc.ABC):
         return {}
 
     def _transform_batch(self, data: "DataBatchType") -> "DataBatchType":
-        # For minimal install to locally import air modules
         import numpy as np
         import pandas as pd
 

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -13,12 +13,12 @@ logger = logging.getLogger(__name__)
 @PublicAPI(stability="alpha")
 class Concatenator(Preprocessor):
     """Combine numeric columns into a column of type
-    :class:`~ray.air.util.tensor_extensions.pandas.TensorDtype`. Only columns
+    :class:`~ray.data._internal.tensor_extensions.pandas.TensorDtype`. Only columns
     specified in ``columns`` will be concatenated.
 
     This preprocessor concatenates numeric columns and stores the result in a new
     column. The new column contains
-    :class:`~ray.air.util.tensor_extensions.pandas.TensorArrayElement` objects of
+    :class:`~ray.data._internal.tensor_extensions.pandas.TensorArrayElement` objects of
     shape :math:`(m,)`, where :math:`m` is the number of columns concatenated.
     The :math:`m` concatenated columns are dropped after concatenation.
     The preprocessor preserves the order of the columns provided in the ``colummns``
@@ -31,7 +31,7 @@ class Concatenator(Preprocessor):
         >>> from ray.data.preprocessors import Concatenator
 
         :py:class:`Concatenator` combines numeric columns into a column of
-        :py:class:`~ray.air.util.tensor_extensions.pandas.TensorDtype`.
+        :py:class:`~ray.data._internal.tensor_extensions.pandas.TensorDtype`.
 
         >>> df = pd.DataFrame({"X0": [0, 3, 1], "X1": [0.5, 0.2, 0.9]})
         >>> ds = ray.data.from_pandas(df)  # doctest: +SKIP


### PR DESCRIPTION
## Description
- Remove outdated air library in ray data
- Update some old usage from `ray.air` to `ray.data` 

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
