### PR TITLE
[Core] Fix test_failed_task_runtime_env_setup failure on windows

### DIFF
--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -246,7 +246,12 @@ def test_failed_task_runtime_env_setup(shutdown_only):
     def f():
         pass
 
-    bad_env = RuntimeEnv(conda={"dependencies": ["_this_does_not_exist"]})
+    bad_env = RuntimeEnv(
+        conda={
+            "channels": ["defaults"],
+            "dependencies": ["_this_does_not_exist"],
+        }
+    )
     with pytest.raises(
         RuntimeEnvSetupError,
     ):


### PR DESCRIPTION
## Description
Fix test_failed_task_runtime_env_setup failure on windows by setting conda channel

https://buildkite.com/ray-project/microcheck/builds/37778#019c40d7-bbd1-42fb-92cb-098a04061767/L11749

