### PR TITLE
[Data] Fixing `ActorPoolMapOperator` to guarantee dispatch of all given inputs

### DIFF
--- a/python/ray/data/_internal/execution/bundle_queue/base.py
+++ b/python/ray/data/_internal/execution/bundle_queue/base.py
@@ -48,6 +48,9 @@ class BaseBundleQueue:
         """Return the total # of blocks across all bundles."""
         return self._num_blocks
 
+    def num_bundles(self) -> int:
+        return self._num_bundles
+
     def num_rows(self) -> int:
         """Return the total # of rows across all bundles."""
         return self._num_rows

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -424,7 +424,6 @@ class PhysicalOperator(Operator):
         #       - All input blocks have been ingested
         #       - Internal queue is empty
         #       - There are no active or pending tasks
-
         return self._is_execution_marked_finished or (
             self._inputs_complete
             and self.num_active_tasks() == 0
@@ -450,8 +449,9 @@ class PhysicalOperator(Operator):
         # Draining the internal output queue is important to free object refs.
         return (
             self.has_execution_finished()
-            and not self.has_next()
             and internal_output_queue_num_blocks == 0
+            # TODO following check is redundant; remove
+            and not self.has_next()
         )
 
     def get_stats(self) -> StatsDict:
@@ -553,7 +553,7 @@ class PhysicalOperator(Operator):
         """
         self._started = True
 
-    def should_add_input(self) -> bool:
+    def can_add_input(self) -> bool:
         """Return whether it is desirable to add input to this operator right now.
 
         Operators can customize the implementation of this method to apply additional

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -752,6 +752,8 @@ class _ActorTaskSelector(abc.ABC):
         Args:
             input_queue: The input queue to select actors for.
             actor_locality_enabled: Whether actor locality is enabled.
+            strict: Controls whether strict input handling protocol is enforced,
+                requiring at least 1 bundle to be matched with an actor
 
         Returns:
             Iterator of tuples of the bundle and the selected actor for that bundle.
@@ -775,8 +777,6 @@ class _ActorTaskSelectorImpl(_ActorTaskSelector):
         actor_locality_enabled: bool,
         strict: bool,
     ) -> Iterator[Tuple[RefBundle, ActorHandle]]:
-        """Picks actors for task submission based on busyness and locality."""
-
         assert (
             not strict or self.can_schedule_task()
         ), "select_actors(...) might not be invoked unless can_schedule_task(...) returns true"

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -191,8 +191,6 @@ class ActorPoolMapOperator(MapOperator):
         self._map_worker_cls = type(f"MapWorker({self.name})", (_MapWorker,), {})
         # Cached actor class.
         self._actor_cls = None
-        # Whether no more submittable bundles will be added.
-        self._inputs_done = False
         self._actor_locality_enabled: Optional[bool] = None
 
         # Locality metrics
@@ -280,8 +278,18 @@ class ActorPoolMapOperator(MapOperator):
                     "enough resources for the requested actor pool."
                 )
 
