### PR TITLE
[core] periodically reload Ray service account tokens

### DIFF
--- a/src/ray/rpc/authentication/BUILD.bazel
+++ b/src/ray/rpc/authentication/BUILD.bazel
@@ -52,6 +52,8 @@ ray_cc_library(
         ":authentication_token",
         ":k8s_constants",
         "//src/ray/util:logging",
+        "@com_google_absl//absl/strings",
+        "@nlohmann_json",
     ],
 )
 

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -48,9 +48,6 @@ constexpr const char *kNoTokenErrorMessage =
     "or store the token in any file and set RAY_AUTH_TOKEN_PATH to point to it, "
     "or set the RAY_AUTH_TOKEN environment variable.";
 
-constexpr int kRaySATokenDefaultTTLSeconds = 600;
-constexpr int kRaySATokenExpirationBufferSeconds = 300;
-
 std::optional<std::chrono::system_clock::time_point>
 AuthenticationTokenLoader::GetJWTTokenExpiration(const std::string &token) {
   std::vector<std::string> parts = absl::StrSplit(token, '.');
@@ -70,14 +67,14 @@ AuthenticationTokenLoader::GetJWTTokenExpiration(const std::string &token) {
     if (json.contains("exp") && json["exp"].is_number()) {
       int64_t exp = json["exp"].get<int64_t>();
       return std::chrono::system_clock::from_time_t(exp) -
-             std::chrono::seconds(kRaySATokenExpirationBufferSeconds);
+             std::chrono::seconds(ray::rpc::k8s::kRaySATokenExpirationBufferSeconds);
     }
   } catch (...) {
     return std::nullopt;
   }
 
   return std::chrono::system_clock::now() +
-         std::chrono::seconds(kRaySATokenDefaultTTLSeconds);
+         std::chrono::seconds(ray::rpc::k8s::kRaySATokenDefaultTTLSeconds);
 }
 
 AuthenticationTokenLoader &AuthenticationTokenLoader::instance() {

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -48,7 +48,7 @@ constexpr const char *kNoTokenErrorMessage =
     "or store the token in any file and set RAY_AUTH_TOKEN_PATH to point to it, "
     "or set the RAY_AUTH_TOKEN environment variable.";
 
-constexpr int kRaySATokenTTLSeconds = 300;
+constexpr int kRaySATokenDefaultTTLSeconds = 300;
 
 std::optional<std::chrono::system_clock::time_point>
 AuthenticationTokenLoader::GetTokenExpiration(const std::string &token) {
@@ -131,13 +131,12 @@ std::shared_ptr<const AuthenticationToken> AuthenticationTokenLoader::GetToken(
   // Cache and return the loaded token
   if (has_token) {
     cached_token_ = std::make_shared<const AuthenticationToken>(std::move(*result.token));
-    last_load_time_ = std::chrono::steady_clock::now();
     auto exp = GetTokenExpiration(cached_token_->GetRawValue());
     if (exp) {
       cached_token_expiration_time_ = *exp;
     } else {
-      cached_token_expiration_time_ =
-          std::chrono::system_clock::now() + std::chrono::seconds(kRaySATokenTTLSeconds);
+      cached_token_expiration_time_ = std::chrono::system_clock::now() +
+                                      std::chrono::seconds(kRaySATokenDefaultTTLSeconds);
     }
   }
   return cached_token_;
@@ -185,13 +184,12 @@ TokenLoadResult AuthenticationTokenLoader::TryLoadToken(bool ignore_auth_mode) {
   }
   // Cache and return success
   cached_token_ = std::make_shared<const AuthenticationToken>(std::move(*result.token));
-  last_load_time_ = std::chrono::steady_clock::now();
   auto exp = GetTokenExpiration(cached_token_->GetRawValue());
   if (exp) {
     cached_token_expiration_time_ = *exp;
   } else {
-    cached_token_expiration_time_ =
-        std::chrono::system_clock::now() + std::chrono::seconds(kRaySATokenTTLSeconds);
+    cached_token_expiration_time_ = std::chrono::system_clock::now() +
+                                    std::chrono::seconds(kRaySATokenDefaultTTLSeconds);
   }
   result.token = *cached_token_;  // Copy back for return
   return result;

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -59,22 +59,8 @@ AuthenticationTokenLoader::GetTokenExpiration(const std::string &token) {
     return std::nullopt;
   }
 
-  std::string payload_b64 = parts[1];
-  // Convert Base64URL to Base64
-  for (char &c : payload_b64) {
-    if (c == '-') {
-      c = '+';
-    } else if (c == '_') {
-      c = '/';
-    }
-  }
-  // Add padding if necessary
-  while (payload_b64.size() % 4 != 0) {
-    payload_b64 += '=';
-  }
-
   std::string payload;
-  if (!absl::Base64Unescape(payload_b64, &payload)) {
+  if (!absl::WebSafeBase64Unescape(parts[1], &payload)) {
     RAY_LOG(WARNING) << "Unable to base64 decode JWT token.";
     return std::nullopt;
   }

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -44,7 +44,7 @@ constexpr const char *kNoTokenErrorMessage =
     "or store the token in any file and set RAY_AUTH_TOKEN_PATH to point to it, "
     "or set the RAY_AUTH_TOKEN environment variable.";
 
-const int32_t kRaySATokenTTLSeconds = 300;
+constexpr int kRaySATokenTTLSeconds = 300;
 
 AuthenticationTokenLoader &AuthenticationTokenLoader::instance() {
   static AuthenticationTokenLoader instance;

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -48,7 +48,8 @@ constexpr const char *kNoTokenErrorMessage =
     "or store the token in any file and set RAY_AUTH_TOKEN_PATH to point to it, "
     "or set the RAY_AUTH_TOKEN environment variable.";
 
-constexpr int kRaySATokenDefaultTTLSeconds = 300;
+constexpr int kRaySATokenDefaultTTLSeconds = 600;
+constexpr int kRaySATokenExpirationBufferSeconds = 300;
 
 std::optional<std::chrono::system_clock::time_point>
 AuthenticationTokenLoader::GetTokenExpiration(const std::string &token) {
@@ -133,7 +134,8 @@ std::shared_ptr<const AuthenticationToken> AuthenticationTokenLoader::GetToken(
     cached_token_ = std::make_shared<const AuthenticationToken>(std::move(*result.token));
     auto exp = GetTokenExpiration(cached_token_->GetRawValue());
     if (exp) {
-      cached_token_expiration_time_ = *exp;
+      cached_token_expiration_time_ =
+          *exp - std::chrono::seconds(kRaySATokenExpirationBufferSeconds);
     } else {
       cached_token_expiration_time_ = std::chrono::system_clock::now() +
                                       std::chrono::seconds(kRaySATokenDefaultTTLSeconds);
@@ -186,7 +188,8 @@ TokenLoadResult AuthenticationTokenLoader::TryLoadToken(bool ignore_auth_mode) {
   cached_token_ = std::make_shared<const AuthenticationToken>(std::move(*result.token));
   auto exp = GetTokenExpiration(cached_token_->GetRawValue());
   if (exp) {
-    cached_token_expiration_time_ = *exp;
+    cached_token_expiration_time_ =
+        *exp - std::chrono::seconds(kRaySATokenExpirationBufferSeconds);
   } else {
     cached_token_expiration_time_ = std::chrono::system_clock::now() +
                                     std::chrono::seconds(kRaySATokenDefaultTTLSeconds);

--- a/src/ray/rpc/authentication/authentication_token_loader.cc
+++ b/src/ray/rpc/authentication/authentication_token_loader.cc
@@ -52,7 +52,7 @@ constexpr int kRaySATokenDefaultTTLSeconds = 600;
 constexpr int kRaySATokenExpirationBufferSeconds = 300;
 
 std::optional<std::chrono::system_clock::time_point>
-AuthenticationTokenLoader::GetTokenExpiration(const std::string &token) {
+AuthenticationTokenLoader::GetJWTTokenExpiration(const std::string &token) {
   std::vector<std::string> parts = absl::StrSplit(token, '.');
   if (parts.size() != 3) {
     RAY_LOG(WARNING) << "Invalid JWT token format.";
@@ -121,7 +121,7 @@ std::shared_ptr<const AuthenticationToken> AuthenticationTokenLoader::GetToken(
   if (has_token) {
     cached_token_ = std::make_shared<const AuthenticationToken>(std::move(*result.token));
     if (IsK8sTokenAuthEnabled()) {
-      auto exp = GetTokenExpiration(cached_token_->GetRawValue());
+      auto exp = GetJWTTokenExpiration(cached_token_->GetRawValue());
       if (exp) {
         cached_token_expiration_time_ =
             *exp - std::chrono::seconds(kRaySATokenExpirationBufferSeconds);
@@ -178,7 +178,7 @@ TokenLoadResult AuthenticationTokenLoader::TryLoadToken(bool ignore_auth_mode) {
   // Cache and return success
   cached_token_ = std::make_shared<const AuthenticationToken>(std::move(*result.token));
   if (IsK8sTokenAuthEnabled()) {
-    auto exp = GetTokenExpiration(cached_token_->GetRawValue());
+    auto exp = GetJWTTokenExpiration(cached_token_->GetRawValue());
     if (exp) {
       cached_token_expiration_time_ =
           *exp - std::chrono::seconds(kRaySATokenExpirationBufferSeconds);

--- a/src/ray/rpc/authentication/authentication_token_loader.h
+++ b/src/ray/rpc/authentication/authentication_token_loader.h
@@ -63,7 +63,7 @@ class AuthenticationTokenLoader {
   void ResetCache() {
     absl::MutexLock lock(&token_mutex_);
     cached_token_ = nullptr;
-    cached_token_expiration_time_ = std::chrono::system_clock::time_point();
+    cached_token_expiration_time_ = std::nullopt;
   }
 
   AuthenticationTokenLoader(const AuthenticationTokenLoader &) = delete;

--- a/src/ray/rpc/authentication/authentication_token_loader.h
+++ b/src/ray/rpc/authentication/authentication_token_loader.h
@@ -93,7 +93,7 @@ class AuthenticationTokenLoader {
 
   absl::Mutex token_mutex_;
   std::shared_ptr<const AuthenticationToken> cached_token_;
-  std::chrono::system_clock::time_point cached_token_expiration_time_;
+  std::optional<std::chrono::system_clock::time_point> cached_token_expiration_time_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/authentication/authentication_token_loader.h
+++ b/src/ray/rpc/authentication/authentication_token_loader.h
@@ -88,7 +88,7 @@ class AuthenticationTokenLoader {
   /// Extract expiration time from a JWT token.
   /// \param token The JWT token string.
   /// \return The expiration time, or std::nullopt if not a valid JWT or no exp claim.
-  std::optional<std::chrono::system_clock::time_point> GetTokenExpiration(
+  std::optional<std::chrono::system_clock::time_point> GetJWTTokenExpiration(
       const std::string &token);
 
   absl::Mutex token_mutex_;

--- a/src/ray/rpc/authentication/authentication_token_loader.h
+++ b/src/ray/rpc/authentication/authentication_token_loader.h
@@ -64,6 +64,7 @@ class AuthenticationTokenLoader {
     absl::MutexLock lock(&token_mutex_);
     cached_token_ = nullptr;
     last_load_time_ = std::chrono::steady_clock::time_point();
+    cached_token_expiration_time_ = std::chrono::system_clock::time_point();
   }
 
   AuthenticationTokenLoader(const AuthenticationTokenLoader &) = delete;
@@ -85,9 +86,16 @@ class AuthenticationTokenLoader {
   /// Trim whitespace from the beginning and end of the string.
   std::string TrimWhitespace(const std::string &str);
 
+  /// Extract expiration time from a JWT token.
+  /// \param token The JWT token string.
+  /// \return The expiration time, or std::nullopt if not a valid JWT or no exp claim.
+  std::optional<std::chrono::system_clock::time_point> GetTokenExpiration(
+      const std::string &token);
+
   absl::Mutex token_mutex_;
   std::shared_ptr<const AuthenticationToken> cached_token_;
   std::chrono::steady_clock::time_point last_load_time_;
+  std::chrono::system_clock::time_point cached_token_expiration_time_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/authentication/authentication_token_loader.h
+++ b/src/ray/rpc/authentication/authentication_token_loader.h
@@ -63,7 +63,6 @@ class AuthenticationTokenLoader {
   void ResetCache() {
     absl::MutexLock lock(&token_mutex_);
     cached_token_ = nullptr;
-    last_load_time_ = std::chrono::steady_clock::time_point();
     cached_token_expiration_time_ = std::chrono::system_clock::time_point();
   }
 
@@ -94,7 +93,6 @@ class AuthenticationTokenLoader {
 
   absl::Mutex token_mutex_;
   std::shared_ptr<const AuthenticationToken> cached_token_;
-  std::chrono::steady_clock::time_point last_load_time_;
   std::chrono::system_clock::time_point cached_token_expiration_time_;
 };
 

--- a/src/ray/rpc/authentication/authentication_token_loader.h
+++ b/src/ray/rpc/authentication/authentication_token_loader.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
@@ -62,6 +63,7 @@ class AuthenticationTokenLoader {
   void ResetCache() {
     absl::MutexLock lock(&token_mutex_);
     cached_token_ = nullptr;
+    last_load_time_ = std::chrono::steady_clock::time_point();
   }
 
   AuthenticationTokenLoader(const AuthenticationTokenLoader &) = delete;
@@ -85,6 +87,7 @@ class AuthenticationTokenLoader {
 
   absl::Mutex token_mutex_;
   std::shared_ptr<const AuthenticationToken> cached_token_;
+  std::chrono::steady_clock::time_point last_load_time_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/authentication/k8s_constants.h
+++ b/src/ray/rpc/authentication/k8s_constants.h
@@ -43,6 +43,9 @@ constexpr char kRayResourceGroup[] = "ray.io";
 constexpr char kRayClusterResourceName[] = "rayclusters";
 constexpr char kRayClusterRayUserVerb[] = "ray:write";
 
+constexpr int kRaySATokenDefaultTTLSeconds = 600;
+constexpr int kRaySATokenExpirationBufferSeconds = 300;
+
 }  // namespace k8s
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
+++ b/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
@@ -362,9 +362,9 @@ TEST_F(AuthenticationTokenLoaderTest, TestJWTExpiration) {
       R"({"AUTH_MODE": "token", "ENABLE_K8S_TOKEN_AUTH": true})");
   AuthenticationTokenLoader::instance().ResetCache();
 
-  // Create a JWT that expires in 1 second
+  // Create a JWT with expiration time buffer (300) + 2 seconds
   auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-  int64_t exp = now + 1;
+  int64_t exp = now + 302;
 
   std::string header =
       "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0";  // {"alg":"none","typ":"JWT"}

--- a/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
+++ b/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
@@ -362,9 +362,9 @@ TEST_F(AuthenticationTokenLoaderTest, TestJWTExpiration) {
       R"({"AUTH_MODE": "token", "ENABLE_K8S_TOKEN_AUTH": true})");
   AuthenticationTokenLoader::instance().ResetCache();
 
-  // Create a JWT with expiration time buffer (300) + 2 seconds
+  // Create a JWT with expiration time buffer (300) + 1 seconds
   auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-  int64_t exp = now + 302;
+  int64_t exp = now + 301;
 
   std::string header =
       "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0";  // {"alg":"none","typ":"JWT"}

--- a/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
+++ b/src/ray/rpc/authentication/tests/authentication_token_loader_test.cc
@@ -14,9 +14,13 @@
 
 #include "ray/rpc/authentication/authentication_token_loader.h"
 
+#include <algorithm>
+#include <chrono>
 #include <fstream>
 #include <string>
+#include <thread>
 
+#include "absl/strings/escaping.h"
 #include "gtest/gtest.h"
 #include "ray/common/ray_config.h"
 #include "ray/util/env.h"
@@ -350,6 +354,49 @@ TEST_F(AuthenticationTokenLoaderTest, TestIgnoreAuthModeGetToken) {
 
   // Re-enable auth for other tests
   RayConfig::instance().initialize(R"({"AUTH_MODE": "token"})");
+}
+
+TEST_F(AuthenticationTokenLoaderTest, TestJWTExpiration) {
+  // Enable K8s token auth
+  RayConfig::instance().initialize(
+      R"({"AUTH_MODE": "token", "ENABLE_K8S_TOKEN_AUTH": true})");
+  AuthenticationTokenLoader::instance().ResetCache();
+
+  // Create a JWT that expires in 1 second
+  auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  int64_t exp = now + 1;
+
+  std::string header =
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0";  // {"alg":"none","typ":"JWT"}
+  std::string payload_json = "{\"exp\":" + std::to_string(exp) + "}";
+  std::string payload;
+  absl::Base64Escape(payload_json, &payload);
+  std::replace(payload.begin(), payload.end(), '+', '-');
+  std::replace(payload.begin(), payload.end(), '/', '_');
+  payload.erase(std::remove(payload.begin(), payload.end(), '='), payload.end());
+
+  std::string jwt = header + "." + payload + ".signature";
+
+  set_env_var("RAY_AUTH_TOKEN", jwt.c_str());
+
+  auto &loader = AuthenticationTokenLoader::instance();
+  auto token1 = loader.GetToken();
+  ASSERT_TRUE(token1 != nullptr);
+  EXPECT_EQ(token1->GetRawValue(), jwt);
+
+  // Wait for it to expire
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  // Next call should revoke and reload. Change the env var to verify it reloads.
+  set_env_var("RAY_AUTH_TOKEN", "new-token");
+
+  auto token2 = loader.GetToken();
+  ASSERT_TRUE(token2 != nullptr);
+  EXPECT_EQ(token2->GetRawValue(), "new-token");
+
+  // Re-enable auth for other tests
+  RayConfig::instance().initialize(
+      R"({"AUTH_MODE": "token", "ENABLE_K8S_TOKEN_AUTH": false})");
 }
 
 }  // namespace rpc


### PR DESCRIPTION
## Description

Ray token auth (with k8s) loads a projected Kubernetes service account token in `/var/run/secrets/ray.io/serviceaccount/token`. However, this token expires every hour by default. This PR updates Ray to periodically reload this token every 5 minutes to ensure expired service tokens are not cached.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
