### PR TITLE
[release test] assign job url when runner exists

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -535,17 +535,19 @@ def run_release_test_anyscale(
             start_time_unix,
         )
 
-        # Obtain the cluster info again as it is set after the
-        # command was run in case of anyscale jobs
-        result.job_url = runner.job_url()
-        result.job_id = runner.job_id()
-        result.last_logs = runner.get_last_logs()
-
     except Exception as e:
         logger.exception(e)
         buildkite_open_last()
         pipeline_exception = e
         metrics = {}
+
+    # Obtain the cluster info again as it is set after the
+    # command was run in case of anyscale jobs
+    if runner:
+        result.job_url = runner.job_url()
+        result.job_id = runner.job_id()
+        if result.job_id:
+            result.last_logs = runner.get_last_logs()
 
     reset_signal_handling()
 

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -234,6 +234,9 @@ class GlueTest(unittest.TestCase):
 
         self.command_runner_return["run_prepare_command"] = None
 
+        self.command_runner_return["job_url"] = "http://mock-job-url"
+        self.command_runner_return["job_id"] = "mock-job-id"
+
         if until == "prepare_command":
             return
 
@@ -318,6 +321,7 @@ class GlueTest(unittest.TestCase):
         # Special case: Prepare commands are usually waiting for nodes
         # (this may change in the future!)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_WAIT_TIMEOUT.value)
+        self.assertIsNone(result.job_url)
 
     def testTestCommandFails(self):
         result = Result()
@@ -335,6 +339,7 @@ class GlueTest(unittest.TestCase):
         with self.assertRaises(TestCommandTimeout):
             self._run(result)
         self.assertEqual(result.return_code, ExitCode.COMMAND_TIMEOUT.value)
+        self.assertIsNotNone(result.job_url)
 
     def testTestCommandTimeoutLongRunning(self):
         result = Result()


### PR DESCRIPTION
rather than exit early. this makes sure that the job url and job ids are all assigned even for release test jobs that failed.
