### PR TITLE
[train] Add Elastic Training Capability for Ray Train

### DIFF
--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -182,6 +182,22 @@ py_test(
 )
 
 py_test(
+    name = "test_elastic_scaling_policy",
+    size = "small",
+    srcs = ["tests/test_elastic_scaling_policy.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_data_integration",
     size = "large",
     srcs = ["tests/test_data_integration.py"],

--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -198,6 +198,22 @@ py_test(
 )
 
 py_test(
+    name = "test_elastic_e2e",
+    size = "medium",
+    srcs = ["tests/test_elastic_e2e.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_data_integration",
     size = "large",
     srcs = ["tests/test_data_integration.py"],

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -74,6 +74,12 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
     ) -> Dict[str, float]:
         """Return the resources reserved for training, so that Data can exclude
         these resources logically from its available pool."""
+        if scaling_config.elasticity_enabled:
+            # If Train is running with a variable number of workers,
+            # we can't provide a fixed number of resources to exclude.
+            # Instead, Train and Data should coordinate via the autoscaling
+            # coordinator to allocate resources dynamically.
+            return {}
         return scaling_config.total_resources
 
     def _get_coordinator_actors(

--- a/python/ray/train/v2/_internal/execution/scaling_policy/__init__.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/__init__.py
@@ -1,5 +1,6 @@
 # isort: off
 from .scaling_policy import ScalingDecision, ScalingPolicy, NoopDecision, ResizeDecision
+from .elastic import ElasticScalingPolicy
 from .fixed import FixedScalingPolicy
 from .factory import create_scaling_policy
 
@@ -8,6 +9,7 @@ from .factory import create_scaling_policy
 
 __all__ = [
     "ScalingPolicy",
+    "ElasticScalingPolicy",
     "FixedScalingPolicy",
     "ScalingDecision",
     "NoopDecision",

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -211,7 +211,8 @@ class ElasticScalingPolicy(ScalingPolicy):
                     resources=[resources_per_worker] * max_workers,
                     expire_after_s=self.AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
                     priority=ResourceRequestPriority.HIGH,
-                )
+                ),
+                timeout=self.AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
             )
             self._latest_autoscaling_request_time = time_monotonic()
         except Exception:

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -241,7 +241,7 @@ class ElasticScalingPolicy(ScalingPolicy):
                 ),
                 timeout=self.AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
             )
