### PR TITLE
[Doc][LLM]Update LLM documentation links to point to the correct page

### DIFF
--- a/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/03-Online-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads/notebooks/03-Online-Serving.ipynb
@@ -397,7 +397,7 @@
     "- Integrate with [FastAPI and HTTP](https://docs.ray.io/en/latest/serve/http-guide.html).\n",
     "- Set up a [gRPC service](https://docs.ray.io/en/latest/serve/advanced-guides/grpc-guide.html#set-up-a-grpc-service) to build distributed systems and microservices.\n",
     "- Enable [dynamic batching](https://docs.ray.io/en/latest/serve/advanced-guides/dyn-req-batch.html) based on batch size, time, etc.\n",
-    "- Access a suite of [utilities for serving LLMs](https://docs.ray.io/en/latest/serve/llm/serving-llms.html) that are inference-engine agnostic and have batteries-included support for LLM-specific features such as multi-LoRA support\n",
+    "- Access a suite of [utilities for serving LLMs](https://docs.ray.io/en/latest/serve/llm/index.html) that are inference-engine agnostic and have batteries-included support for LLM-specific features such as multi-LoRA support\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/anyscale/multimodal-ai/refs/heads/main/images/ray_serve.png\" width=500>"
    ]

--- a/doc/source/ray-overview/examples/e2e-rag/notebooks/03_Deploy_LLM_with_Ray_Serve.ipynb
+++ b/doc/source/ray-overview/examples/e2e-rag/notebooks/03_Deploy_LLM_with_Ray_Serve.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "The example maintains compatibility with the OpenAI API while leveraging Ray Serve LLM’s powerful features for production-grade deployments.\n",
     "\n",
-    "For more details, see the Ray Serve LLM API documentation: https://docs.ray.io/en/latest/serve/llm/serving-llms.html\n",
+    "For more details, see the Ray Serve LLM API documentation: https://docs.ray.io/en/latest/serve/llm/index.html\n",
     "\n"
    ]
   },
@@ -83,7 +83,7 @@
     "\n",
     "**Load Huggingface gated models:** \n",
     "\n",
-    "Qwen models do not require the Hugging Face token, but some models (such as Llama 3.1 models) may require registration and access.  To use the gated Huggingface models, follow the link: https://docs.ray.io/en/latest/serve/llm/serving-llms.html#how-do-i-use-gated-huggingface-models\n",
+    "Qwen models do not require the Hugging Face token, but some models (such as Llama 3.1 models) may require registration and access.  To use the gated Huggingface models, follow the link: https://docs.ray.io/en/latest/serve/llm/troubleshooting.html#how-do-i-use-gated-huggingface-models\n",
     "\n",
     "**To use other engine arguments from vLLM**\n",
     "\n",
@@ -136,7 +136,7 @@
    "source": [
     "### Tips for Faster Model Downloading / Loading:\n",
     "\n",
-    "1. **For faster model downloading**, you can enable fast download by setting HF_HUB_ENABLE_HF_TRANSFER and installing with `pip install hf_transfer`. Check out: https://docs.ray.io/en/latest/serve/llm/serving-llms.html#why-is-downloading-the-model-so-slow\n",
+    "1. **For faster model downloading**, you can enable fast download by setting HF_HUB_ENABLE_HF_TRANSFER and installing with `pip install hf_transfer`. Check out: https://docs.ray.io/en/latest/serve/llm/troubleshooting.html#why-is-downloading-the-model-so-slow\n",
     "\n",
     "\n",
     "2. **For faster model loading**, you can download model weights to Anyscale’s cluster storage improves cluster startup times and scaling efficiency. For example, we can specify the Qwen model files (around 60GB in size)  stored at: `/mnt/cluster_storage/Qwen/Qwen2.5-32B-Instruct`\n",

--- a/doc/source/ray-overview/examples/e2e-timeseries/e2e_timeseries/03-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-timeseries/e2e_timeseries/03-Serving.ipynb
@@ -29,7 +29,7 @@
     "- Integrate with [FastAPI and HTTP](https://docs.ray.io/en/latest/serve/http-guide.html)\n",
     "- Set up a [gRPC service](https://docs.ray.io/en/latest/serve/advanced-guides/grpc-guide.html#set-up-a-grpc-service) to build distributed systems and microservices\n",
     "- Enable [dynamic batching](https://docs.ray.io/en/latest/serve/advanced-guides/dyn-req-batch.html) based on batch size, time, etc.\n",
-    "- Access a suite of [utilities for serving LLMs](https://docs.ray.io/en/latest/serve/llm/serving-llms.html) that are inference-engine agnostic and have batteries-included support for LLM-specific features such as multi-LoRA support\n",
+    "- Access a suite of [utilities for serving LLMs](https://docs.ray.io/en/latest/serve/llm/index.html) that are inference-engine agnostic and have batteries-included support for LLM-specific features such as multi-LoRA support\n",
     "\n",
     "<img src=\"https://github.com/anyscale/e2e-timeseries/blob/main/images/ray_serve.png?raw=true\" width=600>\n",
     "\n",

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
@@ -33,7 +33,7 @@
     "- Integrate with [FastAPI and HTTP](https://docs.ray.io/en/latest/serve/http-guide.html)\n",
     "- Set up a [gRPC service](https://docs.ray.io/en/latest/serve/advanced-guides/grpc-guide.html#set-up-a-grpc-service) to build distributed systems and microservices\n",
     "- Enable [dynamic batching](https://docs.ray.io/en/latest/serve/advanced-guides/dyn-req-batch.html) based on batch size, time, etc.\n",
-    "- Access a suite of [utilities for serving LLMs](https://docs.ray.io/en/latest/serve/llm/serving-llms.html) that are inference-engine agnostic and have batteries-included support for LLM-specific features such as multi-LoRA support\n",
+    "- Access a suite of [utilities for serving LLMs](https://docs.ray.io/en/latest/serve/llm/index.html) that are inference-engine agnostic and have batteries-included support for LLM-specific features such as multi-LoRA support\n",
     "\n",
     "<img src=\"https://github.com/anyscale/e2e-xgboost/blob/main/images/ray_serve.png?raw=true\" width=600>"
    ]

