### PR TITLE
[core] Adding a private core debugging API to get the internal state of the ReferenceCounter as a JSON string.

### DIFF
--- a/python/ray/_private/debug_api.py
+++ b/python/ray/_private/debug_api.py
@@ -2,7 +2,7 @@ import ray._private.worker
 
 
 def get_reference_counter_debug_json() -> str:
-    """Returns the full state of the reference counter as a json string.
+    """Returns the full state of the reference counter as a JSON string.
 
     This is NOT a stable API. It should only be used for debugging and
     NEVER in tests or production code.

--- a/python/ray/_private/debug_api.py
+++ b/python/ray/_private/debug_api.py
@@ -1,0 +1,12 @@
+import ray._private.worker
+
+
+def get_reference_counter_debug_json() -> str:
+    """Returns the full state of the reference counter as a json string.
+
+    This is NOT a stable API. It should only be used for debugging and
+    NEVER in tests or production code.
+    """
+    worker = ray._private.worker.global_worker
+    worker.check_connected()
+    return worker.core_worker.get_reference_counter_debug_json()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -4601,6 +4601,17 @@ cdef class CoreWorker:
 
         return ref_counts
 
+    def get_reference_counter_debug_json(self):
+        """Returns a JSON string of the internal state of the ReferenceCounter.
+
+        NOTE: This is an expensive method and must only be used for debugging.
+        Do NOT use this for writing tests or production observability.
+        """
+        cdef:
+            c_string debug_json
+        debug_json = CCoreWorkerProcess.GetCoreWorker().GetReferenceCounterDebugJson()
+        return debug_json.decode('utf-8')
+
     def set_get_async_callback(self, ObjectRef object_ref, user_callback: Callable):
         # NOTE: we need to manually increment the Python reference count to avoid the
         # callback object being garbage collected before it's called by the core worker.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -4604,8 +4604,8 @@ cdef class CoreWorker:
     def get_reference_counter_debug_json(self):
         """Returns a JSON string of the internal state of the ReferenceCounter.
 
-        NOTE: This is an expensive method and must only be used for debugging.
-        Do NOT use this for writing tests or production observability.
+        NOTE: This is NOT a stable API. It should only be used for debugging and
+        NEVER in tests or production code.
         """
         cdef:
             c_string debug_json

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -328,6 +328,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         void YieldCurrentFiber(CFiberEvent &coroutine_done)
 
         unordered_map[CObjectID, pair[size_t, size_t]] GetAllReferenceCounts()
+        c_string GetReferenceCounterDebugJson() const
         c_vector[CTaskID] GetPendingChildrenTasks(const CTaskID &task_id) const
 
         void GetAsync(const CObjectID &object_id,

--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -169,6 +169,7 @@ ray_cc_library(
         "//src/ray/util:network_util",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/synchronization",
+        "@nlohmann_json",
     ],
 )
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -856,6 +856,10 @@ CoreWorker::GetAllReferenceCounts() const {
   return counts;
 }
 
+std::string CoreWorker::GetReferenceCounterDebugJson() const {
+  return reference_counter_->ToJsonString();
+}
+
 std::vector<TaskID> CoreWorker::GetPendingChildrenTasks(const TaskID &task_id) const {
   return task_manager_->GetPendingChildrenTasks(task_id);
 }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -404,6 +404,12 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// (local, submitted_task) reference counts. For debugging purposes.
   std::unordered_map<ObjectID, std::pair<size_t, size_t>> GetAllReferenceCounts() const;
 
