### PR TITLE
[Core] Batch CancelResourceReserve RPC to reduce RPC count from O(bundles) to O(nodes)

### DIFF
--- a/src/mock/ray/raylet_client/raylet_client.h
+++ b/src/mock/ray/raylet_client/raylet_client.h
@@ -74,7 +74,7 @@ class MockRayletClientInterface : public RayletClientInterface {
   MOCK_METHOD(
       void,
       CancelResourceReserve,
-      (const BundleSpecification &bundle_spec,
+      (const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
        const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback),
       (override));
   MOCK_METHOD(void,

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -387,16 +387,16 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const std::optional<std::shared_ptr<const ray::rpc::GcsNodeInfo>> &node,
       const rpc::StatusCallback callback);
 
-  /// Cacnel prepared or committed resources from a node.
+  /// Cancel prepared or committed resources from a node.
   /// Nodes will be in charge of tracking state of a bundle.
   /// This method is supposed to be idempotent.
   ///
-  /// \param bundle A description of the bundle to return.
+  /// \param bundle_specs The bundles to cancel resource reservations for.
   /// \param node The node that the worker will be returned for.
   /// \param max_retry The maximum times cancel request can be retried.
   /// \param retry_cnt The number of times the cancel request is retried.
   void CancelResourceReserve(
-      const std::shared_ptr<const BundleSpecification> &bundle_spec,
+      const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
       const std::optional<std::shared_ptr<const ray::rpc::GcsNodeInfo>> &node,
       int max_retry,
       int current_retry_cnt);

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -547,10 +547,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, DestroyPlacementGroup) {
   const auto &placement_group_id = placement_group->GetPlacementGroupID();
   scheduler_->DestroyPlacementGroupBundleResourcesIfExists(placement_group_id);
   ASSERT_TRUE(raylet_clients_[0]->GrantCancelResourceReserve());
-  ASSERT_TRUE(raylet_clients_[0]->GrantCancelResourceReserve());
   // Subsequent destroy request should not do anything.
   scheduler_->DestroyPlacementGroupBundleResourcesIfExists(placement_group_id);
-  ASSERT_FALSE(raylet_clients_[0]->GrantCancelResourceReserve());
   ASSERT_FALSE(raylet_clients_[0]->GrantCancelResourceReserve());
 }
 

--- a/src/ray/gcs/tests/gcs_server_test_util.h
+++ b/src/ray/gcs/tests/gcs_server_test_util.h
@@ -228,10 +228,10 @@ struct GcsServerMocker {
     }
 
     void CancelResourceReserve(
-        const BundleSpecification &bundle_spec,
+        const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
         const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback)
         override {
-      num_return_requested += 1;
+      num_return_requested += bundle_specs.size();
       return_callbacks.push_back(callback);
     }
 

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -127,7 +127,7 @@ message CommitBundleResourcesReply {}
 
 message CancelResourceReserveRequest {
   // Bundle containing the requested resources.
-  Bundle bundle_spec = 1;
+  repeated Bundle bundle_specs = 1;
 }
 
 message CancelResourceReserveReply {}

--- a/src/ray/raylet_rpc_client/fake_raylet_client.h
+++ b/src/ray/raylet_rpc_client/fake_raylet_client.h
@@ -172,9 +172,9 @@ class FakeRayletClient : public RayletClientInterface {
   }
 
   void CancelResourceReserve(
-      const BundleSpecification &bundle_spec,
+      const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
       const ClientCallback<CancelResourceReserveReply> &callback) override {
-    num_return_requested += 1;
+    num_return_requested += bundle_specs.size();
     return_callbacks.push_back(callback);
   }
 

--- a/src/ray/raylet_rpc_client/raylet_client.cc
+++ b/src/ray/raylet_rpc_client/raylet_client.cc
@@ -287,10 +287,12 @@ void RayletClient::CommitBundleResources(
 }
 
 void RayletClient::CancelResourceReserve(
-    const BundleSpecification &bundle_spec,
+    const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
     const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback) {
   rpc::CancelResourceReserveRequest request;
-  request.mutable_bundle_spec()->CopyFrom(bundle_spec.GetMessage());
+  for (const auto &bundle_spec : bundle_specs) {
+    request.add_bundle_specs()->CopyFrom(bundle_spec->GetMessage());
+  }
   INVOKE_RPC_CALL(NodeManagerService,
                   CancelResourceReserve,
                   request,

--- a/src/ray/raylet_rpc_client/raylet_client.h
+++ b/src/ray/raylet_rpc_client/raylet_client.h
@@ -107,7 +107,7 @@ class RayletClient : public RayletClientInterface {
       override;
 
   void CancelResourceReserve(
-      const BundleSpecification &bundle_spec,
+      const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
       const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback)
       override;
 

--- a/src/ray/raylet_rpc_client/raylet_client_interface.h
+++ b/src/ray/raylet_rpc_client/raylet_client_interface.h
@@ -127,7 +127,7 @@ class RayletClientInterface {
       const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback) = 0;
 
   virtual void CancelResourceReserve(
-      const BundleSpecification &bundle_spec,
+      const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
       const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback) = 0;
 
   virtual void ReleaseUnusedBundles(


### PR DESCRIPTION
## Description

This PR batches `CancelResourceReserve` RPCs by node, reducing the RPC count from O(bundles) to O(nodes) per placement group removal.

### Motivation

1. **Consistency with creation flow**: The PG creation flow already groups bundles by node and sends one `CommitBundleResources` RPC per node. However, the removal flow was sending one `CancelResourceReserve` RPC per bundle. This inconsistency was confusing and inefficient.

2. **Avoid redundant work in Raylet**: Many Raylet functions already operate at the PG level during removal:
   - `CancelLeases(placement_group_id)` - cancels all pending lease requests for the PG
   - `KillWorkersAssociatedWithPg(placement_group_id)` - kills all workers belonging to the PG
   
   Before this PR, if a node had N bundles, these functions would be called N times redundantly. While correctness was preserved (the operations are idempotent), this was wasteful.

3. **Prevent Raylet overload under concurrent PG scheduling**: During testing of concurrent PG scheduling, I observed that removal operations could send a massive burst of `CancelResourceReserve` RPCs simultaneously, overwhelming the Raylet and causing P99 queue time to spike dramatically. After batching to O(nodes), this issue is resolved.

4. **Performance improvement**: Even in the existing test framework, this change shows measurable throughput improvements (see benchmark results below).



## Performance
### placement_group_performance_test.aws

##### Environment
- Head node: m5.8xlarge (32 vCPU, 128 GB RAM)
- Worker nodes: 4x m5.4xlarge (16 vCPU, 64 GB RAM)
- PR image:[029272617770.dkr.ecr.us-west-2.amazonaws.com/anyscale/ray:14c48a3f-py312](https://console.anyscale-staging.com/container-images/apt_grmwyfm6iz93ibespheqgfzr8c/versions/bld_hxrg8ebezmm2ixwfevr1e7lmza)
- master image: [029272617770.dkr.ecr.us-west-2.amazonaws.com/anyscale/ray:bb4fadfe-py312](https://console.anyscale-staging.com/container-images/apt_kjx4d7i14t4rphc2zg4rpxc7vs/versions/bld_si9zmkucxiq6thix1y9v21xczi)


#### Single Bundle PG Creation Throughput (varying PG count)

| Num PGs | Batch (pg/s) | Master (pg/s) | Change |
|---------|--------------|---------------|--------|
| 10 | 728.94 ± 11.09 | 724.67 ± 15.58 | +0.6% |
| 100 | 752.33 ± 5.10 | 731.20 ± 5.04 | **+2.9%** |
| 200 | 713.84 ± 8.04 | 714.22 ± 4.14 | ~0% |
| 400 | 664.03 ± 6.12 | 670.36 ± 4.51 | -0.9% |
| 800 | 587.39 ± 7.72 | 582.59 ± 9.82 | +0.8% |
| 1600 | 456.15 ± 5.26 | 440.52 ± 7.11 | **+3.5%** |

#### Multi-Bundle PG Creation Throughput (100 PGs, varying bundle count)

| Bundles/PG | Batch (pg/s) | Master (pg/s) | Change |
|------------|--------------|---------------|--------|
| 1 | 742.89 ± 1.36 | 732.04 ± 2.18 | +1.5% |
| 10 | 264.79 ± 4.31 | 259.07 ± 3.45 | **+2.2%** |
| 20 | 128.71 ± 2.09 | 124.15 ± 1.89 | **+3.7%** |
| 40 | 46.35 ± 0.45 | 39.68 ± 2.56 | **+16.8%** |

Clearly, the more bundles in one node, the more benefit this PR brings.


