### PR TITLE
[Data] Compute Expressions image 

### DIFF
--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -786,9 +786,9 @@ class Expr(ABC):
 
         Example:
             >>> from ray.data.expressions import col
-            >>> from torchvision import transforms
-            >>> augmentation = [transforms.ToTensor(), transforms.RandomResizedCrop(224)]
-            >>> ds.with_column("augmented", col("image").image.compose(augmentation))
+            >>> from torchvision.transforms import v2
+            >>> augmentation = [v2.ToTensor(), v2.RandomResizedCrop(224)]
+            >>> ds.with_column("augmented", col("image").image.compose(augmentation))  # doctest: +SKIP
         """
         from ray.data.namespace_expressions.image_namespace import _ImageNamespace
 

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
     from ray.data.namespace_expressions.arr_namespace import _ArrayNamespace
     from ray.data.namespace_expressions.dt_namespace import _DatetimeNamespace
+    from ray.data.namespace_expressions.image_namespace import _ImageNamespace
     from ray.data.namespace_expressions.list_namespace import _ListNamespace
     from ray.data.namespace_expressions.map_namespace import _MapNamespace
     from ray.data.namespace_expressions.string_namespace import _StringNamespace
@@ -775,6 +776,23 @@ class Expr(ABC):
         from ray.data.namespace_expressions.dt_namespace import _DatetimeNamespace
 
         return _DatetimeNamespace(self)
+
+    @property
+    def image(self) -> "_ImageNamespace":
+        """Access image operations for this expression.
+
+        Returns:
+            An _ImageNamespace that provides image-specific operations.
+
+        Example:
+            >>> from ray.data.expressions import col
+            >>> from torchvision import transforms
+            >>> augmentation = [transforms.ToTensor(), transforms.RandomResizedCrop(224)]
+            >>> ds.with_column("augmented", col("image").image.compose(augmentation))
+        """
+        from ray.data.namespace_expressions.image_namespace import _ImageNamespace
+
+        return _ImageNamespace(self)
 
     def _unalias(self) -> "Expr":
         return self
@@ -1891,6 +1909,7 @@ __all__ = [
     "star",
     "uuid",
     "_ArrayNamespace",
+    "_ImageNamespace",
     "_ListNamespace",
     "_StringNamespace",
     "_StructNamespace",
@@ -1905,6 +1924,10 @@ def __getattr__(name: str):
         from ray.data.namespace_expressions.arr_namespace import _ArrayNamespace
 
         return _ArrayNamespace
+    elif name == "_ImageNamespace":
+        from ray.data.namespace_expressions.image_namespace import _ImageNamespace
+
+        return _ImageNamespace
     elif name == "_ListNamespace":
         from ray.data.namespace_expressions.list_namespace import _ListNamespace
 

--- a/python/ray/data/namespace_expressions/image_namespace.py
+++ b/python/ray/data/namespace_expressions/image_namespace.py
@@ -16,7 +16,7 @@ class _ImageNamespace:
 
     _expr: "Expr"
 
-    def compose(self, transforms: List) -> "UDFExpr":
+    def compose(self, transforms: List[Callable]) -> "UDFExpr":
         """Apply a pipeline of torchvision transforms to images.
 
         Reuses the transform logic from TorchVisionPreprocessor with batched=False,