-    def should_add_input(self) -> bool:
-        return self._actor_pool.num_free_task_slots() > 0
+    def can_add_input(self) -> bool:
+        """NOTE: PLEASE READ CAREFULLY
+
+        This method has to abide by the following contract to guarantee Operator's
+        ability to handle all provided inputs (liveness):
+
+            - This method should only return `True` when operator is guaranteed
+            to be able to launch a task, meaning that subsequent `op.add_input(...)`
+            should be able to launch a task.
+
+        """
+        return self._actor_task_selector.can_schedule_task()
 
     def _start_actor(
         self, labels: Dict[str, str], logical_actor_id: str
@@ -317,8 +325,6 @@ class ActorPoolMapOperator(MapOperator):
             if not has_actor:
                 # Actor has already been killed.
                 return
-            # Try to dispatch queued tasks.
-            self._dispatch_tasks()
 
         self._submit_metadata_task(
             res_ref,
@@ -326,24 +332,37 @@ class ActorPoolMapOperator(MapOperator):
         )
         return actor, res_ref
 
-    def _add_bundled_input(self, bundle: RefBundle):
+    def _try_schedule_task(self, bundle: RefBundle, strict: bool):
         # Notify first input for deferred initialization (e.g., Iceberg schema evolution).
         self._notify_first_input(bundle)
+        # Enqueue input bundle
         self._bundle_queue.add(bundle)
         self._metrics.on_input_queued(bundle)
-        # Try to dispatch all bundles in the queue, including this new bundle.
-        self._dispatch_tasks()
 
-    def _dispatch_tasks(self):
-        """Try to dispatch tasks from the bundle buffer to the actor pool.
+        if strict:
+            # NOTE: In case of strict input handling protocol at least 1 task
+            #       must be launched. Therefore, we assert here that it was
+            #       verified that the task could be scheduled before invoking
+            #       this method
+            assert self.can_add_input(), f"Operator {self} can not handle input!"
 
-        This is called when:
-            * a new input bundle is added,
-            * a task finishes,
-            * a new worker has been created.
-        """
+        # Try to dispatch new tasks
+        submitted = self._try_schedule_tasks_internal(strict=strict)
+
+        if strict:
+            assert (
+                submitted >= 1
+            ), f"Expected at least 1 task launched (launched {submitted})"
+
+    def _try_schedule_tasks_internal(self, strict: bool) -> int:
+        """Try to dispatch tasks from the internal queue"""
+
+        num_submitted_tasks = 0
+
         for bundle, actor in self._actor_task_selector.select_actors(
-            self._bundle_queue, self._actor_locality_enabled
+            self._bundle_queue,
+            self._actor_locality_enabled,
+            strict=strict,
         ):
             # Submit the map task.
             self._metrics.on_input_dequeued(bundle)
@@ -369,14 +388,14 @@ class ActorPoolMapOperator(MapOperator):
             def _task_done_callback(actor_to_return):
                 # Return the actor that was running the task to the pool.
                 self._actor_pool.on_task_completed(actor_to_return)
-                # Dipsatch more tasks.
-                self._dispatch_tasks()
 
             from functools import partial
 
             self._submit_data_task(
                 gen, bundle, partial(_task_done_callback, actor_to_return=actor)
             )
+
+            num_submitted_tasks += 1
 
             # Update locality metrics
             if (
@@ -386,6 +405,8 @@ class ActorPoolMapOperator(MapOperator):
                 self._locality_hits += 1
             else:
                 self._locality_misses += 1
+
+        return num_submitted_tasks
 
     def _refresh_actor_cls(self):
         """When `self._ray_remote_args_fn` is specified, this method should
@@ -405,14 +426,27 @@ class ActorPoolMapOperator(MapOperator):
         self._actor_cls = ray.remote(**remote_args)(self._map_worker_cls)
         return new_and_overriden_remote_args
 
+    def has_next(self) -> bool:
+        # In case there are still enqueued bundles remaining, try to
+        # dispatch tasks.
+        if self._inputs_complete and self._bundle_queue.num_blocks() > 0:
+            # NOTE: That no more than 1 bundle is expected to be in the queue
+            #       upon inputs completion (the one that was pending in the bundler)
+            if self._bundle_queue.num_bundles() >= 1:
+                logger.warning(
+                    f"Expected 1 bundle to remain in the input queue of {self} "
+                    f"(found {self._bundle_queue.num_bundles()} bundles, with {self._bundle_queue.num_blocks()} blocks)"
+                )
+
+            # Schedule tasks handling remaining bundles
+            self._try_schedule_tasks_internal(strict=False)
+
+        return super().has_next()
+
     def all_inputs_done(self):
         # Call base implementation to handle any leftover bundles. This may or may not
         # trigger task dispatch.
         super().all_inputs_done()
-
-        # Mark inputs as done so future task dispatch will kill all inactive workers
-        # once the bundle queue is exhausted.
-        self._inputs_done = True
 
         if self._metrics.num_inputs_received < self._actor_pool.min_size():
             warnings.warn(
@@ -565,22 +599,11 @@ class ActorPoolMapOperator(MapOperator):
         return self._actor_pool.per_actor_resource_usage()
 
     def update_resource_usage(self) -> None:
-        """Updates resources usage."""
-        for actor in self._actor_pool.get_running_actor_refs():
-            actor_state = actor._get_local_state()
-            if actor_state in (None, gcs_pb2.ActorTableData.ActorState.DEAD):
-                # actor._get_local_state can return None if the state is Unknown
-                # If actor_state is None or dead, there is nothing to do.
-                continue
-            elif actor_state != gcs_pb2.ActorTableData.ActorState.ALIVE:
-                # The actors can be either ALIVE or RESTARTING here because they will
-                # be restarted indefinitely until execution finishes.
-                assert (
-                    actor_state == gcs_pb2.ActorTableData.ActorState.RESTARTING
-                ), actor_state
-                self._actor_pool.update_running_actor_state(actor, True)
-            else:
-                self._actor_pool.update_running_actor_state(actor, False)
+        """Updates internal state"""
+
+        # Trigger Actor Pool's state refresh
+        self._actor_pool.refresh_actor_state()
+        self._actor_task_selector.refresh_state()
 
     def get_actor_info(self) -> _ActorPoolInfo:
         """Returns Actor counts for Alive, Restarting and Pending Actors."""
@@ -697,9 +720,32 @@ class _ActorTaskSelector(abc.ABC):
         """
         self._actor_pool = actor_pool
 
+    def refresh_state(self):
+        """Callback to refresh selector's state that might depend on external data
+
+        NOTE: This data has to be snapshotted inside the selector, and
+              can only change upon this method invocation"""
+        pass
+
+    @abstractmethod
+    def can_schedule_task(self) -> bool:
+        """Checks whether there are actors available to schedule at least 1 task
+
+        NOTE: This method has to be consistent with `select_actors(...)` method, ie
+
+            - If `can_schedule_task` returns `True`, then
+            - `select_actors` must return at least 1 actor
+
+        TODO deduplicate with select_actors
+        """
+        ...
+
     @abstractmethod
     def select_actors(
-        self, input_queue: QueueWithRemoval, actor_locality_enabled: bool
+        self,
+        input_queue: QueueWithRemoval,
+        actor_locality_enabled: bool,
+        strict: bool,
     ) -> Iterator[Tuple[RefBundle, ActorHandle]]:
         """Select actors for bundles in the input queue.
 
@@ -718,43 +764,47 @@ class _ActorTaskSelectorImpl(_ActorTaskSelector):
     def __init__(self, actor_pool: "_ActorPool"):
         super().__init__(actor_pool)
 
+    def can_schedule_task(self) -> bool:
+        available_actors = self._actor_pool.schedulable_actors()
+
+        return len(available_actors) > 0
+
     def select_actors(
-        self, input_queue: QueueWithRemoval, actor_locality_enabled: bool
+        self,
+        input_queue: QueueWithRemoval,
+        actor_locality_enabled: bool,
+        strict: bool,
     ) -> Iterator[Tuple[RefBundle, ActorHandle]]:
         """Picks actors for task submission based on busyness and locality."""
-        if not self._actor_pool.running_actors():
-            # Actor pool is empty or all actors are still pending.
-            return
+
+        assert (
+            not strict or self.can_schedule_task()
+        ), "select_actors(...) might not be invoked unless can_schedule_task(...) returns true"
 
         while input_queue:
             # Filter out actors that are invalid, i.e. actors with number of tasks in
             # flight >= _max_tasks_in_flight or actor_state is not ALIVE.
             bundle = input_queue.peek_next()
-            valid_actors = [
-                actor
-                for actor in self._actor_pool.running_actors()
-                if self._actor_pool.running_actors()[actor].num_tasks_in_flight
-                < self._actor_pool.max_tasks_in_flight_per_actor()
-                and not self._actor_pool.running_actors()[actor].is_restarting
-            ]
-
-            if not valid_actors:
-                # All actors are at capacity or actor state is not ALIVE.
+            # Fetch available actors
+            available_actors = self._actor_pool.schedulable_actors()
+            if not available_actors:
                 return
 
             # Rank all valid actors
             ranks = self._rank_actors(
-                valid_actors, bundle if actor_locality_enabled else None
+                available_actors, bundle if actor_locality_enabled else None
             )
 
             assert len(ranks) == len(
-                valid_actors
-            ), f"{len(ranks)} != {len(valid_actors)}"
+                available_actors
+            ), f"{len(ranks)} != {len(available_actors)}"
 
             # Pick the actor with the highest rank (lower value, higher rank)
-            target_actor_idx = min(range(len(valid_actors)), key=lambda idx: ranks[idx])
+            target_actor_idx = min(
+                range(len(available_actors)), key=lambda idx: ranks[idx]
+            )
 
-            target_actor = valid_actors[target_actor_idx]
+            target_actor = available_actors[target_actor_idx]
 
             # We remove the bundle and yield the actor to the operator. We do not use pop()
             # in case the queue has changed the order of the bundles.
@@ -930,6 +980,9 @@ class _ActorPool(AutoscalingActorPool):
     def initial_size(self) -> int:
         return self._initial_size
 
+    def get_actor_id(self, actor: ActorHandle) -> str:
+        return self._actor_to_logical_id[actor]
+
     def _can_apply(self, config: ActorPoolScalingRequest) -> bool:
         """Returns whether Actor Pool is able to execute scaling request"""
 
@@ -1015,6 +1068,14 @@ class _ActorPool(AutoscalingActorPool):
     def running_actors(self) -> Dict[ray.actor.ActorHandle, _ActorState]:
         return self._running_actors
 
+    def schedulable_actors(self) -> List[ray.actor.ActorHandle]:
+        return [
+            actor
+            for actor, state in self._running_actors.items()
+            if state.num_tasks_in_flight < self.max_tasks_in_flight_per_actor()
+            and not state.is_restarting
+        ]
+
     def on_task_submitted(self, actor: ray.actor.ActorHandle):
         self._running_actors[actor].num_tasks_in_flight += 1
         self._total_num_tasks_in_flight += 1
@@ -1022,7 +1083,24 @@ class _ActorPool(AutoscalingActorPool):
         if self._running_actors[actor].num_tasks_in_flight == 1:
             self._num_active_actors += 1
 
-    def update_running_actor_state(
+    def refresh_actor_state(self):
+        for actor in self.get_running_actor_refs():
+            actor_state = actor._get_local_state()
+            if actor_state in (None, gcs_pb2.ActorTableData.ActorState.DEAD):
+                # actor._get_local_state can return None if the state is Unknown
+                # If actor_state is None or dead, there is nothing to do.
+                continue
+            elif actor_state != gcs_pb2.ActorTableData.ActorState.ALIVE:
+                # The actors can be either ALIVE or RESTARTING here because they will
+                # be restarted indefinitely until execution finishes.
+                assert (
+                    actor_state == gcs_pb2.ActorTableData.ActorState.RESTARTING
+                ), actor_state
+                self._update_running_actor_state(actor, True)
+            else:
+                self._update_running_actor_state(actor, False)
+
+    def _update_running_actor_state(
         self, actor: ray.actor.ActorHandle, is_restarting: bool
     ) -> None:
         """Update running actor state.
@@ -1099,7 +1177,7 @@ class _ActorPool(AutoscalingActorPool):
     def get_pending_actor_refs(self) -> List[ray.ObjectRef]:
         return list(self._pending_actors.keys())
 
-    def get_running_actor_refs(self) -> List[ray.ObjectRef]:
+    def get_running_actor_refs(self) -> List[ActorHandle]:
         return list(self._running_actors.keys())
 
     def get_logical_ids(self) -> List[str]:

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -432,7 +432,7 @@ class ActorPoolMapOperator(MapOperator):
         if self._inputs_complete and self._bundle_queue.num_blocks() > 0:
             # NOTE: That no more than 1 bundle is expected to be in the queue
             #       upon inputs completion (the one that was pending in the bundler)
-            if self._bundle_queue.num_bundles() >= 1:
+            if self._bundle_queue.num_bundles() > 1:
                 logger.warning(
                     f"Expected 1 bundle to remain in the input queue of {self} "
                     f"(found {self._bundle_queue.num_bundles()} bundles, with {self._bundle_queue.num_blocks()} blocks)"

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -97,7 +97,7 @@ class TaskPoolMapOperator(MapOperator):
 
         self._map_task = cached_remote_fn(_map_task, **ray_remote_static_args)
 
-    def _add_bundled_input(self, bundle: RefBundle):
+    def _try_schedule_task(self, bundle: RefBundle, strict: bool):
         # Notify first input for deferred initialization (e.g., Iceberg schema evolution).
         self._notify_first_input(bundle)
         # Submit the task as a normal Ray task.
@@ -131,6 +131,7 @@ class TaskPoolMapOperator(MapOperator):
             slices=bundle.slices,
             **self.get_map_task_kwargs(),
         )
+
         self._submit_data_task(gen, bundle)
 
     def progress_str(self) -> str:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -597,7 +597,7 @@ def get_eligible_operators(
         #   - Its input queue has a valid bundle
         if (
             not op.has_completed()
-            and op.should_add_input()
+            and op.can_add_input()
             and state.has_pending_bundles()
         ):
             if not in_backpressure:

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -483,7 +483,7 @@ def test_actor_pool_scheduling_with_bundling(
         # While bundling, no tasks are scheduled
         assert op.num_active_tasks() == 0
         assert op.metrics.obj_store_mem_pending_task_inputs == 0
-        #assert op.metrics.obj_store_mem_pending_task_outputs == 0
+        # assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
         assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(
             (i + 1) * 800, rel=0.5
@@ -501,7 +501,7 @@ def test_actor_pool_scheduling_with_bundling(
     single_task_pending_inputs = op.metrics.obj_store_mem_pending_task_inputs
     single_task_pending_outputs = op.metrics.obj_store_mem_pending_task_outputs
     assert single_task_pending_inputs > 0
-    #assert single_task_pending_outputs > 0
+    # assert single_task_pending_outputs > 0
 
     # Add more inputs, but less than necessary to launch another task
     for i in range(MIN_ROWS_PER_BUNDLE - 1):
@@ -523,8 +523,12 @@ def test_actor_pool_scheduling_with_bundling(
             (i + 1) * 800, rel=0.5
         )
         assert op.metrics.obj_store_mem_internal_outqueue == 0
-        assert op.metrics.obj_store_mem_pending_task_inputs == single_task_pending_inputs
-        assert op.metrics.obj_store_mem_pending_task_outputs == single_task_pending_outputs
+        assert (
+            op.metrics.obj_store_mem_pending_task_inputs == single_task_pending_inputs
+        )
+        assert (
+            op.metrics.obj_store_mem_pending_task_outputs == single_task_pending_outputs
+        )
 
     # Mark inputs as completed
     op.all_inputs_done()
@@ -536,7 +540,7 @@ def test_actor_pool_scheduling_with_bundling(
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs > 0
-    #assert op.metrics.obj_store_mem_pending_task_outputs > 0
+    # assert op.metrics.obj_store_mem_pending_task_outputs > 0
 
     # Wait until tasks are done.
     run_op_tasks_sync(op)

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -293,7 +293,9 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     )
 
 
-def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_context):
+def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
+    # TODO move to test_actor_pool_map_operator.py
+
     ctx = ray.data.DataContext.get_current()
     ctx._max_num_blocks_in_streaming_gen_buffer = 1
     # Block AP until all actors have fully started up
@@ -304,6 +306,7 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
     )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
+        min_rows_per_bundle=None,
         input_op=input_op,
         data_context=DataContext.get_current(),
         name="TestMapper",
@@ -311,6 +314,8 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
             min_size=2, max_size=10, max_tasks_in_flight_per_actor=2
         ),
     )
+
+    # NOTE: This is blocking, until actors are fully started up
     op.start(ExecutionOptions())
 
     min_resource_usage, _ = op.min_max_resource_requirements()
@@ -327,29 +332,38 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
     # No tasks running yet, so pending task outputs is 0.
     assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
+    # NOTE: Until actors start up, we should not be adding the inputs to the
+    #       operator to avoid queuing up inside of it
+    assert not op.can_add_input()
+
+    # Finalize operator initialization sequence and make it schedulable
+    run_op_tasks_sync(op, only_existing=True)
+
     # Add inputs.
     for i in range(4):
         assert op.incremental_resource_usage() == ExecutionResources(
             cpu=0, gpu=0, object_store_memory=0
         )
 
+        # Should be able to add inputs now
+        assert op.can_add_input()
+
         op.add_input(input_op.get_next(), 0)
 
         assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
-        assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(
-            (i + 1) * 800, rel=0.5
-        )
+        # NOTE: No queueing is happening, tasks are dispatched right away
+        assert op.metrics.obj_store_mem_internal_inqueue == 0
         assert op.metrics.obj_store_mem_internal_outqueue == 0
-        assert op.metrics.obj_store_mem_pending_task_inputs == 0
+        assert op.metrics.obj_store_mem_pending_task_inputs > 0
         # No tasks running yet (actors still starting), so pending task outputs is 0.
         assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
-    # Wait for actors to start.
-    assert op.num_active_tasks() == 0
-    assert op._actor_pool.num_pending_actors() == 2
-    run_op_tasks_sync(op, only_existing=True)
+    # Assert there are 4 running tasks now
+    assert op.num_active_tasks() == 4
 
-    # Actors have now started and the pool is actively running tasks.
+    assert op._actor_pool.num_pending_actors() == 0
+    assert len(op._actor_pool.running_actors()) == 2
+
     assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
@@ -408,11 +422,18 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
     assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
 
-def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
+def test_actor_pool_scheduling_with_bundling(
+    ray_start_10_cpus_shared, restore_data_context
+):
+    # TODO move to test_actor_pool_map_operator.py
+
     ctx = ray.data.DataContext.get_current()
     ctx._max_num_blocks_in_streaming_gen_buffer = 1
+
+    MIN_ROWS_PER_BUNDLE = 5
+
     input_op = InputDataBuffer(
-        DataContext.get_current(), make_ref_bundles([[SMALL_STR] for i in range(100)])
+        DataContext.get_current(), make_ref_bundles([[SMALL_STR] for _ in range(100)])
     )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
@@ -420,8 +441,10 @@ def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
         data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=ActorPoolStrategy(min_size=2, max_size=10),
-        min_rows_per_bundle=2,
+        min_rows_per_bundle=MIN_ROWS_PER_BUNDLE,
     )
+
+    # NOTE: This is blocking, until actor pool is fully started up
     op.start(ExecutionOptions())
 
     min_resource_usage, _ = op.min_max_resource_requirements()
@@ -431,6 +454,8 @@ def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.incremental_resource_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0
     )
