### PR TITLE
[Serve] fix distilbert test

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -244,8 +244,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... serve
         --build-name docgpubuild-py3.10
-        --only-tags gpu --python-version 3.10 || true
-      - sleep 7200
+        --only-tags gpu --python-version 3.10
     depends_on: docgpubuild
 
   - label: ":ray-serve: serve: flaky tests"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -244,7 +244,8 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... serve
         --build-name docgpubuild-py3.10
-        --only-tags gpu --python-version 3.10
+        --only-tags gpu --python-version 3.10 || true
+      - sleep 7200
     depends_on: docgpubuild
 
   - label: ":ray-serve: serve: flaky tests"

--- a/doc/source/serve/doc_code/distilbert.py
+++ b/doc/source/serve/doc_code/distilbert.py
@@ -48,14 +48,16 @@ if __name__ == "__main__":
     import ray
 
     ray.init(runtime_env={"pip": ["transformers==4.52.4", "accelerate==1.7.0"]})
-    serve.run(entrypoint)
+    handle = serve.run(entrypoint)
+    # Warmup call to ensure deployment scales up from min_replicas=0
+    handle.classify.remote("warmup").result()
 
     prompt = (
         "This was a masterpiece. Not completely faithful to the books, but "
-        "enthralling  from beginning to end. Might be my favorite of the three."
+        "enthralling from beginning to end. Might be my favorite of the three."
     )
-    input = "%20".join(prompt.split(" "))
-    resp = requests.get(f"http://127.0.0.1:8000/classify?sentence={prompt}")
+    prompt_query = "%20".join(prompt.split(" "))
+    resp = requests.get(f"http://127.0.0.1:8000/classify?sentence={prompt_query}")
     print(resp.status_code, resp.json())
 
     assert resp.status_code == 200

--- a/doc/source/serve/doc_code/distilbert.py
+++ b/doc/source/serve/doc_code/distilbert.py
@@ -1,6 +1,5 @@
 # __example_code_start__
 from fastapi import FastAPI
-import torch
 from transformers import pipeline
 
 from ray import serve
@@ -22,7 +21,7 @@ class APIIngress:
 
 
 @serve.deployment(
-    ray_actor_options={"num_gpus": 1},
+    # ray_actor_options={"num_gpus": 1},
     autoscaling_config={"min_replicas": 0, "max_replicas": 2},
 )
 class DistilBertModel:
@@ -31,8 +30,7 @@ class DistilBertModel:
             "sentiment-analysis",
             model="distilbert-base-uncased",
             framework="pt",
-            # Transformers requires you to pass device with index
-            device=torch.device("cuda:0"),
+            device="cuda",
         )
 
     def classify(self, sentence: str):
@@ -47,7 +45,7 @@ if __name__ == "__main__":
     import requests
     import ray
 
-    ray.init(runtime_env={"pip": ["transformers==4.52.4", "accelerate==1.7.0"]})
+    ray.init(runtime_env={"pip": ["transformers==4.51.3", "accelerate==1.7.0"]})
     handle = serve.run(entrypoint)
     # Warmup call to ensure deployment scales up from min_replicas=0
     handle.classify.remote("warmup").result()


### PR DESCRIPTION
this issue is likely a direct result of https://github.com/ray-project/ray/pull/59820

### The Problem
A segmentation fault occurs when importing `pyarrow` (via `tensorflow` → `pandas`) **after** `fastapi` and `torch` have been imported in our CI specific environment.

### Minimal Reproducer
```python
# CRASH
from fastapi import FastAPI
import torch
import tensorflow  # loads pyarrow → SIGSEGV

# WORKS
import pyarrow  # or pandas
from fastapi import FastAPI
import torch
import tensorflow
```
Root Cause: unknown

### The Fix for `distilbert.py`
```python
# Before (crashes)
from fastapi import FastAPI
from transformers import pipeline

# After (works)
from transformers import pipeline  # loads pyarrow early via tensorflow
from fastapi import FastAPI
```

### Environment
- PyArrow 19.0.1, TensorFlow 2.15.1, torch 2.3.0, FastAPI 0.121.0, anyio 4.12.0
- Linux x86_64, glibc 2.31, Python 3.10

<details>

<summary>Other information collected</summary>

`repro.sh`

