### PR TITLE
[doc] deps: pin setuptools and upgrade sphinxemoji

### DIFF
--- a/ci/raydepsets/configs/docs.depsets.yaml
+++ b/ci/raydepsets/configs/docs.depsets.yaml
@@ -18,3 +18,4 @@ depsets:
       - --unsafe-package ray
     build_arg_sets:
       - py310
+    include_setuptools: true

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,7 +1,7 @@
 # Production requirements. This is what readthedocs.com picks up
 
 # Required to build the docs on 3.12 due to pkg_resources deprecation
-setuptools>=70.0.0
+setuptools==80.9.0
 
 # Syntax highlighting
 Pygments==2.16.1

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -10,7 +10,7 @@ Pygments==2.16.1
 sphinx==7.3.7
 sphinx-click==5.1.0
 sphinx-copybutton==0.5.2
-sphinxemoji==0.2.0
+sphinxemoji>=0.3.2
 sphinx-jsonschema==1.19.1
 sphinx-sitemap==2.5.1
 sphinxcontrib-redoc==1.6.0

--- a/python/deplocks/docs/docbuild_depset_py3.10.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.10.lock
@@ -1157,8 +1157,9 @@ sphinxcontrib-serializinghtml==2.0.0 \
     --hash=sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331 \
     --hash=sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d
     # via sphinx
-sphinxemoji==0.2.0 \
-    --hash=sha256:27861d1dd7c6570f5e63020dac9a687263f7481f6d5d6409eb31ecebcc804e4c
+sphinxemoji==0.3.2 \
+    --hash=sha256:0fb07a95bca5960a3b312bc05b65b0c3040456414a076c363f4ecaf546c6e09e \
+    --hash=sha256:814da89a9a7603b7e4d85c487c7381656fa83632f20065e5ed782ab1dbbb5083
     # via -r doc/requirements-doc.txt
 sqlalchemy==2.0.44 \
     --hash=sha256:0765e318ee9179b3718c4fd7ba35c434f4dd20332fbc6857a5e8df17719c24d7 \

--- a/python/deplocks/docs/docbuild_depset_py3.10.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.10.lock
@@ -1063,6 +1063,10 @@ s3transfer==0.10.4 \
     --hash=sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e \
     --hash=sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7
     # via boto3
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
+    # via -r doc/requirements-doc.txt
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -1524,6 +1528,3 @@ zipp==3.23.0 \
     --hash=sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e \
     --hash=sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166
     # via importlib-metadata
-
-# The following packages were excluded from the output:
-# setuptools


### PR DESCRIPTION
newer setuptools no longer come with `pkg_resources` and breaks the docs build.