### PR TITLE
[Data][2/4] Rename logical operator attributes to public

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -30,7 +30,7 @@ class LogicalOperator(Operator):
         for x in input_dependencies:
             assert isinstance(x, LogicalOperator), x
 
-        self._num_outputs: Optional[int] = num_outputs
+        self.num_outputs: Optional[int] = num_outputs
 
     def estimated_num_outputs(self) -> Optional[int]:
         """Returns the estimated number of blocks that
@@ -41,8 +41,8 @@ class LogicalOperator(Operator):
         `Dataset.repartition(num_blocks=X)`. A more accurate estimation can be given by
         `PhysicalOperator.num_outputs_total()` during execution.
         """
-        if self._num_outputs is not None:
-            return self._num_outputs
+        if self.num_outputs is not None:
+            return self.num_outputs
         elif len(self.input_dependencies) == 1:
             return self.input_dependencies[0].estimated_num_outputs()
         return None
@@ -71,7 +71,14 @@ class LogicalOperator(Operator):
 
     def _get_args(self) -> Dict[str, Any]:
         """This Dict must be serializable"""
-        return vars(self)
+        args: Dict[str, Any] = {}
+        for key, value in vars(self).items():
+            if key.startswith("_"):
+                args[key] = value
+            else:
+                # Keep underscore-prefixed keys to preserve legacy export schema.
+                args[f"_{key}"] = value
+        return args
 
     def infer_schema(self) -> Optional["Schema"]:
         """Returns the inferred schema of the output blocks."""

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -49,8 +49,8 @@ class AbstractAllToAll(LogicalOperator):
             ray_remote_args: Args to provide to :func:`ray.remote`.
         """
         super().__init__(name, [input_op], num_outputs=num_outputs)
-        self._ray_remote_args = ray_remote_args or {}
-        self._sub_progress_bar_names = sub_progress_bar_names
+        self.ray_remote_args = ray_remote_args or {}
+        self.sub_progress_bar_names = sub_progress_bar_names
 
 
 class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
@@ -65,7 +65,7 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
             "RandomizeBlockOrder",
             input_op,
         )
-        self._seed = seed
+        self.seed = seed
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -103,7 +103,7 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
             ],
             ray_remote_args=ray_remote_args,
         )
-        self._seed = seed
+        self.seed = seed
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -148,9 +148,9 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
             num_outputs=num_outputs,
             sub_progress_bar_names=sub_progress_bar_names,
         )
-        self._shuffle = shuffle
-        self._keys = keys
-        self._sort = sort
+        self.shuffle = shuffle
+        self.keys = keys
+        self.sort = sort
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -187,8 +187,8 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        self._sort_key = sort_key
-        self._batch_format = batch_format
+        self.sort_key = sort_key
+        self.batch_format = batch_format
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -227,7 +227,7 @@ class Aggregate(AbstractAllToAll):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        self._key = key
-        self._aggs = aggs
-        self._num_partitions = num_partitions
-        self._batch_format = batch_format
+        self.key = key
+        self.aggs = aggs
+        self.num_partitions = num_partitions
+        self.batch_format = batch_format

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -47,7 +47,7 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
         )
 
         # `owns_blocks` is False because this op may be shared by multiple Datasets.
-        self._input_data = [
+        self.input_data = [
             RefBundle(
                 [(input_blocks[i], input_metadata[i])],
                 owns_blocks=False,
@@ -56,12 +56,8 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
             for i in range(len(input_blocks))
         ]
 
-    @property
-    def input_data(self) -> List[RefBundle]:
-        return self._input_data
-
     def output_data(self) -> Optional[List[RefBundle]]:
-        return self._input_data
+        return self.input_data
 
     @functools.cached_property
     def _cached_output_metadata(self) -> BlockMetadata:
@@ -73,13 +69,13 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
         )
 
     def _num_rows(self):
-        if all(bundle.num_rows() is not None for bundle in self._input_data):
-            return sum(bundle.num_rows() for bundle in self._input_data)
+        if all(bundle.num_rows() is not None for bundle in self.input_data):
+            return sum(bundle.num_rows() for bundle in self.input_data)
         else:
             return None
 
     def _size_bytes(self):
-        metadata = [m for bundle in self._input_data for m in bundle.metadata]
+        metadata = [m for bundle in self.input_data for m in bundle.metadata]
         if all(m.size_bytes is not None for m in metadata):
             return sum(m.size_bytes for m in metadata)
         else:
@@ -89,7 +85,7 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
         return self._cached_output_metadata
 
     def infer_schema(self):
-        return unify_ref_bundles_schema(self._input_data)
+        return unify_ref_bundles_schema(self.input_data)
 
     def is_lineage_serializable(self) -> bool:
         # This operator isn't serializable because it contains ObjectRefs.

--- a/python/ray/data/_internal/logical/operators/join_operator.py
+++ b/python/ray/data/_internal/logical/operators/join_operator.py
@@ -84,15 +84,15 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
 
         super().__init__(left_input_op, right_input_op, num_outputs=num_partitions)
 
-        self._left_key_columns = left_key_columns
-        self._right_key_columns = right_key_columns
-        self._join_type = join_type_enum
+        self.left_key_columns = left_key_columns
+        self.right_key_columns = right_key_columns
+        self.join_type = join_type_enum
 
-        self._left_columns_suffix = left_columns_suffix
-        self._right_columns_suffix = right_columns_suffix
+        self.left_columns_suffix = left_columns_suffix
+        self.right_columns_suffix = right_columns_suffix
 
-        self._partition_size_hint = partition_size_hint
-        self._aggregator_ray_remote_args = aggregator_ray_remote_args
+        self.partition_size_hint = partition_size_hint
+        self.aggregator_ray_remote_args = aggregator_ray_remote_args
 
     @staticmethod
     def _validate_schemas(
@@ -171,8 +171,8 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
         # Get column sets for each side
         left_columns = set(left_schema.names)
         right_columns = set(right_schema.names)
-        left_join_keys = set(self._left_key_columns)
-        right_join_keys = set(self._right_key_columns)
+        left_join_keys = set(self.left_key_columns)
+        right_join_keys = set(self.right_key_columns)
 
         # Get pushdown rules for this join type
         can_push_left, can_push_right = self._get_pushdown_rules()
@@ -212,7 +212,7 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
             JoinType.RIGHT_ANTI: (False, True),
             JoinType.FULL_OUTER: (False, False),
         }
-        return pushdown_rules.get(self._join_type, (False, False))
+        return pushdown_rules.get(self.join_type, (False, False))
 
     def _get_referenced_columns(self, expr: "Expr") -> set[str]:
         """Extract all column names referenced in an expression."""

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.logical.interfaces import (
@@ -72,14 +72,14 @@ class AbstractMap(AbstractOneToOne):
                 autoscaling actor pool.
         """
         super().__init__(name, input_op, can_modify_num_rows, num_outputs)
