### PR TITLE
[data][llm] Avoid deprecated TRANSFORMERS_CACHE and treat inability to load HuggingFace config as non-fatal

### DIFF
--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -494,10 +494,10 @@ class CloudModelAccessor:
         if Path(self.model_id).exists():
             return Path(self.model_id)
         # Delayed import to avoid circular dependencies
-        from transformers.utils.hub import TRANSFORMERS_CACHE
+        from huggingface_hub.constants import HF_HUB_CACHE
 
         return Path(
-            TRANSFORMERS_CACHE, f"models--{self.model_id.replace('/', '--')}"
+            HF_HUB_CACHE, f"models--{self.model_id.replace('/', '--')}"
         ).expanduser()
 
 

--- a/python/ray/llm/_internal/common/utils/download_utils.py
+++ b/python/ray/llm/_internal/common/utils/download_utils.py
@@ -57,7 +57,7 @@ class NodeModelDownloadable(enum.Enum):
 def get_model_entrypoint(model_id: str) -> str:
     """Get the path to entrypoint of the model on disk if it exists, otherwise return the model id as is.
 
-    Entrypoint is typically <TRANSFORMERS_CACHE>/models--<model_id>/
+    Entrypoint is typically <HF_HUB_CACHE>/models--<model_id>/
 
     Args:
         model_id: Hugging Face model ID.
@@ -65,10 +65,10 @@ def get_model_entrypoint(model_id: str) -> str:
     Returns:
         The path to the entrypoint of the model on disk if it exists, otherwise the model id as is.
     """
-    from transformers.utils.hub import TRANSFORMERS_CACHE
+    from huggingface_hub.constants import HF_HUB_CACHE
 
     model_dir = Path(
-        TRANSFORMERS_CACHE, f"models--{model_id.replace('/', '--')}"
+        HF_HUB_CACHE, f"models--{model_id.replace('/', '--')}"
     ).expanduser()
     if not model_dir.exists():
         return model_id

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -613,6 +613,14 @@ def test_audio_model(
 
 
 class TestVLLMEngineProcessorConfig:
+    def test_build_processor_autoconfig_failure(self):
+        config = vLLMEngineProcessorConfig(
+            model_source="nonexistent-org/nonexistent-model",
+        )
+
+        processor = build_processor(config)
+        assert processor is not None
+
     @pytest.mark.parametrize(
         "experimental_config",
         [


### PR DESCRIPTION
## Description
`transformers` deprecates `TRANSFORMERS_CACHE` in versions ≥ 5.0.0 (see https://github.com/huggingface/transformers/pull/42391). Although Ray currently pins `transformers==4.57.3`, users may override this pin to access newer models, which makes Ray Data LLM incompatible with `transformers>5.0.0`.

While vLLM applies a similar <5.0.0 pin, it avoids relying on `TRANSFORMERS_CACHE`, allowing users to run vLLM with newer transformers versions. For instance, the transformers library is used for tokenization.

In this PR, we adopt the same approach by removing the dependency on `TRANSFORMERS_CACHE` without bumping the pinned transformers version, which would have broader implications for other Ray components. Both the deprecation PR and the code snipped below confirm that `HF_HUB_CACHE` is the preferred, equivalent replacement for `TRANSFORMERS_CACHE`.

```
# transformers==4.57.3
>>> from huggingface_hub.constants import HF_HUB_CACHE
>>> HF_HUB_CACHE
'/home/ray/.cache/huggingface/hub'
>>> from transformers.utils.hub import TRANSFORMERS_CACHE
>>> TRANSFORMERS_CACHE
'/home/ray/.cache/huggingface/hub'
```

We also treat the inability to load huggigface config for telemetry purposes as non-fatal. Here's a relevant discussion thread: https://github.com/ray-project/ray/issues/60780#issuecomment-3880760526.

## Related issues
Closes https://github.com/ray-project/ray/issues/60780.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
