### PR TITLE
[Data] Fixing `ReservationOpResourceAllocator` to properly borrow resources for `ActorPoolMapOperator`

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -967,7 +967,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         for i, op in enumerate(reversed(eligible_ops)):
             # By default, divide the remaining shared resources equally.
             op_shared = remaining_shared.scale(1.0 / (len(eligible_ops) - i))
-            # But if the op's budget is less than `incremental_resource_usage`,
+            # But if the op's budget is less than `min_scheduling_resources`,
             # it will be useless. So we'll let the downstream operator
             # borrow some resources from the upstream operator, if remaining_shared
             # is still enough.

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -972,7 +972,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             # borrow some resources from the upstream operator, if remaining_shared
             # is still enough.
             to_borrow = (
-                op.incremental_resource_usage()
+                op.min_scheduling_resources()
                 .subtract(self._op_budgets[op].add(op_shared))
                 .max(ExecutionResources.zero())
             )

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -729,7 +729,9 @@ class TestReservationOpResourceAllocator:
         topo = build_streaming_topology(o5, ExecutionOptions())
 
         # Cluster with 2 GPUs available
-        global_limits = ExecutionResources(cpu=16, gpu=2, object_store_memory=10_000_000)
+        global_limits = ExecutionResources(
+            cpu=16, gpu=2, object_store_memory=10_000_000
+        )
 
         # Simulate state where GPU operator has 1 actor running
         op_usages = {

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -757,7 +757,7 @@ class TestReservationOpResourceAllocator:
         # With 2 GPUs total, 1 used, the operator should have budget for 1 more.
         # Before the fix: budget.gpu=0 (couldn't scale)
         # After the fix: budget.gpu=1 (can scale to 1 more actor)
-        assert allocator._op_budgets[o4] == ExecutionResources(
+        assert allocator.get_budget(o4) == ExecutionResources(
             cpu=0, gpu=1, object_store_memory=625000
         )
         assert allocator.get_allocation(o4) == ExecutionResources(

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -44,8 +44,9 @@ class TestReservationOpResourceAllocator:
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
-        o2 = mock_map_op(o1, incremental_resource_usage=ExecutionResources(1, 0, 15))
-        o3 = mock_map_op(o2, incremental_resource_usage=ExecutionResources(1, 0, 10))
+        # Use ray_remote_args to set CPU requirements instead of mocking
+        o2 = mock_map_op(o1, ray_remote_args={"num_cpus": 1})
+        o3 = mock_map_op(o2, ray_remote_args={"num_cpus": 1})
         o4 = LimitOperator(1, o3, DataContext.get_current())
 
         # Mock min_max_resource_requirements to return default unbounded behavior
@@ -201,26 +202,27 @@ class TestReservationOpResourceAllocator:
         assert allocator.get_allocation(o2) == ExecutionResources(7.5, 0, 550)
         assert allocator.get_allocation(o3) == ExecutionResources(4.5, 0, 245)
 
-    def test_reserve_incremental_resource_usage(self, restore_data_context):
-        """Test that we'll reserve at least incremental_resource_usage()
+    def test_reserve_min_resource_requirements(self, restore_data_context):
+        """Test that we'll reserve at least min_resource_requirements
         for each operator."""
         DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         global_limits = ExecutionResources(cpu=7, gpu=0, object_store_memory=800)
-        incremental_usage = ExecutionResources(cpu=3, gpu=0, object_store_memory=500)
+        min_resources = ExecutionResources(cpu=3, gpu=0, object_store_memory=500)
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
-        o2 = mock_map_op(o1, incremental_resource_usage=incremental_usage)
-        o3 = mock_map_op(o2, incremental_resource_usage=incremental_usage)
-        o4 = mock_map_op(o3, incremental_resource_usage=incremental_usage)
-        o5 = mock_map_op(o4, incremental_resource_usage=incremental_usage)
+        # Use ray_remote_args to set CPU requirements
+        o2 = mock_map_op(o1, ray_remote_args={"num_cpus": 3})
+        o3 = mock_map_op(o2, ray_remote_args={"num_cpus": 3})
+        o4 = mock_map_op(o3, ray_remote_args={"num_cpus": 3})
+        o5 = mock_map_op(o4, ray_remote_args={"num_cpus": 3})
 
-        # Set min_max_resource_requirements to use incremental_resource_usage as minimum
+        # Set min_max_resource_requirements to specify minimum resources
         for op in [o2, o3, o4, o5]:
             op.min_max_resource_requirements = MagicMock(
                 return_value=(
-                    incremental_usage,
+                    min_resources,
                     ExecutionResources(cpu=100, gpu=0, object_store_memory=10000),
                 )
             )
@@ -241,23 +243,23 @@ class TestReservationOpResourceAllocator:
         allocator.update_budgets(
             limits=global_limits,
         )
-        # incremental_usage should be reserved for o2.
-        assert allocator._op_reserved[o2] == incremental_usage
+        # min_resources should be reserved for o2.
+        assert allocator._op_reserved[o2] == min_resources
         # Remaining resources are CPU = 7 - 3 = 4, object_store_memory = 800 - 500 = 300.
-        # We have enough CPUs for o3's incremental_usage, but not enough
-        # object_store_memory. We'll still reserve the incremental_usage by
+        # We have enough CPUs for o3's min_resources, but not enough
+        # object_store_memory. We'll still reserve the min_resources by
         # oversubscribing object_store_memory.
-        assert allocator._op_reserved[o3] == incremental_usage
+        assert allocator._op_reserved[o3] == min_resources
         # Now the remaining resources are CPU = 4 - 3 = 1,
         # object_store_memory = 300 - 500 = -200.
-        # We don't oversubscribing CPUs, we'll only reserve
-        # incremental_usage.object_store_memory.
+        # We don't oversubscribe CPUs, we'll only reserve
+        # min_resources.object_store_memory.
         assert allocator._op_reserved[o4] == ExecutionResources(
-            0, 0, incremental_usage.object_store_memory
+            0, 0, min_resources.object_store_memory
         )
         # Same for o5
         assert allocator._op_reserved[o5] == ExecutionResources(
-            0, 0, incremental_usage.object_store_memory
+            0, 0, min_resources.object_store_memory
         )
         assert allocator._total_shared == ExecutionResources(1, 0, 0)
         for op in [o2, o3, o4]:
@@ -351,8 +353,8 @@ class TestReservationOpResourceAllocator:
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
-        o2 = mock_map_op(o1, incremental_resource_usage=ExecutionResources(1, 0, 10))
-        o3 = mock_map_op(o2, incremental_resource_usage=ExecutionResources(1, 0, 10))
+        o2 = mock_map_op(o1, ray_remote_args={"num_cpus": 1})
+        o3 = mock_map_op(o2, ray_remote_args={"num_cpus": 1})
 
         # o2 has a small max CPU, so its CPU shared allocation will be capped.
         # o3 has unlimited max_resource_usage.
@@ -426,8 +428,8 @@ class TestReservationOpResourceAllocator:
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
-        o2 = mock_map_op(o1, incremental_resource_usage=ExecutionResources(1, 0, 10))
-        o3 = mock_map_op(o2, incremental_resource_usage=ExecutionResources(1, 0, 10))
+        o2 = mock_map_op(o1, ray_remote_args={"num_cpus": 1})
+        o3 = mock_map_op(o2, ray_remote_args={"num_cpus": 1})
 
         # Both operators are capped.
         o2.min_max_resource_requirements = MagicMock(
@@ -840,9 +842,9 @@ class TestReservationOpResourceAllocator:
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
-        o2 = mock_map_op(o1, incremental_resource_usage=ExecutionResources(1, 0, 10))
-        o3 = mock_map_op(o2, incremental_resource_usage=ExecutionResources(1, 0, 10))
-        o4 = mock_map_op(o3, incremental_resource_usage=ExecutionResources(1, 0, 10))
+        o2 = mock_map_op(o1, ray_remote_args={"num_cpus": 1})
+        o3 = mock_map_op(o2, ray_remote_args={"num_cpus": 1})
+        o4 = mock_map_op(o3, ray_remote_args={"num_cpus": 1})
 
         # Mock min_max_resource_requirements to return default unbounded behavior
         for op in [o2, o3, o4]:
@@ -925,17 +927,13 @@ class TestReservationOpResourceAllocator:
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
-        o2 = mock_map_op(o1, incremental_resource_usage=ExecutionResources(1, 0, 15))
+        o2 = mock_map_op(o1, ray_remote_args={"num_cpus": 1})
         o3 = LimitOperator(1, o2, DataContext.get_current())
         o4 = InputDataBuffer(DataContext.get_current(), [])
-        o5 = mock_map_op(o4, incremental_resource_usage=ExecutionResources(1, 0, 10))
-        o6 = mock_union_op(
-            [o3, o5], incremental_resource_usage=ExecutionResources(1, 0, 20)
-        )
+        o5 = mock_map_op(o4, ray_remote_args={"num_cpus": 1})
+        o6 = mock_union_op([o3, o5])
         o7 = InputDataBuffer(DataContext.get_current(), [])
-        o8 = mock_join_op(
-            o7, o6, incremental_resource_usage=ExecutionResources(1, 0, 30)
-        )
+        o8 = mock_join_op(o7, o6)
 
         o1.mark_execution_finished()
         o2.mark_execution_finished()

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -38,7 +38,6 @@ def mock_map_op(
     input_op: PhysicalOperator,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     compute_strategy: Optional[ComputeStrategy] = None,
-    incremental_resource_usage: Optional[ExecutionResources] = None,
     name="Map",
 ):
     op = MapOperator.create(
@@ -50,34 +49,19 @@ def mock_map_op(
         name=name,
     )
     op.start(ExecutionOptions())
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 
-def mock_union_op(
-    input_ops,
-    incremental_resource_usage=None,
-):
+def mock_union_op(input_ops):
     op = UnionOperator(
         DataContext.get_current(),
         *input_ops,
     )
     op.start = MagicMock(side_effect=lambda _: None)
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 
-def mock_join_op(
-    left_input_op,
-    right_input_op,
-    incremental_resource_usage=None,
-):
+def mock_join_op(left_input_op, right_input_op):
     left_input_op._logical_operators = [(MagicMock())]
     right_input_op._logical_operators = [(MagicMock())]
 
@@ -98,10 +82,6 @@ def mock_join_op(
         )
 
     op.start = MagicMock(side_effect=lambda _: None)
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 


### PR DESCRIPTION
## Description

`ActorPoolMapOperator.incremental_resource_usage` returns 0, since no new incremental resources are necessary to launch new tasks.

However, for resource allocation to properly borrow from shared resources `min_scheduling_resources` should be used instead.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
