### PR TITLE
[tune] Avoid file deletion race by using unique tmp file names

### DIFF
--- a/python/ray/tune/callback.py
+++ b/python/ray/tune/callback.py
@@ -464,7 +464,7 @@ class CallbackList(Callback):
 
         if state_dict:
             file_name = self.CKPT_FILE_TMPL.format(session_str)
-            tmp_file_name = f".tmp-{file_name}"
+            tmp_file_name = f"tmp-{file_name}"
             _atomic_save(
                 state=state_dict,
                 checkpoint_dir=checkpoint_dir,

--- a/python/ray/tune/search/basic_variant.py
+++ b/python/ray/tune/search/basic_variant.py
@@ -407,7 +407,7 @@ class BasicVariantGenerator(SearchAlgorithm):
             state=state_dict,
             checkpoint_dir=dirpath,
             file_name=file_name,
-            tmp_file_name=f".tmp-{file_name}",
+            tmp_file_name=f"tmp-{file_name}",
         )
 
     def has_checkpoint(self, dirpath: str):

--- a/python/ray/tune/search/basic_variant.py
+++ b/python/ray/tune/search/basic_variant.py
@@ -402,11 +402,12 @@ class BasicVariantGenerator(SearchAlgorithm):
         if any(iterator.lazy_eval for iterator in self._iterators):
             return False
         state_dict = self.get_state()
+        file_name = self.CKPT_FILE_TMPL.format(session_str)
         _atomic_save(
             state=state_dict,
             checkpoint_dir=dirpath,
-            file_name=self.CKPT_FILE_TMPL.format(session_str),
-            tmp_file_name=".tmp_generator",
+            file_name=file_name,
+            tmp_file_name=f".tmp-{file_name}",
         )
 
     def has_checkpoint(self, dirpath: str):

--- a/python/ray/tune/search/search_generator.py
+++ b/python/ray/tune/search/search_generator.py
@@ -184,11 +184,12 @@ class SearchGenerator(SearchAlgorithm):
         # We save the base searcher separately for users to easily
         # separate the searcher.
         base_searcher.save_to_dir(dirpath, session_str)
+        file_name = self.CKPT_FILE_TMPL.format(session_str)
         _atomic_save(
             state=search_alg_state,
             checkpoint_dir=dirpath,
-            file_name=self.CKPT_FILE_TMPL.format(session_str),
-            tmp_file_name=".tmp_search_generator_ckpt",
+            file_name=file_name,
+            tmp_file_name=f".tmp-{file_name}",
         )
 
     def restore_from_dir(self, dirpath: str):

--- a/python/ray/tune/search/search_generator.py
+++ b/python/ray/tune/search/search_generator.py
@@ -189,7 +189,7 @@ class SearchGenerator(SearchAlgorithm):
             state=search_alg_state,
             checkpoint_dir=dirpath,
             file_name=file_name,
-            tmp_file_name=f".tmp-{file_name}",
+            tmp_file_name=f"tmp-{file_name}",
         )
 
     def restore_from_dir(self, dirpath: str):

--- a/python/ray/tune/search/searcher.py
+++ b/python/ray/tune/search/searcher.py
@@ -375,7 +375,9 @@ class Searcher:
             session_str: Unique identifier of the current run
                 session.
         """
-        tmp_search_ckpt_path = os.path.join(checkpoint_dir, ".tmp_searcher_ckpt")
+        file_name = self.CKPT_FILE_TMPL.format(session_str)
+        tmp_file_name = f".tmp-{file_name}"
+        tmp_search_ckpt_path = os.path.join(checkpoint_dir, tmp_file_name)
         success = True
         try:
             self.save(tmp_search_ckpt_path)
@@ -387,7 +389,7 @@ class Searcher:
         if success and os.path.exists(tmp_search_ckpt_path):
             os.replace(
                 tmp_search_ckpt_path,
-                os.path.join(checkpoint_dir, self.CKPT_FILE_TMPL.format(session_str)),
+                os.path.join(checkpoint_dir, file_name),
             )
 
     def restore_from_dir(self, checkpoint_dir: str):

--- a/python/ray/tune/search/searcher.py
+++ b/python/ray/tune/search/searcher.py
@@ -2,6 +2,7 @@ import copy
 import glob
 import logging
 import os
+import uuid
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -376,7 +377,7 @@ class Searcher:
                 session.
         """
         file_name = self.CKPT_FILE_TMPL.format(session_str)
