### PR TITLE
[Data] Fuse `MapBatches` even if they modify the row count

### DIFF
--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -667,7 +667,7 @@ class FuseOperators(Rule):
             # incorrectly marked as not modifying row counts, so it was always
             # fused. We preserve that behavior here to avoid regressions.
             #
-            # For the full history, see #TODO.
+            # For the full history, see https://github.com/ray-project/ray/pull/60756.
             and not isinstance(upstream_op, MapBatches)
         ) and downstream_op.min_rows_per_bundled_input is not None:
             logger.debug(

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -337,9 +337,9 @@ def test_map_batches_batch_size_fusion(
         LogicalPlan(input_op, context),
     )
 
-    mapped_ds = ds.map_batches(
-        lambda x: x, batch_size=2, udf_modifying_row_count=False
-    ).map_batches(lambda x: x, batch_size=5, udf_modifying_row_count=False)
+    mapped_ds = ds.map_batches(lambda x: x, batch_size=2).map_batches(
+        lambda x: x, batch_size=5
+    )
 
     physical_plan = get_execution_plan(mapped_ds._logical_plan)
 
@@ -382,11 +382,9 @@ def test_map_batches_with_batch_size_specified_fusion(
     mapped_ds = ds.map_batches(
         lambda x: x,
         batch_size=upstream_batch_size,
-        udf_modifying_row_count=False,
     ).map_batches(
         lambda x: x,
         batch_size=downstream_batch_size,
-        udf_modifying_row_count=False,
     )
 
     physical_plan = get_execution_plan(mapped_ds._logical_plan)
@@ -804,19 +802,11 @@ def test_streaming_repartition_no_further_fuse(
     # Case 1: map_batches -> map_batches -> streaming_repartition -> map_batches -> map_batches
     # Result: map -> (map -> s_r)-> (map -> map)
     ds1 = ray.data.range(n, override_num_blocks=2)
-    ds1 = ds1.map_batches(
-        lambda x: x, batch_size=target_rows, udf_modifying_row_count=False
-    )
-    ds1 = ds1.map_batches(
-        lambda x: x, batch_size=target_rows, udf_modifying_row_count=False
-    )
+    ds1 = ds1.map_batches(lambda x: x, batch_size=target_rows)
+    ds1 = ds1.map_batches(lambda x: x, batch_size=target_rows)
     ds1 = ds1.repartition(target_num_rows_per_block=target_rows)
-    ds1 = ds1.map_batches(
-        lambda x: x, batch_size=target_rows, udf_modifying_row_count=False
-    )
-    ds1 = ds1.map_batches(
-        lambda x: x, batch_size=target_rows, udf_modifying_row_count=False
-    )
+    ds1 = ds1.map_batches(lambda x: x, batch_size=target_rows)
+    ds1 = ds1.map_batches(lambda x: x, batch_size=target_rows)
 
     assert len(ds1.take_all()) == n
     stats1 = ds1.stats()


### PR DESCRIPTION
This PR updates the operator fusion rule to fuse `MapBatches` even if they modify the row counts. The intention of this PR is to preserve the historical operator fusion behavior and avoid introducing regressions. 

For more details, see the timeline below.
---

### Timeline of Changes

| Date | Event | Description |
| :--- | :--- | :--- |
| **June 8, 2023** | **Limit pushdown added** | Added limit pushdown and a property to `MapBatches` incorrectly stating it doesn't modify row counts. (https://github.com/ray-project/ray/pull/35950) |
| **June 27, 2023** | **Limit pushdown disabled** | Rule disabled because it incorrectly pushed limits past UDFs that modified row counts. (https://github.com/ray-project/ray/pull/36831) |
| **April 28, 2025** | **Fusion restricted** | Added logic to stop fusing operators that modify row counts when the downstream has a batch size. `MapBatches` stayed fused only because of its incorrect property (https://github.com/ray-project/ray/pull/52570). |
| **July 8, 2025** | **Limit pushdown re-enabled with special case** | Re-enabled with a special case to prevent pushing limits past `MapBatches`. ([#39486](https://github.com/ray-project/ray/pull/39486)) |
| **Oct 24, 2025** | **Special case removed** | Special case removed, re-introducing the bug where limits are pushed past `MapBatches`. ([#57880](https://github.com/ray-project/ray/pull/57880)) |
| **Feb 2, 2026** | **Property Fix** | Updated `MapBatches` to correctly report it modifies rows by default. This fixed the pushdown bug but broke fusion logic. ([PR #60448](https://github.com/ray-project/ray/pull/60448)) |
| **Feb 4, 2026** | (This PR) | Add a special-case to preserve the historical `MapBatches` fusion behavior |
---

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>d99e7b1</u></sup><!-- /BUGBOT_STATUS -->