### PR TITLE
[Data] Fixing output backpressure unblocking sequence to properly handle terminal ops

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -692,12 +692,14 @@ class OpResourceAllocator(ABC):
     def _should_unblock_streaming_output_backpressure(
         self, op: PhysicalOperator
     ) -> bool:
+        downstream_eligible_ops = list(self._get_downstream_eligible_ops(op))
+
         # NOTE: If this operator is a terminal one, extracting outputs from it
         #       should not be throttled
-        if not op.output_dependencies:
+        if not downstream_eligible_ops:
             return True
 
-        for downstream_op in self._get_downstream_eligible_ops(op):
+        for downstream_op in downstream_eligible_ops:
             # To maintain liveness of the pipeline, we relax output backpressure
             # in one of the following cases
             if downstream_op.num_active_tasks() == 0:


### PR DESCRIPTION
## Description

Currently, `_should_unblock_streaming_output_backpressure` incorrectly unblocks output backpressure only for truly terminal Operators, ie ones w/o any downstream deps.

This however incorrectly rules out operators that hove ineligible downstream op like `Limit`, `OutputSplitter`, etc. (disproportionately affecting training ingest cases)

Instead, this should be expanded to be unblocking Operators that don't have any **eligible** downstream operators.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
