### PR TITLE
[core] use AuthenticationValidator in Ray sync server

### DIFF
--- a/src/ray/ray_syncer/BUILD.bazel
+++ b/src/ray/ray_syncer/BUILD.bazel
@@ -24,6 +24,7 @@ ray_cc_library(
         "//src/ray/protobuf:ray_syncer_cc_grpc",
         "//src/ray/rpc/authentication:authentication_token",
         "//src/ray/rpc/authentication:authentication_token_loader",
+        "//src/ray/rpc/authentication:authentication_token_validator",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/container:flat_hash_map",
     ],

--- a/src/ray/ray_syncer/BUILD.bazel
+++ b/src/ray/ray_syncer/BUILD.bazel
@@ -22,6 +22,7 @@ ray_cc_library(
         "//src/ray/common:constants",
         "//src/ray/common:id",
         "//src/ray/protobuf:ray_syncer_cc_grpc",
+        "//src/ray/rpc/authentication:authentication_mode",
         "//src/ray/rpc/authentication:authentication_token",
         "//src/ray/rpc/authentication:authentication_token_loader",
         "//src/ray/rpc/authentication:authentication_token_validator",

--- a/src/ray/ray_syncer/ray_syncer.cc
+++ b/src/ray/ray_syncer/ray_syncer.cc
@@ -254,6 +254,7 @@ ServerBidiReactor *RaySyncerService::StartSync(grpc::CallbackServerContext *cont
         syncer_.node_state_->RemoveNode(node_id);
       },
       /*auth_token=*/auth_token_,
+      /*auth_token_validator=*/auth_token_validator_,
       /*max_batch_size=*/syncer_.max_batch_size_,
       /*max_batch_delay_ms=*/syncer_.max_batch_delay_ms_);
   RAY_LOG(DEBUG).WithField(NodeID::FromBinary(reactor->GetRemoteNodeID()))

--- a/src/ray/ray_syncer/ray_syncer.h
+++ b/src/ray/ray_syncer/ray_syncer.h
@@ -30,6 +30,7 @@
 #include "ray/common/id.h"
 #include "ray/ray_syncer/common.h"
 #include "ray/rpc/authentication/authentication_token.h"
+#include "ray/rpc/authentication/authentication_token_validator.h"
 #include "src/ray/protobuf/ray_syncer.grpc.pb.h"
 
 namespace ray::syncer {
@@ -213,8 +214,12 @@ class RaySyncerService : public ray::rpc::syncer::RaySyncer::CallbackService {
  public:
   explicit RaySyncerService(
       RaySyncer &syncer,
-      std::shared_ptr<const ray::rpc::AuthenticationToken> auth_token = nullptr)
-      : syncer_(syncer), auth_token_(std::move(auth_token)) {}
+      std::shared_ptr<const ray::rpc::AuthenticationToken> auth_token = nullptr,
+      ray::rpc::AuthenticationTokenValidator &auth_token_validator =
+          ray::rpc::AuthenticationTokenValidator::instance())
+      : syncer_(syncer),
+        auth_token_(std::move(auth_token)),
+        auth_token_validator_(auth_token_validator) {}
 
   grpc::ServerBidiReactor<RaySyncMessageBatch, RaySyncMessageBatch> *StartSync(
       grpc::CallbackServerContext *context) override;
@@ -225,6 +230,9 @@ class RaySyncerService : public ray::rpc::syncer::RaySyncer::CallbackService {
   // Authentication token for validation, will be nullptr if token authentication is
   // disabled
   std::shared_ptr<const ray::rpc::AuthenticationToken> auth_token_;
+
+  // Validator for authentication token
+  ray::rpc::AuthenticationTokenValidator &auth_token_validator_;
 };
 
 }  // namespace ray::syncer

