### PR TITLE
[Core] Bump python/java protobuf version to 3.20.3

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -329,8 +329,8 @@ def ray_deps_setup():
     # protobuf library that Ray supports.
     auto_http_archive(
         name = "com_google_protobuf_rules_proto_grpc",
-        url = "https://github.com/protocolbuffers/protobuf/archive/v3.19.4.tar.gz",
-        sha256 = "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568",
+        url = "https://github.com/protocolbuffers/protobuf/archive/v3.20.3.tar.gz",
+        sha256 = "9c0fd39c7a08dff543c643f0f4baf081988129a411b977a07c46221793605638",
     )
     auto_http_archive(
         name = "rules_proto_grpc",

--- a/python/ray/tests/test_protobuf_compatibility.py
+++ b/python/ray/tests/test_protobuf_compatibility.py
@@ -11,7 +11,7 @@ import ray
 )
 def test_protobuf_compatibility(shutdown_only):
     protobuf_4_21_0 = {"pip": ["protobuf==4.21.0"]}
-    protobuf_3_19_6 = {"pip": ["protobuf==3.19.6"]}
+    protobuf_3_20_3 = {"pip": ["protobuf==3.20.3"]}
 
     ray.init()
 
@@ -26,7 +26,7 @@ def test_protobuf_compatibility(shutdown_only):
         return google.protobuf.__version__
 
     assert "4.21.0" == ray.get(load_ray.options(runtime_env=protobuf_4_21_0).remote())
-    assert "3.19.6" == ray.get(load_ray.options(runtime_env=protobuf_3_19_6).remote())
+    assert "3.20.3" == ray.get(load_ray.options(runtime_env=protobuf_3_20_3).remote())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Bump python/java protobuf version to 3.20.3 to get the [3.20.x](https://protobuf.dev/support/cross-version-runtime-guarantee/#python) compatibility guarantees

## Related issues
closes https://github.com/ray-project/ray/issues/60395

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
