### PR TITLE
[Data][Release] Increase num_partitions for autoscaling map_groups release test

### DIFF
--- a/release/nightly_tests/dataset/groupby_benchmark.py
+++ b/release/nightly_tests/dataset/groupby_benchmark.py
@@ -34,6 +34,13 @@ def parse_args() -> argparse.Namespace:
         type=str,
         help="Strategy to use when shuffling data (see ShuffleStrategy for accepted values)",
     )
+    parser.add_argument(
+        "--num-partitions",
+        required=False,
+        default=None,
+        type=int,
+        help="Number of partitions for groupby (defaults to auto)",
+    )
 
     consume_group = parser.add_mutually_exclusive_group()
     consume_group.add_argument("--aggregate", action="store_true")
@@ -61,7 +68,7 @@ def main(args):
         )
         grouped_ds = ray.data.read_parquet(
             path, override_num_blocks=override_num_blocks
-        ).groupby(args.group_by)
+        ).groupby(args.group_by, num_partitions=args.num_partitions)
         consume_fn(grouped_ds)
 
         # Report arguments for the benchmark.

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -177,11 +177,12 @@
       --shuffle-strategy {{shuffle_strategy}}
 
 
+# Non-autoscaling hash_shuffle tests (fixed_size or sort_shuffle)
 - name: "map_groups_{{scaling}}_{{shuffle_strategy}}_{{columns}}"
   python: "3.10"
   matrix:
     setup:
-      scaling: [fixed_size, autoscaling]
+      scaling: [fixed_size]
       shuffle_strategy: [sort_shuffle_pull_based, hash_shuffle]
       columns:
         - "column08 column13 column14"   # 84 groups
@@ -195,6 +196,45 @@
     script: >
       python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
       --shuffle-strategy {{shuffle_strategy}}
+
+- name: "map_groups_{{scaling}}_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      scaling: [autoscaling]
+      shuffle_strategy: [sort_shuffle_pull_based]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+        - "column02 column14"  # 7M groups
+
+  cluster:
+    cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}}
+
+# Autoscaling + hash_shuffle tests with explicit num_partitions to avoid OOM
+- name: "map_groups_{{scaling}}_{{shuffle_strategy}}_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      scaling: [autoscaling]
+      shuffle_strategy: [hash_shuffle]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+        - "column02 column14"  # 7M groups
+
+  cluster:
+    cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}} --num-partitions 1000
 
 ###############
 # Join tests


### PR DESCRIPTION
## Description
The default of 200 partitions resulted in an OOM for the autoscaling test.

Hypothesis: Skew in the data

Old run: https://buildkite.com/anyscale/rayturbo-release/builds/4852#_
New run: https://buildkite.com/ray-project/release/builds/77189

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
