### PR TITLE
[Data] Add descriptive error when using `local://` paths with a zero-resource head node

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -118,6 +118,9 @@ from ray.data.context import DataContext
 from ray.data.datasource import Connection, Datasink, FilenameProvider, SaveMode
 from ray.data.datasource.datasink import WriteResult, _gen_datasink_write_result
 from ray.data.datasource.file_datasink import _FileDatasink
+from ray.data.datasource.util import (
+    _validate_head_node_resources_for_local_scheduling,
+)
 from ray.data.datatype import DataType
 from ray.data.iterator import DataIterator
 from ray.data.random_access_dataset import RandomAccessDataset
@@ -5506,6 +5509,11 @@ class Dataset:
             ray_remote_args["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
                 ray.get_runtime_context().get_node_id(),
                 soft=False,
+            )
+
+            _validate_head_node_resources_for_local_scheduling(
+                ray_remote_args,
+                op_description="Writing to a local:// path",
             )
 
         plan = self._plan.copy()

--- a/python/ray/data/datasource/util.py
+++ b/python/ray/data/datasource/util.py
@@ -1,5 +1,6 @@
-from typing import Iterable
+from typing import Any, Dict, Iterable, Tuple
 
+import ray
 from ray.data.block import Block
 
 
@@ -26,3 +27,83 @@ def _iter_sliced_blocks(
             sliced_block = accessor.slice(0, remaining_rows, copy=True)
             yield sliced_block
             break
+
+
+def _validate_head_node_resources_for_local_scheduling(
+    ray_remote_args: Dict[str, Any],
+    *,
+    op_description: str,
+    default_num_cpus: int = 1,
+    default_num_gpus: int = 0,
+    default_memory: int = 0,
+) -> None:
+    """Ensure the head node has enough resources before pinning work there.
+
+    Local paths (``local://``) and other driver-local I/O schedule tasks on the
+    head node via ``NodeAffinitySchedulingStrategy``. If the head node was
+    intentionally started with zero logical resources (a common practice to
+    avoid OOMs), those tasks become unschedulable. Detect this upfront and
+    raise a clear error with remediation steps.
+    """
+
+    # Ray defaults to reserving 1 CPU per task when num_cpus isn't provided.
+    num_cpus = ray_remote_args.get("num_cpus", default_num_cpus)
+    num_gpus = ray_remote_args.get("num_gpus", default_num_gpus)
+    memory = ray_remote_args.get("memory", default_memory)
+
+    # Resource keys follow the Resources map of ray.nodes() (e.g., CPU, GPU, memory).
+    required_resources: Dict[str, float] = {}
+    required_resources["CPU"] = float(num_cpus)
+    required_resources["GPU"] = float(num_gpus)
+    required_resources["memory"] = float(memory)
+
+    # Include any additional custom resources requested.
+    custom_resources = ray_remote_args.get("resources", {})
+    for name, amount in custom_resources.items():
+        if amount is None:
+            continue
+        try:
+            amount = float(amount)
+        except (TypeError, ValueError) as err:
+            raise ValueError(f"Invalid resource amount for '{name}': {amount}") from err
+        required_resources[name] = amount
+
+    head_node = next(
+        (
+            node
+            for node in ray.nodes()
+            if node.get("Alive")
+            and "node:__internal_head__" in node.get("Resources", {})
+        ),
+        None,
+    )
+    if not head_node:
+        # The head node metadata is unavailable (e.g., during shutdown). Fall back
+        # to the default behavior and let Ray surface its own error.
+        return
+
+    # Build a map of required vs available resources on the head node.
+    head_resources: Dict[str, float] = head_node.get("Resources", {})
+    # Map: resource name -> (required, available).
+    insufficient: Dict[str, Tuple[float, float]] = {}
+    for name, req in required_resources.items():
+        avail = head_resources.get(name, 0.0)
+        if avail < req:
+            insufficient[name] = (req, avail)
+
+    # If nothing is below the required amount, we are good to proceed.
+    if not insufficient:
+        return
+
+    details = "; ".join(
+        f"{name} required {req:g} but head has {avail:g}"
+        for name, (req, avail) in insufficient.items()
+    )
+
+    raise ValueError(
+        f"{op_description} must run on the head node (e.g., for local:// paths), "
+        f"but the head node doesn't have enough resources: {details}. "
+        "Add resources to the head node, switch to a shared filesystem instead "
+        "of local://, or set the resource requests on this operation to 0 "
+        "(for example, num_cpus=0) so it can run without head resources."
+    )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -103,6 +103,9 @@ from ray.data.datasource.file_meta_provider import (
     DefaultFileMetadataProvider,
 )
 from ray.data.datasource.partitioning import Partitioning
+from ray.data.datasource.util import (
+    _validate_head_node_resources_for_local_scheduling,
+)
 from ray.types import ObjectRef
 from ray.util.annotations import DeveloperAPI, PublicAPI
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
@@ -439,6 +442,12 @@ def read_datasource(
         memory,
         ray_remote_args,
     )
+
+    if not datasource.supports_distributed_reads:
+        _validate_head_node_resources_for_local_scheduling(
+            ray_remote_args,
+            op_description="Reading from a local:// path",
+        )
 
     datasource_or_legacy_reader = _get_datasource_or_legacy_reader(
         datasource,

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -18,6 +18,9 @@ from ray.data._internal.execution.interfaces.ref_bundle import (
 )
 from ray.data.block import BlockAccessor
 from ray.data.dataset import Dataset, MaterializedDataset
+from ray.data.datasource.util import (
+    _validate_head_node_resources_for_local_scheduling,
+)
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.conftest import (
     CoreExecutionMetrics,
@@ -741,6 +744,21 @@ def test_read_write_local_node(ray_start_cluster):
         ds = ray.data.read_parquet(
             ["example://iris.parquet", local_path + "/test1.parquet"]
         ).materialize()
+
+
+def test_validate_head_node_resources_zero_head_cpu(ray_start_cluster):
+
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=0)
+    cluster.wait_for_nodes()
+
+    ray.shutdown()
+    ray.init(address=cluster.address)
+
+    with pytest.raises(ValueError, match=r"head node doesn't have enough resources"):
+        _validate_head_node_resources_for_local_scheduling(
+            {}, op_description="read local"
+        )
 
 
 class FlakyCSVDatasource(CSVDatasource):


### PR DESCRIPTION
## Description
When users read from or write to `local://` paths, Ray Data schedules these tasks on the head node using `NodeAffinitySchedulingStrategy(head_node_id, soft=False)`. If the head node has no logical resources (a recommended best practice to avoid head OOM), these tasks become unschedulable and produce a confusing error:

```
ray.exceptions.TaskUnschedulableError: The task is not schedulable: The node specified
via NodeAffinitySchedulingStrategy doesn't exist any more or is infeasible, and soft=False
was specified. task_id=..., task_name=Write
```
Add a clear, actionable error message that explains why the operation failed and how to resolve it.

## Solution
- Add a helper `_validate_head_node_resources_for_local_scheduling` that inspects the final merged `ray_remote_args` and raises a clear, actionable `ValueError` when an operation pinned to the head node requires resources the head node lacks
- Call this validation after `merge_resources_to_ray_remote_args` for head-pinned reads `read_datasource` and writes `Dataset.write_datasink`, so explicit user settings (e.g., `num_cpus=0`) are respected
- Include regression tests that reproduce the zero-resource head-node + `local://` scenario and assert the descriptive error is raised

@tianyi-ge 

## Related issues
Closes #60698
