### PR TITLE
[core|serve] Migrate shared test utilities from _private to _common

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -243,8 +243,6 @@ python/ray/_private/test_utils.py
     DOC103: Function `start_redis_instance`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [db_dir: , fate_share: Optional[bool], free_port: , leader_id: , replica_of: ].
     DOC106: Function `_pid_alive`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Function `_pid_alive`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC101: Function `run_string_as_driver`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `run_string_as_driver`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [encode: str].
     DOC101: Function `run_string_as_driver_stdout_stderr`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `run_string_as_driver_stdout_stderr`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [encode: str].
     DOC101: Function `run_string_as_driver_nonblocking`: Docstring contains fewer arguments than in function signature.

--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -7,13 +7,18 @@ _common/ (not in tests/) to be accessible in the Ray package distribution.
 
 import asyncio
 import inspect
+import logging
 import os
+import subprocess
+import sys
 import threading
 import time
 import traceback
 import uuid
+from collections import defaultdict
 from collections.abc import Awaitable
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set
 
@@ -21,6 +26,19 @@ import ray
 import ray._common.usage.usage_lib as ray_usage_lib
 import ray._private.utils
 from ray._common.network_utils import build_address
+from ray._common.utils import decode
+
+logger = logging.getLogger(__name__)
+
+try:
+    from prometheus_client.core import Metric
+    from prometheus_client.parser import Sample, text_string_to_metric_families
+except (ImportError, ModuleNotFoundError):
+    Metric = None
+    Sample = None
+
+    def text_string_to_metric_families(*args, **kwargs):
+        raise ModuleNotFoundError("`prometheus_client` not found")
 
 
 @ray.remote(num_cpus=0)
@@ -351,3 +369,156 @@ def assert_tensors_equivalent(obj1, obj2):
     else:
         # Fallback for primitives: int, float, str, bool, etc.
         assert obj1 == obj2, f"Non-tensor values differ: {obj1} vs {obj2}"