--- a/python/ray/data/namespace_expressions/image_namespace.py
+++ b/python/ray/data/namespace_expressions/image_namespace.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List
+
+from ray.data.datatype import DataType
+from ray.data.expressions import pyarrow_udf
+
+if TYPE_CHECKING:
+    from ray.data.expressions import Expr, UDFExpr
+
+
+@dataclass
+class _ImageNamespace:
+    """Namespace for image operations on expression columns."""
+
+    _expr: "Expr"
+
+    def compose(self, transforms: List) -> "UDFExpr":
+        """Apply a pipeline of torchvision transforms to images.
+
+        Reuses the transform logic from TorchVisionPreprocessor with batched=False,
+        meaning transforms are applied individually to each image.
+
+        Args:
+            transforms: List of torchvision transform objects. Must be non-empty.
+
+        Returns:
+            UDFExpr that applies the transform pipeline, returning numpy arrays
+
+        Note:
+            The transform pipeline must return torch.Tensor or np.ndarray.
+            For better performance with batch-supporting transforms, consider
+            using TorchVisionPreprocessor directly with batched=True.
+
+        Example:
+            >>> from torchvision import transforms
+            >>> augmentation = [
+            ...     transforms.ToTensor(),
+            ...     transforms.RandomResizedCrop(224),
+            ...     transforms.RandomHorizontalFlip(p=0.5),
+            ... ]
+            >>> ds.with_column("augmented", col("image").image.compose(augmentation))
+        """
+        if not transforms:
+            raise ValueError("transforms list must not be empty")
+
+        try:
+            from torchvision import transforms as T
+        except ImportError:
+            raise ImportError(
+                "torchvision is required for image.compose(). "
+                "Install it with: pip install torchvision"
+            )
+
+        from ray.data.preprocessors import TorchVisionPreprocessor
+
+        # Create composed transform
+        composed = T.Compose(transforms)
+
+        # Reuse TorchVisionPreprocessor's transform logic
+        preprocessor = TorchVisionPreprocessor(
+            columns=["__image__"],
+            transform=composed,
+            batched=False,
+        )
+
+        @pyarrow_udf(return_dtype=DataType(object))
+        def _apply_transforms(images):
+            import pyarrow as pa
+
+            from ray.data._internal.tensor_extensions.arrow import ArrowTensorArray
+
+            # Convert PyArrow ChunkedArray/Array to numpy for TorchVisionPreprocessor
+            if isinstance(images, pa.ChunkedArray):
+                # Combine all chunks to avoid data loss with multi-chunk arrays
+                images = images.combine_chunks()
+
+            if isinstance(images, (pa.Array, ArrowTensorArray)):
+                np_images = images.to_numpy(zero_copy_only=False)
+            else:
+                np_images = images
+
+            # Use preprocessor's internal transform method
+            batch = {"__image__": np_images}
+            result = preprocessor._transform_numpy(batch)
+
+            # Convert result back to ArrowTensorArray for proper storage
+            return ArrowTensorArray.from_numpy(result["__image__"])
+
+        return _apply_transforms(self._expr)

--- a/python/ray/data/namespace_expressions/image_namespace.py
+++ b/python/ray/data/namespace_expressions/image_namespace.py
@@ -37,7 +37,7 @@ class _ImageNamespace:
             ...     v2.RandomResizedCrop(224),
             ...     v2.RandomHorizontalFlip(p=0.5),
             ... ]
