### PR TITLE
[Data] Demote `Sort` from requiring `preserve_order`

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -636,9 +636,9 @@ class ExecutionPlan:
 
     def require_preserve_order(self) -> bool:
         """Whether this plan requires to preserve order."""
-        from ray.data._internal.logical.operators import Sort, Zip
+        from ray.data._internal.logical.operators import Zip
 
         for op in self._logical_plan.dag.post_order_iter():
-            if isinstance(op, (Zip, Sort)):
+            if isinstance(op, Zip):
                 return True
         return False

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -290,12 +290,10 @@ def test_optimize_lazy_reuse_base_data(
 
 
 def test_require_preserve_order(ray_start_regular_shared):
-    ds = ray.data.range(100).map_batches(lambda x: x).sort("id")
-    assert ds._plan.require_preserve_order()
-    ds2 = ray.data.range(100).map_batches(lambda x: x).zip(ds)
-    assert ds2._plan.require_preserve_order()
-    ds3 = ray.data.range(100).map_batches(lambda x: x).repartition(10)
-    assert not ds3._plan.require_preserve_order()
+    ds1 = ray.data.range(100).map_batches(lambda x: x).zip(ray.data.range(100))
+    assert ds1._plan.require_preserve_order()
+    ds2 = ray.data.range(100).map_batches(lambda x: x).repartition(10)
+    assert not ds2._plan.require_preserve_order()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This removes the requirement for pipelines having `Sort`  operations to actually require `preserve_order=True`.

This is an unnecessary strict requirement that has adversarial side-effects, and is strictly not required as there's no global ordering between the blocks established.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
