### PR TITLE
[core][autoscaler][v2] Fix BatchingNodeProvider compatibility in NodeProviderAdapter

### DIFF
--- a/python/ray/autoscaler/v2/tests/test_node_provider.py
+++ b/python/ray/autoscaler/v2/tests/test_node_provider.py
@@ -839,7 +839,6 @@ def test_node_provider_adapter_post_process_logic(is_batching_provider):
     """
     from unittest.mock import Mock
 
-    from ray._common.test_utils import wait_for_condition
     from ray.autoscaler.batching_node_provider import BatchingNodeProvider
     from ray.autoscaler.node_provider import NodeProvider
 


### PR DESCRIPTION
## Description
This PR resolves a compatibility issue where V1 `BatchingNodeProvider` (type: external) failed to submit scale requests in Autoscaler V2.

Previously, the V2 `NodeProviderAdapter` missed invoking `post_process()` after asynchronous `launch()` calls, preventing batching providers from flushing pending node creation requests to the cloud API.

#### v1 autoscaler
https://github.com/ray-project/ray/blob/f05cfe8ffb45ea0ff97d3ec3c362623b8b9beecb/python/ray/autoscaler/_private/autoscaler.py#L462-L464

#### v2 autoscaler
https://github.com/ray-project/ray/blob/f05cfe8ffb45ea0ff97d3ec3c362623b8b9beecb/python/ray/autoscaler/v2/instance_manager/node_provider.py#L384-L389

This fix ensures `post_process()` is automatically called via a callback upon task completion, restoring full functionality for custom V1 providers.

## Related issues
Related to #57153

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.

#### Before (post_process NOT called)
<img width="3060" height="1136" alt="image" src="https://github.com/user-attachments/assets/2dc66261-d5cc-46cb-8479-53fb93c02c85" />

#### After (post_process called)
<img width="3032" height="1034" alt="image" src="https://github.com/user-attachments/assets/7e95d9a3-5671-4a11-8d0b-e2a188ad850a" />
