### PR TITLE
[Data] Refactor TPCH tests

### DIFF
--- a/release/nightly_tests/dataset/tpch/common.py
+++ b/release/nightly_tests/dataset/tpch/common.py
@@ -67,7 +67,7 @@ def load_table(
     return ds
 
 
-def run_tpch_benchmark(name: str, benchmark_fn, args):
+def run_tpch_benchmark(name: str, benchmark_fn):
     benchmark = Benchmark()
     benchmark.run_fn(name, benchmark_fn)
     benchmark.write_result()

--- a/release/nightly_tests/dataset/tpch/common.py
+++ b/release/nightly_tests/dataset/tpch/common.py
@@ -1,0 +1,73 @@
+import argparse
+import sys
+import os
+
+# Allow importing benchmark from parent directory
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import ray
+from ray.data.datatype import DataType
+from ray.data.expressions import udf
+from benchmark import Benchmark
+
+# Define schemas for TPC-H tables
+TABLE_COLUMNS = {
+    "lineitem": {
+        "column00": "l_orderkey",
+        "column01": "l_partkey",
+        "column02": "l_suppkey",
+        "column03": "l_linenumber",
+        "column04": "l_quantity",
+        "column05": "l_extendedprice",
+        "column06": "l_discount",
+        "column07": "l_tax",
+        "column08": "l_returnflag",
+        "column09": "l_linestatus",
+        "column10": "l_shipdate",
+        "column11": "l_commitdate",
+        "column12": "l_receiptdate",
+        "column13": "l_shipinstruct",
+        "column14": "l_shipmode",
+        "column15": "l_comment",
+    }
+}
+
+
+@udf(return_dtype=DataType.float64())
+def to_f64(arr: pa.Array) -> pa.Array:
+    """Cast any numeric type to float64."""
+    return pc.cast(arr, pa.float64())
+
+
+def parse_tpch_args(description: str = "TPC-H Benchmark") -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--sf",
+        choices=[1, 10, 100, 1000, 10000],
+        type=int,
+        default=1,
+        help="Scale factor",
+    )
+    return parser.parse_args()
+
+
+def load_table(
+    table_name: str,
+    scale_factor: int,
+    base_uri: str = "s3://ray-benchmark-data/tpch/parquet",
+) -> ray.data.Dataset:
+    path = f"{base_uri}/sf{scale_factor}/{table_name}"
+    ds = ray.data.read_parquet(path)
+
+    if table_name in TABLE_COLUMNS:
+        ds = ds.rename_columns(TABLE_COLUMNS[table_name])
+
+    return ds
+
+
+def run_tpch_benchmark(name: str, benchmark_fn, args):
+    benchmark = Benchmark()
+    benchmark.run_fn(name, benchmark_fn)
+    benchmark.write_result()

--- a/release/nightly_tests/dataset/tpch/common.py
+++ b/release/nightly_tests/dataset/tpch/common.py
@@ -1,9 +1,4 @@
 import argparse
-import sys
-import os
-
-# Allow importing benchmark from parent directory
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pyarrow as pa
 import pyarrow.compute as pc

--- a/release/nightly_tests/dataset/tpch/tpch_q1.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q1.py
@@ -8,7 +8,7 @@ def main(args):
     def benchmark_fn():
         # The TPC-H queries are a widely used set of benchmarks to measure the
         # performance of data processing systems. See
-        # https://examples.citusdata.com/tpch_queries.html.
+        # https://www.tpc.org/tpch/
         from datetime import datetime
 
         ds = load_table("lineitem", args.sf)

--- a/release/nightly_tests/dataset/tpch/tpch_q1.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q1.py
@@ -74,7 +74,7 @@ def main(args):
         # Report arguments for the benchmark.
         return vars(args)
 
-    run_tpch_benchmark("tpch_q1", benchmark_fn, args)
+    run_tpch_benchmark("tpch_q1", benchmark_fn)
 
 
 if __name__ == "__main__":

--- a/release/nightly_tests/dataset/tpch/tpch_q1.py
+++ b/release/nightly_tests/dataset/tpch/tpch_q1.py
@@ -1,62 +1,19 @@
-import argparse
-
-from benchmark import Benchmark
-
 import ray
