### PR TITLE
[core][GCS] Merge KillActor into DestroyActor with no_restart flag

### DIFF
--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -295,6 +295,7 @@ void GcsActorManager::HandleReportActorOutOfScope(
         actor_id,
         GenActorOutOfScopeCause(actor),
         /*force_kill=*/false,
+        /*no_restart=*/true,
         [reply, send_reply_callback]() {
           GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
         },
@@ -640,11 +641,10 @@ void GcsActorManager::HandleKillActorViaGcs(rpc::KillActorViaGcsRequest request,
   if (it != registered_actors_.end()) {
     bool force_kill = request.force_kill();
     bool no_restart = request.no_restart();
-    if (no_restart) {
-      DestroyActor(actor_id, GenKilledByApplicationCause(GetActor(actor_id)));
-    } else {
-      KillActor(actor_id, force_kill);
-    }
+    DestroyActor(actor_id,
+                 GenKilledByApplicationCause(GetActor(actor_id)),
+                 force_kill,
+                 no_restart);
 
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
     RAY_LOG(DEBUG).WithField(actor_id.JobId()).WithField(actor_id)
@@ -975,6 +975,7 @@ void GcsActorManager::PollOwnerForActorRefDeleted(
           DestroyActor(actor_id,
                        GenActorRefDeletedCause(GetActor(actor_id)),
                        /*force_kill=*/false,
+                       /*no_restart=*/true,
                        nullptr,
                        timeout_ms);
         }
@@ -984,13 +985,14 @@ void GcsActorManager::PollOwnerForActorRefDeleted(
 void GcsActorManager::DestroyActor(const ActorID &actor_id,
                                    const rpc::ActorDeathCause &death_cause,
                                    bool force_kill,
+                                   bool no_restart,
                                    std::function<void()> done_callback,
                                    int64_t graceful_shutdown_timeout_ms) {
   RAY_CHECK(thread_checker_.IsOnSameThread());
   RAY_LOG(INFO).WithField(actor_id.JobId()).WithField(actor_id)
-      << "Destroying actor, force_kill=" << force_kill
+      << "Destroying actor, force_kill=" << force_kill << ", no_restart=" << no_restart
       << ", timeout_ms=" << graceful_shutdown_timeout_ms;
-  actor_to_restart_for_lineage_reconstruction_callbacks_.erase(actor_id);
+
   auto it = registered_actors_.find(actor_id);
   if (it == registered_actors_.end()) {
     RAY_LOG(INFO).WithField(actor_id) << "Tried to destroy actor that does not exist";
@@ -1000,10 +1002,40 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id,
     return;
   }
 
-  gcs_actor_scheduler_->OnActorDestruction(it->second);
-
-  it->second->GetMutableActorTableData()->set_timestamp(current_sys_time_ms());
   const auto actor = it->second;
+  if (!no_restart) {
+    if (actor->GetState() == rpc::ActorTableData::DEAD ||
+        actor->GetState() == rpc::ActorTableData::DEPENDENCIES_UNREADY) {
+      return;
+    }
+
+    // The actor is still alive or pending creation.
+    const auto &node_id = actor->GetNodeID();
+    const auto &worker_id = actor->GetWorkerID();
+    auto node_it = created_actors_.find(node_id);
+    if (node_it != created_actors_.end() && node_it->second.count(worker_id)) {
+      // The actor has already been created. Destroy the process by force-killing
+      // it.
+      NotifyRayletToKillActor(actor, death_cause, force_kill);
+    } else {
+      const auto &lease_id = actor->GetLeaseSpecification().LeaseId();
+      RAY_LOG(DEBUG).WithField(actor->GetActorID()).WithField(lease_id)
+          << "The actor hasn't been created yet, cancel scheduling lease";
+      if (!worker_id.IsNil()) {
+        // The actor is in phase of creating, so we need to notify the core
+        // worker exit to avoid process and resource leak.
+        NotifyRayletToKillActor(actor, death_cause, force_kill);
+      }
+      CancelActorInScheduling(actor);
+      RestartActor(actor_id, /*need_reschedule=*/true, death_cause);
+    }
+    return;
+  }
+
+  // no_restart=true: permanently destroy the actor.
+  actor_to_restart_for_lineage_reconstruction_callbacks_.erase(actor_id);
+  gcs_actor_scheduler_->OnActorDestruction(actor);
+  actor->GetMutableActorTableData()->set_timestamp(current_sys_time_ms());
 
   // Cancel existing timer only on force_kill to interrupt graceful shutdown.
   // For idempotent graceful calls, keep the original timer running.
@@ -1860,47 +1892,6 @@ void GcsActorManager::NotifyRayletToKillActor(const std::shared_ptr<GcsActor> &a
           RAY_LOG(INFO).WithField(actor_id) << "Killed actor successfully.";
         }
       });
-}
-
-void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
-  RAY_LOG(DEBUG).WithField(actor_id.JobId()).WithField(actor_id)
-      << "Killing actor, force_kill = " << force_kill;
-  auto it = registered_actors_.find(actor_id);
-  if (it == registered_actors_.end()) {
-    RAY_LOG(INFO) << "Tried to kill actor that does not exist " << actor_id;
-    return;
-  }
-
-  const auto &actor = it->second;
-  if (actor->GetState() == rpc::ActorTableData::DEAD ||
-      actor->GetState() == rpc::ActorTableData::DEPENDENCIES_UNREADY) {
-    return;
-  }
-
-  // The actor is still alive or pending creation.
-  const auto &node_id = actor->GetNodeID();
-  const auto &worker_id = actor->GetWorkerID();
-  auto node_it = created_actors_.find(node_id);
-  if (node_it != created_actors_.end() && node_it->second.count(worker_id)) {
-    // The actor has already been created. Destroy the process by force-killing
-    // it.
-    NotifyRayletToKillActor(
-        actor, GenKilledByApplicationCause(GetActor(actor_id)), force_kill);
-  } else {
-    const auto &lease_id = actor->GetLeaseSpecification().LeaseId();
-    RAY_LOG(DEBUG).WithField(actor->GetActorID()).WithField(lease_id)
-        << "The actor hasn't been created yet, cancel scheduling lease";
-    if (!worker_id.IsNil()) {
-      // The actor is in phase of creating, so we need to notify the core
-      // worker exit to avoid process and resource leak.
-      NotifyRayletToKillActor(
-          actor, GenKilledByApplicationCause(GetActor(actor_id)), force_kill);
-    }
-    CancelActorInScheduling(actor);
-    RestartActor(actor_id,
-                 /*need_reschedule=*/true,
-                 GenKilledByApplicationCause(GetActor(actor_id)));
-  }
 }
 
 void GcsActorManager::AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &actor) {

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -294,12 +294,15 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   /// \param[in] actor_id The actor id to destroy.
   /// \param[in] death_cause The reason why actor is destroyed.
   /// \param[in] force_kill Whether destory the actor forcelly.
+  /// \param[in] no_restart If true, permanently destroy the actor. If false,
+  ///            allow restart based on max_restarts policy.
   /// \param[in] done_callback Called when destroy finishes.
   /// \param[in] graceful_shutdown_timeout_ms Timeout in ms for graceful shutdown.
   ///            If graceful shutdown doesn't complete, falls back to force kill.
   void DestroyActor(const ActorID &actor_id,
                     const rpc::ActorDeathCause &death_cause,
                     bool force_kill = true,
+                    bool no_restart = true,
                     std::function<void()> done_callback = nullptr,
                     int64_t graceful_shutdown_timeout_ms = -1);
 
@@ -333,12 +336,6 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   ///
   /// \param actor The actor to be removed.
   void RemoveActorFromOwner(const std::shared_ptr<GcsActor> &actor);
-
-  /// Kill the specified actor.
-  ///
-  /// \param actor_id ID of the actor to kill.
-  /// \param force_kill Whether to force kill an actor by killing the worker.
-  void KillActor(const ActorID &actor_id, bool force_kill);
 
   /// Notify Raylet to kill the specified actor.
   ///

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -293,7 +293,7 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   ///
   /// \param[in] actor_id The actor id to destroy.
   /// \param[in] death_cause The reason why actor is destroyed.
-  /// \param[in] force_kill Whether destory the actor forcelly.
+  /// \param[in] force_kill Whether destory the actor forcefully.
   /// \param[in] no_restart If true, permanently destroy the actor. If false,
   ///            allow restart based on max_restarts policy.
   /// \param[in] done_callback Called when destroy finishes.


### PR DESCRIPTION
`KillActor` and `DestroyActor` were basically serving the same purpose except for restartability. This PR consolidates KillActor and DestroyActor into a single method to reduce maintenance complexity.