### PR TITLE
[Serve] Fix sort bug and optimize ClusterNodeInfoCache.update()

### DIFF
--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -80,14 +80,12 @@ class ClusterNodeInfoCache(ABC):
             )
             return self._cached_available_resources_per_node
 
-        available_resources_by_id: Dict[str, Dict[str, float]] = {}
-        for resource_data in reply.resource_usage_data.batch:
-            node_id = binary_to_hex(resource_data.node_id)
-            if node_id in self._alive_node_id_set:
-                available_resources_by_id[node_id] = dict(
-                    resource_data.resources_available
-                )
-        return available_resources_by_id
+        return {
+            node_id: dict(resource_data.resources_available)
+            for resource_data in reply.resource_usage_data.batch
+            if (node_id := binary_to_hex(resource_data.node_id))
+            in self._alive_node_id_set
+        }
 
     def get_alive_nodes(self) -> List[Tuple[str, str, str]]:
         """Get IDs, IPs, and Instance IDs for all live nodes in the cluster.

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -67,12 +67,7 @@ class ClusterNodeInfoCache(ABC):
         )
 
     def _fetch_available_resources_per_node(self) -> Dict[str, Dict[str, float]]:
-        """Fetch available resources per alive node via get_all_resource_usage().
-
-        Uses the existing GcsClient instead of the legacy
-        ray._private.state.available_resources_per_node() which goes through
-        GlobalStateAccessor and creates a redundant connection.
-        """
+        """Fetch available resources per alive node via get_all_resource_usage()."""
         try:
             reply = self._gcs_client.get_all_resource_usage(
                 timeout=RAY_GCS_RPC_TIMEOUT_S

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -1,9 +1,13 @@
+import logging
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple, Union
 
 import ray
+from ray._common.utils import binary_to_hex
 from ray._raylet import GcsClient
-from ray.serve._private.constants import RAY_GCS_RPC_TIMEOUT_S
+from ray.serve._private.constants import RAY_GCS_RPC_TIMEOUT_S, SERVE_LOGGER_NAME
+
+logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
 class ClusterNodeInfoCache(ABC):
@@ -15,6 +19,9 @@ class ClusterNodeInfoCache(ABC):
         self._cached_node_labels = dict()
         self._cached_total_resources_per_node = dict()
         self._cached_available_resources_per_node = dict()
+        # Track alive node IDs to detect cluster membership changes and skip
+        # rebuilding labels / total resources when nothing changed.
+        self._alive_node_id_set: FrozenSet[str] = frozenset()
 
     def update(self):
         """Update the cache by fetching latest node information from GCS.
@@ -32,21 +39,60 @@ class ClusterNodeInfoCache(ABC):
         ]
 
         # Sort on NodeID to ensure the ordering is deterministic across the cluster.
-        sorted(alive_nodes)
+        alive_nodes.sort()
         self._cached_alive_nodes = alive_nodes
-        self._cached_node_labels = {
-            node_id.hex(): dict(node.labels) for (node_id, node) in nodes.items()
-        }
 
-        # Node resources
-        self._cached_total_resources_per_node = {
-            node_id.hex(): dict(node.resources_total)
-            for (node_id, node) in nodes.items()
-        }
+        # Detect whether the set of alive nodes has changed. Rebuild labels
+        # and total resources only when it has, since they are static per-node
+        # properties that don't change while a node stays alive.
+        current_alive_ids = frozenset(node_id for node_id, _, _ in alive_nodes)
+        if current_alive_ids != self._alive_node_id_set:
+            self._alive_node_id_set = current_alive_ids
+            self._cached_node_labels = {
+                node_id.hex(): dict(node.labels)
+                for (node_id, node) in nodes.items()
+                if node_id.hex() in current_alive_ids
+            }
+            self._cached_total_resources_per_node = {
+                node_id.hex(): dict(node.resources_total)
+                for (node_id, node) in nodes.items()
+                if node_id.hex() in current_alive_ids
+            }
 
+        # Fetch available resources using the existing GCS client rather than
+        # the legacy GlobalStateAccessor path (which opens a second connection
+        # and performs redundant protobuf deserialization).
         self._cached_available_resources_per_node = (
-            ray._private.state.available_resources_per_node()
+            self._fetch_available_resources_per_node()
         )
+
+    def _fetch_available_resources_per_node(self) -> Dict[str, Dict[str, float]]:
+        """Fetch available resources per alive node via get_all_resource_usage().
+
+        Uses the existing GcsClient instead of the legacy
+        ray._private.state.available_resources_per_node() which goes through
+        GlobalStateAccessor and creates a redundant connection.
+        """
+        try:
+            reply = self._gcs_client.get_all_resource_usage(
+                timeout=RAY_GCS_RPC_TIMEOUT_S
+            )
+        except Exception:
+            logger.warning(
+                "Failed to fetch resource usage from GCS. "
+                "Available resources cache will be stale.",
+                exc_info=True,
+            )
+            return self._cached_available_resources_per_node
+
+        available_resources_by_id: Dict[str, Dict[str, float]] = {}
+        for resource_data in reply.resource_usage_data.batch:
+            node_id = binary_to_hex(resource_data.node_id)
+            if node_id in self._alive_node_id_set:
+                available_resources_by_id[node_id] = dict(
+                    resource_data.resources_available
+                )
+        return available_resources_by_id
 
     def get_alive_nodes(self) -> List[Tuple[str, str, str]]:
         """Get IDs, IPs, and Instance IDs for all live nodes in the cluster.


### PR DESCRIPTION
`ClusterNodeInfoCache.update()` had three issues:

1. **Sort bug (correctness):** `sorted(alive_nodes)` returns a new sorted list that was immediately discarded. The cached `alive_nodes` were stored in arbitrary dict-iteration order, violating the documented invariant of deterministic NodeID ordering. Fixed by using `alive_nodes.sort()`.

2. **Redundant GCS RPC:** `ray._private.state.available_resources_per_node()` goes through the legacy `GlobalStateAccessor` path, which opens a second connection to GCS and performs a full protobuf serialize/deserialize round-trip per node — every tick. Replaced with `self._gcs_client.get_all_resource_usage()` which reuses the existing `GcsClient` and extracts `resources_available` from the `ResourcesData` batch.

3. **Unconditional cache rebuild:** Node labels and `resources_total` are static per-node properties that don't change while a node stays alive, yet they were rebuilt from scratch every tick. Added change detection via a `frozenset` of alive node IDs — labels and total resources are only rebuilt when cluster membership actually changes.

Related to https://github.com/ray-project/ray/issues/60680