-        self._min_rows_per_bundled_input = min_rows_per_bundled_input
-        self._ray_remote_args = ray_remote_args or {}
-        self._ray_remote_args_fn = ray_remote_args_fn
-        self._compute = compute or TaskPoolStrategy()
-        self._per_block_limit = None
+        self.min_rows_per_bundled_input = min_rows_per_bundled_input
+        self.ray_remote_args = ray_remote_args or {}
+        self.ray_remote_args_fn = ray_remote_args_fn
+        self.compute = compute or TaskPoolStrategy()
+        self.per_block_limit = None
 
     def set_per_block_limit(self, per_block_limit: int):
-        self._per_block_limit = per_block_limit
+        self.per_block_limit = per_block_limit
 
 
 class AbstractUDFMap(AbstractMap):
@@ -140,12 +140,12 @@ class AbstractUDFMap(AbstractMap):
             ray_remote_args=ray_remote_args,
             compute=compute,
         )
-        self._fn = fn
-        self._fn_args = fn_args
-        self._fn_kwargs = fn_kwargs
-        self._fn_constructor_args = fn_constructor_args
-        self._fn_constructor_kwargs = fn_constructor_kwargs
-        self._ray_remote_args_fn = ray_remote_args_fn
+        self.fn = fn
+        self.fn_args = fn_args
+        self.fn_kwargs = fn_kwargs
+        self.fn_constructor_args = fn_constructor_args
+        self.fn_constructor_kwargs = fn_constructor_kwargs
+        self.ray_remote_args_fn = ray_remote_args_fn
 
     def _get_operator_name(self, op_name: str, fn: UserDefinedFunction):
         """Gets the Operator name including the map `fn` UDF name."""
@@ -211,9 +211,9 @@ class MapBatches(AbstractUDFMap):
             ray_remote_args_fn=ray_remote_args_fn,
             ray_remote_args=ray_remote_args,
         )
-        self._batch_size = batch_size
-        self._batch_format = batch_format
-        self._zero_copy_batch = zero_copy_batch
+        self.batch_size = batch_size
+        self.batch_format = batch_format
+        self.zero_copy_batch = zero_copy_batch
 
 
 class MapRows(AbstractUDFMap):
@@ -269,7 +269,7 @@ class Filter(AbstractUDFMap):
                 f"Exactly one of 'fn', or 'predicate_expr' must be provided (received fn={fn}, predicate_expr={predicate_expr})"
             )
 
-        self._predicate_expr = predicate_expr
+        self.predicate_expr = predicate_expr
 
         super().__init__(
             "Filter",
@@ -286,7 +286,7 @@ class Filter(AbstractUDFMap):
         )
 
     def is_expression_based(self) -> bool:
-        return self._predicate_expr is not None
+        return self.predicate_expr is not None
 
     def _get_operator_name(self, op_name: str, fn: UserDefinedFunction):
         if self.is_expression_based():
@@ -295,7 +295,7 @@ class Filter(AbstractUDFMap):
                 _InlineExprReprVisitor,
             )
 
-            expr_str = _InlineExprReprVisitor().visit(self._predicate_expr)
+            expr_str = _InlineExprReprVisitor().visit(self.predicate_expr)
 
             # Truncate only the final result if too long
             max_length = 60
@@ -327,12 +327,12 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
             ray_remote_args=ray_remote_args,
             compute=compute,
         )
-        self._batch_size = None
-        self._exprs = exprs
-        self._batch_format = "pyarrow"
-        self._zero_copy_batch = True
+        self.batch_size = None
+        self.exprs = exprs
+        self.batch_format = "pyarrow"
+        self.zero_copy_batch = True
 
-        for expr in self._exprs:
+        for expr in self.exprs:
             if expr.name is None and not isinstance(expr, StarExpr):
                 raise TypeError(
                     "All Project expressions must be named (use .alias(name) or col(name)), "
@@ -369,15 +369,11 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
 
     def get_star_expr(self) -> Optional[StarExpr]:
         """Check if this projection contains a star() expression."""
-        for expr in self._exprs:
+        for expr in self.exprs:
             if isinstance(expr, StarExpr):
                 return expr
 
         return None
-
-    @property
-    def exprs(self) -> List["Expr"]:
-        return self._exprs
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         return PredicatePassThroughBehavior.PASSTHROUGH_WITH_SUBSTITUTION
@@ -393,7 +389,7 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
             _extract_input_columns_renaming_mapping,
         )
 
-        rename_map = _extract_input_columns_renaming_mapping(self._exprs)
+        rename_map = _extract_input_columns_renaming_mapping(self.exprs)
         return rename_map if rename_map else None
 
 
@@ -444,8 +440,4 @@ class StreamingRepartition(AbstractMap):
             input_op,
             can_modify_num_rows=False,
         )
-        self._target_num_rows_per_block = target_num_rows_per_block
-
-    @property
-    def target_num_rows_per_block(self) -> int:
-        return self._target_num_rows_per_block
+        self.target_num_rows_per_block = target_num_rows_per_block

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -46,16 +46,11 @@ class AbstractOneToOne(LogicalOperator):
             input_dependencies=[input_op] if input_op else [],
             num_outputs=num_outputs,
         )
-        self._can_modify_num_rows = can_modify_num_rows
+        self.can_modify_num_rows = can_modify_num_rows
 
     @property
     def input_dependency(self) -> LogicalOperator:
         return self.input_dependencies[0]
