### PR TITLE
[Data] Revising resource allocator task scheduling decision to factor in pending task outputs

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -16,6 +16,7 @@ from ray.data._internal.execution.interfaces.common import (
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data._internal.memory_tracing import trace_allocation
 from ray.data.block import BlockMetadata
+from ray.data.context import MAX_SAFE_BLOCK_SIZE_FACTOR
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces.physical_operator import (
@@ -689,9 +690,16 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             return None
 
         bytes_per_output = self.average_bytes_per_output
-        # If we don’t have a sample, just return null
+        # If we don’t have a sample yet and the limit is “unlimited”, we can’t
+        # estimate – just bail out.
         if bytes_per_output is None:
-            return None
+            if context.target_max_block_size is None:
+                return None
+            else:
+                # Block size can be up to MAX_SAFE_BLOCK_SIZE_FACTOR larger before being sliced.
+                bytes_per_output = (
+                    context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+                )
 
         num_pending_outputs = context._max_num_blocks_in_streaming_gen_buffer
         if self.average_num_outputs_per_task is not None:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -868,7 +868,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             # Avoid scheduling if there's no more Object Store budget (for
             # task outputs)
             budget.object_store_memory > (
-                self._metrics.obj_store_mem_max_pending_output_per_task or 0
+                op.metrics.obj_store_mem_max_pending_output_per_task or 0
             )
         )
 

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -865,8 +865,11 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         return (
             op.incremental_resource_usage().satisfies_limit(budget)
             and
-            # Avoid scheduling if there's no more Object Store budget (for task outputs)
-            budget.object_store_memory > 0
+            # Avoid scheduling if there's no more Object Store budget (for
+            # task outputs)
+            budget.object_store_memory > (
+                self._metrics.obj_store_mem_max_pending_output_per_task or 0
+            )
         )
 
     def get_budget(self, op: PhysicalOperator) -> Optional[ExecutionResources]:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -868,7 +868,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             # Avoid scheduling if there's no more Object Store budget (for
             # task outputs)
             budget.object_store_memory
-            > (op.metrics.obj_store_mem_max_pending_output_per_task or 0)
+            >= (op.metrics.obj_store_mem_max_pending_output_per_task or 0)
         )
 
     def get_budget(self, op: PhysicalOperator) -> Optional[ExecutionResources]:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -867,9 +867,8 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             and
             # Avoid scheduling if there's no more Object Store budget (for
             # task outputs)
-            budget.object_store_memory > (
-                op.metrics.obj_store_mem_max_pending_output_per_task or 0
-            )
+            budget.object_store_memory
+            > (op.metrics.obj_store_mem_max_pending_output_per_task or 0)
         )
 
     def get_budget(self, op: PhysicalOperator) -> Optional[ExecutionResources]:

--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -236,6 +236,7 @@ def test_no_deadlock_with_preserve_order(
 def test_input_backpressure_e2e(restore_data_context, shutdown_only):  # noqa: F811
     # Tests that backpressure applies even when reading directly from the input
     # datasource. This relies on datasource metadata size estimation.
+
     @ray.remote
     class Counter:
         def __init__(self):
@@ -254,25 +255,27 @@ def test_input_backpressure_e2e(restore_data_context, shutdown_only):  # noqa: F
         def __init__(self):
             self.counter = Counter.remote()
 
-        def prepare_read(self, parallelism, n):
+        def prepare_read(self, parallelism):
+            # Use 50 MiB blocks to exceed the 25 MiB output reservation
+            # and trigger object store backpressure
+            num_bytes = 50 * MiB
+
             def range_(i):
                 print(f">>> Read task: {i=}")
 
                 ray.get(self.counter.increment.remote())
                 return [
-                    pd.DataFrame({"data": np.ones((n // parallelism * 1024 * 1024,))})
+                    pd.DataFrame({"data": np.ones((num_bytes,), dtype=np.uint8)})
                 ]
 
-            sz = (n // parallelism) * 1024 * 1024 * 8
-
-            print(f">>> Block size: {sz}")
+            print(f">>> Block size: {num_bytes}")
 
             return [
                 ReadTask(
                     lambda i=i: range_(i),
                     BlockMetadata(
                         num_rows=1,
-                        size_bytes=sz,
+                        size_bytes=num_bytes,
                         input_files=None,
                         exec_stats=None,
                     ),
@@ -281,14 +284,16 @@ def test_input_backpressure_e2e(restore_data_context, shutdown_only):  # noqa: F
             ]
 
     source = CountingRangeDatasource()
+
     ctx = ray.data.DataContext.get_current()
     ctx.execution_options.resource_limits = ctx.execution_options.resource_limits.copy(
         object_store_memory=100 * MiB,
         cpu=1,
     )
+    ctx.target_max_block_size = 50 * MiB
 
-    # Create 10 GiB dataset
-    ds = ray.data.read_datasource(source, n=10000, override_num_blocks=1000)
+    # Create dataset with many blocks
+    ds = ray.data.read_datasource(source, override_num_blocks=1000)
     it = iter(ds.iter_internal_ref_bundles())
     # Dequeue 1 block
     next(it)
@@ -297,12 +302,11 @@ def test_input_backpressure_e2e(restore_data_context, shutdown_only):  # noqa: F
 
     launched = ray.get(source.counter.get.remote())
 
-    # We'd launch exactly 3 tasks
-    #   - (Budget=100Mb) First task scheduled (produces first output)
-    #   - (Budget=20Mb) Second task scheduled (produces second output)
-    #   - (Budget=0Mb) First output dequed
-    #   - (Budget=20Mb) Third task scheduled
-    assert launched == 3, launched
+    # Clean up
+    del it
+    # With 50 MiB blocks and 100 MiB limit, backpressure should limit to ~2 tasks
+    # because after 2 outputs (100 MiB), the budget is depleted
+    assert launched == 2, launched
 
 
 def test_streaming_backpressure_e2e(

--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -264,9 +264,7 @@ def test_input_backpressure_e2e(restore_data_context, shutdown_only):  # noqa: F
                 print(f">>> Read task: {i=}")
 
                 ray.get(self.counter.increment.remote())
-                return [
-                    pd.DataFrame({"data": np.ones((num_bytes,), dtype=np.uint8)})
-                ]
+                return [pd.DataFrame({"data": np.ones((num_bytes,), dtype=np.uint8)})]
 
             print(f">>> Block size: {num_bytes}")
 

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -10,9 +10,8 @@ from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.context import (
-    DataContext,
-    DEFAULT_TARGET_MAX_BLOCK_SIZE,
     MAX_SAFE_BLOCK_SIZE_FACTOR,
+    DataContext,
 )
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.test_operators import _mul2_map_data_prcessor
@@ -226,7 +225,10 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(1600, rel=0.5)
     # No sample available yet, uses fallback estimate: 2 tasks * per_task_output.
-    assert op.metrics.obj_store_mem_pending_task_outputs == 2 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+    assert (
+        op.metrics.obj_store_mem_pending_task_outputs
+        == 2 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+    )
 
     run_op_tasks_sync(op)
 
@@ -285,7 +287,10 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(2400, rel=0.5)
     # No sample available yet, uses fallback estimate: 1 task * per_task_output.
-    assert op.metrics.obj_store_mem_pending_task_outputs == 1 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+    assert (
+        op.metrics.obj_store_mem_pending_task_outputs
+        == 1 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+    )
 
 
 def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_context):
@@ -351,7 +356,10 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(3200, rel=0.5)
     # No sample available yet, uses fallback estimate. For actor pools, num_tasks_running
     # is capped by num_active_actors (2 actors running 4 tasks => 2 effective tasks).
-    assert op.metrics.obj_store_mem_pending_task_outputs == 2 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+    assert (
+        op.metrics.obj_store_mem_pending_task_outputs
+        == 2 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+    )
 
     # Indicate that no more inputs will arrive.
     op.all_inputs_done()

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -11,7 +11,7 @@ from ray.data._internal.execution.interfaces.op_runtime_metrics import (
 )
 from ray.data._internal.util import KiB
 from ray.data.block import BlockExecStats, BlockMetadata
-from ray.data.context import DataContext, MAX_SAFE_BLOCK_SIZE_FACTOR
+from ray.data.context import MAX_SAFE_BLOCK_SIZE_FACTOR, DataContext
 
 
 def test_average_max_uss_per_task():

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -11,7 +11,7 @@ from ray.data._internal.execution.interfaces.op_runtime_metrics import (
 )
 from ray.data._internal.util import KiB
 from ray.data.block import BlockExecStats, BlockMetadata
-from ray.data.context import DataContext
+from ray.data.context import DataContext, MAX_SAFE_BLOCK_SIZE_FACTOR
 
 
 def test_average_max_uss_per_task():
@@ -349,11 +349,15 @@ def metrics_config_pending_outputs_none(restore_data_context):  # noqa: F811
 @pytest.mark.parametrize(
     "metrics_fixture,test_property,expected_calculator",
     [
-        # When no sample is available, returns None
+        # When no sample is available but target_max_block_size is set, uses fallback
         (
             "metrics_config_no_sample_with_target",
             "obj_store_mem_max_pending_output_per_task",
-            lambda m: None,
+            lambda m: (
+                m._op.data_context.target_max_block_size
+                * MAX_SAFE_BLOCK_SIZE_FACTOR
+                * m._op.data_context._max_num_blocks_in_streaming_gen_buffer
+            ),
         ),
         # When sample is available, uses average_bytes_per_output
         (
@@ -364,11 +368,16 @@ def metrics_config_pending_outputs_none(restore_data_context):  # noqa: F811
                 * m._op.data_context._max_num_blocks_in_streaming_gen_buffer
             ),
         ),
-        # When no sample is available, obj_store_mem_pending_task_outputs returns None
+        # When no sample is available but target_max_block_size is set, uses fallback
         (
             "metrics_config_pending_outputs_no_sample",
             "obj_store_mem_pending_task_outputs",
-            lambda m: None,
+            lambda m: (
+                m.num_tasks_running
+                * m._op.data_context.target_max_block_size
+                * MAX_SAFE_BLOCK_SIZE_FACTOR
+                * m._op.data_context._max_num_blocks_in_streaming_gen_buffer
+            ),
         ),
     ],
 )

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -30,7 +30,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     build_streaming_topology,
 )
 from ray.data._internal.execution.util import make_ref_bundles
-from ray.data.context import DataContext, MAX_SAFE_BLOCK_SIZE_FACTOR
+from ray.data.context import MAX_SAFE_BLOCK_SIZE_FACTOR, DataContext
 from ray.data.tests.conftest import *  # noqa
 
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -30,7 +30,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     build_streaming_topology,
 )
 from ray.data._internal.execution.util import make_ref_bundles
-from ray.data.context import DataContext
+from ray.data.context import DataContext, MAX_SAFE_BLOCK_SIZE_FACTOR
 from ray.data.tests.conftest import *  # noqa
 
 
@@ -351,16 +351,22 @@ class TestResourceManager:
         assert resource_manager.get_op_usage(o2).object_store_memory == 0
         assert resource_manager.get_op_usage(o3).object_store_memory == 0
 
-        # During no-sample phase, obj_store_mem_pending_task_outputs returns None,
-        # which is treated as 0 in resource calculations.
+        # During no-sample phase, obj_store_mem_pending_task_outputs uses fallback
+        # estimate based on target_max_block_size.
         o2.metrics.on_input_dequeued(input)
         o2.metrics.on_task_submitted(0, input)
         resource_manager.update_usages()
         assert resource_manager.get_op_usage(o1).object_store_memory == 0
-        # No sample available yet, so pending task outputs is None (treated as 0)
-        assert o2.metrics.obj_store_mem_pending_task_outputs is None
+        # No sample available yet, uses fallback: target_max_block_size * factor * buffer
+        ctx = ray.data.DataContext.get_current()
+        expected_pending_output = (
+            ctx.target_max_block_size
+            * MAX_SAFE_BLOCK_SIZE_FACTOR
+            * ctx._max_num_blocks_in_streaming_gen_buffer
+        )
+        assert o2.metrics.obj_store_mem_pending_task_outputs == expected_pending_output
         op2_usage = resource_manager.get_op_usage(o2).object_store_memory
-        assert op2_usage == 0
+        assert op2_usage == expected_pending_output
         assert resource_manager.get_op_usage(o3).object_store_memory == 0
 
         # When the task finishes, we move the data from the streaming generator to the
@@ -388,16 +394,16 @@ class TestResourceManager:
         assert resource_manager.get_op_usage(o3).object_store_memory == 0
 
         # Task inputs count toward the previous operator's object store memory
-        # usage. During no-sample phase, pending task outputs returns None.
+        # usage. During no-sample phase, pending task outputs uses fallback estimate.
         o3.metrics.on_input_dequeued(input)
         o3.metrics.on_task_submitted(0, input)
         resource_manager.update_usages()
         assert resource_manager.get_op_usage(o1).object_store_memory == 0
         assert resource_manager.get_op_usage(o2).object_store_memory == 1
-        # No sample available yet, so pending task outputs is None (treated as 0)
-        assert o3.metrics.obj_store_mem_pending_task_outputs is None
+        # No sample available yet, uses fallback estimate
+        assert o3.metrics.obj_store_mem_pending_task_outputs == expected_pending_output
         op3_usage = resource_manager.get_op_usage(o3).object_store_memory
-        assert op3_usage == 0
+        assert op3_usage == expected_pending_output
 
         # Task inputs no longer count once the task is finished.
         o3.metrics.on_output_queued(input)


### PR DESCRIPTION
## Description

This change reverts back to behavior where 

 1. `can_submit_new_task` still evaluates whether to schedule task based on estimated task outputs pending in the buffer.
 2. Estimate of the pending task outputs to rely on `target_max_block_size` until actual estimate becomes available

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