-
-# TODO: We should make these public again.
 from ray.data.aggregate import Count, Mean, Sum
-from ray.data.expressions import col, udf
-from ray.data.datatype import DataType
-import pyarrow as pa
-import pyarrow.compute as pc
-
-
-@udf(return_dtype=DataType.float64())
-def to_f64(arr: pa.Array) -> pa.Array:
-    """Cast any numeric type to float64."""
-    return pc.cast(arr, pa.float64())
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="TPCH Q1")
-    parser.add_argument("--sf", choices=[1, 10, 100, 1000, 10000], type=int, default=1)
-    return parser.parse_args()
+from ray.data.expressions import col
+from common import parse_tpch_args, load_table, to_f64, run_tpch_benchmark
 
 
 def main(args):
-    path = f"s3://ray-benchmark-data/tpch/parquet/sf{args.sf}/lineitem"
-    benchmark = Benchmark()
-
     def benchmark_fn():
         # The TPC-H queries are a widely used set of benchmarks to measure the
         # performance of data processing systems. See
         # https://examples.citusdata.com/tpch_queries.html.
         from datetime import datetime
 
-        ds = (
-            ray.data.read_parquet(path)
-            .rename_columns(
-                {
-                    "column00": "l_orderkey",
-                    "column02": "l_suppkey",
-                    "column03": "l_linenumber",
-                    "column04": "l_quantity",
-                    "column05": "l_extendedprice",
-                    "column06": "l_discount",
-                    "column07": "l_tax",
-                    "column08": "l_returnflag",
-                    "column09": "l_linestatus",
-                    "column10": "l_shipdate",
-                    "column11": "l_commitdate",
-                    "column12": "l_receiptdate",
-                    "column13": "l_shipinstruct",
-                    "column14": "l_shipmode",
-                    "column15": "l_comment",
-                }
-            )
-            .filter(expr=col("l_shipdate") <= datetime(1998, 9, 2))
-        )
+        ds = load_table("lineitem", args.sf)
+
+        ds = ds.filter(expr=col("l_shipdate") <= datetime(1998, 9, 2))
 
         # Build float views + derived columns
         ds = (
@@ -117,11 +74,10 @@ def main(args):
         # Report arguments for the benchmark.
         return vars(args)
 
-    benchmark.run_fn("main", benchmark_fn)
-    benchmark.write_result()
+    run_tpch_benchmark("tpch_q1", benchmark_fn, args)
 
 
 if __name__ == "__main__":
     ray.init()
-    args = parse_args()
+    args = parse_tpch_args()
     main(args)

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -724,7 +724,6 @@
 # TPCH Queries
 ##############
 
-
 - name: "tpch_q1_{{scaling}}"
   python: "3.10"
   matrix:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -724,7 +724,9 @@
 # TPCH Queries
 ##############
 
+
 - name: "tpch_q1_{{scaling}}"
+  working_dir: nightly_tests/dataset/tpch
   python: "3.10"
   matrix:
     setup:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -726,7 +726,6 @@
 
 
 - name: "tpch_q1_{{scaling}}"
-  working_dir: nightly_tests/dataset/tpch
   python: "3.10"
   matrix:
     setup:
@@ -737,7 +736,7 @@
 
   run:
     timeout: 5400
-    script: python tpch_q1.py --sf 100
+    script: python tpch/tpch_q1.py --sf 100
 
 
 #################################################


### PR DESCRIPTION
## Description
The existing release tests only include TPC-H query Q1. To achieve full coverage, we plan to incorporate the remaining 21 TPCH queries, for a total of 22 test cases into our test suite.

This PR move the TPCH tests into a new folder and extract common logic into common.py for other future tests.

Also, [examples.citusdata.com/tpch_queries.html](https://examples.citusdata.com/tpch_queries.html) is unavailable now, so this pr updated to [tpc.org/tpch](https://www.tpc.org/tpch/)

Release test link to make sure the changes is corrrect: https://buildkite.com/ray-project/release/builds/77070/steps/canvas