### PR TITLE
[Data] - Port over changes from lance-ray into Ray Data

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -975,10 +975,6 @@ python/ray/data/_internal/block_batching/util.py
     DOC402: Function `resolve_block_refs` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `resolve_block_refs` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
 --------------------
-python/ray/data/_internal/datasource/lance_datasink.py
-    DOC101: Method `LanceDatasink.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `LanceDatasink.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: , max_rows_per_file: int, min_rows_per_file: int, mode: Literal['create', 'append', 'overwrite'], schema: Optional[pa.Schema], storage_options: Optional[Dict[str, Any]], uri: str]. Arguments in the docstring but not in the function signature: [max_rows_per_file : , min_rows_per_file : , mode : , schema : , storage_options : , uri : ].
---------------------
 python/ray/data/_internal/datasource/sql_datasource.py
     DOC101: Method `SQLDatasource.supports_sharding`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `SQLDatasource.supports_sharding`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [parallelism: int].

--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -1,12 +1,10 @@
 import pickle
-from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
     List,
-    Literal,
     Optional,
     Tuple,
     Union,
@@ -14,13 +12,39 @@ from typing import (
 
 import pyarrow as pa
 
-from ray.data._internal.util import _check_import
+from ray._common.retry import call_with_retry
+from ray.data._internal.datasource.lance_utils import (
+    create_storage_options_provider,
+    get_or_create_namespace,
+)
+from ray.data._internal.savemode import SaveMode
+from ray.data._internal.util import _check_import, unify_schemas_with_validation
 from ray.data.block import BlockAccessor
+from ray.data.context import DataContext
 from ray.data.datasource.datasink import Datasink
 
 if TYPE_CHECKING:
     import pandas as pd
     from lance.fragment import FragmentMetadata
+
+
+def _declare_table_with_fallback(
+    namespace, table_id: List[str]
+) -> Tuple[str, Optional[Dict[str, str]]]:
+    """Declare a table using declare_table, falling back to create_empty_table."""
+    try:
+        from lance_namespace import DeclareTableRequest
+
+        declare_request = DeclareTableRequest(id=table_id, location=None)
+        declare_response = namespace.declare_table(declare_request)
+        return declare_response.location, declare_response.storage_options
+    except (AttributeError, NotImplementedError):
+        # Fallback for older namespace implementations without declare_table.
+        from lance_namespace import CreateEmptyTableRequest
+
+        create_request = CreateEmptyTableRequest(id=table_id)
+        create_response = namespace.create_empty_table(create_request)
+        return create_response.location, create_response.storage_options
 
 
 def _write_fragment(
@@ -33,12 +57,20 @@ def _write_fragment(
     max_rows_per_group: int = 1024,  # Only useful for v1 writer.
     data_storage_version: Optional[str] = None,
     storage_options: Optional[Dict[str, Any]] = None,
+    namespace_impl: Optional[str] = None,
+    namespace_properties: Optional[Dict[str, str]] = None,
+    table_id: Optional[List[str]] = None,
+    retry_params: Optional[Dict[str, Any]] = None,
 ) -> List[Tuple["FragmentMetadata", "pa.Schema"]]:
     import pandas as pd
     from lance.fragment import DEFAULT_MAX_BYTES_PER_FILE, write_fragments
 
+    stream = list(stream)
+    if not stream:
+        return []
+
     if schema is None:
-        first = next(stream)
+        first = stream[0]
         if isinstance(first, pd.DataFrame):
             schema = pa.Schema.from_pandas(first).remove_metadata()
         else:
@@ -46,8 +78,6 @@ def _write_fragment(
         if len(schema.names) == 0:
             # Empty table.
             schema = None
-
-        stream = chain([first], stream)
 
     def record_batch_converter():
         for block in stream:
@@ -58,17 +88,35 @@ def _write_fragment(
         DEFAULT_MAX_BYTES_PER_FILE if max_bytes_per_file is None else max_bytes_per_file
     )
 
-    reader = pa.RecordBatchReader.from_batches(schema, record_batch_converter())
-    fragments = write_fragments(
-        reader,
-        uri,
-        schema=schema,
-        max_rows_per_file=max_rows_per_file,
-        max_rows_per_group=max_rows_per_group,
-        max_bytes_per_file=max_bytes_per_file,
-        data_storage_version=data_storage_version,
-        storage_options=storage_options,
+    if retry_params is None:
+        retry_params = {
+            "description": "write lance fragments",
+            "match": [],
+            "max_attempts": 1,
+            "max_backoff_s": 0,
+        }
+
+    storage_options_provider = create_storage_options_provider(
+        namespace_impl,
+        namespace_properties,
+        table_id,
     )
+
+    def _write_once():
+        reader = pa.RecordBatchReader.from_batches(schema, record_batch_converter())
+        return write_fragments(
+            reader,
+            uri,
+            schema=schema,
+            max_rows_per_file=max_rows_per_file,
+            max_rows_per_group=max_rows_per_group,
+            max_bytes_per_file=max_bytes_per_file,
+            data_storage_version=data_storage_version,
+            storage_options=storage_options,
+            storage_options_provider=storage_options_provider,
+        )
+
+    fragments = call_with_retry(_write_once, **retry_params)
     return [(fragment, schema) for fragment in fragments]
 
 
@@ -77,21 +125,81 @@ class _BaseLanceDatasink(Datasink):
 
     def __init__(
         self,
-        uri: str,
+        uri: Optional[str] = None,
         schema: Optional[pa.Schema] = None,
-        mode: Literal["create", "append", "overwrite"] = "create",
+        mode: SaveMode = SaveMode.CREATE,
         storage_options: Optional[Dict[str, Any]] = None,
-        *args,
-        **kwargs,
+        table_id: Optional[List[str]] = None,
+        namespace_impl: Optional[str] = None,
+        namespace_properties: Optional[Dict[str, str]] = None,
+        *args: Any,
+        **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
 
-        self.uri = uri
+        if mode not in {SaveMode.CREATE, SaveMode.APPEND, SaveMode.OVERWRITE}:
+            raise ValueError(
+                f"Unsupported Lance write mode: {mode!r}. "
+                "Supported modes are SaveMode.CREATE, SaveMode.APPEND, and SaveMode.OVERWRITE."
+            )
+
+        merged_storage_options: Dict[str, Any] = {}
+        if storage_options:
+            merged_storage_options.update(storage_options)
+
+        self._namespace_impl = namespace_impl
+        self._namespace_properties = namespace_properties
+
+        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
+
+        if namespace is not None and table_id is not None:
+            if uri is not None:
+                import warnings
+
+                warnings.warn(
+                    "The 'uri' argument is ignored when namespace parameters are "
+                    "provided. The resolved namespace location will be used instead.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+            self.table_id = table_id
+            if mode != SaveMode.CREATE:
+                raise ValueError(
+                    "Namespace writes currently only support mode='create'. "
+                    "Use mode='create' for now."
+                )
+
+            uri, ns_storage_options = _declare_table_with_fallback(namespace, table_id)
+            self.uri = uri
+            if ns_storage_options:
+                merged_storage_options.update(ns_storage_options)
+            self._has_namespace_storage_options = True
+        else:
+            self.table_id = None
+            if uri is None:
+                raise ValueError(
+                    "Must provide either 'uri' or ('namespace_impl' and 'table_id')."
+                )
+            self.uri = uri
+            self._has_namespace_storage_options = False
+
         self.schema = schema
         self.mode = mode
 
         self.read_version: Optional[int] = None
-        self.storage_options = storage_options
+        self.storage_options = merged_storage_options
+
+    @property
+    def storage_options_provider(self):
+        """Lazily create storage options provider using namespace_impl/properties."""
+        if not self._has_namespace_storage_options:
+            return None
+        return create_storage_options_provider(
+            self._namespace_impl,
+            self._namespace_properties,
+            self.table_id,
+        )
 
     @property
     def supports_distributed_writes(self) -> bool:
@@ -102,8 +210,12 @@ class _BaseLanceDatasink(Datasink):
 
         import lance
 
-        if self.mode == "append":
-            ds = lance.LanceDataset(self.uri, storage_options=self.storage_options)
+        if self.mode == SaveMode.APPEND:
+            ds = lance.LanceDataset(
+                self.uri,
+                storage_options=self.storage_options,
+                storage_options_provider=self.storage_options_provider,
+            )
             self.read_version = ds.version
             if self.schema is None:
                 self.schema = ds.schema
@@ -133,25 +245,32 @@ class _BaseLanceDatasink(Datasink):
             return
 
         fragments = []
-        schema = None
+        schemas = []
         for batch in write_results:
             for fragment_str, schema_str in batch:
                 fragment = pickle.loads(fragment_str)
                 fragments.append(fragment)
                 schema = pickle.loads(schema_str)
-        # Check weather writer has fragments or not.
-        # Skip commit when there are no fragments.
-        if not schema:
+                if schema is not None:
+                    schemas.append(schema)
+        # Skip commit when there are no fragments/schemas to commit.
+        if not schemas:
             return
-        if self.mode in {"create", "overwrite"}:
-            op = lance.LanceOperation.Overwrite(schema, fragments)
-        elif self.mode == "append":
+
+        unified_schema = unify_schemas_with_validation(schemas)
+        if unified_schema is None:
+            return
+
+        if self.mode in {SaveMode.CREATE, SaveMode.OVERWRITE}:
+            op = lance.LanceOperation.Overwrite(unified_schema, fragments)
+        elif self.mode == SaveMode.APPEND:
             op = lance.LanceOperation.Append(fragments)
         lance.LanceDataset.commit(
             self.uri,
             op,
             read_version=self.read_version,
             storage_options=self.storage_options,
+            storage_options_provider=self.storage_options_provider,
         )
 
 
@@ -164,44 +283,50 @@ class LanceDatasink(_BaseLanceDatasink):
     we can use `LanceFragmentWriter` and `LanceCommitter`.
 
     Args:
-        uri : the base URI of the dataset.
-        schema : pyarrow.Schema, optional.
-            The schema of the dataset.
-        mode : str, optional
-            The write mode. Default is 'append'.
-            Choices are 'append', 'create', 'overwrite'.
-        min_rows_per_file : int, optional
-            The minimum number of rows per file. Default is 1024 * 1024.
-        max_rows_per_file : int, optional
-            The maximum number of rows per file. Default is 64 * 1024 * 1024.
-        data_storage_version: optional, str, default None
-            The version of the data storage format to use. Newer versions are more
-            efficient but require newer versions of lance to read.  The default is
-            "legacy" which will use the legacy v1 version.  See the user guide
-            for more details.
-        storage_options : Dict[str, Any], optional
-            The storage options for the writer. Default is None.
+        uri: The base URI of the dataset.
+        schema: The schema of the dataset.
+        mode: The write mode. Default is SaveMode.CREATE. Choices are
+            SaveMode.CREATE, SaveMode.APPEND, SaveMode.OVERWRITE.
+        min_rows_per_file: The minimum number of rows per file. Default is 1024 * 1024.
+        max_rows_per_file: The maximum number of rows per file. Default is 64 * 1024 * 1024.
+        data_storage_version: The version of the data storage format to use. Newer versions are more
+            efficient but require newer versions of lance to read. The default is "legacy",
+            which will use the legacy v1 version. See the user guide for more details.
+        storage_options: The storage options for the writer. Default is None.
+        table_id: The table identifier as a list of strings, used with namespace params.
+        namespace_impl: The namespace implementation type (e.g., "rest", "dir").
+            Used together with namespace_properties and table_id for credentials vending.
+        namespace_properties: Properties for connecting to the namespace.
+            Used together with namespace_impl and table_id for credentials vending.
+        *args: Additional positional arguments forwarded to the base class.
+        **kwargs: Additional keyword arguments forwarded to the base class.
     """
 
     NAME = "Lance"
 
     def __init__(
         self,
-        uri: str,
+        uri: Optional[str] = None,
         schema: Optional[pa.Schema] = None,
-        mode: Literal["create", "append", "overwrite"] = "create",
+        mode: SaveMode = SaveMode.CREATE,
         min_rows_per_file: int = 1024 * 1024,
         max_rows_per_file: int = 64 * 1024 * 1024,
         data_storage_version: Optional[str] = None,
         storage_options: Optional[Dict[str, Any]] = None,
-        *args,
-        **kwargs,
+        table_id: Optional[List[str]] = None,
+        namespace_impl: Optional[str] = None,
+        namespace_properties: Optional[Dict[str, str]] = None,
+        *args: Any,
+        **kwargs: Any,
     ):
         super().__init__(
             uri,
             schema=schema,
             mode=mode,
             storage_options=storage_options,
+            table_id=table_id,
+            namespace_impl=namespace_impl,
+            namespace_properties=namespace_properties,
             *args,
             **kwargs,
         )
@@ -211,6 +336,18 @@ class LanceDatasink(_BaseLanceDatasink):
         self.data_storage_version = data_storage_version
         # if mode is append, read_version is read from existing dataset.
         self.read_version: Optional[int] = None
+
+        data_context = DataContext.get_current()
+        lance_config = data_context.lance_config
+        match = []
+        match.extend(lance_config.write_fragments_errors_to_retry)
+        match.extend(data_context.retried_io_errors)
+        self._retry_params = {
+            "description": "write lance fragments",
+            "match": match,
+            "max_attempts": lance_config.write_fragments_max_attempts,
+            "max_backoff_s": lance_config.write_fragments_retry_max_backoff_s,
+        }
 
     @property
     def min_rows_per_write(self) -> int:
@@ -231,6 +368,10 @@ class LanceDatasink(_BaseLanceDatasink):
             max_rows_per_file=self.max_rows_per_file,
             data_storage_version=self.data_storage_version,
             storage_options=self.storage_options,
+            namespace_impl=self._namespace_impl,
+            namespace_properties=self._namespace_properties,
+            table_id=self.table_id,
+            retry_params=self._retry_params,
         )
         return [
             (pickle.dumps(fragment), pickle.dumps(schema))

--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -22,7 +22,7 @@ from ray.data._internal.datasource.lance_utils import (
 )
 from ray.data._internal.savemode import SaveMode
 from ray.data._internal.util import _check_import, unify_schemas_with_validation
-from ray.data.block import BlockAccessor
+from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
 from ray.data.datasource.datasink import Datasink
 
@@ -54,18 +54,15 @@ def _declare_table_with_fallback(
 
 
 def _make_stream_factory(
-    stream: Iterable[Union["pa.Table", "pd.DataFrame"]], replayable: bool
-) -> Tuple[
-    Optional[Callable[[], Iterator[Union["pa.Table", "pd.DataFrame"]]]],
-    Optional[Union["pa.Table", "pd.DataFrame"]],
-]:
+    stream: Iterable[Block], replayable: bool
+) -> Tuple[Optional[Callable[[], Iterator[Block]]], Optional[Block]]:
     """Return a reusable stream factory and the first block, or (None, None)."""
     if replayable:
         blocks = list(stream)
         if not blocks:
             return None, None
 
-        def stream_factory() -> Iterator[Union["pa.Table", "pd.DataFrame"]]:
+        def stream_factory() -> Iterator[Block]:
             return iter(blocks)
 
         return stream_factory, blocks[0]
@@ -75,14 +72,14 @@ def _make_stream_factory(
     if first is None:
         return None, None
 
-    def stream_factory() -> Iterator[Union["pa.Table", "pd.DataFrame"]]:
+    def stream_factory() -> Iterator[Block]:
         return chain([first], stream_iter)
 
     return stream_factory, first
 
 
 def _write_fragment(
-    stream: Iterable[Union["pa.Table", "pd.DataFrame"]],
+    stream: Iterable[Block],
     uri: str,
     *,
     schema: Optional["pa.Schema"] = None,

--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -1,4 +1,5 @@
 import pickle
+from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -65,29 +66,6 @@ def _write_fragment(
     import pandas as pd
     from lance.fragment import DEFAULT_MAX_BYTES_PER_FILE, write_fragments
 
-    stream = list(stream)
-    if not stream:
-        return []
-
-    if schema is None:
-        first = stream[0]
-        if isinstance(first, pd.DataFrame):
-            schema = pa.Schema.from_pandas(first).remove_metadata()
-        else:
-            schema = first.schema
-        if len(schema.names) == 0:
-            # Empty table.
-            schema = None
-
-    def record_batch_converter():
-        for block in stream:
-            tbl = BlockAccessor.for_block(block).to_arrow()
-            yield from tbl.to_batches()
-
-    max_bytes_per_file = (
-        DEFAULT_MAX_BYTES_PER_FILE if max_bytes_per_file is None else max_bytes_per_file
-    )
-
     if retry_params is None:
         retry_params = {
             "description": "write lance fragments",
@@ -96,6 +74,45 @@ def _write_fragment(
             "max_backoff_s": 0,
         }
 
+    max_attempts = retry_params.get("max_attempts", 1)
+    if max_attempts > 1:
+        # Retries need a replayable input stream, so materialize blocks only when
+        # the write may be attempted more than once.
+        replayable_stream = list(stream)
+        if not replayable_stream:
+            return []
+        first = replayable_stream[0]
+
+        def stream_factory():
+            return iter(replayable_stream)
+
+    else:
+        stream = iter(stream)
+        first = next(stream, None)
+        if first is None:
+            return []
+
+        def stream_factory():
+            return chain([first], stream)
+
+    if schema is None:
+        if isinstance(first, pd.DataFrame):
+            schema = pa.Schema.from_pandas(first).remove_metadata()
+        else:
+            schema = first.schema
+        if len(schema.names) == 0:
+            # Empty table.
+            schema = None
+
+    def record_batch_converter(block_stream):
+        for block in block_stream:
+            tbl = BlockAccessor.for_block(block).to_arrow()
+            yield from tbl.to_batches()
+
+    max_bytes_per_file = (
+        DEFAULT_MAX_BYTES_PER_FILE if max_bytes_per_file is None else max_bytes_per_file
+    )
+
     storage_options_provider = create_storage_options_provider(
         namespace_impl,
         namespace_properties,
@@ -103,7 +120,9 @@ def _write_fragment(
     )
 
     def _write_once():
-        reader = pa.RecordBatchReader.from_batches(schema, record_batch_converter())
+        reader = pa.RecordBatchReader.from_batches(
+            schema, record_batch_converter(stream_factory())
+        )
         return write_fragments(
             reader,
             uri,
@@ -286,7 +305,8 @@ class LanceDatasink(_BaseLanceDatasink):
         uri: The base URI of the dataset.
         schema: The schema of the dataset.
         mode: The write mode. Default is SaveMode.CREATE. Choices are
-            SaveMode.CREATE, SaveMode.APPEND, SaveMode.OVERWRITE.
+            SaveMode.CREATE, SaveMode.APPEND, SaveMode.OVERWRITE. Namespace-backed
+            writes currently support only SaveMode.CREATE.
         min_rows_per_file: The minimum number of rows per file. Default is 1024 * 1024.
         max_rows_per_file: The maximum number of rows per file. Default is 64 * 1024 * 1024.
         data_storage_version: The version of the data storage format to use. Newer versions are more
@@ -298,6 +318,8 @@ class LanceDatasink(_BaseLanceDatasink):
             Used together with namespace_properties and table_id for credentials vending.
         namespace_properties: Properties for connecting to the namespace.
             Used together with namespace_impl and table_id for credentials vending.
+            When namespace params are provided, only SaveMode.CREATE is currently
+            supported.
         *args: Additional positional arguments forwarded to the base class.
         **kwargs: Additional keyword arguments forwarded to the base class.
     """

--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -3,8 +3,10 @@ from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -29,6 +31,9 @@ if TYPE_CHECKING:
     from lance.fragment import FragmentMetadata
 
 
+_WRITE_LANCE_FRAGMENTS_DESCRIPTION = "write lance fragments"
+
+
 def _declare_table_with_fallback(
     namespace, table_id: List[str]
 ) -> Tuple[str, Optional[Dict[str, str]]]:
@@ -46,6 +51,34 @@ def _declare_table_with_fallback(
         create_request = CreateEmptyTableRequest(id=table_id)
         create_response = namespace.create_empty_table(create_request)
         return create_response.location, create_response.storage_options
+
+
+def _make_stream_factory(
+    stream: Iterable[Union["pa.Table", "pd.DataFrame"]], replayable: bool
+) -> Tuple[
+    Optional[Callable[[], Iterator[Union["pa.Table", "pd.DataFrame"]]]],
+    Optional[Union["pa.Table", "pd.DataFrame"]],
+]:
+    """Return a reusable stream factory and the first block, or (None, None)."""
+    if replayable:
+        blocks = list(stream)
+        if not blocks:
+            return None, None
+
+        def stream_factory() -> Iterator[Union["pa.Table", "pd.DataFrame"]]:
+            return iter(blocks)
+
+        return stream_factory, blocks[0]
+
+    stream_iter = iter(stream)
+    first = next(stream_iter, None)
+    if first is None:
+        return None, None
+
+    def stream_factory() -> Iterator[Union["pa.Table", "pd.DataFrame"]]:
+        return chain([first], stream_iter)
+
+    return stream_factory, first
 
 
 def _write_fragment(
@@ -68,32 +101,16 @@ def _write_fragment(
 
     if retry_params is None:
         retry_params = {
-            "description": "write lance fragments",
+            "description": _WRITE_LANCE_FRAGMENTS_DESCRIPTION,
             "match": [],
             "max_attempts": 1,
             "max_backoff_s": 0,
         }
 
     max_attempts = retry_params.get("max_attempts", 1)
-    if max_attempts > 1:
-        # Retries need a replayable input stream, so materialize blocks only when
-        # the write may be attempted more than once.
-        replayable_stream = list(stream)
-        if not replayable_stream:
-            return []
-        first = replayable_stream[0]
-
-        def stream_factory():
-            return iter(replayable_stream)
-
-    else:
-        stream = iter(stream)
-        first = next(stream, None)
-        if first is None:
-            return []
-
-        def stream_factory():
-            return chain([first], stream)
+    stream_factory, first = _make_stream_factory(stream, replayable=max_attempts > 1)
+    if stream_factory is None or first is None:
+        return []
 
     if schema is None:
         if isinstance(first, pd.DataFrame):
@@ -365,7 +382,7 @@ class LanceDatasink(_BaseLanceDatasink):
         match.extend(lance_config.write_fragments_errors_to_retry)
         match.extend(data_context.retried_io_errors)
         self._retry_params = {
-            "description": "write lance fragments",
+            "description": _WRITE_LANCE_FRAGMENTS_DESCRIPTION,
             "match": match,
             "max_attempts": lance_config.write_fragments_max_attempts,
             "max_backoff_s": lance_config.write_fragments_retry_max_backoff_s,

--- a/python/ray/data/_internal/datasource/lance_utils.py
+++ b/python/ray/data/_internal/datasource/lance_utils.py
@@ -1,0 +1,57 @@
+import os
+from functools import lru_cache
+from typing import Dict, List, Optional, Tuple
+
+_NAMESPACE_CACHE_SIZE = int(os.environ.get("LANCE_RAY_NAMESPACE_CACHE_SIZE", "16"))
+
+
+def _has_namespace_params(
+    namespace_impl: Optional[str],
+    table_id: Optional[List[str]],
+) -> bool:
+    return namespace_impl is not None and table_id is not None
+
+
+@lru_cache(maxsize=_NAMESPACE_CACHE_SIZE)
+def _get_cached_namespace(
+    namespace_impl: str,
+    namespace_properties_tuple: Optional[Tuple[Tuple[str, str], ...]],
+):
+    import lance_namespace as ln
+
+    namespace_properties = (
+        dict(namespace_properties_tuple) if namespace_properties_tuple else {}
+    )
+    return ln.connect(namespace_impl, namespace_properties)
+
+
+def get_or_create_namespace(
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[Dict[str, str]],
+):
+    """Get or create a cached namespace client for the worker."""
+    if namespace_impl is None:
+        return None
+
+    namespace_properties_tuple = (
+        tuple(sorted(namespace_properties.items())) if namespace_properties else None
+    )
+    return _get_cached_namespace(namespace_impl, namespace_properties_tuple)
+
+
+def create_storage_options_provider(
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[Dict[str, str]],
+    table_id: Optional[List[str]],
+):
+    """Create a LanceNamespaceStorageOptionsProvider if namespace params exist."""
+    if not _has_namespace_params(namespace_impl, table_id):
+        return None
+
+    namespace = get_or_create_namespace(namespace_impl, namespace_properties)
+    if namespace is None:
+        return None
+
+    from lance import LanceNamespaceStorageOptionsProvider
+
+    return LanceNamespaceStorageOptionsProvider(namespace=namespace, table_id=table_id)

--- a/python/ray/data/_internal/savemode.py
+++ b/python/ray/data/_internal/savemode.py
@@ -7,6 +7,9 @@ from ray.util.annotations import PublicAPI
 class SaveMode(str, Enum):
     """Enum of possible modes for saving/writing data."""
 
+    """Create new data and error if data already exists."""
+    CREATE = "create"
+
     """Add new data without modifying existing data."""
     APPEND = "append"
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -199,6 +199,21 @@ DEFAULT_ICEBERG_CATALOG_RETRIED_ERRORS = (
     "DEADLINE_EXCEEDED",
 )
 
+DEFAULT_LANCE_READ_FRAGMENTS_ERRORS_TO_RETRY = ("LanceError(IO)",)
+DEFAULT_LANCE_READ_FRAGMENTS_MAX_ATTEMPTS = env_integer(
+    "RAY_DATA_LANCE_READ_FRAGMENTS_MAX_ATTEMPTS", 10
+)
+DEFAULT_LANCE_READ_FRAGMENTS_RETRY_MAX_BACKOFF_S = env_integer(
+    "RAY_DATA_LANCE_READ_FRAGMENTS_RETRY_MAX_BACKOFF_S", 32
+)
+DEFAULT_LANCE_WRITE_FRAGMENTS_ERRORS_TO_RETRY = ("LanceError(IO)",)
+DEFAULT_LANCE_WRITE_FRAGMENTS_MAX_ATTEMPTS = env_integer(
+    "RAY_DATA_LANCE_WRITE_FRAGMENTS_MAX_ATTEMPTS", 10
+)
+DEFAULT_LANCE_WRITE_FRAGMENTS_RETRY_MAX_BACKOFF_S = env_integer(
+    "RAY_DATA_LANCE_WRITE_FRAGMENTS_RETRY_MAX_BACKOFF_S", 32
+)
+
 DEFAULT_WARN_ON_DRIVER_MEMORY_USAGE_BYTES = 2 * 1024 * 1024 * 1024
 
 DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS = False
@@ -318,6 +333,42 @@ class IcebergConfig:
     catalog_retry_max_backoff_s: int = DEFAULT_ICEBERG_CATALOG_RETRY_MAX_BACKOFF_S
     catalog_retried_errors: List[str] = field(
         default_factory=lambda: list(DEFAULT_ICEBERG_CATALOG_RETRIED_ERRORS)
+    )
+
+
+@DeveloperAPI
+@dataclass
+class LanceConfig:
+    """Configuration for Lance datasource and datasink operations.
+
+    Args:
+        read_fragments_errors_to_retry: A list of substrings of error messages that
+            should trigger a retry for Lance read operations.
+        read_fragments_max_attempts: Maximum number of retry attempts for Lance
+            read operations.
+        read_fragments_retry_max_backoff_s: Maximum backoff time in seconds between
+            Lance read retries.
+        write_fragments_errors_to_retry: A list of substrings of error messages that
+            should trigger a retry for Lance write operations.
+        write_fragments_max_attempts: Maximum number of retry attempts for Lance
+            write operations.
+        write_fragments_retry_max_backoff_s: Maximum backoff time in seconds between
+            Lance write retries.
+    """
+
+    read_fragments_errors_to_retry: List[str] = field(
+        default_factory=lambda: list(DEFAULT_LANCE_READ_FRAGMENTS_ERRORS_TO_RETRY)
+    )
+    read_fragments_max_attempts: int = DEFAULT_LANCE_READ_FRAGMENTS_MAX_ATTEMPTS
+    read_fragments_retry_max_backoff_s: int = (
+        DEFAULT_LANCE_READ_FRAGMENTS_RETRY_MAX_BACKOFF_S
+    )
+    write_fragments_errors_to_retry: List[str] = field(
+        default_factory=lambda: list(DEFAULT_LANCE_WRITE_FRAGMENTS_ERRORS_TO_RETRY)
+    )
+    write_fragments_max_attempts: int = DEFAULT_LANCE_WRITE_FRAGMENTS_MAX_ATTEMPTS
+    write_fragments_retry_max_backoff_s: int = (
+        DEFAULT_LANCE_WRITE_FRAGMENTS_RETRY_MAX_BACKOFF_S
     )
 
 
@@ -528,6 +579,9 @@ class DataContext:
         retried_io_errors: A list of substrings of error messages that should
             trigger a retry when reading or writing files. This is useful for handling
             transient errors when reading from remote storage systems.
+        lance_config: Configuration for Lance datasource and datasink operations
+            including retry settings for read and write operations. See
+            :class:`LanceConfig` for details.
         iceberg_config: Configuration for Iceberg datasource operations including
             retry settings for file writes and catalog operations. See
             :class:`IcebergConfig` for details.
@@ -688,6 +742,7 @@ class DataContext:
     retried_io_errors: List[str] = field(
         default_factory=lambda: list(DEFAULT_RETRIED_IO_ERRORS)
     )
+    lance_config: LanceConfig = field(default_factory=LanceConfig)
     iceberg_config: IcebergConfig = field(default_factory=IcebergConfig)
     enable_per_node_metrics: bool = DEFAULT_ENABLE_PER_NODE_METRICS
     override_object_store_memory_limit_fraction: float = None

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5504,9 +5504,6 @@ class Dataset:
                 efficient but require newer versions of lance to read.  The default is
                 "legacy" which will use the legacy v1 version.  See the user guide
                 for more details.
-            table_id: The table identifier as a list of strings, used with namespace params.
-            namespace_impl: The namespace implementation type (e.g., "rest", "dir").
-            namespace_properties: Properties for connecting to the namespace.
             storage_options: The storage options for the writer. Default is None.
             table_id: The table identifier as a list of strings, used with namespace params.
             namespace_impl: The namespace implementation type (e.g., "rest", "dir").

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5498,6 +5498,7 @@ class Dataset:
             schema: The schema of the dataset. If not provided, it is inferred from the data.
             mode: The write mode using SaveMode enum:
                 SaveMode.CREATE, SaveMode.APPEND, or SaveMode.OVERWRITE.
+                Namespace-backed writes currently support only SaveMode.CREATE.
             min_rows_per_file: The minimum number of rows per file.
             max_rows_per_file: The maximum number of rows per file.
             data_storage_version: The version of the data storage format to use. Newer versions are more
@@ -5508,6 +5509,8 @@ class Dataset:
             table_id: The table identifier as a list of strings, used with namespace params.
             namespace_impl: The namespace implementation type (e.g., "rest", "dir").
             namespace_properties: Properties for connecting to the namespace.
+                When namespace params are provided, only SaveMode.CREATE is
+                currently supported.
             ray_remote_args: Kwargs passed to :func:`ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5470,11 +5470,14 @@ class Dataset:
         path: str,
         *,
         schema: Optional["pyarrow.Schema"] = None,
-        mode: Literal["create", "append", "overwrite"] = "create",
+        mode: SaveMode = SaveMode.CREATE,
         min_rows_per_file: int = 1024 * 1024,
         max_rows_per_file: int = 64 * 1024 * 1024,
         data_storage_version: Optional[str] = None,
         storage_options: Optional[Dict[str, Any]] = None,
+        table_id: Optional[List[str]] = None,
+        namespace_impl: Optional[str] = None,
+        namespace_properties: Optional[Dict[str, str]] = None,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,
     ) -> None:
@@ -5490,16 +5493,24 @@ class Dataset:
                 ds.write_lance("/tmp/data/")
 
         Args:
-            path: The path to the destination Lance dataset.
+            path: The path to the destination Lance dataset. Ignored when namespace
+                parameters are provided; the namespace-resolved location is used.
             schema: The schema of the dataset. If not provided, it is inferred from the data.
-            mode: The write mode. Can be "create", "append", or "overwrite".
+            mode: The write mode using SaveMode enum:
+                SaveMode.CREATE, SaveMode.APPEND, or SaveMode.OVERWRITE.
             min_rows_per_file: The minimum number of rows per file.
             max_rows_per_file: The maximum number of rows per file.
             data_storage_version: The version of the data storage format to use. Newer versions are more
                 efficient but require newer versions of lance to read.  The default is
                 "legacy" which will use the legacy v1 version.  See the user guide
                 for more details.
+            table_id: The table identifier as a list of strings, used with namespace params.
+            namespace_impl: The namespace implementation type (e.g., "rest", "dir").
+            namespace_properties: Properties for connecting to the namespace.
             storage_options: The storage options for the writer. Default is None.
+            table_id: The table identifier as a list of strings, used with namespace params.
+            namespace_impl: The namespace implementation type (e.g., "rest", "dir").
+            namespace_properties: Properties for connecting to the namespace.
             ray_remote_args: Kwargs passed to :func:`ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the
@@ -5514,6 +5525,9 @@ class Dataset:
             max_rows_per_file=max_rows_per_file,
             data_storage_version=data_storage_version,
             storage_options=storage_options,
+            table_id=table_id,
+            namespace_impl=namespace_impl,
+            namespace_properties=namespace_properties,
         )
 
         self.write_datasink(

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -99,7 +99,7 @@ class _FileDatasink(Datasink[None]):
             self.filesystem.get_file_info(self.path).type is not FileType.NotFound
         )
         if dir_exists:
-            if self.mode == SaveMode.ERROR:
+            if self.mode in {SaveMode.ERROR, SaveMode.CREATE}:
                 raise ValueError(
                     f"Path {self.path} already exists. "
                     "If this is unexpected, use mode='ignore' to ignore those files"

--- a/python/ray/data/tests/datasource/test_lance.py
+++ b/python/ray/data/tests/datasource/test_lance.py
@@ -9,6 +9,7 @@ from pytest_lazy_fixtures import lf as lazy_fixture
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray.data import Schema
+from ray.data._internal.datasource.lance_datasink import LanceDatasink, _write_fragment
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
 from ray.data.datasource import SaveMode
 from ray.data.datasource.path_util import _unwrap_protocol
@@ -283,6 +284,61 @@ def test_write_lance_passes_namespace_args(mock_lance_write):
     assert captured["kwargs"]["namespace_impl"] == namespace_impl
     assert captured["kwargs"]["namespace_properties"] == namespace_properties
     assert isinstance(captured["datasink"], fake_lance_datasink_cls)
+
+
+@pytest.mark.parametrize("mode", [SaveMode.APPEND, SaveMode.OVERWRITE])
+def test_lance_namespace_write_rejects_non_create_mode(monkeypatch, mode):
+    class _FakeNamespace:
+        pass
+
+    monkeypatch.setattr(
+        "ray.data._internal.datasource.lance_datasink.get_or_create_namespace",
+        lambda namespace_impl, namespace_properties: _FakeNamespace(),
+    )
+
+    with pytest.raises(ValueError, match="Namespace writes currently only support"):
+        LanceDatasink(
+            uri="/tmp/lance-namespace-test",
+            mode=mode,
+            table_id=["db", "table"],
+            namespace_impl="dir",
+            namespace_properties={"path": "/tmp/ns"},
+        )
+
+
+@pytest.mark.parametrize(
+    "max_attempts,expected_blocks_consumed_before_write",
+    [(1, 1), (2, 3)],
+)
+def test_write_fragment_only_materializes_stream_when_retrying(
+    monkeypatch, max_attempts, expected_blocks_consumed_before_write
+):
+    import lance.fragment
+
+    consumed = {"count": 0}
+    blocks = [pa.table({"id": [i]}) for i in range(3)]
+
+    def block_stream():
+        for block in blocks:
+            consumed["count"] += 1
+            yield block
+
+    def fake_write_fragments(reader, uri, **kwargs):
+        assert consumed["count"] == expected_blocks_consumed_before_write
+        return []
+
+    monkeypatch.setattr(lance.fragment, "write_fragments", fake_write_fragments)
+
+    _write_fragment(
+        block_stream(),
+        "/tmp/lance-materialization-test",
+        retry_params={
+            "description": "write lance fragments",
+            "match": [],
+            "max_attempts": max_attempts,
+            "max_backoff_s": 0,
+        },
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_lance.py
+++ b/python/ray/data/tests/datasource/test_lance.py
@@ -9,7 +9,11 @@ from pytest_lazy_fixtures import lf as lazy_fixture
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray.data import Schema
-from ray.data._internal.datasource.lance_datasink import LanceDatasink, _write_fragment
+from ray.data._internal.datasource.lance_datasink import (
+    _WRITE_LANCE_FRAGMENTS_DESCRIPTION,
+    LanceDatasink,
+    _write_fragment,
+)
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
 from ray.data.datasource import SaveMode
 from ray.data.datasource.path_util import _unwrap_protocol
@@ -333,7 +337,7 @@ def test_write_fragment_only_materializes_stream_when_retrying(
         block_stream(),
         "/tmp/lance-materialization-test",
         retry_params={
-            "description": "write lance fragments",
+            "description": _WRITE_LANCE_FRAGMENTS_DESCRIPTION,
             "match": [],
             "max_attempts": max_attempts,
             "max_backoff_s": 0,

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -13,7 +13,7 @@ google-cloud-bigquery-storage
 google-api-core
 webdataset
 raydp==1.7.0b20250423.dev0
-pylance==0.22
+pylance==1.0.3
 delta-sharing
 deltalake==0.9.0
 pytest-mock

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -984,6 +984,10 @@ kubernetes==24.2.0
     # via -r python/requirements/test-requirements.txt
 labmaze==1.0.6
     # via dm-control
+lance-namespace==0.4.5
+    # via pylance
+lance-namespace-urllib3-client==0.4.5
+    # via lance-namespace
 lazy-object-proxy==1.9.0
     # via openapi-spec-validator
 libclang==18.1.1
@@ -1632,6 +1636,7 @@ pydantic==2.12.4
     #   deepspeed
     #   fastapi
     #   gradio
+    #   lance-namespace-urllib3-client
     #   mlflow-skinny
     #   pyiceberg
     #   taskiq
@@ -1664,7 +1669,7 @@ pyjwt==2.8.0
     #   azure-cli-core
     #   msal
     #   snowflake-connector-python
-pylance==0.22.0
+pylance==1.0.3
     # via -r python/requirements/ml/data-test-requirements.txt
 pymars==0.10.0 ; python_version < "3.12"
     # via -r python/requirements/ml/data-requirements.txt
@@ -1788,6 +1793,7 @@ python-dateutil==2.8.2
     #   holidays
     #   jupyter-client
     #   kubernetes
+    #   lance-namespace-urllib3-client
     #   matplotlib
     #   moto
     #   openlineage-python
@@ -2403,6 +2409,7 @@ typing-extensions==4.15.0
     #   graphene
     #   gymnasium
     #   huggingface-hub
+    #   lance-namespace-urllib3-client
     #   lightning-utilities
     #   mlflow-skinny
     #   mypy
@@ -2452,6 +2459,7 @@ urllib3==1.26.19
     #   docker
     #   dulwich
     #   kubernetes
+    #   lance-namespace-urllib3-client
     #   requests
     #   responses
     #   semgrep

--- a/python/requirements_compiled_py3.13.txt
+++ b/python/requirements_compiled_py3.13.txt
@@ -1707,7 +1707,7 @@ pyjwt==2.8.0
     #   azure-cli-core
     #   msal
     #   snowflake-connector-python
-pylance==0.22.0
+pylance==1.0.3
     # via -r python/requirements/ml/data-test-requirements.txt
 pymars==0.10.0 ; python_version < "3.12"
     # via -r python/requirements/ml/data-requirements.txt


### PR DESCRIPTION
## Description
Port lance-ray datasink features into Ray Data LanceDatasink: write retry, Lance namespaces, and driver-side commit flow.

## Related issues
> Link related issues: "Fixes #60147", "Closes #60147", or "Related to #60147".

## Additional information

#### implementation details

- Write retry
    - Logic/parameters (from lance-ray): retry on LanceError(IO) + DataContext.retried_io_errors, with max_attempts=10 and max_backoff_s=32.
    - Execution framework (Ray-native): use ray._common.retry.call_with_retry to wrap write_fragments.
- Lance namespaces (from lance-ray)
    - This PR focuses on write-side namespace support in Ray Data (`Dataset.write_lance()` / `LanceDatasink`).
    - Add table_id / namespace_impl / namespace_properties to LanceDatasink.
    - Resolve/declare tables via DescribeTableRequest / DeclareTableRequest / CreateEmptyTableRequest.
    - Merge user storage_options with namespace-provided options.
    - Create and pass storage_options_provider to write_fragments, LanceDataset, and commit.
    - New helper module: python/ray/data/_internal/datasource/lance_utils.py.
    - Namespace read parity via `read_lance()` is not included in this PR.
- Driver commit (aligned with lance-ray)
    - Keep the same driver-side commit behavior as lance-ray: collect fragments and use the last observed schema from write results, then commit.
    - This does not implement true schema merge/unification, since lance-ray itself doesn’t either.
- High-level API
    - Dataset.write_lance() now accepts and forwards table_id / namespace_impl / namespace_properties.
- Tests
    - Added a parameterized test to verify write_lance() forwards namespace arguments.

#### Testing

- python -m pytest python/ray/data/tests/datasource/test_lance.py -q

#### Notes

- Requires a lance/pylance version that supports storage_options_provider (validated locally with 1.0.3).
