### PR TITLE
[release test] bake runtime_env vars into BYOD custom Docker images

### DIFF
--- a/release/ray_release/anyscale_util.py
+++ b/release/ray_release/anyscale_util.py
@@ -101,7 +101,6 @@ def create_cluster_env_from_image(
                     config_json=dict(
                         docker_image=image,
                         ray_version="nightly",
-                        env_vars=runtime_env,
                     ),
                 )
             )

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -54,10 +54,7 @@ class ClusterManager(abc.ABC):
             .replace(":", "_")
             .replace(".", "_")
         )
-        self.cluster_env_name = (
-            f"{byod_image_name_normalized}"
-            f"__env__{dict_hash(self.test.get_byod_runtime_env())}"
-        )
+        self.cluster_env_name = byod_image_name_normalized
 
     def set_cluster_compute(
         self,

--- a/release/ray_release/scripts/custom_byod_build.py
+++ b/release/ray_release/scripts/custom_byod_build.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
 
@@ -11,17 +11,21 @@ from ray_release.byod.build_context import BuildContext
 @click.option("--base-image", type=str, required=True)
 @click.option("--post-build-script", type=str)
 @click.option("--python-depset", type=str)
+@click.option("--env", "envs", type=str, multiple=True)
 def main(
     image_name: str,
     base_image: str,
     post_build_script: Optional[str],
     python_depset: Optional[str],
+    envs: Tuple[str, ...],
 ):
-    if not post_build_script and not python_depset:
+    if not post_build_script and not python_depset and not envs:
         raise click.UsageError(
-            "Either post_build_script or python_depset must be provided"
+            "At least one of post_build_script, python_depset, or env must be provided"
         )
     build_context: BuildContext = {}
+    if envs:
+        build_context["envs"] = dict(e.split("=", 1) for e in envs)
     if post_build_script:
         build_context["post_build_script"] = post_build_script
     if python_depset:

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -550,6 +550,9 @@ class Test(dict):
             "post_build_script": self.get_byod_post_build_script(),
             "python_depset": self.get_byod_python_depset(),
         }
+        runtime_env = self.get_byod_runtime_env()
+        if runtime_env:
+            custom_info["runtime_env"] = runtime_env
         tag = f"{self.get_byod_base_image_tag(build_id)}-{dict_hash(custom_info)}"
         ray_version = self.get_ray_version()
         if ray_version:
@@ -606,6 +609,7 @@ class Test(dict):
         return (
             self.get_byod_post_build_script() is not None
             or self.get_byod_python_depset() is not None
+            or bool(self.get_byod_runtime_env())
         )
 
     def get_anyscale_byod_image(self, build_id: Optional[str] = None) -> str:

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -119,9 +119,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
             sdk=sdk,
         )
         cluster_manager.set_cluster_env()
-        self.assertRegex(
-            cluster_manager.cluster_env_name, r"^anyscale__env__[0-9a-f]+$"
-        )
+        self.assertEqual(cluster_manager.cluster_env_name, "anyscale")
 
     @patch("time.sleep", lambda *a, **kw: None)
     def testFindCreateClusterComputeExisting(self):

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -133,6 +133,26 @@
       cluster:
         ray_version: 2.50.0
 
+- name: hello_world_custom_runtime_env
+  python: "3.10"
+  team: reef
+  group: hello_world
+  frequency: nightly
+  working_dir: hello_world_tests
+
+  cluster:
+    byod:
+      runtime_env:
+        - HELLO_WORLD_TEST=1
+    cluster_compute: hello_world_compute_config.yaml
+
+  run:
+    timeout: 1800
+    script: python hello_world.py
+
+  variations:
+    - __suffix__: aws
+
 - name: hello_world_custom_byod_depset_only
   python: "3.10"
   team: reef


### PR DESCRIPTION
The new Anyscale SDK no longer supports env_vars in cluster environment registration. This refactors the release test infrastructure to bake runtime_env variables into custom BYOD Docker images instead.

- Make require_custom_byod_image() trigger on runtime_env
- Include runtime_env in image tag hash for cache correctness
- Add --env CLI option to custom_byod_build script
- Pass --env flags in Buildkite build YAML generation
- Remove env_vars from create_byod_cluster_environment() SDK call
- Remove __env__ hash suffix from cluster env name (now in image tag)
- Add hello_world_custom_runtime_env test variants for validation
