### PR TITLE
[core] fix dashboard event agent for reporting events without http scheme

### DIFF
--- a/python/ray/dashboard/modules/event/event_agent.py
+++ b/python/ray/dashboard/modules/event/event_agent.py
@@ -66,7 +66,9 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
                 )
                 if not dashboard_http_address:
                     raise ValueError("Dashboard http address not found in InternalKV.")
-                self._dashboard_http_address = dashboard_http_address.decode()
+                self._dashboard_http_address = (
+                    f"http://{dashboard_http_address.decode()}"
+                )
                 return self._dashboard_http_address
             except Exception:
                 logger.exception("Get dashboard http address failed.")

--- a/python/ray/dashboard/modules/event/event_agent.py
+++ b/python/ray/dashboard/modules/event/event_agent.py
@@ -4,6 +4,7 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Union
+from urllib.parse import urlparse
 
 import ray._private.ray_constants as ray_constants
 import ray.dashboard.consts as dashboard_consts
@@ -66,9 +67,10 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
                 )
                 if not dashboard_http_address:
                     raise ValueError("Dashboard http address not found in InternalKV.")
-                self._dashboard_http_address = (
-                    f"http://{dashboard_http_address.decode()}"
-                )
+                address = dashboard_http_address.decode()
+                if not urlparse(address).scheme:
+                    address = f"http://{address}"
+                self._dashboard_http_address = address
                 return self._dashboard_http_address
             except Exception:
                 logger.exception("Get dashboard http address failed.")


### PR DESCRIPTION
## Description

`event_agent.py` fails to report events to the dashboard for a long time. It fails with `aiohttp.client_exceptions.NonHttpUrlClientError` because the address doesn't start with a `http://` scheme.

```
2026-02-06 11:14:08,101 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,101 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,102 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,102 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,102 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,102 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,102 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,102 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,102 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,103 WARNING event_agent.py:98 -- Report event failed, retrying... 10.0.158.13:8265/report_events
2026-02-06 11:14:08,103 ERROR event_agent.py:103 -- Report event failed: ['{"event_id":"2026-02-06 19:14:06.345298544 +0000 UTC m=+39.118057203","source_type":"AUTOSCALER","source_hostname":"...","source_pid":1,"severity":"TRACE","label":"","message":"The following Ray state was observed:  {\\"nodeStates\\":[{\\"instanceId\\":\\"i-022d9225846352e01\\",\\"rayNodeTypeName\\":\\"worker_node\\",\\"availableResources\\":{\\"CPU\\":64,\\"GPU\\":0,\\"memory\\":68719476736,\\"object_store_memory\\":19289486131},\\"totalResources\\":{\\"CPU\\":64,\\"GPU\\":0,\\"memory\\":68719476736,\\"object_store_memory\\":19289486131},\\"status\\":\\"IDLE\\",\\"nodeIpAddress\\":\\"10.0.190.81\\",\\"labels\\":{\\"anyscale.com/instance-type\\":\\"m5.4xlarge\\",\\"ray.io/availability-zone\\":\\"us-west-2c\\",\\"ray.io/market-type\\":\\"on-demand\\",\\"ray.io/node-group\\":\\"worker_node\\",\\"ray.io/node-id\\":\\"3feb50bae0efe29f43559fafb4a4a4cb5a32d2297a1f66caad0b2aad\\",\\"ray.io/region\\":\\"us-west-2\\"}},{\\"instanceId\\":\\"i-05a62ab9bfc5d4400\\",\\"rayNodeT...
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/event/event_agent.py", line 89, in report_events
    async with self._dashboard_agent.http_session.post(
  File "/home/ray/anaconda3/lib/python3.10/site-packages/aiohttp/client.py", line 1510, in __aenter__
    self._resp: _RetType = await self._coro
  File "/home/ray/anaconda3/lib/python3.10/site-packages/aiohttp/client.py", line 558, in _request
    raise NonHttpUrlClientError(url)
aiohttp.client_exceptions.NonHttpUrlClientError: 10.0.158.13:8265/report_events

```

This PR adds the http scheme.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