--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
@@ -34,7 +34,7 @@
     "- Zero-copy GPU data transfer\n",
     "- Composable with preprocessing and postprocessing steps\n",
     "\n",
-    "[`ray.serve.llm`](https://docs.ray.io/en/latest/serve/llm/serving-llms.html):\n",
+    "[`ray.serve.llm`](https://docs.ray.io/en/latest/serve/llm/index.html):\n",
     "- Automatic scaling and load balancing\n",
     "- Unified multi-node multi-model deployment\n",
     "- Multi-LoRA support with shared base models\n",
@@ -1448,7 +1448,7 @@
    "metadata": {},
    "source": [
     "## Online serving\n",
-    "[`Overview`](https://docs.ray.io/en/latest/serve/llm/serving-llms.html) | [`API reference`](https://docs.ray.io/en/latest/serve/api/index.html#llm-api)"
+    "[`Overview`](https://docs.ray.io/en/latest/serve/llm/index.html) | [`API reference`](https://docs.ray.io/en/latest/serve/api/index.html#llm-api)"
    ]
   },
   {
@@ -1624,7 +1624,7 @@
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "💡 See [more examples](https://docs.ray.io/en/latest/serve/llm/serving-llms.html) and the [API reference](https://docs.ray.io/en/latest/serve/llm/api.html) for advanced guides on topics like structured outputs (like JSON), vision LMs, multi-LoRA on shared base models, using other inference engines (like `sglang`), fast model loading, etc.\n",
+    "💡 See [more examples](https://docs.ray.io/en/latest/serve/llm/examples.html) and the [API reference](https://docs.ray.io/en/latest/serve/api/index.html#llm-api) for advanced guides on topics like structured outputs (like JSON), vision LMs, multi-LoRA on shared base models, using other inference engines (like `sglang`), fast model loading, etc.\n",
     "\n",
     "</div>"
    ]

--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
@@ -23,7 +23,7 @@ This tutorial uses the [Ray library](https://github.com/ray-project/ray) to impl
 - Zero-copy GPU data transfer
 - Composable with preprocessing and postprocessing steps
 
-[`ray.serve.llm`](https://docs.ray.io/en/latest/serve/llm/serving-llms.html):
+[`ray.serve.llm`](https://docs.ray.io/en/latest/serve/llm/index.html):
 - Automatic scaling and load balancing
 - Unified multi-node multi-model deployment
 - Multi-LoRA support with shared base models
@@ -924,7 +924,7 @@ Observe the individual steps in the batch inference workload through the Anyscal
 </div>
 
 ## Online serving
-[`Overview`](https://docs.ray.io/en/latest/serve/llm/serving-llms.html) | [`API reference`](https://docs.ray.io/en/latest/serve/api/index.html#llm-api)
+[`Overview`](https://docs.ray.io/en/latest/serve/llm/index.html) | [`API reference`](https://docs.ray.io/en/latest/serve/api/index.html#llm-api)
 
 <img src="https://raw.githubusercontent.com/anyscale/foundational-ray-app/refs/heads/main/images/ray_serve.png" width=600>
 
@@ -1039,7 +1039,7 @@ And of course, you can observe the running service, the deployments, and metrics
 
 <div class="alert alert-info">
 
-💡 See [more examples](https://docs.ray.io/en/latest/serve/llm/serving-llms.html) and the [API reference](https://docs.ray.io/en/latest/serve/llm/api.html) for advanced guides on topics like structured outputs (like JSON), vision LMs, multi-LoRA on shared base models, using other inference engines (like `sglang`), fast model loading, etc.
+💡 See [more examples](https://docs.ray.io/en/latest/serve/llm/examples.html) and the [API reference](https://docs.ray.io/en/latest/serve/api/index.html#llm-api) for advanced guides on topics like structured outputs (like JSON), vision LMs, multi-LoRA on shared base models, using other inference engines (like `sglang`), fast model loading, etc.
 
 </div>
 


### PR DESCRIPTION
## Description
Update LLM documentation links in multiple notebooks and README files to point to the correct page. This change ensures consistency across examples and improves accessibility to the latest API references.

## Related issues
"Closes #60707"
