### PR TITLE
[Serve] Fix test_replica_sync_methods timeout

### DIFF
--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -543,7 +543,7 @@ py_test_module_list(
 # Test currently off-by-default behavior to run replica sync methods in a threadpool.
 # TODO(edoakes): remove this once the FF is flipped on by default.
 py_test_module_list(
-    size = "small",
+    size = "medium",
     env = {"RAY_SERVE_RUN_SYNC_IN_THREADPOOL": "1"},
     files = [
         "test_replica_sync_methods.py",


### PR DESCRIPTION
## Why are these changes needed?

The `test_replica_sync_methods_with_run_sync_in_threadpool` test was configured with `size="small"` (60s Bazel timeout), but after PR #60271 added the `test_asyncio_default_executor_limited_by_num_cpus` test with a `num_cpus=30` parameter, the test suite started consistently timing out during teardown.

The timeout occurs on `test_asyncio_default_executor_limited_by_num_cpus[30-32]` - the test itself passes, but the fixture teardown (`delete_all_apps()`) gets killed by SIGTERM when the 60-second limit is reached.

## Related issue number

Fixes flaky test in postmerge: `test_replica_sync_methods_with_run_sync_in_threadpool`

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - [ ] I've added any new APIs to the API Reference. For example, if I added a
method in Tune, I've added it in `doc/source/tune/api/` under the
temporary heading (to find them later).
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing:
  - [ ] Test manually (explain in PR description)
  - [x] Build change only (no testing needed)