### PR TITLE
Consolidate RAY_VERSION to use rayci.env as single source of truth

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,6 +20,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+exports_files(["rayci.env"])
+
 # C/C++ toolchain constraint configs.
 
 config_setting(

--- a/ci/build/build-ray-docker.sh
+++ b/ci/build/build-ray-docker.sh
@@ -6,7 +6,14 @@ SOURCE_IMAGE="$2"
 DEST_IMAGE="$3"
 PIP_FREEZE_FILE="$4"
 
-RAY_VERSION="$(python python/ray/_version.py | cut -d' ' -f1)"
+# Source RAY_VERSION from rayci.env if not already set
+if [[ -z "${RAY_VERSION:-}" ]]; then
+    if [[ -f "rayci.env" ]]; then
+        source rayci.env
+    else
+        RAY_VERSION="$(python python/ray/_version.py | cut -d' ' -f1)"
+    fi
+fi
 RAY_COMMIT="$(git rev-parse HEAD)"
 
 CPU_TMP="$(mktemp -d)"

--- a/ci/docker/ray-image.Dockerfile
+++ b/ci/docker/ray-image.Dockerfile
@@ -17,7 +17,7 @@ FROM ${RAY_WHEEL_IMAGE} AS wheel-source
 FROM ${BASE_IMAGE}
 
 ARG RAY_COMMIT=unknown-commit
-ARG RAY_VERSION=3.0.0.dev0
+ARG RAY_VERSION
 
 LABEL io.ray.ray-commit="${RAY_COMMIT}"
 LABEL io.ray.ray-version="${RAY_VERSION}"

--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -15,6 +15,7 @@ py_library(
     data = glob(["*.yaml"]),
     visibility = ["//ci/ray_ci:__subpackages__"],
     deps = [
+        "//ci/ray_ci/automation:update_version_lib",
         "//release:bazel",
         "//release:global_config",
         "//release:test",

--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -70,7 +70,11 @@ py_binary(
 py_library(
     name = "update_version_lib",
     srcs = ["update_version_lib.py"],
-    visibility = ["//ci/ray_ci/automation:__subpackages__"],
+    data = ["//:rayci.env"],
+    visibility = [
+        "//ci/ray_ci:__pkg__",
+        "//ci/ray_ci/automation:__subpackages__",
+    ],
     deps = [],
 )
 

--- a/ci/ray_ci/automation/update_version_lib.py
+++ b/ci/ray_ci/automation/update_version_lib.py
@@ -3,7 +3,30 @@ import subprocess
 
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 
-MASTER_BRANCH_VERSION = "3.0.0.dev0"
+# Path to rayci.env relative to this file
+_RAYCI_ENV_PATH = os.path.join(os.path.dirname(__file__), "../../../rayci.env")
+
+
+def read_ray_version_from_rayci_env(rayci_env_path=None):
+    """Read RAY_VERSION from rayci.env file.
+
+    Args:
+        rayci_env_path: Path to rayci.env. Defaults to repo root rayci.env.
+
+    Returns:
+        The RAY_VERSION string, or None if not found.
+    """
+    if rayci_env_path is None:
+        rayci_env_path = _RAYCI_ENV_PATH
+    if os.path.exists(rayci_env_path):
+        with open(rayci_env_path) as f:
+            for line in f:
+                if line.startswith("RAY_VERSION="):
+                    return line.strip().split("=", 1)[1]
+    return None
+
+
+MASTER_BRANCH_VERSION = read_ray_version_from_rayci_env() or "3.0.0.dev0"
 MASTER_BRANCH_JAVA_VERSION = "2.0.0-SNAPSHOT"
 
 

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -11,6 +11,7 @@ from typing import List
 import boto3
 
 import ci.ray_ci.bazel_sharding as bazel_sharding
+from ci.ray_ci.automation.update_version_lib import read_ray_version_from_rayci_env
 
 from ray_release.bazel import bazel_runfile
 from ray_release.configs.global_config import init_global_config
@@ -19,7 +20,10 @@ from ray_release.test import Test, TestState
 GLOBAL_CONFIG_FILE = (
     os.environ.get("RAYCI_GLOBAL_CONFIG") or "ci/ray_ci/oss_config.yaml"
 )
-RAY_VERSION = "3.0.0.dev0"
+
+RAY_VERSION = (
+    os.environ.get("RAY_VERSION") or read_ray_version_from_rayci_env() or "3.0.0.dev0"
+)
 
 
 def ci_init() -> None:

--- a/release/util/pip_download_test.sh
+++ b/release/util/pip_download_test.sh
@@ -4,8 +4,14 @@
 # in various Python version. This script requires conda command to exist.
 
 unset RAY_ADDRESS
-export RAY_HASH=$RAY_HASH
-export RAY_VERSION=$RAY_VERSION
+
+# Source rayci.env if RAY_VERSION not provided
+if [[ -z "${RAY_VERSION:-}" ]] && [[ -f "rayci.env" ]]; then
+    source rayci.env
+fi
+
+export RAY_HASH="${RAY_HASH:-}"
+export RAY_VERSION="${RAY_VERSION:-}"
 
 if [[ -z "$RAY_HASH" ]]; then
     echo "RAY_HASH env var should be provided"

--- a/release/util/sanity_check_windows.sh
+++ b/release/util/sanity_check_windows.sh
@@ -5,6 +5,11 @@
 
 set -euo pipefail
 
+# Source rayci.env if RAY_VERSION not provided
+if [[ -z "${RAY_VERSION:-}" ]] && [[ -f "rayci.env" ]]; then
+    source rayci.env
+fi
+
 export RAY_HASH="${RAY_HASH:-}"
 export RAY_VERSION="${RAY_VERSION:-}"
 


### PR DESCRIPTION
This change makes rayci.env the canonical source for RAY_VERSION during
development and CI, eliminating duplicate hardcoded version strings.

Changes:
- update_version_lib.py: Export read_ray_version_from_rayci_env() and add rayci.env to the list of files updated during version bumps
- utils.py: Import shared function, read from env var -> rayci.env -> fallback
- Shell scripts: Source rayci.env as fallback when RAY_VERSION not set

Files intentionally NOT reading from rayci.env at runtime:
- python/ray/_version.py: Must remain a simple literal because it's imported at runtime by ray/__init__.py to expose ray.__version__. When Ray is installed via pip, rayci.env does not exist in the package. Adding file I/O would break ray.__version__ for all pip-installed users. Instead, the version automation updates both rayci.env and _version.py together, and the build process bakes the version into wheels.
- src/ray/common/constants.h: C++ constant, updated by version automation

Version flow after this change:
  rayci.env (source of truth)
      ├── CI scripts (env_file or source)
      ├── Version automation (updates on release)
      │       ├── python/ray/_version.py (baked into wheels)
      │       ├── src/ray/common/constants.h
      │       └── rayci.env
      └── Build/Wanda (via env_file)

Topic: rayci-env-version
Labels: draft

Signed-off-by: andrew <andrew@anyscale.com>