### PR TITLE
[Data] Use input_dependencies property in logical operator

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -43,8 +43,8 @@ class LogicalOperator(Operator):
         """
         if self._num_outputs is not None:
             return self._num_outputs
-        elif len(self._input_dependencies) == 1:
-            return self._input_dependencies[0].estimated_num_outputs()
+        elif len(self.input_dependencies) == 1:
+            return self.input_dependencies[0].estimated_num_outputs()
         return None
 
     # Override the following 3 methods to correct type hints.
@@ -52,6 +52,10 @@ class LogicalOperator(Operator):
     @property
     def input_dependencies(self) -> List["LogicalOperator"]:
         return super().input_dependencies  # type: ignore
+
+    @input_dependencies.setter
+    def input_dependencies(self, value: List["LogicalOperator"]) -> None:
+        self._input_dependencies = value
 
     @property
     def output_dependencies(self) -> List["LogicalOperator"]:

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -68,16 +68,16 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
         self._seed = seed
 
     def infer_metadata(self) -> "BlockMetadata":
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata()
 
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Randomizing block order doesn't affect filtering correctness
@@ -106,16 +106,16 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
         self._seed = seed
 
     def infer_metadata(self) -> "BlockMetadata":
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata()
 
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Random shuffle doesn't affect filtering correctness
@@ -153,16 +153,16 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
         self._sort = sort
 
     def infer_metadata(self) -> "BlockMetadata":
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata()
 
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Repartition doesn't affect filtering correctness
@@ -191,16 +191,16 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
         self._batch_format = batch_format
 
     def infer_metadata(self) -> "BlockMetadata":
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata()
 
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Sort doesn't affect filtering correctness

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -39,7 +39,7 @@ class Zip(NAry):
 
     def estimated_num_outputs(self):
         total_num_outputs = 0
-        for input in self._input_dependencies:
+        for input in self.input_dependencies:
             num_outputs = input.estimated_num_outputs()
             if num_outputs is None:
                 return None
@@ -58,7 +58,7 @@ class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
 
     def estimated_num_outputs(self):
         total_num_outputs = 0
-        for input in self._input_dependencies:
+        for input in self.input_dependencies:
             num_outputs = input.estimated_num_outputs()
             if num_outputs is None:
                 return None

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -50,7 +50,7 @@ class AbstractOneToOne(LogicalOperator):
 
     @property
     def input_dependency(self) -> LogicalOperator:
-        return self._input_dependencies[0]
+        return self.input_dependencies[0]
 
     def can_modify_num_rows(self) -> bool:
         """Whether this operator can modify the number of rows,
@@ -84,23 +84,23 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
     def infer_schema(
         self,
     ) -> Optional["Schema"]:
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_schema()
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
 
     def _num_rows(self):
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        input_rows = self._input_dependencies[0].infer_metadata().num_rows
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        input_rows = self.input_dependencies[0].infer_metadata().num_rows
         if input_rows is not None:
             return min(input_rows, self._limit)
         else:
             return None
 
     def _input_files(self):
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        assert isinstance(self._input_dependencies[0], LogicalOperator)
-        return self._input_dependencies[0].infer_metadata().input_files
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_metadata().input_files
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Pushing filter through limit is safe: Filter(Limit(data, n), pred)

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -202,7 +202,7 @@ class LimitPushdownRule(Rule):
 
         # Use copy and replace input dependencies approach
         new_op = copy.copy(original_op)
-        new_op._input_dependencies = [new_input]
+        new_op.input_dependencies = [new_input]
         new_op._output_dependencies = []
 
         return new_op

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -78,12 +78,12 @@ class FuseOperators(Rule):
         return new_plan
 
     def _remove_output_deps(self, op: PhysicalOperator) -> None:
-        for input in op._input_dependencies:
+        for input in op.input_dependencies:
             input._output_dependencies = []
             self._remove_output_deps(input)
 
     def _update_output_deps(self, op: PhysicalOperator) -> None:
-        for input in op._input_dependencies:
+        for input in op.input_dependencies:
             input._output_dependencies.append(op)
             self._update_output_deps(input)
 
@@ -229,7 +229,7 @@ class FuseOperators(Rule):
 
         # If the downstream operator takes no input, it cannot be fused with
         # the upstream operator.
-        if not down_logical_op._input_dependencies:
+        if not down_logical_op.input_dependencies:
             return False
 
         # We currently only support fusing for the following cases:

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -318,7 +318,7 @@ class PredicatePushdown(Rule):
             A shallow copy of the operator with updated input dependencies
         """
         new_op = copy.copy(op)
-        new_op._input_dependencies = new_inputs
+        new_op.input_dependencies = new_inputs
         new_op._output_dependencies = []
         new_op._wire_output_deps(new_inputs)
         return new_op


### PR DESCRIPTION
## Description
 This PR updates logical operators and logical rules to consistently access input dependencies via the input_dependencies property instead of the internal _input_dependencies field. This is the first step in the split plan for Issue #60312 and keeps physical operators out of scope.

To keep reviews small, we’re splitting the work into stacked PRs:

  1. PR that just replaces references to _input_dependencies with input_dependencies (this PR)
  2. PR that just renames operator attributes so they don’t have a leading underscore
  3. PR that just removes LogicalOperator.output_dependencies (physical is out of scope)
  4. PR that converts operators to frozen dataclasses (ideally avoiding object.__setattr__ / super().__init__)

This PR implements the first step in the planned four‑PR split.

## Related issues
> Link related issues: "Fixes #60312 ", or "Related to #60312".

## Additional information
  - Scope: logical operators + logical rules only (no physical operator changes).
  - Updated operator classes: AllToAll, NAry, OneToOne.
  - Updated rules: limit_pushdown, operator_fusion, predicate_pushdown.
  - No behavior changes intended; this is a refactor to unify access through the public property.