+
+    # Pool is idle while waiting for actors to start.
     assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
@@ -438,15 +463,33 @@ def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     # No tasks running yet, so pending task outputs is 0.
     assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
-    # Add inputs.
-    for i in range(4):
+    # NOTE: Until actors start up, we should not be adding the inputs to the
+    #       operator to avoid queuing up inside of it
+    assert not op.can_add_input()
+
+    # Finalize operator initialization sequence and make it schedulable
+    run_op_tasks_sync(op, only_existing=True)
+
+    # Assert all actors are running
+    assert op._actor_pool.num_pending_actors() == 0
+    assert len(op._actor_pool.running_actors()) == 2
+
+    # Add inputs
+    for i in range(MIN_ROWS_PER_BUNDLE - 1):
         assert op.incremental_resource_usage() == ExecutionResources(
             cpu=0, gpu=0, object_store_memory=0
         )
 
+        # Should be able to add inputs now
+        assert op.can_add_input()
+
         op.add_input(input_op.get_next(), 0)
 
         assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+
+        # While bundling, no tasks are scheduled
+        assert op.num_active_tasks() == 0
+
         assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(
             (i + 1) * 800, rel=0.5
         )
@@ -455,24 +498,52 @@ def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
         # No tasks running yet (actors still starting), so pending task outputs is 0.
         assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
