### PR TITLE
[core] Add Actor Transformation Logic for Locally Loaded Classes

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -603,7 +603,7 @@ class FunctionActorManager:
             if isinstance(object, ray.actor.ActorClass):
                 return object.__ray_metadata__.modified_class
             else:
-                return object
+                return ray.actor._modify_class(object)
         else:
             return None
 


### PR DESCRIPTION
## Description
This PR ensures that during an actor creation task,  when a worker process loads an actor class locally, the raw class is correctly transformed into modified class using `_modify_class`

Previously, the following conditions led to incorrect behavior:
1. By using `actor_class = ray.remote(Class)` instead of `@ray.remote` decorator, this kept the original class and the new `ActorClass` was stored in a separate variable.  
2. When `load_code_from_local` was set to `True`, worker process would attempt to load class metadata (such as available methods) using the original class's `__name__` and `__module__` attributes from the local file system during actor creation.

Consequently, during the actor creation task, when the worker process tried to load the ActorClass locally using `__name__`, it would incorrectly load the original class instead of the ActorClass

## Related issues
Closes https://github.com/ray-project/ray/issues/59259

## Additional information
### Verification: Attribute Comparison
To confirm the locally loaded class, I added a trace to `FunctionActorManager.load_actor_class` in `python/ray/_private/function_manager.py`
``` python
class FunctionActorManager
    def load_actor_class(self, job_id, actor_creation_function_descriptor):
        # ...
        actor_class = self._load_actor_class_from_local(
                    actor_creation_function_descriptor
                )
        print(dir(actor_class))
```

#### Log Output (Before Fix)
Previously, the loaded class is the original class, which doesn't have `__ray_actor_class__`, `__ray_call__`, `__ray_ready__`, `__ray_terminate__`
```
['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', 'increment']
```
#### Log Output (After Fix)
With the change to apply `_modify_class`, the logs show the correctly transformed class with `__ray_actor_class__`, `__ray_call__`, `__ray_ready__`, `__ray_terminate__`
```
['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__ray_actor_class__', '__ray_call__', '__ray_ready__', '__ray_terminate__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', 'increment']
```

### Verification: The Script in https://github.com/ray-project/ray/issues/59259
After applying the fix, the script mentioned in the https://github.com/ray-project/ray/issues/59259 executes successfully:
```
(.venv) ryanchen@Ryans-MacBook-Air-2 ray % python repro.py
2026-02-03 22:37:16,095 INFO worker.py:1998 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265 
/Users/ryanchen/github/ray/python/ray/_private/worker.py:2046: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
10
```
#### Root Cause


Setting `code_search_path` in `ray.init()` and using `@ray.remote` instead of `ray.remote(Class)` satisfies the above conditions that cause the worker process to import the **raw class**. This raw class lacks the `__ray_actor_class__`, `__ray_call__`, `__ray_ready__`, and `__ray_terminate__` methods. Because `experimental_compile()` needs to call `__ray_call__`—which does not exist in the current worker class information cache—the execution fails.