### PR TITLE
[Docs][Data][minor] Cross-link to Ray Train examples from Ray Data examples

### DIFF
--- a/doc/source/data/examples.yml
+++ b/doc/source/data/examples.yml
@@ -1,4 +1,4 @@
-text: Below are examples for using Ray Data for batch inference workloads or large-scale data processing with a variety of frameworks and use cases.
+text: Below are examples for using Ray Data for batch inference workloads or large-scale data processing with a variety of frameworks and use cases. For examples of using Ray Data for last-mile training ingest, see the <a href="../train/examples.html">Ray Train examples</a>.
 columns_to_show:
   - frameworks
 groupby: skill_level


### PR DESCRIPTION
If a user is looking for examples of Ray Data for last-mile pre-processing, they may reasonably look for them in the [Ray Data examples](https://docs.ray.io/en/latest/data/examples.html). However, they all live under the [Ray Train examples](https://docs.ray.io/en/latest/train/examples.html).

This PR adds a cross-link to the Ray Data examples page.