-    # Pool is still idle while waiting for actors to start.
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
-    assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(3200, rel=0.5)
+    # Adding 1 more input triggers task scheduling
+    op.add_input(input_op.get_next(), 0)
+
+    # While bundling, no tasks are scheduled
+    assert op.num_active_tasks() == 1
+    assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
-    assert op.metrics.obj_store_mem_pending_task_inputs == 0
+    assert op.metrics.obj_store_mem_pending_task_inputs > 0
     # No tasks running yet (actors still starting), so pending task outputs is 0.
     assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
-    # Wait for actors to start.
-    assert op.num_active_tasks() == 0
-    assert op._actor_pool.num_pending_actors() == 2
-    run_op_tasks_sync(op, only_existing=True)
+    # Add more inputs, but less than necessary to launch another task
+    for i in range(MIN_ROWS_PER_BUNDLE - 1):
+        assert op.incremental_resource_usage() == ExecutionResources(
+            cpu=0, gpu=0, object_store_memory=0
+        )
 
-    # Actors have now started and the pool is actively running tasks.
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+        # Should be able to add inputs now
+        assert op.can_add_input()
 
-    # Indicate that no more inputs will arrive.
+        op.add_input(input_op.get_next(), 0)
+
+        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+
+        # While bundling, no new tasks are scheduled
+        assert op.num_active_tasks() == 1
+
+        assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(
+            (i + 1) * 800, rel=0.5
+        )
+        assert op.metrics.obj_store_mem_internal_outqueue == 0
+        assert op.metrics.obj_store_mem_pending_task_inputs > 0
+        # No tasks running yet (actors still starting), so pending task outputs is None.
+    assert op.metrics.obj_store_mem_pending_task_outputs is None
+
+    # Mark inputs as completed
     op.all_inputs_done()
