### PR TITLE
feat(build): add build-wheel.sh, ci/build/build_wheel.py scripts for local wheel generation

### DIFF
--- a/build-wheel.sh
+++ b/build-wheel.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# build-wheel.sh - Build Ray manylinux wheels locally
+#
+# This is a thin wrapper that delegates to ci/build/build_wheel.py via uv.
+# Run with --help for usage information.
+
+set -euo pipefail
+
+# Check for uv
+if ! command -v uv &>/dev/null; then
+    echo "Error: uv is required. Install from: https://docs.astral.sh/uv/" >&2
+    exit 1
+fi
+
+RAY_ROOT="$(git rev-parse --show-toplevel)"
+RAYCI_VERSION=$(cat "$RAY_ROOT/.rayciversion")
+
+# Detect platform for wheel tag
+case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64)  WHEEL_PLATFORM="macosx_12_0_arm64" ;;
+    Linux-x86_64)  WHEEL_PLATFORM="manylinux_2_17_x86_64" ;;
+    Linux-aarch64) WHEEL_PLATFORM="manylinux_2_17_aarch64" ;;
+    *) echo "Error: Unsupported platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+RAYMAKE_URL="https://github.com/ray-project/rayci/releases/download/v${RAYCI_VERSION}/raymake-${RAYCI_VERSION}-py3-none-${WHEEL_PLATFORM}.whl"
+
+exec uv run --with "$RAYMAKE_URL" "$RAY_ROOT/ci/build/build_wheel.py" "$@"

--- a/ci/build/BUILD.bazel
+++ b/ci/build/BUILD.bazel
@@ -16,3 +16,20 @@ py_test(
     ],
     deps = [":container_resource_utils"],
 )
