### PR TITLE
[Docs] Add ray-llm ownership for data working-with-llms docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,6 +79,7 @@
 /python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json @ray-project/ray-llm
 /python/ray/serve/llm/ @ray-project/ray-llm
 /doc/source/serve/llm/ @ray-project/ray-llm
+/doc/source/data/doc_code/working-with-llms/ @ray-project/ray-llm
 
 # ML Docker Dependencies
 /python/requirements/ml/dl-cpu-requirements.txt @richardliaw @matthewdeng


### PR DESCRIPTION
## Summary
- Add CODEOWNERS entry for `/doc/source/data/doc_code/working-with-llms/` to assign ownership to the ray-llm team

## Test plan
- N/A (CODEOWNERS change only)