### PR TITLE
[AIR] Fix MLflowLoggerCallback to save artifacts from persistent storage

### DIFF
--- a/python/ray/air/integrations/mlflow.py
+++ b/python/ray/air/integrations/mlflow.py
@@ -327,7 +327,7 @@ class MLflowLoggerCallback(LoggerCallback):
 
         # Log the artifact if set_artifact is set to True.
         if self.should_save_artifact:
-            self.mlflow_util.save_artifacts(run_id=run_id, dir=trial.local_path)
+            self.mlflow_util.save_artifacts(run_id=run_id, dir=trial.path)
 
         # Stop the run once trial finishes.
         status = "FINISHED" if not failed else "FAILED"

--- a/python/ray/air/integrations/mlflow.py
+++ b/python/ray/air/integrations/mlflow.py
@@ -336,8 +336,6 @@ class MLflowLoggerCallback(LoggerCallback):
             if fs.type_name in ("local", "file"):
                 self.mlflow_util.save_artifacts(run_id=run_id, dir=trial.path)
             else:
-                import tempfile
-                import pyarrow.fs
                 with tempfile.TemporaryDirectory() as tmpdir:
                     pyarrow.fs.copy_files(
                         trial.path,

--- a/python/ray/air/integrations/mlflow.py
+++ b/python/ray/air/integrations/mlflow.py
@@ -1,9 +1,9 @@
 import logging
-import pyarrow.fs
-
 import tempfile
 from types import ModuleType
 from typing import Dict, Optional, Union
+
+import pyarrow.fs
 
 import ray
 from ray.air._internal import usage as air_usage

--- a/python/ray/air/integrations/mlflow.py
+++ b/python/ray/air/integrations/mlflow.py
@@ -266,7 +266,6 @@ class MLflowLoggerCallback(LoggerCallback):
         save_artifact: bool = False,
         log_params_on_trial_end: bool = False,
     ):
-
         self.tracking_uri = tracking_uri
         self.registry_uri = registry_uri
         self.experiment_name = experiment_name
@@ -305,7 +304,6 @@ class MLflowLoggerCallback(LoggerCallback):
     def log_trial_start(self, trial: "Trial"):
         # Create run if not already exists.
         if trial not in self._trial_runs:
-
             # Set trial name in tags
             tags = self.tags.copy()
             tags["trial_name"] = str(trial)
@@ -342,7 +340,7 @@ class MLflowLoggerCallback(LoggerCallback):
                         tmpdir,
                         source_filesystem=fs,
                     )
-                    self.mlflow_util.save_artifacts(run_id=run_id, dir=tmpdir)  
+                    self.mlflow_util.save_artifacts(run_id=run_id, dir=tmpdir)
 
         # Stop the run once trial finishes.
         status = "FINISHED" if not failed else "FAILED"

--- a/python/ray/air/integrations/mlflow.py
+++ b/python/ray/air/integrations/mlflow.py
@@ -329,7 +329,7 @@ class MLflowLoggerCallback(LoggerCallback):
         run_id = self._trial_runs[trial]
 
         # Log the artifact if set_artifact is set to True.
-       if self.should_save_artifact:
+        if self.should_save_artifact:
             fs = trial.storage.storage_filesystem
             # `trial.path` can be a remote URI. `mlflow.log_artifacts` expects a local
             # path. If the filesystem is not local, we need to download it first.

--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -4,11 +4,10 @@ import sys
 import tempfile
 import unittest
 from collections import namedtuple
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from mlflow.tracking import MlflowClient
-
 from pyarrow.fs import LocalFileSystem
 
 import ray

--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -320,7 +320,8 @@ class MLflowTest(unittest.TestCase):
         mlflow.sklearn.save_model(None, "model_directory")
 
     @patch("ray.air.integrations.mlflow._MLflowLoggerUtil", Mock_MLflowLoggerUtil)
