### PR TITLE
[data][llm] Unify the schema of the success and failure rows

### DIFF
--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -126,9 +126,9 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
             or the batch processing latency is too small, but it should be good
             enough for batch size >= 64.
         should_continue_on_error: If True, continue processing when inference fails for a row
-            instead of raising an exception. Failed rows will have a non-null
+            instead of raising an exception. Failed rows will have a non-empty
             ``__inference_error__`` column containing the error message, and other
-            output columns will be None. Error rows bypass postprocess. If False
+            output columns will be empty strings. Error rows bypass postprocess. If False
             (default), any inference error will raise an exception.
         chat_template_stage: Chat templating stage config (bool | dict | ChatTemplateStageConfig).
             Defaults to True. Use nested config for per-stage control over batch_size,

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -161,9 +161,9 @@ class OfflineProcessorConfig(ProcessorConfig):
     should_continue_on_error: bool = Field(
         default=False,
         description="If True, continue processing when inference fails for a row "
-        "instead of raising an exception. Failed rows will have a non-null "
+        "instead of raising an exception. Failed rows will have a non-empty "
         "'__inference_error__' column containing the error message, and other "
-        "output columns will be None. Error rows bypass postprocess. "
+        "output columns will be empty strings. Error rows bypass postprocess. "
         "If False (default), any inference error will raise an exception.",
     )
 
@@ -342,7 +342,7 @@ class Processor:
         )
 
         # When should_continue_on_error is enabled, include __inference_error__ column
-        # in all output rows for consistent schema (None for success, message for error).
+        # in all output rows for consistent schema (Empty string for success, message for error).
         include_error_column = getattr(config, "should_continue_on_error", False)
         self.postprocess = wrap_postprocess(
             postprocess,

--- a/python/ray/llm/_internal/batch/stages/base.py
+++ b/python/ray/llm/_internal/batch/stages/base.py
@@ -52,7 +52,7 @@ def wrap_postprocess(
         fn: The function to be applied.
         processor_data_column: The internal data column name of the processor.
         include_error_column: If True, always include __inference_error__ in output
-            (None for success rows, error message for failures). This ensures
+            (Empty string for success rows, error message for failures). This ensures
             consistent schema across all output rows.
 
     Returns:
@@ -70,12 +70,12 @@ def wrap_postprocess(
         # Error rows bypass user postprocess to avoid crashes when
         # expected output fields are missing. Return entire data dict
         # to preserve debugging info (e.g., prompt).
-        if data.get("__inference_error__") is not None:
+        if data.get("__inference_error__", "") != "":
             return data
 
         result = fn(data)
         if include_error_column:
-            result["__inference_error__"] = None
+            result["__inference_error__"] = ""
         return result
 
     return _postprocess
@@ -175,7 +175,7 @@ class StatefulStageUDF:
         normal_rows = []
         error_row_indices = set()
         for idx, row in enumerate(inputs):
-            if row.get("__inference_error__") is not None:
+            if row.get("__inference_error__", "") != "":
                 error_row_indices.add(idx)
             else:
                 normal_rows.append(row)

--- a/python/ray/llm/_internal/batch/stages/serve_deployment_stage.py
+++ b/python/ray/llm/_internal/batch/stages/serve_deployment_stage.py
@@ -156,7 +156,7 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
                 self.IDX_IN_BATCH_COLUMN: request["idx_in_batch"],
                 "batch_uuid": batch_uuid.hex,
                 "time_taken": time_taken,
-                "__inference_error__": None,
+                "__inference_error__": "",
             }
         except Exception as e:
             # Only recover from known recoverable errors; unknown errors propagate

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -732,11 +732,21 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             )
             # Include snippet of failed prompt for debuggability
             prompt = truncate_str(row.get("prompt", ""), _MAX_PROMPT_LENGTH_IN_ERROR)
+
+            # Construct default vLLMOutputData for schema consistency with success rows
+            default_output = vLLMOutputData(
+                prompt=prompt,
+                prompt_token_ids=None,
+                num_input_tokens=0,
+            )
             return {
+                **default_output.model_dump(),
+                "request_id": "",
                 self.IDX_IN_BATCH_COLUMN: idx_in_batch,
                 "batch_uuid": batch_uuid.hex,
+                "time_taken_llm": -1,
+                "params": "",
                 "__inference_error__": error_msg,
-                "prompt": prompt,
             }
 
     async def udf(self, batch: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -741,7 +741,7 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             )
             return {
                 **default_output.model_dump(),
-                "request_id": "",
+                "request_id": -1,
                 self.IDX_IN_BATCH_COLUMN: idx_in_batch,
                 "batch_uuid": batch_uuid.hex,
                 "time_taken_llm": -1,

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -696,7 +696,7 @@ class vLLMEngineStageUDF(StatefulStageUDF):
                 "batch_uuid": batch_uuid.hex,
                 "time_taken_llm": time_taken_llm,
                 "params": str(request.params),
-                "__inference_error__": None,
+                "__inference_error__": "",
             }
         except _VLLM_FATAL_ERRORS as e:
             # Fatal engine errors (e.g., EngineDeadError) indicate the vLLM

--- a/python/ray/llm/tests/batch/cpu/stages/test_stage_base.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_stage_base.py
@@ -74,7 +74,7 @@ def test_wrap_postprocess_success_rows_run_postprocess():
         "__data": {
             "generated_text": "Hello world",
             "num_tokens": 10,
-            "__inference_error__": None,
+            "__inference_error__": "",
         }
     }
     result = wrapped(success_row)
