### PR TITLE
[train][tests] Download from correct hf link

### DIFF
--- a/python/ray/train/examples/deepspeed/deepspeed_torch_trainer_no_raydata.py
+++ b/python/ray/train/examples/deepspeed/deepspeed_torch_trainer_no_raydata.py
@@ -37,7 +37,8 @@ def train_func(config):
 
     # Prepare PyTorch Data Loaders
     # ====================================================
-    hf_datasets = load_dataset("glue", "mrpc")
+    # TODO: load from s3 instead of hub
+    hf_datasets = load_dataset("nyu-mll/glue", "mrpc")
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
 
     def collate_fn(batch):

--- a/python/ray/train/examples/deepspeed/deepspeed_torch_trainer_no_raydata.py
+++ b/python/ray/train/examples/deepspeed/deepspeed_torch_trainer_no_raydata.py
@@ -37,7 +37,6 @@ def train_func(config):
 
     # Prepare PyTorch Data Loaders
     # ====================================================
-    # TODO: load from s3 instead of hub
     hf_datasets = load_dataset("nyu-mll/glue", "mrpc")
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
 


### PR DESCRIPTION
# Summary

Before this PR we were getting this error 

```
[2026-01-27T07:07:38Z] Traceback (most recent call last):
--
[2026-01-27T07:07:38Z]   File "/root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/bin/python/ray/train/deepspeed_torch_trainer_no_raydata.runfiles/io_ray/python/ray/train/examples/deepspeed/deepspeed_torch_trainer_no_raydata.py", line 173, in <module>
[2026-01-27T07:07:38Z]     result = trainer.fit()
[2026-01-27T07:07:38Z]   File "/rayci/python/ray/train/v2/api/data_parallel_trainer.py", line 191, in fit
[2026-01-27T07:07:38Z]     raise result.error
[2026-01-27T07:07:38Z] ray.train.WorkerGroupError: Training failed due to worker errors:
[2026-01-27T07:07:38Z] [Rank 0 Error Snippet]:
[2026-01-27T07:07:38Z] Traceback (most recent call last):
[2026-01-27T07:07:38Z]   File "/root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/bin/python/ray/train/deepspeed_torch_trainer_no_raydata.runfiles/io_ray/python/ray/train/examples/deepspeed/deepspeed_torch_trainer_no_raydata.py", line 40, in train_func
[2026-01-27T07:07:38Z]     hf_datasets = load_dataset("glue", "mrpc")
[2026-01-27T07:07:38Z]   File "/opt/miniforge/lib/python3.10/site-packages/datasets/load.py", line 2062, in load_dataset
[2026-01-27T07:07:38Z]     builder_instance = load_dataset_builder(...
[2026-01-27T07:07:38Z] ... (Output truncated. See individual worker logs for full details) ...
[2026-01-27T07:07:38Z] r_status(r)
[2026-01-27T07:07:38Z]   File "/opt/miniforge/lib/python3.10/site-packages/huggingface_hub/utils/_http.py", line 477, in hf_raise_for_status
[2026-01-27T07:07:38Z]     raise _format(HfHubHTTPError, str(e), response) from e
[2026-01-27T07:07:38Z] huggingface_hub.errors.HfHubHTTPError: 404 Client Error: Not Found for url: https://huggingface.co/api/datasets/glue/revision/bcdcba79d07bc864c1c254ccfcedcce55bcc9a8c (Request ID: Root=1-697863ee-1836266a1a43ade4417d37f4;b6725682-cf6c-4553-b716-8a8a4f878965)
[2026-01-27T07:07:38Z]
[2026-01-27T07:07:38Z] Sorry, we can't find the page you are looking for.
```

# Testing

Premerge