### PR TITLE
[ci] add upload guards to push_ray_image

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -324,6 +324,7 @@ py_binary(
     deps = [
         ":crane_lib",
         "//ci/ray_ci:ray_ci_lib",
+        "//release:ray_release",
         ci_require("click"),
     ],
 )


### PR DESCRIPTION
Add _should_upload() guard to prevent accidental pushes from feature branches (mirrors RayDockerContainer behavior)
Add --pipeline-id option to validate postmerge pipeline

Topic: upload-guards
Signed-off-by: andrew <andrew@anyscale.com>