### PR TITLE
[core] include ray.io audience in TokenReview requests

### DIFF
--- a/src/ray/rpc/authentication/k8s_constants.h
+++ b/src/ray/rpc/authentication/k8s_constants.h
@@ -42,6 +42,7 @@ constexpr char kAuthorizationAPIVersion[] = "authorization.k8s.io/v1";
 constexpr char kRayResourceGroup[] = "ray.io";
 constexpr char kRayClusterResourceName[] = "rayclusters";
 constexpr char kRayClusterRayUserVerb[] = "ray:write";
+constexpr char kRayTokenAuidence[] = "ray.io";
 
 }  // namespace k8s
 }  // namespace rpc

--- a/src/ray/rpc/authentication/k8s_constants.h
+++ b/src/ray/rpc/authentication/k8s_constants.h
@@ -42,7 +42,7 @@ constexpr char kAuthorizationAPIVersion[] = "authorization.k8s.io/v1";
 constexpr char kRayResourceGroup[] = "ray.io";
 constexpr char kRayClusterResourceName[] = "rayclusters";
 constexpr char kRayClusterRayUserVerb[] = "ray:write";
-constexpr char kRayTokenAuidence[] = "ray.io";
+constexpr char kRayTokenAudience[] = "ray.io";
 
 }  // namespace k8s
 }  // namespace rpc

--- a/src/ray/rpc/authentication/k8s_util.cc
+++ b/src/ray/rpc/authentication/k8s_util.cc
@@ -156,9 +156,10 @@ bool K8sApiPost(const std::string &path,
 bool ValidateToken(const AuthenticationToken &token) {
   std::string token_str = token.GetRawValue();
 
-  nlohmann::json token_review_req = {{"apiVersion", kAuthenticationAPIVersion},
-                                     {"kind", kTokenReviewKind},
-                                     {"spec", {{"token", token_str}}}};
+  nlohmann::json token_review_req = {
+      {"apiVersion", kAuthenticationAPIVersion},
+      {"kind", kTokenReviewKind},
+      {"spec", {{"token", token_str}, {"audiences", {kRayTokenAuidence}}}}};
   nlohmann::json token_review_resp;
 
   if (!k8s::K8sApiPost(

--- a/src/ray/rpc/authentication/k8s_util.cc
+++ b/src/ray/rpc/authentication/k8s_util.cc
@@ -159,7 +159,7 @@ bool ValidateToken(const AuthenticationToken &token) {
   nlohmann::json token_review_req = {
       {"apiVersion", kAuthenticationAPIVersion},
       {"kind", kTokenReviewKind},
-      {"spec", {{"token", token_str}, {"audiences", {kRayTokenAuidence}}}}};
+      {"spec", {{"token", token_str}, {"audiences", {kRayTokenAudience}}}}};
   nlohmann::json token_review_resp;
 
   if (!k8s::K8sApiPost(


### PR DESCRIPTION
## Description

This PR adds a required token audience when Ray makes a TokenReview request to the Kubernetes API. Setting the audience ensures that only tokens with the intended purpose for Ray authentication can be used. This change requires that the service account token mounted to Ray pods set the `ray.io` audience like so:
```yaml
spec:
  containers:
  - name: ray-head
    ...
    ...
    volumeMounts:
    - name: ray-token
      mountPath: "/var/run/ray.io/service-account"
      readOnly: true
  serviceAccountName: default
  volumes:
  - name: ray-token
    projected:
      sources:
      - serviceAccountToken:
          audience: ray.io
          expirationSeconds: 3600
          path: token
```

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