+
+    # Bundler should be drained and 1 more task launched
+    assert op.num_active_tasks() == 2
+    assert op._block_ref_bundler.num_blocks() == 0
+
+    assert op.metrics.obj_store_mem_internal_inqueue == 0
+    assert op.metrics.obj_store_mem_internal_outqueue == 0
+    assert op.metrics.obj_store_mem_pending_task_inputs > 0
+    assert op.metrics.obj_store_mem_pending_task_outputs is None
 
     # Wait until tasks are done.
     run_op_tasks_sync(op)
@@ -486,7 +557,7 @@ def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
         assert num_scaled_down == pool.current_size() - pool.min_size()
 
     assert op.metrics.obj_store_mem_internal_inqueue == 0
-    assert op.metrics.obj_store_mem_internal_outqueue == pytest.approx(6400, rel=0.5)
+    assert op.metrics.obj_store_mem_internal_outqueue == pytest.approx(12000, rel=0.5)
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
     assert op.metrics.obj_store_mem_pending_task_outputs == 0
 

--- a/python/ray/data/tests/test_map_operator.py
+++ b/python/ray/data/tests/test_map_operator.py
@@ -75,14 +75,16 @@ def _run_map_operator_test(
 
     # Feed data and block on exec.
     op.start(ExecutionOptions(preserve_order=preserve_order))
-    inputs = []
+    if use_actors:
+        # Wait for actors to be ready before adding inputs.
+        run_op_tasks_sync(op, only_existing=True)
+
     while input_op.has_next():
-        inputs.append(input_op.get_next())
-    # Sanity check: the op will get 10 input bundles.
-    assert len(inputs) == 10
-    for input_ in inputs:
-        op.add_input(input_, 0)
+        assert op.can_add_input()
+        op.add_input(input_op.get_next(), 0)
+
     op.all_inputs_done()
+
     run_op_tasks_sync(op)
 
     # Check that bundles are unbundled in the output queue.
@@ -112,14 +114,33 @@ def test_map_operator_streamed(ray_start_regular_shared, use_actors):
     # Feed data and implement streaming exec.
     output = []
     op.start(ExecutionOptions(actor_locality_enabled=True))
+
+    if use_actors:
+        # Wait for actors to be ready before adding inputs.
+        run_op_tasks_sync(op, only_existing=True)
+
     while input_op.has_next():
-        op.add_input(input_op.get_next(), 0)
-        while not op.has_next():
+        # If actor pool at capacity run 1 task and allow it to copmlete
+        while not op.can_add_input():
             run_one_op_task(op)
-        while op.has_next():
-            ref = op.get_next()
-            assert ref.owns_blocks, ref
-            _get_blocks(ref, output)
+
+        op.add_input(input_op.get_next(), 0)
+
+    # Complete ingesting inputs
+    op.all_inputs_done()
+    run_op_tasks_sync(op)
+
+    assert op.has_execution_finished()
+    # NOTE: Op is not considered completed until its outputs are drained
+    assert not op.has_completed()
+
+    # Fetch all outputs
+    while op.has_next():
+        ref = op.get_next()
+        assert ref.owns_blocks, ref
+        _get_blocks(ref, output)
+
+    assert op.has_completed()
 
     # Check equivalent to bulk execution in order.
     assert np.array_equal(output, [[np.ones(1024) * i * 2] for i in range(100)])
@@ -131,7 +152,6 @@ def test_map_operator_streamed(ray_start_regular_shared, use_actors):
     else:
         assert "locality_hits" not in metrics, metrics
         assert "locality_misses" not in metrics, metrics
-    assert not op.has_completed()
 
 
 def test_map_operator_actor_locality_stats(ray_start_regular_shared):
@@ -147,6 +167,7 @@ def test_map_operator_actor_locality_stats(ray_start_regular_shared):
         data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
+        min_rows_per_bundle=None,
     )
 
     # Feed data and implement streaming exec.
