### PR TITLE
[Data] Fixed `OpBufferQueue` race condition

### DIFF
--- a/python/ray/data/_internal/execution/bundle_queue/__init__.py
+++ b/python/ray/data/_internal/execution/bundle_queue/__init__.py
@@ -7,6 +7,7 @@ from .base import (
 from .fifo import FIFOBundleQueue
 from .hash_link import HashLinkedQueue
 from .reordering import ReorderingBundleQueue
+from .thread_safe import ThreadSafeBundleQueue
 
 
 def create_bundle_queue() -> QueueWithRemoval:
@@ -20,4 +21,5 @@ __all__ = [
     "FIFOBundleQueue",
     "QueueWithRemoval",
     "HashLinkedQueue",
+    "ThreadSafeBundleQueue",
 ]

--- a/python/ray/data/_internal/execution/bundle_queue/base.py
+++ b/python/ray/data/_internal/execution/bundle_queue/base.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
 
 class BundleQueue(abc.ABC):
-
     @abc.abstractmethod
     def estimate_size_bytes(self) -> int:
         """Returns the estimated size in bytes of all bundles."""

--- a/python/ray/data/_internal/execution/bundle_queue/fifo.py
+++ b/python/ray/data/_internal/execution/bundle_queue/fifo.py
@@ -15,6 +15,8 @@ class FIFOBundleQueue(BaseBundleQueue):
     """A bundle queue that follows fifo-policy. Conceptually
     [ ] <- [ ] <- [ ] ...
      ^ where the leftmost is popped first
+
+    NOTE: Not thread-safe
     """
 
     def __init__(self, bundles: Optional[List[RefBundle]] = None):

--- a/python/ray/data/_internal/execution/bundle_queue/hash_link.py
+++ b/python/ray/data/_internal/execution/bundle_queue/hash_link.py
@@ -23,6 +23,8 @@ class HashLinkedQueue(QueueWithRemoval):
     """A bundle queue that supports these operations quickly:
     - contains(bundle)
     - remove(bundle)
+
+    NOTE: Not thread-safe
     """
 
     def __init__(self):

--- a/python/ray/data/_internal/execution/bundle_queue/reordering.py
+++ b/python/ray/data/_internal/execution/bundle_queue/reordering.py
@@ -21,6 +21,8 @@ class ReorderingBundleQueue(BaseBundleQueue):
 
     Failure to follow this requirement might result in this queue getting
     irreversibly stuck.
+
+    NOTE: Not thread-safe
     """
 
     def __init__(self):

--- a/python/ray/data/_internal/execution/bundle_queue/thread_safe.py
+++ b/python/ray/data/_internal/execution/bundle_queue/thread_safe.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import threading
 from typing import TYPE_CHECKING, Any, Optional
 
-from .base import BaseBundleQueue, BundleQueue
+from .base import BundleQueue
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces import RefBundle

--- a/python/ray/data/_internal/execution/bundle_queue/thread_safe.py
+++ b/python/ray/data/_internal/execution/bundle_queue/thread_safe.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any, Optional
+
+from .base import BaseBundleQueue, BundleQueue
+
+if TYPE_CHECKING:
+    from ray.data._internal.execution.interfaces import RefBundle
+
+
+class ThreadSafeBundleQueue(BundleQueue):
+    """A thread-safe wrapper for a ``BundleQueue``.
+
+    Delegates all operations to the wrapped queue while a lock.
+
+    NOTE: Not safe to use with ``__contains__``/``remove`` from ``QueueWithRemoval``.
+    """
+
+    def __init__(self, inner: BundleQueue):
+        self._inner = inner
+        self._lock = threading.Lock()
+
+    def estimate_size_bytes(self) -> int:
+        with self._lock:
+            return self._inner.estimate_size_bytes()
+
+    def num_blocks(self) -> int:
+        with self._lock:
+            return self._inner.num_blocks()
+
+    def num_bundles(self) -> int:
+        with self._lock:
+            return self._inner.num_bundles()
+
+    def num_rows(self) -> int:
+        with self._lock:
+            return self._inner.num_rows()
+
+    def add(self, bundle: RefBundle, **kwargs: Any):
+        with self._lock:
+            self._inner.add(bundle, **kwargs)
+
+    def get_next(self) -> RefBundle:
+        with self._lock:
+            return self._inner.get_next()
+
+    def peek_next(self) -> Optional[RefBundle]:
+        with self._lock:
+            return self._inner.peek_next()
+
+    def has_next(self) -> bool:
+        with self._lock:
+            return self._inner.has_next()
+
+    def clear(self):
+        with self._lock:
+            self._inner.clear()
+
+    def finalize(self, **kwargs: Any):
+        with self._lock:
+            return self._inner.finalize(**kwargs)

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -688,6 +688,13 @@ class PhysicalOperator(Operator):
         """
         return self._estimated_output_num_rows
 
+    def num_output_splits(self) -> int:
+        """Returns the number of splits for this operator's output is partitioned into.
+
+        Most operators have a single output split.
+        """
+        return 1
+
     def start(self, options: ExecutionOptions) -> None:
         """Called by the executor when execution starts for an operator.
 

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -101,6 +101,9 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
         # The total number of rows is the same as the number of input rows.
         return self.input_dependencies[0].num_output_rows_total()
 
+    def num_output_splits(self) -> int:
+        return len(self._num_output)
+
     def start(self, options: ExecutionOptions) -> None:
         if options.preserve_order:
             # If preserve_order is set, we need to ignore locality hints to ensure determinism.

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -4,7 +4,6 @@ This is split out from streaming_executor.py to facilitate better unit testing.
 """
 
 import logging
-import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -13,7 +12,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 import ray
 from ray.data._internal.execution.backpressure_policy import BackpressurePolicy
 from ray.data._internal.execution.bundle_queue import (
-    BaseBundleQueue,
     ThreadSafeBundleQueue,
     create_bundle_queue,
 )
@@ -114,9 +112,7 @@ class OpBufferQueue:
         for q in self._queues:
             q.clear()
 
-    def _get_queue_for(
-        self, output_split_idx: Optional[int]
-    ) -> ThreadSafeBundleQueue:
+    def _get_queue_for(self, output_split_idx: Optional[int]) -> ThreadSafeBundleQueue:
         target_output_split_idx = output_split_idx or 0
 
         assert target_output_split_idx < len(self._queues), (

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -85,7 +85,7 @@ class OpBufferQueue:
 
     def __len__(self):
         with self._lock:
-            return len(self._queues[0])
+            return sum(len(q) for q in self._queues)
 
     def has_next(self, output_split_idx: Optional[int] = None) -> bool:
         """Whether next RefBundle is available.

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -129,8 +129,15 @@ class OpBufferQueue:
             self._num_blocks = 0
 
     def _get_queue_for(self, output_split_idx: Optional[int]) -> "BaseBundleQueue":
+        target_output_split_idx = output_split_idx or 0
+
+        assert target_output_split_idx < len(self._queues), (
+            f"Output split index is out of range (got {target_output_split_idx}, "
+            f"but only {list(range(len(self._queues)))} splits are available)"
+        )
+
         # If output split idx is null, fallback to the first queue
-        return self._queues[output_split_idx or 0]
+        return self._queues[target_output_split_idx]
 
 
 @dataclass

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -68,6 +68,7 @@ def test_actor_pool_scaling():
         input_dependencies=[MagicMock()],
         internal_input_queue_num_blocks=MagicMock(return_value=1),
         metrics=MagicMock(average_num_inputs_per_task=1, num_inputs_received=1),
+        num_output_splits=MagicMock(return_value=1),
     )
     op_state = OpState(
         op, inqueues=[MagicMock(__len__=MagicMock(return_value=10), num_blocks=10)]

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -308,6 +308,8 @@ class TestResourceManager:
 
     def test_object_store_usage(self, restore_data_context):
         input = make_ref_bundles([[x] for x in range(1)])[0]
+        # Set block metadata size_bytes to 1 (rather than mocking the method on the
+        # instance, which doesn't survive dataclasses.replace in OpBufferQueue.pop).
         block_ref, block_meta = input.blocks[0]
         input = replace(input, blocks=[(block_ref, replace(block_meta, size_bytes=1))])
 
@@ -381,7 +383,10 @@ class TestResourceManager:
 
         # Objects in the current operator's internal inqueue count towards the previous
         # operator's object store memory usage.
-        o3.metrics.on_input_queued(topo[o2].output_queue.pop(), input_index=0)
+        # NOTE: `pop()` returns a copy of the bundle (via `dataclasses.replace`), so we
+        # must use the returned reference for subsequent o3 metric calls.
+        o3_input = topo[o2].output_queue.pop()
+        o3.metrics.on_input_queued(o3_input, input_index=0)
         resource_manager.update_usages()
         assert resource_manager.get_op_usage(o1).object_store_memory == 0
         assert resource_manager.get_op_usage(o2).object_store_memory == 1
@@ -389,8 +394,8 @@ class TestResourceManager:
 
         # Task inputs count toward the previous operator's object store memory
         # usage. During no-sample phase, pending task outputs uses fallback estimate.
-        o3.metrics.on_input_dequeued(input, input_index=0)
-        o3.metrics.on_task_submitted(0, input)
+        o3.metrics.on_input_dequeued(o3_input, input_index=0)
+        o3.metrics.on_task_submitted(0, o3_input)
         resource_manager.update_usages()
         assert resource_manager.get_op_usage(o1).object_store_memory == 0
         assert resource_manager.get_op_usage(o2).object_store_memory == 1
@@ -400,7 +405,7 @@ class TestResourceManager:
         assert op3_usage == expected_pending_output
 
         # Task inputs no longer count once the task is finished.
-        o3.metrics.on_output_queued(input)
+        o3.metrics.on_output_queued(o3_input)
         o3.metrics.on_task_finished(
             0,
             None,

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -257,7 +257,8 @@ class TestResourceManager:
                 return_value=mock_internal_inqueue[op],
             )
             ref_bundle = MagicMock(
-                size_bytes=MagicMock(return_value=mock_external_outqueue_sizes[op])
+                size_bytes=MagicMock(return_value=mock_external_outqueue_sizes[op]),
+                output_split_idx=None,
             )
             topo[op].add_output(ref_bundle)
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1,4 +1,5 @@
 import os
+import threading
 import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
@@ -696,30 +697,41 @@ def test_configure_output_locality_is_deprecated_noop(restore_data_context):
 
 class OpBufferQueueTest(unittest.TestCase):
     def test_multi_threading(self):
-        num_blocks = 5_000
+        num_blocks = 10_000
         num_splits = 8
         num_per_split = num_blocks // num_splits
         ref_bundles = make_ref_bundles([[[i]] for i in range(num_blocks)])
 
-        queue = OpBufferQueue()
-        for i, ref_bundle in enumerate(ref_bundles):
-            ref_bundle = replace(ref_bundle, output_split_idx=i % num_splits)
-            queue.append(ref_bundle)
+        queue = OpBufferQueue(num_splits=num_splits)
+        done = threading.Event()
+
+        def produce():
+            for i, ref_bundle in enumerate(ref_bundles):
+                ref_bundle = replace(ref_bundle, output_split_idx=i % num_splits)
+                queue.append(ref_bundle)
+
+            done.set()
+            return True
 
         def consume(output_split_idx):
-            nonlocal queue
-
             count = 0
-            while queue.has_next(output_split_idx):
-                ref_bundle = queue.pop(output_split_idx)
-                count += 1
-                assert ref_bundle is not None
-                assert ref_bundle.output_split_idx == output_split_idx
+            while True:
+                if queue.has_next(output_split_idx):
+                    ref_bundle = queue.pop(output_split_idx)
+                    if ref_bundle is not None:
+                        count += 1
+                        assert ref_bundle.output_split_idx == output_split_idx
+                elif done.is_set():
+                    break
             assert count == num_per_split
             return True
 
-        with ThreadPoolExecutor(max_workers=num_splits) as executor:
-            futures = [executor.submit(consume, i) for i in range(num_splits)]
+        with ThreadPoolExecutor(max_workers=num_splits + 1) as executor:
+            futures = [
+                executor.submit(consume, i) for i in range(num_splits)
+            ] + [
+                executor.submit(produce)
+            ]
 
         for f in futures:
             assert f.result() is True, f.result()

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -777,7 +777,10 @@ class OpBufferQueueTest(unittest.TestCase):
         # Verify count, FIFO order per split
         for split_idx in range(num_splits):
             consumed = consumed_splits[split_idx]
-            expected = ref_bundles[split_idx::num_splits]
+            expected = [
+                replace(b, output_split_idx=split_idx)
+                for b in ref_bundles[split_idx::num_splits]
+            ]
             assert len(consumed) == num_per_split
             assert consumed == expected, f"Split {split_idx}: FIFO order violated"
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -698,7 +698,7 @@ def test_configure_output_locality_is_deprecated_noop(restore_data_context):
 
 class OpBufferQueueTest(unittest.TestCase):
     def test_multi_threading(self):
-        num_blocks = 10_000
+        num_blocks = 5_000
         num_splits = 4
         num_per_split = num_blocks // num_splits
         ref_bundles = make_ref_bundles([[[i]] for i in range(num_blocks)])
@@ -716,7 +716,7 @@ class OpBufferQueueTest(unittest.TestCase):
                 for i, ref_bundle in enumerate(ref_bundles):
                     if i % 10 == 1:
                         print(f">>> Queue size {len(queue)}")
-                        time.sleep(random.random() * 0.001)
+                        time.sleep(random.random() * 1e-4)
 
                     ref_bundle = replace(ref_bundle, output_split_idx=i % num_splits)
                     queue.append(ref_bundle)

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -750,9 +750,7 @@ class OpBufferQueueTest(unittest.TestCase):
             return True
 
         with ThreadPoolExecutor(max_workers=num_splits + 1) as executor:
-            futures = [
-                executor.submit(produce)
-            ] + [
+            futures = [executor.submit(produce)] + [
                 executor.submit(consume, i) for i in range(num_splits)
             ]
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -779,9 +779,7 @@ class OpBufferQueueTest(unittest.TestCase):
             consumed = consumed_splits[split_idx]
             expected = ref_bundles[split_idx::num_splits]
             assert len(consumed) == num_per_split
-            assert consumed == expected, (
-                f"Split {split_idx}: FIFO order violated"
-            )
+            assert consumed == expected, f"Split {split_idx}: FIFO order violated"
 
         # Verify queue is fully drained
         assert len(q) == 0

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -697,13 +697,21 @@ def test_configure_output_locality_is_deprecated_noop(restore_data_context):
 
 
 class OpBufferQueueTest(unittest.TestCase):
-    def test_multi_threading(self):
+    def test_invalid_split_index(self):
+        """Test that out-of-range split index raises AssertionError."""
+        queue = OpBufferQueue(num_splits=2)
+        with pytest.raises(AssertionError):
+            queue.has_next(2)
+        with pytest.raises(AssertionError):
+            queue.pop(2)
+
+    def test_e2e_multi_threading(self):
         num_blocks = 5_000
-        num_splits = 4
+        num_splits = 20
         num_per_split = num_blocks // num_splits
         ref_bundles = make_ref_bundles([[[i]] for i in range(num_blocks)])
 
-        queue = OpBufferQueue(num_splits=num_splits)
+        q = OpBufferQueue(num_splits=num_splits)
 
         start = threading.Event()
         done = threading.Event()
@@ -715,11 +723,11 @@ class OpBufferQueueTest(unittest.TestCase):
             try:
                 for i, ref_bundle in enumerate(ref_bundles):
                     if i % 10 == 1:
-                        print(f">>> Queue size {len(queue)}")
+                        print(f">>> Queue size {len(q)}")
                         time.sleep(random.random() * 1e-4)
 
                     ref_bundle = replace(ref_bundle, output_split_idx=i % num_splits)
-                    queue.append(ref_bundle)
+                    q.append(ref_bundle)
             except Exception as e:
                 print(f">>> Caught exception: {e}")
                 raise
@@ -727,26 +735,25 @@ class OpBufferQueueTest(unittest.TestCase):
             done.set()
             return True
 
+        consumed_splits = [[] for _ in range(num_splits)]
+
         def consume(output_split_idx):
             # Sync producers and consumers
             start.wait()
-
-            count = 0
 
             try:
                 # Iterate until both are true:
                 #   - Producer is done
                 #   - Queue is empty
-                while not done.is_set() or queue.has_next(output_split_idx):
-                    ref_bundle = queue.pop(output_split_idx)
-                    if ref_bundle is not None:
-                        count += 1
-                        assert ref_bundle.output_split_idx == output_split_idx
+                while not done.is_set() or q.has_next(output_split_idx):
+                    b = q.pop(output_split_idx)
+                    if b is not None:
+                        assert b.output_split_idx == output_split_idx
+                        consumed_splits[output_split_idx].append(b)
             except Exception as e:
                 print(f">>> Caught exception: {e}")
                 raise
 
-            assert count == num_per_split
             return True
 
         with ThreadPoolExecutor(max_workers=num_splits + 1) as executor:
@@ -761,6 +768,20 @@ class OpBufferQueueTest(unittest.TestCase):
 
         for f in futures:
             assert f.result() is True, f.result()
+
+        # Verify count, FIFO order per split
+        for split_idx in range(num_splits):
+            consumed = consumed_splits[split_idx]
+            expected = ref_bundles[split_idx::num_splits]
+            assert len(consumed) == num_per_split
+            assert consumed == expected, (
+                f"Split {split_idx}: FIFO order violated"
+            )
+
+        # Verify queue is fully drained
+        assert len(q) == 0
+        assert q.num_blocks == 0
+        assert q.memory_usage == 0
 
 
 def test_exception_concise_stacktrace():

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -724,6 +724,7 @@ class OpBufferQueueTest(unittest.TestCase):
                 for i, ref_bundle in enumerate(ref_bundles):
                     if i % 10 == 1:
                         print(f">>> Queue size {len(q)}")
+                        # Introduce jitter
                         time.sleep(random.random() * 1e-4)
 
                     ref_bundle = replace(ref_bundle, output_split_idx=i % num_splits)
@@ -746,6 +747,10 @@ class OpBufferQueueTest(unittest.TestCase):
                 #   - Producer is done
                 #   - Queue is empty
                 while not done.is_set() or q.has_next(output_split_idx):
+                    # We add tiny sleep of 1us to avoid thrashing GIL with
+                    # tight loops
+                    time.sleep(1e-6)
+
                     b = q.pop(output_split_idx)
                     if b is not None:
                         assert b.output_split_idx == output_split_idx

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -734,14 +734,14 @@ class OpBufferQueueTest(unittest.TestCase):
             count = 0
 
             try:
-                while True:
-                    if queue.has_next(output_split_idx):
-                        ref_bundle = queue.pop(output_split_idx)
-                        if ref_bundle is not None:
-                            count += 1
-                            assert ref_bundle.output_split_idx == output_split_idx
-                    elif done.is_set():
-                        break
+                # Iterate until both are true:
+                #   - Producer is done
+                #   - Queue is empty
+                while not done.is_set() or queue.has_next(output_split_idx):
+                    ref_bundle = queue.pop(output_split_idx)
+                    if ref_bundle is not None:
+                        count += 1
+                        assert ref_bundle.output_split_idx == output_split_idx
             except Exception as e:
                 print(f">>> Caught exception: {e}")
                 raise

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1,4 +1,5 @@
 import os
+import random
 import threading
 import time
 import unittest
@@ -698,40 +699,67 @@ def test_configure_output_locality_is_deprecated_noop(restore_data_context):
 class OpBufferQueueTest(unittest.TestCase):
     def test_multi_threading(self):
         num_blocks = 10_000
-        num_splits = 8
+        num_splits = 4
         num_per_split = num_blocks // num_splits
         ref_bundles = make_ref_bundles([[[i]] for i in range(num_blocks)])
 
         queue = OpBufferQueue(num_splits=num_splits)
+
+        start = threading.Event()
         done = threading.Event()
 
         def produce():
-            for i, ref_bundle in enumerate(ref_bundles):
-                ref_bundle = replace(ref_bundle, output_split_idx=i % num_splits)
-                queue.append(ref_bundle)
+            # Sync producers and consumers
+            start.wait()
+
+            try:
+                for i, ref_bundle in enumerate(ref_bundles):
+                    if i % 10 == 1:
+                        print(f">>> Queue size {len(queue)}")
+                        time.sleep(random.random() * 0.001)
+
+                    ref_bundle = replace(ref_bundle, output_split_idx=i % num_splits)
+                    queue.append(ref_bundle)
+            except Exception as e:
+                print(f">>> Caught exception: {e}")
+                raise
 
             done.set()
             return True
 
         def consume(output_split_idx):
+            # Sync producers and consumers
+            start.wait()
+
             count = 0
-            while True:
-                if queue.has_next(output_split_idx):
-                    ref_bundle = queue.pop(output_split_idx)
-                    if ref_bundle is not None:
-                        count += 1
-                        assert ref_bundle.output_split_idx == output_split_idx
-                elif done.is_set():
-                    break
+
+            try:
+                while True:
+                    if queue.has_next(output_split_idx):
+                        ref_bundle = queue.pop(output_split_idx)
+                        if ref_bundle is not None:
+                            count += 1
+                            assert ref_bundle.output_split_idx == output_split_idx
+                    elif done.is_set():
+                        break
+            except Exception as e:
+                print(f">>> Caught exception: {e}")
+                raise
+
             assert count == num_per_split
             return True
 
         with ThreadPoolExecutor(max_workers=num_splits + 1) as executor:
             futures = [
-                executor.submit(consume, i) for i in range(num_splits)
-            ] + [
                 executor.submit(produce)
+            ] + [
+                executor.submit(consume, i) for i in range(num_splits)
             ]
+
+            # Start the test
+            start.set()
+
+            print(">>> Test started")
 
         for f in futures:
             assert f.result() is True, f.result()

--- a/python/ray/data/tests/unit/test_deduping_schema.py
+++ b/python/ray/data/tests/unit/test_deduping_schema.py
@@ -226,6 +226,9 @@ class _DummyOp:
             num_external_outqueue_bytes=0,
         )
 
+    def num_output_splits(self):
+        return 1
+
     def get_actor_info(self):
         return SimpleNamespace(running=0, restarting=0, pending=0)
 


### PR DESCRIPTION
## Description

Fixing race condition described in https://github.com/ray-project/ray/issues/60579#issuecomment-3863472847

Changes

 - Added `BundleQueue` interface
 - Added `ThreadSafeBundleQueue`
 - Rewritten `OpBufferQueue` (to be based on `ThreadSafeBundleQueue`)
 - Rewritten test for OBQ to test proper concurrency and all of the methods

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
