### PR TITLE
[Data] Refactor ClusterAutoscalerVersion to extend str

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/__init__.py
+++ b/python/ray/data/_internal/cluster_autoscaler/__init__.py
@@ -1,5 +1,5 @@
+import enum
 import os
-from enum import Enum
 from typing import TYPE_CHECKING
 
 from .base_autoscaling_coordinator import (
@@ -18,11 +18,10 @@ if TYPE_CHECKING:
     from ray.data.context import DataContext
 
 
-CLUSTER_AUTOSCALER_ENV_KEY = "RAY_DATA_CLUSTER_AUTOSCALER"
-CLUSTER_AUTOSCALER_ENV_DEFAULT_VALUE = "V2"
+DEFAULT_CLUSTER_AUTOSCALER_VERSION = os.environ.get("RAY_DATA_CLUSTER_AUTOSCALER", "V2")
 
 
-class ClusterAutoscalerVersion(Enum):
+class ClusterAutoscalerVersion(str, enum.Enum):
     V2 = "V2"
     V1 = "V1"
 
@@ -34,37 +33,27 @@ def create_cluster_autoscaler(
     *,
     execution_id: str,
 ) -> ClusterAutoscaler:
-    selected_autoscaler = _get_cluster_autoscaler_version()
     resource_limits = data_context.execution_options.resource_limits
 
-    if selected_autoscaler == ClusterAutoscalerVersion.V2:
+    if DEFAULT_CLUSTER_AUTOSCALER_VERSION == ClusterAutoscalerVersion.V2:
         return DefaultClusterAutoscalerV2(
             resource_manager,
             execution_id=execution_id,
             resource_limits=resource_limits,
         )
 
-    elif selected_autoscaler == ClusterAutoscalerVersion.V1:
+    elif DEFAULT_CLUSTER_AUTOSCALER_VERSION == ClusterAutoscalerVersion.V1:
         return DefaultClusterAutoscaler(
             topology,
             resource_limits=resource_limits,
             execution_id=execution_id,
         )
 
-    assert False, "Invalid cluster autoscaler option"
-
-
-def _get_cluster_autoscaler_version() -> ClusterAutoscalerVersion:
-    cluster_autoscaler_env_value = os.getenv(
-        CLUSTER_AUTOSCALER_ENV_KEY, CLUSTER_AUTOSCALER_ENV_DEFAULT_VALUE
-    )
-    try:
-        return ClusterAutoscalerVersion(cluster_autoscaler_env_value)
-    except ValueError:
+    else:
         valid_values = [version.value for version in ClusterAutoscalerVersion]
         raise ValueError(
-            f"{cluster_autoscaler_env_value} isn't a valid option for "
-            f"{CLUSTER_AUTOSCALER_ENV_KEY}. Valid options are: {valid_values}."
+            f"Cluster autoscaler version of {DEFAULT_CLUSTER_AUTOSCALER_VERSION}"
+            f"isn't a valid option. Valid options are: {valid_values}."
         )
 
 

--- a/python/ray/data/_internal/cluster_autoscaler/__init__.py
+++ b/python/ray/data/_internal/cluster_autoscaler/__init__.py
@@ -52,7 +52,7 @@ def create_cluster_autoscaler(
     else:
         valid_values = [version.value for version in ClusterAutoscalerVersion]
         raise ValueError(
-            f"Cluster autoscaler version of {DEFAULT_CLUSTER_AUTOSCALER_VERSION}"
+            f"Cluster autoscaler version of {DEFAULT_CLUSTER_AUTOSCALER_VERSION} "
             f"isn't a valid option. Valid options are: {valid_values}."
         )
 


### PR DESCRIPTION
## Description
Refactor ClusterAutoscalerVersion to extend str (matching OpResourceAllocatorVersion pattern), allowing direct string comparison with environment variables and eliminating the need for _get_cluster_autoscaler_version().