-            >>> ds.with_column("augmented", col("image").image.compose(augmentation))
+            >>> ds.with_column("augmented", col("image").image.compose(augmentation))  # doctest: +SKIP
         """
         if not transforms:
             raise ValueError("transforms list must not be empty")

--- a/python/ray/data/namespace_expressions/image_namespace.py
+++ b/python/ray/data/namespace_expressions/image_namespace.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Callable, List
 
 from ray.data.datatype import DataType
 from ray.data.expressions import pyarrow_udf
@@ -45,13 +45,7 @@ class _ImageNamespace:
         if not transforms:
             raise ValueError("transforms list must not be empty")
 
-        try:
-            from torchvision import transforms as T
-        except ImportError:
-            raise ImportError(
-                "torchvision is required for image.compose(). "
-                "Install it with: pip install torchvision"
-            )
+        from torchvision import transforms as T
 
         from ray.data.preprocessors import TorchVisionPreprocessor
 

--- a/python/ray/data/tests/expressions/test_namespace_image.py
+++ b/python/ray/data/tests/expressions/test_namespace_image.py
@@ -27,7 +27,7 @@ class TestImageNamespace:
 
     def test_image_compose_single_transform(self, ray_start_regular_shared):
         """Test compose with a single transform."""
-        from torchvision import transforms
+        from torchvision.transforms import v2
 
         ds = ray.data.from_items(
             [
@@ -36,7 +36,7 @@ class TestImageNamespace:
             ]
         )
 
-        augmentation = [transforms.ToTensor()]
+        augmentation = [v2.ToTensor()]
 
         result_ds = ds.with_column(
             "transformed", col("image").image.compose(augmentation)
@@ -53,7 +53,7 @@ class TestImageNamespace:
 
     def test_image_compose_multiple_transforms(self, ray_start_regular_shared):
         """Test compose with multiple transforms."""
-        from torchvision import transforms
+        from torchvision.transforms import v2
 
         ds = ray.data.from_items(
             [
@@ -63,8 +63,8 @@ class TestImageNamespace:
         )
 
         augmentation = [
-            transforms.ToTensor(),
-            transforms.Resize((32, 32)),
+            v2.ToTensor(),
+            v2.Resize((32, 32)),
         ]
 
         result_ds = ds.with_column("resized", col("image").image.compose(augmentation))
@@ -78,7 +78,7 @@ class TestImageNamespace:
 
     def test_image_compose_with_augmentation_pipeline(self, ray_start_regular_shared):
         """Test compose with a realistic augmentation pipeline."""
-        from torchvision import transforms
+        from torchvision.transforms import v2
 
         ds = ray.data.from_items(
             [
@@ -87,9 +87,9 @@ class TestImageNamespace:
         )
 
         augmentation = [
-            transforms.ToTensor(),
-            transforms.RandomHorizontalFlip(p=1.0),  # Always flip for determinism
-            transforms.Resize((48, 48)),
+            v2.ToTensor(),
+            v2.RandomHorizontalFlip(p=1.0),  # Always flip for determinism
+            v2.Resize((48, 48)),
         ]
 
         result_ds = ds.with_column(
@@ -102,7 +102,7 @@ class TestImageNamespace:
 
     def test_image_compose_preserves_other_columns(self, ray_start_regular_shared):
         """Test that compose preserves other columns in the dataset."""
-        from torchvision import transforms
+        from torchvision.transforms import v2
 
         ds = ray.data.from_items(
             [
@@ -119,7 +119,7 @@ class TestImageNamespace:
             ]
         )
 
-        augmentation = [transforms.ToTensor()]
+        augmentation = [v2.ToTensor()]
 
         result_ds = ds.with_column(
             "transformed", col("image").image.compose(augmentation)
@@ -137,7 +137,7 @@ class TestImageNamespace:
 
     def test_image_compose_ragged_images(self, ray_start_regular_shared):
         """Test compose with images of different sizes."""
-        from torchvision import transforms
+        from torchvision.transforms import v2
 
         ds = ray.data.from_items(
             [
@@ -148,8 +148,8 @@ class TestImageNamespace:
         )
 
         augmentation = [
-            transforms.ToTensor(),
-            transforms.Resize((24, 24)),
+            v2.ToTensor(),
+            v2.Resize((24, 24)),
         ]
 
         result_ds = ds.with_column("resized", col("image").image.compose(augmentation))
@@ -162,7 +162,7 @@ class TestImageNamespace:
 
     def test_image_compose_grayscale_to_rgb(self, ray_start_regular_shared):
         """Test compose can handle grayscale images with Lambda transform."""
-        from torchvision import transforms
+        from torchvision.transforms import v2
 
         # Grayscale image (H, W) - no channel dimension
         ds = ray.data.from_items(
@@ -173,8 +173,8 @@ class TestImageNamespace:
 
         augmentation = [
             # Add channel dimension and convert to RGB
-            transforms.Lambda(lambda x: np.stack([x, x, x], axis=-1)),
-            transforms.ToTensor(),
+            v2.Lambda(lambda x: np.stack([x, x, x], axis=-1)),
+            v2.ToTensor(),
         ]
 
         result_ds = ds.with_column("rgb", col("image").image.compose(augmentation))
@@ -196,7 +196,7 @@ class TestImageNamespace:
 
     def test_image_compose_invalid_dtype_raises(self, ray_start_regular_shared):
         """Test that image.compose on non-image column raises an error."""
-        from torchvision import transforms
+        from torchvision.transforms import v2
 
         ds = ray.data.from_items([{"value": 1}, {"value": 2}])
 
@@ -204,7 +204,7 @@ class TestImageNamespace:
             (ray.exceptions.RayTaskError, ray.exceptions.UserCodeException)
         ):
             ds.with_column(
-                "transformed", col("value").image.compose([transforms.ToTensor()])
+                "transformed", col("value").image.compose([v2.ToTensor()])
             ).materialize()
 
 

--- a/python/ray/data/tests/expressions/test_namespace_image.py
+++ b/python/ray/data/tests/expressions/test_namespace_image.py
@@ -1,0 +1,214 @@
+"""Integration tests for image namespace expressions.
+
+These tests require Ray, torch, and torchvision to test end-to-end
+image namespace expression evaluation.
+"""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+from packaging import version
+
+import ray
+from ray.data.expressions import col
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+pytestmark = [
+    pytest.mark.skipif(
+        version.parse(pa.__version__) < version.parse("19.0.0"),
+        reason="Namespace expressions tests require PyArrow >= 19.0",
+    ),
+]
+
+
+class TestImageNamespace:
+    """Tests for image namespace operations."""
+
+    def test_image_compose_single_transform(self, ray_start_regular_shared):
+        """Test compose with a single transform."""
+        from torchvision import transforms
+
+        ds = ray.data.from_items(
+            [
+                {"image": np.zeros((32, 32, 3), dtype=np.uint8)},
+                {"image": np.ones((32, 32, 3), dtype=np.uint8) * 255},
+            ]
+        )
+
+        augmentation = [transforms.ToTensor()]
+
+        result_ds = ds.with_column(
+            "transformed", col("image").image.compose(augmentation)
+        )
+        results = result_ds.take_all()
+
+        assert len(results) == 2
+        for row in results:
+            assert "transformed" in row
+            assert "image" in row
+            # ToTensor converts (H, W, C) -> (C, H, W) and normalizes to [0, 1]
+            assert row["transformed"].shape == (3, 32, 32)
+            assert row["transformed"].dtype in (np.float32, np.float64)
+
+    def test_image_compose_multiple_transforms(self, ray_start_regular_shared):
+        """Test compose with multiple transforms."""
+        from torchvision import transforms
+
+        ds = ray.data.from_items(
+            [
+                {"image": np.ones((64, 64, 3), dtype=np.uint8) * 128},
+                {"image": np.ones((64, 64, 3), dtype=np.uint8) * 64},
+            ]
+        )
+
+        augmentation = [
+            transforms.ToTensor(),
+            transforms.Resize((32, 32)),
+        ]
+
+        result_ds = ds.with_column("resized", col("image").image.compose(augmentation))
+        results = result_ds.take_all()
+
+        assert len(results) == 2
+        for row in results:
+            assert "resized" in row
+            # ToTensor converts (H, W, C) -> (C, H, W), then Resize to 32x32
+            assert row["resized"].shape == (3, 32, 32)
+
+    def test_image_compose_with_augmentation_pipeline(self, ray_start_regular_shared):
+        """Test compose with a realistic augmentation pipeline."""
+        from torchvision import transforms
+
+        ds = ray.data.from_items(
+            [
+                {"image": np.ones((64, 64, 3), dtype=np.uint8) * 128},
+            ]
+        )
+
+        augmentation = [
+            transforms.ToTensor(),
+            transforms.RandomHorizontalFlip(p=1.0),  # Always flip for determinism
+            transforms.Resize((48, 48)),
+        ]
+
+        result_ds = ds.with_column(
+            "augmented", col("image").image.compose(augmentation)
+        )
+        results = result_ds.take_all()
+
+        assert len(results) == 1
+        assert results[0]["augmented"].shape == (3, 48, 48)
+
+    def test_image_compose_preserves_other_columns(self, ray_start_regular_shared):
+        """Test that compose preserves other columns in the dataset."""
+        from torchvision import transforms
+
+        ds = ray.data.from_items(
+            [
+                {
+                    "image": np.zeros((32, 32, 3), dtype=np.uint8),
+                    "label": 0,
+                    "name": "a",
+                },
+                {
+                    "image": np.ones((32, 32, 3), dtype=np.uint8),
+                    "label": 1,
+                    "name": "b",
+                },
+            ]
+        )
+
+        augmentation = [transforms.ToTensor()]
+
+        result_ds = ds.with_column(
+            "transformed", col("image").image.compose(augmentation)
+        )
+        results = result_ds.take_all()
+
+        assert len(results) == 2
+        for i, row in enumerate(results):
+            assert "image" in row
+            assert "transformed" in row
+            assert "label" in row
+            assert "name" in row
+            assert row["label"] == i
+            assert row["name"] == ["a", "b"][i]
+
+    def test_image_compose_ragged_images(self, ray_start_regular_shared):
+        """Test compose with images of different sizes."""
+        from torchvision import transforms
+
+        ds = ray.data.from_items(
+            [
+                {"image": np.zeros((16, 16, 3), dtype=np.uint8)},
+                {"image": np.zeros((32, 32, 3), dtype=np.uint8)},
+                {"image": np.zeros((64, 64, 3), dtype=np.uint8)},
+            ]
+        )
+
+        augmentation = [
+            transforms.ToTensor(),
+            transforms.Resize((24, 24)),
+        ]
+
+        result_ds = ds.with_column("resized", col("image").image.compose(augmentation))
+        results = result_ds.take_all()
+
+        assert len(results) == 3
+        for row in results:
+            # All images should be resized to 24x24
+            assert row["resized"].shape == (3, 24, 24)
+
+    def test_image_compose_grayscale_to_rgb(self, ray_start_regular_shared):
+        """Test compose can handle grayscale images with Lambda transform."""
+        from torchvision import transforms
+
+        # Grayscale image (H, W) - no channel dimension
+        ds = ray.data.from_items(
+            [
+                {"image": np.zeros((32, 32), dtype=np.uint8)},
+            ]
+        )
+
+        augmentation = [
+            # Add channel dimension and convert to RGB
+            transforms.Lambda(lambda x: np.stack([x, x, x], axis=-1)),
+            transforms.ToTensor(),
+        ]
+
+        result_ds = ds.with_column("rgb", col("image").image.compose(augmentation))
+        results = result_ds.take_all()
+
+        assert len(results) == 1
+        assert results[0]["rgb"].shape == (3, 32, 32)
+
+    def test_image_compose_empty_transforms_raises(self, ray_start_regular_shared):
+        """Test that empty transforms list raises ValueError."""
+        ds = ray.data.from_items(
+            [
+                {"image": np.zeros((32, 32, 3), dtype=np.uint8)},
+            ]
+        )
+
+        with pytest.raises(ValueError, match="transforms list must not be empty"):
+            ds.with_column("transformed", col("image").image.compose([]))
+
+    def test_image_compose_invalid_dtype_raises(self, ray_start_regular_shared):
+        """Test that image.compose on non-image column raises an error."""
+        from torchvision import transforms
+
+        ds = ray.data.from_items([{"value": 1}, {"value": 2}])
+
+        with pytest.raises(
+            (ray.exceptions.RayTaskError, ray.exceptions.UserCodeException)
+        ):
+            ds.with_column(
+                "transformed", col("value").image.compose([transforms.ToTensor()])
+            ).materialize()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

Adds an `image` namespace to expressions with a `compose()` method for applying torchvision transforms inline.

```python
from torchvision import transforms
from ray.data.expressions import col

ds = ray.data.read_images("s3://bucket/images")
ds = ds.with_column("augmented", col("image").image.compose([
    transforms.ToTensor(),
    transforms.RandomResizedCrop(224),
    transforms.RandomHorizontalFlip(),
]))
```

## Changes
- New `_ImageNamespace` class with `compose()` method
- Reuses `TorchVisionPreprocessor` internally
- Added `image` property to `Expr` class

## Related issues
Related to https://github.com/ray-project/ray/issues/58674
Extends https://github.com/ray-project/ray/pull/58745

## Additional information
