### PR TITLE
[Data] [Docs] Add missing MOD operation documentation in Operation enum

### DIFF
--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -50,6 +50,7 @@ class Operation(Enum):
         SUB: Subtraction operation (-)
         MUL: Multiplication operation (*)
         DIV: Division operation (/)
+        MOD: Modulo operation (%)
         FLOORDIV: Floor division operation (//)
         GT: Greater than comparison (>)
         LT: Less than comparison (<)


### PR DESCRIPTION
## Description

Add missing documentation for the `MOD` (modulo) operation in the `Operation` enum's docstring. The `MOD` operation was already implemented in the enum (line 74) and fully functional, but was accidentally omitted from the class-level docstring that lists all available operations.

This PR improves API documentation completeness by documenting the modulo operation alongside other arithmetic operations like `ADD`, `SUB`, `MUL`, `DIV`, and `FLOORDIV`.

## Related issues

N/A - Documentation improvement only

## Additional information

- **Change**: Added `MOD: Modulo operation (%)` to the `Attributes` section of the `Operation` enum docstring