@@ -92,11 +92,11 @@ def test_wrap_postprocess_include_error_column():
     success_row = {
         "__data": {
             "generated_text": "Hello world",
-            "__inference_error__": None,
+            "__inference_error__": "",
         }
     }
     result = wrapped(success_row)
-    assert result == {"response": "Hello world", "__inference_error__": None}
+    assert result == {"response": "Hello world", "__inference_error__": ""}
 
     # Error rows return entire data dict to preserve debugging info
     error_row = {

--- a/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
@@ -134,8 +134,8 @@ def test_serve_deployment_continue_on_error(serve_cleanup):
     assert len(outs) == 60
 
     # Check __inference_error__ directly
-    errors = [o for o in outs if o.get("__inference_error__") is not None]
-    successes = [o for o in outs if o.get("__inference_error__") is None]
+    errors = [o for o in outs if o.get("__inference_error__", "")]
+    successes = [o for o in outs if not o.get("__inference_error__", "")]
 
     assert len(errors) == 6, f"Expected 6 errors, got {len(errors)}: {errors[:3]}..."
     assert len(successes) == 54

--- a/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
@@ -319,8 +319,8 @@ async def test_serve_udf_mixed_success_and_error(mock_serve_deployment_handle):
 
     assert len(results) == 3
 
-    errors = [r for r in results if r.get("__inference_error__") is not None]
-    successes = [r for r in results if r.get("__inference_error__") is None]
+    errors = [r for r in results if r.get("__inference_error__", "")]
+    successes = [r for r in results if not r.get("__inference_error__", "")]
 
     assert len(errors) == 1
     assert len(successes) == 2
@@ -452,7 +452,7 @@ async def test_serve_udf_success_with_continue_on_error_includes_none_error(
         results.extend(result["__data"])
 
     assert len(results) == 1
-    assert results[0]["__inference_error__"] is None
+    assert results[0]["__inference_error__"] == ""
     assert results[0]["generated_text"] == "Hello!"
 
 

--- a/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
@@ -319,8 +319,8 @@ async def test_serve_udf_mixed_success_and_error(mock_serve_deployment_handle):
 
     assert len(results) == 3
 
-    errors = [r for r in results if r.get("__inference_error__", "")]
-    successes = [r for r in results if not r.get("__inference_error__", "")]
+    errors = [r for r in results if r.get("__inference_error__", "") != ""]
+    successes = [r for r in results if r.get("__inference_error__", "") == ""]
 
     assert len(errors) == 1
     assert len(successes) == 2

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -726,6 +726,11 @@ async def test_vllm_udf_mixed_success_and_error(mock_vllm_wrapper):
         idx = row["__idx_in_batch"]
         if idx == 1:
             raise ValueError("prompt too long")
+        output_data = vLLMOutputData(
+            prompt=row["prompt"],
+            prompt_token_ids=None,
+            num_input_tokens=0,
+        )
         return (
             MagicMock(
                 request_id=idx,
@@ -733,10 +738,7 @@ async def test_vllm_udf_mixed_success_and_error(mock_vllm_wrapper):
                 params=row["sampling_params"],
                 idx_in_batch=idx,
             ),
-            {
-                "prompt": row["prompt"],
-                "generated_text": f"Response to: {row['prompt']}",
-            },
+            output_data.model_dump(),
             0.1,
         )
 
@@ -773,6 +775,11 @@ async def test_vllm_udf_mixed_success_and_error(mock_vllm_wrapper):
     assert len(errors) == 1
     assert len(successes) == 2
     assert "ValueError" in errors[0]["__inference_error__"]
+
+    # Verify schema consistency
+    error_keys = set(errors[0].keys())
+    success_keys = set(successes[0].keys())
+    assert error_keys == success_keys
 
 
 @pytest.mark.asyncio

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -767,8 +767,8 @@ async def test_vllm_udf_mixed_success_and_error(mock_vllm_wrapper):
 
     assert len(results) == 3
 
-    errors = [r for r in results if r.get("__inference_error__") is not None]
-    successes = [r for r in results if r.get("__inference_error__") is None]
+    errors = [r for r in results if r.get("__inference_error__", "")]
+    successes = [r for r in results if not r.get("__inference_error__", "")]
 
     assert len(errors) == 1
     assert len(successes) == 2

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -767,8 +767,8 @@ async def test_vllm_udf_mixed_success_and_error(mock_vllm_wrapper):
 
     assert len(results) == 3
 
-    errors = [r for r in results if r.get("__inference_error__", "")]
-    successes = [r for r in results if not r.get("__inference_error__", "")]
+    errors = [r for r in results if r.get("__inference_error__", "") != ""]
+    successes = [r for r in results if r.get("__inference_error__", "") == ""]
 
     assert len(errors) == 1
     assert len(successes) == 2


### PR DESCRIPTION
## Description
When `should_continue_on_error` is enabled, the `__inference_error__` column contains `None` for successful rows and error messages (strings) for failed rows. This can cause issues when writing results to parquet via PyArrow. PyArrow infers column types based on the data it observes, and if the initial batches contain only successful rows, the `__inference_error__` column may be inferred as a null-only type. Subsequent batches that include string error messages will then fail schema validation.

While this could be handled at the application layer by explicitly defining the schema, addressing it within the library avoids this pitfall by default and lowers the burden on application developers.

## Related issues
N/A

## Additional information
N/A
