### PR TITLE
[Core] Use whitelist approach to block mutation requests from browser

### DIFF
--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -105,7 +105,11 @@ class HttpServerAgent:
             dashboard_optional_utils.DashboardAgentRouteTable.bind(c)
 
         app = aiohttp.web.Application(
-            middlewares=[get_token_auth_middleware(aiohttp, PUBLIC_EXACT_PATHS)]
+            middlewares=[
+                get_token_auth_middleware(aiohttp, PUBLIC_EXACT_PATHS),
+                # Block all browser requests - agent is only accessed internally
+                dashboard_optional_utils.get_browser_request_middleware(aiohttp),
+            ]
         )
         app.add_routes(routes=routes.bound_routes())
 

--- a/python/ray/dashboard/modules/job/job_agent.py
+++ b/python/ray/dashboard/modules/job/job_agent.py
@@ -30,7 +30,6 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
         self._job_manager = None
 
     @routes.post("/api/job_agent/jobs/")
-    @optional_utils.deny_browser_requests()
     @optional_utils.init_ray_and_catch_exceptions()
     async def submit_job(self, req: Request) -> Response:
         result = await parse_and_validate_request(req, JobSubmitRequest)
@@ -74,7 +73,6 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
         )
 
     @routes.post("/api/job_agent/jobs/{job_or_submission_id}/stop")
-    @optional_utils.deny_browser_requests()
     @optional_utils.init_ray_and_catch_exceptions()
     async def stop_job(self, req: Request) -> Response:
         job_or_submission_id = req.match_info["job_or_submission_id"]
@@ -108,7 +106,6 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
         )
 
     @routes.delete("/api/job_agent/jobs/{job_or_submission_id}")
-    @optional_utils.deny_browser_requests()
     @optional_utils.init_ray_and_catch_exceptions()
     async def delete_job(self, req: Request) -> Response:
         job_or_submission_id = req.match_info["job_or_submission_id"]

--- a/python/ray/dashboard/modules/job/job_agent.py
+++ b/python/ray/dashboard/modules/job/job_agent.py
@@ -108,6 +108,7 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
         )
 
     @routes.delete("/api/job_agent/jobs/{job_or_submission_id}")
+    @optional_utils.deny_browser_requests()
     @optional_utils.init_ray_and_catch_exceptions()
     async def delete_job(self, req: Request) -> Response:
         job_or_submission_id = req.match_info["job_or_submission_id"]

--- a/python/ray/dashboard/modules/job/tests/test_job_agent.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_agent.py
@@ -172,8 +172,7 @@ ray.get(f.remote())
                 yield {
                     "runtime_env": {"py_modules": [str(Path(tmp_dir) / "test_module")]},
                     "entrypoint": (
-                        "python -c 'import test_module;"
-                        "print(test_module.run_test())'"
+                        "python -c 'import test_module;print(test_module.run_test())'"
                     ),
                     "expected_logs": "Hello from test_module!\n",
                 }