-
-    def can_modify_num_rows(self) -> bool:
-        """Whether this operator can modify the number of rows,
-        i.e. number of input rows != number of output rows."""
-        return self._can_modify_num_rows
 
 
 class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
@@ -71,7 +66,7 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
             input_op=input_op,
             can_modify_num_rows=True,
         )
-        self._limit = limit
+        self.limit = limit
 
     def infer_metadata(self) -> BlockMetadata:
         return BlockMetadata(
@@ -93,7 +88,7 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
         assert isinstance(self.input_dependencies[0], LogicalOperator)
         input_rows = self.input_dependencies[0].infer_metadata().num_rows
         if input_rows is not None:
-            return min(input_rows, self._limit)
+            return min(input_rows, self.limit)
         else:
             return None
 
@@ -127,18 +122,6 @@ class Download(AbstractOneToOne):
                 f"Number of URI columns ({len(uri_column_names)}) must match "
                 f"number of output columns ({len(output_bytes_column_names)})"
             )
-        self._uri_column_names = uri_column_names
-        self._output_bytes_column_names = output_bytes_column_names
-        self._ray_remote_args = ray_remote_args or {}
-
-    @property
-    def uri_column_names(self) -> List[str]:
-        return self._uri_column_names
-
-    @property
-    def output_bytes_column_names(self) -> List[str]:
-        return self._output_bytes_column_names
-
-    @property
-    def ray_remote_args(self) -> Dict[str, Any]:
-        return self._ray_remote_args
+        self.uri_column_names = uri_column_names
+        self.output_bytes_column_names = output_bytes_column_names
+        self.ray_remote_args = ray_remote_args or {}

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -21,6 +21,6 @@ class StreamingSplit(LogicalOperator):
         locality_hints: Optional[List["NodeIdStr"]] = None,
     ):
         super().__init__("StreamingSplit", [input_op])
-        self._num_splits = num_splits
-        self._equal = equal
-        self._locality_hints = locality_hints
+        self.num_splits = num_splits
+        self.equal = equal
+        self.locality_hints = locality_hints

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -37,5 +37,5 @@ class Write(AbstractMap):
             ray_remote_args=ray_remote_args,
             compute=compute,
         )
-        self._datasink_or_legacy_datasource = datasink_or_legacy_datasource
-        self._write_args = write_args
+        self.datasink_or_legacy_datasource = datasink_or_legacy_datasource
+        self.write_args = write_args

--- a/python/ray/data/_internal/logical/rules/combine_shuffles.py
+++ b/python/ray/data/_internal/logical/rules/combine_shuffles.py
@@ -45,13 +45,13 @@ class CombineShuffles(Rule):
         input_op = op.input_dependencies[0]
 
         if isinstance(input_op, Repartition) and isinstance(op, Repartition):
