### PR TITLE
refactor(ci): Unique env name for images

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -13,9 +13,9 @@ steps:
       - "3.10"
       - "3.12"
     env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_build-py{{matrix}}
-      IMAGE_TO: corebuild-py{{matrix}}
       PYTHON: "{{matrix}}"
+      BASE_TYPE: "build"
+      BUILD_VARIANT: "build"
     depends_on: oss-ci-base_build-multipy
 
   - name: coregpubuild-multipy
@@ -24,10 +24,10 @@ steps:
     tags: cibase
     depends_on: oss-ci-base_gpu-multipy
     env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_gpu-py{{matrix}}
-      IMAGE_TO: coregpubuild-py{{matrix}}
-      RAYCI_IS_GPU_BUILD: "true"
       PYTHON: "{{matrix}}"
+      BASE_TYPE: "gpu"
+      BUILD_VARIANT: "gpubuild"
+      RAYCI_IS_GPU_BUILD: "true"
     matrix:
       - "3.10"
 

--- a/.buildkite/llm.rayci.yml
+++ b/.buildkite/llm.rayci.yml
@@ -9,8 +9,9 @@ steps:
     depends_on:
       - oss-ci-base_build-multipy
     env:
-      IMAGE_TO: "llmbuild"
-      IMAGE_FROM: "cr.ray.io/rayproject/oss-ci-base_build-py3.11"
+      PYTHON: "3.11"
+      BASE_TYPE: "build"
+      BUILD_VARIANT: "build"
       RAY_CUDA_CODE: "cpu"
     tags: cibase
 
@@ -19,8 +20,9 @@ steps:
     depends_on:
       - oss-ci-base_cu128-multipy
     env:
-      IMAGE_TO: "llmgpubuild"
-      IMAGE_FROM: "cr.ray.io/rayproject/oss-ci-base_cu128-py3.11"
+      PYTHON: "3.11"
+      BASE_TYPE: "cu128"
+      BUILD_VARIANT: "gpubuild"
       RAY_CUDA_CODE: "cu128"
     tags: cibase
 

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -21,9 +21,9 @@ steps:
     wanda: ci/docker/ml.build.wanda.yaml
     depends_on: oss-ci-base_ml-multipy
     env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_ml-py{{matrix}}
-      IMAGE_TO: mlbuild-py{{matrix}}
       PYTHON: "{{matrix}}"
+      BASE_TYPE: "ml"
+      BUILD_VARIANT: "build"
       RAYCI_IS_GPU_BUILD: "false"
     matrix:
       - "3.10"
@@ -39,9 +39,9 @@ steps:
     wanda: ci/docker/ml.build.wanda.yaml
     depends_on: oss-ci-base_gpu-multipy
     env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_gpu-py{{matrix}}
-      IMAGE_TO: mlgpubuild-py{{matrix}}
       PYTHON: "{{matrix}}"
+      BASE_TYPE: "gpu"
+      BUILD_VARIANT: "gpubuild"
       RAYCI_IS_GPU_BUILD: "true"
     matrix:
       - "3.10"

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -9,8 +9,9 @@ steps:
     wanda: ci/docker/rllib.build.wanda.yaml
     depends_on: oss-ci-base_ml-multipy
     env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_ml-py3.10
-      IMAGE_TO: rllibbuild-py3.10
+      PYTHON: "3.10"
+      BASE_TYPE: "ml"
+      BUILD_VARIANT: "build"
       RAYCI_IS_GPU_BUILD: "false"
     tags: cibase
 
@@ -18,8 +19,9 @@ steps:
     wanda: ci/docker/rllib.build.wanda.yaml
     depends_on: oss-ci-base_gpu-multipy
     env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_gpu-py3.10
-      IMAGE_TO: rllibgpubuild-py3.10
+      PYTHON: "3.10"
+      BASE_TYPE: "gpu"
+      BUILD_VARIANT: "gpubuild"
       RAYCI_IS_GPU_BUILD: "true"
     tags: cibase
 

--- a/ci/docker/core.build.wanda.yaml
+++ b/ci/docker/core.build.wanda.yaml
@@ -1,5 +1,5 @@
-name: "$IMAGE_TO"
-froms: ["$IMAGE_FROM"]
+name: "core$BUILD_VARIANT-py$PYTHON"
+froms: ["cr.ray.io/rayproject/oss-ci-base_$BASE_TYPE-py$PYTHON"]
 dockerfile: ci/docker/core.build.Dockerfile
 srcs:
   - ci/env/install-dependencies.sh