@@ -318,7 +317,7 @@ async def test_submit_job_rejects_browsers(
     with pytest.raises(RuntimeError) as exc:
         _ = await agent_client.submit_job_internal(request)
 
-    assert "status code 405" in str(exc.value)
+    assert "status code 403" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -344,7 +343,7 @@ async def test_delete_job_rejects_browsers(job_sdk_client, monkeypatch):
     with pytest.raises(RuntimeError) as exc:
         _ = await browser_client.delete_job_internal(job_id)
 
-    assert "status code 405" in str(exc.value)
+    assert "status code 403" in str(exc.value)
 
     await browser_client.close()
 
@@ -637,7 +636,7 @@ async def test_non_default_dashboard_agent_http_port(tmp_path):
     import subprocess
 
     dashboard_agent_port = get_current_unused_port()
-    cmd = "ray start --head " f"--dashboard-agent-listen-port {dashboard_agent_port}"
+    cmd = f"ray start --head --dashboard-agent-listen-port {dashboard_agent_port}"
     subprocess.check_output(cmd, shell=True)
 
     try:

--- a/python/ray/dashboard/modules/job/tests/test_job_agent.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_agent.py
@@ -322,6 +322,34 @@ async def test_submit_job_rejects_browsers(
 
 
 @pytest.mark.asyncio
+async def test_delete_job_rejects_browsers(job_sdk_client, monkeypatch):
+    """Test that DELETE job requests from browsers are rejected."""
+    monkeypatch.setenv("RAY_RUNTIME_ENV_LOCAL_DEV_MODE", "1")
+
+    agent_client, head_client = job_sdk_client
+
+    # First, submit a job using the normal client
+    runtime_env = RuntimeEnv().to_dict()
+    request = validate_request_type(
+        {"runtime_env": runtime_env, "entrypoint": "echo hello"},
+        JobSubmitRequest,
+    )
+    submit_result = await agent_client.submit_job_internal(request)
+    job_id = submit_result.submission_id
+
+    # Now try to delete the job using browser-like headers
+    agent_address = agent_client._agent_address
+    browser_client = JobAgentSubmissionBrowserClient(agent_address)
+
+    with pytest.raises(RuntimeError) as exc:
+        _ = await browser_client.delete_job_internal(job_id)
+
+    assert "status code 405" in str(exc.value)
+
+    await browser_client.close()
+
+
+@pytest.mark.asyncio
 async def test_timeout(job_sdk_client):
     agent_client, head_client = job_sdk_client
 

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -12,7 +12,8 @@ import os
 import time
 import traceback
 from collections import namedtuple
-from typing import Callable, Union
+from types import ModuleType
+from typing import Callable, List, Optional, Set, Union
 
 from aiohttp.web import Request, Response
 
@@ -161,9 +162,9 @@ def is_browser_request(req: Request) -> bool:
 
 
 def get_browser_request_middleware(
-    aiohttp_module,
-    allowed_methods=None,
-    allowed_paths=None,
+    aiohttp_module: ModuleType,
+    allowed_methods: Optional[Set[str]] = None,
+    allowed_paths: Optional[List[str]] = None,
 ):
     """Create middleware that restricts browser access to specified HTTP methods.
 

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -2,6 +2,7 @@
 Optional utils module contains utility methods
 that require optional dependencies.
 """
+
 import asyncio
 import collections
 import functools
@@ -159,23 +160,51 @@ def is_browser_request(req: Request) -> bool:
     )
 
 
-def deny_browser_requests() -> Callable:
-    """Reject any requests that appear to be made by a browser."""
+def get_browser_request_middleware(
+    aiohttp_module,
+    allowed_methods=None,
+    allowed_paths=None,
+):
+    """Create middleware that restricts browser access to specified HTTP methods.
 
-    def decorator_factory(f: Callable) -> Callable:
-        @functools.wraps(f)
-        async def decorator(self, req: Request):
-            if is_browser_request(req):
-                return Response(
-                    text="Browser requests not allowed",
-                    status=aiohttp.web.HTTPMethodNotAllowed.status_code,
+    This middleware blocks browser requests to prevent DNS rebinding and CSRF
+    attacks. Only explicitly allowed methods are permitted from browsers.
+
+    Args:
+        aiohttp_module: The aiohttp module to use
+        allowed_methods: Set of HTTP methods browsers are allowed to use.
+        allowed_paths: List of paths that bypass the method check entirely,
+            allowing any method from browsers.
+
+    Returns:
+        An aiohttp middleware function
+    """
+    allowed_methods = allowed_methods or set()
+
+    @aiohttp_module.web.middleware
+    async def browser_request_middleware(request, handler):
+        if not is_browser_request(request):
+            return await handler(request)
+
+        # Allow whitelisted paths to bypass the check
+        if allowed_paths and request.path in allowed_paths:
+            return await handler(request)
+
+        if request.method not in allowed_methods:
+            # 403 if no methods allowed (all browsers blocked)
+            # 405 if some methods allowed but not this one
+            if allowed_methods:
+                return aiohttp_module.web.Response(
+                    status=405, text="Method Not Allowed for browser traffic."
+                )
+            else:
+                return aiohttp_module.web.Response(
+                    status=403, text="Browser requests not allowed."
                 )
 
-            return await f(self, req)
+        return await handler(request)
 
-        return decorator
-
-    return decorator_factory
+    return browser_request_middleware
 
 
 def init_ray_and_catch_exceptions() -> Callable:


### PR DESCRIPTION
## Description
Currently we use `get_browsers_no_post_put_middleware` to block PUT/POST requests from browsers since these endpoints are not intended to be called from a browser context (e.g., via DNS rebinding or CSRF). However, DELETE methods were not blocked, allowing browser-based requests to delete jobs or shut down Serve applications.

This PR switches from a blocklist (POST/PUT) to an allowlist (GET/HEAD/OPTIONS) approach, ensuring only explicitly safe methods are permitted from browsers. This also covers PATCH and any future HTTP methods by default.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