-        tmp_file_name = f".tmp-{file_name}"
+        tmp_file_name = f".{str(uuid.uuid4())}-tmp-{file_name}"
         tmp_search_ckpt_path = os.path.join(checkpoint_dir, tmp_file_name)
         success = True
         try:

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -410,7 +410,7 @@ def _atomic_save(state: Dict, checkpoint_dir: str, file_name: str, tmp_file_name
     import ray.cloudpickle as cloudpickle
 
     tmp_search_ckpt_path = os.path.join(
-        checkpoint_dir, tmp_file_name + str(uuid.uuid4())
+        checkpoint_dir, f"{tmp_file_name}-{str(uuid.uuid4())}"
     )
     with open(tmp_search_ckpt_path, "wb") as f:
         cloudpickle.dump(state, f)

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -405,12 +405,12 @@ def _atomic_save(state: Dict, checkpoint_dir: str, file_name: str, tmp_file_name
         state: Object state to be serialized.
         checkpoint_dir: Directory location for the checkpoint.
         file_name: Final name of file.
-        tmp_file_name: Temporary name of file.
+        tmp_file_name: Temporary name of file with .uuid prefix.
     """
     import ray.cloudpickle as cloudpickle
 
     tmp_search_ckpt_path = os.path.join(
-        checkpoint_dir, f"{str(uuid.uuid4())}-{tmp_file_name}"
+        checkpoint_dir, f".{str(uuid.uuid4())}-{tmp_file_name}"
     )
     with open(tmp_search_ckpt_path, "wb") as f:
         cloudpickle.dump(state, f)

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -410,7 +410,7 @@ def _atomic_save(state: Dict, checkpoint_dir: str, file_name: str, tmp_file_name
     import ray.cloudpickle as cloudpickle
 
     tmp_search_ckpt_path = os.path.join(
-        checkpoint_dir, f"{tmp_file_name}-{str(uuid.uuid4())}"
+        checkpoint_dir, f"{str(uuid.uuid4())}-{tmp_file_name}"
     )
     with open(tmp_search_ckpt_path, "wb") as f:
         cloudpickle.dump(state, f)

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -5,6 +5,7 @@ import logging
 import os
 import threading
 import time
+import uuid
 from collections import defaultdict
 from datetime import datetime
 from numbers import Number
@@ -408,7 +409,9 @@ def _atomic_save(state: Dict, checkpoint_dir: str, file_name: str, tmp_file_name
     """
     import ray.cloudpickle as cloudpickle
 
-    tmp_search_ckpt_path = os.path.join(checkpoint_dir, tmp_file_name)
+    tmp_search_ckpt_path = os.path.join(
+        checkpoint_dir, tmp_file_name + str(uuid.uuid4())
+    )
     with open(tmp_search_ckpt_path, "wb") as f:
         cloudpickle.dump(state, f)
 

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -405,7 +405,7 @@ def _atomic_save(state: Dict, checkpoint_dir: str, file_name: str, tmp_file_name
         state: Object state to be serialized.
         checkpoint_dir: Directory location for the checkpoint.
         file_name: Final name of file.
-        tmp_file_name: Temporary name of file with .uuid prefix.
+        tmp_file_name: Temporary name of file. We prepend a .uuid- prefix.
     """
     import ray.cloudpickle as cloudpickle
 


### PR DESCRIPTION
# Summary

Tune occasionally ran into issues like this

```
Traceback (most recent call last):
  File "/tmp/ray/session_2025-07-07_16-48-33_740950_2862/runtime_resources/working_dir_files/gs_anyscale-public-cloud_org_7c1Kalm9WcX2bNIjW53GUT_cld_6zjdsbn3kbphvk3luhyrd3eg6e_runtime_env_packages_pkg_bc103b49178145e7933f685e54dedda4/run_simple_tune_job.py", line 23, in <module>
    analysis = tune.run(
               ^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/tune/tune.py", line 994, in run
    runner.step()
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/tune/execution/tune_controller.py", line 701, in step
    raise e
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/tune/execution/tune_controller.py", line 698, in step
    self.checkpoint()
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/tune/execution/tune_controller.py", line 352, in checkpoint
    self._checkpoint_manager.sync_up_experiment_state(
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/tune/execution/experiment_state.py", line 167, in sync_up_experiment_state
    save_fn()
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/tune/execution/tune_controller.py", line 348, in save_to_dir
    self._search_alg.save_to_dir(driver_staging_path, session_str=self._session_str)
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/tune/search/basic_variant.py", line 405, in save_to_dir
    _atomic_save(
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/tune/utils/util.py", line 415, in _atomic_save
    os.replace(tmp_search_ckpt_path, os.path.join(checkpoint_dir, file_name))
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/ray/session_2025-07-07_16-48-33_740950_2862/artifacts/2025-07-07_16-49-27/training_function_2025-07-07_16-49-27/driver_artifacts/.tmp_generator' -> '/tmp/ray/session_2025-07-07_16-48-33_740950_2862/artifacts/2025-07-07_16-49-27/training_function_2025-07-07_16-49-27/driver_artifacts/basic-variant-state-2025-07-07_16-49-27.json'
```

I was unable to reproduce this issue. However, I was able to get Claude Code to generate a [script](https://gist.github.com/TimothySeah/b033410c2b0b60fb4c4e5849c96cc497) that shows that the following sequence of events is a possible cause:
* process A: writes to .tmp_generator
* process B: writes to .tmp_generator (same name!)
* process A: renames .tmp_generator to final.json
* process B: FileNotFoundError when trying to rename

This PR attempts to solve the problem by making `.tmp_generator` a unique name instead, which is the same approach we are doing here: https://github.com/ray-project/ray/blob/b2be3a336d1f292de1f785a6dae29afc6b4611d7/python/ray/tune/callback.py#L467. This should have no further conflicts since the `CKPT_FILE_TMPL` of the different components are all different.

Before this change, tmp files looked like `.tmp_generator`. Now they look like `.uuid-tmp-filename.json`.

# Testing

Unit tests. 