### PR TITLE
[RLlib] Add custom_resources_per_learner flag to AlgorithmConfig

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -263,6 +263,7 @@ class Algorithm(Checkpointable, Trainable):
         "model",
         "optimizer",
         "custom_resources_per_env_runner",
+        "custom_resources_per_learner",
         "custom_resources_per_worker",
         "evaluation_config",
         "exploration_config",

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -371,6 +371,7 @@ class AlgorithmConfig(_Config):
         self.num_aggregator_actors_per_learner = 0
         self.max_requests_in_flight_per_aggregator_actor = 3
         self.local_gpu_idx = 0
+        self.custom_resources_per_learner = {}
         # TODO (sven): This probably works even without any restriction
         #  (allowing for any arbitrary number of requests in-flight). Test with
         #  3 first, then with unlimited, and if both show the same behavior on
@@ -2281,6 +2282,7 @@ class AlgorithmConfig(_Config):
         ] = NotProvided,
         add_default_connectors_to_learner_pipeline: Optional[bool] = NotProvided,
         learner_config_dict: Optional[Dict[str, Any]] = NotProvided,
+        custom_resources_per_learner: Optional[Dict] = NotProvided,
     ) -> Self:
         """Sets LearnerGroup and Learner worker related configurations.
 
@@ -2348,6 +2350,8 @@ class AlgorithmConfig(_Config):
                 Learner subclasses and in case the user doesn't want to write an extra
                 `AlgorithmConfig` subclass just to add a few settings to the base Algo's
                 own config class.
+            custom_resources_per_learner: Any custom Ray resources to allocate per
+                Learner.
 
         Returns:
             This updated AlgorithmConfig object.
@@ -2378,6 +2382,8 @@ class AlgorithmConfig(_Config):
             )
         if learner_config_dict is not NotProvided:
             self.learner_config_dict.update(learner_config_dict)
+        if custom_resources_per_learner is not NotProvided:
+            self.custom_resources_per_learner = custom_resources_per_learner
 
         return self
 

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -2282,7 +2282,7 @@ class AlgorithmConfig(_Config):
         ] = NotProvided,
         add_default_connectors_to_learner_pipeline: Optional[bool] = NotProvided,
         learner_config_dict: Optional[Dict[str, Any]] = NotProvided,
-        custom_resources_per_learner: Optional[Dict] = NotProvided,
+        custom_resources_per_learner: Optional[Dict[str, Any]] = NotProvided,
     ) -> Self:
         """Sets LearnerGroup and Learner worker related configurations.
 

--- a/rllib/algorithms/utils.py
+++ b/rllib/algorithms/utils.py
@@ -197,6 +197,7 @@ def _get_learner_bundles(config):
         {
             "CPU": num_cpus_per_learner + config.num_aggregator_actors_per_learner,
             "GPU": config.num_gpus_per_learner,
+            **config.custom_resources_per_learner,
         }
         for _ in range(config.num_learners)
     ]

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -182,6 +182,7 @@ class LearnerGroup(Checkpointable):
                 "CPU": num_cpus_per_learner,
                 "GPU": num_gpus_per_learner,
             }
+            resources_per_learner.update(self.config.custom_resources_per_learner)
 
             backend_executor = RLlibBackendExecutor(
                 backend_config=backend_config,


### PR DESCRIPTION
## Description
This PR adds a configuration option to RLlib's `AlgorithmConfig` that allows users to configure [custom resources](https://docs.ray.io/en/latest/ray-core/scheduling/resources.html#custom-resources) per Learner as is already possible per `EnvRunner`. This feature would enable users to e.g. control which GPUs a `Learner` will be scheduled on by adding different types as custom resources.


