### PR TITLE
[core][autoscaler] remove half of ssh keys from gcp metadata on CI if the metadata reaches its size limit

### DIFF
--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -812,14 +812,46 @@ def _create_project_ssh_key_pair(project, public_key, ssh_user, compute):
 
     common_instance_metadata["items"] = items
 
-    operation = (
-        compute.projects()
-        .setCommonInstanceMetadata(
-            project=project["name"], body=common_instance_metadata
+    try:
+        operation = (
+            compute.projects()
+            .setCommonInstanceMetadata(
+                project=project["name"], body=common_instance_metadata
+            )
+            .execute()
         )
-        .execute()
-    )
-
-    response = wait_for_compute_global_operation(project["name"], operation, compute)
+        response = wait_for_compute_global_operation(
+            project["name"], operation, compute
+        )
+    except errors.HttpError as e:  # Only trim when explicitly opted in.
+        if (
+            e.resp.status != 413
+            or ssh_keys_i is None
+            or os.environ.get("RAY_TRIM_AUTOSCALER_SSH_KEYS") != "1"
+        ):
+            raise
+        logger.warning(
+            "GCP project metadata size limit reached for %s (%s); "
+            "removing half of ssh keys and retrying",
+            project["name"],
+            e,
+        )
+        ssh_keys_value = items[ssh_keys_i].get("value", "")
+        ssh_keys = [key for key in ssh_keys_value.splitlines() if key.strip()]
+        trim_start = (  # If our new key is the only one, this preserves it.
+            len(ssh_keys) // 2
+        )
+        items[ssh_keys_i]["value"] = "\n".join(ssh_keys[trim_start:])
+        common_instance_metadata["items"] = items
+        operation = (
+            compute.projects()
+            .setCommonInstanceMetadata(
+                project=project["name"], body=common_instance_metadata
+            )
+            .execute()
+        )
+        response = wait_for_compute_global_operation(
+            project["name"], operation, compute
+        )
 
     return response

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3708,10 +3708,10 @@
   variations:
     - __suffix__: v1
       run:
-        script: RAY_UP_enable_autoscaler_v2=0 python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
+        script: RAY_UP_enable_autoscaler_v2=0 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
     - __suffix__: v2
       run:
-        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
+        script: RAY_UP_enable_autoscaler_v2=1 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
 
 - name: gcp_cluster_launcher_full
   python: "3.10"
@@ -3731,10 +3731,10 @@
   variations:
     - __suffix__: v1
       run:
-        script: RAY_UP_enable_autoscaler_v2=0 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 30 --docker-override latest
+        script: RAY_UP_enable_autoscaler_v2=0 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 30 --docker-override latest
     - __suffix__: v2
       run:
-        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 30 --docker-override latest
+        script: RAY_UP_enable_autoscaler_v2=1 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 30 --docker-override latest
 
 - name: gcp_cluster_launcher_latest_image
   group: cluster-launcher-test
@@ -3753,10 +3753,10 @@
   variations:
     - __suffix__: v1
       run:
-        script: RAY_UP_enable_autoscaler_v2=0 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
+        script: RAY_UP_enable_autoscaler_v2=0 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
     - __suffix__: v2
       run:
-        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
+        script: RAY_UP_enable_autoscaler_v2=1 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
 
 - name: gcp_cluster_launcher_nightly_image
   python: "3.10"
@@ -3776,10 +3776,10 @@
   variations:
     - __suffix__: v1
       run:
-        script: RAY_UP_enable_autoscaler_v2=0 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
+        script: RAY_UP_enable_autoscaler_v2=0 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
     - __suffix__: v2
       run:
-        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
+        script: RAY_UP_enable_autoscaler_v2=1 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
 
 - name: gcp_cluster_launcher_release_image
   python: "3.10"
@@ -3799,10 +3799,10 @@
   variations:
     - __suffix__: v1
       run:
-        script: RAY_UP_enable_autoscaler_v2=0 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override commit
+        script: RAY_UP_enable_autoscaler_v2=0 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override commit
     - __suffix__: v2
       run:
-        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override commit
+        script: RAY_UP_enable_autoscaler_v2=1 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override commit
 
 - name: gcp_cluster_launcher_gpu_docker
   python: "3.10"
@@ -3822,10 +3822,10 @@
   variations:
     - __suffix__: v1
       run:
-        script: RAY_UP_enable_autoscaler_v2=0 python launch_and_verify_cluster.py gcp/example-gpu-docker.yaml
+        script: RAY_UP_enable_autoscaler_v2=0 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-gpu-docker.yaml
     - __suffix__: v2
       run:
-        script: RAY_UP_enable_autoscaler_v2=1 python launch_and_verify_cluster.py gcp/example-gpu-docker.yaml
+        script: RAY_UP_enable_autoscaler_v2=1 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-gpu-docker.yaml
 
 - name: autoscaler_aws
   python: "3.10"


### PR DESCRIPTION
This PR adds a new `RAY_TRIM_AUTOSCALER_SSH_KEYS` env toggle for the autoscaler to remove the old half of ssh keys from the cloud project metadata (GCP only currently) if the metadata size limit is exceeded. This is useful for CI tests. It only removes the old half to have a lower chance of breaking others.