### PR TITLE
[Data] Added tracking of block serialization time 

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1105,7 +1105,7 @@ cdef class StreamingGeneratorExecutionContext:
 
 @dataclass(frozen=True)
 class StreamingGeneratorStats:
-    serialization_dur_s: float
+    object_creation_dur_s: float
 
 
 cdef report_streaming_generator_output(
@@ -1170,7 +1170,7 @@ cdef report_streaming_generator_output(
 
 
     return StreamingGeneratorStats(
-        serialization_dur_s=serialization_dur_s,
+        object_creation_dur_s=serialization_dur_s,
     )
 
 

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -654,7 +654,10 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
     def obj_store_mem_pending_task_inputs(self) -> int:
         return self._pending_task_inputs.estimate_size_bytes()
 
-    @property
+    @metric_property(
+        description="Byte size of *pending* (not yielded yet) output blocks in running tasks.",
+        metrics_group=MetricsGroup.OBJECT_STORE_MEMORY,
+    )
     def obj_store_mem_pending_task_outputs(self) -> Optional[float]:
         """Estimated size in bytes of output blocks in Ray generator buffers.
 

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -894,27 +894,29 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         task_info.num_rows_produced += num_rows_produced
 
         for block_ref, meta in output.blocks:
+            exec_stats = meta.exec_stats
+
             assert (
-                meta.exec_stats is not None and
-                meta.exec_stats.wall_time_s is not None and
-                meta.exec_stats.block_ser_time_s is not None
+                exec_stats is not None and
+                exec_stats.wall_time_s is not None and
+                exec_stats.block_ser_time_s is not None
             )
 
-            self.block_generation_time += meta.exec_stats.wall_time_s
-            self.block_serialization_time_s += meta.exec_stats.block_ser_time_s
+            self.block_generation_time += exec_stats.wall_time_s
+            self.block_serialization_time_s += exec_stats.block_ser_time_s
 
-            task_info.cum_block_gen_time_s += meta.exec_stats.wall_time_s
-            task_info.cum_block_ser_time_s += meta.exec_stats.block_ser_time_s
+            task_info.cum_block_gen_time_s += exec_stats.wall_time_s
+            task_info.cum_block_ser_time_s += exec_stats.block_ser_time_s
 
             assert meta.num_rows is not None
 
             trace_allocation(block_ref, "operator_output")
 
-            if meta.exec_stats.max_uss_bytes is not None:
+            if exec_stats.max_uss_bytes is not None:
                 if self._cum_max_uss_bytes is None:
-                    self._cum_max_uss_bytes = meta.exec_stats.max_uss_bytes
+                    self._cum_max_uss_bytes = exec_stats.max_uss_bytes
                 else:
-                    self._cum_max_uss_bytes += meta.exec_stats.max_uss_bytes
+                    self._cum_max_uss_bytes += exec_stats.max_uss_bytes
 
         # Update per node metrics
         if self._per_node_metrics_enabled:

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -897,9 +897,9 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             exec_stats = meta.exec_stats
 
             assert (
-                exec_stats is not None and
-                exec_stats.wall_time_s is not None and
-                exec_stats.block_ser_time_s is not None
+                exec_stats is not None
+                and exec_stats.wall_time_s is not None
+                and exec_stats.block_ser_time_s is not None
             )
 
             self.block_generation_time += exec_stats.wall_time_s
@@ -948,8 +948,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         if task_info.num_outputs > 0:
             # Calculate the average block generation time per block
             block_time_delta = (
-                task_info.cum_block_gen_time_s +
-                task_info.cum_block_ser_time_s
+                task_info.cum_block_gen_time_s + task_info.cum_block_ser_time_s
             ) / task_info.num_outputs
 
             self.block_completion_time.observe(
@@ -960,8 +959,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         self._op_task_duration_stats.add_duration(task_time_delta)
 
         self.task_completion_time_excl_backpressure_s += (
-            task_info.cum_block_gen_time_s +
-            task_info.cum_block_ser_time_s
+            task_info.cum_block_gen_time_s + task_info.cum_block_ser_time_s
         )
         inputs = self._running_tasks[task_index].inputs
         self.num_task_inputs_processed += len(inputs)

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -33,6 +33,7 @@ from ray import ObjectRef
 from ray._private.ray_constants import (
     env_integer,
 )
+from ray._raylet import StreamingGeneratorStats
 from ray.actor import ActorHandle
 from ray.data._internal.arrow_block import ArrowBlockBuilder
 from ray.data._internal.arrow_ops.transform_pyarrow import (
@@ -1747,10 +1748,10 @@ class HashShuffleAggregator:
             exec_stats = exec_stats_builder.build()
             exec_stats_builder = BlockExecStats.builder()
 
-            block_ser_time_s = yield block
+            stats: StreamingGeneratorStats = yield block
 
             # Update block serialization time
-            exec_stats.block_ser_time_s = block_ser_time_s
+            exec_stats.block_ser_time_s = stats.serialization_dur_s
 
             yield BlockMetadataWithSchema.from_block(block, stats=exec_stats)
 

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1751,7 +1751,7 @@ class HashShuffleAggregator:
             stats: StreamingGeneratorStats = yield block
 
             # Update block serialization time
-            exec_stats.block_ser_time_s = stats.serialization_dur_s
+            exec_stats.block_ser_time_s = stats.object_creation_dur_s
 
             yield BlockMetadataWithSchema.from_block(block, stats=exec_stats)
 

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1751,7 +1751,8 @@ class HashShuffleAggregator:
             stats: StreamingGeneratorStats = yield block
 
             # Update block serialization time
-            exec_stats.block_ser_time_s = stats.object_creation_dur_s
+            if stats:
+                exec_stats.block_ser_time_s = stats.object_creation_dur_s
 
             yield BlockMetadataWithSchema.from_block(block, stats=exec_stats)
 

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -273,7 +273,9 @@ def _shuffle_block(
     )
 
     if block.num_rows == 0:
-        empty = BlockAccessor.for_block(block).get_metadata(exec_stats=stats.build(block_ser_time_s=0))
+        empty = BlockAccessor.for_block(block).get_metadata(
+            exec_stats=stats.build(block_ser_time_s=0)
+        )
         return (empty, {})
 
     num_partitions = pool.num_partitions

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -273,7 +273,7 @@ def _shuffle_block(
     )
 
     if block.num_rows == 0:
-        empty = BlockAccessor.for_block(block).get_metadata(exec_stats=stats.build())
+        empty = BlockAccessor.for_block(block).get_metadata(exec_stats=stats.build(block_ser_time_s=0))
         return (empty, {})
 
     num_partitions = pool.num_partitions
@@ -346,7 +346,7 @@ def _shuffle_block(
         i += 1
 
     original_block_metadata = BlockAccessor.for_block(block).get_metadata(
-        exec_stats=stats.build()
+        exec_stats=stats.build(block_ser_time_s=0)
     )
 
     if logger.isEnabledFor(logging.DEBUG):
@@ -1745,7 +1745,11 @@ class HashShuffleAggregator:
             exec_stats = exec_stats_builder.build()
             exec_stats_builder = BlockExecStats.builder()
 
-            yield block
+            block_ser_time_s = yield block
+
+            # Update block serialization time
+            exec_stats.block_ser_time_s = block_ser_time_s
+
             yield BlockMetadataWithSchema.from_block(block, stats=exec_stats)
 
     def _debug_dump(self):

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -768,7 +768,7 @@ def _map_task(
             # Yield block and retrieve its Ray object serialization timing
             stats: StreamingGeneratorStats = yield block
 
-            exec_stats.block_ser_time_s = stats.serialization_dur_s
+            exec_stats.block_ser_time_s = stats.object_creation_dur_s
             exec_stats.udf_time_s = map_transformer.udf_time_s(reset=True)
             exec_stats.task_idx = ctx.task_idx
             exec_stats.max_uss_bytes = profiler.estimate_max_uss()

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -767,8 +767,9 @@ def _map_task(
             exec_stats = stats.build()
             # Yield block and retrieve its Ray object serialization timing
             stats: StreamingGeneratorStats = yield block
+            if stats:
+                exec_stats.block_ser_time_s = stats.object_creation_dur_s
 
-            exec_stats.block_ser_time_s = stats.object_creation_dur_s
             exec_stats.udf_time_s = map_transformer.udf_time_s(reset=True)
             exec_stats.task_idx = ctx.task_idx
             exec_stats.max_uss_bytes = profiler.estimate_max_uss()

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 import ray
 from ray import ObjectRef
-from ray._raylet import ObjectRefGenerator
+from ray._raylet import ObjectRefGenerator, StreamingGeneratorStats
 from ray.data._internal.compute import (
     ActorPoolStrategy,
     ComputeStrategy,
@@ -766,9 +766,9 @@ def _map_task(
             # Derive block execution stats
             exec_stats = stats.build()
             # Yield block and retrieve its Ray object serialization timing
-            block_ser_time_s = yield block
+            stats: StreamingGeneratorStats = yield block
 
-            exec_stats.block_ser_time_s = block_ser_time_s
+            exec_stats.block_ser_time_s = stats.serialization_dur_s
             exec_stats.udf_time_s = map_transformer.udf_time_s(reset=True)
             exec_stats.task_idx = ctx.task_idx
             exec_stats.max_uss_bytes = profiler.estimate_max_uss()

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import replace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -746,7 +747,9 @@ def _map_task(
     )
     DataContext._set_current(data_context)
     ctx.kwargs.update(kwargs)
+
     TaskContext.set_current(ctx)
+
     stats = BlockExecStats.builder()
     map_transformer.override_target_max_block_size(ctx.target_max_block_size_override)
     block_iter: Iterable[Block]
@@ -756,17 +759,26 @@ def _map_task(
         block_iter = iter(blocks)
 
     with MemoryProfiler(data_context.memory_usage_poll_interval_s) as profiler:
-        for b_out in map_transformer.apply_transform(block_iter, ctx):
-            # TODO(Clark): Add input file propagation from input blocks.
-            m_out = BlockAccessor.for_block(b_out).get_metadata()
-            s_out = BlockAccessor.for_block(b_out).schema()
-            m_out.exec_stats = stats.build()
-            m_out.exec_stats.udf_time_s = map_transformer.udf_time()
-            m_out.exec_stats.task_idx = ctx.task_idx
-            m_out.exec_stats.max_uss_bytes = profiler.estimate_max_uss()
-            meta_with_schema = BlockMetadataWithSchema(metadata=m_out, schema=s_out)
-            yield b_out
-            yield meta_with_schema
+        for block in map_transformer.apply_transform(block_iter, ctx):
+            block_meta = BlockAccessor.for_block(block).get_metadata()
+            block_schema = BlockAccessor.for_block(block).schema()
+
+            # Derive block execution stats
+            exec_stats = stats.build()
+            # Yield block and retrieve its Ray object serialization timing
+            block_ser_time_s = yield block
+
+            exec_stats.block_ser_time_s = block_ser_time_s
+            exec_stats.udf_time_s = map_transformer.udf_time_s(reset=True)
+            exec_stats.task_idx = ctx.task_idx
+            exec_stats.max_uss_bytes = profiler.estimate_max_uss()
+
+            yield BlockMetadataWithSchema(
+                metadata=replace(block_meta, exec_stats=exec_stats),
+                schema=block_schema
+            )
+
+            # Reset trackers
             stats = BlockExecStats.builder()
             profiler.reset()
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -774,8 +774,7 @@ def _map_task(
             exec_stats.max_uss_bytes = profiler.estimate_max_uss()
 
             yield BlockMetadataWithSchema(
-                metadata=replace(block_meta, exec_stats=exec_stats),
-                schema=block_schema
+                metadata=replace(block_meta, exec_stats=exec_stats), schema=block_schema
             )
 
             # Reset trackers

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -160,7 +160,7 @@ class MapTransformer:
         self._transform_fns = []
         self._init_fn = init_fn if init_fn is not None else lambda: None
         self._output_block_size_option_override = output_block_size_option_override
-        self._udf_time = 0
+        self._udf_time_s = 0
 
         # Add transformations
         self.add_transform_fns(transform_fns)
@@ -202,7 +202,7 @@ class MapTransformer:
             try:
                 start = time.perf_counter()
                 output = next(input)
-                self._udf_time += time.perf_counter() - start
+                self._udf_time_s += time.perf_counter() - start
                 yield output
             except StopIteration:
                 break
@@ -274,8 +274,10 @@ class MapTransformer:
     ) -> list[Any]:
         return ones + others
 
-    def udf_time(self) -> float:
-        return self._udf_time
+    def udf_time_s(self, reset: bool) -> float:
+        cur_time_s = self._udf_time_s
+        self._udf_time_s = 0
+        return cur_time_s
 
 
 # Below are subclasses of MapTransformFn.

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -276,7 +276,8 @@ class MapTransformer:
 
     def udf_time_s(self, reset: bool) -> float:
         cur_time_s = self._udf_time_s
-        self._udf_time_s = 0
+        if reset:
+            self._udf_time_s = 0
         return cur_time_s
 
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -174,6 +174,7 @@ class BlockExecStats:
         self.end_time_s: Optional[float] = None
         self.wall_time_s: Optional[float] = None
         self.udf_time_s: Optional[float] = 0
+        self.block_ser_time_s: Optional[float] = None
         self.cpu_time_s: Optional[float] = None
         self.node_id = ray.runtime_context.get_runtime_context().get_node_id()
         self.max_uss_bytes: int = 0
@@ -205,7 +206,7 @@ class _BlockExecStatsBuilder:
         self._start_time = time.perf_counter()
         self._start_cpu = time.process_time()
 
-    def build(self) -> "BlockExecStats":
+    def build(self, block_ser_time_s: Optional[int] = None) -> "BlockExecStats":
         # Record end times.
         end_time = time.perf_counter()
         end_cpu = time.process_time()
@@ -216,6 +217,7 @@ class _BlockExecStatsBuilder:
         stats.end_time_s = end_time
         stats.wall_time_s = end_time - self._start_time
         stats.cpu_time_s = end_cpu - self._start_cpu
+        stats.block_ser_time_s = block_ser_time_s
 
         return stats
 

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -108,7 +108,7 @@ def test_block_completion_time_histogram():
 
         # Manually set the task info to simulate the block generation
         metrics._running_tasks[i].num_outputs = num_blocks
-        metrics._running_tasks[i].cum_block_gen_time = total_time
+        metrics._running_tasks[i].cum_block_gen_time_s = total_time
 
         # Complete the task
         metrics.on_task_finished(i, None)  # None means no exception

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -140,7 +140,10 @@ def test_task_completion_time_excl_backpressure():
     This metric is critical for productivity calculation in resource allocators
     as it represents the actual work time excluding output backpressure delays.
     """
-    metrics = OpRuntimeMetrics(MagicMock())
+    op = MagicMock()
+    op.data_context.enable_get_object_locations_for_metrics = False
+
+    metrics = OpRuntimeMetrics(op)
 
     # Submit and complete multiple tasks with different gen/ser times
     test_cases = [

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -148,9 +148,9 @@ def test_task_completion_time_excl_backpressure():
     # Submit and complete multiple tasks with different gen/ser times
     test_cases = [
         # (gen_time, ser_time, num_outputs)
-        (0.5, 0.1, 2),   # Task 0: 0.5s gen + 0.1s ser = 0.6s
+        (0.5, 0.1, 2),  # Task 0: 0.5s gen + 0.1s ser = 0.6s
         (0.3, 0.05, 1),  # Task 1: 0.3s gen + 0.05s ser = 0.35s
-        (0.8, 0.2, 3),   # Task 2: 0.8s gen + 0.2s ser = 1.0s
+        (0.8, 0.2, 3),  # Task 2: 0.8s gen + 0.2s ser = 1.0s
     ]
 
     expected_total = 0

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -27,6 +27,7 @@ def test_average_max_uss_per_task():
         stats = BlockExecStats()
         stats.max_uss_bytes = uss_bytes
         stats.wall_time_s = 0
+        stats.block_ser_time_s = 0
         metadata = BlockMetadata(
             num_rows=0,
             size_bytes=0,
@@ -87,19 +88,28 @@ def test_task_completion_time_histogram():
 
 
 def test_block_completion_time_histogram():
-    """Test block completion time histogram bucket assignment and counting."""
+    """Test block completion time histogram bucket assignment and counting.
+
+    Block completion time = (cum_block_gen_time_s + cum_block_ser_time_s) / num_outputs
+    """
     metrics = OpRuntimeMetrics(MagicMock())
 
     # Test different block generation scenarios
     # Buckets: [0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 7.5, 10.0, 15.0, 20.0, 25.0, 50.0, 75.0, 100.0, 150.0, 500.0, 1000.0, 2500.0, 5000.0]
+    # Each test case: (num_blocks, gen_time, ser_time, expected_bucket)
+    # Per-block time = (gen_time + ser_time) / num_blocks
     test_cases = [
-        (1, 0.1, 0),  # 1 block, 0.1s total time -> 0.1s per block -> bucket 0 (0.1)
-        (2, 0.5, 1),  # 2 blocks, 0.5s total time -> 0.25s per block -> bucket 1 (0.25)
-        (1, 0.6, 3),  # 1 block, 0.6s total time -> 0.6s per block -> bucket 3 (1.0)
-        (3, 1.5, 2),  # 3 blocks, 1.5s total time -> 0.5s per block -> bucket 2 (0.5)
+        # 1 block, 0.08s gen + 0.02s ser = 0.1s total -> 0.1s per block -> bucket 0 (0.1)
+        (1, 0.08, 0.02, 0),
+        # 2 blocks, 0.4s gen + 0.1s ser = 0.5s total -> 0.25s per block -> bucket 1 (0.25)
+        (2, 0.4, 0.1, 1),
+        # 1 block, 0.5s gen + 0.1s ser = 0.6s total -> 0.6s per block -> bucket 3 (1.0)
+        (1, 0.5, 0.1, 3),
+        # 3 blocks, 1.2s gen + 0.3s ser = 1.5s total -> 0.5s per block -> bucket 2 (0.5)
+        (3, 1.2, 0.3, 2),
     ]
 
-    for i, (num_blocks, total_time, expected_bucket) in enumerate(test_cases):
+    for i, (num_blocks, gen_time, ser_time, expected_bucket) in enumerate(test_cases):
         # Create input bundle
         input_bundle = RefBundle([], owns_blocks=False, schema=None)
 
@@ -108,7 +118,8 @@ def test_block_completion_time_histogram():
 
         # Manually set the task info to simulate the block generation
         metrics._running_tasks[i].num_outputs = num_blocks
-        metrics._running_tasks[i].cum_block_gen_time_s = total_time
+        metrics._running_tasks[i].cum_block_gen_time_s = gen_time
+        metrics._running_tasks[i].cum_block_ser_time_s = ser_time
 
         # Complete the task
         metrics.on_task_finished(i, None)  # None means no exception
@@ -122,6 +133,46 @@ def test_block_completion_time_histogram():
         metrics.block_completion_time._bucket_counts[expected_bucket] = 0
 
 
+def test_task_completion_time_excl_backpressure():
+    """Test that task_completion_time_excl_backpressure_s includes both
+    block generation time and serialization time.
+
+    This metric is critical for productivity calculation in resource allocators
+    as it represents the actual work time excluding output backpressure delays.
+    """
+    metrics = OpRuntimeMetrics(MagicMock())
+
+    # Submit and complete multiple tasks with different gen/ser times
+    test_cases = [
+        # (gen_time, ser_time, num_outputs)
+        (0.5, 0.1, 2),   # Task 0: 0.5s gen + 0.1s ser = 0.6s
+        (0.3, 0.05, 1),  # Task 1: 0.3s gen + 0.05s ser = 0.35s
+        (0.8, 0.2, 3),   # Task 2: 0.8s gen + 0.2s ser = 1.0s
+    ]
+
+    expected_total = 0
+    for i, (gen_time, ser_time, num_outputs) in enumerate(test_cases):
+        input_bundle = RefBundle([], owns_blocks=False, schema=None)
+        metrics.on_task_submitted(i, input_bundle)
+
+        # Set task info
+        metrics._running_tasks[i].num_outputs = num_outputs
+        metrics._running_tasks[i].cum_block_gen_time_s = gen_time
+        metrics._running_tasks[i].cum_block_ser_time_s = ser_time
+
+        metrics.on_task_finished(i, None)
+        expected_total += gen_time + ser_time
+
+    assert metrics.task_completion_time_excl_backpressure_s == pytest.approx(
+        expected_total
+    )
+
+    expected_avg = expected_total / len(test_cases)
+    assert metrics.average_task_completion_excl_backpressure_time_s == pytest.approx(
+        expected_avg
+    )
+
+
 def test_block_size_bytes_histogram():
     """Test block size bytes histogram bucket assignment and counting."""
     metrics = OpRuntimeMetrics(MagicMock())
@@ -131,6 +182,7 @@ def test_block_size_bytes_histogram():
         stats = BlockExecStats()
         stats.max_uss_bytes = 0
         stats.wall_time_s = 0
+        stats.block_ser_time_s = 0
         metadata = BlockMetadata(
             num_rows=0,
             size_bytes=size_bytes,
@@ -178,6 +230,7 @@ def test_block_size_rows_histogram():
         stats = BlockExecStats()
         stats.max_uss_bytes = 0
         stats.wall_time_s = 0
+        stats.block_ser_time_s = 0
         metadata = BlockMetadata(
             num_rows=num_rows,
             size_bytes=0,

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -89,6 +89,7 @@ def gen_expected_metrics(
             "'obj_store_mem_internal_inqueue': Z",
             "'obj_store_mem_internal_outqueue': Z",
             "'obj_store_mem_pending_task_inputs': Z",
+            "'obj_store_mem_pending_task_outputs': Z",
             "'average_bytes_inputs_per_task': N",
             "'average_rows_inputs_per_task': N",
             "'average_bytes_outputs_per_task': N",
@@ -158,6 +159,7 @@ def gen_expected_metrics(
             "'obj_store_mem_internal_inqueue': Z",
             "'obj_store_mem_internal_outqueue': Z",
             "'obj_store_mem_pending_task_inputs': Z",
+            "'obj_store_mem_pending_task_outputs': Z",
             "'average_bytes_inputs_per_task': None",
             "'average_rows_inputs_per_task': None",
             "'average_bytes_outputs_per_task': None",
@@ -630,6 +632,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      obj_store_mem_internal_inqueue: Z,\n"
         "      obj_store_mem_internal_outqueue: Z,\n"
         "      obj_store_mem_pending_task_inputs: Z,\n"
+        "      obj_store_mem_pending_task_outputs: Z,\n"
         "      average_bytes_inputs_per_task: N,\n"
         "      average_rows_inputs_per_task: N,\n"
         "      average_bytes_outputs_per_task: N,\n"
@@ -775,6 +778,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      obj_store_mem_internal_inqueue: Z,\n"
         "      obj_store_mem_internal_outqueue: Z,\n"
         "      obj_store_mem_pending_task_inputs: Z,\n"
+        "      obj_store_mem_pending_task_outputs: Z,\n"
         "      average_bytes_inputs_per_task: N,\n"
         "      average_rows_inputs_per_task: N,\n"
         "      average_bytes_outputs_per_task: N,\n"
@@ -873,6 +877,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            obj_store_mem_internal_inqueue: Z,\n"
         "            obj_store_mem_internal_outqueue: Z,\n"
         "            obj_store_mem_pending_task_inputs: Z,\n"
+        "            obj_store_mem_pending_task_outputs: Z,\n"
         "            average_bytes_inputs_per_task: N,\n"
         "            average_rows_inputs_per_task: N,\n"
         "            average_bytes_outputs_per_task: N,\n"

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -121,6 +121,7 @@ def gen_expected_metrics(
             "'num_tasks_finished': N",
             "'num_tasks_failed': Z",
             "'block_generation_time': N",
+            "'block_serialization_time_s': N",
             (
                 "'task_submission_backpressure_time': "
                 f"{'N' if task_backpressure else 'Z'}"
@@ -189,6 +190,7 @@ def gen_expected_metrics(
             "'num_tasks_finished': Z",
             "'num_tasks_failed': Z",
             "'block_generation_time': Z",
+            "'block_serialization_time_s': Z",
             (
                 "'task_submission_backpressure_time': "
                 f"{'N' if task_backpressure else 'Z'}"
@@ -660,6 +662,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      num_tasks_finished: N,\n"
         "      num_tasks_failed: Z,\n"
         "      block_generation_time: N,\n"
+        "      block_serialization_time_s: N,\n"
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
         "      task_completion_time_total_s: N,\n"
@@ -804,6 +807,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      num_tasks_finished: N,\n"
         "      num_tasks_failed: Z,\n"
         "      block_generation_time: N,\n"
+        "      block_serialization_time_s: N,\n"
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
         "      task_completion_time_total_s: N,\n"
@@ -901,6 +905,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            num_tasks_finished: N,\n"
         "            num_tasks_failed: Z,\n"
         "            block_generation_time: N,\n"
+        "            block_serialization_time_s: N,\n"
         "            task_submission_backpressure_time: N,\n"
         "            task_output_backpressure_time: Z,\n"
         "            task_completion_time_total_s: N,\n"


### PR DESCRIPTION
Changes
---
1. Modified Ray Core's generator handling sequence to inject back object creation & serialization durations
2. Updated `task_completion_time_excl_backpressure_s` to track both UDF block generation time AND block serialization overhead

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
