### PR TITLE
[Serve] Fix O(n²) replica counting in allow_new_compaction

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3953,7 +3953,7 @@ class DeploymentStateManager:
             and ds.get_num_running_replicas(ds.target_version) == ds.target_num_replicas
             # To be extra conservative, only actively compact if there
             # are no non-running replicas
-            and len(ds._replicas.get()) == ds.target_num_replicas
+            and ds._replicas.count() == ds.target_num_replicas
             for ds in self._deployment_states.values()
         )
         if RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY:


### PR DESCRIPTION
### Why

`allow_new_compaction` is evaluated every control-loop tick for every deployment. It was calling `len(ds._replicas.get())` which invokes `get()` with no arguments — this builds a full materialized list of **all** replicas via `sum(list_a + list_b, [])`, an O(n²) pattern that copies the accumulator on every concatenation, only to immediately discard the list after taking `len()`.

### What

Replace `len(ds._replicas.get())` with `ds._replicas.count()`.

`count()` without version filters simply sums `len()` of each state bucket — O(1) with zero allocation.

### Benchmark (50 deployments per tick)

<details>

<summary> Benchmark script - AI </summary>

```python
"""Micro-benchmark: len(get()) vs count() on ReplicaStateContainer.

Demonstrates that the original pattern:

    len(container.get())          # O(n²) — sum([], []) copies every element
                                  #          into a throwaway list

is far more expensive than:

    container.count()             # O(1) — sums len() of each bucket

Run:
    python benchmarks/bench_replica_count.py
"""

import enum
import time
import tracemalloc
from collections import defaultdict
from typing import Dict, List, Optional


# ---------------------------------------------------------------------------
# Minimal stubs – just enough to exercise the hot paths faithfully.
# ---------------------------------------------------------------------------
class ReplicaState(str, enum.Enum):
    STARTING = "STARTING"
    UPDATING = "UPDATING"
    RECOVERING = "RECOVERING"
    RUNNING = "RUNNING"
    STOPPING = "STOPPING"
    PENDING_MIGRATION = "PENDING_MIGRATION"


ALL_REPLICA_STATES = list(ReplicaState)


class _FakeReplica:
    """Lightweight stand-in for DeploymentReplica (avoids importing Ray)."""

    __slots__ = ("_state",)

    def __init__(self):
        self._state = None

    def update_state(self, state: ReplicaState):
        self._state = state


class ReplicaStateContainer:
    """Faithful copy of the real container with get() and count()."""

    def __init__(self):
        self._replicas: Dict[ReplicaState, List[_FakeReplica]] = defaultdict(list)

    # -- production helpers --------------------------------------------------
    def add(self, state: ReplicaState, replica: _FakeReplica):
        replica.update_state(state)
        self._replicas[state].append(replica)

    def get(
        self, states: Optional[List[ReplicaState]] = None
    ) -> List[_FakeReplica]:
        if states is None:
            states = ALL_REPLICA_STATES
        return sum((self._replicas[state] for state in states), [])

    def count(
        self,
        states: Optional[List[ReplicaState]] = None,
    ) -> int:
        if states is None:
            states = ALL_REPLICA_STATES
        return sum(len(self._replicas[state]) for state in states)


# ---------------------------------------------------------------------------
# Benchmark helpers
# ---------------------------------------------------------------------------
def populate(n: int) -> ReplicaStateContainer:
    """Create a container with *n* replicas spread across states."""
    container = ReplicaStateContainer()
    states = list(ReplicaState)
    for i in range(n):
        container.add(states[i % len(states)], _FakeReplica())
    return container


def bench_latency(container: ReplicaStateContainer, iterations: int):
    """Time len(get()) vs count() over *iterations* calls."""

    # -- len(get()) ----------------------------------------------------------
    start = time.perf_counter_ns()
    for _ in range(iterations):
        _ = len(container.get())
    len_get_ns = time.perf_counter_ns() - start

    # -- count() -------------------------------------------------------------
    start = time.perf_counter_ns()
    for _ in range(iterations):
        _ = container.count()
    count_ns = time.perf_counter_ns() - start

    return len_get_ns, count_ns


def bench_memory(container: ReplicaStateContainer, iterations: int):
    """Measure peak memory of len(get()) vs count() over *iterations* calls."""

    # -- len(get()) ----------------------------------------------------------
    tracemalloc.start()
    for _ in range(iterations):
        _ = len(container.get())
    _, peak_get = tracemalloc.get_traced_memory()
    tracemalloc.stop()

    # -- count() -------------------------------------------------------------
    tracemalloc.start()
    for _ in range(iterations):
        _ = container.count()
    _, peak_count = tracemalloc.get_traced_memory()
    tracemalloc.stop()

    return peak_get, peak_count


# ---------------------------------------------------------------------------
# Main
# ---------------------------------------------------------------------------
def main():
    replica_counts = [2**p for p in range(4, 13)]  # 16 … 4096
    num_deployments = 50  # simulate allow_new_compaction iterating deployments
    iterations = num_deployments  # one call per deployment per control-loop tick

    hdr = (
        f"{'replicas':>10}  "
        f"{'len(get()) µs':>15}  "
        f"{'count() µs':>12}  "
        f"{'speedup':>8}  "
        f"{'mem get (KB)':>13}  "
        f"{'mem count (KB)':>15}  "
        f"{'mem saved':>10}"
    )
    print(hdr)
    print("-" * len(hdr))

    for n in replica_counts:
        container = populate(n)

        # Latency
        len_get_ns, count_ns = bench_latency(container, iterations)
        len_get_us = len_get_ns / 1_000
        count_us = count_ns / 1_000
        speedup = len_get_us / count_us if count_us else float("inf")

        # Memory
        peak_get, peak_count = bench_memory(container, iterations)
        peak_get_kb = peak_get / 1024
        peak_count_kb = peak_count / 1024
        mem_ratio = peak_get / peak_count if peak_count else float("inf")

        print(
            f"{n:>10}  "
            f"{len_get_us:>15.1f}  "
            f"{count_us:>12.1f}  "
            f"{speedup:>7.1f}x  "
            f"{peak_get_kb:>13.1f}  "
            f"{peak_count_kb:>15.1f}  "
            f"{mem_ratio:>9.1f}x"
        )


if __name__ == "__main__":
    main()

```

