### PR TITLE
[Data] Prevent `Limit` from getting pushed past `map_groups`

### DIFF
--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -303,7 +303,7 @@ class GroupedData:
             num_gpus=num_gpus,
             memory=memory,
             concurrency=concurrency,
-            udf_modifying_row_count=False,
+            udf_modifying_row_count=True,
             ray_remote_args_fn=ray_remote_args_fn,
             **ray_remote_args,
         )

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -615,5 +615,17 @@ def test_does_not_pushdown_limit_past_map_batches_by_default(
     assert num_rows == 1, num_rows
 
 
+def test_does_not_pushdown_limit_past_map_groups_by_default(
+    ray_start_regular_shared_2_cpus,
+):
+    def duplicate_id(batch):
+        yield {"data": list(batch["id"]) * 2}
+
+    # If the optimizer incorrectly pushes the limit past the map operator, then the
+    # returned count is 2.
+    num_rows = ray.data.range(1).groupby("id").map_groups(duplicate_id).limit(1).count()
+    assert num_rows == 1, num_rows
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
This PR updates `map_groups` to assume that the UDF might change the row count. This change is necessary to fix a bug where `Limit` gets incorrectly pushed past the `map_groups` (fixes https://github.com/ray-project/ray/issues/60872).

For more context, see:
* https://github.com/ray-project/ray/pull/60448
* https://github.com/ray-project/ray/pull/60756