@@ -9,7 +9,7 @@ srcs:
   - python/requirements/ml/dl-cpu-requirements.txt
   - python/requirements/ml/dl-gpu-requirements.txt
 build_args:
-  - DOCKER_IMAGE_BASE_BUILD=$IMAGE_FROM
+  - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_$BASE_TYPE-py$PYTHON
   - RAYCI_IS_GPU_BUILD
 tags:
-  - cr.ray.io/rayproject/$IMAGE_TO
+  - cr.ray.io/rayproject/core$BUILD_VARIANT-py$PYTHON

--- a/ci/docker/llm.build.wanda.yaml
+++ b/ci/docker/llm.build.wanda.yaml
@@ -1,5 +1,5 @@
-name: "$IMAGE_TO"
-froms: ["$IMAGE_FROM"]
+name: "llm$BUILD_VARIANT"
+froms: ["cr.ray.io/rayproject/oss-ci-base_$BASE_TYPE-py$PYTHON"]
 dockerfile: ci/docker/llm.build.Dockerfile
 srcs:
   - ci/env/install-dependencies.sh
@@ -8,7 +8,7 @@ srcs:
   - python/deplocks/llm/rayllm_test_py311_cpu.lock
   - python/deplocks/llm/rayllm_test_py311_cu128.lock
 tags:
-  - cr.ray.io/rayproject/$IMAGE_TO
+  - cr.ray.io/rayproject/llm$BUILD_VARIANT
 build_args:
-  - DOCKER_IMAGE_BASE_BUILD=$IMAGE_FROM
+  - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_$BASE_TYPE-py$PYTHON
   - RAY_CUDA_CODE=$RAY_CUDA_CODE

--- a/ci/docker/ml.build.wanda.yaml
+++ b/ci/docker/ml.build.wanda.yaml
@@ -1,5 +1,5 @@
-name: "$IMAGE_TO"
-froms: ["$IMAGE_FROM"]
+name: "ml$BUILD_VARIANT-py$PYTHON"
+froms: ["cr.ray.io/rayproject/oss-ci-base_$BASE_TYPE-py$PYTHON"]
 dockerfile: ci/docker/ml.build.Dockerfile
 srcs:
   - ci/env/install-dependencies.sh
@@ -20,8 +20,8 @@ srcs:
   - python/requirements/ml/rllib-requirements.txt
   - python/requirements/ml/rllib-test-requirements.txt
 build_args:
-  - DOCKER_IMAGE_BASE_BUILD=$IMAGE_FROM
+  - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_$BASE_TYPE-py$PYTHON
   - RAYCI_IS_GPU_BUILD
   - PYTHON
 tags:
-  - cr.ray.io/rayproject/$IMAGE_TO
+  - cr.ray.io/rayproject/ml$BUILD_VARIANT-py$PYTHON

--- a/ci/docker/rllib.build.wanda.yaml
+++ b/ci/docker/rllib.build.wanda.yaml
@@ -1,5 +1,5 @@
-name: "$IMAGE_TO"
-froms: ["$IMAGE_FROM"]
+name: "rllib$BUILD_VARIANT-py$PYTHON"
+froms: ["cr.ray.io/rayproject/oss-ci-base_$BASE_TYPE-py$PYTHON"]
 dockerfile: ci/docker/rllib.build.Dockerfile
 srcs:
   - ci/env/install-dependencies.sh
@@ -12,7 +12,7 @@ srcs:
   - python/requirements/ml/rllib-requirements.txt
   - python/requirements/ml/rllib-test-requirements.txt
 build_args:
-  - DOCKER_IMAGE_BASE_BUILD=$IMAGE_FROM
+  - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_$BASE_TYPE-py$PYTHON
   - RAYCI_IS_GPU_BUILD
 tags:
-  - cr.ray.io/rayproject/$IMAGE_TO
+  - cr.ray.io/rayproject/rllib$BUILD_VARIANT-py$PYTHON


### PR DESCRIPTION
Blocker for spec discovery. wanda files raised in the error message all share the same name attribute of name: "$IMAGE_TO", so spec discovery cannot successfully tie a single name -> Wanda Spec. This property is required, since the discovery uses the name to resolve building pre-req images of form cr.ray.io/rayproject/{name}

Topic: refac-names
Signed-off-by: andrew <andrew@anyscale.com>