### PR TITLE
[train][doc] Document checkpoint_upload_fn backend and support cuda:nccl backend

### DIFF
--- a/doc/source/train/doc_code/checkpoints.py
+++ b/doc/source/train/doc_code/checkpoints.py
@@ -545,6 +545,14 @@ def train_fn(config):
             checkpoint_upload_fn=wait_async_save,
         )
 
+trainer = TorchTrainer(
+   train_fn,
+   train_loop_config={"num_epochs": 3},
+   scaling_config=train.ScalingConfig(num_workers=2, use_gpu=True),
+   # we need a cpu backend for async_save and a gpu backend for training
+   torch_config=train.torch.TorchConfig(backend="cpu:gloo,cuda:nccl"),
+   run_config=train.RunConfig(storage_path="s3://bucket/")
+)
 
 # __checkpoint_upload_fn_end__
 

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -70,6 +70,17 @@ class TorchConfig(BackendConfig):
         return TorchConfigContextManager
 
 
+def _is_backend_nccl(backend: str) -> bool:
+    # Check containment because comma separated lists of backends like cpu:gloo,cuda:nccl are supported.
+    return backend == "nccl" or any(
+        [
+            item.split(":")[1] == "nccl"
+            for item in backend.split(",")
+            if item.startswith("cuda:")
+        ]
+    )
+
+
 def _setup_torch_process_group(
     backend: str,
     world_rank: int,
@@ -98,7 +109,7 @@ def _setup_torch_process_group(
         )
     logger.debug(f"using {backend}")
 
-    if backend == "nccl":
+    if _is_backend_nccl(backend):
         # See https://github.com/pytorch/pytorch/blob/c263bd43e8e8502d4726643bc6fd046f0130ac0e/torch/distributed/distributed_c10d.py#L803-L823 # noqa: E501
         # We do not use TORCH_NCCL_BLOCKING_WAIT due to performance overhead.
         if Version(torch.__version__) < Version("2.2.0"):

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -73,11 +73,9 @@ class TorchConfig(BackendConfig):
 def _is_backend_nccl(backend: str) -> bool:
     # Check containment because comma separated lists of backends like cpu:gloo,cuda:nccl are supported.
     return backend == "nccl" or any(
-        [
-            item.split(":")[1] == "nccl"
-            for item in backend.split(",")
-            if item.startswith("cuda:")
-        ]
+        item.split(":")[1] == "nccl"
+        for item in backend.split(",")
+        if item.startswith("cuda:")
     )
 
 

--- a/python/ray/train/v2/tests/test_torch_trainer.py
+++ b/python/ray/train/v2/tests/test_torch_trainer.py
@@ -8,6 +8,7 @@ from ray.train.examples.pytorch.torch_linear_example import (
     train_func as linear_train_func,
 )
 from ray.train.torch import TorchConfig, TorchTrainer
+from ray.train.torch.config import _is_backend_nccl
 from ray.train.v2._internal.constants import HEALTH_CHECK_INTERVAL_S_ENV_VAR
 
 
@@ -83,6 +84,16 @@ def test_torch_process_group_shutdown_timeout(ray_start_4_cpus, monkeypatch, tim
     # Even if shutdown times out (timeout_s=0),
     # the training should complete successfully.
     trainer.fit()
+
+
+def test_is_backend_nccl():
+    assert _is_backend_nccl("nccl")
+    assert _is_backend_nccl("cuda:nccl")
+    assert _is_backend_nccl("cpu:gloo,cuda:nccl")
+    assert not _is_backend_nccl("gloo")
+    assert not _is_backend_nccl("cpu:nccl")
+    assert not _is_backend_nccl("cuda:gloo")
+    assert not _is_backend_nccl("cpu:gloo,cuda:gloo")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary

This PR makes the following changes:
1) Updates `checkpoint_upload_fn` documentation to mention that `backend="cpu:gloo,cuda:nccl"` is required. Thanks @marwan116 for observing this.
2) Update ray train code that checks for `backend="nccl"` to check `_is_backend_nccl` instead. 

# Testing

Unit tests