### PR TITLE
[ci] Add push_release_test_image to push wanda anyscale images

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -368,3 +368,52 @@ py_test(
         ci_require("pytest"),
     ],
 )
+
+py_binary(
+    name = "push_release_test_image",
+    srcs = ["push_release_test_image.py"],
+    data = [
+        "//release:aws2gce_iam.json",
+        "//release:azure_docker_login.sh",
+    ],
+    exec_compatible_with = ["//bazel:py3"],
+    deps = [
+        ":image_tags_lib",
+        "//ci/ray_ci:ray_ci_lib",
+        "//release:ray_release",
+        ci_require("bazel-runfiles"),
+        ci_require("click"),
+    ],
+)
+
+py_test(
+    name = "test_push_release_test_image",
+    size = "small",
+    srcs = ["test_push_release_test_image.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":image_tags_lib",
+        ":push_release_test_image",
+        ci_require("pytest"),
+    ],
+)
+
+py_test(
+    name = "test_push_release_test_image_diff",
+    size = "small",
+    srcs = ["test_push_release_test_image_diff.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":push_release_test_image",
+        "//ci/ray_ci:ray_ci_lib",
+        ci_require("pytest"),
+    ],
+)

--- a/ci/ray_ci/automation/push_release_test_image.py
+++ b/ci/ray_ci/automation/push_release_test_image.py
@@ -1,0 +1,328 @@
+"""
+Push Wanda-cached release test images to ECR, GCP, and Azure registries used for
+release tests:
+- AWS ECR: anyscale/{image_type}:{tag}
+- GCP Artifact Registry: anyscale/{image_type}:{tag}
+- Azure Container Registry: anyscale/{image_type}:{tag}
+
+Example:
+    bazel run //ci/ray_ci/automation:push_release_test_image -- \\
+        --python-version 3.10 \\
+        --platform cpu \\
+        --image-type ray \\
+        --upload
+
+Run with --help to see all options.
+"""
+
+import logging
+import subprocess
+import sys
+from typing import List
+
+import click
+import runfiles
+
+from ci.ray_ci.automation.image_tags_lib import (
+    ImageTagsError,
+    copy_image,
+    get_platform_suffixes,
+    get_python_suffixes,
+    get_variation_suffix,
+    image_exists,
+)
+from ci.ray_ci.container import _AZURE_REGISTRY_NAME
+from ci.ray_ci.utils import ci_init, ecr_docker_login
+
+from ray_release.configs.global_config import get_global_config
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+_runfiles = runfiles.Create()
+
+
+class PushReleaseTestImageError(Exception):
+    """Error raised when pushing release test images fails."""
+
+
+def _run_gcloud_docker_login() -> None:
+    """Authenticate with GCP Artifact Registry using gcloud."""
+    credentials_path = _runfiles.Rlocation("io_ray/release/aws2gce_iam.json")
+
+    logger.info("Authenticating with GCP Artifact Registry...")
+
+    result = subprocess.run(
+        ["gcloud", "auth", "login", "--cred-file", credentials_path, "--quiet"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PushReleaseTestImageError(f"GCP auth login failed: {result.stderr}")
+
+    gcp_registry = get_global_config()["byod_gcp_cr"]
+    gcp_hostname = gcp_registry.split("/")[0]
+    result = subprocess.run(
+        ["gcloud", "auth", "configure-docker", gcp_hostname, "--quiet"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PushReleaseTestImageError(f"GCP docker config failed: {result.stderr}")
+
+
+def _run_azure_docker_login() -> None:
+    """Authenticate with Azure Container Registry."""
+    script_path = _runfiles.Rlocation("io_ray/release/azure_docker_login.sh")
+
+    logger.info("Authenticating with Azure Container Registry...")
+    result = subprocess.run(
+        ["bash", script_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PushReleaseTestImageError(f"Azure authentication failed: {result.stderr}")
+
+    logger.info(f"Logging into Azure ACR: {_AZURE_REGISTRY_NAME}...")
+    result = subprocess.run(
+        ["az", "acr", "login", "--name", _AZURE_REGISTRY_NAME],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PushReleaseTestImageError(f"Azure ACR login failed: {result.stderr}")
+
+
+class ReleaseTestImagePushContext:
+    """Context for publishing an anyscale image from Wanda cache to cloud registries."""
+
+    image_type: str
+    python_version: str
+    platform: str
+    branch: str
+    commit: str
+    rayci_build_id: str
+    pull_request: str
+    # Computed fields (set in __init__)
+    wanda_tag: str
+
+    def __init__(
+        self,
+        image_type: str,
+        python_version: str,
+        platform: str,
+        branch: str,
+        commit: str,
+        rayci_build_id: str,
+        pull_request: str,
+    ) -> None:
+        self.image_type = image_type
+        self.python_version = python_version
+        self.platform = platform
+        self.branch = branch
+        self.commit = commit
+        self.rayci_build_id = rayci_build_id
+        self.pull_request = pull_request
+
+        self.wanda_tag = f"{rayci_build_id}-{self.wanda_image_name()}"
+
+    def destination_tags(self) -> List[str]:
+        """
+        Compute the destination tags for this context.
+
+        Tags are formed as:
+        {version}{variation}{python_suffix}{platform_suffix}
+
+        For example:
+        - abc123-py310-cpu
+        - abc123-py310-gpu
+        - abc123-py310
+        - 2.53.0.abc123-py310-cu121
+        """
+        tags = []
+        for version in self._versions():
+            for plat in self._platform_suffixes():
+                for py in self._python_suffixes():
+                    tags.append(f"{version}{self._variation_suffix()}{py}{plat}")
+        return tags
+
+    def wanda_image_name(self) -> str:
+        """Get the wanda source image name for this context."""
+        return f"{self.image_type}-anyscale-py{self.python_version}-{self.platform}"
+
+    def _versions(self) -> List[str]:
+        """Compute version tags based on branch/PR status.
+
+        Priority matches original DockerContainer._get_image_version_tags:
+        1. master branch -> sha_tag
+        2. release branch -> release_version.sha_tag
+        3. PR -> pr-{number}.sha_tag
+        4. other branches -> sha_tag
+        """
+        sha_tag = self.commit[:6]
+
+        if self.branch == "master":
+            primary_tag = sha_tag
+        elif self.branch and self.branch.startswith("releases/"):
+            primary_tag = f"{self.branch[len('releases/'):]}.{sha_tag}"
+        elif self.pull_request != "false":
+            primary_tag = f"pr-{self.pull_request}.{sha_tag}"
+        else:
+            primary_tag = sha_tag
+
+        versions = [primary_tag]
+        if self.rayci_build_id:
+            versions.append(self.rayci_build_id)
+
+        return versions
+
+    def _variation_suffix(self) -> str:
+        """Get -extra suffix for extra image types."""
+        return get_variation_suffix(self.image_type)
+
+    def _python_suffixes(self) -> List[str]:
+        """Get python version suffixes (includes empty for default version)."""
+        return get_python_suffixes(self.python_version)
+
+    def _platform_suffixes(self) -> List[str]:
+        """Get platform suffixes (includes aliases like -gpu for GPU_PLATFORM)."""
+        return get_platform_suffixes(self.platform, self.image_type)
+
+
+@click.command()
+@click.option(
+    "--python-version",
+    type=str,
+    required=True,
+    help="Python version (e.g., '3.10')",
+)
+@click.option(
+    "--platform",
+    type=str,
+    required=True,
+    help="Platform (e.g., 'cpu', 'cu12.3.2-cudnn9')",
+)
+@click.option(
+    "--image-type",
+    type=str,
+    default="ray",
+    help="Image type (e.g., 'ray', 'ray-llm', 'ray-ml')",
+)
+@click.option(
+    "--upload",
+    is_flag=True,
+    default=False,
+    help="Actually push to registries. Without this flag, runs in dry-run mode.",
+)
+@click.option(
+    "--rayci-work-repo",
+    type=str,
+    required=True,
+    envvar="RAYCI_WORK_REPO",
+    help="ECR work repo (e.g., '029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp')",
+)
+@click.option(
+    "--rayci-build-id",
+    type=str,
+    required=True,
+    envvar="RAYCI_BUILD_ID",
+    help="Rayci build ID",
+)
+@click.option("--branch", type=str, required=True, envvar="BUILDKITE_BRANCH")
+@click.option("--commit", type=str, required=True, envvar="BUILDKITE_COMMIT")
+@click.option(
+    "--pull-request", type=str, default="false", envvar="BUILDKITE_PULL_REQUEST"
+)
+def main(
+    python_version: str,
+    platform: str,
+    image_type: str,
+    upload: bool,
+    rayci_work_repo: str,
+    rayci_build_id: str,
+    branch: str,
+    commit: str,
+    pull_request: str,
+) -> None:
+    """
+    Push a Wanda-cached release test image to ECR, GCP, and Azure registries.
+
+    Handles authentication for all three registries internally.
+    """
+    ci_init()
+
+    dry_run = not upload
+    if dry_run:
+        logger.info("DRY RUN MODE - no images will be pushed")
+
+    ctx = ReleaseTestImagePushContext(
+        image_type=image_type,
+        python_version=python_version,
+        platform=platform,
+        branch=branch,
+        commit=commit,
+        rayci_build_id=rayci_build_id,
+        pull_request=pull_request,
+    )
+
+    ecr_registry = rayci_work_repo.split("/")[0]
+    source_tag = f"{rayci_work_repo}:{ctx.wanda_tag}"
+    logger.info(f"Source image (Wanda): {source_tag}")
+
+    # Get image tags
+    try:
+        tags = ctx.destination_tags()
+    except ImageTagsError as e:
+        raise PushReleaseTestImageError(str(e))
+
+    canonical_tag = tags[0]
+    logger.info(f"Canonical tag: {canonical_tag}")
+    logger.info(f"All tags: {tags}")
+
+    # Destination registries (from global config)
+    global_config = get_global_config()
+    registries = [
+        (ecr_registry, "ECR"),
+        (global_config["byod_gcp_cr"], "GCP"),
+        (global_config["byod_azure_cr"], "Azure"),
+    ]
+
+    if dry_run:
+        for tag in tags:
+            for registry, name in registries:
+                dest_image = f"{registry}/anyscale/{image_type}:{tag}"
+                logger.info(f"Would push to {name}: {dest_image}")
+        return
+
+    # Authenticate with all registries
+    ecr_docker_login(ecr_registry)
+    _run_gcloud_docker_login()
+    _run_azure_docker_login()
+
+    # Verify source image exists
+    logger.info("Verifying source image in Wanda cache...")
+    if not image_exists(source_tag):
+        raise PushReleaseTestImageError(
+            f"Source image not found in Wanda cache: {source_tag}"
+        )
+
+    # Push to all three registries
+    try:
+        for tag in tags:
+            for registry, name in registries:
+                dest_image = f"{registry}/anyscale/{image_type}:{tag}"
+                logger.info(f"Pushing to {name}: {dest_image}")
+                copy_image(source_tag, dest_image, dry_run=False)
+    except ImageTagsError as e:
+        raise PushReleaseTestImageError(str(e))
+
+    logger.info("Successfully pushed release test images to all registries")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/automation/test_push_release_test_image.py
+++ b/ci/ray_ci/automation/test_push_release_test_image.py
@@ -1,0 +1,267 @@
+import sys
+
+import pytest
+
+from ci.ray_ci.automation.image_tags_lib import (
+    format_platform_tag,
+    format_python_tag,
+)
+from ci.ray_ci.automation.push_release_test_image import ReleaseTestImagePushContext
+from ci.ray_ci.configs import DEFAULT_PYTHON_TAG_VERSION
+from ci.ray_ci.docker_container import GPU_PLATFORM
+
+
+def make_ctx(
+    image_type: str = "ray",
+    python_version: str = "3.11",
+    platform: str = "cu12.3.2-cudnn9",
+    branch: str = "master",
+    commit: str = "abc123def456",
+    rayci_build_id: str = "build-123",
+    pull_request: str = "false",
+) -> ReleaseTestImagePushContext:
+    """Helper to create a context with defaults."""
+    return ReleaseTestImagePushContext(
+        image_type=image_type,
+        python_version=python_version,
+        platform=platform,
+        branch=branch,
+        commit=commit,
+        rayci_build_id=rayci_build_id,
+        pull_request=pull_request,
+    )
+
+
+class TestFormatPythonTag:
+    @pytest.mark.parametrize(
+        ("python_version", "expected"),
+        [
+            ("3.10", "-py310"),
+            ("3.11", "-py311"),
+            ("3.12", "-py312"),
+            ("3.9", "-py39"),
+        ],
+    )
+    def test_format_python_tag(self, python_version, expected):
+        assert format_python_tag(python_version) == expected
+
+
+class TestFormatPlatformTag:
+    @pytest.mark.parametrize(
+        ("platform", "expected"),
+        [
+            ("cpu", "-cpu"),
+            ("cu11.7.1-cudnn8", "-cu117"),
+            ("cu11.8.0-cudnn8", "-cu118"),
+            ("cu12.1.1-cudnn8", "-cu121"),
+            ("cu12.3.2-cudnn9", "-cu123"),
+            ("cu12.8.1-cudnn", "-cu128"),
+        ],
+    )
+    def test_format_platform_tag(self, platform, expected):
+        assert format_platform_tag(platform) == expected
+
+
+class TestWandaImageName:
+    @pytest.mark.parametrize(
+        ("python_version", "platform", "image_type", "expected"),
+        [
+            ("3.10", "cpu", "ray", "ray-anyscale-py3.10-cpu"),
+            ("3.11", "cu12.1.1-cudnn8", "ray", "ray-anyscale-py3.11-cu12.1.1-cudnn8"),
+            ("3.10", "cpu", "ray-llm", "ray-llm-anyscale-py3.10-cpu"),
+            (
+                "3.11",
+                "cu12.8.1-cudnn",
+                "ray-llm",
+                "ray-llm-anyscale-py3.11-cu12.8.1-cudnn",
+            ),
+            ("3.10", "cpu", "ray-ml", "ray-ml-anyscale-py3.10-cpu"),
+            (
+                "3.11",
+                "cu12.3.2-cudnn9",
+                "ray-ml",
+                "ray-ml-anyscale-py3.11-cu12.3.2-cudnn9",
+            ),
+        ],
+    )
+    def test_wanda_image_name(self, python_version, platform, image_type, expected):
+        ctx = make_ctx(
+            python_version=python_version, platform=platform, image_type=image_type
+        )
+        assert ctx.wanda_image_name() == expected
+
+
+class TestDestinationTags:
+    def test_master_branch_tags(self):
+        ctx = make_ctx(
+            python_version="3.11",
+            platform="cu12.3.2-cudnn9",
+            image_type="ray",
+            branch="master",
+            commit="abc123def456",
+            rayci_build_id="build-123",
+        )
+        tags = ctx.destination_tags()
+
+        assert tags == [
+            "abc123-py311-cu123",
+            "build-123-py311-cu123",
+        ]
+
+    def test_release_branch_tags(self):
+        ctx = make_ctx(
+            python_version="3.11",
+            platform="cu12.3.2-cudnn9",
+            image_type="ray",
+            branch="releases/2.44.0",
+            commit="abc123def456",
+            rayci_build_id="build-456",
+        )
+        tags = ctx.destination_tags()
+
+        assert tags == [
+            "2.44.0.abc123-py311-cu123",
+            "build-456-py311-cu123",
+        ]
+
+    def test_gpu_platform_includes_alias(self):
+        """GPU_PLATFORM gets -gpu alias, other platforms do not."""
+        gpu_ctx = make_ctx(
+            python_version="3.11", platform=GPU_PLATFORM, image_type="ray"
+        )
+        other_cuda_ctx = make_ctx(
+            python_version="3.11", platform="cu12.3.2-cudnn9", image_type="ray"
+        )
+        cpu_ctx = make_ctx(python_version="3.11", platform="cpu", image_type="ray")
+
+        gpu_tags = gpu_ctx.destination_tags()
+        other_cuda_tags = other_cuda_ctx.destination_tags()
+        cpu_tags = cpu_ctx.destination_tags()
+
+        assert any("-gpu" in tag for tag in gpu_tags)
+        assert not any("-gpu" in tag for tag in other_cuda_tags)
+        assert not any("-gpu" in tag for tag in cpu_tags)
+
+    def test_ray_ml_gpu_platform_includes_empty_platform_suffix(self):
+        """ray-ml with GPU_PLATFORM gets -gpu alias AND empty platform suffix."""
+        ctx = make_ctx(
+            python_version="3.11", platform=GPU_PLATFORM, image_type="ray-ml"
+        )
+        tags = ctx.destination_tags()
+
+        # Should have: -cu121, -gpu, and empty suffix (no platform)
+        assert "abc123-py311-cu121" in tags
+        assert "abc123-py311-gpu" in tags
+        assert "abc123-py311" in tags
+        assert "build-123-py311-cu121" in tags
+        assert "build-123-py311-gpu" in tags
+        assert "build-123-py311" in tags
+
+    def test_ray_ml_non_gpu_platform_no_empty_suffix(self):
+        """ray-ml with non-GPU_PLATFORM does NOT get empty suffix."""
+        ctx = make_ctx(
+            python_version="3.11", platform="cu12.3.2-cudnn9", image_type="ray-ml"
+        )
+        tags = ctx.destination_tags()
+
+        assert tags == [
+            "abc123-py311-cu123",
+            "build-123-py311-cu123",
+        ]
+
+    def test_pr_branch_tags(self):
+        ctx = make_ctx(
+            python_version="3.12",
+            platform="cu12.3.2-cudnn9",
+            image_type="ray",
+            branch="feature-branch",
+            commit="abc123def456",
+            rayci_build_id="build-789",
+            pull_request="123",
+        )
+        tags = ctx.destination_tags()
+
+        assert tags == [
+            "pr-123.abc123-py312-cu123",
+            "build-789-py312-cu123",
+        ]
+
+    def test_non_pr_feature_branch_tags(self):
+        ctx = make_ctx(
+            python_version="3.11",
+            platform="cu12.3.2-cudnn9",
+            image_type="ray",
+            branch="feature-branch",
+            commit="abc123def456",
+            rayci_build_id="build-789",
+            pull_request="false",
+        )
+        tags = ctx.destination_tags()
+
+        assert tags == [
+            "abc123-py311-cu123",
+            "build-789-py311-cu123",
+        ]
+
+    def test_default_python_version_includes_empty_suffix(self):
+        """DEFAULT_PYTHON_TAG_VERSION (3.10) gets empty python suffix."""
+        assert DEFAULT_PYTHON_TAG_VERSION == "3.10"
+        ctx = make_ctx(
+            python_version="3.10", platform="cu12.3.2-cudnn9", image_type="ray"
+        )
+        tags = ctx.destination_tags()
+
+        # Should have both -py310 and empty python suffix
+        assert "abc123-py310-cu123" in tags
+        assert "abc123-cu123" in tags
+        assert "build-123-py310-cu123" in tags
+        assert "build-123-cu123" in tags
+
+    def test_cpu_ray_includes_empty_platform_suffix(self):
+        """ray with cpu gets empty platform suffix."""
+        ctx = make_ctx(python_version="3.11", platform="cpu", image_type="ray")
+        tags = ctx.destination_tags()
+
+        # Should have both -cpu and empty platform suffix
+        assert "abc123-py311-cpu" in tags
+        assert "abc123-py311" in tags
+        assert "build-123-py311-cpu" in tags
+        assert "build-123-py311" in tags
+
+    def test_cpu_ray_ml_no_empty_platform_suffix(self):
+        """ray-ml with cpu does NOT get empty platform suffix."""
+        ctx = make_ctx(python_version="3.11", platform="cpu", image_type="ray-ml")
+        tags = ctx.destination_tags()
+
+        assert tags == [
+            "abc123-py311-cpu",
+            "build-123-py311-cpu",
+        ]
+
+    def test_extra_image_type_includes_variation_suffix(self):
+        """-extra image types get -extra variation suffix."""
+        ray_extra_ctx = make_ctx(
+            python_version="3.11", platform="cu12.3.2-cudnn9", image_type="ray-extra"
+        )
+        ray_ml_extra_ctx = make_ctx(
+            python_version="3.11", platform="cu12.3.2-cudnn9", image_type="ray-ml-extra"
+        )
+
+        ray_extra_tags = ray_extra_ctx.destination_tags()
+        ray_ml_extra_tags = ray_ml_extra_ctx.destination_tags()
+
+        assert "abc123-extra-py311-cu123" in ray_extra_tags
+        assert "abc123-extra-py311-cu123" in ray_ml_extra_tags
+
+    def test_ray_extra_cpu_includes_empty_platform_suffix(self):
+        """ray-extra with cpu gets empty platform suffix (like ray)."""
+        ctx = make_ctx(python_version="3.11", platform="cpu", image_type="ray-extra")
+        tags = ctx.destination_tags()
+
+        # Should have both -cpu and empty platform suffix
+        assert "abc123-extra-py311-cpu" in tags
+        assert "abc123-extra-py311" in tags
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-vv", __file__]))

--- a/ci/ray_ci/automation/test_push_release_test_image_diff.py
+++ b/ci/ray_ci/automation/test_push_release_test_image_diff.py
@@ -1,0 +1,240 @@
+"""
+Diff test to ensure ReleaseTestImagePushContext produces identical tags
+to the original AnyscaleDockerContainer/DockerContainer implementation.
+"""
+
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+from ci.ray_ci.anyscale_docker_container import AnyscaleDockerContainer
+from ci.ray_ci.automation.push_release_test_image import ReleaseTestImagePushContext
+from ci.ray_ci.docker_container import GPU_PLATFORM, RayType
+
+# Test matrix covering various scenarios
+TEST_CASES = [
+    # (python_version, platform, image_type, branch, commit, build_id, pr)
+    # Master branch scenarios
+    ("3.11", "cpu", "ray", "master", "abc123def456", "build-123", "false"),
+    ("3.11", "cpu", "ray-ml", "master", "abc123def456", "build-123", "false"),
+    ("3.11", GPU_PLATFORM, "ray", "master", "abc123def456", "build-123", "false"),
+    ("3.11", GPU_PLATFORM, "ray-ml", "master", "abc123def456", "build-123", "false"),
+    ("3.10", "cpu", "ray", "master", "abc123def456", "build-123", "false"),
+    ("3.10", GPU_PLATFORM, "ray-ml", "master", "abc123def456", "build-123", "false"),
+    # Release branch scenarios
+    ("3.11", "cpu", "ray", "releases/2.44.0", "abc123def456", "build-456", "false"),
+    (
+        "3.11",
+        GPU_PLATFORM,
+        "ray-ml",
+        "releases/2.44.0",
+        "abc123def456",
+        "build-456",
+        "false",
+    ),
+    ("3.10", "cpu", "ray", "releases/2.44.0", "abc123def456", "build-456", "false"),
+    # PR scenarios
+    ("3.11", "cpu", "ray", "feature-branch", "abc123def456", "build-789", "123"),
+    (
+        "3.11",
+        GPU_PLATFORM,
+        "ray-ml",
+        "feature-branch",
+        "abc123def456",
+        "build-789",
+        "456",
+    ),
+    # Feature branch (no PR)
+    ("3.11", "cpu", "ray", "feature-branch", "abc123def456", "build-789", "false"),
+    # Other CUDA versions (not GPU_PLATFORM) - only valid for ray, not ray-ml
+    ("3.11", "cu12.3.2-cudnn9", "ray", "master", "abc123def456", "build-123", "false"),
+    # Extra image types
+    ("3.11", "cpu", "ray-extra", "master", "abc123def456", "build-123", "false"),
+    (
+        "3.11",
+        GPU_PLATFORM,
+        "ray-ml-extra",
+        "master",
+        "abc123def456",
+        "build-123",
+        "false",
+    ),
+]
+
+
+def image_type_to_ray_type(image_type: str) -> RayType:
+    """Convert string image type to RayType enum."""
+    return RayType(image_type)
+
+
+class TestAnyscaleImageTagsDiff:
+    """Test that new implementation matches original exactly."""
+
+    @pytest.mark.parametrize(
+        (
+            "python_version",
+            "platform",
+            "image_type",
+            "branch",
+            "commit",
+            "build_id",
+            "pr",
+        ),
+        TEST_CASES,
+    )
+    def test_tags_match_original(
+        self,
+        python_version: str,
+        platform: str,
+        image_type: str,
+        branch: str,
+        commit: str,
+        build_id: str,
+        pr: str,
+    ):
+        """Compare tags from new ReleaseTestImagePushContext with original DockerContainer."""
+        env = {
+            "RAYCI_CHECKOUT_DIR": "/ray",
+            "RAYCI_BUILD_ID": build_id,
+            "RAYCI_WORK_REPO": "rayproject/citemp",
+            "BUILDKITE_COMMIT": commit,
+            "BUILDKITE_BRANCH": branch,
+            "BUILDKITE_PIPELINE_ID": "123456",
+            "BUILDKITE_PULL_REQUEST": pr,
+        }
+
+        with mock.patch.dict(os.environ, env, clear=False):
+            # Create original container (AnyscaleDockerContainer inherits from DockerContainer)
+            original = AnyscaleDockerContainer(
+                python_version=python_version,
+                platform=platform,
+                image_type=image_type_to_ray_type(image_type),
+                upload=False,
+            )
+            original_tags = original._get_image_tags()
+
+            # Create new context
+            new_ctx = ReleaseTestImagePushContext(
+                image_type=image_type,
+                python_version=python_version,
+                platform=platform,
+                branch=branch,
+                commit=commit,
+                rayci_build_id=build_id,
+                pull_request=pr,
+            )
+            new_tags = new_ctx.destination_tags()
+
+            # Compare - sort both to ignore order differences
+            assert sorted(original_tags) == sorted(new_tags), (
+                f"Tags mismatch for {image_type} py{python_version} {platform} on {branch}\n"
+                f"Original: {sorted(original_tags)}\n"
+                f"New:      {sorted(new_tags)}"
+            )
+
+    @pytest.mark.parametrize(
+        (
+            "python_version",
+            "platform",
+            "image_type",
+            "branch",
+            "commit",
+            "build_id",
+            "pr",
+        ),
+        TEST_CASES,
+    )
+    def test_wanda_image_name_format(
+        self,
+        python_version: str,
+        platform: str,
+        image_type: str,
+        branch: str,
+        commit: str,
+        build_id: str,
+        pr: str,
+    ):
+        """Verify wanda image name follows expected format."""
+        new_ctx = ReleaseTestImagePushContext(
+            image_type=image_type,
+            python_version=python_version,
+            platform=platform,
+            branch=branch,
+            commit=commit,
+            rayci_build_id=build_id,
+            pull_request=pr,
+        )
+
+        wanda_name = new_ctx.wanda_image_name()
+
+        # Wanda image name should be: {image_type}-anyscale-py{version}-{platform}
+        assert wanda_name.startswith(f"{image_type}-anyscale-py{python_version}-")
+        if platform == "cpu":
+            assert wanda_name.endswith("-cpu")
+        else:
+            assert wanda_name.endswith(f"-{platform}")
+
+    @pytest.mark.parametrize(
+        (
+            "python_version",
+            "platform",
+            "image_type",
+            "branch",
+            "commit",
+            "build_id",
+            "pr",
+        ),
+        TEST_CASES,
+    )
+    def test_canonical_tag_matches(
+        self,
+        python_version: str,
+        platform: str,
+        image_type: str,
+        branch: str,
+        commit: str,
+        build_id: str,
+        pr: str,
+    ):
+        """Verify the canonical (first) tag matches between implementations."""
+        env = {
+            "RAYCI_CHECKOUT_DIR": "/ray",
+            "RAYCI_BUILD_ID": build_id,
+            "RAYCI_WORK_REPO": "rayproject/citemp",
+            "BUILDKITE_COMMIT": commit,
+            "BUILDKITE_BRANCH": branch,
+            "BUILDKITE_PIPELINE_ID": "123456",
+            "BUILDKITE_PULL_REQUEST": pr,
+        }
+
+        with mock.patch.dict(os.environ, env, clear=False):
+            original = AnyscaleDockerContainer(
+                python_version=python_version,
+                platform=platform,
+                image_type=image_type_to_ray_type(image_type),
+                upload=False,
+            )
+            original_canonical = original._get_canonical_tag()
+
+            new_ctx = ReleaseTestImagePushContext(
+                image_type=image_type,
+                python_version=python_version,
+                platform=platform,
+                branch=branch,
+                commit=commit,
+                rayci_build_id=build_id,
+                pull_request=pr,
+            )
+            new_canonical = new_ctx.destination_tags()[0]
+
+            assert original_canonical == new_canonical, (
+                f"Canonical tag mismatch for {image_type} py{python_version} {platform}\n"
+                f"Original: {original_canonical}\n"
+                f"New:      {new_canonical}"
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-vv", __file__]))

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -2,6 +2,14 @@ load("@py_deps_py310//:requirements.bzl", bk_require = "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
+exports_files(
+    [
+        "aws2gce_iam.json",
+        "azure_docker_login.sh",
+    ],
+    visibility = ["//ci/ray_ci/automation:__pkg__"],
+)
+
 compile_pip_requirements(
     name = "requirements_py310",
     data = [":requirements-doc.txt"],


### PR DESCRIPTION
Add push_release_test_image.py to copy Wanda-cached Release Test images to ECR, GCP, and Azure registries for release tests. This replaces the Docker-based build approach in AnyscaleDockerContainer with crane-based image copying.

- AnyscaleImagePushContext class encapsulating tag generation logic
- Uses shared image_tags_lib for tag formatting (python/platform suffixes)
- Pushes to all three cloud registries (ECR, GCP, Azure)
- Includes diff test verifying tag parity with original implementation

Topic: push-anyscale-wanda
Relative: forge-google-cli

Signed-off-by: andrew <andrew@anyscale.com>