### PR TITLE
feat(ci): add wandaspecs for local discovery

### DIFF
--- a/.wandaspecs
+++ b/.wandaspecs
@@ -1,0 +1,10 @@
+# Wanda spec discovery configuration.
+#
+# Lists directories (relative to this file) to scan for .wanda.yaml specs.
+# When a spec depends on an image with default prefix cr.ray.io/rayproject/,
+# wanda looks for a matching local spec by name and builds it instead of pulling.
+#
+# Note: In CI mode (-rayci), dependencies are NOT rebuilt - they are assumed
+# to have been built by prior pipeline steps and are pulled from the work repo.
+
+ci/docker/


### PR DESCRIPTION
Pre-req to local wheel+image building using Wanda. This will allow spec discovery to source pre-req images for the wheel.

Topic: wanda-specs
Relative: refac-names
Signed-off-by: andrew <andrew@anyscale.com>