### PR TITLE
[Data] Add UnresolvedExpr placeholder for future schema resolution

### DIFF
--- a/doc/source/data/api/expressions.rst
+++ b/doc/source/data/api/expressions.rst
@@ -41,6 +41,7 @@ instantiate them directly, but you may encounter them when working with expressi
     UnaryExpr
     UDFExpr
     StarExpr
+    UnresolvedExpr
 
 Expression namespaces
 ------------------------------------

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -25,6 +25,7 @@ from ray.data.expressions import (
     StarExpr,
     UDFExpr,
     UnaryExpr,
+    UnresolvedExpr,
 )
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI
@@ -174,6 +175,14 @@ class _IcebergExpressionVisitor(
         """Star expressions cannot be converted to Iceberg expressions."""
         raise TypeError(
             "Star expressions cannot be converted to Iceberg filter expressions."
+        )
+
+    def visit_unresolved(
+        self, expr: "UnresolvedExpr"
+    ) -> "BooleanExpression | UnboundTerm[Any] | Literal[Any]":
+        """Unresolved expressions cannot be converted to Iceberg expressions."""
+        raise TypeError(
+            "Unresolved expressions cannot be converted to Iceberg filter expressions."
         )
 
 

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -683,6 +683,9 @@ class NativeExpressionEvaluator(_ExprVisitor[Union[BlockColumn, ScalarType]]):
         Args:
             expr: The unresolved expression.
 
+        Returns:
+            This method does not return; it always raises TypeError.
+
         Raises:
             TypeError: UnresolvedExpr cannot be evaluated.
         """

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -683,7 +683,7 @@ class NativeExpressionEvaluator(_ExprVisitor[Union[BlockColumn, ScalarType]]):
         Args:
             expr: The unresolved expression.
 
-        Returns:
+        Raises:
             TypeError: UnresolvedExpr cannot be evaluated.
         """
         raise TypeError(

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -26,6 +26,7 @@ from ray.data.expressions import (
     StarExpr,
     UDFExpr,
     UnaryExpr,
+    UnresolvedExpr,
     _ExprVisitor,
     col,
 )
@@ -674,6 +675,20 @@ class NativeExpressionEvaluator(_ExprVisitor[Union[BlockColumn, ScalarType]]):
         raise TypeError(
             "StarExpr cannot be evaluated as a regular expression. "
             "It should only be used in Project operations."
+        )
+
+    def visit_unresolved(self, expr: UnresolvedExpr) -> Union[BlockColumn, ScalarType]:
+        """Visit an unresolved expression.
+
+        Args:
+            expr: The unresolved expression.
+
+        Returns:
+            TypeError: UnresolvedExpr cannot be evaluated.
+        """
+        raise TypeError(
+            "UnresolvedExpr cannot be evaluated. "
+            "Resolve it to a concrete expression before evaluation."
         )
 
     def visit_download(self, expr: DownloadExpr) -> Union[BlockColumn, ScalarType]:

--- a/python/ray/data/tests/unit/expressions/test_conversion.py
+++ b/python/ray/data/tests/unit/expressions/test_conversion.py
@@ -34,6 +34,7 @@ from ray.data.expressions import (
     BinaryExpr,
     Operation,
     UDFExpr,
+    UnresolvedExpr,
     col,
     download,
     lit,
@@ -303,6 +304,13 @@ class TestToPyArrow:
         with pytest.raises(TypeError, match="Star expressions cannot be converted"):
             star().to_pyarrow()
 
+    def test_unresolved_expression_raises(self):
+        """Test that unresolved expressions raise TypeError."""
+        with pytest.raises(
+            TypeError, match="Unresolved expressions cannot be converted"
+        ):
+            UnresolvedExpr("pending").to_pyarrow()
+
 
 # ──────────────────────────────────────
 # Iceberg Conversion Tests
@@ -537,6 +545,14 @@ class TestIcebergExpressionVisitor:
             TypeError, match="Star expressions cannot be converted to Iceberg"
         ):
             visitor.visit(star())
+
+    def test_unresolved_expression_raises(self):
+        """Test that unresolved expressions raise TypeError."""
+        visitor = _IcebergExpressionVisitor()
+        with pytest.raises(
+            TypeError, match="Unresolved expressions cannot be converted to Iceberg"
+        ):
+            visitor.visit(UnresolvedExpr("pending"))
 
     def test_is_in_requires_literal_list(self):
         """Test that IN/NOT_IN operations require literal lists."""


### PR DESCRIPTION
## Description

This PR introduces `UnresolvedExpr` as a new expression type to represent column references that have not yet been resolved against a concrete schema. This is a foundational change that prepares the expression system for future schema-aware resolution workflows.

**Key changes:**
- Added `UnresolvedExpr` class with `name` property and `data_type: None`
- Updated all expression visitors to handle `UnresolvedExpr` (PyArrow, Iceberg, evaluator, collectors, repr visitors)
- Changed `StarExpr.data_type` and `Expr.data_type` to `DataType | None` for semantic consistency
- Added comprehensive unit tests and API documentation

**Why this is needed:**
Currently, the expression system cannot represent column references that haven't been resolved against a schema. This is needed for string-based expression parsing, lazy schema evaluation, and deferred type checking scenarios. `UnresolvedExpr` serves as an explicit placeholder that fails fast when accidentally evaluated or converted, preventing subtle bugs.

**Note:** This PR does **not** implement resolution logic. `UnresolvedExpr` currently cannot be evaluated or converted—it only serves as a placeholder. The resolver will be added in a follow-up PR.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information

### Implementation Details

**New Expression Type:**
- `UnresolvedExpr(name: str)` - immutable dataclass with no defined `data_type`
- Structural equality based on name comparison
- Repr: `UNRESOLVED('name')` (tree) / `unresolved('name')` (inline)

**Visitor Updates:**
All expression visitors now handle `UnresolvedExpr`:
- **Conversion visitors** (`_PyArrowExpressionVisitor`, `_IcebergExpressionVisitor`): Raise `TypeError` with clear error messages
- **Evaluator** (`NativeExpressionEvaluator`): Rejects evaluation with helpful error
- **Column collectors** (`_ColumnReferenceCollector`): Collects unresolved names like regular column references
- **Substitution visitor** (`_ColumnSubstitutionVisitor`): Supports substituting unresolved expressions
- **Repr visitors**: Displays unresolved state clearly in debug output

**Type System Alignment:**
Both `StarExpr` and `UnresolvedExpr` now use `data_type: None` instead of `DataType(object)`, making it explicit that these are placeholders without concrete types.

### Follow-up Work Plan
The resolution mechanism will be implemented in subsequent PRs:
- Define creation entry points - Add string-to-expression parsing that produces UnresolvedExpr
- Implement resolution/binding phase - Design resolver pass that converts UnresolvedExpr → ColumnExpr with schema validation
- Add resolution strategy - Define resolution rules and error handling for missing/ambiguous columns
- Comprehensive resolution tests - Cover success cases, schema mismatches, and edge cases