### PR TITLE
[data] Skip upscaling validation warning for fixed-size actor pools

### DIFF
--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -231,6 +231,10 @@ class DefaultActorAutoscaler(ActorAutoscaler):
             actor_pool: Actor pool to validate configuration thereof.
             op: ``PhysicalOperator`` using target actor pool.
         """
+        # Fixed-size pools don't autoscale by design
+        if actor_pool.min_size() == actor_pool.max_size():
+            return
+
         max_tasks_in_flight_per_actor = actor_pool.max_tasks_in_flight_per_actor()
         max_concurrency = actor_pool.max_actor_concurrency()
 


### PR DESCRIPTION
## Description
The autoscaling validation warning was incorrectly raised for fixed-size actor pools (`min_size == max_size`). These pools don't scale up, so the warning doesn't apply.

## Related issues
Context: https://github.com/ray-project/ray/pull/60477#discussion_r2737938392

## Additional information
After this change, when we run `python -m pytest -v -s test_vllm_engine_proc.py::test_generation_model`, we no longer observe autoscaling warnings in the log.
