### PR TITLE
[Serve] Fix test fixtures to check ray.is_initialized() before serve.shutdown()

### DIFF
--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -45,19 +45,19 @@ if os.environ.get("RAY_SERVE_INTENTIONALLY_CRASH", False) == 1:
 
 @pytest.fixture
 def ray_shutdown():
-    serve.shutdown()
     if ray.is_initialized():
+        serve.shutdown()
         ray.shutdown()
     yield
-    serve.shutdown()
     if ray.is_initialized():
+        serve.shutdown()
         ray.shutdown()
 
 
 @pytest.fixture
 def ray_cluster():
-    serve.shutdown()
     if ray.is_initialized():
+        serve.shutdown()
         ray.shutdown()
     cluster = Cluster()
     yield cluster
@@ -68,8 +68,8 @@ def ray_cluster():
 
 @pytest.fixture
 def ray_autoscaling_cluster(request):
-    serve.shutdown()
     if ray.is_initialized():
+        serve.shutdown()
         ray.shutdown()
     # NOTE(zcin): We have to make a deepcopy here because AutoscalingCluster
     # modifies the dictionary that's passed in.
@@ -147,8 +147,8 @@ def _shared_serve_instance():
     # os.environ["SERVE_DEBUG_LOG"] = "1" <- Do not uncomment this.
 
     # Ensure Ray is not already running before starting this session-scoped instance
-    serve.shutdown()
     if ray.is_initialized():
+        serve.shutdown()
         ray.shutdown()
 
     # Overriding task_retry_delay_ms to relaunch actors more quickly


### PR DESCRIPTION
## Why are these changes needed?

PR #60461 introduced a bug where `serve.shutdown()` is called before checking if Ray is initialized. This causes `serve.shutdown()` to internally call `ray.init()`, which fails on Windows CI when a stale `ray_current_cluster` file exists from a previous test run.

**Error flow:**
1. Test starts, fixture runs
2. Fixture calls `serve.shutdown()` before `ray.is_initialized()` check
3. `serve.shutdown()` → `_get_global_client()` → `_connect()`
4. `_connect()` sees Ray is not initialized, calls `ray.init(namespace=SERVE_NAMESPACE)`
5. `ray.init()` reads stale `ray_current_cluster` file (from previous test/build)
6. Tries to connect to dead Ray cluster → `ConnectionError`

**Failing Buildkite job:** https://buildkite.com/ray-project/postmerge/builds/15764#019c1d81-611d-4733-bcfa-660e422e2a5d

## Related issue number

Fixes Windows test failures in `python/ray/serve/tests/test_deploy.py` introduced by #60461.

## Checks

- [x] I've signed all my commits
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - [ ] I've added any new APIs to the API Reference. For example, if I added a
method in Tune, I've added it in `doc/source/tune/api/` under the
temporary doc directory.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing:
  - [ ] N/A