+
+
+def run_string_as_driver(
+    driver_script: str, env: Dict = None, encode: str = "utf-8"
+) -> str:
+    """Run a driver as a separate process.
+
+    Args:
+        driver_script: A string to run as a Python script.
+        env: The environment variables for the driver.
+        encode: The encoding to use for the driver script.
+
+    Returns:
+        The script's output.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    with proc:
+        output = proc.communicate(driver_script.encode(encoding=encode))[0]
+        if proc.returncode:
+            print(decode(output, encode_type=encode))
+            logger.error(proc.stderr)
+            raise subprocess.CalledProcessError(
+                proc.returncode, proc.args, output, proc.stderr
+            )
+        out = decode(output, encode_type=encode)
+    return out
+
+
+@dataclass
+class MetricSamplePattern:
+    name: Optional[str] = None
+    value: Optional[str] = None
+    partial_label_match: Optional[Dict[str, str]] = None
+
+    def matches(self, sample: "Sample"):
+        if self.name is not None:
+            if self.name != sample.name:
+                return False
+
+        if self.value is not None:
+            if self.value != sample.value:
+                return False
+
+        if self.partial_label_match is not None:
+            for label, value in self.partial_label_match.items():
+                if sample.labels.get(label) != value:
+                    return False
+
+        return True
+
+
+@dataclass
+class PrometheusTimeseries:
+    """A collection of timeseries from multiple addresses. Each timeseries is a
+    collection of samples with the same metric name and labels. Concretely:
+    - components_dict: a dictionary of addresses to the Component labels
+    - metric_descriptors: a dictionary of metric names to the Metric object
+    - metric_samples: the latest value of each label
+    """
+
+    components_dict: Dict[str, Set[str]] = field(default_factory=dict)
+    metric_descriptors: Dict[str, "Metric"] = field(default_factory=dict)
+    metric_samples: Dict[frozenset, "Sample"] = field(default_factory=dict)
+
+    def flush(self):
+        self.components_dict.clear()
+        self.metric_descriptors.clear()
+        self.metric_samples.clear()
+
+
+def fetch_raw_prometheus(prom_addresses):
+    # Local import so minimal dependency tests can run without requests
+    import requests
+
+    for address in prom_addresses:
+        try:
+            response = requests.get(f"http://{address}/metrics")
+            yield address, response.text
+        except requests.exceptions.ConnectionError:
+            continue
+
+
+def fetch_prometheus(prom_addresses):
+    components_dict = {}
+    metric_descriptors = {}
+    metric_samples = []
+
+    for address in prom_addresses:
+        if address not in components_dict:
+            components_dict[address] = set()
+
+    for address, response in fetch_raw_prometheus(prom_addresses):
+        for metric in text_string_to_metric_families(response):
+            for sample in metric.samples:
+                metric_descriptors[sample.name] = metric
+                metric_samples.append(sample)
+                if "Component" in sample.labels:
+                    components_dict[address].add(sample.labels["Component"])
+    return components_dict, metric_descriptors, metric_samples
+
+
+def fetch_prometheus_timeseries(
+    prom_addreses: List[str],
+    result: PrometheusTimeseries,
+) -> PrometheusTimeseries:
+    components_dict, metric_descriptors, metric_samples = fetch_prometheus(
+        prom_addreses
+    )
+    for address, components in components_dict.items():
+        if address not in result.components_dict:
+            result.components_dict[address] = set()
+        result.components_dict[address].update(components)
+    result.metric_descriptors.update(metric_descriptors)
+    for sample in metric_samples:
+        # udpate sample to the latest value
+        result.metric_samples[
+            frozenset(list(sample.labels.items()) + [("_metric_name_", sample.name)])
+        ] = sample
+    return result
+
+
+def fetch_prometheus_metrics(prom_addresses: List[str]) -> Dict[str, List[Any]]:
+    """Return prometheus metrics from the given addresses.
+
+    Args:
+        prom_addresses: List of metrics_agent addresses to collect metrics from.
+
+    Returns:
+        Dict mapping from metric name to list of samples for the metric.
+    """
+    _, _, samples = fetch_prometheus(prom_addresses)
+    samples_by_name = defaultdict(list)
+    for sample in samples:
+        samples_by_name[sample.name].append(sample)
+    return samples_by_name
+
+
+def fetch_prometheus_metric_timeseries(
+    prom_addresses: List[str], result: PrometheusTimeseries
+) -> Dict[str, List[Any]]:
+    samples = fetch_prometheus_timeseries(
+        prom_addresses, result
+    ).metric_samples.values()
+    samples_by_name = defaultdict(list)
+    for sample in samples:
+        samples_by_name[sample.name].append(sample)
+    return samples_by_name

--- a/python/ray/_common/tests/test_usage_stats.py
+++ b/python/ray/_common/tests/test_usage_stats.py
@@ -16,12 +16,14 @@ from jsonschema import validate
 import ray
 import ray._common.usage.usage_constants as usage_constants
 import ray._common.usage.usage_lib as ray_usage_lib
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._common.usage.usage_lib import ClusterConfigToReport, UsageStatsEnabledness
 from ray._private.accelerators import NvidiaGPUAcceleratorManager
 from ray._private.test_utils import (
     format_web_url,
-    run_string_as_driver,
     wait_until_server_available,
 )
 from ray._raylet import GcsClient

--- a/python/ray/dag/tests/experimental/test_compiled_graphs.py
+++ b/python/ray/dag/tests/experimental/test_compiled_graphs.py
@@ -13,10 +13,10 @@ import torch
 import ray
 import ray._private
 import ray.cluster_utils
+from ray._common.test_utils import run_string_as_driver
 from ray._common.utils import (
     get_or_create_event_loop,
 )
-from ray._private.test_utils import run_string_as_driver
 from ray.dag import DAGContext, InputNode, MultiOutputNode
 from ray.dag.tests.experimental.actor_defs import Actor, Collector
 from ray.exceptions import RayChannelTimeoutError

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -10,9 +10,9 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 import ray.dashboard.consts as dashboard_consts
 from ray._common.network_utils import find_free_port
+from ray._common.test_utils import wait_for_condition
 from ray._private import ray_constants
 from ray._private.grpc_utils import init_grpc_channel
-from ray._private.test_utils import wait_for_condition
 from ray._raylet import GcsClient, JobID, TaskID
 from ray.core.generated.common_pb2 import (
     ErrorType,

--- a/python/ray/dashboard/modules/aggregator/tests/test_ray_actor_events.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_ray_actor_events.py
@@ -5,10 +5,8 @@ import sys
 import pytest
 
 import ray
-from ray._private.test_utils import (
-    wait_for_condition,
-    wait_for_dashboard_agent_available,
-)
+from ray._common.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_dashboard_agent_available
 from ray.dashboard.tests.conftest import *  # noqa
 
 _ACTOR_EVENT_PORT = 12346

--- a/python/ray/dashboard/modules/aggregator/tests/test_ray_job_events.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_ray_job_events.py
@@ -5,10 +5,8 @@ import sys
 import pytest
 
 import ray
-from ray._private.test_utils import (
-    wait_for_condition,
-    wait_for_dashboard_agent_available,
-)
+from ray._common.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_dashboard_agent_available
 from ray.dashboard.tests.conftest import *  # noqa
 
 _RAY_EVENT_PORT = 12345

--- a/python/ray/dashboard/modules/aggregator/tests/test_ray_node_events.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_ray_node_events.py
@@ -7,10 +7,8 @@ import sys
 import pytest
 
 import ray
-from ray._private.test_utils import (
-    wait_for_condition,
-    wait_for_dashboard_agent_available,
-)
+from ray._common.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_dashboard_agent_available
 from ray.dashboard.tests.conftest import *  # noqa
 
 _RAY_EVENT_PORT = 12345

--- a/python/ray/dashboard/modules/job/tests/test_component_activities.py
+++ b/python/ray/dashboard/modules/job/tests/test_component_activities.py
@@ -7,10 +7,12 @@ import jsonschema
 import pytest
 import requests
 
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.test_utils import (
     format_web_url,
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
 )
 from ray.dashboard import dashboard

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -15,11 +15,13 @@ from google.protobuf import text_format
 import ray
 import ray._common.usage.usage_lib as ray_usage_lib
 from ray._common.network_utils import build_address
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    fetch_prometheus,
+    wait_for_condition,
+)
 from ray._private import ray_constants
 from ray._private.metrics_agent import fix_grpc_metric
 from ray._private.test_utils import (
-    fetch_prometheus,
     format_web_url,
     wait_until_server_available,
 )

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -29,7 +29,11 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BACKUP_COUNT,
     LOGGING_ROTATE_BYTES,
 )
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    fetch_prometheus_metrics,
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._common.utils import get_or_create_event_loop
 from ray._private.ray_constants import (
     AGENT_PROCESS_TYPE_DASHBOARD_AGENT,
@@ -37,11 +41,9 @@ from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_STATUS_LEGACY,
 )
 from ray._private.test_utils import (
-    fetch_prometheus_metrics,
     format_web_url,
     get_error_message,
     init_error_pubsub,
-    run_string_as_driver,
     wait_until_server_available,
     wait_until_succeeded_without_exception,
 )

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -12,7 +12,7 @@ import pytest
 from pyarrow import ArrowInvalid
 
 import ray
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 from ray.data._internal.arrow_block import (
     ArrowBlockAccessor,
     ArrowBlockBuilder,

--- a/python/ray/data/tests/test_context_propagation.py
+++ b/python/ray/data/tests/test_context_propagation.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 import ray
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext
 from ray.data.datasource import Datasource, ReadTask

--- a/python/ray/data/tests/test_import.py
+++ b/python/ray/data/tests/test_import.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 
 
 def test_dynamically_imported():

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -15,8 +15,10 @@ import pyarrow.compute as pc
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray.data._internal.arrow_ops.transform_pyarrow import (
     MIN_PYARROW_VERSION_TYPE_PROMOTION,
 )

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -14,8 +14,10 @@ import numpy as np
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray.data._internal.block_batching.iter_batches import BatchIterator
 from ray.data._internal.execution.backpressure_policy import (
     ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -16,12 +16,12 @@ from starlette.requests import Request
 import ray
 from ray import serve
 from ray._common.network_utils import build_address
-from ray._common.test_utils import wait_for_condition
-from ray._common.utils import TimerBase
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     PrometheusTimeseries,
     fetch_prometheus_metric_timeseries,
+    wait_for_condition,
 )
+from ray._common.utils import TimerBase
 from ray.actor import ActorHandle
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import (

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -20,7 +20,6 @@ import ray
 import ray.util.serialization_addons
 from ray._common.constants import HEAD_NODE_RESOURCE_NAME
 from ray._common.utils import get_random_alphanumeric_string, import_attr
-from ray._private.worker import SCRIPT_MODE
 from ray._raylet import MessagePackSerializer
 from ray.actor import ActorHandle
 from ray.serve._private.common import RequestMetadata, ServeComponentType
@@ -532,7 +531,7 @@ def get_current_actor_id() -> str:
     """
 
     worker_mode = ray.get_runtime_context().worker.mode
