### PR TITLE
[Data] Fix concurrent dataset logging to use separate files (#48633)

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1124,10 +1124,6 @@ python/ray/data/_internal/iterator/stream_split_iterator.py
     DOC101: Method `SplitCoordinator.start_epoch`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `SplitCoordinator.start_epoch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [split_idx: int].
 --------------------
-python/ray/data/_internal/logging.py
-    DOC201: Function `register_dataset_logger` does not have a return section in docstring
-    DOC201: Function `unregister_dataset_logger` does not have a return section in docstring
---------------------
 python/ray/data/_internal/logical/operators/all_to_all_operator.py
     DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
     DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)


### PR DESCRIPTION
## Description

This PR fixes the concurrent dataset logging issue where multiple Ray Data operations running simultaneously would have their logs interleaved or dropped entirely, making debugging extremely difficult.

**Problem**: When multiple Ray Data datasets ran concurrently (e.g., in separate Ray tasks), only one dataset could actively log at a time. Other concurrent datasets were silently ignored, resulting in missing execution logs.

**Solution**: This PR enables multiple datasets to log concurrently, each writing to its own separate log file (`ray-data-{dataset_id}.log`). Console output now includes dataset ID prefixes when multiple datasets are active, making it easy to distinguish between concurrent executions.

**Key changes**:
- Changed `_ACTIVE_DATASET` (singular) → `_ACTIVE_DATASETS` (set) to track multiple active datasets
- Modified `register_dataset_logger()` to immediately activate all datasets instead of queuing them
- Modified `unregister_dataset_logger()` to properly clean up individual datasets
- Added `DatasetContextFilter` to add `[dataset_id]` prefix to console logs when multiple datasets are active
- Updated logging configuration to use the new filter


## Related issues
> Link related issues: "Fixes #48633", "Closes #48633", or "Related to #48633".

## Additional information

### Implementation details
The core change is in python/ray/data/_internal/logging.py:

1. **Global state management**: Replaced single `_ACTIVE_DATASET` with `_ACTIVE_DATASETS` set to allow tracking multiple concurrent datasets

2. **Logger registration**: `register_dataset_logger()` now:
- Immediately activates all dataset loggers
- Creates separate file handler for each dataset
- Logs informative message when concurrent logging is detected

3. **Console output filtering**: New `DatasetContextFilter` class:
- Adds `[dataset_id]` prefix only when multiple datasets are active
- Uses first 8 characters of dataset ID for readability
- Gracefully handles edge cases to avoid breaking logging

4. **Cleanup**: `unregister_dataset_logger()` now:
- Properly removes individual datasets from active set
- Returns remaining active datasets (or None)
- No longer disrupts other concurrent datasets during cleanup