### PR TITLE
[Serve] [1/n] Add core types and public API for gRPC bidirectional streaming

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -139,6 +139,8 @@ nitpick_ignore_regex = [
     # UnknownPreprocessorError is an internal exception not exported in public API
     ("py:exc", "UnknownPreprocessorError"),
     ("py:exc", "ray\\.data\\.preprocessors\\.version_support\\.UnknownPreprocessorError"),
+    # TypeVar for gRPCInputStream generic type
+    ("py:obj", "ray\\.serve\\.grpc_util\\.T"),
 ]
 
 # Cache notebook outputs in _build/.jupyter_cache

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -141,6 +141,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
    serve.get_app_handle
    serve.get_deployment_handle
    serve.grpc_util.RayServegRPCContext
+   serve.grpc_util.gRPCInputStream
    serve.exceptions.BackPressureError
    serve.exceptions.RayServeException
    serve.exceptions.RequestCancelledError

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -721,6 +721,21 @@ class gRPCRequest:
     user_request_proto: Any
 
 
+@dataclass
+class gRPCStreamingRequest:
+    """Sent from the GRPC proxy to replicas for client/bidirectional streaming.
+
+    This class carries metadata about the streaming session. The actual request
+    messages are delivered through a separate channel/callback mechanism.
+    """
+
+    # Session ID for tracking this streaming session
+    session_id: str
+
+    # Name of the proxy actor to call back for receiving messages
+    proxy_actor_name: str
+
+
 class RequestProtocol(str, Enum):
     UNDEFINED = "UNDEFINED"
     HTTP = "HTTP"

--- a/python/ray/serve/_private/proxy_request_response.py
+++ b/python/ray/serve/_private/proxy_request_response.py
@@ -2,6 +2,7 @@ import logging
 import pickle
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, AsyncIterator, List, Tuple, Union
 
 import grpc
@@ -13,6 +14,21 @@ from ray.serve._private.utils import DEFAULT
 from ray.serve.grpc_util import RayServegRPCContext
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+
+class gRPCStreamingType(str, Enum):
+    """Enum representing the gRPC streaming type."""
+
+    UNARY_UNARY = "unary_unary"  # Single request, single response
+    UNARY_STREAM = (
+        "unary_stream"  # Single request, streaming response (server streaming)
+    )
+    STREAM_UNARY = (
+        "stream_unary"  # Streaming request, single response (client streaming)
+    )
+    STREAM_STREAM = (
+        "stream_stream"  # Streaming request, streaming response (bidirectional)
+    )
 
 
 class ProxyRequest(ABC):

--- a/python/ray/serve/grpc_util.py
+++ b/python/ray/serve/grpc_util.py
@@ -1,8 +1,104 @@
-from typing import Any, Dict, List, Optional, Tuple
+import asyncio
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, TypeVar
 
 import grpc
 
 from ray.util.annotations import PublicAPI
+
+T = TypeVar("T")
+
+
+@PublicAPI(stability="beta")
+class gRPCInputStream(AsyncIterator[T]):
+    """Async iterator wrapping an incoming gRPC request stream.
+
+    This class is used for client streaming and bidirectional streaming RPCs.
+    It allows deployment methods to iterate over incoming request messages
+    from the client.
+
+    Example usage in a deployment:
+
+    .. code-block:: python
+
+        @serve.deployment
+        class BidiService:
+            # Client streaming (stream-unary)
+            async def ClientStreaming(self, request_stream: gRPCInputStream):
+                total = 0
+                async for request in request_stream:
+                    total += request.value
+                return Response(result=total)
+
+            # Bidirectional streaming (stream-stream)
+            async def BidiStreaming(self, request_stream: gRPCInputStream):
+                async for request in request_stream:
+                    yield Response(greeting=f"Hello {request.name}")
+    """
+
+    def __init__(
+        self,
+        request_iterator: AsyncIterator[Any],
+        *,
+        cancel_event: Optional[asyncio.Event] = None,
+    ):
+        """Initialize the gRPCInputStream.
+
+        Args:
+            request_iterator: The underlying async iterator of request messages.
+            cancel_event: Optional event that signals cancellation from the client.
+        """
+        self._request_iterator = request_iterator
+        self._cancel_event = cancel_event or asyncio.Event()
+        self._exhausted = False
+
+    def __aiter__(self) -> "gRPCInputStream[T]":
+        return self
+
+    async def __anext__(self) -> T:
+        """Get the next request message from the stream.
+
+        Returns:
+            The next request message from the stream.
+
+        Raises:
+            StopAsyncIteration: When the stream is exhausted or cancelled.
+        """
+        if self._exhausted:
+            raise StopAsyncIteration
+
+        if self._cancel_event.is_set():
+            self._exhausted = True
+            raise StopAsyncIteration
+
+        try:
+            return await self._request_iterator.__anext__()
+        except StopAsyncIteration:
+            self._exhausted = True
+            raise
+
+    def is_cancelled(self) -> bool:
+        """Check if the client has cancelled the stream.
+
+        Returns:
+            True if the stream has been cancelled, False otherwise.
+        """
+        return self._cancel_event.is_set()
+
+    def cancel(self) -> None:
+        """Mark the stream as cancelled.
+
+        This will cause subsequent iteration to stop.
+        """
+        self._cancel_event.set()
+
+    @property
+    def is_exhausted(self) -> bool:
+        """Check if the stream has been fully consumed.
+
+        Returns:
+            True if all messages have been consumed, False otherwise.
+        """
+        return self._exhausted
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/serve/grpc_util.py
+++ b/python/ray/serve/grpc_util.py
@@ -37,7 +37,7 @@ class gRPCInputStream(AsyncIterator[T]):
 
     def __init__(
         self,
-        request_iterator: AsyncIterator[Any],
+        request_iterator: AsyncIterator[T],
         *,
         cancel_event: Optional[asyncio.Event] = None,
     ):
@@ -65,12 +65,9 @@ class gRPCInputStream(AsyncIterator[T]):
         """
         if self._exhausted:
             raise StopAsyncIteration
-
-        if self._cancel_event.is_set():
-            self._exhausted = True
-            raise StopAsyncIteration
-
         try:
+            if self._cancel_event.is_set():
+                raise StopAsyncIteration
             return await self._request_iterator.__anext__()
         except StopAsyncIteration:
             self._exhausted = True


### PR DESCRIPTION
This PR adds the foundational types needed for gRPC client streaming and bidirectional streaming support:

- gRPCStreamingType enum: Represents the four gRPC streaming types (UNARY_UNARY, UNARY_STREAM, STREAM_UNARY, STREAM_STREAM)
- gRPCStreamingRequest dataclass: Carries metadata about streaming sessions from proxy to replicas
- gRPCInputStream class: Public API for deployments to iterate over incoming request messages in client/bidirectional streaming RPCs

This is PR 1 of N for adding gRPC bidirectional streaming support. https://github.com/ray-project/ray/pull/60490