### PR TITLE
[Serve] Replace O(n²) list concatenation in ReplicaStateContainer.get()

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import logging
 import math
@@ -1544,7 +1545,9 @@ class ReplicaStateContainer:
 
         assert isinstance(states, list)
 
-        return sum((self._replicas[state] for state in states), [])
+        return list(
+            itertools.chain.from_iterable(self._replicas[state] for state in states)
+        )
 
     def pop(
         self,


### PR DESCRIPTION
`ReplicaStateContainer.get()` uses `sum(lists, [])` to flatten replica lists across states. This is a well-known anti-pattern: each `+` allocates a new intermediate list and copies all elements accumulated so far, yielding O(R·k) total element copies (where R = replicas, k = 7 states). The method is called ~8 times per deployment per tick (broadcast, health checks, active node IDs, routing info, etc.), so the throwaway intermediate lists create meaningful GC pressure at scale.

Replace with `list(itertools.chain.from_iterable(...))`, which lazily iterates all sub-lists and builds the result in a single allocation.

**Microbenchmark results (Python 3.10):**

<details>

<summary> bench code - AI </summary>

```python
"""Microbenchmark: ReplicaStateContainer.get() performance.

Compares the old O(n^2) `sum(lists, [])` approach against the new
O(n) `itertools.chain.from_iterable` approach at various replica counts.

The quadratic cost of `sum(lists, [])` comes from repeated list
concatenation: each `+` allocates a *new* list and copies all elements
accumulated so far.  With k sub-lists of average length R/k:

    total element copies = R/k * (1 + 2 + … + k) = R*(k+1)/2

With k = 7 (ALL_REPLICA_STATES), every element is copied ~4 times on
average.  `itertools.chain.from_iterable` avoids this entirely by lazily
iterating, and `list(...)` builds the result in one allocation.

At small R the fixed Python-level overhead of the iterator machinery can
mask the savings; the benefit becomes clear as R grows and the repeated
copying dominates.
"""

import itertools
import time
import statistics
import tracemalloc

# ---------------------------------------------------------------------------
# Simulate the two implementations
# ---------------------------------------------------------------------------

NUM_STATES = 7  # matches len(ALL_REPLICA_STATES) in deployment_state.py


class FakeReplica:
    """Lightweight stand-in for DeploymentReplica so list elements are
    heap-allocated objects (not cached small ints), which is more realistic
    for pointer-copy and GC-pressure measurements."""
    __slots__ = ("_id",)

    def __init__(self, replica_id: int):
        self._id = replica_id


def build_replicas(num_replicas: int) -> dict:
    """Distribute `num_replicas` FakeReplica objects across NUM_STATES buckets."""
    replicas = {s: [] for s in range(NUM_STATES)}
    for i in range(num_replicas):
        replicas[i % NUM_STATES].append(FakeReplica(i))
    return replicas


def get_old(replicas: dict, states: list) -> list:
    """Old O(n^2) implementation using sum(lists, [])."""
    return sum((replicas[state] for state in states), [])


def get_new(replicas: dict, states: list) -> list:
    """New O(n) implementation using itertools.chain.from_iterable."""
    return list(itertools.chain.from_iterable(
        replicas[state] for state in states
    ))


# ---------------------------------------------------------------------------
# Benchmark harness
# ---------------------------------------------------------------------------

REPLICA_COUNTS = [32, 64, 128, 512, 1024, 4096]
CALLS_PER_TICK = 8  # .get() is called ~8 times per deployment per tick
WARMUP = 200
TRIALS = 1000


def bench(fn, replicas, states, warmup=WARMUP, trials=TRIALS):
    """Return (median, p95) time in µs for a single call."""
    for _ in range(warmup):
        fn(replicas, states)

    times = []
    for _ in range(trials):
        t0 = time.perf_counter()
        fn(replicas, states)
        t1 = time.perf_counter()
        times.append((t1 - t0) * 1e6)
    times.sort()
    med = statistics.median(times)
    p95 = times[int(len(times) * 0.95)]
    return med, p95


def measure_peak_mem(fn, replicas, states, runs=20):
    """Return median peak memory delta (bytes) for a single call.

    Uses tracemalloc peak tracking which captures intermediate/temporary
    allocations (the main source of GC pressure from sum(lists, [])),
    not just the surviving result list.
    """
    import gc
    peaks = []
    for _ in range(runs):
        gc.collect()
        tracemalloc.start()
        tracemalloc.reset_peak()
        fn(replicas, states)
        _, peak = tracemalloc.get_traced_memory()
        tracemalloc.stop()
        peaks.append(peak)
    return int(statistics.median(peaks))


def main():
    # ── Part 1: Latency ────────────────────────────────────────────────
    header = (
        f"{'Replicas':>10}  "
        f"{'sum [] med':>11}  "
        f"{'chain med':>11}  "
        f"{'Speedup':>8}  "
        f"{'sum [] p95':>11}  "
        f"{'chain p95':>11}  "
        f"{'sum/tick':>10}  "
        f"{'chain/tick':>10}"
    )
    sep = "-" * len(header)

    print("=" * len(header))
    print("ReplicaStateContainer.get() microbenchmark")
    print("=" * len(header))
    print(f"  States per call : {NUM_STATES}")
    print(f"  Calls per tick  : {CALLS_PER_TICK}")
    print(f"  Warmup / Trials : {WARMUP} / {TRIALS}")
    print(f"  Element type    : FakeReplica (heap object)")
    print()
    print("PART 1: LATENCY")
    print(header)
    print(sep)

    for n in REPLICA_COUNTS:
        replicas = build_replicas(n)
        states = list(range(NUM_STATES))

        med_old, p95_old = bench(get_old, replicas, states)
        med_new, p95_new = bench(get_new, replicas, states)
        speedup = med_old / med_new if med_new > 0 else float("inf")

        print(
            f"{n:>10}  "
            f"{med_old:>10.2f}µ  "
            f"{med_new:>10.2f}µ  "
            f"{speedup:>7.2f}x  "
            f"{p95_old:>10.2f}µ  "
            f"{p95_new:>10.2f}µ  "
            f"{med_old * CALLS_PER_TICK:>9.1f}µ  "
            f"{med_new * CALLS_PER_TICK:>9.1f}µ"
        )

    print(sep)
    print()

    # ── Part 2: Memory / allocation pressure ───────────────────────────
    print("PART 2: PEAK MEMORY PER CALL (includes temporary allocations)")
    alloc_header = (
        f"{'Replicas':>10}  "
        f"{'sum [] peak':>13}  "
        f"{'chain peak':>13}  "
        f"{'Reduction':>10}  "
        f"{'sum/tick peak':>14}  "
        f"{'chain/tick pk':>14}"
    )
    alloc_sep = "-" * len(alloc_header)
    print(alloc_header)
    print(alloc_sep)

    for n in REPLICA_COUNTS:
        replicas = build_replicas(n)
        states = list(range(NUM_STATES))

        peak_old = measure_peak_mem(get_old, replicas, states)
        peak_new = measure_peak_mem(get_new, replicas, states)
        reduction = (1 - peak_new / peak_old) * 100 if peak_old > 0 else 0

        def fmt_bytes(b):
            if b < 1024:
                return f"{b:,} B"
            elif b < 1024 * 1024:
                return f"{b / 1024:,.1f} KB"
            else:
                return f"{b / (1024 * 1024):,.2f} MB"

        print(
            f"{n:>10}  "
            f"{fmt_bytes(peak_old):>13}  "
            f"{fmt_bytes(peak_new):>13}  "
            f"{reduction:>9.1f}%  "
            f"{fmt_bytes(peak_old * CALLS_PER_TICK):>14}  "
            f"{fmt_bytes(peak_new * CALLS_PER_TICK):>14}"
        )

    print(alloc_sep)
    print()
    print("Legend:")
    print("  sum [] = old: sum((self._replicas[s] for s in states), [])")
    print("  chain  = new: list(chain.from_iterable(self._replicas[s] …))")
    print("  med / p95 = median / 95th-percentile single-call latency (µs)")
    print("  */tick = median × 8 (estimated cost across all .get() calls per tick)")
    print("  peak = peak heap memory during a single call (includes temporaries)")
    print("  Reduction = % less peak memory with 'chain' vs 'sum []'")


if __name__ == "__main__":
    main()

```

</details>

<img width="378" height="201" alt="image" src="https://github.com/user-attachments/assets/84a0451d-a987-4006-bba0-b63e71cd54d4" />


related to https://github.com/ray-project/ray/issues/60680