### PR TITLE
[ci] refactor push_ray_image shared functions to image_tags_lib

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -115,6 +115,31 @@ py_library(
 )
 
 py_library(
+    name = "image_tags_lib",
+    srcs = ["image_tags_lib.py"],
+    visibility = ["//ci/ray_ci/automation:__subpackages__"],
+    deps = [
+        ":crane_lib",
+        "//ci/ray_ci:ray_ci_lib",
+    ],
+)
+
+py_test(
+    name = "test_image_tags_lib",
+    size = "small",
+    srcs = ["test_image_tags_lib.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":image_tags_lib",
+        ci_require("pytest"),
+    ],
+)
+
+py_library(
     name = "test_utils",
     srcs = ["test_utils.py"],
     data = [
@@ -322,7 +347,7 @@ py_binary(
     srcs = ["push_ray_image.py"],
     exec_compatible_with = ["//bazel:py3"],
     deps = [
-        ":crane_lib",
+        ":image_tags_lib",
         "//ci/ray_ci:ray_ci_lib",
         "//release:ray_release",
         ci_require("click"),

--- a/ci/ray_ci/automation/image_tags_lib.py
+++ b/ci/ray_ci/automation/image_tags_lib.py
@@ -1,0 +1,137 @@
+"""
+Shared utilities for generating Docker image tags for Ray and Anyscale images.
+"""
+
+import logging
+from typing import List
+
+from ci.ray_ci.automation.crane_lib import (
+    CraneError,
+    call_crane_copy,
+    call_crane_manifest,
+)
+from ci.ray_ci.configs import DEFAULT_PYTHON_TAG_VERSION
+from ci.ray_ci.docker_container import GPU_PLATFORM
+
+logger = logging.getLogger(__name__)
+
+
+class ImageTagsError(Exception):
+    """Error raised when image tag operations fail."""
+
+
+def format_platform_tag(platform: str) -> str:
+    """
+    Format platform as -cpu or shortened CUDA version.
+
+    Examples:
+        cpu -> -cpu
+        cu12.1.1-cudnn8 -> -cu121
+        cu12.3.2-cudnn9 -> -cu123
+    """
+    if platform == "cpu":
+        return "-cpu"
+    # cu12.3.2-cudnn9 -> -cu123
+    platform_base = platform.split("-", 1)[0]
+    parts = platform_base.split(".")
+    if len(parts) < 2:
+        raise ImageTagsError(f"Unrecognized GPU platform format: {platform}")
+    return f"-{parts[0]}{parts[1]}"
+
+
+def format_python_tag(python_version: str) -> str:
+    """
+    Format python version as -py310 (no dots, with hyphen prefix).
+
+    Examples:
+        3.10 -> -py310
+        3.11 -> -py311
+    """
+    return f"-py{python_version.replace('.', '')}"
+
+
+def get_python_suffixes(python_version: str) -> List[str]:
+    """
+    Get python version suffixes (includes empty for default version).
+
+    For DEFAULT_PYTHON_TAG_VERSION (3.10), returns both the explicit
+    suffix and an empty suffix for backward compatibility.
+
+    Examples:
+        3.10 -> ["-py310", ""]
+        3.11 -> ["-py311"]
+    """
+    suffixes = [format_python_tag(python_version)]
+    if python_version == DEFAULT_PYTHON_TAG_VERSION:
+        suffixes.append("")
+    return suffixes
+
+
+def get_platform_suffixes(platform: str, image_type: str) -> List[str]:
+    """
+    Get platform suffixes (includes aliases like -gpu for GPU_PLATFORM).
+
+    Handles the following cases:
+    - CPU with ray/ray-extra: adds empty suffix alias
+    - GPU_PLATFORM: adds -gpu alias
+    - GPU_PLATFORM with ray-ml/ray-ml-extra: adds empty suffix alias
+
+    Args:
+        platform: The platform string (e.g., "cpu", "cu12.1.1-cudnn8")
+        image_type: The image type (e.g., "ray", "ray-ml", "ray-extra")
+
+    Returns:
+        List of platform suffixes to use for tagging.
+    """
+    platform_tag = format_platform_tag(platform)
+    suffixes = [platform_tag]
+
+    if platform == "cpu":
+        # no tag is alias to cpu for ray image
+        if image_type in ("ray", "ray-extra"):
+            suffixes.append("")
+    elif platform == GPU_PLATFORM:
+        # gpu is alias to GPU_PLATFORM
+        suffixes.append("-gpu")
+        # no tag is alias to gpu for ray-ml image
+        if image_type in ("ray-ml", "ray-ml-extra"):
+            suffixes.append("")
+
+    return suffixes
+
+
+def get_variation_suffix(image_type: str) -> str:
+    """
+    Get variation suffix for -extra image types.
+
+    Examples:
+        ray -> ""
+        ray-extra -> "-extra"
+        ray-ml-extra -> "-extra"
+    """
+    if image_type in ("ray-extra", "ray-ml-extra", "ray-llm-extra"):
+        return "-extra"
+    return ""
+
+
+def image_exists(tag: str) -> bool:
+    """Check if a container image manifest exists using crane."""
+    try:
+        call_crane_manifest(tag)
+        return True
+    except CraneError:
+        return False
+
+
+def copy_image(source: str, destination: str, dry_run: bool = False) -> None:
+    """Copy a container image from source to destination using crane."""
+    if dry_run:
+        logger.info(f"DRY RUN: Would copy {source} -> {destination}")
+        return
+
+    logger.info(f"Copying {source} -> {destination}")
+    try:
+        call_crane_copy(source, destination)
+        logger.info(f"Successfully copied to {destination}")
+    except CraneError as e:
+        raise ImageTagsError(f"Crane copy failed: {e}")

--- a/ci/ray_ci/automation/test_image_tags_lib.py
+++ b/ci/ray_ci/automation/test_image_tags_lib.py
@@ -1,0 +1,130 @@
+import sys
+
+import pytest
+
+from ci.ray_ci.automation.image_tags_lib import (
+    ImageTagsError,
+    format_platform_tag,
+    format_python_tag,
+    get_platform_suffixes,
+    get_python_suffixes,
+    get_variation_suffix,
+)
+from ci.ray_ci.configs import DEFAULT_PYTHON_TAG_VERSION
+from ci.ray_ci.docker_container import GPU_PLATFORM
+
+
+class TestFormatPlatformTag:
+    @pytest.mark.parametrize(
+        ("platform", "expected"),
+        [
+            ("cpu", "-cpu"),
+            ("cu11.7.1-cudnn8", "-cu117"),
+            ("cu11.8.0-cudnn8", "-cu118"),
+            ("cu12.1.1-cudnn8", "-cu121"),
+            ("cu12.3.2-cudnn9", "-cu123"),
+            ("cu12.8.1-cudnn", "-cu128"),
+        ],
+    )
+    def test_format_platform_tag(self, platform, expected):
+        assert format_platform_tag(platform) == expected
+
+    def test_invalid_platform_raises_error(self):
+        with pytest.raises(ImageTagsError):
+            format_platform_tag("invalid")
+
+
+class TestFormatPythonTag:
+    @pytest.mark.parametrize(
+        ("python_version", "expected"),
+        [
+            ("3.9", "-py39"),
+            ("3.10", "-py310"),
+            ("3.11", "-py311"),
+            ("3.12", "-py312"),
+        ],
+    )
+    def test_format_python_tag(self, python_version, expected):
+        assert format_python_tag(python_version) == expected
+
+
+class TestGetPythonSuffixes:
+    def test_default_python_version_includes_empty(self):
+        """DEFAULT_PYTHON_TAG_VERSION gets both explicit and empty suffix."""
+        assert DEFAULT_PYTHON_TAG_VERSION == "3.10"
+        suffixes = get_python_suffixes("3.10")
+        assert suffixes == ["-py310", ""]
+
+    def test_non_default_python_version(self):
+        """Non-default python versions only get explicit suffix."""
+        assert get_python_suffixes("3.11") == ["-py311"]
+        assert get_python_suffixes("3.12") == ["-py312"]
+
+
+class TestGetPlatformSuffixes:
+    def test_cpu_ray_includes_empty(self):
+        """ray with cpu gets empty platform suffix."""
+        assert get_platform_suffixes("cpu", "ray") == ["-cpu", ""]
+
+    def test_cpu_ray_extra_includes_empty(self):
+        """ray-extra with cpu gets empty platform suffix."""
+        assert get_platform_suffixes("cpu", "ray-extra") == ["-cpu", ""]
+
+    def test_cpu_ray_ml_no_empty(self):
+        """ray-ml with cpu does NOT get empty platform suffix."""
+        assert get_platform_suffixes("cpu", "ray-ml") == ["-cpu"]
+
+    def test_cpu_ray_llm_no_empty(self):
+        """ray-llm with cpu does NOT get empty platform suffix."""
+        assert get_platform_suffixes("cpu", "ray-llm") == ["-cpu"]
+
+    def test_gpu_platform_ray_includes_gpu_alias(self):
+        """GPU_PLATFORM with ray gets -gpu alias but not empty suffix."""
+        suffixes = get_platform_suffixes(GPU_PLATFORM, "ray")
+        assert "-cu121" in suffixes
+        assert "-gpu" in suffixes
+        assert "" not in suffixes
+
+    def test_gpu_platform_ray_ml_includes_empty(self):
+        """GPU_PLATFORM with ray-ml gets -gpu alias AND empty suffix."""
+        suffixes = get_platform_suffixes(GPU_PLATFORM, "ray-ml")
+        assert "-cu121" in suffixes
+        assert "-gpu" in suffixes
+        assert "" in suffixes
+
+    def test_gpu_platform_ray_ml_extra_includes_empty(self):
+        """GPU_PLATFORM with ray-ml-extra gets -gpu alias AND empty suffix."""
+        suffixes = get_platform_suffixes(GPU_PLATFORM, "ray-ml-extra")
+        assert "-cu121" in suffixes
+        assert "-gpu" in suffixes
+        assert "" in suffixes
+
+    def test_non_gpu_platform_cuda_no_aliases(self):
+        """Non-GPU_PLATFORM CUDA versions get no aliases."""
+        suffixes = get_platform_suffixes("cu12.3.2-cudnn9", "ray")
+        assert suffixes == ["-cu123"]
+
+    def test_non_gpu_platform_ray_ml_no_aliases(self):
+        """Non-GPU_PLATFORM with ray-ml gets no aliases."""
+        suffixes = get_platform_suffixes("cu12.3.2-cudnn9", "ray-ml")
+        assert suffixes == ["-cu123"]
+
+
+class TestGetVariationSuffix:
+    @pytest.mark.parametrize(
+        ("image_type", "expected"),
+        [
+            ("ray", ""),
+            ("ray-ml", ""),
+            ("ray-llm", ""),
+            ("ray-extra", "-extra"),
+            ("ray-ml-extra", "-extra"),
+            ("ray-llm-extra", "-extra"),
+        ],
+    )
+    def test_variation_suffix(self, image_type, expected):
+        assert get_variation_suffix(image_type) == expected
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-vv", __file__]))

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -433,7 +433,7 @@ class TestShouldUpload:
 class TestCopyImage:
     """Test _copy_image function."""
 
-    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_copy")
+    @mock.patch("ci.ray_ci.automation.image_tags_lib.call_crane_copy")
     def test_copy_image_dry_run_skips_crane(self, mock_copy):
         """Test that dry run mode does not call crane copy."""
         from ci.ray_ci.automation.push_ray_image import _copy_image
@@ -441,7 +441,7 @@ class TestCopyImage:
         _copy_image("src", "dest", dry_run=True)
         mock_copy.assert_not_called()
 
-    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_copy")
+    @mock.patch("ci.ray_ci.automation.image_tags_lib.call_crane_copy")
     def test_copy_image_calls_crane(self, mock_copy):
         """Test that non-dry-run mode calls crane copy."""
         from ci.ray_ci.automation.push_ray_image import _copy_image
@@ -449,7 +449,7 @@ class TestCopyImage:
         _copy_image("src", "dest", dry_run=False)
         mock_copy.assert_called_once_with("src", "dest")
 
-    @mock.patch("ci.ray_ci.automation.push_ray_image.call_crane_copy")
+    @mock.patch("ci.ray_ci.automation.image_tags_lib.call_crane_copy")
     def test_copy_image_raises_on_crane_error(self, mock_copy):
         """Test that crane errors are wrapped in PushRayImageError."""
         from ci.ray_ci.automation.crane_lib import CraneError


### PR DESCRIPTION
There is significant overlap with the next feature of push_anyscale_image, so this refactor reduces on a lot of duplicated work.

Topic: image-tags-lib
Signed-off-by: andrew <andrew@anyscale.com>