### PR TITLE
[Data] Update outdated TCPH website link

### DIFF
--- a/release/nightly_tests/dataset/tpch_q1.py
+++ b/release/nightly_tests/dataset/tpch_q1.py
@@ -31,7 +31,7 @@ def main(args):
     def benchmark_fn():
         # The TPC-H queries are a widely used set of benchmarks to measure the
         # performance of data processing systems. See
-        # https://examples.citusdata.com/tpch_queries.html.
+        # https://www.tpc.org/tpch/
         from datetime import datetime
 
         ds = (


### PR DESCRIPTION
## Description
https://examples.citusdata.com/tpch_queries.html is unavailable now, update to https://www.tpc.org/tpch/

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
