### PR TITLE
[core] deflaky test_plasma_store_operation_after_raylet_dies

### DIFF
--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -57,7 +57,7 @@ def test_plasma_store_operation_after_raylet_dies(ray_start_cluster):
     cluster = ray_start_cluster
     system_configs = {
         "health_check_initial_delay_ms": 0,
-        "health_check_timeout_ms": 10,
+        "health_check_timeout_ms": 100,
         "health_check_failure_threshold": 1,
     }
     cluster.add_node(


### PR DESCRIPTION
## Description

test_plasma_store_operation_after_raylet_dies is flaky on `cluster.add_node` timeouts.

<img width="1742" height="844" alt="image" src="https://github.com/user-attachments/assets/c404c60b-a0d9-43a3-b9ca-b02a5349ca89" />

The flaky can become deterministic if we reduce the `health_check_timeout_ms` to `1`. I guess in some situations a local grpc connection can still take more than 10ms to setup. This PR gives it more time (100ms).
