### PR TITLE
[release test] treat test as non jailed when github issue disappeared

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -361,6 +361,8 @@ class Test(dict):
         """
         Returns whether this test is jailed with open issue.
         """
+        from github import GithubException
+
         # is jailed
         state = self.get_state()
         if state != TestState.JAILED:
@@ -370,8 +372,14 @@ class Test(dict):
         issue_number = self.get(self.KEY_GITHUB_ISSUE_NUMBER)
         if issue_number is None:
             return False
-        issue = ray_github.get_issue(issue_number)
-        return issue.state == "open"
+        try:
+            issue = ray_github.get_issue(issue_number)
+            return issue.state == "open"
+        except GithubException as e:
+            logger.warning(
+                f"Failed to get issue {issue_number} for test {self.get_name()} from GitHub: {e}"
+            )
+            return False
 
     def is_stable(self) -> bool:
         """

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -191,6 +191,15 @@ def test_is_jailed_with_open_issue(mock_repo, mock_issue) -> None:
     )
 
 
+@patch("github.Repository")
+def test_is_jailed_with_open_issue_github_exception(mock_repo) -> None:
+    from github import GithubException
+
+    mock_repo.get_issue.side_effect = GithubException(404, {"message": "Not Found"}, {})
+    test = Test(name="test", state="jailed", github_issue_number="1")
+    assert not test.is_jailed_with_open_issue(mock_repo)
+
+
 def test_is_stable() -> None:
     assert Test().is_stable()
     assert Test(stable=True).is_stable()


### PR DESCRIPTION
this can happen when the testdb has incorrect data
