### PR TITLE
[RLLib] [DQN] Old API Stack, Fixed TypeError: argument of type 'ABCMeta' is not iterable

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -4379,7 +4379,7 @@ class Algorithm(Checkpointable, Trainable):
             return
 
         # Add parameters, if necessary.
-        if "EpisodeReplayBuffer" in config["replay_buffer_config"]["type"]:
+        if isinstance(config["replay_buffer_config"]["type"], str) and "EpisodeReplayBuffer" in config["replay_buffer_config"]["type"]:
             # TODO (simon): Subclassing needs a proper class and therefore
             # we need at this moment the string checking. Because we add
             # this keyword argument the old stack ReplayBuffer constructors


### PR DESCRIPTION
# Pull Request: [RLLib] Fix TypeError in _create_local_replay_buffer_if_necessary when replay_buffer_config['type'] is a class

## Summary
This PR fixes a critical `TypeError: argument of type 'ABCMeta' is not iterable` that occurs within the **Old API Stack** initialization path. The error happens when `replay_buffer_config["type"]` has already been resolved to a Python Class object (e.g., during config validation) instead of a string.

## The Problem
When using the legacy stack (Old API Stack), `Algorithm._create_local_replay_buffer_if_necessary` attempts to perform a string containment check:

```python
if "EpisodeReplayBuffer" in config["replay_buffer_config"]["type"]:
```

If `config["replay_buffer_config"]["type"]` is a class object (like `MultiAgentPrioritizedReplayBuffer`), which is a common state after configuration resolution, Python throws a `TypeError` because class objects are not iterable for string containment.

### Why standard CartPole examples might not catch this
In recent Ray versions (2.0+), many standard examples automatically use the **New API Stack**. The buggy code path resides in the legacy initialization logic (`Old API Stack`), which remains essential for multi-agent PettingZoo environments or complex custom scenarios.

## Reproduction Script
The following script reproduces the crash by forcing the **Old API Stack**:

```python
from ray.rllib.algorithms.dqn import DQNConfig
from ray.rllib.utils.replay_buffers import MultiAgentPrioritizedReplayBuffer
import ray

ray.init()

config = (
    DQNConfig()
    .environment("CartPole-v1")
    # Force Old API Stack to reach the faulty internal creation logic
    .api_stack(
        enable_rl_module_and_learner=False,
        enable_env_runner_and_connector_v2=False
    )
    .training(replay_buffer_config={"type": MultiAgentPrioritizedReplayBuffer})
)

# Skip validation to ensure we reach the creation logic in algorithm.py
config.experimental(_validate_config=False)

# This Build() call crashes with TypeError: argument of type 'ABCMeta' is not iterable
algo = config.build()
```

## The Fix
Added an `isinstance(..., str)` check to ensure the membership test is only performed if the type is a string.

**File:** `rllib/algorithms/algorithm.py`

```python
     def _create_local_replay_buffer_if_necessary(
         self, config: PartialAlgorithmConfigDict
     ) -> Optional[MultiAgentReplayBuffer]:
         # ...
         
         # Add parameters, if necessary.
-        if "EpisodeReplayBuffer" in config["replay_buffer_config"]["type"]:
+        if isinstance(config["replay_buffer_config"]["type"], str) and "EpisodeReplayBuffer" in config["replay_buffer_config"]["type"]:
             # ...
```

## Verification
- **Broken State:** Verified that the reproduction script above fails with `TypeError`.
- **Fixed State:** Verified that using reproduction script above.

## Side Effects
I don't have enough information about all the functionality of the library; it should be checked for side effects.