-    def testMlFlowLoggerWithRemoteStorage(self):
+    @patch("pyarrow.fs.copy_files")
+    def testMlFlowLoggerWithRemoteStorage(self, mock_copy_files):
         """Test that artifacts work with remote storage filesystems."""
         clear_env_vars()
         trial_config = {"par1": "a", "par2": "b"}
@@ -344,6 +345,7 @@ class MLflowTest(unittest.TestCase):
         
         self.assertTrue(logger.mlflow_util.artifact_saved)
 
+        mock_copy_files.assert_called_once()
 
 class MLflowUtilTest(unittest.TestCase):
     def setUp(self):

--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -18,12 +18,17 @@ from ray.air.integrations.mlflow import MLflowLoggerCallback, _NoopModule, setup
 from ray.train.torch import TorchTrainer
 from ray.tune import Tuner
 
+
 class MockStorage:
     def __init__(self, storage_filesystem):
         self.storage_filesystem = storage_filesystem
 
+
 class MockTrial(
-    namedtuple("MockTrial", ["config", "trial_name", "trial_id", "local_path", "path", "storage"])
+    namedtuple(
+        "MockTrial",
+        ["config", "trial_name", "trial_id", "local_path", "path", "storage"],
+    )
 ):
     def __hash__(self):
         return hash(self.trial_id)
@@ -187,7 +192,9 @@ class MLflowTest(unittest.TestCase):
         clear_env_vars()
         trial_config = {"par1": "a", "par2": "b"}
         mock_storage = MockStorage(LocalFileSystem())
