### PR TITLE
[Data] Include logical memory in resource manager scheduling decisions

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -549,8 +549,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             result.append((metric.name, value))
 
         # TODO: record resource usage in OpRuntimeMetrics,
-        # avoid calling self._op.current_processor_usage()
-        resource_usage = self._op.current_processor_usage()
+        # avoid calling self._op.current_logical_usage()
+        resource_usage = self._op.current_logical_usage()
         result.extend(
             [
                 ("cpu_usage", resource_usage.cpu or 0),

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -679,14 +679,14 @@ class PhysicalOperator(Operator):
         # Default implementation simply cancels any outstanding active task
         self._cancel_active_tasks(force=force)
 
-    def current_processor_usage(self) -> ExecutionResources:
-        """Returns the current estimated CPU and GPU usage of this operator, excluding
-        object store memory.
+    def current_logical_usage(self) -> ExecutionResources:
+        """Returns the current estimated CPU, GPU, and memory usage of this operator,
+        excluding object store memory.
 
         This method is called by the executor to decide how to allocate processors
         between different operators.
         """
-        return ExecutionResources(0, 0, 0)
+        return ExecutionResources(0, 0, 0, 0)
 
     def running_processor_usage(self) -> ExecutionResources:
         """Returns the estimated running CPU and GPU usage of this operator, excluding
@@ -696,11 +696,11 @@ class PhysicalOperator(Operator):
         executor to display the number of currently running CPUs and GPUs in the
         progress bar.
 
-        Note, this method returns `current_processor_usage() -
+        Note, this method returns `current_logical_usage() -
         pending_processor_usage()` by default. Subclasses should only override
         `pending_processor_usage()` if needed.
         """
-        usage = self.current_processor_usage()
+        usage = self.current_logical_usage()
         usage = usage.subtract(self.pending_processor_usage())
         return usage
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -683,7 +683,7 @@ class PhysicalOperator(Operator):
         """Returns the current estimated CPU, GPU, and memory usage of this operator,
         excluding object store memory.
 
-        This method is called by the executor to decide how to allocate processors
+        This method is called by the executor to decide how to allocate resources
         between different operators.
         """
         return ExecutionResources.zero()

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -697,22 +697,22 @@ class PhysicalOperator(Operator):
         progress bar.
 
         Note, this method returns `current_logical_usage() -
-        pending_processor_usage()` by default. Subclasses should only override
-        `pending_processor_usage()` if needed.
+        pending_logical_usage()` by default. Subclasses should only override
+        `pending_logical_usage()` if needed.
         """
         usage = self.current_logical_usage()
-        usage = usage.subtract(self.pending_processor_usage())
+        usage = usage.subtract(self.pending_logical_usage())
         return usage
 
-    def pending_processor_usage(self) -> ExecutionResources:
-        """Returns the estimated pending CPU and GPU usage of this operator, excluding
-        object store memory.
+    def pending_logical_usage(self) -> ExecutionResources:
+        """Returns the estimated pending CPU, GPU, and memory usage of this operator,
+        excluding object store memory.
 
         This method is called by the resource manager and the streaming
         executor to display the number of currently pending actors in the
         progress bar.
         """
-        return ExecutionResources(0, 0, 0)
+        return ExecutionResources(0, 0, 0, 0)
 
     def min_max_resource_requirements(
         self,

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -686,7 +686,7 @@ class PhysicalOperator(Operator):
         This method is called by the executor to decide how to allocate processors
         between different operators.
         """
-        return ExecutionResources(0, 0, 0, 0)
+        return ExecutionResources.zero()
 
     def running_logical_usage(self) -> ExecutionResources:
         """Returns the estimated running CPU, GPU, and memory usage of this operator,
@@ -712,7 +712,7 @@ class PhysicalOperator(Operator):
         executor to display the number of currently pending actors in the
         progress bar.
         """
-        return ExecutionResources(0, 0, 0, 0)
+        return ExecutionResources.zero()
 
     def min_max_resource_requirements(
         self,

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -688,13 +688,13 @@ class PhysicalOperator(Operator):
         """
         return ExecutionResources(0, 0, 0, 0)
 
-    def running_processor_usage(self) -> ExecutionResources:
-        """Returns the estimated running CPU and GPU usage of this operator, excluding
-        object store memory.
+    def running_logical_usage(self) -> ExecutionResources:
+        """Returns the estimated running CPU, GPU, and memory usage of this operator,
+        excluding object store memory.
 
         This method is called by the resource manager and the streaming
-        executor to display the number of currently running CPUs and GPUs in the
-        progress bar.
+        executor to display the number of currently running CPUs, GPUs, and memory in
+        the progress bar.
 
         Note, this method returns `current_logical_usage() -
         pending_logical_usage()` by default. Subclasses should only override

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -524,7 +524,7 @@ class ActorPoolMapOperator(MapOperator):
             memory=self._ray_remote_args.get("memory", 0) * num_active_workers,
         )
 
-    def pending_processor_usage(self) -> ExecutionResources:
+    def pending_logical_usage(self) -> ExecutionResources:
         # Both pending and restarting actors count towards pending processor usage
         num_pending_workers = (
             self._actor_pool.num_pending_actors()
@@ -533,6 +533,7 @@ class ActorPoolMapOperator(MapOperator):
         return ExecutionResources(
             cpu=self._ray_remote_args.get("num_cpus", 0) * num_pending_workers,
             gpu=self._ray_remote_args.get("num_gpus", 0) * num_pending_workers,
+            memory=self._ray_remote_args.get("memory", 0) * num_pending_workers,
         )
 
     def incremental_resource_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -515,12 +515,13 @@ class ActorPoolMapOperator(MapOperator):
 
         return min_resource_usage, max_resource_usage
 
-    def current_processor_usage(self) -> ExecutionResources:
+    def current_logical_usage(self) -> ExecutionResources:
         # Both pending and running actors count towards our current resource usage.
         num_active_workers = self._actor_pool.current_size()
         return ExecutionResources(
             cpu=self._ray_remote_args.get("num_cpus", 0) * num_active_workers,
             gpu=self._ray_remote_args.get("num_gpus", 0) * num_active_workers,
+            memory=self._ray_remote_args.get("memory", 0) * num_active_workers,
         )
 
     def pending_processor_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1014,7 +1014,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
             reduce_name: self._output_blocks_stats,
         }
 
-    def current_processor_usage(self) -> ExecutionResources:
+    def current_logical_usage(self) -> ExecutionResources:
         # Current processors resource usage is comprised by
         #   - Base Aggregator actors resource utilization (captured by
         #     `base_resource_usage` method)
@@ -1023,19 +1023,21 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         base_usage = self.base_resource_usage
         running_usage = self._shuffling_resource_usage
 
-        # TODO add memory to resources being tracked
         return base_usage.add(running_usage)
 
     @property
     def base_resource_usage(self) -> ExecutionResources:
-        # TODO add memory to resources being tracked
         return ExecutionResources(
             cpu=(
                 self._aggregator_pool.num_aggregators
                 * self._aggregator_pool._aggregator_ray_remote_args["num_cpus"]
             ),
-            object_store_memory=0,
             gpu=0,
+            memory=(
+                self._aggregator_pool.num_aggregators
+                * self._aggregator_pool._aggregator_ray_remote_args.get("memory", 0)
+            ),
+            object_store_memory=0,
         )
 
     def incremental_resource_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -706,7 +706,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def pending_processor_usage(self) -> ExecutionResources:
+    def pending_logical_usage(self) -> ExecutionResources:
         raise NotImplementedError
 
     @abstractmethod

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -702,7 +702,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         self._metadata_tasks.clear()
 
     @abstractmethod
-    def current_processor_usage(self) -> ExecutionResources:
+    def current_logical_usage(self) -> ExecutionResources:
         raise NotImplementedError
 
     @abstractmethod

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -145,7 +145,7 @@ class TaskPoolMapOperator(MapOperator):
             memory=self._ray_remote_args.get("memory", 0) * num_active_workers,
         )
 
-    def pending_processor_usage(self) -> ExecutionResources:
+    def pending_logical_usage(self) -> ExecutionResources:
         return ExecutionResources()
 
     def incremental_resource_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -137,11 +137,12 @@ class TaskPoolMapOperator(MapOperator):
     def progress_str(self) -> str:
         return ""
 
-    def current_processor_usage(self) -> ExecutionResources:
+    def current_logical_usage(self) -> ExecutionResources:
         num_active_workers = self.num_active_tasks()
         return ExecutionResources(
             cpu=self._ray_remote_args.get("num_cpus", 0) * num_active_workers,
             gpu=self._ray_remote_args.get("num_gpus", 0) * num_active_workers,
+            memory=self._ray_remote_args.get("memory", 0) * num_active_workers,
         )
 
     def pending_processor_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -216,7 +216,7 @@ class ResourceManager:
             op.update_resource_usage()
             op_usage = op.current_logical_usage()
             op_running_usage = op.running_processor_usage()
-            op_pending_usage = op.pending_processor_usage()
+            op_pending_usage = op.pending_logical_usage()
 
             assert not op_usage.object_store_memory
             assert not op_running_usage.object_store_memory

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -215,7 +215,7 @@ class ResourceManager:
             # and `self._op_pending_usages`.
             op.update_resource_usage()
             op_usage = op.current_logical_usage()
-            op_running_usage = op.running_processor_usage()
+            op_running_usage = op.running_logical_usage()
             op_pending_usage = op.pending_logical_usage()
 
             assert not op_usage.object_store_memory

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -214,7 +214,7 @@ class ResourceManager:
             # Update `self._op_usages`, `self._op_running_usages`,
             # and `self._op_pending_usages`.
             op.update_resource_usage()
-            op_usage = op.current_processor_usage()
+            op_usage = op.current_logical_usage()
             op_running_usage = op.running_processor_usage()
             op_pending_usage = op.pending_processor_usage()
 

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -211,7 +211,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     )
     op.start(ExecutionOptions())
 
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -220,7 +220,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
 
     op.add_input(input_op.get_next(), 0)
     op.add_input(input_op.get_next(), 0)
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(1600, rel=0.5)
@@ -232,7 +232,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
 
     run_op_tasks_sync(op)
 
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == pytest.approx(3200, rel=0.5)
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -255,7 +255,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     )
     op.start(ExecutionOptions())
 
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -264,7 +264,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
 
     op.add_input(input_op.get_next(), 0)
     # No tasks submitted yet due to bundling.
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(800, rel=0.5)
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -273,7 +273,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
 
     op.add_input(input_op.get_next(), 0)
     # No tasks submitted yet due to bundling.
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(1600, rel=0.5)
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -282,7 +282,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
 
     op.add_input(input_op.get_next(), 0)
     # Task has now been submitted since we've met the minimum bundle size.