</details>

| Replicas | `len(get())` µs | `count()` µs | Speedup | mem `get` (KB) | mem `count` (KB) | Mem saved |
|-------:|----------------:|------------:|--------:|---------------:|----------------:|----------:|
| 16 | 43.5 | 32.1 | 1.4x | 0.5 | 0.4 | 1.3x |
| 32 | 36.5 | 30.9 | 1.2x | 0.7 | 0.4 | 1.9x |
| 64 | 48.8 | 30.4 | 1.6x | 1.2 | 0.4 | 3.1x |
| 128 | 56.0 | 29.2 | 1.9x | 2.1 | 0.4 | 5.5x |
| 256 | 90.6 | 28.7 | 3.2x | 3.9 | 0.4 | 10.4x |
| 512 | 157.6 | 29.5 | 5.3x | 7.6 | 0.4 | 20.2x |
| 1024 | 291.3 | 29.4 | 9.9x | 14.9 | 0.4 | 39.8x |
| 2048 | 550.8 | 29.9 | 18.4x | 29.6 | 0.4 | 78.9x |
| 4096 | 1094.2 | 31.9 | 34.3x | 58.9 | 0.4 | 157.1x |

`count()` stays flat (~30 µs, ~0.4 KB) regardless of replica count. At 1k replicas the old path is ~10x slower and uses ~40x more memory; at 4k replicas it's 34x slower and 157x more memory.

Related to https://github.com/ray-project/ray/issues/60680