### PR TITLE
[rllib] Fix ValueError in PrioritizedEpisodeReplayBuffer.add() when eps_evicted_idxs contains 0 not in new_episode_ids

### DIFF
--- a/rllib/utils/replay_buffers/prioritized_episode_buffer.py
+++ b/rllib/utils/replay_buffers/prioritized_episode_buffer.py
@@ -254,7 +254,7 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
             if eps_evicted_ids[-1] in new_episode_ids:
                 # TODO (simon): Apply the same logic as in the MA-case.
                 len_to_subtract = len(
-                    episodes[new_episode_ids.index(eps_evicted_idxs[-1])]
+                    episodes[new_episode_ids.index(eps_evicted_ids[-1])]
                 )
                 self._num_timesteps -= len_to_subtract
                 self._num_timesteps_added -= len_to_subtract


### PR DESCRIPTION
## What does this PR do?
Fixes #60773

### Problem
When `num_envs_per_env_runner` is set to high values (e.g., 16, 32), the `PrioritizedEpisodeReplayBuffer.add()` method raises `ValueError: 0 is not in list`.

### Root Cause
In line 257 of `prioritized_episode_buffer.py`, the code incorrectly uses `eps_evicted_idxs[-1]` (an index) to look up in `new_episode_ids` (which contains episode IDs). When `eps_evicted_idxs[-1]` is `0`, but `0` is not in `new_episode_ids` (which contains string IDs), `new_episode_ids.index(0)` throws `ValueError: 0 is not in list`.

### Solution
Changed `eps_evicted_idxs[-1]` to `eps_evicted_ids[-1]` to use the episode ID for lookup, which matches the contents of `new_episode_ids`.

Closes #60773