### PR TITLE
[Data] Cleaning `BlockRefBundler` implementation

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -855,7 +855,7 @@ class BlockRefBundler(BaseRefBundler):
 
             # Add bundle to the output buffer so long as either
             #   - Output buffer size is still 0
-            #   - Output buffer doesn't exceeds the `_min_rows_per_bundle` threshold
+            #   - Output buffer doesn't exceed the `_min_rows_per_bundle` threshold
             if (
                 output_buffer_size < self._min_rows_per_bundle
                 or output_buffer_size == 0
@@ -864,6 +864,7 @@ class BlockRefBundler(BaseRefBundler):
                 output_buffer_size += bundle_size
             else:
                 remainder = self._bundle_buffer[idx:]
+                break
 
         self._bundle_buffer = remainder
         self._bundle_buffer_size = sum(

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -651,7 +651,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
 
     def all_inputs_done(self):
         self._block_ref_bundler.done_adding_bundles()
-        if self._block_ref_bundler.has_bundle():
+        while self._block_ref_bundler.has_bundle():
             # Handle any leftover bundles in the bundler.
             (
                 _,
@@ -659,6 +659,8 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
             ) = self._block_ref_bundler.get_next_bundle()
 
             self._add_bundled_input(bundled_input)
+
+        assert self._block_ref_bundler.num_blocks() == 0, "Bundler must be empty"
 
         super().all_inputs_done()
 

--- a/python/ray/data/tests/test_block_ref_bundler.py
+++ b/python/ray/data/tests/test_block_ref_bundler.py
@@ -194,6 +194,47 @@ def test_block_ref_bundler_uniform(
     assert flat_out == list(range(n))
 
 
+def test_block_ref_bundler_get_next_regression():
+    """Test that all remaining bundles are appropriately preserved after `get_next_bundle`.
+    """
+
+    # Create 4 blocks, each with 1 row
+    bundler = BlockRefBundler(min_rows_per_bundle=2)
+    bundles = _make_ref_bundles([[[1]], [[2]], [[3]], [[4]]])
+
+    # Add all bundles at once
+    for b in bundles:
+        bundler.add_bundle(b)
+
+    # Buffer now has 4 rows total
+    assert bundler.num_blocks() == 4
+
+    # First get_next_bundle should return bundles with 2 rows
+    assert bundler.has_bundle()
+    _, out_bundle = bundler.get_next_bundle()
+    assert out_bundle.num_rows() == 2
+    assert _get_bundles(out_bundle) == [[1], [2]]
+
+    # Remainder should have 2 bundles with 2 rows total
+    # BUG: Without the break statement, only 1 bundle (1 row) remains
+    assert bundler.num_blocks() == 2, (
+        f"Expected 2 rows remaining, got {bundler._bundle_buffer_size}. "
+        "This indicates the remainder was overwritten in the loop."
+    )
+
+    # Second get_next_bundle (after finalization) should return remaining bundles
+    bundler.done_adding_bundles()
+
+    assert bundler.has_bundle()
+    _, out_bundle = bundler.get_next_bundle()
+
+    assert out_bundle.num_rows() == 2
+    assert _get_bundles(out_bundle) == [[3], [4]]
+
+    # Buffer should now be empty
+    assert bundler.num_blocks() == 0
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_block_ref_bundler.py
+++ b/python/ray/data/tests/test_block_ref_bundler.py
@@ -195,8 +195,7 @@ def test_block_ref_bundler_uniform(
 
 
 def test_block_ref_bundler_get_next_regression():
-    """Test that all remaining bundles are appropriately preserved after `get_next_bundle`.
-    """
+    """Test that all remaining bundles are appropriately preserved after `get_next_bundle`."""
 
     # Create 4 blocks, each with 1 row
     bundler = BlockRefBundler(min_rows_per_bundle=2)


### PR DESCRIPTION
## Description

Currently, `BlockRefBundler` implementation actually looks really scary -- if considered in isolation and not how it's actually used, it's actually looking like it could be dropping inputs.

In reality, it's being used inside `MapOperator` like following 

```
self._block_ref_bundler.add_bundle(refs)
# ...

if self._block_ref_bundler.has_bundle():
    (input_refs, bundled_input) = self._block_ref_bundler.get_next_bundle()

```

This in turn guarantees that no more than 1 incomplete bundle can be in the bundler at any given moment.

Nevertheless, i'm addressing this madneess:

 - Fixed `BlockRefBundler` to guarantee no inputs could be dropped under any usage scenario
 - Added test to verify

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