--- a/src/ray/ray_syncer/ray_syncer_server.cc
+++ b/src/ray/ray_syncer/ray_syncer_server.cc
@@ -53,14 +53,7 @@ RayServerBidiReactor::RayServerBidiReactor(
       server_context_(server_context),
       auth_token_(std::move(auth_token)),
       auth_token_validator_(auth_token_validator) {
-  if (ray::rpc::GetAuthenticationMode() == ray::rpc::AuthenticationMode::TOKEN) {
-    if ((!auth_token_ || auth_token_->empty()) && !ray::rpc::IsK8sTokenAuthEnabled()) {
-      RAY_LOG(WARNING) << "Missing token in syncer "
-                       << NodeID::FromBinary(GetRemoteNodeID());
-      Finish(grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Missing token in syncer"));
-      return;
-    }
-
+  if ((auth_token_ && !auth_token_->empty()) || ray::rpc::IsK8sTokenAuthEnabled()) {
     // Validate authentication token
     const auto &metadata = server_context->client_metadata();
     auto it = metadata.find(kAuthTokenKey);

--- a/src/ray/ray_syncer/ray_syncer_server.cc
+++ b/src/ray/ray_syncer/ray_syncer_server.cc
@@ -54,10 +54,10 @@ RayServerBidiReactor::RayServerBidiReactor(
       auth_token_(std::move(auth_token)),
       auth_token_validator_(auth_token_validator) {
   if (ray::rpc::GetAuthenticationMode() == ray::rpc::AuthenticationMode::TOKEN) {
-    if (!auth_token_ || auth_token_->empty()) {
-      RAY_LOG(WARNING) << "Missing bearer token in syncer "
+    if ((!auth_token_ || auth_token_->empty()) && !IsK8sTokenAuthEnabled()) {
+      RAY_LOG(WARNING) << "Missing token in syncer "
                        << NodeID::FromBinary(GetRemoteNodeID());
-      Finish(grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Missing bearer token"));
+      Finish(grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Missing token in syncer"));
       return;
     }
 

--- a/src/ray/ray_syncer/ray_syncer_server.cc
+++ b/src/ray/ray_syncer/ray_syncer_server.cc
@@ -54,7 +54,7 @@ RayServerBidiReactor::RayServerBidiReactor(
       auth_token_(std::move(auth_token)),
       auth_token_validator_(auth_token_validator) {
   if (ray::rpc::GetAuthenticationMode() == ray::rpc::AuthenticationMode::TOKEN) {
-    if (!auth_token_ || auth_token->empty()) {
+    if (auth_token->empty()) {
       RAY_LOG(WARNING) << "Missing bearer token in syncer "
                        << NodeID::FromBinary(GetRemoteNodeID());
       Finish(grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Missing bearer token"));

--- a/src/ray/ray_syncer/ray_syncer_server.cc
+++ b/src/ray/ray_syncer/ray_syncer_server.cc
@@ -54,7 +54,7 @@ RayServerBidiReactor::RayServerBidiReactor(
       auth_token_(std::move(auth_token)),
       auth_token_validator_(auth_token_validator) {
   if (ray::rpc::GetAuthenticationMode() == ray::rpc::AuthenticationMode::TOKEN) {
-    if ((!auth_token_ || auth_token_->empty()) && !IsK8sTokenAuthEnabled()) {
+    if ((!auth_token_ || auth_token_->empty()) && !ray::rpc::IsK8sTokenAuthEnabled()) {
       RAY_LOG(WARNING) << "Missing token in syncer "
                        << NodeID::FromBinary(GetRemoteNodeID());
       Finish(grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Missing token in syncer"));

--- a/src/ray/ray_syncer/ray_syncer_server.cc
+++ b/src/ray/ray_syncer/ray_syncer_server.cc
@@ -54,7 +54,7 @@ RayServerBidiReactor::RayServerBidiReactor(
       auth_token_(std::move(auth_token)),
       auth_token_validator_(auth_token_validator) {
   if (ray::rpc::GetAuthenticationMode() == ray::rpc::AuthenticationMode::TOKEN) {
-    if (auth_token->empty()) {
+    if (!auth_token_ || auth_token_->empty()) {
       RAY_LOG(WARNING) << "Missing bearer token in syncer "
                        << NodeID::FromBinary(GetRemoteNodeID());
       Finish(grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Missing bearer token"));

--- a/src/ray/ray_syncer/ray_syncer_server.cc
+++ b/src/ray/ray_syncer/ray_syncer_server.cc
@@ -39,6 +39,7 @@ RayServerBidiReactor::RayServerBidiReactor(
     std::function<void(std::shared_ptr<const RaySyncMessage>)> message_processor,
     std::function<void(RaySyncerBidiReactor *, bool)> cleanup_cb,
     std::shared_ptr<const ray::rpc::AuthenticationToken> auth_token,
+    ray::rpc::AuthenticationTokenValidator &auth_token_validator,
     size_t max_batch_size,
     uint64_t max_batch_delay_ms)
     : RaySyncerBidiReactorBase<ServerBidiReactor>(
@@ -49,7 +50,8 @@ RayServerBidiReactor::RayServerBidiReactor(
           max_batch_delay_ms),
       cleanup_cb_(std::move(cleanup_cb)),
       server_context_(server_context),
-      auth_token_(std::move(auth_token)) {
+      auth_token_(std::move(auth_token)),
+      auth_token_validator_(auth_token_validator) {
   if (auth_token_ && !auth_token_->empty()) {
     // Validate authentication token
     const auto &metadata = server_context->client_metadata();
@@ -64,7 +66,7 @@ RayServerBidiReactor::RayServerBidiReactor(
 
     const std::string_view header(it->second.data(), it->second.length());
 
-    if (!auth_token_->CompareWithMetadata(header)) {
+    if (!auth_token_validator_.ValidateToken(auth_token_, header)) {
       RAY_LOG(WARNING) << "Invalid bearer token in syncer connection from node "
                        << NodeID::FromBinary(GetRemoteNodeID());
       Finish(grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Invalid bearer token"));

--- a/src/ray/ray_syncer/ray_syncer_server.h
+++ b/src/ray/ray_syncer/ray_syncer_server.h
@@ -24,6 +24,7 @@
 #include "ray/ray_syncer/ray_syncer_bidi_reactor.h"
 #include "ray/ray_syncer/ray_syncer_bidi_reactor_base.h"
 #include "ray/rpc/authentication/authentication_token.h"
+#include "ray/rpc/authentication/authentication_token_validator.h"
 
 namespace ray::syncer {
 
@@ -41,6 +42,7 @@ class RayServerBidiReactor : public RaySyncerBidiReactorBase<ServerBidiReactor> 
       std::function<void(std::shared_ptr<const RaySyncMessage>)> message_processor,
       std::function<void(RaySyncerBidiReactor *, bool)> cleanup_cb,
       std::shared_ptr<const ray::rpc::AuthenticationToken> auth_token,
+      ray::rpc::AuthenticationTokenValidator &auth_token_validator,
       size_t max_batch_size,
       uint64_t max_batch_delay_ms);
 
@@ -67,6 +69,9 @@ class RayServerBidiReactor : public RaySyncerBidiReactorBase<ServerBidiReactor> 
   /// Authentication token for validation, will be nullptr if token authentication is
   /// disabled
   std::shared_ptr<const ray::rpc::AuthenticationToken> auth_token_;
+
+  /// Validator for authentication token
+  ray::rpc::AuthenticationTokenValidator &auth_token_validator_;
 
   /// Track if Finish() has been called to avoid using a reactor that is terminating
   std::atomic<bool> finished_{false};

--- a/src/ray/ray_syncer/tests/ray_syncer_test.cc
+++ b/src/ray/ray_syncer/tests/ray_syncer_test.cc
@@ -925,6 +925,7 @@ struct MockRaySyncerService : public ray::rpc::syncer::RaySyncer::CallbackServic
                                        message_processor,
                                        cleanup_cb,
                                        nullptr,
+                                       ray::rpc::AuthenticationTokenValidator::instance(),
                                        /*max_batch_size=*/1,
                                        /*max_batch_delay_ms=*/0);
     return reactor;


### PR DESCRIPTION
## Description

This is a bug fix to Ray sync server to use authentication token validator which will delegate token auth to Kubernetes if Ray is configured to do so.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