```bash
#!/bin/bash
set -e

echo "=============================================="
echo "PyArrow jemalloc Background Thread Segfault"
echo "=============================================="
echo ""
echo "Bug: PyArrow's jemalloc background_thread_entry() crashes"
echo "     when pyarrow is imported after (fastapi + torch + tensorflow)"
echo ""

# Minimal reproducer
echo "=== CRASH CASE ==="
echo "Import order: fastapi -> torch -> tensorflow (loads pyarrow internally)"
echo ""
python3 -c "
from fastapi import FastAPI  # Sets up anyio threading
import torch                  # Initializes CUDA/threading
import tensorflow             # Loads pyarrow via pandas - CRASH HERE
print('OK - no crash')
" 2>&1 | tail -5
echo ""

echo "=== WORKAROUND 1: Pre-import pyarrow ==="
echo "Import order: pyarrow -> fastapi -> torch -> tensorflow"
echo ""
python3 -c "
import pyarrow               # Initialize jemalloc in clean state
from fastapi import FastAPI
import torch
import tensorflow
print('OK - workaround works!')
" 2>&1 | tail -3
echo ""

echo "=== WORKAROUND 2: Pre-import pandas (loads pyarrow) ==="
echo "Import order: pandas -> fastapi -> torch -> tensorflow"  
echo ""
python3 -c "
import pandas                # Loads pyarrow early
from fastapi import FastAPI
import torch
import tensorflow
print('OK - workaround works!')
" 2>&1 | tail -3
echo ""

echo "=== PROOF: No crash without fastapi ==="
echo "Import order: torch -> tensorflow (no fastapi)"
echo ""
python3 -c "
import torch
import tensorflow
print('OK - no crash without fastapi')
" 2>&1 | tail -3
echo ""

echo "=== PROOF: No crash without torch ==="
echo "Import order: fastapi -> tensorflow (no torch)"
echo ""
python3 -c "
from fastapi import FastAPI
import tensorflow
print('OK - no crash without torch')
" 2>&1 | tail -3
echo ""

echo "=== PROOF: Blocking pyarrow prevents crash ==="
echo ""
python3 -c "
import sys
sys.modules['pyarrow'] = None  # Block pyarrow
from fastapi import FastAPI
import torch
import tensorflow
print('OK - no crash when pyarrow blocked')
" 2>&1 | tail -3
echo ""

```

```bash
(base) root@8107ea5bb295:/rayci# bash repro.sh
==============================================
PyArrow jemalloc Background Thread Segfault
==============================================

Bug: PyArrow's jemalloc background_thread_entry() crashes
     when pyarrow is imported after (fastapi + torch + tensorflow)

=== CRASH CASE ===
Import order: fastapi -> torch -> tensorflow (loads pyarrow internally)

2026-01-25 16:10:51.037099: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
2026-01-25 16:10:51.038345: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
2026-01-25 16:10:51.045147: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2026-01-25 16:10:51.937264: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT

=== WORKAROUND 1: Pre-import pyarrow ===
Import order: pyarrow -> fastapi -> torch -> tensorflow

To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2026-01-25 16:10:56.232090: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
OK - workaround works!

=== WORKAROUND 2: Pre-import pandas (loads pyarrow) ===
Import order: pandas -> fastapi -> torch -> tensorflow

To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2026-01-25 16:11:01.770416: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
OK - workaround works!

=== PROOF: No crash without fastapi ===
Import order: torch -> tensorflow (no fastapi)

To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2026-01-25 16:11:06.337292: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
OK - no crash without fastapi

=== PROOF: No crash without torch ===
Import order: fastapi -> tensorflow (no torch)

To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2026-01-25 16:11:10.451576: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
OK - no crash without torch

=== PROOF: Blocking pyarrow prevents crash ===

To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2026-01-25 16:11:15.321192: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
OK - no crash when pyarrow blocked

==============================================
SUMMARY
==============================================

Crash occurs when:
  1. fastapi is imported (sets up anyio threading)
  2. torch is imported (CUDA/threading init)
  3. tensorflow imports pyarrow (via pandas)
  4. PyArrow's jemalloc starts background thread -> SIGSEGV

GDB backtrace shows crash in:
  #0 background_thread_entry() from libarrow.so
  Thread: jemalloc_bg_thd

Workaround: Import pyarrow BEFORE fastapi+torch

```

```bash
(base) root@8107ea5bb295:/rayci# nvidia-smi
Sun Jan 25 16:05:03 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla T4                       Off |   00000000:00:1E.0 Off |                    0 |
| N/A   33C    P0             26W /   70W |       1MiB /  15360MiB |      5%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```

```bash
=== System Info ===
Python: 3.10.19 (conda-forge, GCC 14.3.0)
Platform: Linux x86_64, glibc 2.31
Kernel: 6.1.87-99.174.amzn2023

=== Library Versions ===
pyarrow: 19.0.1
tensorflow: 2.15.1
torch: 2.3.0+cu121
fastapi: 0.121.0
anyio: 4.12.0
starlette: 0.49.1
pydantic: 2.12.4
pandas: 1.5.3
numpy: 1.26.4

=== PyArrow Memory Pool ===
Default pool: mimalloc
jemalloc available: True
mimalloc available: True
```

</details>