+
+py_library(
+    name = "build_wheel",
+    srcs = ["build_wheel.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "build_wheel_test",
+    size = "small",
+    srcs = ["build_wheel_test.py"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [":build_wheel"],
+)

--- a/ci/build/build_wheel.py
+++ b/ci/build/build_wheel.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""
+Build Ray manylinux wheels locally using raymake.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Generator
+
+# Configuration Constants
+SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12", "3.13")
+RAYMAKE_SPEC = "ci/docker/ray-wheel.wanda.yaml"
+
+
+class _ColorFormatter(logging.Formatter):
+    BLUE, RED, RESET = "\033[34m", "\033[31m", "\033[0m"
+    COLORS = {logging.INFO: BLUE, logging.ERROR: RED}
+
+    def format(self, record: logging.LogRecord) -> str:
+        color = self.COLORS.get(record.levelno, "")
+        return f"{color}[{record.levelname}]{self.RESET} {record.getMessage()}"
+
+
+_handler = logging.StreamHandler()
+_handler.setFormatter(_ColorFormatter())
+log = logging.getLogger("raybuild")
+log.addHandler(_handler)
+log.setLevel(logging.INFO)
+
+
+class BuildError(Exception):
+    """Raised when a build operation fails."""
+
+
+@dataclass(frozen=True)
+class BuildConfig:
+    python_version: str
+    output_dir: Path
+    ray_root: Path
+    hosttype: str
+    arch_suffix: str
+    raymake_version: str
+    manylinux_version: str
+    commit: str
+
+    @property
+    def image_name(self) -> str:
+        return (
+            f"cr.ray.io/rayproject/ray-wheel-py{self.python_version}{self.arch_suffix}"
+        )
+
+    @property
+    def build_env(self) -> dict[str, str]:
+        return {
+            "PYTHON_VERSION": self.python_version,
+            "MANYLINUX_VERSION": self.manylinux_version,
+            "HOSTTYPE": self.hosttype,
+            "ARCH_SUFFIX": self.arch_suffix,
+            "BUILDKITE_COMMIT": self.commit,
+            "IS_LOCAL_BUILD": "true",
+        }
+
+    @classmethod
+    def from_env(cls, python_version: str, output_dir: str) -> BuildConfig:
+        root = cls._find_ray_root()
+        host, suffix = cls._detect_platform()
+
+        # Extract metadata
+        rayciversion_path = root / ".rayciversion"
+        if not rayciversion_path.exists():
+            raise BuildError(f"Missing {rayciversion_path}")
+        raymake_version = rayciversion_path.read_text().strip()
+        manylinux_version = cls._parse_file(
+            root / "rayci.env", r'MANYLINUX_VERSION=["\']?([^"\'\s]+)'
+        )
+        commit = cls._get_git_commit(root)
+
+        return cls(
+            python_version=python_version,
+            output_dir=Path(output_dir),
+            ray_root=root,
+            hosttype=host,
+            arch_suffix=suffix,
+            raymake_version=raymake_version,
+            manylinux_version=manylinux_version,
+            commit=commit,
+        )
+
+    @staticmethod
+    def _find_ray_root() -> Path:
+        start = Path(__file__).resolve()
+        for parent in [start, *start.parents]:
+            if (parent / ".rayciversion").exists():
+                return parent
+        if (Path.cwd() / ".rayciversion").exists():
+            return Path.cwd()
+        raise BuildError("Could not find Ray root (missing .rayciversion).")
+
+    @staticmethod
+    def _detect_platform() -> tuple[str, str]:
+        """Return (hosttype, arch_suffix) for current platform."""
+        sys_os = platform.system()
+        m = platform.machine().lower()
+        arch = (
+            "x86_64"
+            if m in ("amd64", "x86_64")
+            else "aarch64"
+            if m in ("arm64", "aarch64")
+            else m
+        )
+
+        mapping = {
+            ("Darwin", "aarch64"): ("aarch64", "-aarch64"),
+            ("Linux", "x86_64"): ("x86_64", ""),
+            ("Linux", "aarch64"): ("aarch64", "-aarch64"),
+        }
+        if (sys_os, arch) not in mapping:
+            raise BuildError(f"Unsupported platform: {sys_os}-{m}")
+        return mapping[(sys_os, arch)]
+
+    @staticmethod
+    def _parse_file(path: Path, pattern: str) -> str:
+        if not path.exists():
+            raise BuildError(f"Missing {path}")
+        match = re.search(pattern, path.read_text(), re.M)
+        if not match:
+            raise BuildError(f"Pattern {pattern} not found in {path}")
+        return match.group(1).strip()
+
+    @staticmethod
+    def _get_git_commit(root: Path) -> str:
+        try:
+            return subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except Exception:
+            return "unknown"
+
+
+class WheelBuilder:
+    def __init__(self, config: BuildConfig):
+        self.config = config
+
+    @contextmanager
+    def _container(self) -> Generator[str, None, None]:
+        # Dummy command used for images without CMD/ENTRYPOINT
+        res = subprocess.run(
+            ["docker", "create", self.config.image_name, "true"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        cid = res.stdout.strip()
+        try:
+            yield cid
+        finally:
+            subprocess.run(["docker", "rm", "-f", cid], capture_output=True)
+
+    def build(self) -> list[Path]:
+        if not shutil.which("raymake"):
+            raise BuildError("raymake not found. Run via ./build-wheel.sh")
+
+        log.info("Build configuration:")
+        summary = {
+            "Python": self.config.python_version,
+            "Arch": self.config.hosttype,
+            "Commit": self.config.commit,
+            "Raymake": self.config.raymake_version,
+            "Manylinux": self.config.manylinux_version,
+            "Ray Root": self.config.ray_root,
+            "Output Dir": self.config.output_dir,
+        }
+        print("-" * 50)
+        for k, v in summary.items():
+            print(f"{k:<12}: {v}")
+        print("-" * 50)
+
+        cmd = ["raymake", str(self.config.ray_root / RAYMAKE_SPEC)]
+
+        log.info(f"Running raymake: {RAYMAKE_SPEC}")
+        log.info(f"Build environment: {self.config.build_env}")
+        proc = subprocess.Popen(cmd, env={**os.environ, **self.config.build_env})
+        try:
+            if proc.wait() != 0:
+                raise BuildError("raymake failed")
+        except KeyboardInterrupt:
+            # We don't need to do much here; the child received the SIGINT too.
+            # Just wait a moment for it to exit to avoid the "No such process" error.
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            raise
+
+        self.config.output_dir.mkdir(parents=True, exist_ok=True)
+        # TODO(andrew-anyscale): Artifact extraction will soon be built-in to
+        # raymake. For now, we extract the wheels manually using docker.
+        with self._container() as cid:
+            log.info("Extracting wheels...")
+            # List files via docker export (image has no shell for ls)
+            export_proc = subprocess.Popen(
+                ["docker", "export", cid], stdout=subprocess.PIPE
+            )
+            tar_list = subprocess.run(
+                ["tar", "-tf", "-"],
+                stdin=export_proc.stdout,
+                capture_output=True,
+                text=True,
+            )
+            export_proc.stdout.close()
+            export_rc = export_proc.wait()
+            if export_rc != 0:
+                raise BuildError(f"docker export failed with exit code {export_rc}")
+            if tar_list.returncode != 0:
+                raise BuildError(f"tar listing failed: {tar_list.stderr}")
+
+            # Filter for wheel files at root level (tar may output ./file or file)
+            wheel_files = [
+                f.lstrip("./")
+                for f in tar_list.stdout.splitlines()
+                if f.endswith(".whl") and "/" not in f.lstrip("./")
+            ]
+            if not wheel_files:
+                raise BuildError("No wheel files found in image")
+
+            extracted = []
+            for f in wheel_files:
+                dest = self.config.output_dir / f
+                if dest.exists():
+                    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+                    bak = dest.with_suffix(f".whl.backup-{ts}")
+                    log.info(f"Backing up existing {dest.name} -> {bak.name}")
+                    dest.replace(bak)
+                subprocess.run(["docker", "cp", f"{cid}:/{f}", str(dest)], check=True)
+                extracted.append(dest)
+            return extracted
+
+
+def main():
+    # Override the program name to match the root script name
+    parser = argparse.ArgumentParser(
+        prog="./build-wheel.sh",
+        description="Build Ray wheel using a manylinux base image.",
+        epilog="Example: ./build-wheel.sh 3.13",
+    )
+
+    parser.add_argument(
+        "python_version",
+        choices=SUPPORTED_PYTHON_VERSIONS,
+        metavar="PYTHON_VERSION",
+        help="Target Python version: %(choices)s",
+    )
+
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        default=".whl",
+        help="Directory to store wheels (default: .whl)",
+    )
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
+    args = parser.parse_args()
+
+    try:
+        builder = WheelBuilder(
+            BuildConfig.from_env(args.python_version, args.output_dir)
+        )
+        wheels = builder.build()
+        log.info(f"Success! saved to {args.output_dir}")
+        log.info("To install, run:")
+        for w in wheels:
+            print(f"  pip install {w}")
+    except BuildError as e:
+        log.error(e)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build/build_wheel_test.py
+++ b/ci/build/build_wheel_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Tests for build_wheel.py"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from build_wheel import (
+    BuildConfig,
+    BuildError,
+)
+
+
+class TestBuildConfigPlatformDetection(unittest.TestCase):
+    """Test _detect_platform() returns correct values for supported platforms."""
+
+    def test_darwin_arm64(self):
+        with mock.patch(
+            "build_wheel.platform.system", return_value="Darwin"
+        ), mock.patch("build_wheel.platform.machine", return_value="arm64"):
+            hosttype, arch_suffix = BuildConfig._detect_platform()
+        self.assertEqual((hosttype, arch_suffix), ("aarch64", "-aarch64"))
+
+    def test_linux_x86_64(self):
+        with mock.patch(
+            "build_wheel.platform.system", return_value="Linux"
+        ), mock.patch("build_wheel.platform.machine", return_value="x86_64"):
+            hosttype, arch_suffix = BuildConfig._detect_platform()
+        self.assertEqual((hosttype, arch_suffix), ("x86_64", ""))
+
+    def test_linux_aarch64(self):
+        with mock.patch(
+            "build_wheel.platform.system", return_value="Linux"
+        ), mock.patch("build_wheel.platform.machine", return_value="aarch64"):
+            hosttype, arch_suffix = BuildConfig._detect_platform()
+        self.assertEqual((hosttype, arch_suffix), ("aarch64", "-aarch64"))
+
+    def test_unsupported_platform_raises(self):
+        with mock.patch(
+            "build_wheel.platform.system", return_value="Windows"
+        ), mock.patch("build_wheel.platform.machine", return_value="AMD64"):
+            with self.assertRaises(BuildError) as ctx:
+                BuildConfig._detect_platform()
+        self.assertIn("Unsupported platform", str(ctx.exception))
+
+
+class TestBuildConfigParseFile(unittest.TestCase):
+    """Test _parse_file() extracts values from config files."""
+
+    def test_parses_quoted_value(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write('MANYLINUX_VERSION="260128.221a193"\n')
+            f.flush()
+            result = BuildConfig._parse_file(
+                Path(f.name), r'MANYLINUX_VERSION=["\']?([^"\'\s]+)'
+            )
+        self.assertEqual(result, "260128.221a193")
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(BuildError) as ctx:
+            BuildConfig._parse_file(Path("/nonexistent"), r".*")
+        self.assertIn("Missing", str(ctx.exception))
+
+    def test_missing_pattern_raises(self):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("OTHER_VAR=value\n")
+            f.flush()
+            with self.assertRaises(BuildError) as ctx:
+                BuildConfig._parse_file(Path(f.name), r"MISSING_VAR=(\w+)")
+        self.assertIn("not found in", str(ctx.exception))
+
+
+class TestBuildConfigProperties(unittest.TestCase):
+    """Test computed properties of BuildConfig."""
+
+    def setUp(self):
+        self.config = BuildConfig(
+            python_version="3.11",
+            output_dir=Path(".whl"),
+            ray_root=Path("/fake/ray"),
+            hosttype="x86_64",
+            arch_suffix="",
+            raymake_version="0.28.0",
+            manylinux_version="260128.221a193",
+            commit="abc1234",
+        )
+
+    def test_image_name_x86(self):
+        self.assertEqual(
+            self.config.image_name, "cr.ray.io/rayproject/ray-wheel-py3.11"
+        )
+
+    def test_image_name_aarch64(self):
+        config = BuildConfig(
+            python_version="3.12",
+            output_dir=Path(".whl"),
+            ray_root=Path("/fake/ray"),
+            hosttype="aarch64",
+            arch_suffix="-aarch64",
+            raymake_version="0.28.0",
+            manylinux_version="260128.221a193",
+            commit="abc1234",
+        )
+        self.assertEqual(
+            config.image_name, "cr.ray.io/rayproject/ray-wheel-py3.12-aarch64"
+        )
+
+    def test_build_env_contains_required_vars(self):
+        env = self.config.build_env
+        self.assertEqual(env["PYTHON_VERSION"], "3.11")
+        self.assertEqual(env["MANYLINUX_VERSION"], "260128.221a193")
+        self.assertEqual(env["HOSTTYPE"], "x86_64")
+        self.assertEqual(env["ARCH_SUFFIX"], "")
+        self.assertEqual(env["BUILDKITE_COMMIT"], "abc1234")
+        self.assertEqual(env["IS_LOCAL_BUILD"], "true")
+
+
+class TestBuildConfigFromEnv(unittest.TestCase):
+    """Test BuildConfig.from_env() factory method."""
+
+    def test_from_env_creates_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ray_root = Path(tmpdir)
+            (ray_root / ".rayciversion").write_text("0.28.0")
+            (ray_root / "rayci.env").write_text('MANYLINUX_VERSION="260128.221a193"')
+
+            with mock.patch(
+                "build_wheel.platform.system", return_value="Linux"
+            ), mock.patch(
+                "build_wheel.platform.machine", return_value="x86_64"
+            ), mock.patch.object(
+                BuildConfig, "_find_ray_root", return_value=ray_root
+            ), mock.patch.object(
+                BuildConfig, "_get_git_commit", return_value="abc1234"
+            ):
+                config = BuildConfig.from_env("3.11", ".whl")
+
+            self.assertEqual(config.python_version, "3.11")
+            self.assertEqual(config.output_dir, Path(".whl"))
+            self.assertEqual(config.hosttype, "x86_64")
+            self.assertEqual(config.raymake_version, "0.28.0")
+            self.assertEqual(config.manylinux_version, "260128.221a193")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds new top-level script for building wheel across Py3.10->3.13. Script handles environment setup, using `uvx` to facilitate using the raymake tool from the releases section of Rayci.

Post-build, wheel is extracted from the Docker image defaulting to .whl/ directory

```shell
$ ./build-wheel.sh
usage: ./build-wheel.sh [-h] PYTHON_VERSION [output_dir]

Build Ray manylinux wheels locally.

positional arguments:
  PYTHON_VERSION  Target Python version: 3.10, 3.11,
                  3.12, 3.13
  output_dir      Directory to store wheels (default:
                  .whl)

options:
  -h, --help      show this help message and exit

Example: ./build-wheel.sh 3.13
```

Topic: local-wheel-script

Signed-off-by: andrew <andrew@anyscale.com>