### PR TITLE
[Data] Fix flaky test_runtime_metrics by adding tolerance for rounding errors

### DIFF
--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1548,8 +1548,13 @@ def test_runtime_metrics(ray_start_regular_shared):
     total_time, total_percent = metrics_dict.pop("Total")
     assert total_percent == 100
 
+    # Tolerance for floating-point rounding errors (100ms)
+    # Individual operator times may appear slightly larger than total time
+    # due to rounding (e.g., 2.265s rounds to 2.27s for operator but 2.26s for total)
+    TOLERANCE = 0.1
+
     for time_s, percent in metrics_dict.values():
-        assert time_s <= total_time
+        assert time_s <= total_time + TOLERANCE
         # Check percentage, this is done with some expected loss of precision
         # due to rounding in the intital output.
         assert isclose(percent, time_s / total_time * 100, rel_tol=0.01)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1551,7 +1551,7 @@ def test_runtime_metrics(ray_start_regular_shared):
     # Tolerance for floating-point rounding errors (100ms)
     # Individual operator times may appear slightly larger than total time
     # due to rounding (e.g., 2.265s rounds to 2.27s for operator but 2.26s for total)
-    TOLERANCE = 0.1
+    TOLERANCE = 0.02
 
     for time_s, percent in metrics_dict.values():
         assert time_s <= total_time + TOLERANCE


### PR DESCRIPTION
## Description

This PR fixes a flaky test `test_runtime_metrics` that fails approximately 30% of the time due to floating-point rounding errors.

The test compares individual operator execution times against the total execution time. However, the `fmt()` function in `stats.py` rounds time values to 2 decimal places when formatting them as strings. This can cause rounding discrepancies where an operator's time appears slightly larger than the total time (e.g., operator: 2.27s, total: 2.26s from internal value 2.265s), causing the assertion `assert time_s <= total_time` to fail.

The fix adds a tolerance of 0.1 seconds (100ms) to account for these rounding errors while still validating that operator times don't significantly exceed the total time.


## Related issues
> Link related issues: "Fixes #60542", "Closes #60542", or "Related to #60542".

## Additional information

**Root cause analysis:**

- call stack

```
test_runtime_metrics (test_stats.py:1528)
  → DatasetStats.runtime_metrics() (stats.py:1110)
    → DatasetStatsSummary.runtime_metrics() (stats.py:1253-1271)
      → fmt_line() (stats.py:1256-1258)
        → fmt(seconds) (stats.py:57-63) round(seconds, 2)
```

1. The `fmt()` function in `python/ray/data/_internal/stats.py` rounds time values:
   ```python
   def fmt(seconds: float) -> str:
       if seconds > 1:
           return str(round(seconds, 2)) + "s"  # Rounds to 2 decimal places
   ```

2. When an internal time value is 2.265 seconds:
   - Operator time formatted: `2.27s` (rounds up)
   - Total time formatted: `2.26s` (rounds differently due to accumulated precision)

3. Test parses these strings back to floats and fails on: `assert 2.27 <= 2.26`

**Solution:**

Added `TOLERANCE = 0.1` (100ms) to the comparison:
```python
TOLERANCE = 0.1
for time_s, percent in metrics_dict.values():
    assert time_s <= total_time + TOLERANCE  # Was: assert time_s <= total_time
```
