### PR TITLE
[Data] Drop output_dependencies from logical operators

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -57,10 +57,6 @@ class LogicalOperator(Operator):
     def input_dependencies(self, value: List["LogicalOperator"]) -> None:
         self._input_dependencies = value
 
-    @property
-    def output_dependencies(self) -> List["LogicalOperator"]:
-        return super().output_dependencies  # type: ignore
-
     def post_order_iter(self) -> Iterator["LogicalOperator"]:
         return super().post_order_iter()  # type: ignore
 
@@ -78,6 +74,8 @@ class LogicalOperator(Operator):
             else:
                 # Keep underscore-prefixed keys to preserve legacy export schema.
                 args[f"_{key}"] = value
+        # Preserve legacy export shape even though output deps are no longer tracked.
+        args["_output_dependencies"] = []
         return args
 
     def infer_schema(self) -> Optional["Schema"]:

--- a/python/ray/data/_internal/logical/rules/inherit_batch_format.py
+++ b/python/ray/data/_internal/logical/rules/inherit_batch_format.py
@@ -30,7 +30,6 @@ class InheritBatchFormatRule(Rule):
                 if isinstance(upstream_op, MapBatches) and upstream_op.batch_format:
                     new_op = copy.copy(node)
                     new_op.batch_format = upstream_op.batch_format
-                    new_op._output_dependencies = []
                     return new_op
                 upstream_op = upstream_op.input_dependencies[0]
 

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -203,6 +203,4 @@ class LimitPushdownRule(Rule):
         # Use copy and replace input dependencies approach
         new_op = copy.copy(original_op)
         new_op.input_dependencies = [new_input]
-        new_op._output_dependencies = []
-
         return new_op

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -319,6 +319,4 @@ class PredicatePushdown(Rule):
         """
         new_op = copy.copy(op)
         new_op.input_dependencies = new_inputs
-        new_op._output_dependencies = []
-        new_op._wire_output_deps(new_inputs)
         return new_op


### PR DESCRIPTION
## Description
This PR removes output_dependencies from logical operators. Since the base Operator implementation relies on output deps for traversal and transform, this PR makes LogicalOperator self‑contained by implementing its own post_order_iter, _apply_transform, and dag_str. This keeps the logical DAG functional while dropping the reverse‑edge maintenance.

To keep reviews small, we’re splitting the work into stacked PRs:

  1. PR that just replaces references to _input_dependencies with input_dependencies 
  2. PR that just renames operator attributes so they don’t have a leading underscore
  3. PR that just removes LogicalOperator.output_dependencies (physical is out of scope) (this PR)
  4. PR that converts operators to frozen dataclasses (ideally avoiding `object.__setattr__ `/ `super().__init__`)

This PR implements the step 3 in the planned four‑PR split.


## Related issues
> Link related issues: "Fixes #60312", or "Related to #60312".

## Additional information
  - Scope: logical operators only; physical operators remain unchanged.
  - Rules updated to stop writing _output_dependencies (limit/predicate/inherit_batch_format).
  - LogicalOperator._get_args() preserves legacy export shape with _output_dependencies: [] for compatibility.