-    assert op.current_processor_usage() == ExecutionResources(cpu=1, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=1, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(2400, rel=0.5)
@@ -325,7 +325,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
     assert op.incremental_resource_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0
     )
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
 
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
@@ -350,7 +350,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
 
         op.add_input(input_op.get_next(), 0)
 
-        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
         # NOTE: No queueing is happening, tasks are dispatched right away
         assert op.metrics.obj_store_mem_internal_inqueue == 0
         assert op.metrics.obj_store_mem_internal_outqueue == 0
@@ -363,7 +363,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
     assert op._actor_pool.num_pending_actors() == 0
     assert len(op._actor_pool.running_actors()) == 2
 
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(3200, rel=0.5)
@@ -450,7 +450,7 @@ def test_actor_pool_scheduling_with_bundling(
     )
 
     # Pool is idle while waiting for actors to start.
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -478,7 +478,7 @@ def test_actor_pool_scheduling_with_bundling(
 
         op.add_input(input_op.get_next(), 0)
 
-        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
 
         # While bundling, no tasks are scheduled
         assert op.num_active_tasks() == 0
@@ -506,7 +506,7 @@ def test_actor_pool_scheduling_with_bundling(
     # Add more inputs, but less than necessary to launch another task
     for i in range(MIN_ROWS_PER_BUNDLE - 1):
         assert op.incremental_resource_usage() == ExecutionResources(
-            cpu=0, gpu=0, object_store_memory=0
+            cpu=0, gpu=0, object_store_memory=0, memory=0
         )
 
         # Should be able to add inputs now
@@ -514,7 +514,7 @@ def test_actor_pool_scheduling_with_bundling(
 
         op.add_input(input_op.get_next(), 0)
 
-        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0)
+        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
 
         # While bundling, no *new* tasks are scheduled
         assert op.num_active_tasks() == 1
@@ -592,7 +592,7 @@ def test_limit_resource_reporting(ray_start_10_cpus_shared):
     op.start(ExecutionOptions())
 
     assert op.current_processor_usage() == ExecutionResources(
-        cpu=0, gpu=0, object_store_memory=0
+        cpu=0, gpu=0, object_store_memory=0, memory=0
     )
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
@@ -625,7 +625,7 @@ def test_output_splitter_resource_reporting(ray_start_10_cpus_shared):
     op.start(ExecutionOptions(actor_locality_enabled=True))
 
     assert op.current_processor_usage() == ExecutionResources(
-        cpu=0, gpu=0, object_store_memory=0
+        cpu=0, gpu=0, object_store_memory=0, memory=0
     )
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -211,7 +211,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     )
     op.start(ExecutionOptions())
 
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -220,7 +220,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
 
     op.add_input(input_op.get_next(), 0)
     op.add_input(input_op.get_next(), 0)
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(1600, rel=0.5)
@@ -232,7 +232,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
 
     run_op_tasks_sync(op)
 
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == pytest.approx(3200, rel=0.5)
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -255,7 +255,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     )
     op.start(ExecutionOptions())
 
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -264,7 +264,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
 
     op.add_input(input_op.get_next(), 0)
     # No tasks submitted yet due to bundling.
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(800, rel=0.5)
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -273,7 +273,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
 
     op.add_input(input_op.get_next(), 0)
     # No tasks submitted yet due to bundling.