-        trial = MockTrial(trial_config, "trial1", 0, "artifact", "artifact", mock_storage)
+        trial = MockTrial(
+            trial_config, "trial1", 0, "artifact", "artifact", mock_storage
+        )
 
         logger = MLflowLoggerCallback(
             tracking_uri=self.tracking_uri,
@@ -249,7 +256,9 @@ class MLflowTest(unittest.TestCase):
         clear_env_vars()
         trial_config = {"par1": "a", "par2": "b"}
         mock_storage = MockStorage(LocalFileSystem())
-        trial = MockTrial(trial_config, "trial1", 0, "artifact", "artifact", mock_storage)
+        trial = MockTrial(
+            trial_config, "trial1", 0, "artifact", "artifact", mock_storage
+        )
 
         logger = MLflowLoggerCallback(
             tracking_uri=self.tracking_uri,
@@ -325,12 +334,19 @@ class MLflowTest(unittest.TestCase):
         """Test that artifacts work with remote storage filesystems."""
         clear_env_vars()
         trial_config = {"par1": "a", "par2": "b"}
-        
+
         mock_fs = Mock()
         mock_fs.type_name = "s3"
         mock_storage = MockStorage(mock_fs)
-        
-        trial = MockTrial(trial_config, "trial1", 0, "local_artifact", "s3://bucket/path", mock_storage)
+
+        trial = MockTrial(
+            trial_config,
+            "trial1",
+            0,
+            "local_artifact",
+            "s3://bucket/path",
+            mock_storage,
+        )
 
         logger = MLflowLoggerCallback(
             tracking_uri=self.tracking_uri,
@@ -342,10 +358,11 @@ class MLflowTest(unittest.TestCase):
 
         logger.on_trial_start(iteration=0, trials=[], trial=trial)
         logger.on_trial_complete(0, [], trial)
-        
+
         self.assertTrue(logger.mlflow_util.artifact_saved)
 
         mock_copy_files.assert_called_once()
+
 
 class MLflowUtilTest(unittest.TestCase):
     def setUp(self):

--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -4,10 +4,12 @@ import sys
 import tempfile
 import unittest
 from collections import namedtuple
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, MagicMock, patch
 
 import pytest
 from mlflow.tracking import MlflowClient
+
+from pyarrow.fs import LocalFileSystem
 
 import ray
 from ray._private.dict import flatten_dict
@@ -16,9 +18,12 @@ from ray.air.integrations.mlflow import MLflowLoggerCallback, _NoopModule, setup
 from ray.train.torch import TorchTrainer
 from ray.tune import Tuner
 
+class MockStorage:
+    def __init__(self, storage_filesystem):
+        self.storage_filesystem = storage_filesystem
 
 class MockTrial(
-    namedtuple("MockTrial", ["config", "trial_name", "trial_id", "local_path"])
+    namedtuple("MockTrial", ["config", "trial_name", "trial_id", "local_path", "path", "storage"])
 ):
     def __hash__(self):
         return hash(self.trial_id)
@@ -181,7 +186,8 @@ class MLflowTest(unittest.TestCase):
     def testMlFlowLoggerLogging(self):
         clear_env_vars()
         trial_config = {"par1": "a", "par2": "b"}
-        trial = MockTrial(trial_config, "trial1", 0, "artifact")
+        mock_storage = MockStorage(LocalFileSystem())
+        trial = MockTrial(trial_config, "trial1", 0, "artifact", "artifact", mock_storage)
 
         logger = MLflowLoggerCallback(
             tracking_uri=self.tracking_uri,
@@ -242,7 +248,8 @@ class MLflowTest(unittest.TestCase):
     def testMlFlowLoggerLogging_logAtEnd(self):
         clear_env_vars()
         trial_config = {"par1": "a", "par2": "b"}
-        trial = MockTrial(trial_config, "trial1", 0, "artifact")
+        mock_storage = MockStorage(LocalFileSystem())
+        trial = MockTrial(trial_config, "trial1", 0, "artifact", "artifact", mock_storage)
 
         logger = MLflowLoggerCallback(
             tracking_uri=self.tracking_uri,
@@ -311,6 +318,31 @@ class MLflowTest(unittest.TestCase):
 
         mlflow.log_metrics()
         mlflow.sklearn.save_model(None, "model_directory")
+
+    @patch("ray.air.integrations.mlflow._MLflowLoggerUtil", Mock_MLflowLoggerUtil)
+    def testMlFlowLoggerWithRemoteStorage(self):
+        """Test that artifacts work with remote storage filesystems."""
+        clear_env_vars()
+        trial_config = {"par1": "a", "par2": "b"}
+        
+        mock_fs = Mock()
+        mock_fs.type_name = "s3"
+        mock_storage = MockStorage(mock_fs)
+        
+        trial = MockTrial(trial_config, "trial1", 0, "local_artifact", "s3://bucket/path", mock_storage)
+
+        logger = MLflowLoggerCallback(
+            tracking_uri=self.tracking_uri,
+            registry_uri=self.registry_uri,
+            experiment_name="test_remote",
+            save_artifact=True,
+        )
+        logger.setup()
+
+        logger.on_trial_start(iteration=0, trials=[], trial=trial)
+        logger.on_trial_complete(0, [], trial)
+        
+        self.assertTrue(logger.mlflow_util.artifact_saved)
 
 
 class MLflowUtilTest(unittest.TestCase):

--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -343,7 +343,7 @@ class MLflowTest(unittest.TestCase):
             "trial1",
             0,
             "local_artifact",
-            "s3://bucket/path",
+            "bucket/path",
             mock_storage,
         )
 


### PR DESCRIPTION
## Description

Fixes #46569

In Ray 2.10+, `trial.local_path` points to a temporary staging directory, where `trial.path` points to persistent storage where checkpoints are saved.

The `MLflowLoggerCallback` was using `trial.local_path` to save artifacts, which doesn't include checkpoints. This PR updates it to use `trial.path` instead.

## Related issues

Closes #46569

## Testing

Manually tested with the reproduction script from the issue. Verified that checkpoints now appear in MLflow artifacts after the fix.

**Before the fix:**
- MLflow artifacts: `params.json`, `result.json`, `progress.csv`

**After the fix:**
- MLflow artifacts: `params.json`, `result.json`, `progress.csv`, `checkpoint_000000`, `checkpoint_000001`