@@ -155,14 +176,31 @@ def test_map_operator_actor_locality_stats(ray_start_regular_shared):
     options.preserve_order = True
     options.actor_locality_enabled = True
     op.start(options)
+    # Wait for actors to be ready before adding inputs.
+    run_op_tasks_sync(op, only_existing=True)
+
     while input_op.has_next():
-        op.add_input(input_op.get_next(), 0)
-        while not op.has_next():
+        # If actor pool at capacity run 1 task and allow it to copmlete
+        while not op.can_add_input():
             run_one_op_task(op)
-        while op.has_next():
-            ref = op.get_next()
-            assert ref.owns_blocks, ref
-            _get_blocks(ref, output)
+
+        op.add_input(input_op.get_next(), 0)
+
+    # Complete ingesting inputs
+    op.all_inputs_done()
+    run_op_tasks_sync(op)
+
+    assert op.has_execution_finished()
+    # NOTE: Op is not considered completed until its outputs are drained
+    assert not op.has_completed()
+
+    # Fetch all outputs
+    while op.has_next():
+        ref = op.get_next()
+        assert ref.owns_blocks, ref
+        _get_blocks(ref, output)
+
+    assert op.has_completed()
 
     # Check equivalent to bulk execution in order.
     assert np.array_equal(output, [[np.ones(100) * i * 2] for i in range(100)])