-    assert op.current_processor_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(1600, rel=0.5)
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -282,7 +282,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
 
     op.add_input(input_op.get_next(), 0)
     # Task has now been submitted since we've met the minimum bundle size.
-    assert op.current_processor_usage() == ExecutionResources(cpu=1, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=1, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(2400, rel=0.5)
@@ -325,7 +325,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
     assert op.incremental_resource_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0
     )
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
 
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
@@ -350,7 +350,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
 
         op.add_input(input_op.get_next(), 0)
 
-        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
+        assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
         # NOTE: No queueing is happening, tasks are dispatched right away
         assert op.metrics.obj_store_mem_internal_inqueue == 0
         assert op.metrics.obj_store_mem_internal_outqueue == 0
@@ -363,7 +363,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
     assert op._actor_pool.num_pending_actors() == 0
     assert len(op._actor_pool.running_actors()) == 2
 
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(3200, rel=0.5)
@@ -389,7 +389,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
             pool.per_actor_resource_usage().scale(pool.min_size())
         )
 
-    assert op.current_processor_usage() == min_usage
+    assert op.current_logical_usage() == min_usage
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == pytest.approx(
         6400,
@@ -450,7 +450,7 @@ def test_actor_pool_scheduling_with_bundling(
     )
 
     # Pool is idle while waiting for actors to start.
-    assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
+    assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -478,7 +478,7 @@ def test_actor_pool_scheduling_with_bundling(
 
         op.add_input(input_op.get_next(), 0)
 
-        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
+        assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
 
         # While bundling, no tasks are scheduled
         assert op.num_active_tasks() == 0
@@ -514,7 +514,7 @@ def test_actor_pool_scheduling_with_bundling(
 
         op.add_input(input_op.get_next(), 0)
 
-        assert op.current_processor_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
+        assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
 
         # While bundling, no *new* tasks are scheduled
         assert op.num_active_tasks() == 1
@@ -576,7 +576,7 @@ def test_actor_pool_scheduling_with_bundling(
             pool.per_actor_resource_usage().scale(pool.min_size())
         )
 
-    assert op.current_processor_usage() == min_usage
+    assert op.current_logical_usage() == min_usage
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
@@ -591,7 +591,7 @@ def test_limit_resource_reporting(ray_start_10_cpus_shared):
     op = LimitOperator(3, input_op, DataContext.get_current())
     op.start(ExecutionOptions())
 
-    assert op.current_processor_usage() == ExecutionResources(
+    assert op.current_logical_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0, memory=0
     )
     assert op.metrics.obj_store_mem_internal_inqueue == 0
@@ -624,7 +624,7 @@ def test_output_splitter_resource_reporting(ray_start_10_cpus_shared):
     )
     op.start(ExecutionOptions(actor_locality_enabled=True))
 
-    assert op.current_processor_usage() == ExecutionResources(
+    assert op.current_logical_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0, memory=0
     )
     assert op.metrics.obj_store_mem_internal_inqueue == 0

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -253,7 +253,7 @@ class TestResourceManager:
 
         for op in [o1, o2, o3]:
             op.update_resource_usage = MagicMock()
-            op.current_processor_usage = MagicMock(
+            op.current_logical_usage = MagicMock(
                 return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0, memory=0)
             )
             op.running_processor_usage = MagicMock(

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -259,7 +259,7 @@ class TestResourceManager:
             op.running_processor_usage = MagicMock(
                 return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0, memory=0)
             )
-            op.pending_processor_usage = MagicMock(
+            op.pending_logical_usage = MagicMock(
                 return_value=ExecutionResources.zero()
             )
             op.extra_resource_usage = MagicMock(return_value=ExecutionResources.zero())

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -256,7 +256,7 @@ class TestResourceManager:
             op.current_logical_usage = MagicMock(
                 return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0, memory=0)
             )
-            op.running_processor_usage = MagicMock(
+            op.running_logical_usage = MagicMock(
                 return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0, memory=0)
             )
             op.pending_logical_usage = MagicMock(

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -260,9 +260,7 @@ class TestResourceManager:
             op.running_logical_usage = MagicMock(
                 return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0, memory=0)
             )
-            op.pending_logical_usage = MagicMock(
-                return_value=ExecutionResources.zero()
-            )
+            op.pending_logical_usage = MagicMock(return_value=ExecutionResources.zero())
             op.extra_resource_usage = MagicMock(return_value=ExecutionResources.zero())
             op._metrics = MagicMock(
                 obj_store_mem_pending_task_outputs=mock_pending_task_outputs[op],
@@ -582,18 +580,20 @@ class TestResourceManager:
             topology=topo,
             options=options,
             get_total_resources=lambda: cluster_resources,
-            data_context=DataContext.get_current()
+            data_context=DataContext.get_current(),
         )
         resource_manager.update_usages()
 
         # Task cannot be submitted because it exceeds memory limit
-        allocator = create_resource_allocator(resource_manager, DataContext.get_current())
+        allocator = create_resource_allocator(
+            resource_manager, DataContext.get_current()
+        )
         assert allocator is not None
         allocator.update_budgets(limits=resource_manager.get_global_limits())
         can_submit = allocator.can_submit_new_task(o2)
-        assert not can_submit, (
-            "Task should be blocked: requires 2000 bytes but only 1000 bytes memory available"
-        )
+        assert (
+            not can_submit
+        ), "Task should be blocked: requires 2000 bytes but only 1000 bytes memory available"
 
 
 class TestResourceAllocatorUnblockingStreamingOutputBackpressure:

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -254,10 +254,10 @@ class TestResourceManager:
         for op in [o1, o2, o3]:
             op.update_resource_usage = MagicMock()
             op.current_processor_usage = MagicMock(
-                return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0)
+                return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0, memory=0)
             )
             op.running_processor_usage = MagicMock(
-                return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0)
+                return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0, memory=0)
             )
             op.pending_processor_usage = MagicMock(
                 return_value=ExecutionResources.zero()


### PR DESCRIPTION
## Description

Rename: 
- `current_processor_usage` to `current_logical_usage`
- `pending_processor_usage` to `pending_logical_usage`
- `running_processor_usage` to `running_logical_usage`

and update the methods to include logical memory (`memory`) alongside CPU and GPU. This ensures the resource manager accounts for memory when making scheduling decisions.

Add new test `test_memory_limit_blocks_task_submission` to ensure task submission is blocked when a task requests more memory than available

## Related issues

Closes #60744

## Additional information