### PR TITLE
[Docker] Add HAProxy to base-deps image

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -167,3 +167,5 @@ sudo rm -rf /var/lib/apt/lists/*
 sudo apt-get clean
 
 EOF
+
+WORKDIR $HOME

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -8,8 +8,6 @@ ARG BASE_IMAGE="ubuntu:22.04"
 # --- HAProxy Build Stage ---
 FROM ${BASE_IMAGE} AS haproxy-builder
 
-USER root
-
 RUN <<EOF
 #!/bin/bash
 set -euo pipefail
@@ -24,8 +22,6 @@ apt-get install -y --no-install-recommends \
     libpcre3-dev \
     libssl-dev \
     zlib1g-dev
-
-rm -rf /var/lib/apt/lists/*
 
 # Install HAProxy from source
 HAPROXY_VERSION="2.8.12"
@@ -90,6 +86,10 @@ APT_PKGS=(
     netbase
     openssh-client
     gnupg
+
+    # For HAProxy
+    socat
+    liblua5.3-0
 )
 
 apt-get install -y "${APT_PKGS[@]}"
@@ -98,7 +98,12 @@ useradd -ms /bin/bash -d /home/ray ray --uid $RAY_UID --gid $RAY_GID
 usermod -aG sudo ray
 echo 'ray ALL=NOPASSWD: ALL' >> /etc/sudoers
 
+mkdir -p /etc/haproxy /run/haproxy /var/log/haproxy
+chown -R ray:"$(id -gn ray)" /run/haproxy
+
 EOF
+
+COPY --from=haproxy-builder /usr/local/bin/haproxy /usr/local/bin/haproxy
 
 USER $RAY_UID
 ENV HOME=/home/ray
@@ -162,25 +167,3 @@ sudo rm -rf /var/lib/apt/lists/*
 sudo apt-get clean
 
 EOF
-
-# Copy HAProxy binary from builder stage
-COPY --from=haproxy-builder /usr/local/bin/haproxy /usr/local/bin/haproxy
-
-# Install HAProxy runtime dependency and setup
-USER root
-
-RUN <<EOF
-#!/bin/bash
-set -euo pipefail
-
-apt-get update -y
-apt-get install -y --no-install-recommends socat liblua5.3-0
-
-mkdir -p /etc/haproxy /run/haproxy /var/log/haproxy
-chown -R ray:"$(id -gn ray)" /run/haproxy
-
-rm -rf /var/lib/apt/lists/*
-EOF
-
-USER $RAY_UID
-WORKDIR $HOME

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -4,6 +4,41 @@
 
 # The GPU options are NVIDIA CUDA developer images.
 ARG BASE_IMAGE="ubuntu:22.04"
+
+# --- HAProxy Build Stage ---
+FROM ${BASE_IMAGE} AS haproxy-builder
+
+USER root
+
+RUN <<EOF
+#!/bin/bash
+set -euo pipefail
+
+apt-get update -y
+apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    libc6-dev \
+    liblua5.3-dev \
+    libpcre3-dev \
+    libssl-dev \
+    zlib1g-dev
+
+rm -rf /var/lib/apt/lists/*
+
+# Install HAProxy from source
+HAPROXY_VERSION="2.8.12"
+HAPROXY_BUILD_DIR=$(mktemp -d)
+curl -sSfL -o "${HAPROXY_BUILD_DIR}/haproxy.tar.gz" "https://www.haproxy.org/download/2.8/src/haproxy-${HAPROXY_VERSION}.tar.gz"
+tar -xzf "${HAPROXY_BUILD_DIR}/haproxy.tar.gz" -C "${HAPROXY_BUILD_DIR}" --strip-components=1
+make -C "${HAPROXY_BUILD_DIR}" TARGET=linux-glibc USE_OPENSSL=1 USE_ZLIB=1 USE_PCRE=1 USE_LUA=1 USE_PROMEX=1 -j$(nproc)
+make -C "${HAPROXY_BUILD_DIR}" install SBINDIR=/usr/local/bin
+rm -rf "${HAPROXY_BUILD_DIR}"
+
+EOF
+
+# --- Main image ---
 FROM ${BASE_IMAGE}
 # If this arg is not "autoscaler" then no autoscaler requirements will be included
 ENV TZ=America/Los_Angeles
@@ -128,4 +163,24 @@ sudo apt-get clean
 
 EOF
 
+# Copy HAProxy binary from builder stage
+COPY --from=haproxy-builder /usr/local/bin/haproxy /usr/local/bin/haproxy
+
+# Install HAProxy runtime dependency and setup
+USER root
+
+RUN <<EOF
+#!/bin/bash
+set -euo pipefail
+
+apt-get update -y
+apt-get install -y --no-install-recommends socat liblua5.3-0
+
+mkdir -p /etc/haproxy /run/haproxy /var/log/haproxy
+chown -R ray:"$(id -gn ray)" /run/haproxy
+
+rm -rf /var/lib/apt/lists/*
+EOF
+
+USER $RAY_UID
 WORKDIR $HOME

--- a/docker/base-extra/Dockerfile
+++ b/docker/base-extra/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG BASE_IMAGE="rayproject/ray:latest"
 
-FROM "$BASE_IMAGE" AS main-build
+FROM "$BASE_IMAGE"
 
 ENV TERM=xterm
 
@@ -189,59 +189,5 @@ sudo rm -rf /etc/apt/sources.list.d/*
 sudo rm -rf /var/lib/apt/lists/*
 
 EOF
-
-# --- HAProxy Build Stage ---
-FROM $BASE_IMAGE AS haproxy-builder
-
-USER root
-
-RUN <<EOF
-#!/bin/bash
-set -euo pipefail
-
-apt-get update -y
-apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    curl \
-    libc6-dev \
-    liblua5.3-dev \
-    libpcre3-dev \
-    libssl-dev \
-    zlib1g-dev
-
-rm -rf /var/lib/apt/lists/*
-
-# Install HAProxy from source
-HAPROXY_VERSION="2.8.12"
-HAPROXY_BUILD_DIR=$(mktemp -d)
-curl -sSfL -o "${HAPROXY_BUILD_DIR}/haproxy.tar.gz" "https://www.haproxy.org/download/2.8/src/haproxy-${HAPROXY_VERSION}.tar.gz"
-tar -xzf "${HAPROXY_BUILD_DIR}/haproxy.tar.gz" -C "${HAPROXY_BUILD_DIR}" --strip-components=1
-make -C "${HAPROXY_BUILD_DIR}" TARGET=linux-glibc USE_OPENSSL=1 USE_ZLIB=1 USE_PCRE=1 USE_LUA=1 USE_PROMEX=1 -j$(nproc)
-make -C "${HAPROXY_BUILD_DIR}" install SBINDIR=/usr/local/bin
-rm -rf "${HAPROXY_BUILD_DIR}"
-
-EOF
-
-# --- Return to main image ---
-FROM main-build AS main
-
-USER root
-
-# Copy HAProxy binary from builder stage
-COPY --from=haproxy-builder /usr/local/bin/haproxy /usr/local/bin/haproxy
-
-# Install HAProxy runtime dependency and setup
-RUN <<EOF
-#!/bin/bash
-set -euo pipefail
-
-mkdir -p /etc/haproxy /run/haproxy /var/log/haproxy
-chown -R ray:"$(id -gn ray)" /run/haproxy
-
-EOF
-
-USER ray
-WORKDIR /home/ray
 
 RUN mkdir -p /tmp/supervisord

--- a/docker/base-extra/Dockerfile
+++ b/docker/base-extra/Dockerfile
@@ -59,10 +59,6 @@ APT_PKGS=(
     ssh
     curl
     gdb
-
-    # For HAProxy
-    socat
-    liblua5.3-0
 )
 
 sudo apt-get update -y


### PR DESCRIPTION
## Summary

- Move HAProxy 2.8.12 multi-stage build from `base-extra` to `base-deps` so the binary is available earlier in the Docker image hierarchy
- Simplify `base-extra/Dockerfile` by removing its HAProxy build stage (now inherited from base-deps)
- Install HAProxy runtime dependencies (`socat`, `liblua5.3-0`) in base-deps

## Context

Needed for #60586 (Ray Serve HAProxy support)

## Test plan

- [ ] Verify base-deps image builds successfully with HAProxy binary
- [ ] Verify base-extra image still builds correctly without its own HAProxy stage