-    if worker_mode == SCRIPT_MODE:
+    if worker_mode == ray.SCRIPT_MODE:
         return "DRIVER"
     else:
         try:

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -16,8 +16,7 @@ from starlette.responses import PlainTextResponse
 
 import ray
 from ray import serve
-from ray._common.test_utils import Semaphore, SignalActor
-from ray._private.test_utils import wait_for_condition
+from ray._common.test_utils import Semaphore, SignalActor, wait_for_condition
 from ray.actor import ActorHandle
 from ray.dashboard.modules.serve.sdk import ServeSubmissionClient
 from ray.serve._private.common import DeploymentID

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -19,10 +19,11 @@ from websockets.sync.client import connect
 import ray
 from ray import serve
 from ray._common.network_utils import parse_address
-from ray._common.test_utils import SignalActor, wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     PrometheusTimeseries,
+    SignalActor,
     fetch_prometheus_metric_timeseries,
+    wait_for_condition,
 )
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_DIRECT_INGRESS,

--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -9,10 +9,11 @@ from fastapi import FastAPI
 
 import ray
 from ray import serve
-from ray._common.test_utils import SignalActor, wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     PrometheusTimeseries,
+    SignalActor,
     fetch_prometheus_metric_timeseries,
+    wait_for_condition,
 )
 from ray.serve._private.constants import DEFAULT_LATENCY_BUCKET_MS
 from ray.serve._private.test_utils import (

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -13,8 +13,7 @@ from starlette.requests import Request
 
 import ray
 from ray import serve
-from ray._common.test_utils import SignalActor, wait_for_condition
-from ray._private.test_utils import PrometheusTimeseries
+from ray._common.test_utils import PrometheusTimeseries, SignalActor, wait_for_condition
 from ray.serve._private.common import DeploymentID
 from ray.serve._private.constants import (
     RAY_SERVE_RUN_ROUTER_IN_SEPARATE_LOOP,

--- a/python/ray/serve/tests/test_persistence.py
+++ b/python/ray/serve/tests/test_persistence.py
@@ -1,6 +1,6 @@
 import ray
 from ray import serve
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 
 
 def test_new_driver(serve_instance):

--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -8,7 +8,7 @@ import pytest
 
 import ray
 from ray import serve
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 from ray.serve._private.utils import inside_ray_client_context
 
 # https://tools.ietf.org/html/rfc6335#section-6

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -4,7 +4,7 @@ import pytest
 
 import ray
 from ray import serve
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")

--- a/python/ray/serve/tests/test_runtime_env_2.py
+++ b/python/ray/serve/tests/test_runtime_env_2.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -15,10 +15,7 @@ import pytest
 
 import ray
 from ray import serve
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
-    run_string_as_driver,
-)
+from ray._common.test_utils import run_string_as_driver, wait_for_condition
 from ray._raylet import GcsClient
 from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.serve._private.constants import (

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -9,11 +9,14 @@ import pytest
 import ray
 import ray._private.gcs_utils as gcs_utils
 import ray.cluster_utils
-from ray._common.test_utils import SignalActor, wait_for_condition
+from ray._common.test_utils import (
+    SignalActor,
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.test_utils import (
     kill_actor_and_wait_for_failure,
     make_global_state_accessor,
-    run_string_as_driver,
     wait_for_pid_to_exit,
 )
 from ray.experimental.internal_kv import _internal_kv_get, _internal_kv_put

--- a/python/ray/tests/test_actor_lineage_reconstruction.py
+++ b/python/ray/tests/test_actor_lineage_reconstruction.py
@@ -7,10 +7,10 @@ import sys
 import pytest
 
 import ray
+from ray._common.test_utils import wait_for_condition
 from ray._private.test_utils import (
     RPC_FAILURE_MAP,
     RPC_FAILURE_TYPES,
-    wait_for_condition,
 )
 from ray.core.generated import common_pb2, gcs_pb2
 

--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -7,12 +7,12 @@ from typing import Dict
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     PrometheusTimeseries,
-    raw_metric_timeseries,
     run_string_as_driver,
+    wait_for_condition,
 )
+from ray._private.test_utils import raw_metric_timeseries
 from ray._private.worker import RayContext
 from ray.util.state import list_actors
 

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -7,12 +7,15 @@ import pytest
 import ray
 import ray._private.ray_constants as ray_constants
 from ray._common.network_utils import parse_address
-from ray._common.test_utils import Semaphore, wait_for_condition
+from ray._common.test_utils import (
+    Semaphore,
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.test_utils import (
     client_test_enabled,
     external_redis_test_enabled,
     get_gcs_memory_used,
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
 )
 from ray._raylet import GCS_PID_KEY, GcsClient

--- a/python/ray/tests/test_annotations.py
+++ b/python/ray/tests/test_annotations.py
@@ -3,9 +3,7 @@ import warnings
 
 import pytest
 
-from ray._private.test_utils import (
-    run_string_as_driver,
-)
+from ray._common.test_utils import run_string_as_driver
 from ray.util.annotations import Deprecated
 
 

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -5,12 +5,13 @@ import pytest
 
 import ray
 from ray._common.network_utils import build_address
-from ray._common.test_utils import SignalActor, wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     MetricSamplePattern,
     PrometheusTimeseries,
-    get_metric_check_condition,
+    SignalActor,
+    wait_for_condition,
 )
+from ray._private.test_utils import get_metric_check_condition
 from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
 from ray.autoscaler.node_launch_exception import NodeLaunchException
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -11,11 +11,11 @@ import pytest
 
 import ray
 import ray.cluster_utils
-from ray._common.test_utils import SignalActor
-from ray._private.test_utils import (
-    client_test_enabled,
+from ray._common.test_utils import (
+    SignalActor,
     run_string_as_driver,
 )
+from ray._private.test_utils import client_test_enabled
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 import psutil

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -13,9 +13,9 @@ import pytest
 import ray
 import ray.cluster_utils
 from ray._common.constants import HEAD_NODE_RESOURCE_NAME
+from ray._common.test_utils import run_string_as_driver
 from ray._private.test_utils import (
     client_test_enabled,
-    run_string_as_driver,
     wait_for_pid_to_exit,
 )
 

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -18,12 +18,12 @@ import ray
 import ray.cloudpickle as cloudpickle
 import ray.util.client.server.server as ray_client_server
 from ray._common.network_utils import build_address
+from ray._common.test_utils import run_string_as_driver
 from ray._private.client_mode_hook import (
     client_mode_should_convert,
     disable_client_hook,
     enable_client_mode,
 )
-from ray._private.test_utils import run_string_as_driver
 from ray.tests.client_test_utils import (
     create_remote_signal_actor,
     run_wrapped_actor_creation,

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -9,11 +9,11 @@ import pytest
 import ray
 import ray.client_builder as client_builder
 import ray.util.client.server.server as ray_client_server
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     run_string_as_driver,
-    run_string_as_driver_nonblocking,
+    wait_for_condition,
 )
+from ray._private.test_utils import run_string_as_driver_nonblocking
 from ray.util.state import list_workers
 
 

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -14,9 +14,11 @@ import ray
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 import ray.util.client.server.proxier as proxier
 from ray._common.network_utils import parse_address
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.ray_constants import REDIS_DEFAULT_PASSWORD
-from ray._private.test_utils import run_string_as_driver
 from ray.cloudpickle.compat import pickle
 from ray.job_config import JobConfig
 

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -8,9 +8,11 @@ from typing import Any, Tuple
 import pytest
 
 import ray
-from ray._common.test_utils import SignalActor
+from ray._common.test_utils import (
+    SignalActor,
+    run_string_as_driver,
+)
 from ray._common.utils import get_or_create_event_loop
-from ray._private.test_utils import run_string_as_driver
 
 
 # This tests the methods are executed in the correct eventloop.

--- a/python/ray/tests/test_core_worker_fault_tolerance.py
+++ b/python/ray/tests/test_core_worker_fault_tolerance.py
@@ -5,11 +5,13 @@ import numpy as np
 import pytest
 
 import ray
-from ray._common.test_utils import SignalActor
+from ray._common.test_utils import (
+    SignalActor,
+    wait_for_condition,
+)
 from ray._private.test_utils import (
     RPC_FAILURE_MAP,
     RPC_FAILURE_TYPES,
-    wait_for_condition,
 )
 from ray.core.generated import common_pb2, gcs_pb2
 from ray.exceptions import GetTimeoutError, TaskCancelledError

--- a/python/ray/tests/test_dashboard.py
+++ b/python/ray/tests/test_dashboard.py
@@ -7,9 +7,11 @@ import pytest
 import requests
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private import ray_constants
-from ray._private.test_utils import run_string_as_driver
 
 import psutil
 

--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -6,9 +6,11 @@ import sys
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.state_api_test_utils import verify_failed_task
-from ray._private.test_utils import run_string_as_driver
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray.util.state import list_nodes, list_tasks, list_workers
 

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -11,13 +11,16 @@ import ray
 import ray._private.ray_constants as ray_constants
 from ray import NodeID
 from ray._common.network_utils import build_address
-from ray._common.test_utils import SignalActor, wait_for_condition
+from ray._common.test_utils import (
+    SignalActor,
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.state_api_test_utils import verify_failed_task
 from ray._private.test_utils import (
     get_error_message,
     init_error_pubsub,
     kill_raylet,
-    run_string_as_driver,
 )
 from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.core.generated import (

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -14,14 +14,16 @@ from filelock import FileLock
 
 import ray
 from ray._common.network_utils import parse_address
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private import ray_constants
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.test_utils import (
     external_redis_test_enabled,
     generate_system_config_map,
     redis_sentinel_replicas,
-    run_string_as_driver,
     wait_for_pid_to_exit,
 )
 from ray._raylet import GcsClient

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -12,10 +12,12 @@ import pytest
 
 import ray
 import ray.cloudpickle as pickle
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.test_utils import (
     format_web_url,
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
     wait_for_pid_to_exit,
 )

--- a/python/ray/tests/test_list_actors_3.py
+++ b/python/ray/tests/test_list_actors_3.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 import ray
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 
 
 def test_list_named_actors_ray_kill(ray_start_regular):

--- a/python/ray/tests/test_list_actors_4.py
+++ b/python/ray/tests/test_list_actors_4.py
@@ -5,7 +5,7 @@ import time
 import pytest
 
 import ray
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 
 
 def test_list_named_actors_namespace(ray_start_regular):

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -15,7 +15,10 @@ import colorama
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private import ray_constants
 from ray._private.log_monitor import (
     LOG_NAME_UPDATE_INTERVAL_S,
@@ -44,7 +47,6 @@ from ray._private.test_utils import (
     get_log_data,
     get_log_message,
     init_log_pubsub,
-    run_string_as_driver,
 )
 from ray._private.worker import print_worker_logs
 from ray.autoscaler._private.cli_logger import cli_logger

--- a/python/ray/tests/test_logging_2.py
+++ b/python/ray/tests/test_logging_2.py
@@ -3,8 +3,8 @@ import sys
 import pytest
 
 import ray
+from ray._common.test_utils import run_string_as_driver
 from ray._private.ray_logging.logging_config import LoggingConfig
-from ray._private.test_utils import run_string_as_driver
 
 
 def test_invalid_encoding():

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -6,14 +6,17 @@ import numpy as np
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    PrometheusTimeseries,
+    wait_for_condition,
+)
 from ray._common.utils import get_system_memory
 from ray._private import (
     ray_constants,
 )
 from ray._private.grpc_utils import init_grpc_channel
 from ray._private.state_api_test_utils import verify_failed_task
-from ray._private.test_utils import PrometheusTimeseries, raw_metric_timeseries
+from ray._private.test_utils import raw_metric_timeseries
 from ray._private.utils import get_used_memory
 from ray.util.state.state_manager import StateDataSourceClient
 

--- a/python/ray/tests/test_metric_cardinality.py
+++ b/python/ray/tests/test_metric_cardinality.py
@@ -7,10 +7,10 @@ import os
 import pytest
 
 import ray
-from ray._private.test_utils import (
-    PrometheusTimeseries,
+from ray._private.test_utils import wait_for_assertion
+from ray._common.test_utils import (
     fetch_prometheus_metric_timeseries,
-    wait_for_assertion,
+    PrometheusTimeseries,
 )
 from ray._common.network_utils import build_address
 from ray._private.telemetry.metric_cardinality import (

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -16,7 +16,13 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 import ray
 from ray._common.network_utils import build_address, find_free_port
-from ray._common.test_utils import SignalActor, wait_for_condition
+from ray._common.test_utils import (
+    PrometheusTimeseries,
+    SignalActor,
+    fetch_prometheus_metric_timeseries,
+    fetch_prometheus_timeseries,
+    wait_for_condition,
+)
 from ray._private.metrics_agent import (
     Gauge as MetricsAgentGauge,
     PrometheusServiceDiscoveryWriter,
@@ -27,9 +33,6 @@ from ray._private.ray_constants import (
     PROMETHEUS_SERVICE_DISCOVERY_FILE,
 )
 from ray._private.test_utils import (
-    PrometheusTimeseries,
-    fetch_prometheus_metric_timeseries,
-    fetch_prometheus_timeseries,
     get_log_batch,
     raw_metric_timeseries,
 )

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -18,7 +18,11 @@ from opencensus.stats.view_manager import ViewManager
 from prometheus_client.core import REGISTRY
 
 import ray._private.prometheus_exporter as prometheus_exporter
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    fetch_prometheus_metrics,
+    fetch_raw_prometheus,
+    wait_for_condition,
+)
 from ray._private.metrics_agent import (
     RAY_WORKER_TIMEOUT_S,
     Gauge,
@@ -28,10 +32,6 @@ from ray._private.metrics_agent import (
     Record,
 )
 from ray._private.telemetry.metric_cardinality import WORKER_ID_TAG_KEY
-from ray._private.test_utils import (
-    fetch_prometheus_metrics,
-    fetch_raw_prometheus,
-)
 from ray._raylet import WorkerID
 from ray.core.generated.metrics_pb2 import (
     LabelKey,

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -5,13 +5,15 @@ import time
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private import ray_constants
 from ray._private.test_utils import (
     get_error_message,
     init_error_pubsub,
     object_memory_usage,
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
 )
 

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -8,12 +8,14 @@ import pytest
 
 import ray
 import ray._private.ray_constants as ray_constants
-from ray._common.test_utils import Semaphore
+from ray._common.test_utils import (
+    Semaphore,
+    run_string_as_driver,
+)
 from ray._private.test_utils import (
     check_call_ray,
     check_call_subprocess,
     kill_process_by_name,
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
     start_redis_instance,
     wait_for_children_of_pid,

--- a/python/ray/tests/test_multi_tenancy.py
+++ b/python/ray/tests/test_multi_tenancy.py
@@ -10,11 +10,11 @@ import numpy as np
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     run_string_as_driver,
-    run_string_as_driver_nonblocking,
+    wait_for_condition,
 )
+from ray._private.test_utils import run_string_as_driver_nonblocking
 from ray.util.state import list_workers
 from ray.util.state.common import WorkerState
 

--- a/python/ray/tests/test_namespace.py
+++ b/python/ray/tests/test_namespace.py
@@ -4,11 +4,11 @@ import time
 import pytest
 
 import ray
+from ray._common.test_utils import run_string_as_driver
 from ray._private import ray_constants
 from ray._private.test_utils import (
     get_error_message,
     init_error_pubsub,
-    run_string_as_driver,
 )
 from ray.cluster_utils import Cluster
 

--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -11,13 +11,15 @@ from typing import List, Optional
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.test_utils import (
     get_load_metrics_report,
     get_resource_usage,
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
 )
 from ray._private.utils import get_num_cpus

--- a/python/ray/tests/test_object_manager_fault_tolerance.py
+++ b/python/ray/tests/test_object_manager_fault_tolerance.py
@@ -5,11 +5,11 @@ import numpy as np
 import pytest
 
 import ray
+from ray._common.test_utils import wait_for_condition
 from ray._private.internal_api import get_memory_info_reply, get_state_from_address
 from ray._private.test_utils import (
     RPC_FAILURE_MAP,
     RPC_FAILURE_TYPES,
-    wait_for_condition,
 )
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 

--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -9,11 +9,13 @@ import numpy as np
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.external_storage import (
     FileSystemStorage,
 )
-from ray._private.test_utils import run_string_as_driver
 from ray.tests.test_object_spilling import is_dir_empty
 
 # Note: Disk write speed can be as low as 6 MiB/s in AWS Mac instances, so we have to

--- a/python/ray/tests/test_object_store_metrics.py
+++ b/python/ray/tests/test_object_store_metrics.py
@@ -7,11 +7,11 @@ import pytest
 import requests
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     PrometheusTimeseries,
-    raw_metric_timeseries,
+    wait_for_condition,
 )
+from ray._private.test_utils import raw_metric_timeseries
 from ray._private.worker import RayContext
 from ray.dashboard.consts import RAY_DASHBOARD_STATS_UPDATING_INTERVAL
 

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -8,9 +8,11 @@ import time
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     run_string_as_driver,
+    wait_for_condition,
+)
+from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
     run_string_as_driver_stdout_stderr,
 )

--- a/python/ray/tests/test_placement_group_2.py
+++ b/python/ray/tests/test_placement_group_2.py
@@ -5,12 +5,14 @@ import pytest
 
 import ray
 import ray.cluster_utils
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.test_utils import (
     get_other_nodes,
     kill_actor_and_wait_for_failure,
     placement_group_assert_no_leak,
-    run_string_as_driver,
 )
 from ray.util.placement_group import get_current_placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -9,7 +9,10 @@ import ray
 import ray.cluster_utils
 import ray.experimental.internal_kv as internal_kv
 from ray import ObjectRef
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_ERROR,
     DEBUG_AUTOSCALING_STATUS,
@@ -19,7 +22,6 @@ from ray._private.test_utils import (
     is_placement_group_removed,
     kill_actor_and_wait_for_failure,
     reset_autoscaler_v2_enabled_cache,
-    run_string_as_driver,
 )
 from ray.autoscaler._private.commands import debug_status
 from ray.autoscaler._private.constants import AUTOSCALER_UPDATE_INTERVAL_S

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -10,12 +10,12 @@ from click.testing import CliRunner
 import ray
 import ray.scripts.scripts as scripts
 from ray._common.network_utils import build_address
-from ray._common.test_utils import wait_for_condition
-from ray._private.runtime_env.plugin import RuntimeEnvPlugin
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     fetch_prometheus_metrics,
-    placement_group_assert_no_leak,
+    wait_for_condition,
 )
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.test_utils import placement_group_assert_no_leak
 from ray.tests.test_placement_group import are_pairwise_unique
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray.util.state import list_actors, list_placement_groups

--- a/python/ray/tests/test_placement_group_metrics.py
+++ b/python/ray/tests/test_placement_group_metrics.py
@@ -5,11 +5,11 @@ from typing import Dict
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     PrometheusTimeseries,
-    raw_metric_timeseries,
+    wait_for_condition,
 )
+from ray._private.test_utils import raw_metric_timeseries
 from ray._private.worker import RayContext
 from ray.util.placement_group import remove_placement_group
 

--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -10,11 +10,11 @@ import pytest
 
 import ray
 from ray._common.network_utils import build_address
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
-    check_spilled_mb,
+from ray._common.test_utils import (
     fetch_prometheus,
+    wait_for_condition,
 )
+from ray._private.test_utils import check_spilled_mb
 
 import psutil
 

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -12,9 +12,11 @@ from pexpect.popen_spawn import PopenSpawn
 
 import ray
 from ray._common.network_utils import parse_address
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private import ray_constants, services
-from ray._private.test_utils import run_string_as_driver
 from ray.cluster_utils import Cluster, cluster_not_supported
 
 

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -11,13 +11,13 @@ import pytest
 import ray
 import ray._private.services
 from ray._common.network_utils import parse_address
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.ray_constants import DEFAULT_RESOURCES, RAY_OVERRIDE_DASHBOARD_URL
 from ray._private.services import get_node_ip_address
-from ray._private.test_utils import (
-    get_current_unused_port,
-    run_string_as_driver,
-)
+from ray._private.test_utils import get_current_unused_port
 from ray.dashboard.utils import ray_address_to_api_server_url
 from ray.util.client.ray_client_helpers import ray_start_client_server
 

--- a/python/ray/tests/test_resource_metrics.py
+++ b/python/ray/tests/test_resource_metrics.py
@@ -5,11 +5,11 @@ import pytest
 
 import ray
 from ray._common.network_utils import build_address
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     fetch_prometheus_metrics,
-    run_string_as_driver_nonblocking,
+    wait_for_condition,
 )
+from ray._private.test_utils import run_string_as_driver_nonblocking
 
 METRIC_CONFIG = {
     "_system_config": {

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -12,7 +12,10 @@ import pytest
 import yaml
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._common.utils import try_to_create_directory
 from ray._private.runtime_env.conda import (
     _current_py_version,
@@ -27,7 +30,6 @@ from ray._private.runtime_env.conda_utils import (
 )
 from ray._private.test_utils import (
     chdir,
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
 )
 from ray._private.utils import (

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -6,15 +6,13 @@ from pathlib import Path
 import pytest
 
 import ray
+from ray._common.test_utils import run_string_as_driver
 from ray._private.runtime_env.packaging import (
     GCS_STORAGE_MAX_SIZE,
     get_uri_for_directory,
     upload_package_if_needed,
 )
-from ray._private.test_utils import (
-    chdir,
-    run_string_as_driver,
-)
+from ray._private.test_utils import chdir
 from ray._private.utils import get_directory_size_bytes
 from ray.exceptions import RuntimeEnvSetupError
 

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -12,11 +12,14 @@ import pytest
 import ray
 import ray.cluster_utils
 import ray.util.accelerators
-from ray._common.test_utils import SignalActor, wait_for_condition
-from ray._private.internal_api import memory_summary
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     MetricSamplePattern,
     PrometheusTimeseries,
+    SignalActor,
+    wait_for_condition,
+)
+from ray._private.internal_api import memory_summary
+from ray._private.test_utils import (
     get_metric_check_condition,
     object_memory_usage,
 )

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -9,10 +9,13 @@ import pytest
 import ray
 import ray._private.gcs_utils as gcs_utils
 import ray.experimental.internal_kv as internal_kv
-from ray._common.test_utils import SignalActor, wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     MetricSamplePattern,
     PrometheusTimeseries,
+    SignalActor,
+    wait_for_condition,
+)
+from ray._private.test_utils import (
     client_test_enabled,
     get_metric_check_condition,
     make_global_state_accessor,

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -23,6 +23,7 @@ from ray._common.network_utils import find_free_port, parse_address
 from ray._common.test_utils import (
     SignalActor,
     async_wait_for_condition,
+    run_string_as_driver,
     wait_for_condition,
 )
 from ray._private.grpc_utils import init_grpc_channel
@@ -31,10 +32,7 @@ from ray._private.state_api_test_utils import (
     get_state_api_manager,
     verify_schema,
 )
-from ray._private.test_utils import (
-    run_string_as_driver,
-    wait_for_aggregator_agent_if_enabled,
-)
+from ray._private.test_utils import wait_for_aggregator_agent_if_enabled
 from ray._raylet import ActorID, GcsClient, JobID, NodeID, TaskID
 from ray.cluster_utils import cluster_not_supported
 from ray.core.generated.common_pb2 import (

--- a/python/ray/tests/test_system_metrics.py
+++ b/python/ray/tests/test_system_metrics.py
@@ -5,11 +5,11 @@ import time
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     PrometheusTimeseries,
-    raw_metric_timeseries,
+    wait_for_condition,
 )
+from ray._private.test_utils import raw_metric_timeseries
 
 METRIC_CONFIG = {
     "_system_config": {

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -7,12 +7,15 @@ from typing import Dict
 import pytest
 
 import ray
-from ray._common.test_utils import SignalActor, wait_for_condition
+from ray._common.test_utils import (
+    PrometheusTimeseries,
+    SignalActor,
+    wait_for_condition,
+)
 from ray._private.state_api_test_utils import (
     verify_failed_task,
 )
 from ray._private.test_utils import (
-    PrometheusTimeseries,
     raw_metric_timeseries,
     wait_for_aggregator_agent_if_enabled,
 )

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -9,7 +9,11 @@ from typing import Dict
 import pytest
 
 import ray
-from ray._common.test_utils import async_wait_for_condition, wait_for_condition
+from ray._common.test_utils import (
+    async_wait_for_condition,
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private import ray_constants
 from ray._private.state_api_test_utils import (
     PidActor,
@@ -19,7 +23,6 @@ from ray._private.state_api_test_utils import (
     verify_tasks_running_or_terminated,
 )
 from ray._private.test_utils import (
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
     wait_for_aggregator_agent_if_enabled,
 )

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -6,12 +6,14 @@ from collections import defaultdict
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
+from ray._common.test_utils import (
+    PrometheusTimeseries,
+    run_string_as_driver,
+    wait_for_condition,
+)
 from ray._private.metrics_agent import RAY_WORKER_TIMEOUT_S
 from ray._private.test_utils import (
-    PrometheusTimeseries,
     raw_metric_timeseries,
-    run_string_as_driver,
     run_string_as_driver_nonblocking,
     wait_for_assertion,
     wait_for_dashboard_agent_available,

--- a/python/ray/tests/test_task_metrics_reconstruction.py
+++ b/python/ray/tests/test_task_metrics_reconstruction.py
@@ -5,10 +5,8 @@ import pytest
 
 import ray
 from ray._common.test_utils import (
-    wait_for_condition,
-)
-from ray._private.test_utils import (
     PrometheusTimeseries,
+    wait_for_condition,
 )
 from ray.tests.test_task_metrics import METRIC_CONFIG, tasks_by_all
 

--- a/python/ray/tests/test_tls_auth.py
+++ b/python/ray/tests/test_tls_auth.py
@@ -6,7 +6,7 @@ import sys
 
 import pytest
 
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_token_auth_integration.py
+++ b/python/ray/tests/test_token_auth_integration.py
@@ -11,12 +11,12 @@ import pytest
 import ray
 import ray.dashboard.consts as dashboard_consts
 from ray._common.network_utils import build_address
-from ray._private.test_utils import (
+from ray._common.test_utils import (
     PrometheusTimeseries,
-    client_test_enabled,
     fetch_prometheus_timeseries,
     wait_for_condition,
 )
+from ray._private.test_utils import client_test_enabled
 
 try:
     from ray._raylet import AuthenticationTokenLoader

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -4,7 +4,7 @@ from inspect import getmembers, isfunction, ismodule
 import pytest
 
 import ray
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 
 
 # NOTE: Before adding a new API to Ray (and modifying this test), the new API

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -8,7 +8,7 @@ import pytest
 import regex as re
 
 from ray import tune
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 from ray.tune.experiment.trial import Trial
 from ray.tune.progress_reporter import (
     CLIReporter,

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -17,7 +17,7 @@ import pytest
 
 import ray
 from ray import tune
-from ray._private.test_utils import run_string_as_driver
+from ray._common.test_utils import run_string_as_driver
 from ray.exceptions import RayTaskError
 from ray.train._internal.session import _TrainingResult
 from ray.tune import Checkpoint, TuneError


### PR DESCRIPTION
## Summary
- Moves `run_string_as_driver`, `PrometheusTimeseries`, `MetricSamplePattern`, and related Prometheus helpers (`fetch_prometheus`, `fetch_prometheus_timeseries`, `fetch_prometheus_metrics`, `fetch_prometheus_metric_timeseries`, `fetch_raw_prometheus`) from `ray._private.test_utils` to `ray._common.test_utils`.
- Replaces `from ray._private.worker import SCRIPT_MODE` in Serve with the public `ray.SCRIPT_MODE`.

## Why
Part of #53478. `ray._common` is the intended home for utilities shared across Ray libraries. These test helpers were already used broadly outside Core and belong in `_common`, not `_private`.
