### PR TITLE
[Serve] Cache deserialized policy in `AutoscalingPolicy.get_policy()` to avoid repeated `cloudpickle.loads()`

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -351,6 +351,8 @@ class AggregationFunction(str, Enum):
 class AutoscalingPolicy(BaseModel):
     # Cloudpickled policy definition.
     _serialized_policy_def: bytes = PrivateAttr(default=b"")
+    # Cached deserialized policy to avoid repeated cloudpickle.loads() calls.
+    _cached_policy: Optional[Callable] = PrivateAttr(default=None)
 
     policy_function: Union[str, Callable] = Field(
         default=DEFAULT_AUTOSCALING_POLICY_NAME,
@@ -368,6 +370,7 @@ class AutoscalingPolicy(BaseModel):
 
     def set_serialized_policy_def(self, serialized_policy_def: bytes) -> None:
         self._serialized_policy_def = serialized_policy_def
+        self._cached_policy = None
 
     @classmethod
     def from_serialized_policy_def(
@@ -403,9 +406,15 @@ class AutoscalingPolicy(BaseModel):
         return self.policy_function == DEFAULT_AUTOSCALING_POLICY_NAME
 
     def get_policy(self) -> Callable:
-        """Deserialize policy from cloudpickled bytes."""
+        """Deserialize policy from cloudpickled bytes.
+
+        The result is cached to avoid repeated cloudpickle deserialization on
+        every call (e.g. on every autoscaling tick).
+        """
+        if self._cached_policy is not None:
+            return self._cached_policy
         try:
-            return cloudpickle.loads(self._serialized_policy_def)
+            policy = cloudpickle.loads(self._serialized_policy_def)
         except (ModuleNotFoundError, ImportError) as e:
             raise ImportError(
                 f"Failed to deserialize custom autoscaling policy: {e}\n\n"
@@ -417,6 +426,8 @@ class AutoscalingPolicy(BaseModel):
                 "For more details, see: https://docs.ray.io/en/latest/serve/advanced-guides/"
                 "advanced-autoscaling.html#gotchas-and-limitations"
             ) from e
+        self._cached_policy = policy
+        return policy
 
 
 @PublicAPI(stability="stable")


### PR DESCRIPTION
`AutoscalingPolicy.get_policy()` calls `cloudpickle.loads()` on every invocation. This is called on every autoscaling tick in `_create_deployment_snapshot()` just to extract the policy's `__module__` and `__name__` for the snapshot. Since the serialized policy bytes are immutable after construction, the deserialized result can be safely cached.

This PR adds a `_cached_policy` private attribute to `AutoscalingPolicy` that lazily caches the first `cloudpickle.loads()` result and returns it on subsequent calls. The cache is invalidated in `set_serialized_policy_def()` for safety.

**Benchmark (10k iterations, default policy):**
- Before: 0.9 µs/call
- After: 0.1 µs/call
- **~8x speedup** per call; larger gains expected for custom policies with heavier dependencies

Related to https://github.com/ray-project/ray/issues/60680