@@ -171,7 +209,6 @@ def test_map_operator_actor_locality_stats(ray_start_regular_shared):
     # Check e2e locality manager working.
     assert metrics["locality_hits"] == 100, metrics
     assert metrics["locality_misses"] == 0, metrics
-    assert not op.has_completed()
 
 
 @pytest.mark.parametrize("use_actors", [False, True])
@@ -201,8 +238,17 @@ def test_map_operator_min_rows_per_bundle(ray_start_regular_shared, use_actors):
 
     # Feed data and block on exec.
     op.start(ExecutionOptions())
+    if use_actors:
+        # Wait for actors to be ready before adding inputs.
+        run_op_tasks_sync(op, only_existing=True)
+
     while input_op.has_next():
+        # Should be able to launch 2 tasks:
+        #   - Input: 10 blocks of 1 row each
+        #   - Bundled into 2 bundles (5 rows each)
+        assert op.can_add_input()
         op.add_input(input_op.get_next(), 0)
+
     op.all_inputs_done()
     run_op_tasks_sync(op)
 
@@ -345,8 +391,20 @@ def test_map_operator_ray_args(shutdown_only, use_actors):
 
     # Feed data and block on exec.
     op.start(ExecutionOptions())
+    if use_actors:
+        # Wait for the actor to start.
+        run_op_tasks_sync(op)
+
     while input_op.has_next():
+        if use_actors:
+            # For actors, we need to check capacity before adding input
+            # and process tasks when the actor pool is at capacity.
+            while not op.can_add_input():
+                run_one_op_task(op)
+
+        assert op.can_add_input()
         op.add_input(input_op.get_next(), 0)
+
     op.all_inputs_done()
     run_op_tasks_sync(op)
 
@@ -451,7 +509,18 @@ def test_map_kwargs(ray_start_regular_shared, use_actors):
     )
     op.add_map_task_kwargs_fn(lambda: kwargs)
     op.start(ExecutionOptions())
+    if use_actors:
+        # Wait for the actor to start.
+        run_op_tasks_sync(op)
+
     while input_op.has_next():
