### PR TITLE
[doc][ci] Fix basic_llm_example test and CI triggering

### DIFF
--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -26,6 +26,7 @@ python/ray/air/
 
 python/ray/llm/
 doc/source/llm/
+doc/source/data/doc_code/working-with-llms/
 .buildkite/llm.rayci.yml
 ci/docker/llm.build.Dockerfile
 python/deplocks/llm/*.lock

--- a/doc/source/data/doc_code/working-with-llms/basic_llm_example.py
+++ b/doc/source/data/doc_code/working-with-llms/basic_llm_example.py
@@ -8,9 +8,6 @@ import subprocess
 import sys
 
 subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "ray[llm]"])
-subprocess.check_call(
-    [sys.executable, "-m", "pip", "install", "--upgrade", "transformers"]
-)
 subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
 
 

--- a/doc/source/data/doc_code/working-with-llms/basic_llm_example.py
+++ b/doc/source/data/doc_code/working-with-llms/basic_llm_example.py
@@ -3,14 +3,6 @@ This file serves as a documentation example and CI test for basic LLM batch infe
 
 """
 
-# Dependency setup
-import subprocess
-import sys
-
-subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "ray[llm]"])
-subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
-
-
 # __basic_llm_example_start__
 import ray
 from ray.data.llm import vLLMEngineProcessorConfig, build_processor


### PR DESCRIPTION
## Summary
- Remove all runtime pip install commands from basic_llm_example.py
- Add `doc/source/data/doc_code/working-with-llms/` to LLM CI test rules

## Why is this change needed?

### 1. Remove unnecessary pip installs
The basic_llm_example.py doc test was running pip install commands at runtime:
- `pip install --upgrade ray[llm]`
- `pip install --upgrade transformers`
- `pip install numpy==1.26.4`

These are unnecessary because the llmgpubuild Docker image already has all dependencies installed via the lock file. 

The `pip install --upgrade transformers` line specifically caused the test to break when transformers v5.0.0 was released (Jan 26, 2026), because vLLM 0.13.0 imports `ALLOWED_LAYER_TYPES` from `transformers.configuration_utils` - a constant that was split into separate constants in v5.

### 2. Fix CI test triggering
Changes to `doc/source/data/doc_code/working-with-llms/` were not triggering LLM CI tests because the path wasn't in `.buildkite/test.rules.txt`. The tests have `team:llm` and `gpu` tags and run on the llmgpubuild image, so they should be triggered by the LLM rules.

## Related issue
- vLLM issue: https://github.com/vllm-project/vllm/issues/31181

## Test plan
- [ ] LLM CI tests should now be triggered for this PR
- [ ] `//doc:source/data/doc_code/working-with-llms/basic_llm_example` test should pass