### PR TITLE
[Typing] Preserve function signatures through Ray decorators

### DIFF
--- a/python/ray/_common/deprecation.py
+++ b/python/ray/_common/deprecation.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 from functools import wraps
-from typing import Any, Callable, Optional, TypeVar, Union, overload
+from typing import Any, Callable, Optional, TypeVar, Union, cast, overload
 
 from ray.util import log_once
 from ray.util.annotations import _mark_annotated
@@ -168,7 +168,7 @@ def Deprecated(
             return obj(*args, **kwargs)
 
         # Return the patched class method/function.
-        return _ctor  # type: ignore[return-value]
+        return cast(F, _ctor)
 
     # Return the prepared decorator.
     return _inner

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -549,6 +549,11 @@ def _all_to_all_api() -> Callable[[F], F]:
     return wrap
 
 
+@overload
+def AllToAllAPI(obj: F) -> F:
+    ...
+
+
 def AllToAllAPI(*args, **kwargs):
     """Annotate the function with an indication that it's a all to all API, and that it
     is an operation that requires all inputs to be materialized in-memory to execute.

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -25,6 +25,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    overload,
 )
 
 import numpy as np
@@ -40,6 +41,9 @@ from ray.data.context import DEFAULT_READ_OP_MIN_NUM_BLOCKS, WARN_PREFIX, DataCo
 from ray.util.annotations import DeveloperAPI
 
 import psutil
+
+# TypeVar for preserving function/class signatures through decorators
+F = TypeVar("F", bound=Callable[..., Any])
 
 if TYPE_CHECKING:
     import pandas
@@ -461,9 +465,9 @@ def _consumption_api(
     datasource_metadata: Optional[str] = None,
     extra_condition: Optional[str] = None,
     delegate: Optional[str] = None,
-    pattern="Examples:",
-    insert_after=False,
-):
+    pattern: str = "Examples:",
+    insert_after: bool = False,
+) -> Callable[[F], F]:
     """Annotate the function with an indication that it's a consumption API, and that it
     will trigger Dataset execution.
     """
@@ -486,7 +490,7 @@ def _consumption_api(
             condition += extra_condition + ", "
         message = condition + "then this operation" + base
 
-    def wrap(obj):
+    def wrap(obj: F) -> F:
         _insert_doc_at_pattern(
             obj,
             message=message,
@@ -499,6 +503,22 @@ def _consumption_api(
     return wrap
 
 
+@overload
+def ConsumptionAPI(obj: F) -> F:
+    ...
+
+
+@overload
+def ConsumptionAPI(
+    *,
+    if_more_than_read: bool = False,
+    datasource_metadata: Optional[str] = None,
+    extra_condition: Optional[str] = None,
+    delegate: Optional[str] = None,
+) -> Callable[[F], F]:
+    ...
+
+
 def ConsumptionAPI(*args, **kwargs):
     """Annotate the function with an indication that it's a consumption API, and that it
     will trigger Dataset execution.
@@ -508,12 +528,12 @@ def ConsumptionAPI(*args, **kwargs):
     return _consumption_api(*args, **kwargs)
 
 
-def _all_to_all_api(*args, **kwargs):
+def _all_to_all_api() -> Callable[[F], F]:
     """Annotate the function with an indication that it's a all to all API, and that it
     is an operation that requires all inputs to be materialized in-memory to execute.
     """
 
-    def wrap(obj):
+    def wrap(obj: F) -> F:
         _insert_doc_at_pattern(
             obj,
             message=(

--- a/rllib/utils/annotations.py
+++ b/rllib/utils/annotations.py
@@ -205,7 +205,7 @@ def OverrideToImplementCustomLogic_CallToSuperRecommended(obj: F) -> F:
     return obj
 
 
-def is_overridden(obj: F) -> bool:
+def is_overridden(obj: Callable[..., Any]) -> bool:
     """Check whether a function has been overridden.
 
     Note, this only works for API calls decorated with OverrideToImplementCustomLogic

--- a/rllib/utils/annotations.py
+++ b/rllib/utils/annotations.py
@@ -1,8 +1,13 @@
+from typing import Any, Callable, TypeVar
+
 from ray._common.deprecation import Deprecated
 from ray.util.annotations import _mark_annotated
 
+# TypeVar for preserving function/class signatures through decorators
+F = TypeVar("F", bound=Callable[..., Any])
 
-def override(parent_cls):
+
+def override(parent_cls: type) -> Callable[[F], F]:
     """Decorator for documenting method overrides.
 
     Args:
@@ -41,7 +46,7 @@ def override(parent_cls):
             # Set the function as a regular method on the class.
             setattr(owner, name, self.func)
 
-    def decorator(method):
+    def decorator(method: F) -> F:
         # Check, whether `method` is actually defined by the parent class.
         if method.__name__ not in dir(parent_cls):
             raise NameError(
@@ -56,7 +61,7 @@ def override(parent_cls):
     return decorator
 
 
-def PublicAPI(obj):
+def PublicAPI(obj: F) -> F:
     """Decorator for documenting public APIs.
 
     Public APIs are classes and methods exposed to end users of RLlib. You
@@ -84,7 +89,7 @@ def PublicAPI(obj):
     return obj
 
 
-def DeveloperAPI(obj):
+def DeveloperAPI(obj: F) -> F:
     """Decorator for documenting developer APIs.
 
     Developer APIs are classes and methods explicitly exposed to developers
@@ -111,7 +116,7 @@ def DeveloperAPI(obj):
     return obj
 
 
-def ExperimentalAPI(obj):
+def ExperimentalAPI(obj: F) -> F:
     """Decorator for documenting experimental APIs.
 
     Experimental APIs are classes and methods that are in development and may
@@ -140,7 +145,7 @@ def ExperimentalAPI(obj):
     return obj
 
 
-def OldAPIStack(obj):
+def OldAPIStack(obj: F) -> F:
     """Decorator for classes/methods/functions belonging to the old API stack.
 
     These should be deprecated at some point after Ray 3.0 (RLlib GA).
@@ -153,7 +158,7 @@ def OldAPIStack(obj):
     return obj
 
 
-def OverrideToImplementCustomLogic(obj):
+def OverrideToImplementCustomLogic(obj: F) -> F:
     """Users should override this in their sub-classes to implement custom logic.
 
     Used in Algorithm and Policy to tag methods that need overriding, e.g.
@@ -171,11 +176,11 @@ def OverrideToImplementCustomLogic(obj):
             ...
 
     """
-    obj.__is_overridden__ = False
+    obj.__is_overridden__ = False  # type: ignore[attr-defined]
     return obj
 
 
-def OverrideToImplementCustomLogic_CallToSuperRecommended(obj):
+def OverrideToImplementCustomLogic_CallToSuperRecommended(obj: F) -> F:
     """Users should override this in their sub-classes to implement custom logic.
 
     Thereby, it is recommended (but not required) to call the super-class'
@@ -196,11 +201,11 @@ def OverrideToImplementCustomLogic_CallToSuperRecommended(obj):
             super().setup(config)
             # ... or here (after having called super()'s setup method.
     """
-    obj.__is_overridden__ = False
+    obj.__is_overridden__ = False  # type: ignore[attr-defined]
     return obj
 
 
-def is_overridden(obj):
+def is_overridden(obj: F) -> bool:
     """Check whether a function has been overridden.
 
     Note, this only works for API calls decorated with OverrideToImplementCustomLogic

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -399,6 +399,7 @@ def get_variable(
     return value
 
 
+@DeveloperAPI
 @Deprecated(
     old="rllib/utils/framework.py::get_activation_fn",
     new="rllib/models/utils.py::get_activation_fn",

--- a/rllib/utils/policy.py
+++ b/rllib/utils/policy.py
@@ -20,7 +20,7 @@ from ray.rllib.core.rl_module import validate_module_id
 from ray.rllib.models.preprocessors import ATARI_OBS_SHAPE
 from ray.rllib.policy.policy import PolicySpec
 from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.utils.annotations import OldAPIStack
+from ray.rllib.utils.annotations import DeveloperAPI, OldAPIStack
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.typing import (
     ActionConnectorDataType,
@@ -276,6 +276,7 @@ def compute_log_likelihoods_from_input_dict(
     return log_likelihoods
 
 
+@DeveloperAPI
 @Deprecated(new="Policy.from_checkpoint([checkpoint path], [policy IDs]?)", error=True)
 def load_policies_from_checkpoint(path, policy_ids=None):
     pass


### PR DESCRIPTION
## Description
Add type annotations to Ray's annotation decorators so type checkers can properly infer return types through decorated functions.

Before this change, decorators like `@PublicAPI` caused type checkers to lose function signature information. After this change, decorated functions retain their full type signatures.

## Related issues
Related to #59303

## Additional information
Running pyrefly with ray was complaining when calling take_all() which led me down this rabbit hole. I tried to add annotations to all the public facing decorators I could find that had reasonably clear fixes.
I did some drive-by type fixes in annotations.py to make it fully pass
