### PR TITLE
[Data] Fix attribute error in `UnionOperator.clear_internal_output_queue`

### DIFF
--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -93,7 +93,7 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def clear_internal_output_queue(self) -> None:
         """Clear internal output queue."""
         while self._output_buffer:
-            bundle = self._output_buffer.popleft()
+            bundle = self._output_buffer.get_next()
             self._metrics.on_output_dequeued(bundle)
 
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/60017 and https://github.com/ray-project/ray/pull/60228 refactored the `FIFOBundleQueue` interface and renamed `FIFOBundleQueue.popleft` with  `FIFOBundleQueue.get_next`. However, this name change wasn't reflected in the `UnionOperator` implementation, and as a result the operator can error when it clears its output queue.

This change also fixes the flaky `test_union.py`.