### PR TITLE
[ci] fix missed wheel upload for non-postsubmit

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -56,8 +56,7 @@ steps:
       - ray-java-build
       - ray-dashboard-build
 
-  # Upload wheels to S3
-  - label: ":s3: upload: wheel py{{matrix}} (x86_64)"
+  - label: ":arrow_up: upload: wheel py{{matrix}} (x86_64)"
     key: linux_wheels_upload
     instance_type: small
     commands:
@@ -74,7 +73,7 @@ steps:
       - forge
     tags:
       - release_wheels
-      - skip-on-premerge
+      - linux_wheels
       - oss
 
   - name: ray-cpp-core-build
@@ -106,8 +105,7 @@ steps:
       - ray-java-build
       - ray-dashboard-build
 
-  # Upload cpp wheel to S3
-  - label: ":s3: upload: cpp wheel (x86_64)"
+  - label: ":arrow_up: upload: cpp wheel (x86_64)"
     key: linux_cpp_wheels_upload
     instance_type: small
     commands:
@@ -119,7 +117,7 @@ steps:
       - forge
     tags:
       - release_wheels
-      - skip-on-premerge
+      - linux_wheels
       - oss
 
   - label: ":tapioca: build: jar"

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -168,7 +168,7 @@ steps:
       - ray-dashboard-build-aarch64
     instance_type: builder-arm64
 
-  - label: ":s3: upload: wheel py{{matrix}} (aarch64)"
+  - label: ":arrow_up: upload: wheel py{{matrix}} (aarch64)"
     key: linux_wheels_upload_aarch64
     instance_type: small  # x86_64 instance since crane is currently only x86_64
     commands:
@@ -185,7 +185,7 @@ steps:
       - forge
     tags:
       - release_wheels
-      - skip-on-premerge
+      - linux_wheels
       - oss
 
   - name: ray-cpp-core-build-aarch64
@@ -219,7 +219,7 @@ steps:
       - ray-dashboard-build-aarch64
     instance_type: builder-arm64
 
-  - label: ":s3: upload: cpp wheel (aarch64)"
+  - label: ":arrow_up: upload: cpp wheel (aarch64)"
     key: linux_cpp_wheels_upload_aarch64
     instance_type: small  # x86_64 instance since crane is currently only x86_64
     commands:
@@ -231,7 +231,7 @@ steps:
       - forge
     tags:
       - release_wheels
-      - skip-on-premerge
+      - linux_wheels
       - oss
 
   - label: ":tapioca: build: ray-extra py{{matrix}} docker (aarch64)"


### PR DESCRIPTION
While migrating the wheel build+publish to Wanda, I missed that ci/build/copy_build_artifacts is also the mechanism by which the Buildkite Artifacts tab is populated (instead of a buildkite-agent upload flow).
ci/build/copy_build_artifacts has a guard-clause against publishing in non-postmerge, so let's run this step on PRs so that devs can access wheels via the Artifacts tab as needed

I've also added the same tagset to upload as is build, to ensure we always accompany a build with an upload.

Guard clause: https://github.com/ray-project/ray/blob/f685a50dc5f1757f4c9b6d431c6c1697701dae87/ci/build/copy_build_artifacts.sh#L49-L57

Topic: fix-upload-wheel-artifact
Signed-off-by: andrew <andrew@anyscale.com>