-            shuffle = input_op._shuffle or op._shuffle
+            shuffle = input_op.shuffle or op.shuffle
             return Repartition(
                 input_op.input_dependencies[0],
-                num_outputs=op._num_outputs,
+                num_outputs=op.num_outputs,
                 shuffle=shuffle,
-                keys=op._keys,
-                sort=op._sort,
+                keys=op.keys,
+                sort=op.sort,
             )
         elif isinstance(input_op, StreamingRepartition) and isinstance(
             op, StreamingRepartition
@@ -63,24 +63,24 @@ class CombineShuffles(Rule):
         elif isinstance(input_op, Repartition) and isinstance(op, Aggregate):
             return Aggregate(
                 input_op=input_op.input_dependencies[0],
-                key=op._key,
-                aggs=op._aggs,
-                num_partitions=op._num_partitions,
-                batch_format=op._batch_format,
+                key=op.key,
+                aggs=op.aggs,
+                num_partitions=op.num_partitions,
+                batch_format=op.batch_format,
             )
         elif isinstance(input_op, StreamingRepartition) and isinstance(op, Repartition):
             return Repartition(
                 input_op.input_dependencies[0],
-                num_outputs=op._num_outputs,
-                shuffle=op._shuffle,
-                keys=op._keys,
-                sort=op._sort,
+                num_outputs=op.num_outputs,
+                shuffle=op.shuffle,
+                keys=op.keys,
+                sort=op.sort,
             )
         elif isinstance(input_op, Sort) and isinstance(op, Sort):
             return Sort(
                 input_op.input_dependencies[0],
-                sort_key=op._sort_key,
-                batch_format=op._batch_format,
+                sort_key=op.sort_key,
+                batch_format=op.batch_format,
             )
 
         return op

--- a/python/ray/data/_internal/logical/rules/inherit_batch_format.py
+++ b/python/ray/data/_internal/logical/rules/inherit_batch_format.py
@@ -27,9 +27,9 @@ class InheritBatchFormatRule(Rule):
             # or we reach to source op and do nothing
             upstream_op = node.input_dependencies[0]
             while upstream_op.input_dependencies:
-                if isinstance(upstream_op, MapBatches) and upstream_op._batch_format:
+                if isinstance(upstream_op, MapBatches) and upstream_op.batch_format:
                     new_op = copy.copy(node)
-                    new_op._batch_format = upstream_op._batch_format
+                    new_op.batch_format = upstream_op.batch_format
                     new_op._output_dependencies = []
                     return new_op
                 upstream_op = upstream_op.input_dependencies[0]

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -46,7 +46,7 @@ class LimitPushdownRule(Rule):
                 upstream_op = node.input_dependency
                 if isinstance(upstream_op, Limit):
                     # Fuse consecutive Limits: Limit[n] -> Limit[m] becomes Limit[min(n,m)]
-                    new_limit = min(node._limit, upstream_op._limit)
+                    new_limit = min(node.limit, upstream_op.limit)
                     return Limit(upstream_op.input_dependency, new_limit)
 
                 # If no fusion, apply pushdown logic
@@ -105,25 +105,25 @@ class LimitPushdownRule(Rule):
             current = op
             while (
                 isinstance(current, AbstractOneToOne)
-                and not current.can_modify_num_rows()
+                and not current.can_modify_num_rows
                 and current.input_dependencies
             ):
                 if isinstance(current, Limit):
-                    return current._limit == limit
+                    return current.limit == limit
                 # Safe to use input_dependency: current is an AbstractOneToOne here.
                 current = current.input_dependency
 
-            return isinstance(current, Limit) and current._limit == limit
+            return isinstance(current, Limit) and current.limit == limit
 
         # Insert a branch-local Limit and push it further upstream.
         branch_tails: List[LogicalOperator] = []
         for child in union_op.input_dependencies:
             # Avoid inserting a duplicate Limit on a branch that already has the same
             # limit upstream of row-preserving ops.
-            if _branch_has_limit(child, limit_op._limit):
+            if _branch_has_limit(child, limit_op.limit):
                 branch_tails.append(child)
                 continue
-            raw_limit = Limit(child, limit_op._limit)  # child → limit
+            raw_limit = Limit(child, limit_op.limit)  # child → limit
 
             if isinstance(raw_limit.input_dependency, Union):
                 # This represents the limit operator appended after the union.
@@ -134,7 +134,7 @@ class LimitPushdownRule(Rule):
             branch_tails.append(pushed_tail)
 
         new_union = Union(*branch_tails)
-        return Limit(new_union, limit_op._limit)
+        return Limit(new_union, limit_op.limit)
 
     def _push_limit_down(self, limit_op: Limit) -> LogicalOperator:
         """Push a single limit down through compatible operators conservatively.
@@ -147,15 +147,15 @@ class LimitPushdownRule(Rule):
         num_rows_preserving_ops: List[LogicalOperator] = []
         while (
             isinstance(current_op, AbstractOneToOne)
-            and not current_op.can_modify_num_rows()
+            and not current_op.can_modify_num_rows
         ):
             if isinstance(current_op, AbstractMap):
-                min_rows = current_op._min_rows_per_bundled_input
-                if min_rows is not None and min_rows > limit_op._limit:
+                min_rows = current_op.min_rows_per_bundled_input
+                if min_rows is not None and min_rows > limit_op.limit:
                     # Avoid pushing the limit past batch-based maps that require more
                     # rows than the limit to produce stable outputs (e.g. schema).
                     logger.info(
-                        f"Skipping push down of limit {limit_op._limit} through map {current_op} because it requires {min_rows} rows to produce stable outputs"
+                        f"Skipping push down of limit {limit_op.limit} through map {current_op} because it requires {min_rows} rows to produce stable outputs"
                     )
                     break
             num_rows_preserving_ops.append(current_op)
@@ -166,11 +166,11 @@ class LimitPushdownRule(Rule):
             return limit_op
         # Apply per-block limit to the deepest operator if it supports it
         limit_input = self._apply_per_block_limit_if_supported(
-            current_op, limit_op._limit
+            current_op, limit_op.limit
         )
 
         # Build the new operator chain: Chain non-preserving number of rows -> Limit -> Operators preserving number of rows
-        new_limit = Limit(limit_input, limit_op._limit)
+        new_limit = Limit(limit_input, limit_op.limit)
         result_op = new_limit
 
         # Recreate the intermediate operators and apply per-block limits
@@ -198,7 +198,7 @@ class LimitPushdownRule(Rule):
         """Create a new operator of the same type as original_op but with new_input as its input."""
 
         if isinstance(original_op, Limit):
-            return Limit(new_input, original_op._limit)
+            return Limit(new_input, original_op.limit)
 
         # Use copy and replace input dependencies approach
         new_op = copy.copy(original_op)

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -251,22 +251,22 @@ class FuseOperators(Rule):
             or (
                 isinstance(up_logical_op, AbstractMap)
                 and isinstance(down_logical_op, Repartition)
-                and down_logical_op._shuffle
+                and down_logical_op.shuffle
             )
         ):
             return False
 
         # Only fuse if the ops' remote arguments are compatible.
         if not are_remote_args_compatible(
-            getattr(up_logical_op, "_ray_remote_args", {}),
-            getattr(down_logical_op, "_ray_remote_args", {}),
+            getattr(up_logical_op, "ray_remote_args", {}),
+            getattr(down_logical_op, "ray_remote_args", {}),
         ):
             return False
 
-        # Do not fuse if either op specifies a `_ray_remote_args_fn`,
+        # Do not fuse if either op specifies a `ray_remote_args_fn`,
         # since it is not known whether the generated args will be compatible.
-        if getattr(up_logical_op, "_ray_remote_args_fn", None) or getattr(
-            down_logical_op, "_ray_remote_args_fn", None
+        if getattr(up_logical_op, "ray_remote_args_fn", None) or getattr(
+            down_logical_op, "ray_remote_args_fn", None
         ):
             return False
 
@@ -280,7 +280,7 @@ class FuseOperators(Rule):
         if isinstance(down_logical_op, StreamingRepartition):
             return (
                 isinstance(up_logical_op, MapBatches)
-                and up_logical_op._batch_size is not None
+                and up_logical_op.batch_size is not None
                 and down_logical_op.target_num_rows_per_block is not None
                 and down_logical_op.target_num_rows_per_block > 0
                 # When the batch_size is a multiple of target_num_rows_per_block, fusing would still produce exactly identical sequence of blocks.
@@ -288,8 +288,7 @@ class FuseOperators(Rule):
                 # TODO: when the StreamingRepartition supports none_strict_mode, we can fuse
                 # `MapBatches -> StreamingRepartition` no matter what the `batch_size` and `target_num_rows` are.
                 # https://anyscale1.atlassian.net/browse/DATA-1731
-                and up_logical_op._batch_size
-                % down_logical_op.target_num_rows_per_block
+                and up_logical_op.batch_size % down_logical_op.target_num_rows_per_block
                 == 0
             )
         # Other operators cannot fuse with StreamingRepartition.
@@ -313,21 +312,19 @@ class FuseOperators(Rule):
         up_logical_op = self._op_map.pop(up_op)
         assert isinstance(up_logical_op, MapBatches)
         assert isinstance(down_logical_op, StreamingRepartition)
-        assert (
-            up_logical_op._batch_size % down_logical_op.target_num_rows_per_block == 0
-        )
-        batch_size = up_logical_op._batch_size
+        assert up_logical_op.batch_size % down_logical_op.target_num_rows_per_block == 0
+        batch_size = up_logical_op.batch_size
 
         compute = self._fuse_compute_strategy(
-            up_logical_op._compute, down_logical_op._compute
+            up_logical_op.compute, down_logical_op.compute
         )
         assert compute is not None
 
         map_task_kwargs = {**up_op._map_task_kwargs, **down_op._map_task_kwargs}
 
-        ray_remote_args = up_logical_op._ray_remote_args
+        ray_remote_args = up_logical_op.ray_remote_args
         ray_remote_args_fn = (
-            up_logical_op._ray_remote_args_fn or down_logical_op._ray_remote_args_fn
+            up_logical_op.ray_remote_args_fn or down_logical_op.ray_remote_args_fn
         )
         input_deps = up_op.input_dependencies
         assert len(input_deps) == 1
@@ -358,12 +355,12 @@ class FuseOperators(Rule):
         logical_op = AbstractUDFMap(
             name,
             input_op,
-            up_logical_op._fn,
-            can_modify_num_rows=up_logical_op.can_modify_num_rows(),
-            fn_args=up_logical_op._fn_args,
-            fn_kwargs=up_logical_op._fn_kwargs,
-            fn_constructor_args=up_logical_op._fn_constructor_args,
-            fn_constructor_kwargs=up_logical_op._fn_constructor_kwargs,
+            up_logical_op.fn,
+            can_modify_num_rows=up_logical_op.can_modify_num_rows,
+            fn_args=up_logical_op.fn_args,
+            fn_kwargs=up_logical_op.fn_kwargs,
+            fn_constructor_args=up_logical_op.fn_constructor_args,
+            fn_constructor_kwargs=up_logical_op.fn_constructor_kwargs,
             min_rows_per_bundled_input=batch_size,
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
@@ -449,16 +446,16 @@ class FuseOperators(Rule):
         )
 
         compute = self._fuse_compute_strategy(
-            up_logical_op._compute, down_logical_op._compute
+            up_logical_op.compute, down_logical_op.compute
         )
         assert compute is not None
 
         # Merge map task kwargs
         map_task_kwargs = {**up_op._map_task_kwargs, **down_op._map_task_kwargs}
 
-        ray_remote_args = up_logical_op._ray_remote_args
+        ray_remote_args = up_logical_op.ray_remote_args
         ray_remote_args_fn = (
-            up_logical_op._ray_remote_args_fn or down_logical_op._ray_remote_args_fn
+            up_logical_op.ray_remote_args_fn or down_logical_op.ray_remote_args_fn
         )
         # Make the upstream operator's inputs the new, fused operator's inputs.
         input_deps = up_op.input_dependencies
@@ -510,17 +507,17 @@ class FuseOperators(Rule):
             input_op = up_logical_op
 
         can_modify_num_rows = (
-            up_logical_op.can_modify_num_rows() or down_logical_op.can_modify_num_rows()
+            up_logical_op.can_modify_num_rows or down_logical_op.can_modify_num_rows
         )
         if isinstance(down_logical_op, AbstractUDFMap):
             logical_op = AbstractUDFMap(
                 name,
                 input_op,
-                down_logical_op._fn,
-                fn_args=down_logical_op._fn_args,
-                fn_kwargs=down_logical_op._fn_kwargs,
-                fn_constructor_args=down_logical_op._fn_constructor_args,
-                fn_constructor_kwargs=down_logical_op._fn_constructor_kwargs,
+                down_logical_op.fn,
+                fn_args=down_logical_op.fn_args,
+                fn_kwargs=down_logical_op.fn_kwargs,
+                fn_constructor_args=down_logical_op.fn_constructor_args,
+                fn_constructor_kwargs=down_logical_op.fn_constructor_kwargs,
                 min_rows_per_bundled_input=min_rows_per_bundled_input,
                 compute=compute,
                 can_modify_num_rows=can_modify_num_rows,
@@ -547,8 +544,8 @@ class FuseOperators(Rule):
         down_logical_op: AbstractMap,
         up_logical_op: AbstractMap,
     ) -> Optional[int]:
-        us_bundle_min_rows_req = up_logical_op._min_rows_per_bundled_input
-        ds_bundle_min_rows_req = down_logical_op._min_rows_per_bundled_input
+        us_bundle_min_rows_req = up_logical_op.min_rows_per_bundled_input
+        ds_bundle_min_rows_req = down_logical_op.min_rows_per_bundled_input
 
         # In case neither of the ops specify `min_rows_per_bundled_input`,
         # return None
@@ -579,7 +576,7 @@ class FuseOperators(Rule):
         assert isinstance(up_logical_op, AbstractMap)
 
         # Fuse transformation functions.
-        ray_remote_args = up_logical_op._ray_remote_args
+        ray_remote_args = up_logical_op.ray_remote_args
         down_transform_fn = down_op.get_transformation_fn()
         up_map_transformer = up_op.get_map_transformer()
 
@@ -627,8 +624,8 @@ class FuseOperators(Rule):
         elif isinstance(down_logical_op, Repartition):
             logical_op = Repartition(
                 input_op,
-                num_outputs=down_logical_op._num_outputs,
-                shuffle=down_logical_op._shuffle,
+                num_outputs=down_logical_op.num_outputs,
+                shuffle=down_logical_op.shuffle,
             )
         self._op_map[op] = logical_op
         # Return the fused physical operator.
@@ -642,8 +639,8 @@ class FuseOperators(Rule):
     ) -> bool:
         if (
             cls._fuse_compute_strategy(
-                upstream_op._compute,
-                downstream_op._compute,
+                upstream_op.compute,
+                downstream_op.compute,
             )
             is None
         ):
@@ -664,13 +661,13 @@ class FuseOperators(Rule):
         #   ``Filter->MapBatches(batch_size=...)``
         #
         if (
-            upstream_op.can_modify_num_rows()
-            and downstream_op._min_rows_per_bundled_input is not None
+            upstream_op.can_modify_num_rows
+            and downstream_op.min_rows_per_bundled_input is not None
         ):
             logger.debug(
                 f"Upstream operator '{upstream_op}' could be modifying # of input "
                 f"rows, while downstream operator '{downstream_op}' expects at least "
-                f"{downstream_op._min_rows_per_bundled_input} rows in a batch. "
+                f"{downstream_op.min_rows_per_bundled_input} rows in a batch. "
                 f"Skipping fusion"
             )
 

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -59,7 +59,7 @@ class PredicatePushdown(Rule):
             return op
 
         # Combine predicates
-        combined_predicate = op._predicate_expr & input_op._predicate_expr
+        combined_predicate = op.predicate_expr & input_op.predicate_expr
 
         # Create new filter on the input of the lower filter
         return Filter(
@@ -93,7 +93,7 @@ class PredicatePushdown(Rule):
         from ray.data.expressions import AliasExpr
 
         collector = _ColumnReferenceCollector()
-        collector.visit(filter_op._predicate_expr)
+        collector.visit(filter_op.predicate_expr)
         predicate_columns = set(collector.get_column_refs() or [])
 
         output_columns = set()
@@ -180,7 +180,7 @@ class PredicatePushdown(Rule):
             return op
         filter_op: Filter = op
         input_op = filter_op.input_dependencies[0]
-        predicate_expr = filter_op._predicate_expr
+        predicate_expr = filter_op.predicate_expr
 
         # Case 1: Check if operator supports predicate pushdown (e.g., Read)
         if (
@@ -283,7 +283,7 @@ class PredicatePushdown(Rule):
             return filter_op
 
         push_side = conditional_op.which_side_to_push_predicate(
-            filter_op._predicate_expr
+            filter_op.predicate_expr
         )
 
         if push_side is None:
@@ -297,7 +297,7 @@ class PredicatePushdown(Rule):
         new_inputs = list(conditional_op.input_dependencies)
         branch_filter = Filter(
             new_inputs[branch_idx],
-            predicate_expr=filter_op._predicate_expr,
+            predicate_expr=filter_op.predicate_expr,
         )
         new_inputs[branch_idx] = cls._try_push_down_predicate(branch_filter)
 

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -145,15 +145,15 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
 
     # Check if remote args (num_cpus, num_gpus, etc.) are compatible
     if not are_remote_args_compatible(
-        upstream_project._ray_remote_args or {},
-        downstream_project._ray_remote_args or {},
+        upstream_project.ray_remote_args or {},
+        downstream_project.ray_remote_args or {},
     ):
         # Resources don't match - cannot fuse
         return downstream_project
 
     # Check if compute strategies are compatible
     fused_compute = FuseOperators._fuse_compute_strategy(
-        upstream_project._compute, downstream_project._compute
+        upstream_project.compute, downstream_project.compute
     )
     if fused_compute is None:
         # Compute strategies incompatible - cannot fuse
@@ -264,7 +264,7 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
         upstream_project.input_dependency,
         exprs=new_exprs,
         compute=fused_compute,
-        ray_remote_args=downstream_project._ray_remote_args,
+        ray_remote_args=downstream_project.ray_remote_args,
     )
 
 
@@ -406,8 +406,8 @@ class ProjectionPushdown(Rule):
                 return Project(
                     projected_input_op,
                     exprs=current_project.exprs,
-                    compute=current_project._compute,
-                    ray_remote_args=current_project._ray_remote_args,
+                    compute=current_project.compute,
+                    ray_remote_args=current_project.ray_remote_args,
                 )
 
         return current_project

--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -121,14 +121,14 @@ class SetReadParallelismRule(Rule):
             estimated_num_blocks,
             k,
         ) = compute_additional_split_factor(
-            logical_op._datasource_or_legacy_reader,
-            logical_op._parallelism,
+            logical_op.datasource_or_legacy_reader,
+            logical_op.parallelism,
             estimated_in_mem_bytes,
             op.target_max_block_size_override or op.data_context.target_max_block_size,
             op._additional_split_factor,
         )
 
-        if logical_op._parallelism == -1:
+        if logical_op.parallelism == -1:
             assert reason != ""
             logger.debug(
                 f"Using autodetected parallelism={detected_parallelism} "

--- a/python/ray/data/_internal/logical/util.py
+++ b/python/ray/data/_internal/logical/util.py
@@ -90,11 +90,11 @@ def _collect_operators_to_dict(op: LogicalOperator, ops_dict: Dict[str, int]):
 
     # Check read and write operator, and anonymize user-defined data source.
     if isinstance(op, Read):
-        op_name = f"Read{op._datasource.get_name()}"
+        op_name = f"Read{op.datasource.get_name()}"
         if op_name not in _op_name_white_list:
             op_name = "ReadCustom"
     elif isinstance(op, Write):
-        op_name = f"Write{op._datasink_or_legacy_datasource.get_name()}"
+        op_name = f"Write{op.datasink_or_legacy_datasource.get_name()}"
         if op_name not in _op_name_white_list:
             op_name = "WriteCustom"
     elif isinstance(op, AbstractUDFMap):

--- a/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
@@ -46,7 +46,7 @@ def plan_write_op_with_checkpoint_writer(
 def _generate_checkpoint_writing_transform(
     data_context: DataContext, logical_op: Write
 ) -> BlockMapTransformFn:
-    datasink = logical_op._datasink_or_legacy_datasource
+    datasink = logical_op.datasink_or_legacy_datasource
     if not isinstance(datasink, Datasink):
         raise InvalidCheckpointingOperators(
             f"To enable checkpointing, Write operation must use a "

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -72,9 +72,9 @@ def plan_read_op(
         ), "Read parallelism must be set by the optimizer before execution"
 
         # Get the original read tasks
-        read_tasks = op._datasource_or_legacy_reader.get_read_tasks(
+        read_tasks = op.datasource_or_legacy_reader.get_read_tasks(
             parallelism,
-            per_task_row_limit=op._per_block_limit,
+            per_task_row_limit=op.per_block_limit,
             data_context=data_context,
         )
 
@@ -125,6 +125,6 @@ def plan_read_op(
         inputs,
         data_context,
         name=op.name,
-        compute_strategy=op._compute,
-        ray_remote_args=op._ray_remote_args,
+        compute_strategy=op.compute,
+        ray_remote_args=op.ray_remote_args,
     )

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -140,7 +140,7 @@ def plan_project_op(
     # datasources with weak references, e.g., PyIceberg tables)
     projection_exprs = op.exprs
 
-    compute = get_compute(op._compute)
+    compute = get_compute(op.compute)
 
     # Create init_fn to initialize all callable class UDFs at actor startup
     from ray.data.util.expression_utils import (
@@ -174,8 +174,8 @@ def plan_project_op(
         data_context,
         name=op.name,
         compute_strategy=compute,
-        ray_remote_args=op._ray_remote_args,
-        ray_remote_args_fn=op._ray_remote_args_fn,
+        ray_remote_args=op.ray_remote_args,
+        ray_remote_args_fn=op.ray_remote_args_fn,
     )
 
 
@@ -186,7 +186,7 @@ def plan_streaming_repartition_op(
 ) -> MapOperator:
     assert len(physical_children) == 1
     input_physical_dag = physical_children[0]
-    compute = get_compute(op._compute)
+    compute = get_compute(op.compute)
     transform_fn = BlockMapTransformFn(
         lambda blocks, ctx: blocks,
         output_block_size_option=OutputBlockSizeOption.of(
@@ -203,8 +203,8 @@ def plan_streaming_repartition_op(
         name=op.name,
         compute_strategy=compute,
         ref_bundler=StreamingRepartitionRefBundler(op.target_num_rows_per_block),
-        ray_remote_args=op._ray_remote_args,
-        ray_remote_args_fn=op._ray_remote_args_fn,
+        ray_remote_args=op.ray_remote_args,
+        ray_remote_args_fn=op.ray_remote_args_fn,
     )
 
     return operator
@@ -222,8 +222,8 @@ def plan_filter_op(
         target_max_block_size=data_context.target_max_block_size,
     )
 
-    predicate_expr = op._predicate_expr
-    compute = get_compute(op._compute)
+    predicate_expr = op.predicate_expr
+    compute = get_compute(op.compute)
     if predicate_expr is not None:
 
         def filter_block_fn(
@@ -241,13 +241,13 @@ def plan_filter_op(
             output_block_size_option=output_block_size_option,
         )
     else:
-        udf_is_callable_class = isinstance(op._fn, CallableClass)
+        udf_is_callable_class = isinstance(op.fn, CallableClass)
         filter_fn, init_fn = _get_udf(
-            op._fn,
-            op._fn_args,
-            op._fn_kwargs,
-            op._fn_constructor_args if udf_is_callable_class else None,
-            op._fn_constructor_kwargs if udf_is_callable_class else None,
+            op.fn,
+            op.fn_args,
+            op.fn_kwargs,
+            op.fn_constructor_args if udf_is_callable_class else None,
+            op.fn_constructor_kwargs if udf_is_callable_class else None,
             compute=compute,
         )
 
@@ -265,8 +265,8 @@ def plan_filter_op(
         data_context,
         name=op.name,
         compute_strategy=compute,
-        ray_remote_args=op._ray_remote_args,
-        ray_remote_args_fn=op._ray_remote_args_fn,
+        ray_remote_args=op.ray_remote_args,
+        ray_remote_args_fn=op.ray_remote_args_fn,
     )
 
 
@@ -287,23 +287,23 @@ def plan_udf_map_op(
         target_max_block_size=data_context.target_max_block_size,
     )
 
-    compute = get_compute(op._compute)
-    udf_is_callable_class = isinstance(op._fn, CallableClass)
+    compute = get_compute(op.compute)
+    udf_is_callable_class = isinstance(op.fn, CallableClass)
     fn, init_fn = _get_udf(
-        op._fn,
-        op._fn_args,
-        op._fn_kwargs,
-        op._fn_constructor_args if udf_is_callable_class else None,
-        op._fn_constructor_kwargs if udf_is_callable_class else None,
+        op.fn,
+        op.fn_args,
+        op.fn_kwargs,
+        op.fn_constructor_args if udf_is_callable_class else None,
+        op.fn_constructor_kwargs if udf_is_callable_class else None,
         compute=compute,
     )
 
     if isinstance(op, MapBatches):
         transform_fn = BatchMapTransformFn(
             _generate_transform_fn_for_map_batches(fn),
-            batch_size=op._batch_size,
-            batch_format=op._batch_format,
-            zero_copy_batch=op._zero_copy_batch,
+            batch_size=op.batch_size,
+            batch_format=op.batch_format,
+            zero_copy_batch=op.zero_copy_batch,
             is_udf=True,
             output_block_size_option=output_block_size_option,
         )
@@ -330,10 +330,10 @@ def plan_udf_map_op(
         data_context,
         name=op.name,
         compute_strategy=compute,
-        min_rows_per_bundle=op._min_rows_per_bundled_input,
-        ray_remote_args_fn=op._ray_remote_args_fn,
-        ray_remote_args=op._ray_remote_args,
-        per_block_limit=op._per_block_limit,
+        min_rows_per_bundle=op.min_rows_per_bundled_input,
+        ray_remote_args_fn=op.ray_remote_args_fn,
+        ray_remote_args=op.ray_remote_args,
+        per_block_limit=op.per_block_limit,
     )
 
 

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -91,8 +91,8 @@ def _plan_write_op_internal(
     assert len(physical_children) == 1
     input_physical_dag = physical_children[0]
 
-    datasink = op._datasink_or_legacy_datasource
-    write_fn = generate_write_fn(datasink, **op._write_args)
+    datasink = op.datasink_or_legacy_datasource
+    write_fn = generate_write_fn(datasink, **op.write_args)
 
     # Create a MapTransformer for a write operator
     transform_fns = [
@@ -121,9 +121,9 @@ def _plan_write_op_internal(
         # Add a UUID to write tasks to prevent filename collisions. This a UUID for the
         # overall write operation, not the individual write tasks.
         map_task_kwargs={WRITE_UUID_KWARG_NAME: uuid.uuid4().hex},
-        ray_remote_args=op._ray_remote_args,
-        min_rows_per_bundle=op._min_rows_per_bundled_input,
-        compute_strategy=op._compute,
+        ray_remote_args=op.ray_remote_args,
+        min_rows_per_bundle=op.min_rows_per_bundled_input,
+        compute_strategy=op.compute,
         on_start=on_start,
     )
 

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -97,7 +97,7 @@ def plan_union_op(_, physical_children, data_context):
 
 def plan_limit_op(logical_op, physical_children, data_context):
     assert len(physical_children) == 1
-    return LimitOperator(logical_op._limit, physical_children[0], data_context)
+    return LimitOperator(logical_op.limit, physical_children[0], data_context)
 
 
 def plan_count_op(logical_op, physical_children, data_context):
@@ -117,14 +117,14 @@ def plan_join_op(
         data_context=data_context,
         left_input_op=physical_children[0],
         right_input_op=physical_children[1],
-        join_type=logical_op._join_type,
-        left_key_columns=logical_op._left_key_columns,
-        right_key_columns=logical_op._right_key_columns,
-        left_columns_suffix=logical_op._left_columns_suffix,
-        right_columns_suffix=logical_op._right_columns_suffix,
-        num_partitions=logical_op._num_outputs,
-        partition_size_hint=logical_op._partition_size_hint,
-        aggregator_ray_remote_args_override=logical_op._aggregator_ray_remote_args,
+        join_type=logical_op.join_type,
+        left_key_columns=logical_op.left_key_columns,
+        right_key_columns=logical_op.right_key_columns,
+        left_columns_suffix=logical_op.left_columns_suffix,
+        right_columns_suffix=logical_op.right_columns_suffix,
+        num_partitions=logical_op.num_outputs,
+        partition_size_hint=logical_op.partition_size_hint,
+        aggregator_ray_remote_args_override=logical_op.aggregator_ray_remote_args,
     )
 
 
@@ -136,10 +136,10 @@ def plan_streaming_split_op(
     assert len(physical_children) == 1
     return OutputSplitter(
         physical_children[0],
-        n=logical_op._num_splits,
-        equal=logical_op._equal,
+        n=logical_op.num_splits,
+        equal=logical_op.equal,
         data_context=data_context,
-        locality_hints=logical_op._locality_hints,
+        locality_hints=logical_op.locality_hints,
     )
 
 

--- a/python/ray/data/_internal/planner/randomize_blocks.py
+++ b/python/ray/data/_internal/planner/randomize_blocks.py
@@ -32,10 +32,10 @@ def generate_randomize_blocks_fn(
             )
 
         if len(blocks_with_metadata) == 0:
-            return refs, {op._name: []}
+            return refs, {op.name: []}
         else:
-            if op._seed is not None:
-                random.seed(op._seed)
+            if op.seed is not None:
+                random.seed(op.seed)
             input_owned = all(b.owns_blocks for b in refs)
             random.shuffle(blocks_with_metadata)
             output = []
@@ -54,6 +54,6 @@ def generate_randomize_blocks_fn(
                         schema=index_to_schema[i],
                     )
                 )
-            return output, {op._name: stats_list}
+            return output, {op.name: stats_list}
 
     return fn

--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -255,7 +255,7 @@ def test_inherit_batch_format_rule():
 
     rule = InheritBatchFormatRule()
     optimized_plan = rule.apply(original_plan)
-    assert optimized_plan.dag._batch_format == "pandas"
+    assert optimized_plan.dag.batch_format == "pandas"
 
 
 def test_batch_format_on_sort(ray_start_regular_shared_2_cpus):

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -210,7 +210,7 @@ def test_spread_hint_inherit(ray_start_regular_shared):
 
     shuffle_op = ds._plan._logical_plan.dag
     read_op = shuffle_op.input_dependencies[0].input_dependencies[0]
-    assert read_op._ray_remote_args == {"scheduling_strategy": "SPREAD"}
+    assert read_op.ray_remote_args == {"scheduling_strategy": "SPREAD"}
 
 
 def test_optimize_randomize_block_order(ray_start_regular_shared):

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1037,15 +1037,15 @@ def test_execution_callbacks_executor_arg(tmp_path, restore_data_context):
 
     assert len(logical_ops) == 3
     assert isinstance(logical_ops[0], Read)
-    datasource = logical_ops[0]._datasource
+    datasource = logical_ops[0].datasource
     assert isinstance(datasource, ParquetDatasource)
     assert datasource._source_paths == input_path
 
     assert isinstance(logical_ops[1], MapRows)
-    assert logical_ops[1]._fn == udf
+    assert logical_ops[1].fn == udf
 
     assert isinstance(logical_ops[2], Write)
-    datasink = logical_ops[2]._datasink_or_legacy_datasource
+    datasink = logical_ops[2].datasink_or_legacy_datasource
     assert isinstance(datasink, ParquetDatasink)
     assert datasink.unresolved_path == output_path
 


### PR DESCRIPTION
## Description
This PR updates Ray Data logical operators to use public attribute names (e.g., limit instead of _limit) and aligns all logical rules, planners, and call sites accordingly. This is part of the larger effort to make logical plans immutable and comparable (Issue #60312), and it keeps physical operators out of scope.


This PR implements the second step in the planned 4‑PR split.

  Split plan for review:

  1. PR that just replaces references to _input_dependencies with input_dependencies
  2. PR that just renames operator attributes so they don’t have a leading underscore (this PR)
  3. PR that just removes LogicalOperator.output_dependencies (physical is out of scope)
  4. PR that converts operators to frozen dataclasses (ideally avoiding object.__setattr__ / super().__init__)

## Related issues
> Link related issues: "Fixes #60312", or "Related to #60312".

## Additional information
  - Scope: logical operators + logical rules/planner + affected tests/callers.
  - Physical operators unchanged; any test access to physical internals reverted to private fields.
  - Preserved legacy export shape in LogicalOperator._get_args() to keep dataset metadata export stable.
  - Metadata export safely reads sub‑stage names without assuming every op implements get_sub_progress_bar_names().