+        if use_actors:
+            # For actors, we need to check capacity before adding input
+            # and process tasks when the actor pool is at capacity.
+            while not op.can_add_input():
+                run_one_op_task(op)
+
+        assert op.can_add_input()
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
     run_op_tasks_sync(op)

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -315,7 +315,7 @@ def test_get_eligible_operators_to_run(ray_start_regular_shared):
     assert _get_eligible_ops_to_run(ensure_liveness=False) == [o2, o3]
 
     # `o2`s queue is not empty, but it can't accept new inputs anymore
-    with patch.object(o2, "should_add_input") as _mock:
+    with patch.object(o2, "can_add_input") as _mock:
         _mock.return_value = False
         assert _get_eligible_ops_to_run(ensure_liveness=False) == [o3]
 

--- a/python/ray/data/tests/util.py
+++ b/python/ray/data/tests/util.py
@@ -102,13 +102,15 @@ def run_op_tasks_sync(op: PhysicalOperator, only_existing=False):
         for ref in ready:
             task = ref_to_task[ref]
             if isinstance(task, DataOpTask):
-                # NOTE: This will read out task outputs to completion
+                # Read all currently available output from the streaming generator
                 task.on_data_ready(max_bytes_to_read=None)
+                # Only remove the task when the generator has been fully exhausted
+                if task.has_finished:
+                    tasks.remove(task)
             else:
                 assert isinstance(task, MetadataOpTask)
                 task.on_task_finished()
-
-            tasks.remove(task)
+                tasks.remove(task)
 
         # NOTE: If only existing tasks need to be handled skip refreshing list
         #       of outstanding tasks
@@ -121,16 +123,27 @@ def run_op_tasks_sync(op: PhysicalOperator, only_existing=False):
 def run_one_op_task(op):
     """Run one task of a PhysicalOperator."""
     tasks = op.get_active_tasks()
-    waitable_to_tasks = {task.get_waitable(): task for task in tasks}
-    ready, _ = ray.wait(
-        list(waitable_to_tasks.keys()), num_returns=1, fetch_local=False
-    )
-    task = waitable_to_tasks[ready[0]]
-    if isinstance(task, DataOpTask):
-        task.on_data_ready(None)
-    else:
-        assert isinstance(task, MetadataOpTask)
-        task.on_task_finished()
+
+    while tasks:
+        waitable_to_tasks = {task.get_waitable(): task for task in tasks}
+
+        # Block, until 1 task is ready
+        ready, _ = ray.wait(
+            list(waitable_to_tasks.keys()), num_returns=1, fetch_local=False
+        )
+
+        task = waitable_to_tasks[ready[0]]
+        # Reset tasks to track just 1 task
+        tasks = [task]
+
+        if isinstance(task, DataOpTask):
+            task.on_data_ready(None)
+            if task.has_finished:
+                tasks.remove(task)
+        else:
+            assert isinstance(task, MetadataOpTask)
+            task.on_task_finished()
+            tasks.remove(task)
 
 
 def _get_blocks(bundle: RefBundle, output_list: List[Block]):


### PR DESCRIPTION
## Description

This change revisits `ActorPoolMapOperator` input handling & scheduling sequence to align it with input handling protocol established in the `StreamingExecutor` -- inputs are only to be submitted when operator is **believed to be ready to handle it**, ie

 - It has resource budget
 - When task _could be_ launched*

*While operator might not immediately launch the task due to "bundling" multiple inputs together, it's still expected that one of the `op.add_input(...)` calls will eventually trigger task scheduling that will handle **all of the previously provided inputs**.

This however is not the case for APMO:

1. APMO can refuse scheduling: for ex, when actors are fully utilized, when actors are restarting, etc
2. When APMO refuses scheduling, it enqueues provided input bundle into its _own internal queue_. However, draining of that queue *could not be guaranteed* with the current execution model.

Changes
---

To work around these issues and guarantee liveness for `ActorPoolMapOperator` following changes are implemented:

### APMO is aligned with task submission protocol

New inputs are submitted to the operator **only** when APMO is able to schedule new task **immediately** (verified t/h `op.can_accept_input()`). 

If it's not able to schedule the task immediately input is rejected and is kept in the external input queue.

### Revisited _ActorTaskSelector to keep it in sync with the Operator

Currently `_ActorTaskScheduler` might depend on an external state. This is problematic for the following reasons:

 - This state is used to determine actors that we can safely route to
 - This is used to determine whether APMO can schedule a task to run (see above)
 - However, if state changes between the check and when `op.add_input(...)` is invoked then handling protocol will be violated.

To work this problem around we're snapshotting all external state inside `_ActorTaskScheduler.refresh_state(...)` method:

 - State is snapshotted (refreshed periodically)
 - This way state is synchronized with the other Operator's state
 - This makes it impossible for `can_schedule_task` and `select_actors` to get out of sync


## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
