### PR TITLE
[Serve] Fix Direct Ingress CI failures: add SO_REUSEADDR for replica sockets

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -756,6 +756,9 @@ async def start_asgi_http_server(
         socket.AF_INET6 if is_ipv6(http_options.host) else socket.AF_INET,
         socket.SOCK_STREAM,
     )
+    # Always set SO_REUSEADDR to allow binding to ports in TIME_WAIT state.
+    # This is needed for both proxy (SO_REUSEPORT=True) and replica (SO_REUSEPORT=False).
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     if enable_so_reuseport:
         set_socket_reuse_port(sock)
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -158,6 +158,12 @@ from ray.serve.handle import DeploymentHandle
 from ray.serve.schema import EncodingType, LoggingConfig, ReplicaRank
 from ray.util import metrics as ray_metrics
 
+# isort: off
+import gc
+from ray.anyscale.serve._private.constants import ANYSCALE_FREEZE_GC_ON_STARTUP
+
+# isort: on
+
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2034,6 +2034,8 @@ class Replica(ReplicaBase):
                     except StopAsyncIteration:
                         pass
                 except BaseException as e:
+                    # Wrap exception with user-set status code before getting response
+                    e = self._maybe_wrap_grpc_exception(e, request_metadata)
                     status = get_grpc_response_status(
                         e,
                         self._grpc_options.request_timeout_s,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2034,8 +2034,6 @@ class Replica(ReplicaBase):
                     except StopAsyncIteration:
                         pass
                 except BaseException as e:
-                    # Wrap exception with user-set status code before getting response
-                    e = self._maybe_wrap_grpc_exception(e, request_metadata)
                     status = get_grpc_response_status(
                         e,
                         self._grpc_options.request_timeout_s,

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -553,6 +553,10 @@ def test_exception_without_grpc_context_code(
     When the deployment raises an exception without setting a status code on the
     gRPC context, the response should be INTERNAL error.
     """
+    # TODO(landscapepainter): This skipping mechanism needs to be removed when gRPC streaming for DI is implemented.
+    if streaming and RAY_SERVE_ENABLE_DIRECT_INGRESS:
+        pytest.skip()
+
     grpc_port = 9000
     grpc_servicer_functions = [
         "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -553,10 +553,6 @@ def test_exception_without_grpc_context_code(
     When the deployment raises an exception without setting a status code on the
     gRPC context, the response should be INTERNAL error.
     """
-    # TODO(landscapepainter): This skipping mechanism needs to be removed when gRPC streaming for DI is implemented.
-    if streaming and RAY_SERVE_ENABLE_DIRECT_INGRESS:
-        pytest.skip()
-
     grpc_port = 9000
     grpc_servicer_functions = [
         "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",


### PR DESCRIPTION
## Summary

Fix port binding failures in Direct Ingress mode by always setting `SO_REUSEADDR` on sockets.

### Root Cause

PR #50081 refactored socket creation into `start_asgi_http_server()`.

**Before #50081** (`proxy.py:run_http_server()`):
- `SO_REUSEADDR` was set inside `set_socket_reuse_port()` (http_util.py:442)
- Only proxies created HTTP sockets, and `SOCKET_REUSE_PORT_ENABLED` defaulted to true
- So `SO_REUSEADDR` was effectively always set

**After #50081** (`http_util.py:start_asgi_http_server()`):
- Socket creation moved to a shared function used by both proxies AND Direct Ingress replicas
- Direct Ingress passes `enable_so_reuseport=False` (each replica needs its own port, not shared)
- This skipped `set_socket_reuse_port()`, which was the only place setting `SO_REUSEADDR`

### Fix

Always set `SO_REUSEADDR` in `start_asgi_http_server()`, independent of `enable_so_reuseport`.

## Test plan
- [ ] Direct Ingress tests pass without port binding failures