### PR TITLE
[Serve LLM] Handle missing state attributes from vLLM's task-conditional init_app_state

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -350,72 +350,54 @@ class VLLMEngine(LLMEngine):
             self._oai_models, "load_lora_adapter"
         ), "oai_models must have a load_lora_adapter attribute"
 
-    def _validate_openai_serving_chat(self):
+    @staticmethod
+    def _make_error(message: str) -> ErrorResponse:
+        return ErrorResponse(
+            error=ErrorInfo(
+                message=message, type="invalid_request_error", code=400
+            )
+        )
+
+    def _validate_openai_serving_chat(self) -> Optional[ErrorResponse]:
         if self._oai_serving_chat is None:
-            raise ValueError(
+            return self._make_error(
                 "This model does not support the 'generate' task. "
                 "The chat completion endpoint is not available for this model."
             )
-        if not hasattr(self._oai_serving_chat, "create_chat_completion"):
-            raise ValueError(
-                "oai_serving_chat must have a create_chat_completion attribute"
-            )
 
-    def _validate_openai_serving_completion(self):
+    def _validate_openai_serving_completion(self) -> Optional[ErrorResponse]:
         if self._oai_serving_completion is None:
-            raise ValueError(
+            return self._make_error(
                 "This model does not support the 'generate' task. "
                 "The completion endpoint is not available for this model."
             )
-        if not hasattr(self._oai_serving_completion, "create_completion"):
-            raise ValueError(
-                "oai_serving_completion must have a create_completion attribute"
-            )
 
-    def _validate_openai_serving_embedding(self):
+    def _validate_openai_serving_embedding(self) -> Optional[ErrorResponse]:
         if self._oai_serving_embedding is None:
-            raise ValueError(
+            return self._make_error(
                 "This model does not support the 'embed' task. "
                 "The embedding endpoint is not available for this model."
             )
-        if not hasattr(self._oai_serving_embedding, "create_embedding"):
-            raise ValueError(
-                "oai_serving_embedding must have a create_embedding attribute"
-            )
 
-    def _validate_openai_serving_transcription(self):
+    def _validate_openai_serving_transcription(self) -> Optional[ErrorResponse]:
         if self._oai_serving_transcription is None:
-            raise ValueError(
+            return self._make_error(
                 "This model does not support the 'transcription' task. "
                 "The transcription endpoint is not available for this model."
             )
-        if not hasattr(self._oai_serving_transcription, "create_transcription"):
-            raise ValueError(
-                "oai_serving_transcription must have a create_transcription attribute"
-            )
 
-    def _validate_openai_serving_scores(self):
+    def _validate_openai_serving_scores(self) -> Optional[ErrorResponse]:
         if self._oai_serving_scores is None:
-            raise ValueError(
+            return self._make_error(
                 "This model does not support the 'score' task. "
                 "The score endpoint is not available for this model."
             )
-        if not hasattr(self._oai_serving_scores, "create_score"):
-            raise ValueError("oai_serving_scores must have a create_score attribute")
 
-    def _validate_openai_serving_tokenization(self):
+    def _validate_openai_serving_tokenization(self) -> Optional[ErrorResponse]:
         if self._oai_serving_tokenization is None:
-            raise ValueError(
+            return self._make_error(
                 "This model does not support the 'tokenization' task. "
                 "The tokenization endpoint is not available for this model."
-            )
-        if not hasattr(self._oai_serving_tokenization, "create_tokenize"):
-            raise ValueError(
-                "oai_serving_tokenization must have a create_tokenize attribute"
-            )
-        if not hasattr(self._oai_serving_tokenization, "create_detokenize"):
-            raise ValueError(
-                "oai_serving_tokenization must have a create_detokenize attribute"
             )
 
     def _validate_engine_client(self):

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -353,9 +353,7 @@ class VLLMEngine(LLMEngine):
     @staticmethod
     def _make_error(message: str) -> ErrorResponse:
         return ErrorResponse(
-            error=ErrorInfo(
-                message=message, type="invalid_request_error", code=400
-            )
+            error=ErrorInfo(message=message, type="invalid_request_error", code=400)
         )
 
     def _validate_openai_serving_chat(self) -> Optional[ErrorResponse]:

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -505,12 +505,8 @@ class VLLMEngine(LLMEngine):
         request: ChatCompletionRequest,
         raw_request_info: Optional[RawRequestInfo] = None,
     ) -> AsyncGenerator[Union[str, ChatCompletionResponse, ErrorResponse], None]:
-        try:
-            self._validate_openai_serving_chat()
-        except ValueError as e:
-            yield ErrorResponse(
-                error=ErrorInfo(message=str(e), type="invalid_request_error", code=400)
-            )
+        if error := self._validate_openai_serving_chat():
+            yield error
             return
 
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
@@ -539,12 +535,8 @@ class VLLMEngine(LLMEngine):
         request: CompletionRequest,
         raw_request_info: Optional[RawRequestInfo] = None,
     ) -> AsyncGenerator[Union[str, CompletionResponse, ErrorResponse], None]:
-        try:
-            self._validate_openai_serving_completion()
-        except ValueError as e:
-            yield ErrorResponse(
-                error=ErrorInfo(message=str(e), type="invalid_request_error", code=400)
-            )
+        if error := self._validate_openai_serving_completion():
+            yield error
             return
 
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
@@ -575,12 +567,8 @@ class VLLMEngine(LLMEngine):
         request: EmbeddingRequest,
         raw_request_info: Optional[RawRequestInfo] = None,
     ) -> AsyncGenerator[Union[EmbeddingResponse, ErrorResponse], None]:
-        try:
-            self._validate_openai_serving_embedding()
-        except ValueError as e:
-            yield ErrorResponse(
-                error=ErrorInfo(message=str(e), type="invalid_request_error", code=400)
-            )
+        if error := self._validate_openai_serving_embedding():
+            yield error
             return
 
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
@@ -603,12 +591,8 @@ class VLLMEngine(LLMEngine):
         request: TranscriptionRequest,
         raw_request_info: Optional[RawRequestInfo] = None,
     ) -> AsyncGenerator[Union[str, TranscriptionResponse, ErrorResponse], None]:
-        try:
-            self._validate_openai_serving_transcription()
-        except ValueError as e:
-            yield ErrorResponse(
-                error=ErrorInfo(message=str(e), type="invalid_request_error", code=400)
-            )
+        if error := self._validate_openai_serving_transcription():
+            yield error
             return
 
         # Extract audio data from the request file
@@ -643,12 +627,8 @@ class VLLMEngine(LLMEngine):
         request: ScoreRequest,
         raw_request_info: Optional[RawRequestInfo] = None,
     ) -> AsyncGenerator[Union[ScoreResponse, ErrorResponse], None]:
-        try:
-            self._validate_openai_serving_scores()
-        except ValueError as e:
-            yield ErrorResponse(
-                error=ErrorInfo(message=str(e), type="invalid_request_error", code=400)
-            )
+        if error := self._validate_openai_serving_scores():
+            yield error
             return
 
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
@@ -669,12 +649,8 @@ class VLLMEngine(LLMEngine):
         request: TokenizeRequest,
         raw_request_info: Optional[RawRequestInfo] = None,
     ) -> AsyncGenerator[Union[TokenizeResponse, ErrorResponse], None]:
-        try:
-            self._validate_openai_serving_tokenization()
-        except ValueError as e:
-            yield ErrorResponse(
-                error=ErrorInfo(message=str(e), type="invalid_request_error", code=400)
-            )
+        if error := self._validate_openai_serving_tokenization():
+            yield error
             return
 
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
@@ -695,12 +671,8 @@ class VLLMEngine(LLMEngine):
         request: DetokenizeRequest,
         raw_request_info: Optional[RawRequestInfo] = None,
     ) -> AsyncGenerator[Union[DetokenizeResponse, ErrorResponse], None]:
-        try:
-            self._validate_openai_serving_tokenization()
-        except ValueError as e:
-            yield ErrorResponse(
-                error=ErrorInfo(message=str(e), type="invalid_request_error", code=400)
-            )
+        if error := self._validate_openai_serving_tokenization():
+            yield error
             return
 
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(


### PR DESCRIPTION
vLLM's `init_app_state` (on nightly) now conditionally sets state attributes (e.g. `openai_serving_chat`, `openai_serving_embedding`) based on the model's `supported_tasks`. If a model doesn't support a particular task (e.g. an embedding model won't have `"generate"` in its supported tasks), the corresponding state attributes are never set. This was causing `AttributeError` crashes in Ray Serve LLM.

- Use `getattr(state, ..., None)` for all state attribute reads so missing attributes default to `None` instead of raising.
- Replace bare `assert hasattr(...)` in validation methods with explicit `None` checks that `raise ValueError` with clear messages referencing the correct vLLM task name (e.g. `"generate"` for chat/completion, `"embed"` for embedding).
- Wrap validation calls in each request handler with `try/except ValueError` to yield a proper `ErrorResponse(code=400, type="invalid_request_error")` instead of crashing the replica.