+  /// Returns a JSON string representation of the internal state of the
+  /// ReferenceCounter.
+  /// NOTE: This is very expensive and must only be used for debugging.
+  /// Please do NOT use this for production observability or testing.
+  std::string GetReferenceCounterDebugJson() const;
+
   /// Return all pending children task ids for a given parent task id.
   /// The parent task id should exist in the current worker.
   /// For debugging and testing only.

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -1874,6 +1874,7 @@ json ReferenceCounter::Reference::ToJson() const {
       {"num_object_ref_deleted_callbacks", object_ref_deleted_callbacks.size()},
       {"publish_ref_removed", publish_ref_removed},
       {"spilled_url", spilled_url},
+      {"spilled_node_id", spilled_node_id.Hex()},
       {"spilled", spilled},
       {"foreign_owner_already_monitoring", foreign_owner_already_monitoring},
       {"has_nested_refs_report", has_nested_refs_to_report},

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -15,6 +15,7 @@
 #include "ray/core_worker/reference_counter.h"
 
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -23,6 +24,52 @@
 
 #include "ray/util/logging.h"
 #include "ray/util/network_util.h"
+
+using json = nlohmann::json;
+
+namespace {
+
+json AddressToJson(const ray::rpc::Address &address) {
+  return {
+      {"node_id", ray::NodeID::FromBinary(address.node_id()).Hex()},
+      {"ip_address", address.ip_address()},
+      {"port", address.port()},
+      {"worker_id", ray::WorkerID::FromBinary(address.worker_id()).Hex()},
+  };
+}
+
+template <class Container>
+json IdContainerToJsonArray(const Container &c) {
+  json output = json::array();
+  for (const auto &id : c) {
+    output.push_back(id.Hex());
+  }
+  return output;
+}
+
+constexpr const char *LineageReconstructionEligibilityToString(
+    ray::core::LineageReconstructionEligibility lre) noexcept {
+  switch (lre) {
+  case ray::core::LineageReconstructionEligibility::ELIGIBLE:
+    return "ELIGIBLE";
+  case ray::core::LineageReconstructionEligibility::INELIGIBLE_PUT:
+    return "INELIGIBLE_PUT";
+  case ray::core::LineageReconstructionEligibility::INELIGIBLE_NO_RETRIES:
+    return "INELIGIBLE_NO_RETRIES";
+  case ray::core::LineageReconstructionEligibility::INELIGIBLE_LOCAL_MODE:
+    return "INELIGIBLE_LOCAL_MODE";
+  case ray::core::LineageReconstructionEligibility::INELIGIBLE_LINEAGE_EVICTED:
+    return "INELIGIBLE_LINEAGE_EVICTED";
+  case ray::core::LineageReconstructionEligibility::INELIGIBLE_LINEAGE_DISABLED:
+    return "INELIGIBLE_LINEAGE_DISABLED";
+  case ray::core::LineageReconstructionEligibility::INELIGIBLE_REF_NOT_FOUND:
+    return "INELIGIBLE_REF_NOT_FOUND";
+  default:
+    return "UNKNOWN";
+  };
+};
+
+};  // namespace
 
 #define PRINT_REF_COUNT(it) \
   RAY_LOG(DEBUG) << "REF " << it->first << ": " << it->second.DebugString();
@@ -1764,6 +1811,90 @@ std::string ReferenceCounter::DebugString() const {
   }
   ss << "}";
   return ss.str();
+}
+
+json ReferenceCounter::NestedReferenceCount::ToJson() const {
+  auto object_id_container_to_json = [](const absl::flat_hash_set<ObjectID> &object_ids) {
+    json output = json::array();
+    for (const auto &object_id : object_ids) {
+      output.push_back(object_id.Hex());
+    }
+    return output;
+  };
+  return {{"contained_in_owned", object_id_container_to_json(contained_in_owned)},
+          {"contained_in_borrowed_ids",
+           object_id_container_to_json(contained_in_borrowed_ids)},
+          {"contains", object_id_container_to_json(contains)}};
+}
+
+json ReferenceCounter::BorrowInfo::ToJson() const {
+  json stored_in_objects_json = json::array();
+  for (const auto &[object_id, addr] : stored_in_objects) {
+    stored_in_objects_json.push_back(
+        {{"object_id", object_id.Hex()}, {"address", AddressToJson(addr)}});
+  }
+  json borrowers_json = json::array();
+  for (const auto &address : borrowers) {
+    borrowers_json.push_back(AddressToJson(address));
+  }
+  return {{"stored_in_objects", stored_in_objects_json}, {"borrowers", borrowers_json}};
+}
+
+std::string ReferenceCounter::ToJsonString() const {
+  absl::MutexLock lock(&mutex_);
+  json ref_table_json = json::array();
+  for (const auto &[obj_id, reference] : object_id_refs_) {
+    ref_table_json.push_back({
+        {"object_id", obj_id.Hex()},
+        {"reference", reference.ToJson()},
+    });
+  }
+  json output = {{"rpc_address", AddressToJson(rpc_address_)},
+                 {"reference_table", ref_table_json},
+                 {"freed_objects", IdContainerToJsonArray(freed_objects_)},
+                 {"reconstructable_owned_objects",
+                  IdContainerToJsonArray(reconstructable_owned_objects_)},
+                 {"objects_to_recover", IdContainerToJsonArray(objects_to_recover_)}};
+  return output.dump();
+}
+
+json ReferenceCounter::Reference::ToJson() const {
+  auto node_id_collection_to_json = [](const absl::flat_hash_set<NodeID> &node_ids) {
+    json output = json::array();
+    for (const auto &node_id : node_ids) {
+      output.push_back(node_id.Hex());
+    }
+    return output;
+  };
+  return {
+      {"call_site", call_site_},
+      {"object_size", object_size_},
+      {"locations", node_id_collection_to_json(locations)},
+      {"owner_address", owner_address_ ? AddressToJson(*owner_address_) : json(nullptr)},
+      {"pinned_at_node_id",
+       pinned_at_node_id_ ? json(pinned_at_node_id_->Hex()) : json(nullptr)},
+      {"tensport_transport",
+       tensor_transport_ ? json(*tensor_transport_) : json(nullptr)},
+      {"owned_by_us", owned_by_us_},
+      {"lineage_eligibility",
+       LineageReconstructionEligibilityToString(lineage_eligibility_)},
+      {"lineage_ref_count", lineage_ref_count},
+      {"local_ref_count", local_ref_count},
+      {"submitted_task_ref_count", submitted_task_ref_count},
+      {"nested_reference_count",
+       nested_reference_count ? nested_reference_count->ToJson() : json(nullptr)},
+      {"borrow_info", borrow_info ? borrow_info->ToJson() : json(nullptr)},
+      {"num_object_out_of_scope_or_freed_callbacks",
+       on_object_out_of_scope_or_freed_callbacks.size()},
+      {"num_object_ref_deleted_callbacks", object_ref_deleted_callbacks.size()},
+      {"publish_ref_removed", publish_ref_removed},
+      {"spilled_url", spilled_url},
+      {"spilled", spilled},
+      {"foreign_owner_already_monitoring", foreign_owner_already_monitoring},
+      {"has_nested_refs_report", has_nested_refs_to_report},
+      {"pending_creation", pending_creation_},
+      {"did_spill", did_spill},
+  };
 }
 
 std::string ReferenceCounter::Reference::DebugString() const {

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -1814,17 +1814,10 @@ std::string ReferenceCounter::DebugString() const {
 }
 
 json ReferenceCounter::NestedReferenceCount::ToJson() const {
-  auto object_id_container_to_json = [](const absl::flat_hash_set<ObjectID> &object_ids) {
-    json output = json::array();
-    for (const auto &object_id : object_ids) {
-      output.push_back(object_id.Hex());
-    }
-    return output;
-  };
-  return {{"contained_in_owned", object_id_container_to_json(contained_in_owned)},
-          {"contained_in_borrowed_ids",
-           object_id_container_to_json(contained_in_borrowed_ids)},
-          {"contains", object_id_container_to_json(contains)}};
+  return {
+      {"contained_in_owned", IdContainerToJsonArray(contained_in_owned)},
+      {"contained_in_borrowed_ids", IdContainerToJsonArray(contained_in_borrowed_ids)},
+      {"contains", IdContainerToJsonArray(contains)}};
 }
 
 json ReferenceCounter::BorrowInfo::ToJson() const {
@@ -1859,22 +1852,14 @@ std::string ReferenceCounter::ToJsonString() const {
 }
 
 json ReferenceCounter::Reference::ToJson() const {
-  auto node_id_collection_to_json = [](const absl::flat_hash_set<NodeID> &node_ids) {
-    json output = json::array();
-    for (const auto &node_id : node_ids) {
-      output.push_back(node_id.Hex());
-    }
-    return output;
-  };
   return {
       {"call_site", call_site_},
       {"object_size", object_size_},
-      {"locations", node_id_collection_to_json(locations)},
+      {"locations", IdContainerToJsonArray(locations)},
       {"owner_address", owner_address_ ? AddressToJson(*owner_address_) : json(nullptr)},
       {"pinned_at_node_id",
        pinned_at_node_id_ ? json(pinned_at_node_id_->Hex()) : json(nullptr)},
-      {"tensport_transport",
-       tensor_transport_ ? json(*tensor_transport_) : json(nullptr)},
+      {"tensor_transport", tensor_transport_ ? json(*tensor_transport_) : json(nullptr)},
       {"owned_by_us", owned_by_us_},
       {"lineage_eligibility",
        LineageReconstructionEligibilityToString(lineage_eligibility_)},

--- a/src/ray/core_worker/reference_counter.h
+++ b/src/ray/core_worker/reference_counter.h
@@ -16,6 +16,7 @@
 
 #include <list>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -35,6 +36,8 @@
 #include "ray/pubsub/subscriber_interface.h"
 #include "ray/rpc/utils.h"
 #include "src/ray/protobuf/common.pb.h"
+
+using json = nlohmann::json;
 
 namespace ray {
 namespace core {
@@ -182,6 +185,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   std::string DebugString() const override ABSL_LOCKS_EXCLUDED(mutex_);
 
+  std::string ToJsonString() const override ABSL_LOCKS_EXCLUDED(mutex_);
+
   void PopAndClearLocalBorrowers(const std::vector<ObjectID> &borrowed_ids,
                                  ReferenceTableProto *proto,
                                  std::vector<ObjectID> *deleted) override
@@ -279,6 +284,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
     ///  2. We call ray.get() on an ID whose contents we do not know and we
     ///     discover that it contains these IDs.
     absl::flat_hash_set<ObjectID> contains;
+
+    json ToJson() const;
   };
 
   /// Contains information related to borrowing only.
@@ -302,6 +309,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
     ///     borrowers. A borrower is removed from the list when it responds
     ///     that it is no longer using the reference.
     absl::flat_hash_set<rpc::Address> borrowers;
+
+    json ToJson() const;
   };
 
   struct Reference {
@@ -422,6 +431,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     }
 
     std::string DebugString() const;
+    json ToJson() const;
 
     /// Description of the call site where the reference was created.
     std::string call_site_ = "<unknown>";

--- a/src/ray/core_worker/reference_counter.h
+++ b/src/ray/core_worker/reference_counter.h
@@ -37,10 +37,10 @@
 #include "ray/rpc/utils.h"
 #include "src/ray/protobuf/common.pb.h"
 
-using json = nlohmann::json;
-
 namespace ray {
 namespace core {
+
+using json = nlohmann::json;
 
 /// Class used by the core worker to keep track of ObjectID reference counts for garbage
 /// collection. This class is thread safe.

--- a/src/ray/core_worker/reference_counter.h
+++ b/src/ray/core_worker/reference_counter.h
@@ -40,8 +40,6 @@
 namespace ray {
 namespace core {
 
-using json = nlohmann::json;
-
 /// Class used by the core worker to keep track of ObjectID reference counts for garbage
 /// collection. This class is thread safe.
 class ReferenceCounter : public ReferenceCounterInterface,
@@ -285,7 +283,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     ///     discover that it contains these IDs.
     absl::flat_hash_set<ObjectID> contains;
 
-    json ToJson() const;
+    nlohmann::json ToJson() const;
   };
 
   /// Contains information related to borrowing only.
@@ -310,7 +308,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     ///     that it is no longer using the reference.
     absl::flat_hash_set<rpc::Address> borrowers;
 
-    json ToJson() const;
+    nlohmann::json ToJson() const;
   };
 
   struct Reference {
@@ -431,7 +429,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     }
 
     std::string DebugString() const;
-    json ToJson() const;
+    nlohmann::json ToJson() const;
 
     /// Description of the call site where the reference was created.
     std::string call_site_ = "<unknown>";

--- a/src/ray/core_worker/reference_counter_interface.h
+++ b/src/ray/core_worker/reference_counter_interface.h
@@ -391,6 +391,11 @@ class ReferenceCounterInterface {
 
   virtual std::string DebugString() const = 0;
 
+  /// Converts the entire private state into a JSON string.
+  /// NOTE: This is a very expensive method. It is only available for debugging.
+  /// Do not use it for production observability or testing.
+  virtual std::string ToJsonString() const = 0;
+
   /// Populate a table with ObjectIDs that we were or are still borrowing.
   /// This should be called when a task returns, and the argument should be any
   /// IDs that were passed by reference in the task spec or that were


### PR DESCRIPTION
To debug Ray Core issues effectively, we need to be able to interrogate the internal state of our data structures. This PR is a step in the direction of providing an easily parsable (JSON) API to dump the internal state of CoreWorker. 

I've put the method under `debug_api`. This is purely for debugging purposes and should NEVER be used for integration tests or building production observability tools.

Example output from Python
```
{'freed_objects': [],
 'objects_to_recover': [],
 'reconstructable_owned_objects': ['c8ef45ccd0112571ffffffffffffffffffffffff0100000001000000',
                                   'ffffffffffffffff573b6d6a4d38384dac6ad3a60100000001000000'],
 'reference_table': [{'object_id': 'c8ef45ccd0112571ffffffffffffffffffffffff0100000001000000',
                      'reference': {'borrow_info': {'borrowers': [{'ip_address': '172.31.4.214',
                                                                   'node_id': 'f2129485024476a802e92988bec07553fe5ff0b67d04294a7728825c',
                                                                   'port': 36281,
                                                                   'worker_id': '375b8076ee1d5d446b9deeacc37e78545ae990e04e157b9c3d2267d9'}],
                                                    'stored_in_objects': []},
                                    'call_site': '',
                                    'did_spill': False,
                                    'foreign_owner_already_monitoring': False,
                                    'has_nested_refs_report': False,
                                    'lineage_eligibility': 'ELIGIBLE',
                                    'lineage_ref_count': 0,
                                    'local_ref_count': 1,
                                    'locations': ['e7e696111bc2d009c63bf76abd4ca7b19fc086db133b9ff5b24a378d'],
                                    'nested_reference_count': None,
                                    'num_object_out_of_scope_or_freed_callbacks': 1,
                                    'num_object_ref_deleted_callbacks': 0,
                                    'object_size': 131075,
                                    'owned_by_us': True,
                                    'owner_address': {'ip_address': '172.31.4.214',
                                                      'node_id': 'e7e696111bc2d009c63bf76abd4ca7b19fc086db133b9ff5b24a378d',
                                                      'port': 40139,
                                                      'worker_id': '01000000ffffffffffffffffffffffffffffffffffffffffffffffff'},
                                    'pending_creation': False,
                                    'pinned_at_node_id': 'e7e696111bc2d009c63bf76abd4ca7b19fc086db133b9ff5b24a378d',
                                    'publish_ref_removed': False,
                                    'spilled': False,
                                    'spilled_url': '',
                                    'submitted_task_ref_count': 0,
                                    'tensor_transport': None}},
                     {'object_id': 'ffffffffffffffff573b6d6a4d38384dac6ad3a60100000001000000',
                      'reference': {'borrow_info': None,
                                    'call_site': '',
                                    'did_spill': False,
                                    'foreign_owner_already_monitoring': False,
                                    'has_nested_refs_report': False,
                                    'lineage_eligibility': 'ELIGIBLE',
                                    'lineage_ref_count': 0,
                                    'local_ref_count': 1,
                                    'locations': [],
                                    'nested_reference_count': None,
                                    'num_object_out_of_scope_or_freed_callbacks': 2,
                                    'num_object_ref_deleted_callbacks': 1,
                                    'object_size': -1,
                                    'owned_by_us': True,
                                    'owner_address': {'ip_address': '172.31.4.214',
                                                      'node_id': 'e7e696111bc2d009c63bf76abd4ca7b19fc086db133b9ff5b24a378d',
                                                      'port': 40139,
                                                      'worker_id': '01000000ffffffffffffffffffffffffffffffffffffffffffffffff'},
                                    'pending_creation': True,
                                    'pinned_at_node_id': None,
                                    'publish_ref_removed': False,
                                    'spilled': False,
                                    'spilled_url': '',
                                    'submitted_task_ref_count': 0,
                                    'tensor_transport': None}}],
 'rpc_address': {'ip_address': '172.31.4.214',
                 'node_id': 'e7e696111bc2d009c63bf76abd4ca7b19fc086db133b9ff5b24a378d',
                 'port': 40139,
                 'worker_id': '01000000ffffffffffffffffffffffffffffffffffffffffffffffff'}}
```