-        except (ray.exceptions.GetTimeoutError, ray.exceptions.RayError):
+        except Exception:
             msg = (
                 f"Failed to get allocated resources for {self._requester_id}."
                 " Will not resize the worker group."

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -1,0 +1,288 @@
+import logging
+import uuid
+from functools import cached_property
+from typing import Dict, List, Optional
+
+import ray
+from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+    ResourceDict,
+    ResourceRequestPriority,
+    get_or_create_autoscaling_coordinator,
+)
+from ray.train.v2._internal.execution.context import TrainRunContext
+from ray.train.v2._internal.execution.scaling_policy import (
+    NoopDecision,
+    ResizeDecision,
+    ScalingDecision,
+    ScalingPolicy,
+)
+from ray.train.v2._internal.execution.worker_group import (
+    WorkerGroupPollStatus,
+    WorkerGroupState,
+)
+from ray.train.v2._internal.util import time_monotonic
+from ray.train.v2.api.config import ScalingConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticScalingPolicy(ScalingPolicy):
+
+    # The time in seconds after which an autoscaling request will expire.
+    AUTOSCALING_REQUESTS_EXPIRE_TIME_S = 180
+    # Minimum interval in seconds between two consecutive autoscaling requests.
+    AUTOSCALING_REQUESTS_INTERVAL_S = 20
+    # Timeout in seconds for getting the result of a call to the AutoscalingCoordinator.
+    AUTOSCALING_REQUESTS_GET_TIMEOUT_S = 5
+    # Minimum interval in seconds between querying the AutoscalingCoordinator for allocated resources.
+    GET_ALLOCATED_RESOURCES_INTERVAL_S = 1
+    # Minimum interval in seconds between logging warnings about insufficient workers.
+    INSUFFICIENT_WORKERS_WARNING_INTERVAL_S = 30
+
+    def __init__(self, scaling_config: ScalingConfig):
+        super().__init__(scaling_config)
+
+        self._latest_monitor_time = float("-inf")
+        # Requester ID for AutoscalingCoordinator.
+        # TODO: define the UUID in TrainController.
+        self._requester_id = "train-" + uuid.uuid4().hex
+        self._latest_autoscaling_request_time = float("-inf")
+        self._latest_insufficient_workers_warning_time = float("-inf")
+        self._latest_allocated_resources_query_time = float("-inf")
+        self._latest_allocated_resources: Optional[List[ResourceDict]] = None
+
+    def _count_possible_workers(
+        self, allocated_resources: List[Dict[str, float]]
+    ) -> int:
+        """Count the number of workers that can be started/restarted with the given
+        the list of node resources. The returned number is capped at the maximum
+        number of workers.
+        """
+        # TODO: Fractional resources do not work well here.
+        single_worker_resources = self.scaling_config._resources_per_worker_not_none
+        total_num_workers = 0
+
+        # If workers require no resources, we can run as many as we want.
+        if sum(single_worker_resources.values()) == 0:
+            return self.scaling_config.max_workers
+
+        for resources in allocated_resources:
+            num_workers = min(
+                [
+                    resources.get(resource, 0.0) // single_worker_resources[resource]
+                    for resource in single_worker_resources
+                    if single_worker_resources[resource] > 0
+                ]
+            )
+            total_num_workers += num_workers
+
+        return min(int(total_num_workers), self.scaling_config.max_workers)
+
+    def _get_resize_decision(self, num_workers: int) -> ResizeDecision:
+        return ResizeDecision(
+            num_workers=num_workers,
+            resources_per_worker=self.scaling_config._resources_per_worker_not_none,
+        )
+
+    def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
+        self._maybe_send_resource_request()
+
+        allocated_resources = self._get_allocated_resources()
+        if allocated_resources is None:
+            return NoopDecision()
+
+        num_workers = self._count_possible_workers(allocated_resources)
+
+        if num_workers < self.scaling_config.min_workers:
+            now = time_monotonic()
+            # Only log this warning periodically to avoid spamming logs
+            if (
+                now - self._latest_insufficient_workers_warning_time
+                >= self.INSUFFICIENT_WORKERS_WARNING_INTERVAL_S
+            ):
+                logger.info(
+                    f"Detected ready resources for {num_workers} workers "
+                    "in the cluster. "
+                    "Deciding NOT to start/restart training due to the number of workers "
+                    "falling below the minimum "
+                    f"(min_workers={self.scaling_config.min_workers})."
+                )
+                self._latest_insufficient_workers_warning_time = now
+            return NoopDecision()
+
+        logger.info(
+            f"Detected ready resources for {num_workers} workers "
+            "in the cluster. "
+            "Deciding to start/restart training with this worker group size."
+        )
+        return self._get_resize_decision(num_workers)
+
+    def make_decision_for_running_worker_group(
+        self,
+        worker_group_state: WorkerGroupState,
+        worker_group_status: WorkerGroupPollStatus,
+    ) -> ScalingDecision:
+        self._maybe_send_resource_request()
+
+        # Ensure that we don't make resizing decisions too frequently.
+        # The latest restart time and the latest monitor time (whichever is later)
+        # determine the time of the next resize consideration.
+        latest_consideration_time = max(
+            worker_group_state.start_time, self._latest_monitor_time
+        )
+
+        now = time_monotonic()
+        time_since_latest_consideration = now - latest_consideration_time
+        if (
+            time_since_latest_consideration
+            < self.scaling_config.elastic_resize_monitor_interval_s
+        ):
+            logger.debug(
+                "Skipping resize decision due to the latest resizing consideration "
+                "happening too recently: "
+                "%.2f seconds < ScalingConfig(elastic_resize_monitor_interval_s=%.2f seconds).",
+                time_since_latest_consideration,
+                self.scaling_config.elastic_resize_monitor_interval_s,
+            )
+            return NoopDecision()
+
+        self._latest_monitor_time = now
+
+        allocated_resources = self._get_allocated_resources()
+        if allocated_resources is None:
+            return NoopDecision()
+
+        num_workers = self._count_possible_workers(allocated_resources)
+
+        if num_workers == worker_group_state.num_workers:
+            logger.info(
+                "Did not detect any changes in the cluster resources. "
+                "Training will continue with the same worker group size "
+                f"({num_workers})."
+            )
+            return NoopDecision()
+        elif num_workers < self.scaling_config.min_workers:
+            # This covers an edge case where allocated resources decrease to less
+            # than the minimum number of workers.
+            # This situation is rare, since cluster downsizing typically involves
+            # worker failures. However, this check is still useful to fully
+            # avoid entering an invalid state with fewer workers than the minimum.
+            return NoopDecision()
+
+        logger.info(
+            "Detected changes in the cluster resources. "
+            "Deciding to resize the worker group from "
+            f"{worker_group_state.num_workers} -> {num_workers} workers."
+        )
+        return self._get_resize_decision(num_workers)
+
+    # ---------------------------------------------------
+    # Methods for interacting with AutoscalingCoordinator
+    # ---------------------------------------------------
+
+    @cached_property
+    def _autoscaling_coordinator(self):
+        return get_or_create_autoscaling_coordinator()
+
+    def _maybe_send_resource_request(self):
+        """Send a resource request to AutoscalingCoordinator,
+        if AUTOSCALING_REQUESTS_INTERVAL_S has passed since the last send."""
+        now = time_monotonic()
+        if (
+            now - self._latest_autoscaling_request_time
+            < self.AUTOSCALING_REQUESTS_INTERVAL_S
+        ):
+            return
+
+        resources_per_worker = self.scaling_config._resources_per_worker_not_none
+        max_workers = self.scaling_config.max_workers
+        try:
+            ray.get(
+                self._autoscaling_coordinator.request_resources.remote(
+                    requester_id=self._requester_id,
+                    resources=[resources_per_worker] * max_workers,
+                    expire_after_s=self.AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+                    priority=ResourceRequestPriority.HIGH,
+                )
+            )
+            self._latest_autoscaling_request_time = time_monotonic()
+        except Exception:
+            msg = (
+                f"Failed to send resource request for {self._requester_id}."
+                " If this only happens transiently during network partition or"
+                " CPU being overloaded, it's safe to ignore this error."
+                " If this error persists, file a GitHub issue."
+            )
+            logger.warning(msg, exc_info=True)
+
+    def _get_allocated_resources(self) -> Optional[List[ResourceDict]]:
+        """Get allocated resources from AutoscalingCoordinator.
+        Return None if there is an error."""
+        now = time_monotonic()
+        time_since_last_call = now - self._latest_allocated_resources_query_time
+
+        if time_since_last_call < self.GET_ALLOCATED_RESOURCES_INTERVAL_S:
+            return self._latest_allocated_resources
+
+        allocated_resources = None
+        try:
+            allocated_resources = ray.get(
+                self._autoscaling_coordinator.get_allocated_resources.remote(
+                    self._requester_id
+                ),
+                timeout=self.AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+        except Exception:
+            msg = (
+                f"Failed to get allocated resources for {self._requester_id}."
+                " Will not resize the worker group."
+                " If this only happens transiently during network partition or"
+                " CPU being overloaded, it's safe to ignore this error."
+                " If this error persists, file a GitHub issue."
+            )
+            logger.warning(msg, exc_info=True)
+        finally:
+            self._latest_allocated_resources_query_time = time_monotonic()
+            self._latest_allocated_resources = allocated_resources
+            return self._latest_allocated_resources
+
+    def _cancel_resource_request(self):
+        """Cancel the resource request to AutoscalingCoordinator."""
+        try:
+            ray.get(
+                self._autoscaling_coordinator.cancel_request.remote(
+                    requester_id=self._requester_id,
+                ),
+                timeout=self.AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+        except Exception:
+            msg = (
+                f"Failed to cancel resource request for {self._requester_id}."
+                " The request will still expire after the timeout of"
+                f" {self.AUTOSCALING_REQUESTS_EXPIRE_TIME_S} seconds."
+            )
+            logger.warning(msg, exc_info=True)
+
+    # --------------------------
+    # ControllerCallback
+    # --------------------------
+
+    def after_controller_start(self, train_run_context: TrainRunContext):
+        """Send cluster autoscaling requests when the control loop starts."""
+        resources_per_worker = self.scaling_config._resources_per_worker_not_none
+        max_workers = self.scaling_config.max_workers
+        logger.info(
+            "Requesting resources to fit the maximum number of workers: "
+            f"{resources_per_worker} * {max_workers}"
+        )
+        self._maybe_send_resource_request()
+
+    def before_controller_shutdown(self):
+        """Clear the autoscaling request eagerly when the control loop shuts down.
+        So that cluster can scale down more quickly before the request timeout.
+        """
+        self._cancel_resource_request()
+
+    def before_controller_abort(self):
+        """Cancel the autoscaling request when the controller is aborted."""
+        self._cancel_resource_request()

--- a/python/ray/train/v2/_internal/execution/scaling_policy/factory.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/factory.py
@@ -1,4 +1,5 @@
 from ray.train.v2._internal.execution.scaling_policy import (
+    ElasticScalingPolicy,
     FixedScalingPolicy,
     ScalingPolicy,
 )
@@ -10,4 +11,6 @@ def create_scaling_policy(scaling_config: ScalingConfig) -> ScalingPolicy:
 
     Defaults to the `FixedScalingPolicy` implementation.
     """
+    if scaling_config.elasticity_enabled:
+        return ElasticScalingPolicy(scaling_config=scaling_config)
     return FixedScalingPolicy(scaling_config=scaling_config)

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -75,13 +75,15 @@ class ScalingConfig(ScalingConfigV1):
     """
 
     num_workers: Union[int, Tuple[int, int]] = 1
-    elastic_resize_monitor_interval_s: float = 60.0
     trainer_resources: Optional[dict] = None
     label_selector: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None
 
     # Accelerator specific fields.
     use_tpu: Union[bool] = False
     topology: Optional[str] = None
+
+    # Elasticity specific fields.
+    elastic_resize_monitor_interval_s: float = 60.0
 
     def __post_init__(self):
         if self.trainer_resources is not None:
@@ -115,7 +117,7 @@ class ScalingConfig(ScalingConfigV1):
         ):
             raise ValueError(
                 "If `label_selector` is a list, it must be the same length as "
-                "`max_workers`."
+                "`max_workers` (or `num_workers` when fixed)."
             )
 
         if self.num_workers == 0:

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
 
 import pyarrow.fs
 
@@ -37,7 +37,11 @@ class ScalingConfig(ScalingConfigV1):
             reserved by each worker can be overridden with the
             ``resources_per_worker`` argument. If the number of workers is 0,
             the training function will run in local mode, meaning the training
-            function runs in the same process.
+            function runs in the same process. To enable elasticity, provide a
+            ``(min_workers, max_workers)`` tuple of ints.
+        elastic_resize_monitor_interval_s: While the worker group is healthy,
+            consider resizing the worker group every
+            ``elastic_resize_monitor_interval_s`` seconds.
         use_gpu: If True, training will be done on GPUs (1 per worker).
             Defaults to False. The number of GPUs reserved by each
             worker can be overridden with the ``resources_per_worker``
@@ -70,6 +74,8 @@ class ScalingConfig(ScalingConfigV1):
             when `use_tpu` is True and `num_workers` is greater than 1.
     """
 
+    num_workers: Union[int, Tuple[int, int]] = 1
+    elastic_resize_monitor_interval_s: float = 60.0
     trainer_resources: Optional[dict] = None
     label_selector: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None
 
@@ -81,15 +87,35 @@ class ScalingConfig(ScalingConfigV1):
         if self.trainer_resources is not None:
             raise DeprecationWarning(TRAINER_RESOURCES_DEPRECATION_MESSAGE)
 
+        is_fixed = isinstance(self.num_workers, int)
+        is_elastic = (
+            isinstance(self.num_workers, tuple)
+            and len(self.num_workers) == 2
+            and all(isinstance(x, int) for x in self.num_workers)
+        )
+        if not (is_fixed or is_elastic):
+            raise ValueError(
+                "ScalingConfig(num_workers) must be an int or a tuple of two ints."
+            )
+        if self.elastic_resize_monitor_interval_s < 0:
+            raise ValueError(
+                "ScalingConfig(elastic_resize_monitor_interval_s) must be non-negative."
+            )
+        if self.min_workers > self.max_workers:
+            raise ValueError(
+                f"Invalid ScalingConfig(num_workers={self.num_workers}): "
+                f"min_workers={self.min_workers} must be <= max_workers={self.max_workers}."
+            )
+
         self._validate_tpu_config()
 
         if (
             isinstance(self.label_selector, list)
-            and isinstance(self.num_workers, int)
-            and len(self.label_selector) != self.num_workers
+            and len(self.label_selector) != self.max_workers
         ):
             raise ValueError(
-                "If `label_selector` is a list, it must be the same length as `num_workers`."
+                "If `label_selector` is a list, it must be the same length as "
+                "`max_workers`."
             )
 
         if self.num_workers == 0:
@@ -101,8 +127,29 @@ class ScalingConfig(ScalingConfigV1):
 
         super().__post_init__()
 
+    @property
+    def elasticity_enabled(self) -> bool:
+        return isinstance(self.num_workers, tuple)
+
+    @property
+    def min_workers(self) -> int:
+        return (
+            self.num_workers
+            if isinstance(self.num_workers, int)
+            else self.num_workers[0]
+        )
+
+    @property
+    def max_workers(self) -> int:
+        return (
+            self.num_workers
+            if isinstance(self.num_workers, int)
+            else self.num_workers[1]
+        )
+
     def _validate_tpu_config(self):
         """Validates configuration specifically for TPU usage."""
+        max_workers = self.max_workers
 
         if self.use_gpu and self.use_tpu:
             raise ValueError("Cannot specify both `use_gpu=True` and `use_tpu=True`.")
@@ -125,7 +172,7 @@ class ScalingConfig(ScalingConfigV1):
                 "`resources_per_worker."
             )
 
-        if self.num_workers > 1:
+        if max_workers > 1:
             if not self.topology:
                 raise ValueError(
                     "`topology` must be specified in ScalingConfig when `use_tpu=True` "
@@ -158,7 +205,7 @@ class ScalingConfig(ScalingConfigV1):
                     f"topology={self.topology}. Error: {e}"
                 )
 
-            if workers_per_slice > 0 and self.num_workers % workers_per_slice != 0:
+            if workers_per_slice > 0 and max_workers % workers_per_slice != 0:
                 raise ValueError(
                     f"The configured `num_workers` ({self.num_workers}) must be a "
                     f"multiple of {workers_per_slice} for the specified topology ({self.topology}). "

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -154,6 +154,19 @@ class ScalingConfig(ScalingConfigV1):
             else self.num_workers[1]
         )
 
+    @property
+    def total_resources(self):
+        """Map of total resources required for training.
+
+        For elastic configs, this returns an upper bound based on max_workers.
+        """
+        total_resource_map = dict(self._trainer_resources_not_none)
+        for k, value in self._resources_per_worker_not_none.items():
+            total_resource_map[k] = total_resource_map.get(k, 0.0) + (
+                value * self.max_workers
+            )
+        return total_resource_map
+
     def _validate_tpu_config(self):
         """Validates configuration specifically for TPU usage."""
         max_workers = self.max_workers

--- a/python/ray/train/v2/api/config.py
+++ b/python/ray/train/v2/api/config.py
@@ -103,6 +103,11 @@ class ScalingConfig(ScalingConfigV1):
             raise ValueError(
                 "ScalingConfig(elastic_resize_monitor_interval_s) must be non-negative."
             )
+        if self.min_workers < 0:
+            raise ValueError(
+                f"Invalid ScalingConfig(num_workers={self.num_workers}): "
+                "Number of workers cannot be negative."
+            )
         if self.min_workers > self.max_workers:
             raise ValueError(
                 f"Invalid ScalingConfig(num_workers={self.num_workers}): "
@@ -210,6 +215,13 @@ class ScalingConfig(ScalingConfigV1):
             if workers_per_slice > 0 and max_workers % workers_per_slice != 0:
                 raise ValueError(
                     f"The configured `num_workers` ({self.num_workers}) must be a "
+                    f"multiple of {workers_per_slice} for the specified topology ({self.topology}). "
+                    "TPU workloads typically require symmetric resource distribution "
+                    "across all slices to function correctly."
+                )
+            if workers_per_slice > 0 and self.min_workers % workers_per_slice != 0:
+                raise ValueError(
+                    f"The configured `min_workers` ({self.min_workers}) must be a "
                     f"multiple of {workers_per_slice} for the specified topology ({self.topology}). "
                     "TPU workloads typically require symmetric resource distribution "
                     "across all slices to function correctly."

--- a/python/ray/train/v2/tests/test_config.py
+++ b/python/ray/train/v2/tests/test_config.py
@@ -52,6 +52,17 @@ def test_scaling_config_accelerator_type():
     }
 
 
+def test_scaling_config_tpu_min_workers_multiple():
+    with pytest.raises(ValueError, match="min_workers"):
+        ScalingConfig(
+            num_workers=(1, 2),
+            use_tpu=True,
+            topology="2x2x2",
+            accelerator_type="TPU-V4",
+            resources_per_worker={"TPU": 4},
+        )
+
+
 def test_storage_filesystem_repr():
     """Test for https://github.com/ray-project/ray/pull/40851"""
     config = RunConfig(storage_filesystem=pyarrow.fs.S3FileSystem())

--- a/python/ray/train/v2/tests/test_config.py
+++ b/python/ray/train/v2/tests/test_config.py
@@ -17,9 +17,23 @@ def test_scaling_config_validation():
 
     with pytest.raises(
         ValueError,
-        match="If `label_selector` is a list, it must be the same length as `num_workers`",
+        match=(
+            "If `label_selector` is a list, it must be the same length as "
+            "`max_workers`"
+        ),
     ):
         ScalingConfig(num_workers=2, label_selector=[{"subcluster": "my_subcluster"}])
+    with pytest.raises(
+        ValueError,
+        match=(
+            "If `label_selector` is a list, it must be the same length as "
+            "`max_workers`"
+        ),
+    ):
+        ScalingConfig(
+            num_workers=(2, 3),
+            label_selector=[{"subcluster": "a"}, {"subcluster": "b"}],
+        )
 
 
 def test_scaling_config_accelerator_type():

--- a/python/ray/train/v2/tests/test_elastic_e2e.py
+++ b/python/ray/train/v2/tests/test_elastic_e2e.py
@@ -1,0 +1,206 @@
+import sys
+import time
+from pathlib import Path
+from typing import List
+
+import pytest
+
+import ray
+import ray.train
+from ray.cluster_utils import Cluster
+from ray.train.tests.util import create_dict_checkpoint, load_dict_checkpoint
+from ray.train.v2._internal.constants import HEALTH_CHECK_INTERVAL_S_ENV_VAR
+from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
+
+
+@pytest.fixture
+def cluster():
+    cluster = Cluster(initialize_head=True, head_node_args=dict(num_cpus=0))
+    cluster.wait_for_nodes()
+    ray.init(
+        address=cluster.address,
+        runtime_env={"working_dir": str(Path(__file__).parent)},
+    )
+    yield cluster
+    ray.shutdown()
+    cluster.shutdown()
+
+
+def train_fn(config: dict):
+    train_context = ray.train.get_context()
+    rank = train_context.get_world_rank()
+
+    start_epoch = 1
+    checkpoint = ray.train.get_checkpoint()
+    min_world_size = None
+    max_world_size = None
+    if checkpoint:
+        checkpoint_data = load_dict_checkpoint(checkpoint)
+        start_epoch = checkpoint_data["epoch"] + 1
+        min_world_size = checkpoint_data.get("min_world_size")
+        max_world_size = checkpoint_data.get("max_world_size")
+        if rank == 0:
+            print("Restoring from epoch: ", start_epoch)
+
+    for epoch in range(start_epoch, config.get("num_epochs", 60) + 1):
+        world_size = train_context.get_world_size()
+        if min_world_size is None:
+            min_world_size = world_size
+        if max_world_size is None:
+            max_world_size = world_size
+        min_world_size = min(min_world_size, world_size)
+        max_world_size = max(max_world_size, world_size)
+        # TODO: This test injects errors by "killing nodes," which ungracefully
+        # kills processes. This means that any backlog in the checkpoint queue
+        # will not be flushed to the controller.
+        # This means that the checkpoint populated on restore may not be
+        # the most recent one.
+        # Set the poll interval < health check interval to reduce the
+        # backlog size to mitigate the issue.
+        time.sleep(2 * config.get("health_check_interval_s", 1))
+
+        with create_dict_checkpoint(
+            {
+                "epoch": epoch,
+                "min_world_size": min_world_size,
+                "max_world_size": max_world_size,
+            }
+        ) as checkpoint:
+            ray.train.report(
+                {
+                    "epoch": epoch,
+                    "world_size": world_size,
+                    "min_world_size": min_world_size,
+                    "max_world_size": max_world_size,
+                },
+                checkpoint=checkpoint if rank == 0 else None,
+                checkpoint_dir_name=f"checkpoint-epoch={epoch}",
+            )
+        if rank == 0:
+            print("Finished epoch: ", epoch)
+
+
+def test_elastic_training(monkeypatch, tmp_path, cluster):
+    """End to end test for elastic training.
+
+    This test covers:
+    * Elastic startup (0 resources -> min resources)
+    * Elastic scale up while running (min resources -> max resources)
+    * Elastic scale down due to failure while running
+    * Checkpointing + restoration
+    * Preemption failure handling
+    """
+    unit_time_s = 0.1
+    health_check_interval_s = unit_time_s
+    elastic_resize_monitor_interval_s = unit_time_s * 10
+    num_epochs = 30
+
+    monkeypatch.setenv(HEALTH_CHECK_INTERVAL_S_ENV_VAR, str(health_check_interval_s))
+
+    @ray.remote(num_cpus=0)
+    def run_training():
+        trainer = DataParallelTrainer(
+            train_fn,
+            train_loop_config={
+                "num_epochs": num_epochs,
+                "health_check_interval_s": health_check_interval_s,
+            },
+            scaling_config=ray.train.ScalingConfig(
+                num_workers=(4, 32),
+                use_gpu=True,
+                elastic_resize_monitor_interval_s=elastic_resize_monitor_interval_s,
+            ),
+            run_config=ray.train.RunConfig(
+                storage_path=str(tmp_path),
+                checkpoint_config=ray.train.CheckpointConfig(num_to_keep=2),
+                # NOTE: The outer test script will inject 2 node failures.
+                failure_config=ray.train.FailureConfig(max_failures=2),
+            ),
+        )
+        return trainer.fit()
+
+    run_training_future = run_training.remote()
+
+    start = time.time()
+    ALL_NODES = []
+
+    def print_status(message):
+        elapsed = time.time() - start
+        print()
+        print("-" * 80)
+        cluster_resources = {
+            resource: value
+            for resource, value in ray.cluster_resources().items()
+            if resource in ("CPU", "GPU")
+        }
+        print(f"[elapsed={elapsed:.1f}s] {cluster_resources=}")
+        print(message)
+        print("-" * 80)
+        print()
+
+    def sleep(num_units):
+        time.sleep(unit_time_s * num_units)
+
+    def add_nodes(gpus: List[int]) -> List:
+        added_nodes = []
+        for num_gpus in gpus:
+            node = cluster.add_node(num_gpus=num_gpus, wait=False)
+            added_nodes.append(node)
+
+        print_status(f"Added {len(gpus)} node(s) with num_gpus: {gpus}")
+        cluster.wait_for_nodes()
+        return added_nodes
+
+    def remove_nodes(nodes: List):
+        for node in nodes:
+            cluster.remove_node(node)
+
+        cluster.wait_for_nodes()
+        print_status(f"Removed nodes: {nodes}")
+
+    # Wait a bit before adding resources.
+    print_status("Waiting for training to start...")
+    sleep(8)
+
+    # Add a node with 4 GPUs
+    ALL_NODES.extend(add_nodes([4]))
+
+    # Wait a bit before adding more resources.
+    sleep(8)
+    print("Adding 4 GPU node.")
+    ALL_NODES.extend(add_nodes([4]))
+    sleep(1)
+    ALL_NODES.extend(add_nodes([4]))
+    # Should not upscale here due to the elastic resize monitor interval.
+
+    # Should upscale to 12 during this sleep.
+    sleep(20)
+
+    # Kill a node.
+    remove_nodes([ALL_NODES.pop(0)])
+    sleep(12)
+
+    # Kill all worker nodes.
+    remove_nodes(ALL_NODES)
+    ALL_NODES = []
+
+    sleep(8)
+    ALL_NODES.extend(add_nodes(gpus=[1] * 16))
+
+    sleep(12)
+    # 4 extra GPUs shouldn't be used.
+    ALL_NODES.extend(add_nodes(gpus=[4] * 4 + [1] * 4))
+
+    result: ray.train.Result = ray.get(run_training_future)
+
+    print_status(f"Training finished with result: {result}")
+    assert not result.error
+    assert result.metrics["min_world_size"] >= 4
+    assert result.metrics["max_world_size"] <= 32
+    assert result.metrics["max_world_size"] >= result.metrics["min_world_size"]
+    assert result.checkpoint
+    assert Path(result.checkpoint.path).name == f"checkpoint-epoch={num_epochs}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_elastic_scaling_policy.py
+++ b/python/ray/train/v2/tests/test_elastic_scaling_policy.py
@@ -1,0 +1,423 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from freezegun import freeze_time
+
+from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+    ResourceRequestPriority,
+)
+from ray.train.v2._internal.execution.callback import ControllerCallback
+from ray.train.v2._internal.execution.scaling_policy import NoopDecision, ResizeDecision
+from ray.train.v2._internal.execution.scaling_policy.elastic import (
+    ElasticScalingPolicy,
+)
+from ray.train.v2._internal.execution.worker_group import (
+    WorkerGroupPollStatus,
+    WorkerGroupState,
+    WorkerStatus,
+)
+from ray.train.v2._internal.util import time_monotonic
+from ray.train.v2.api.config import ScalingConfig
+
+
+@pytest.fixture(autouse=True)
+def mock_autoscaling_coordinator(monkeypatch):
+    mock_coordinator = MagicMock()
+    mock_coordinator._allocated_resources = None
+    mock_coordinator.get_allocated_resources.remote = MagicMock(
+        side_effect=lambda _: mock_coordinator._allocated_resources
+    )
+
+    monkeypatch.setattr(
+        ElasticScalingPolicy, "_autoscaling_coordinator", mock_coordinator
+    )
+
+
+@pytest.fixture(autouse=True)
+def patch_ray_get():
+    with patch(
+        "ray.get",
+        side_effect=lambda x, **_: x,
+    ):
+        yield
+
+
+def _get_mock_worker_group_status(num_workers: int) -> WorkerGroupPollStatus:
+    return WorkerGroupPollStatus(
+        worker_statuses={
+            i: WorkerStatus(running=True, error=None) for i in range(num_workers)
+        },
+    )
+
+
+def _get_mock_worker_group_state(
+    num_workers: int, start_time: float
+) -> WorkerGroupState:
+    return WorkerGroupState(
+        start_time=start_time,
+        placement_group_handle=MagicMock(),
+        workers=[MagicMock() for _ in range(num_workers)],
+        sync_actor=MagicMock(),
+    )
+
+
+@patch.object(ElasticScalingPolicy, "GET_ALLOCATED_RESOURCES_INTERVAL_S", 0.0)
+def test_non_running_worker_group_decision():
+    """Test decisions being made when the worker group is initializing/restarting.
+    Ensures that the policy will resize the worker group as soon as resources are available.
+    """
+    min_workers, max_workers = 4, 64
+    resources_per_worker = {"CPU": 8, "GPU": 1}
+
+    scaling_config = ScalingConfig(
+        num_workers=(min_workers, max_workers),
+        resources_per_worker=resources_per_worker,
+        use_gpu=True,
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+    mock_coordinator = policy._autoscaling_coordinator
+
+    # No resources are available at the start
+    decision = policy.make_decision_for_non_running_worker_group()
+    assert isinstance(decision, NoopDecision)
+
+    # Resources for < min workers are available
+    mock_coordinator._allocated_resources = [resources_per_worker] * (min_workers - 1)
+    decision = policy.make_decision_for_non_running_worker_group()
+    assert isinstance(decision, NoopDecision)
+
+    # Resources for >= min workers are available
+    mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+    decision = policy.make_decision_for_non_running_worker_group()
+    assert isinstance(decision, ResizeDecision)
+    assert decision.num_workers == min_workers
+
+    # Resources for >= max workers are available
+    mock_coordinator._allocated_resources = [resources_per_worker] * max_workers
+    decision = policy.make_decision_for_non_running_worker_group()
+    assert isinstance(decision, ResizeDecision)
+    assert decision.num_workers == max_workers
+
+
+def test_before_controller_abort():
+    """Test that before_controller_abort sends a cancel request to the AutoscalingCoordinator."""
+    resources_per_worker = {"CPU": 4, "GPU": 1}
+    scaling_config = ScalingConfig(
+        num_workers=(2, 4),
+        resources_per_worker=resources_per_worker,
+        use_gpu=True,
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+    mock_coordinator = policy._autoscaling_coordinator
+
+    # Call before_controller_abort and check that cancel_request is called with the requester_id
+    policy.before_controller_abort()
+    mock_coordinator.cancel_request.remote.assert_called_once_with(
+        requester_id=policy._requester_id
+    )
+
+
+def test_get_allocated_resources_interval():
+    """Tests that remote calls to the AutoscalingCoordinator are spaced out by a minimum time interval."""
+    min_workers, max_workers = 4, 64
+    resources_per_worker = {"CPU": 8, "GPU": 1}
+    get_allocated_resources_interval_s = (
+        ElasticScalingPolicy.GET_ALLOCATED_RESOURCES_INTERVAL_S
+    )
+
+    scaling_config = ScalingConfig(
+        num_workers=(min_workers, max_workers),
+        resources_per_worker=resources_per_worker,
+        use_gpu=True,
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+    mock_coordinator = policy._autoscaling_coordinator
+
+    with freeze_time() as frozen_time:
+        # No resources are available at the start
+        allocated_resources = policy._get_allocated_resources()
+        assert allocated_resources is None
+
+        # Resources for < min workers are available
+        frozen_time.tick(get_allocated_resources_interval_s)
+        mock_coordinator._allocated_resources = [resources_per_worker] * (
+            min_workers - 1
+        )
+        allocated_resources = policy._get_allocated_resources()
+        assert allocated_resources == [resources_per_worker] * (min_workers - 1)
+
+        # Resources for >= min workers are available, but get_allocated_resources interval
+        # has not yet passed.
+        mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+        allocated_resources = policy._get_allocated_resources()
+        assert allocated_resources == [resources_per_worker] * (min_workers - 1)
+
+        # Resources for >= min workers are available and the get_allocated_resources
+        # interval has passed.
+        frozen_time.tick(get_allocated_resources_interval_s)
+        mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+        allocated_resources = policy._get_allocated_resources()
+        assert allocated_resources == [resources_per_worker] * min_workers
+
+        # Resources for >= max workers are available but the get_allocated_resources
+        # interval has not yet passed.
+        mock_coordinator._allocated_resources = [resources_per_worker] * max_workers
+        allocated_resources = policy._get_allocated_resources()
+        assert allocated_resources == [resources_per_worker] * min_workers
+
+        # Resources for >= max workers are available and the get_allocated_resources
+        # interval has passed.
+        frozen_time.tick(get_allocated_resources_interval_s)
+        allocated_resources = policy._get_allocated_resources()
+        assert allocated_resources == [resources_per_worker] * max_workers
+
+
+@patch.object(ElasticScalingPolicy, "GET_ALLOCATED_RESOURCES_INTERVAL_S", 0.0)
+def test_running_worker_group_decision():
+    """Test decisions being made when the worker group is running.
+    Ensures that the policy will resize the worker group when there is a change
+    in available resources.
+    """
+    min_workers, max_workers = 4, 64
+    resources_per_worker = {"CPU": 8, "GPU": 1}
+
+    scaling_config = ScalingConfig(
+        num_workers=(min_workers, max_workers),
+        resources_per_worker=resources_per_worker,
+        use_gpu=True,
+        # NOTE: This test just asserts the policy decisions, not the monitor interval.
+        elastic_resize_monitor_interval_s=0.0,
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+    mock_coordinator = policy._autoscaling_coordinator
+
+    # The worker group just started
+    worker_group_state = _get_mock_worker_group_state(min_workers, time_monotonic())
+    worker_group_status = _get_mock_worker_group_status(min_workers)
+
+    # No change in resources
+    mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+    decision = policy.make_decision_for_running_worker_group(
+        worker_group_state=worker_group_state,
+        worker_group_status=worker_group_status,
+    )
+    assert isinstance(decision, NoopDecision)
+
+    # Resources for < min workers are available
+    mock_coordinator._allocated_resources = [resources_per_worker] * (min_workers - 1)
+    decision = policy.make_decision_for_running_worker_group(
+        worker_group_state=worker_group_state,
+        worker_group_status=worker_group_status,
+    )
+    assert isinstance(decision, NoopDecision)
+
+    # More resources are available.
+    mock_coordinator._allocated_resources = [resources_per_worker] * max_workers
+    decision = policy.make_decision_for_running_worker_group(
+        worker_group_state=worker_group_state,
+        worker_group_status=worker_group_status,
+    )
+    assert isinstance(decision, ResizeDecision)
+    assert decision.num_workers == max_workers
+
+
+def test_monitor_recently_started_worker_group():
+    """Test monitor decisions being made when the worker group is running.
+    Ensures that resizing decisions are not made too soon after the worker group starts.
+    """
+    min_workers, max_workers = 4, 64
+    monitor_interval_s = 60
+    resources_per_worker = {"CPU": 8, "GPU": 1}
+
+    scaling_config = ScalingConfig(
+        num_workers=(min_workers, max_workers),
+        resources_per_worker=resources_per_worker,
+        use_gpu=True,
+        elastic_resize_monitor_interval_s=monitor_interval_s,
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+    mock_coordinator = policy._autoscaling_coordinator
+
+    with freeze_time() as frozen_time:
+        # The worker group just started
+        worker_group_state = _get_mock_worker_group_state(min_workers, time_monotonic())
+        worker_group_status = _get_mock_worker_group_status(min_workers)
+
+        # Advance time partway through the monitor interval
+        frozen_time.tick(delta=monitor_interval_s / 2)
+
+        # Even though there are new resources available, we should not resize yet
+        # because the monitor interval has not passed since
+        mock_coordinator._allocated_resources = [resources_per_worker] * (
+            max_workers - 1
+        )
+
+        assert isinstance(
+            policy.make_decision_for_running_worker_group(
+                worker_group_state=worker_group_state,
+                worker_group_status=worker_group_status,
+            ),
+            NoopDecision,
+        )
+
+        frozen_time.tick(delta=monitor_interval_s / 2)
+
+        # The monitor interval has passed, should detect resources and resize
+        decision = policy.make_decision_for_running_worker_group(
+            worker_group_state=worker_group_state,
+            worker_group_status=worker_group_status,
+        )
+        assert isinstance(decision, ResizeDecision)
+        assert decision.num_workers == max_workers - 1
+
+
+def test_monitor_long_running_worker_group():
+    """Test monitor decisions being made when the worker group is running.
+    Ensures that the resizing considerations are not made too frequently.
+    """
+    min_workers, max_workers = 4, 64
+    monitor_interval_s = 60
+    resources_per_worker = {"CPU": 8, "GPU": 1}
+
+    scaling_config = ScalingConfig(
+        num_workers=(min_workers, max_workers),
+        resources_per_worker=resources_per_worker,
+        use_gpu=True,
+        elastic_resize_monitor_interval_s=monitor_interval_s,
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+    mock_coordinator = policy._autoscaling_coordinator
+
+    with freeze_time() as frozen_time:
+        worker_group_state = _get_mock_worker_group_state(min_workers, time_monotonic())
+        worker_group_status = _get_mock_worker_group_status(min_workers)
+        mock_coordinator._allocated_resources = [resources_per_worker] * min_workers
+
+        # The worker group has been running for a while at the same size
+        frozen_time.tick(monitor_interval_s * 60)
+
+        # Consider resizing.
+        decision = policy.make_decision_for_running_worker_group(
+            worker_group_state=worker_group_state,
+            worker_group_status=worker_group_status,
+        )
+        assert isinstance(decision, NoopDecision)
+
+        # We recently considered resizing, so we should wait until the next interval
+        # to consider again --> no-op even if new resources are available
+        mock_coordinator._allocated_resources = [resources_per_worker] * max_workers
+        frozen_time.tick(monitor_interval_s / 2)
+        decision = policy.make_decision_for_running_worker_group(
+            worker_group_state=worker_group_state,
+            worker_group_status=worker_group_status,
+        )
+        assert isinstance(decision, NoopDecision)
+
+        frozen_time.tick(monitor_interval_s / 2)
+        decision = policy.make_decision_for_running_worker_group(
+            worker_group_state=worker_group_state,
+            worker_group_status=worker_group_status,
+        )
+        assert isinstance(decision, ResizeDecision)
+        assert decision.num_workers == max_workers
+
+
+def test_count_possible_workers():
+    """Test counting the number of workers that can be started with
+    available node resources."""
+    resources_per_worker = {"CPU": 8, "GPU": 1}
+    scaling_config = ScalingConfig(
+        num_workers=(1, 8),
+        use_gpu=True,
+        resources_per_worker=resources_per_worker,
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+
+    # No resources
+    assert policy._count_possible_workers([]) == 0
+
+    # Single node
+    assert policy._count_possible_workers([{"CPU": 8, "GPU": 1}]) == 1
+    assert policy._count_possible_workers([{"CPU": 16, "GPU": 2}]) == 2
+    assert policy._count_possible_workers([{"CPU": 16, "GPU": 1}]) == 1
+
+    # Multinode
+    assert policy._count_possible_workers([{"CPU": 7, "GPU": 1}] * 2) == 0
+    assert policy._count_possible_workers([{"CPU": 9, "GPU": 2}] * 8) == 8
+    assert policy._count_possible_workers([{"CPU": 16, "GPU": 2}] * 2) == 4
+    assert policy._count_possible_workers([{"CPU": 8, "GPU": 1}] * 4) == 4
+
+    # If there are excess resources, the number of workers is still capped at max_workers
+    assert policy._count_possible_workers([{"CPU": 16, "GPU": 2}] * 10) == 8
+
+
+def test_count_possible_workers_with_zero_resources():
+    max_workers = 4
+    scaling_config = ScalingConfig(
+        num_workers=(1, max_workers),
+        resources_per_worker={"CPU": 0, "GPU": 0, "memory": 0},
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+
+    assert (
+        policy._count_possible_workers([{"CPU": 1, "GPU": 1, "memory": 1}])
+        == max_workers
+    )
+
+
+def test_request_and_clear():
+    """Tests that the policy makes resource requests and clears the requests."""
+    resources_per_worker = {"CPU": 8, "GPU": 1}
+    policy = ElasticScalingPolicy(
+        scaling_config=ScalingConfig(
+            use_gpu=True, resources_per_worker=resources_per_worker, num_workers=(2, 4)
+        )
+    )
+    assert isinstance(policy, ControllerCallback)
+    mock_coordinator = policy._autoscaling_coordinator
+
+    def assert_resource_request_called_with():
+        nonlocal mock_coordinator
+
+        mock_coordinator.request_resources.remote.assert_called_with(
+            requester_id=policy._requester_id,
+            resources=[resources_per_worker] * 4,
+            expire_after_s=ElasticScalingPolicy.AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+            priority=ResourceRequestPriority.HIGH,
+        )
+
+    with freeze_time() as frozen_time:
+        worker_group_state = _get_mock_worker_group_state(2, time_monotonic())
+        worker_group_status = _get_mock_worker_group_status(2)
+
+        # Test request_resources is called when the controller starts.
+        policy.after_controller_start(train_run_context=MagicMock())
+        assert mock_coordinator.request_resources.remote.call_count == 1
+        assert_resource_request_called_with()
+
+        # Test request_resources is only called in
+        # `make_decision_for_running_worker_group`,
+        # if `AUTOSCALING_REQUESTS_INTERVAL_S` has passed.
+        frozen_time.tick(ElasticScalingPolicy.AUTOSCALING_REQUESTS_INTERVAL_S / 2)
+        policy.make_decision_for_running_worker_group(
+            worker_group_state=worker_group_state,
+            worker_group_status=worker_group_status,
+        )
+        assert mock_coordinator.request_resources.remote.call_count == 1
+
+        frozen_time.tick(ElasticScalingPolicy.AUTOSCALING_REQUESTS_INTERVAL_S / 2)
+        policy.make_decision_for_running_worker_group(
+            worker_group_state=worker_group_state,
+            worker_group_status=worker_group_status,
+        )
+        assert mock_coordinator.request_resources.remote.call_count == 2
+        assert_resource_request_called_with()
+
+    # Test cancel_request is called when the controller is shutting down.
+    policy.before_controller_shutdown()
+    mock_coordinator.cancel_request.remote.assert_called_once()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description
This PR adds the Elastic Training capability in Ray Train.
1. we add a new `ElasticScalingPolicy` that can take `ScalingConfig(num_workers=(2,4))`
2. `ElasticScalingPolicy` talks with `AutoScalingCoordinator` to decide the number of possible workers in the cluster to launch with the worker group.

<img width="1600" height="826" alt="227f8a4c06729567220ca059206248cc" src="https://github.com/user-attachments/assets/a77fbd55-7e08-4a0e-8973-363aecd37f4e" />
3. elastic training will be automatically enabled if user passed in num_workers=(2,4).   
4. added corresponding unit test coverage

## Related issues

## Additional information

Tested on Anyscale platform:

https://console.anyscale-staging.com/cld_kvedZWag2qA8i5BjxUevf5i7/prj_92c7b71w55flm6gv6imv4m6vqg/workspaces/expwrk_ab5kfa4v9ci15t56dbr8rhmks3/train/train/f5fa9fc5f8d94dc0bd7b545876d660ab?workspace-tab=ray-turbo-dashboard&command-history-section=application_logs

<img width="1318" height="612" alt="ee28696c710f21511022a5d0ea9b93b8" src="https://github.com/user-attachments/assets/019cde08-0598-41c6-be21-5f74c98524a2" />

