### PR TITLE
[data] Add read_zarr() to Ray Data

### DIFF
--- a/.vale/styles/config/vocabularies/Data/accept.txt
+++ b/.vale/styles/config/vocabularies/Data/accept.txt
@@ -50,6 +50,7 @@ UDF(s)?
 VLM(s)?
 XGBoost
 YOLO
+[Zz]arr
 [Ss]harding
 [Ss]harded
 [Pp]arameterization(s)?

--- a/doc/source/data/api/loading_data.rst
+++ b/doc/source/data/api/loading_data.rst
@@ -353,6 +353,15 @@ WebDataset
 
    read_webdataset
 
+Zarr
+^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   read_zarr
+
 Partitioning API
 ^^^^^^^^^^^^^^^^
 

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -819,6 +819,20 @@ py_test(
 )
 
 py_test(
+    name = "test_zarr",
+    size = "medium",
+    srcs = ["tests/test_zarr.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_pandas",
     size = "small",
     srcs = ["tests/datasource/test_pandas.py"],

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -79,6 +79,7 @@ from ray.data.read_api import (  # noqa: F401
     read_unity_catalog,
     read_videos,
     read_webdataset,
+    read_zarr,
 )
 
 # Module-level cached global functions for callable classes. It needs to be defined here
@@ -187,6 +188,7 @@ __all__ = [
     "read_unity_catalog",
     "read_videos",
     "read_webdataset",
+    "read_zarr",
     "Preprocessor",
     "TFXReadOptions",
 ]

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -28,6 +28,7 @@ class ZarrDatasource(Datasource):
         paths: Union[str, List[str]],
         storage_options: Optional[Dict[str, Any]] = None,
     ):
+        super().__init__()
         _check_import(self, module="zarr", package="zarr")
         self._paths = [paths] if isinstance(paths, str) else list(paths)
         self._storage_options = storage_options

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -69,7 +69,7 @@ class ZarrDatasource(Datasource):
                 if fi.type != pafs.FileType.File:
                     continue
 
-                rel_path = fi.path[len(store_path):].lstrip("/")
+                rel_path = fi.path[len(store_path) :].lstrip("/")
                 filename = rel_path.split("/")[-1]
 
                 if filename in _METADATA_FILENAMES:
@@ -90,7 +90,9 @@ class ZarrDatasource(Datasource):
 
             for array_name, arr in _get_arrays(store):
                 for chunk_idx in _get_chunk_indices(arr):
-                    chunk_rel_path, chunk_abs_path = chunk_lookup[(array_name, chunk_idx)]
+                    chunk_rel_path, chunk_abs_path = chunk_lookup[
+                        (array_name, chunk_idx)
+                    ]
 
                     chunk_shape = tuple(
                         min(c, s - i * c)
@@ -134,7 +136,7 @@ class ZarrDatasource(Datasource):
             for fi in file_infos:
                 if fi.type != pafs.FileType.File:
                     continue
-                rel_path = fi.path[len(store_path):].lstrip("/")
+                rel_path = fi.path[len(store_path) :].lstrip("/")
                 filename = rel_path.split("/")[-1]
                 if filename in _METADATA_FILENAMES:
                     with self._filesystem.open_input_file(fi.path) as f:
@@ -160,7 +162,7 @@ def _parse_chunk_path(rel_path: str) -> Optional[Tuple[str, Tuple[int, ...]]]:
     if "c" in parts:
         c_idx = parts.index("c")
         array_parts = parts[:c_idx]
-        index_parts = parts[c_idx + 1:]
+        index_parts = parts[c_idx + 1 :]
     else:
         # Find where array name ends and chunk indices begin
         # Chunk indices are numeric, possibly with "." separator
@@ -226,8 +228,7 @@ def _create_read_fn(
 
         all_bytes = {**metadata_bytes, chunk_rel_path: chunk_bytes}
         store_dict = {
-            k: zarr.core.buffer.cpu.Buffer.from_bytes(v)
-            for k, v in all_bytes.items()
+            k: zarr.core.buffer.cpu.Buffer.from_bytes(v) for k, v in all_bytes.items()
         }
         store = zarr.open(zarr.storage.MemoryStore(store_dict=store_dict), mode="r")
 
@@ -238,12 +239,14 @@ def _create_read_fn(
         )
         chunk_data = arr[slices]
 
-        yield pa.table({
-            "array_name": [array_name],
-            "data": [chunk_data.tobytes()],
-            "shape": [list(chunk_data.shape)],
-            "dtype": [str(chunk_data.dtype)],
-            "chunk_index": [list(chunk_idx)],
-        })
+        yield pa.table(
+            {
+                "array_name": [array_name],
+                "data": [chunk_data.tobytes()],
+                "shape": [list(chunk_data.shape)],
+                "dtype": [str(chunk_data.dtype)],
+                "chunk_index": [list(chunk_idx)],
+            }
+        )
 
     return read_fn

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -1,7 +1,7 @@
 """Zarr datasource for Ray Data."""
 
 import itertools
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
@@ -168,7 +168,9 @@ def _get_chunk_path(
     return chunk_part
 
 
-def _get_arrays(store) -> List[Tuple[str, "zarr.Array"]]:
+def _get_arrays(
+    store: Union["zarr.Array", "zarr.Group"]
+) -> List[Tuple[str, "zarr.Array"]]:
     """Recursively get all arrays from a zarr store."""
     import zarr
 
@@ -185,7 +187,7 @@ def _get_arrays(store) -> List[Tuple[str, "zarr.Array"]]:
     return arrays
 
 
-def _get_chunk_indices(arr) -> List[Tuple[int, ...]]:
+def _get_chunk_indices(arr: "zarr.Array") -> List[Tuple[int, ...]]:
     """Get all chunk indices for an array."""
     chunks_per_dim = [(s + c - 1) // c for s, c in zip(arr.shape, arr.chunks)]
     return list(itertools.product(*[range(n) for n in chunks_per_dim]))
@@ -200,7 +202,7 @@ def _create_read_fn(
     shape: Tuple[int, ...],
     metadata_bytes: Dict[str, bytes],
     filesystem: "pafs.FileSystem",
-):
+) -> Callable[[], Iterable[Block]]:
     def read_fn() -> Iterable[Block]:
         import zarr
 

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -1,0 +1,145 @@
+"""Zarr datasource for Ray Data."""
+
+import itertools
+from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
+
+import numpy as np
+import pyarrow as pa
+
+from ray.data._internal.util import _check_import
+from ray.data.block import Block, BlockMetadata
+from ray.data.datasource.datasource import Datasource, ReadTask
+from ray.data.datasource.path_util import _resolve_paths_and_filesystem
+
+if TYPE_CHECKING:
+    import pyarrow.fs
+    import zarr
+
+    from ray.data.context import DataContext
+
+
+class ZarrDatasource(Datasource):
+    """Datasource for reading Zarr arrays.
+
+    Each Zarr chunk becomes one block in the Dataset. Supports both single
+    arrays and groups containing multiple arrays.
+    """
+
+    def __init__(
+        self,
+        paths: Union[str, List[str]],
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ):
+        _check_import(self, module="zarr", package="zarr")
+        self._paths, self._filesystem = _resolve_paths_and_filesystem(paths, filesystem)
+
+    def get_read_tasks(
+        self,
+        parallelism: int,
+        per_task_row_limit: Optional[int] = None,
+        data_context: Optional["DataContext"] = None,
+    ) -> List[ReadTask]:
+        import zarr
+
+        read_tasks = []
+        for path in self._paths:
+            zarr_path = _get_zarr_path(path, self._filesystem)
+            store = zarr.open(zarr_path, mode="r")
+            for array_name, arr in _get_arrays(store):
+                for chunk_idx in _get_chunk_indices(arr):
+                    # Estimate size of this chunk
+                    chunk_shape = tuple(
+                        min(c, s - i * c)
+                        for i, c, s in zip(chunk_idx, arr.chunks, arr.shape)
+                    )
+                    chunk_size = int(np.prod(chunk_shape) * arr.dtype.itemsize)
+                    metadata = BlockMetadata(
+                        num_rows=1,
+                        size_bytes=chunk_size,
+                        input_files=[path],
+                        exec_stats=None,
+                    )
+                    read_tasks.append(
+                        ReadTask(
+                            _create_read_fn(zarr_path, array_name, chunk_idx),
+                            metadata,
+                        )
+                    )
+        return read_tasks
+
+    def estimate_inmemory_data_size(self) -> Optional[int]:
+        import zarr
+
+        total = 0
+        for path in self._paths:
+            zarr_path = _get_zarr_path(path, self._filesystem)
+            store = zarr.open(zarr_path, mode="r")
+            for _, arr in _get_arrays(store):
+                total += arr.nbytes
+        return total
+
+
+def _get_zarr_path(path: str, filesystem: Optional["pyarrow.fs.FileSystem"]) -> str:
+    """Build a zarr-compatible path from the resolved path and filesystem.
+
+    The `_resolve_paths_and_filesystem` function strips URI schemes from paths.
+    Since zarr uses fsspec for remote storage and expects full URIs, we
+    reconstruct the URI from the filesystem type.
+    """
+    if filesystem is None:
+        return path
+    fs_type = filesystem.type_name
+    if fs_type == "s3":
+        return f"s3://{path}"
+    elif fs_type == "gcs":
+        return f"gs://{path}"
+    return path
+
+
+def _get_arrays(
+    store: Union["zarr.Array", "zarr.Group"],
+) -> List[Tuple[str, "zarr.Array"]]:
+    """Recursively get all arrays from a Zarr store."""
+    import zarr
+
+    if isinstance(store, zarr.Array):
+        return [("", store)]
+    arrays = []
+    for name, arr in store.arrays():
+        arrays.append((name, arr))
+    for name, group in store.groups():
+        for sub_name, arr in _get_arrays(group):
+            arrays.append((f"{name}/{sub_name}" if sub_name else name, arr))
+    return arrays
+
+
+def _get_chunk_indices(arr: "zarr.Array") -> List[Tuple[int, ...]]:
+    """Get all chunk indices for an array."""
+    chunks_per_dim = [(s + c - 1) // c for s, c in zip(arr.shape, arr.chunks)]
+    return list(itertools.product(*[range(n) for n in chunks_per_dim]))
+
+
+def _create_read_fn(zarr_path: str, array_name: str, chunk_idx: Tuple[int, ...]):
+    """Create a read function for a specific chunk."""
+
+    def read_fn() -> Iterable[Block]:
+        import zarr
+
+        store = zarr.open(zarr_path, mode="r")
+        arr = store[array_name] if array_name else store
+        slices = tuple(
+            slice(i * c, min((i + 1) * c, s))
+            for i, c, s in zip(chunk_idx, arr.chunks, arr.shape)
+        )
+        chunk_data = arr[slices]
+        yield pa.table(
+            {
+                "array_name": [array_name],
+                "data": [chunk_data.tobytes()],
+                "shape": [list(chunk_data.shape)],
+                "dtype": [str(chunk_data.dtype)],
+                "chunk_index": [list(chunk_idx)],
+            }
+        )
+
+    return read_fn

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1905,7 +1905,7 @@ def read_numpy(
     )
 
 
-@PublicAPI
+@PublicAPI(stability="alpha")
 def read_zarr(
     paths: Union[str, List[str]],
     *,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -52,7 +52,6 @@ from ray.data._internal.datasource.mcap_datasource import MCAPDatasource, TimeRa
 from ray.data._internal.datasource.mongo_datasource import MongoDatasource
 from ray.data._internal.datasource.numpy_datasource import NumpyDatasource
 from ray.data._internal.datasource.parquet_datasource import ParquetDatasource
-from ray.data._internal.datasource.zarr_datasource import ZarrDatasource
 from ray.data._internal.datasource.range_datasource import RangeDatasource
 from ray.data._internal.datasource.sql_datasource import SQLDatasource
 from ray.data._internal.datasource.text_datasource import TextDatasource
@@ -61,6 +60,7 @@ from ray.data._internal.datasource.torch_datasource import TorchDatasource
 from ray.data._internal.datasource.uc_datasource import UnityCatalogConnector
 from ray.data._internal.datasource.video_datasource import VideoDatasource
 from ray.data._internal.datasource.webdataset_datasource import WebDatasetDatasource
+from ray.data._internal.datasource.zarr_datasource import ZarrDatasource
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators import (

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1928,6 +1928,11 @@ def read_zarr(
     ``storage_options`` for different cloud providers, see
     https://docs.dask.org/en/stable/how-to/connect-to-remote-data.html
 
+    .. note::
+        The ``storage_options`` parameter may change to a ``filesystem`` parameter
+        in a future release to align with other Ray Data readers like
+        :func:`~ray.data.read_parquet`.
+
     Examples:
         Read a single Zarr array.
 

--- a/python/ray/data/tests/datasource/test_zarr.py
+++ b/python/ray/data/tests/datasource/test_zarr.py
@@ -1,0 +1,300 @@
+"""Tests for Zarr datasource."""
+
+import numpy as np
+import pytest
+
+import ray
+
+zarr = pytest.importorskip("zarr")
+
+
+# =============================================================================
+# Unit tests for helper functions (no Ray required)
+# =============================================================================
+
+
+class TestGetChunkPath:
+    """Test _get_chunk_path helper function."""
+
+    def test_zarr_v3_root_array(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_path
+
+        # zarr v3 root array: c/0/1
+        assert _get_chunk_path("", (0, 1), is_zarr_v3=True) == "c/0/1"
+        assert _get_chunk_path("", (0,), is_zarr_v3=True) == "c/0"
+        assert _get_chunk_path("", (2, 3, 4), is_zarr_v3=True) == "c/2/3/4"
+
+    def test_zarr_v3_named_array(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_path
+
+        # zarr v3 named array: array_name/c/0/1
+        assert _get_chunk_path("myarray", (0, 1), is_zarr_v3=True) == "myarray/c/0/1"
+        assert _get_chunk_path("nested/arr", (0,), is_zarr_v3=True) == "nested/arr/c/0"
+
+    def test_zarr_v2_dot_separator(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_path
+
+        # zarr v2 with "." separator (default): 0.1
+        assert _get_chunk_path("", (0, 1), is_zarr_v3=False) == "0.1"
+        assert _get_chunk_path("", (0,), is_zarr_v3=False) == "0"
+        assert _get_chunk_path("myarray", (2, 3), is_zarr_v3=False) == "myarray/2.3"
+
+    def test_zarr_v2_slash_separator(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_path
+
+        # zarr v2 with "/" separator: 0/1
+        result = _get_chunk_path("", (0, 1), is_zarr_v3=False, dimension_separator="/")
+        assert result == "0/1"
+        result = _get_chunk_path(
+            "myarray", (2, 3), is_zarr_v3=False, dimension_separator="/"
+        )
+        assert result == "myarray/2/3"
+
+    def test_numeric_array_name(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_path
+
+        # Array with numeric name should not be confused with chunk index
+        assert _get_chunk_path("123", (0, 1), is_zarr_v3=False) == "123/0.1"
+        assert _get_chunk_path("0", (0,), is_zarr_v3=True) == "0/c/0"
+
+
+class TestGetChunkIndices:
+    """Test _get_chunk_indices helper function."""
+
+    def test_single_chunk(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_indices
+
+        arr = zarr.zeros((10,), chunks=(10,))
+        indices = _get_chunk_indices(arr)
+        assert indices == [(0,)]
+
+    def test_multiple_chunks_1d(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_indices
+
+        arr = zarr.zeros((100,), chunks=(25,))
+        indices = _get_chunk_indices(arr)
+        assert indices == [(0,), (1,), (2,), (3,)]
+
+    def test_multiple_chunks_2d(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_indices
+
+        arr = zarr.zeros((10, 10), chunks=(5, 5))
+        indices = _get_chunk_indices(arr)
+        assert set(indices) == {(0, 0), (0, 1), (1, 0), (1, 1)}
+
+    def test_uneven_chunks(self):
+        from ray.data._internal.datasource.zarr_datasource import _get_chunk_indices
+
+        # 10 elements with chunk size 4 = 3 chunks (4+4+2)
+        arr = zarr.zeros((10,), chunks=(4,))
+        indices = _get_chunk_indices(arr)
+        assert indices == [(0,), (1,), (2,)]
+
+
+class TestGetArrays:
+    """Test _get_arrays helper function."""
+
+    def test_single_array(self, tmp_path):
+        from ray.data._internal.datasource.zarr_datasource import _get_arrays
+
+        arr = zarr.open(str(tmp_path / "arr.zarr"), mode="w", shape=(10,), chunks=(5,))
+        arr[:] = np.arange(10)
+        store = zarr.open(str(tmp_path / "arr.zarr"), mode="r")
+
+        arrays = _get_arrays(store)
+        assert len(arrays) == 1
+        assert arrays[0][0] == ""  # Root array has empty name
+
+    def test_group_with_arrays(self, tmp_path):
+        from ray.data._internal.datasource.zarr_datasource import _get_arrays
+
+        root = zarr.open(str(tmp_path / "group.zarr"), mode="w")
+        root.create_array("arr1", shape=(10,), dtype=np.int64)
+        root["arr1"][:] = np.arange(10)
+        root.create_array("arr2", shape=(5, 5), dtype=np.float64)
+        root["arr2"][:] = np.ones((5, 5))
+
+        store = zarr.open(str(tmp_path / "group.zarr"), mode="r")
+        arrays = _get_arrays(store)
+
+        names = {name for name, _ in arrays}
+        assert names == {"arr1", "arr2"}
+
+    def test_nested_groups(self, tmp_path):
+        from ray.data._internal.datasource.zarr_datasource import _get_arrays
+
+        root = zarr.open(str(tmp_path / "nested.zarr"), mode="w")
+        root.create_group("subgroup")
+        root["subgroup"].create_array("nested_arr", shape=(5,), dtype=np.int64)
+        root["subgroup/nested_arr"][:] = np.arange(5)
+        root.create_array("top_arr", shape=(3,), dtype=np.float64)
+        root["top_arr"][:] = np.ones(3)
+
+        store = zarr.open(str(tmp_path / "nested.zarr"), mode="r")
+        arrays = _get_arrays(store)
+
+        names = {name for name, _ in arrays}
+        assert names == {"subgroup/nested_arr", "top_arr"}
+
+
+# =============================================================================
+# Unit tests for zarr format detection
+# =============================================================================
+
+
+class TestZarrFormats:
+    """Test reading zarr v2 and v3 formats."""
+
+    def test_zarr_v2_dot_separator(self, tmp_path):
+        """Test zarr v2 with default '.' dimension separator."""
+        from ray.data._internal.datasource.zarr_datasource import ZarrDatasource
+
+        # Create v2 store with "." separator (default)
+        arr = zarr.open(
+            str(tmp_path / "v2_dot.zarr"),
+            mode="w",
+            shape=(10, 10),
+            chunks=(5, 5),
+            zarr_format=2,
+        )
+        arr[:] = np.arange(100).reshape(10, 10)
+
+        # Verify it works
+        ds = ZarrDatasource(str(tmp_path / "v2_dot.zarr"))
+        tasks = ds.get_read_tasks(parallelism=4)
+        assert len(tasks) == 4  # 2x2 chunks
+
+    def test_zarr_v2_slash_separator(self, tmp_path):
+        """Test zarr v2 with '/' dimension separator."""
+        from ray.data._internal.datasource.zarr_datasource import ZarrDatasource
+
+        # Create v2 store with "/" separator
+        arr = zarr.open(
+            str(tmp_path / "v2_slash.zarr"),
+            mode="w",
+            shape=(10, 10),
+            chunks=(5, 5),
+            zarr_format=2,
+            dimension_separator="/",
+        )
+        arr[:] = np.arange(100).reshape(10, 10)
+
+        # Verify it works
+        ds = ZarrDatasource(str(tmp_path / "v2_slash.zarr"))
+        tasks = ds.get_read_tasks(parallelism=4)
+        assert len(tasks) == 4  # 2x2 chunks
+
+    def test_zarr_v3(self, tmp_path):
+        """Test zarr v3 format."""
+        from ray.data._internal.datasource.zarr_datasource import ZarrDatasource
+
+        # Create v3 store (default in zarr 3.x)
+        arr = zarr.open(
+            str(tmp_path / "v3.zarr"),
+            mode="w",
+            shape=(10, 10),
+            chunks=(5, 5),
+        )
+        arr[:] = np.arange(100).reshape(10, 10)
+
+        # Verify it works
+        ds = ZarrDatasource(str(tmp_path / "v3.zarr"))
+        tasks = ds.get_read_tasks(parallelism=4)
+        assert len(tasks) == 4  # 2x2 chunks
+
+
+# =============================================================================
+# Integration tests with Ray Data
+# =============================================================================
+
+
+def test_read_zarr_single_array(ray_start_regular_shared, tmp_path):
+    """Test reading a single zarr array."""
+    arr = zarr.open(str(tmp_path / "single.zarr"), mode="w", shape=(100,), chunks=(25,))
+    arr[:] = np.arange(100)
+
+    ds = ray.data.read_zarr(str(tmp_path / "single.zarr"))
+
+    assert ds.count() == 4  # 100 / 25 = 4 chunks
+    rows = ds.take_all()
+    assert all(row["array_name"] == "" for row in rows)
+
+
+def test_read_zarr_group(ray_start_regular_shared, tmp_path):
+    """Test reading a zarr group with multiple arrays."""
+    root = zarr.open(str(tmp_path / "group.zarr"), mode="w")
+    root.create_array("arr1", shape=(10, 10), chunks=(5, 5), dtype=np.int64)
+    root["arr1"][:] = np.arange(100).reshape(10, 10)
+    root.create_array("arr2", shape=(20,), chunks=(10,), dtype=np.float64)
+    root["arr2"][:] = np.ones(20)
+
+    ds = ray.data.read_zarr(str(tmp_path / "group.zarr"))
+
+    # arr1: 4 chunks (2x2), arr2: 2 chunks
+    assert ds.count() == 6
+
+
+def test_read_zarr_multiple_paths(ray_start_regular_shared, tmp_path):
+    """Test reading from multiple zarr stores."""
+    arr1 = zarr.open(str(tmp_path / "store1.zarr"), mode="w", shape=(10,), chunks=(5,))
+    arr1[:] = np.arange(10)
+    arr2 = zarr.open(str(tmp_path / "store2.zarr"), mode="w", shape=(10,), chunks=(5,))
+    arr2[:] = np.arange(10, 20)
+
+    ds = ray.data.read_zarr(
+        [str(tmp_path / "store1.zarr"), str(tmp_path / "store2.zarr")]
+    )
+
+    assert ds.count() == 4  # 2 chunks from each store
+
+
+def test_read_zarr_data_integrity(ray_start_regular_shared, tmp_path):
+    """Test that data is read correctly."""
+    data = np.arange(100).reshape(10, 10)
+    arr = zarr.open(
+        str(tmp_path / "test.zarr"), mode="w", shape=data.shape, chunks=(5, 5)
+    )
+    arr[:] = data
+
+    ds = ray.data.read_zarr(str(tmp_path / "test.zarr"))
+    rows = ds.take_all()
+
+    assert len(rows) == 4
+    for row in rows:
+        chunk_data = np.frombuffer(row["data"], dtype=row["dtype"]).reshape(
+            row["shape"]
+        )
+        assert chunk_data.shape == (5, 5)
+
+
+def test_read_zarr_nested_group(ray_start_regular_shared, tmp_path):
+    """Test reading nested groups."""
+    root = zarr.open(str(tmp_path / "nested.zarr"), mode="w")
+    root.create_group("subgroup")
+    root["subgroup"].create_array("arr", shape=(10,), chunks=(5,), dtype=np.float64)
+    root["subgroup/arr"][:] = np.ones(10)
+
+    ds = ray.data.read_zarr(str(tmp_path / "nested.zarr"))
+    rows = ds.take_all()
+
+    assert len(rows) == 2
+    assert all(row["array_name"] == "subgroup/arr" for row in rows)
+
+
+def test_read_zarr_schema(ray_start_regular_shared, tmp_path):
+    """Test that the output schema is correct."""
+    arr = zarr.open(str(tmp_path / "test.zarr"), mode="w", shape=(10,), chunks=(5,))
+    arr[:] = np.arange(10)
+
+    ds = ray.data.read_zarr(str(tmp_path / "test.zarr"))
+    row = ds.take(1)[0]
+
+    assert "array_name" in row
+    assert "data" in row
+    assert "shape" in row
+    assert "dtype" in row
+    assert "chunk_index" in row
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/python/ray/data/tests/test_zarr.py
+++ b/python/ray/data/tests/test_zarr.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pytest
+
+import ray
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+
+def test_read_zarr(ray_start_regular_shared, tmp_path):
+    """Test reading zarr arrays: groups, single arrays, nested groups, multiple paths."""
+    zarr = pytest.importorskip("zarr")
+
+    # Test 1: Group with multiple arrays
+    store_path = tmp_path / "group.zarr"
+    root = zarr.open(str(store_path), mode="w")
+    arr1 = root.create_array("arr1", shape=(4, 4), chunks=(2, 2), dtype=np.int64)
+    arr1[:] = np.arange(16).reshape(4, 4)
+    arr2 = root.create_array("arr2", shape=(4,), chunks=(2,), dtype=np.float32)
+    arr2[:] = np.ones((4,), dtype=np.float32)
+
+    ds = ray.data.read_zarr(str(store_path))
+
+    # Verify schema
+    schema = ds.schema()
+    assert set(schema.names) == {"array_name", "data", "shape", "dtype", "chunk_index"}
+
+    # Verify chunk count and data (4 chunks from arr1 + 2 from arr2 = 6)
+    rows = ds.take_all()
+    assert len(rows) == 6
+    arr1_rows = [r for r in rows if r["array_name"] == "arr1"]
+    arr2_rows = [r for r in rows if r["array_name"] == "arr2"]
+    assert len(arr1_rows) == 4
+    assert len(arr2_rows) == 2
+    assert arr1_rows[0]["dtype"] == "int64"
+    assert arr2_rows[0]["dtype"] == "float32"
+    assert arr1_rows[0]["shape"] == [2, 2]
+    assert arr2_rows[0]["shape"] == [2]
+
+    # Test 2: Single array (not a group)
+    arr = zarr.open(
+        str(tmp_path / "single.zarr"),
+        mode="w",
+        shape=(4,),
+        chunks=(2,),
+        dtype=np.int64,
+    )
+    arr[:] = np.arange(4)
+
+    ds = ray.data.read_zarr(str(tmp_path / "single.zarr"))
+    rows = ds.take_all()
+    assert len(rows) == 2
+    assert all(row["array_name"] == "" for row in rows)
+
+    # Test 3: Nested groups
+    store_path = tmp_path / "nested.zarr"
+    root = zarr.open(str(store_path), mode="w")
+    root.create_group("level1")
+    root["level1"].create_group("level2")
+    arr = root["level1"]["level2"].create_array(
+        "arr", shape=(4,), chunks=(2,), dtype=np.float64
+    )
+    arr[:] = np.ones((4,))
+
+    ds = ray.data.read_zarr(str(store_path))
+    rows = ds.take_all()
+    assert len(rows) == 2
+    assert rows[0]["array_name"] == "level1/level2/arr"
+
+    # Test 4: Multiple paths
+    arr1 = zarr.open(
+        str(tmp_path / "store1.zarr"),
+        mode="w",
+        shape=(4,),
+        chunks=(2,),
+        dtype=np.int64,
+    )
+    arr1[:] = np.arange(4)
+    arr2 = zarr.open(
+        str(tmp_path / "store2.zarr"),
+        mode="w",
+        shape=(4,),
+        chunks=(2,),
+        dtype=np.int64,
+    )
+    arr2[:] = np.arange(4, 8)
+
+    ds = ray.data.read_zarr(
+        [str(tmp_path / "store1.zarr"), str(tmp_path / "store2.zarr")]
+    )
+    rows = ds.take_all()
+    assert len(rows) == 4  # 2 chunks from each store
+
+    # Test 5: Empty array
+    zarr.open(
+        str(tmp_path / "empty.zarr"), mode="w", shape=(0,), chunks=(1,), dtype=np.int64
+    )
+
+    ds = ray.data.read_zarr(str(tmp_path / "empty.zarr"))
+    assert len(ds.take_all()) == 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Add `ray.data.read_zarr()` for reading Zarr arrays into Ray Datasets. Each Zarr chunk becomes one block in the Dataset, providing natural parallelism that aligns with Zarr's chunked storage format.

Features:
- Support for single arrays and groups with multiple arrays
- Support for nested groups (arrays named by path, e.g., "group/subgroup/arr")
- Support for local paths and cloud storage (s3://, gs://)
- Automatic filesystem detection from URI scheme
- Optional custom filesystem configuration

Output schema:
- array_name: string (path within zarr store)
- data: binary (chunk data as bytes)
- shape: list[int64] (chunk dimensions)
- dtype: string (numpy dtype)
- chunk_index: list[int64] (chunk position)

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>2842da7</u></sup><!-- /BUGBOT_STATUS -->