### PR TITLE
[Data] Fixing `ReservationOpResourceAllocator` to properly borrow resources for `ActorPoolMapOperator`

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -967,12 +967,12 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         for i, op in enumerate(reversed(eligible_ops)):
             # By default, divide the remaining shared resources equally.
             op_shared = remaining_shared.scale(1.0 / (len(eligible_ops) - i))
-            # But if the op's budget is less than `incremental_resource_usage`,
+            # But if the op's budget is less than `min_scheduling_resources`,
             # it will be useless. So we'll let the downstream operator
             # borrow some resources from the upstream operator, if remaining_shared
             # is still enough.
             to_borrow = (
-                op.incremental_resource_usage()
+                op.min_scheduling_resources()
                 .subtract(self._op_budgets[op].add(op_shared))
                 .max(ExecutionResources.zero())
             )

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -38,7 +38,6 @@ def mock_map_op(
     input_op: PhysicalOperator,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     compute_strategy: Optional[ComputeStrategy] = None,
-    incremental_resource_usage: Optional[ExecutionResources] = None,
     name="Map",
 ):
     op = MapOperator.create(
@@ -50,34 +49,19 @@ def mock_map_op(
         name=name,
     )
     op.start(ExecutionOptions())
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 
-def mock_union_op(
-    input_ops,
-    incremental_resource_usage=None,
-):
+def mock_union_op(input_ops):
     op = UnionOperator(
         DataContext.get_current(),
         *input_ops,
     )
     op.start = MagicMock(side_effect=lambda _: None)
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 
-def mock_join_op(
-    left_input_op,
-    right_input_op,
-    incremental_resource_usage=None,
-):
+def mock_join_op(left_input_op, right_input_op):
     left_input_op._logical_operators = [(MagicMock())]
     right_input_op._logical_operators = [(MagicMock())]
 
@@ -98,10 +82,6 @@ def mock_join_op(
         )
 
     op.start = MagicMock(side_effect=lambda _: None)
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/ray-project/ray/pull/60882

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
