### PR TITLE
[Data] Add logs to `create_autoscaler` and `create_resource_allocator`

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/__init__.py
+++ b/python/ray/data/_internal/cluster_autoscaler/__init__.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
     from ray.data._internal.execution.streaming_executor_state import Topology
     from ray.data.context import DataContext
 
+logger = logging.getLogger(__name__)
 
 CLUSTER_AUTOSCALER_ENV_KEY = "RAY_DATA_CLUSTER_AUTOSCALER"
 DEFAULT_CLUSTER_AUTOSCALER_VERSION = "V2"
@@ -41,6 +43,7 @@ def create_cluster_autoscaler(
     cluster_autoscaler_version = os.environ.get(
         CLUSTER_AUTOSCALER_ENV_KEY, DEFAULT_CLUSTER_AUTOSCALER_VERSION
     )
+    logger.debug(f"Using cluster autoscaler version: {cluster_autoscaler_version!r}")
 
     if cluster_autoscaler_version == ClusterAutoscalerVersion.V2:
         return DefaultClusterAutoscalerV2(

--- a/python/ray/data/_internal/execution/__init__.py
+++ b/python/ray/data/_internal/execution/__init__.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 import os
 from typing import TYPE_CHECKING, Optional
 
@@ -8,6 +9,8 @@ if TYPE_CHECKING:
     from ... import DataContext
     from .resource_manager import OpResourceAllocator, ResourceManager
 
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_USE_OP_RESOURCE_ALLOCATOR_VERSION = os.environ.get(
     "RAY_DATA_USE_OP_RESOURCE_ALLOCATOR_VERSION", "V1"
@@ -28,6 +31,11 @@ def create_resource_allocator(
         # This is a historical kill-switch to disable resource allocator, that
         # will be soon deprecated and removed.
         return None
+
+    logger.debug(
+        f"Using op resource allocator version: "
+        f"{DEFAULT_USE_OP_RESOURCE_ALLOCATOR_VERSION!r}"
+    )
 
     if DEFAULT_USE_OP_RESOURCE_ALLOCATOR_VERSION == OpResourceAllocatorVersion.V1:
         from .resource_manager import ReservationOpResourceAllocator


### PR DESCRIPTION
To make it easier to debug Ray Data workloads, this PR makes `Dataset` executions log which cluster autoscaler and resource allocator version it's using.