### PR TITLE
feat(build): add container-resource-utils

### DIFF
--- a/ci/build/BUILD.bazel
+++ b/ci/build/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+py_library(
+    name = "container_resource_utils",
+    srcs = ["container_resource_utils.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "container_resource_utils_test",
+    size = "small",
+    srcs = ["container_resource_utils_test.py"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [":container_resource_utils"],
+)

--- a/ci/build/container_resource_utils.py
+++ b/ci/build/container_resource_utils.py
@@ -1,0 +1,89 @@
+#! /usr/bin/env python3
+
+"""
+Generates Bazel resource flags by cross-referencing cgroup limits with a
+RAM-per-job ratio to prevent OOM kills in containerized environments.
+"""
+import argparse
+import math
+import os
+from pathlib import Path
+
+DEFAULT_RESERVE_MB = 2048
+DEFAULT_MB_PER_JOB = 3072
+
+
+def get_system_ram_mb() -> int:
+    # Fallback: os.sysconf reports host RAM, ignoring container quotas.
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        return (pages * page_size) // (1024**2)
+    except (ValueError, AttributeError):
+        return 8192
+
+
+def get_container_mem_limit_mb() -> int:
+    # Cgroup v2 is preferred because it's more accurate and portable.
+    paths = ["/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory/memory.limit_in_bytes"]
+    for path in paths:
+        p = Path(path)
+        if p.exists():
+            val = p.read_text().strip()
+            if val and val != "max":
+                limit_bytes = int(val)
+                if limit_bytes < 1024**5:  # Filter unlimited host values
+                    return limit_bytes // (1024**2)
+    return get_system_ram_mb()
+
+
+def get_container_cpu_limit() -> int:
+    v2_cpu = Path("/sys/fs/cgroup/cpu.max")
+    if v2_cpu.exists():
+        parts = v2_cpu.read_text().split()
+        if len(parts) == 2 and parts[0] != "max":
+            return max(1, math.ceil(int(parts[0]) / int(parts[1])))
+
+    quota_p = Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    period_p = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    if quota_p.exists() and period_p.exists():
+        try:
+            quota, period = int(quota_p.read_text()), int(period_p.read_text())
+            if quota > 0:
+                return max(1, math.ceil(quota / period))
+        except ValueError:
+            pass
+
+    return os.cpu_count() or 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Bazel resource flags.")
+    parser.add_argument(
+        "--reserve-mb",
+        type=int,
+        default=int(os.getenv("RESERVE_MB", DEFAULT_RESERVE_MB)),
+        help="RAM to reserve for the OS/Container overhead",
+    )
+    parser.add_argument(
+        "--mb-per-job",
+        type=int,
+        default=int(os.getenv("BAZEL_MB_PER_JOB", DEFAULT_MB_PER_JOB)),
+        help="Estimated RAM usage per concurrent Bazel job",
+    )
+    args = parser.parse_args()
+
+    mem_limit = get_container_mem_limit_mb()
+    cpu_limit = get_container_cpu_limit()
+
+    usable_mem = max(mem_limit - args.reserve_mb, args.mb_per_job)
+    jobs_by_ram = usable_mem // args.mb_per_job
+    bazel_jobs = max(1, min(cpu_limit, jobs_by_ram))
+
+    print(
+        f"--jobs={bazel_jobs} --local_cpu_resources={cpu_limit} --local_ram_resources={mem_limit}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build/container_resource_utils_test.py
+++ b/ci/build/container_resource_utils_test.py
@@ -1,0 +1,79 @@
+import io
+import unittest
+from unittest import mock
+
+from container_resource_utils import (
+    get_container_cpu_limit,
+    get_container_mem_limit_mb,
+    get_system_ram_mb,
+    main,
+)
+
+
+class TestResourceUtils(unittest.TestCase):
+    def test_get_system_ram_mb_calculates_correctly(self):
+        with mock.patch("os.sysconf") as m:
+            m.side_effect = lambda k: 4096 if k == "SC_PAGE_SIZE" else 1048576
+            # 1048576 pages * 4096 bytes / 1024^2 = 4096 MB
+            self.assertEqual(get_system_ram_mb(), 4096)
+
+    def test_get_container_cpu_limit_rounds_up_fractional(self):
+        """Ensures container fractional CPUs (e.g., 1.5) round up to 2."""
+        with mock.patch("pathlib.Path.exists", return_value=True), mock.patch(
+            "pathlib.Path.read_text", return_value="150000 100000"
+        ):
+            self.assertEqual(get_container_cpu_limit(), 2)
+
+    def test_mem_limit_falls_back_when_unlimited(self):
+        """Tests that 'max' or huge values fall back to host system RAM."""
+        with mock.patch("pathlib.Path.read_text", return_value="max"), mock.patch(
+            "container_resource_utils.get_system_ram_mb", return_value=16384
+        ):
+            self.assertEqual(get_container_mem_limit_mb(), 16384)
+
+    def test_main_bottleneck_by_ram(self):
+        """8GB RAM, 16 CPUs. Reserve 2GB, 3GB/job -> (8-2)/3 = 2 jobs max."""
+        with mock.patch(
+            "container_resource_utils.get_container_mem_limit_mb", return_value=8192
+        ), mock.patch(
+            "container_resource_utils.get_container_cpu_limit", return_value=16
+        ), mock.patch(
+            "sys.argv", ["prog"]
+        ), mock.patch(
+            "sys.stdout", new=io.StringIO()
+        ) as out:
+            main()
+            self.assertIn("--jobs=2", out.getvalue())
+
+    def test_main_bottleneck_by_cpu(self):
+        """32GB RAM, 2 CPUs. RAM allows ~10 jobs, but CPU limits to 2."""
+        with mock.patch(
+            "container_resource_utils.get_container_mem_limit_mb", return_value=32768
+        ), mock.patch(
+            "container_resource_utils.get_container_cpu_limit", return_value=2
+        ), mock.patch(
+            "sys.argv", ["prog"]
+        ), mock.patch(
+            "sys.stdout", new=io.StringIO()
+        ) as out:
+            main()
+            self.assertIn("--jobs=2", out.getvalue())
+
+    def test_cli_args_override_defaults(self):
+        """Verify CLI flags correctly change the calculation."""
+        # 8GB RAM, 8 CPUs. Reserve 4GB, 1GB/job -> (8-4)/1 = 4 jobs.
+        with mock.patch(
+            "container_resource_utils.get_container_mem_limit_mb", return_value=8192
+        ), mock.patch(
+            "container_resource_utils.get_container_cpu_limit", return_value=8
+        ), mock.patch(
+            "sys.argv", ["prog", "--reserve-mb", "4096", "--mb-per-job", "1024"]
+        ), mock.patch(
+            "sys.stdout", new=io.StringIO()
+        ) as out:
+            main()
+            self.assertIn("--jobs=4", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/docker/ray-core.Dockerfile
+++ b/ci/docker/ray-core.Dockerfile
@@ -8,6 +8,7 @@ ARG PYTHON_VERSION=3.10
 ARG BUILDKITE_BAZEL_CACHE_URL
 ARG BUILDKITE_CACHE_READONLY
 ARG HOSTTYPE
+ARG IS_LOCAL_BUILD=false
 ARG CACHE_DIR=/opt/cache
 
 ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
@@ -46,9 +47,15 @@ elif [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
   BAZEL_CACHE_ARGS="--remote_upload_local_results=false"
 fi
 
+BAZEL_RESOURCE_FLAGS=""
+if [[ "$IS_LOCAL_BUILD" == "true" ]]; then
+  BAZEL_RESOURCE_FLAGS=$(python3 "$HOME/ray/ci/build/container_resource_utils.py")
+fi
+
 bazelisk --output_base=$BAZEL_CACHE build --config=ci \
     --repository_cache=$REPOSITORY_CACHE \
     $BAZEL_CACHE_ARGS \
+    $BAZEL_RESOURCE_FLAGS \
     //:ray_pkg_zip //:ray_py_proto_zip
 
 cp bazel-bin/ray_pkg.zip /home/forge/ray_pkg.zip

--- a/ci/docker/ray-core.wanda.yaml
+++ b/ci/docker/ray-core.wanda.yaml
@@ -19,6 +19,7 @@ srcs:
   - java/dependencies.bzl
   - release/BUILD.bazel
   - release/requirements_py310.txt
+  - ci/build/container_resource_utils.py
 build_args:
   - PYTHON_VERSION
   - ARCH_SUFFIX
@@ -27,3 +28,4 @@ build_args:
   - MANYLINUX_VERSION
 build_hint_args:
   - BUILDKITE_CACHE_READONLY
+  - IS_LOCAL_BUILD

--- a/ci/docker/ray-java.Dockerfile
+++ b/ci/docker/ray-java.Dockerfile
@@ -7,6 +7,7 @@ FROM rayproject/manylinux2014:${MANYLINUX_VERSION}-jdk-${HOSTTYPE} AS builder
 ARG BUILDKITE_BAZEL_CACHE_URL
 ARG BUILDKITE_CACHE_READONLY
 ARG HOSTTYPE
+ARG IS_LOCAL_BUILD=false
 ARG CACHE_DIR=/opt/cache
 
 ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
@@ -40,9 +41,15 @@ elif [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
   BAZEL_CACHE_ARGS="--remote_upload_local_results=false"
 fi
 
+BAZEL_RESOURCE_FLAGS=""
+if [[ "$IS_LOCAL_BUILD" == "true" ]]; then
+  BAZEL_RESOURCE_FLAGS=$(python3 "$HOME/ray/ci/build/container_resource_utils.py")
+fi
+
 bazelisk --output_base=$BAZEL_CACHE run --config=ci \
     --repository_cache=$REPOSITORY_CACHE \
     $BAZEL_CACHE_ARGS \
+    $BAZEL_RESOURCE_FLAGS \
     //java:gen_ray_java_pkg
 
 cp bazel-bin/java/ray_java_pkg.zip /home/forge/ray_java_pkg.zip

--- a/ci/docker/ray-java.wanda.yaml
+++ b/ci/docker/ray-java.wanda.yaml
@@ -13,6 +13,7 @@ srcs:
   - gen_ray_pkg.py
   - release/BUILD.bazel
   - release/requirements_py310.txt
+  - ci/build/container_resource_utils.py
 build_args:
   - ARCH_SUFFIX
   - BUILDKITE_BAZEL_CACHE_URL
@@ -20,3 +21,4 @@ build_args:
   - MANYLINUX_VERSION
 build_hint_args:
   - BUILDKITE_CACHE_READONLY
+  - IS_LOCAL_BUILD


### PR DESCRIPTION
Feature required for building images locally and not running into OOMs. On my 14 core 24GB macbook, we spin up 14 jobs that result in OOM kills during cpp compilation+linking steps. This makes it take multiple attempts to build ray-core and ray-java locally.

For the above example of 14core 24GB, we cap to 7 jobs which is sustainable. Additionally, timing out a build from a freshly pruned state looks like this, so limiting jobs is not having a noticeable impact on wallclock. It's likely related to less resource contention, but I have not had time to dig into it further.

Longer term we will want to do a more Bazel-native way to tune builds. For now, we can defer to the heavy-hammer approach of capping jobs proportional to the amount of available memory.

For CI, this is a no-op, as the machines are expected to be beefy enough to not need these caps (as they are today).

export PYTHON_VERSION=3.13
export MANYLINUX_VERSION=260103.868e54c
export HOSTTYPE=aarch64
export ARCH_SUFFIX=-aarch64
export BUILDKITE_COMMIT=3cf4076a3e
export IS_LOCAL_BUILD=false

time wanda ci/docker/ray-core.wanda.yaml

failed at 5119.8 (05:22:24) [32mINFO: [0mElapsed time: 5089.441s, Critical Path: 1009.68s
ERROR: failed to build: failed to solve: ResourceExhausted: process "/bin/sh -c /dev/pipes/EOF" did not complete successfully: cannot allocate memory

export PYTHON_VERSION=3.13
export MANYLINUX_VERSION=260103.868e54c
export HOSTTYPE=aarch64
export ARCH_SUFFIX=-aarch64
export BUILDKITE_COMMIT=3cf4076a3e
export IS_LOCAL_BUILD=true

time wanda ci/docker/ray-core.wanda.yaml

12 2396.0 (16:10:16) [32mINFO:[0m Build completed successfully, 8104 total actions
12 DONE 2396.4s

Topic: local-build-container-utils
Relative: wanda-specs
Signed-off-by: andrew <andrew@anyscale.com>