### PR TITLE
[train] Make controller resilient to errors in all lifecycle hooks

### DIFF
--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -219,6 +219,22 @@ py_test(
 )
 
 py_test(
+    name = "test_controller_callback_behaviour",
+    size = "small",
+    srcs = ["tests/test_controller_callback_behaviour.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_data_integration",
     size = "large",
     srcs = ["tests/test_data_integration.py"],

--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -220,7 +220,7 @@ py_test(
 
 py_test(
     name = "test_controller_callback_behaviour",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_controller_callback_behaviour.py"],
     env = {"RAY_TRAIN_V2_ENABLED": "1"},
     tags = [

--- a/python/ray/train/v2/_internal/execution/callback_manager.py
+++ b/python/ray/train/v2/_internal/execution/callback_manager.py
@@ -47,3 +47,21 @@ class CallbackManager:
                     f"'{callback_name}'."
                 )
                 raise ControllerError(e) from e
+
+    def invoke_best_effort(self, hook_name: str, *args, **context) -> None:
+        """Invoke a hook on every callback, logging and suppressing errors.
+
+        Unlike ``invoke``, this does not fail fast — every callback is
+        attempted even if earlier ones raise.  Used for cleanup hooks
+        (e.g. ``before_controller_abort``) where partial execution is
+        better than skipping remaining callbacks.
+        """
+        for callback in self._callbacks:
+            method, callback_name = self._get_method(callback, hook_name)
+            try:
+                method(*args, **context)
+            except Exception as e:
+                logger.exception(
+                    f"Error in callback hook '{hook_name}' from callback "
+                    f"'{callback_name}': {e}"
+                )

--- a/python/ray/train/v2/_internal/execution/callback_manager.py
+++ b/python/ray/train/v2/_internal/execution/callback_manager.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 
 from ray.train.v2.api.exceptions import ControllerError
@@ -9,22 +10,41 @@ class CallbackManager:
     def __init__(self, callbacks):
         self._callbacks = callbacks
 
-    # change this return type later
+    def _get_method(self, callback, hook_name: str):
+        """Look up a hook method on a callback, raising if missing."""
+        callback_name = type(callback).__name__
+        method = getattr(callback, hook_name, None)
+        if method is None or not callable(method):
+            raise ControllerError(
+                AttributeError(
+                    f"Callback '{callback_name}' hook '{hook_name}' is missing "
+                    "or not callable."
+                )
+            )
+        return method, callback_name
+
     def invoke(self, hook_name: str, *args, **context) -> None:
         for callback in self._callbacks:
-            callback_name = type(callback).__name__
-            method = getattr(callback, hook_name, None)
-            if method is None or not callable(method):
-                raise ControllerError(
-                    AttributeError(
-                        f"Callback '{callback_name}' hook '{hook_name}' is missing "
-                        "or not callable."
-                    )
-                )
+            method, callback_name = self._get_method(callback, hook_name)
             try:
                 method(*args, **context)
             except Exception as e:
                 # TODO: Enable configuration to suppress exceptions.
+                logger.exception(
+                    f"Exception raised in callback hook '{hook_name}' from callback "
+                    f"'{callback_name}'."
+                )
+                raise ControllerError(e) from e
+
+    async def async_invoke(self, hook_name: str, *args, **context) -> None:
+        """Invoke a hook that may be sync or async (e.g. before_controller_shutdown)."""
+        for callback in self._callbacks:
+            method, callback_name = self._get_method(callback, hook_name)
+            try:
+                result = method(*args, **context)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as e:
                 logger.exception(
                     f"Exception raised in callback hook '{hook_name}' from callback "
                     f"'{callback_name}'."

--- a/python/ray/train/v2/_internal/execution/callback_manager.py
+++ b/python/ray/train/v2/_internal/execution/callback_manager.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 
 from ray.train.v2.api.exceptions import ControllerError
@@ -37,14 +36,12 @@ class CallbackManager:
                 raise ControllerError(e) from e
 
     async def async_invoke(self, hook_name: str, *args, **context) -> None:
-        """Invoke a hook that may be sync or async (e.g. before_controller_shutdown)."""
         for callback in self._callbacks:
             method, callback_name = self._get_method(callback, hook_name)
             try:
-                result = method(*args, **context)
-                if inspect.isawaitable(result):
-                    await result
+                await method(*args, **context)
             except Exception as e:
+                # TODO: Enable configuration to suppress exceptions.
                 logger.exception(
                     f"Exception raised in callback hook '{hook_name}' from callback "
                     f"'{callback_name}'."

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -465,7 +465,7 @@ class TrainController:
             self._controller_callback_manager.invoke("before_controller_shutdown")
         except ControllerError as e:
             if shutdown_error:
-                logger.warning(
+                logger.exception(
                     "An additional error occurred in the before_controller_shutdown "
                     "callback after a worker group shutdown error. "
                     "This error is being ignored to preserve the original "
@@ -477,11 +477,12 @@ class TrainController:
 
         if shutdown_error:
             if isinstance(controller_state.next_state, ErroredState):
-                logger.warning(
+                logger.exception(
                     "Another error occurred during shutdown after a training error. "
                     "This error is being ignored to preserve the original "
                     "training error. Error: %s",
                     shutdown_error,
+                    exc_info=shutdown_error,
                 )
             else:
                 return TrainControllerLoopIterationResult(

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -461,10 +461,18 @@ class TrainController:
             except Exception as e:
                 shutdown_error = ControllerError(e)
 
-        if not shutdown_error:
-            try:
-                self._controller_callback_manager.invoke("before_controller_shutdown")
-            except ControllerError as e:
+        try:
+            self._controller_callback_manager.invoke("before_controller_shutdown")
+        except ControllerError as e:
+            if shutdown_error:
+                logger.warning(
+                    "An additional error occurred in the before_controller_shutdown "
+                    "callback after a worker group shutdown error. "
+                    "This error is being ignored to preserve the original "
+                    "shutdown error. Error: %s",
+                    e,
+                )
+            else:
                 shutdown_error = e
 
         if shutdown_error:

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -257,7 +257,15 @@ class TrainController:
             return failure_result
 
         if self._worker_group:
-            self._shutdown_worker_group()
+            try:
+                self._shutdown_worker_group()
+            except Exception as e:
+                controller_error = ControllerError(e)
+                failure_decision = self._make_failure_decision(controller_error)
+                return self._execute_failure_decision(
+                    failure_decision,
+                    training_failed_error=controller_error,
+                )
 
         optional_controller_error = self._start_worker_group(
             num_workers=decision.num_workers,

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -251,11 +251,7 @@ class TrainController:
             return failure_result
 
         if self._worker_group:
-            try:
-                self._shutdown_worker_group()
-            except Exception:
-                logger.exception("Error shutting down worker group during resize.")
-                raise
+            self._shutdown_worker_group()
 
         self._start_worker_group(
             num_workers=decision.num_workers,
@@ -590,10 +586,13 @@ class TrainController:
                     ),
                 )
             if worker_group_status.errors:
-                # Raise the worker group error so it is handled by the
-                # catch-all in run(), which routes it through the failure
-                # policy (retry / raise) like any other error.
-                raise worker_group_status.get_worker_group_error()
+                worker_group_error = worker_group_status.get_worker_group_error()
+                failure_decision = self._failure_policy.make_decision(
+                    training_failed_error=worker_group_error,
+                )
+                return self._execute_failure_decision(
+                    failure_decision, training_failed_error=worker_group_error
+                )
 
             scaling_decision = (
                 self._scaling_policy.make_decision_for_running_worker_group(
@@ -719,15 +718,7 @@ class TrainController:
         if self.get_state().is_terminal():
             return
 
-        # Use a manual for-loop instead of CallbackManager here because abort
-        # requires best-effort semantics: every callback must be attempted even
-        # if earlier ones fail. CallbackManager.invoke is fail-fast (raises on
-        # the first error), which would skip remaining callbacks.
-        for callback in self._controller_callbacks:
-            try:
-                callback.before_controller_abort()
-            except Exception as e:
-                logger.exception("Error in before_controller_abort callback: %s", e)
+        self._controller_callback_manager.invoke_best_effort("before_controller_abort")
 
         # Intentionally abort worker group before setting train run state because
         # we only reconcile the states of live train runs.

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -722,12 +722,12 @@ class TrainController:
 
         # Intentionally abort worker group before setting train run state because
         # we only reconcile the states of live train runs.
-        if self._worker_group:
-            try:
+        try:
+            if self._worker_group:
                 self._worker_group.abort()
-                self._set_state(AbortedState())
-            except Exception as e:
-                logger.exception("Error aborting worker group: %s", e)
+            self._set_state(AbortedState())
+        except Exception as e:
+            logger.exception("Error aborting worker group: %s", e)
 
         ray.actor.exit_actor()
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -479,6 +479,7 @@ class TrainController:
             try:
                 self._shutdown_worker_group()
             except Exception as e:
+                logger.exception("Error shutting down worker group.")
                 shutdown_error = ControllerError(e)
 
         try:
@@ -487,7 +488,7 @@ class TrainController:
             )
         except ControllerError as e:
             if shutdown_error:
-                logger.exception(
+                logger.warning(
                     "An additional error occurred in the before_controller_shutdown "
                     "callback after a worker group shutdown error. "
                     "This error is being ignored to preserve the original "
@@ -499,12 +500,11 @@ class TrainController:
 
         if shutdown_error:
             if isinstance(controller_state.next_state, ErroredState):
-                logger.exception(
+                logger.warning(
                     "Another error occurred during shutdown after a training error. "
                     "This error is being ignored to preserve the original "
                     "training error. Error: %s",
                     shutdown_error,
-                    exc_info=shutdown_error,
                 )
             else:
                 return TrainControllerLoopIterationResult(

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -235,30 +235,6 @@ class TrainController:
             )
         return None
 
-    async def _run_controller_hook_async(
-        self,
-        hook_name: str,
-        *args,
-        invoke_failure_decision_callbacks: bool = True,
-        **context,
-    ) -> Optional["TrainControllerLoopIterationResult"]:
-        """Async variant of _run_controller_hook for hooks that may be async
-        (e.g. before_controller_shutdown)."""
-        try:
-            await self._controller_callback_manager.async_invoke(
-                hook_name, *args, **context
-            )
-        except ControllerError as error:
-            failure_decision = self._failure_policy.make_decision(
-                training_failed_error=error,
-            )
-            return self._execute_failure_decision(
-                failure_decision,
-                training_failed_error=error,
-                invoke_failure_decision_callbacks=invoke_failure_decision_callbacks,
-            )
-        return None
-
     def _execute_resize_decision(
         self, decision: ResizeDecision
     ) -> TrainControllerLoopIterationResult:

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -3,7 +3,7 @@ import logging
 import os
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 import pandas as pd
 
@@ -235,6 +235,30 @@ class TrainController:
             )
         return None
 
+    async def _run_controller_hook_async(
+        self,
+        hook_name: str,
+        *args,
+        invoke_failure_decision_callbacks: bool = True,
+        **context,
+    ) -> Optional["TrainControllerLoopIterationResult"]:
+        """Async variant of _run_controller_hook for hooks that may be async
+        (e.g. before_controller_shutdown)."""
+        try:
+            await self._controller_callback_manager.async_invoke(
+                hook_name, *args, **context
+            )
+        except ControllerError as error:
+            failure_decision = self._failure_policy.make_decision(
+                training_failed_error=error,
+            )
+            return self._execute_failure_decision(
+                failure_decision,
+                training_failed_error=error,
+                invoke_failure_decision_callbacks=invoke_failure_decision_callbacks,
+            )
+        return None
+
     def _execute_resize_decision(
         self, decision: ResizeDecision
     ) -> TrainControllerLoopIterationResult:
@@ -247,17 +271,7 @@ class TrainController:
             return failure_result
 
         if self._worker_group:
-            try:
-                self._shutdown_worker_group()
-            except Exception as e:
-                controller_error = ControllerError(e)
-                failure_decision = self._failure_policy.make_decision(
-                    training_failed_error=controller_error,
-                )
-                return self._execute_failure_decision(
-                    failure_decision,
-                    training_failed_error=controller_error,
-                )
+            self._shutdown_worker_group()
 
         optional_controller_error = self._start_worker_group(
             num_workers=decision.num_workers,
@@ -281,17 +295,23 @@ class TrainController:
 
     def _get_retry_state(
         self,
-        controller_state: Union[RunningState, SchedulingState],
+        controller_state: TrainControllerState,
         training_failed_error: TrainingFailedError,
     ) -> TrainControllerState:
-        assert isinstance(controller_state, (RunningState, SchedulingState))
-
         if isinstance(controller_state, RunningState):
             return RestartingState(training_failed_error=training_failed_error)
         elif isinstance(controller_state, SchedulingState):
             return ReschedulingState(training_failed_error=training_failed_error)
         else:
-            raise ValueError(f"Unexpected controller state: {controller_state}")
+            # Cannot retry from this state (e.g. InitializingState,
+            # ShuttingDownState); force shutdown with error.
+            logger.warning(
+                "Cannot retry from state %s; forcing shutdown.",
+                type(controller_state).__name__,
+            )
+            return ShuttingDownState(
+                next_state=ErroredState(training_failed_error=training_failed_error)
+            )
 
     def _execute_failure_decision(
         self,
@@ -441,7 +461,7 @@ class TrainController:
         if failure_result:
             self._set_state(failure_result.next_state)
 
-    def _shutdown(self) -> "TrainControllerLoopIterationResult":
+    async def _shutdown(self) -> "TrainControllerLoopIterationResult":
         """Execute shutdown and return the final state transition.
 
         Shutdown errors are never retried. If an error occurs during shutdown:
@@ -462,7 +482,9 @@ class TrainController:
                 shutdown_error = ControllerError(e)
 
         try:
-            self._controller_callback_manager.invoke("before_controller_shutdown")
+            await self._controller_callback_manager.async_invoke(
+                "before_controller_shutdown"
+            )
         except ControllerError as e:
             if shutdown_error:
                 logger.exception(
@@ -652,7 +674,7 @@ class TrainController:
                 ),
             )
         elif isinstance(controller_state, ShuttingDownState):
-            return self._shutdown()
+            return await self._shutdown()
         else:
             raise ValueError(f"Unexpected controller state: {controller_state}")
 
@@ -688,7 +710,26 @@ class TrainController:
     async def run(self):
         """Run the main control loop. Exits when training is finished or errored."""
         while not self.get_state().is_terminal():
-            await self._run_control_loop_iteration()
+            try:
+                await self._run_control_loop_iteration()
+            except Exception as e:
+                logger.exception("Unhandled error in control loop: %s", e)
+                controller_error = ControllerError(e)
+                try:
+                    failure_decision = self._failure_policy.make_decision(
+                        training_failed_error=controller_error,
+                    )
+                    result = self._execute_failure_decision(
+                        failure_decision,
+                        training_failed_error=controller_error,
+                    )
+                    self._set_state(result.next_state)
+                except Exception:
+                    # Last resort: force into errored state, bypassing callbacks.
+                    logger.exception(
+                        "Failed to execute failure decision, " "forcing error state."
+                    )
+                    self._state = ErroredState(training_failed_error=controller_error)
 
         # Call after_controller_finish with the final result.
         result = self._build_result()
@@ -712,12 +753,19 @@ class TrainController:
             return
 
         for callback in self._controller_callbacks:
-            callback.before_controller_abort()
+            try:
+                callback.before_controller_abort()
+            except Exception as e:
+                logger.exception("Error in before_controller_abort callback: %s", e)
 
         # Intentionally abort worker group before setting train run state because
         # we only reconcile the states of live train runs.
         if self._worker_group:
-            self._worker_group.abort()
+            try:
+                self._worker_group.abort()
+            except Exception as e:
+                logger.exception("Error aborting worker group: %s", e)
+
         self._set_state(AbortedState())
         ray.actor.exit_actor()
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -224,7 +224,9 @@ class TrainController:
         try:
             self._controller_callback_manager.invoke(hook_name, *args, **context)
         except ControllerError as error:
-            failure_decision = self._make_failure_decision(error)
+            failure_decision = self._failure_policy.make_decision(
+                training_failed_error=error,
+            )
             # Avoid re-entering controller callback hooks while handling a callback failure.
             return self._execute_failure_decision(
                 failure_decision,
@@ -232,18 +234,6 @@ class TrainController:
                 invoke_failure_decision_callbacks=invoke_failure_decision_callbacks,
             )
         return None
-
-    def _make_failure_decision(
-        self, training_failed_error: TrainingFailedError
-    ) -> FailureDecision:
-        controller_state = self.get_state()
-        if isinstance(controller_state, ShuttingDownState) and isinstance(
-            controller_state.next_state, ErroredState
-        ):
-            return FailureDecision.RAISE
-        return self._failure_policy.make_decision(
-            training_failed_error=training_failed_error,
-        )
 
     def _execute_resize_decision(
         self, decision: ResizeDecision
@@ -261,7 +251,9 @@ class TrainController:
                 self._shutdown_worker_group()
             except Exception as e:
                 controller_error = ControllerError(e)
-                failure_decision = self._make_failure_decision(controller_error)
+                failure_decision = self._failure_policy.make_decision(
+                    training_failed_error=controller_error,
+                )
                 return self._execute_failure_decision(
                     failure_decision,
                     training_failed_error=controller_error,
@@ -273,7 +265,9 @@ class TrainController:
         )
 
         if optional_controller_error:
-            failure_decision = self._make_failure_decision(optional_controller_error)
+            failure_decision = self._failure_policy.make_decision(
+                training_failed_error=optional_controller_error,
+            )
             return self._execute_failure_decision(
                 failure_decision,
                 training_failed_error=optional_controller_error,
@@ -317,28 +311,6 @@ class TrainController:
             )
             if failure_result:
                 return failure_result
-
-        if isinstance(controller_state, ShuttingDownState):
-            if isinstance(controller_state.next_state, ErroredState):
-                logger.warning(
-                    "Another error occurred during shutdown after a training error. "
-                    "This error is being ignored to preserve the original "
-                    "training error. Error: %s",
-                    training_failed_error,
-                )
-                return TrainControllerLoopIterationResult(
-                    run_attempt_id=self._get_run_attempt_id(),
-                    previous_state=controller_state,
-                    next_state=controller_state.next_state,
-                    training_failed_error=controller_state.next_state.training_failed_error,
-                )
-
-            return TrainControllerLoopIterationResult(
-                run_attempt_id=self._get_run_attempt_id(),
-                previous_state=controller_state,
-                next_state=ErroredState(training_failed_error=training_failed_error),
-                training_failed_error=training_failed_error,
-            )
 
         # TODO: What should we do here?
         # This currently never happens because there must be errors.
@@ -469,19 +441,53 @@ class TrainController:
         if failure_result:
             self._set_state(failure_result.next_state)
 
-    def _shutdown(self) -> Optional["TrainControllerLoopIterationResult"]:
+    def _shutdown(self) -> "TrainControllerLoopIterationResult":
+        """Execute shutdown and return the final state transition.
+
+        Shutdown errors are never retried. If an error occurs during shutdown:
+        - If we're already shutting down after a training error
+          (next_state is ErroredState), the original error is preserved.
+        - Otherwise the shutdown error becomes the training failure.
+        """
+        controller_state = self.get_state()
+        assert isinstance(controller_state, ShuttingDownState)
+
+        shutdown_error = None
+
+        # TODO: move to __del__ after https://github.com/ray-project/ray/issues/53169
         if self._worker_group:
             try:
                 self._shutdown_worker_group()
             except Exception as e:
-                controller_error = ControllerError(e)
-                failure_decision = self._make_failure_decision(controller_error)
-                return self._execute_failure_decision(
-                    failure_decision,
-                    training_failed_error=controller_error,
+                shutdown_error = ControllerError(e)
+
+        if not shutdown_error:
+            try:
+                self._controller_callback_manager.invoke("before_controller_shutdown")
+            except ControllerError as e:
+                shutdown_error = e
+
+        if shutdown_error:
+            if isinstance(controller_state.next_state, ErroredState):
+                logger.warning(
+                    "Another error occurred during shutdown after a training error. "
+                    "This error is being ignored to preserve the original "
+                    "training error. Error: %s",
+                    shutdown_error,
+                )
+            else:
+                return TrainControllerLoopIterationResult(
+                    run_attempt_id=self._get_run_attempt_id(),
+                    previous_state=controller_state,
+                    next_state=ErroredState(training_failed_error=shutdown_error),
+                    training_failed_error=shutdown_error,
                 )
 
-        return self._run_controller_hook("before_controller_shutdown")
+        return TrainControllerLoopIterationResult(
+            run_attempt_id=self._get_run_attempt_id(),
+            previous_state=controller_state,
+            next_state=controller_state.next_state,
+        )
 
     def _shutdown_worker_group(self):
         """Shutdown the worker group and set the worker group to None."""
@@ -585,7 +591,9 @@ class TrainController:
                 raise
             except Exception as e:
                 training_failed_error = ControllerError(e)
-                failure_decision = self._make_failure_decision(training_failed_error)
+                failure_decision = self._failure_policy.make_decision(
+                    training_failed_error=training_failed_error,
+                )
                 return self._execute_failure_decision(
                     failure_decision, training_failed_error=training_failed_error
                 )
@@ -600,7 +608,9 @@ class TrainController:
                 )
             if worker_group_status.errors:
                 worker_group_error = worker_group_status.get_worker_group_error()
-                failure_decision = self._make_failure_decision(worker_group_error)
+                failure_decision = self._failure_policy.make_decision(
+                    training_failed_error=worker_group_error,
+                )
                 return self._execute_failure_decision(
                     failure_decision, training_failed_error=worker_group_error
                 )
@@ -633,15 +643,7 @@ class TrainController:
                 ),
             )
         elif isinstance(controller_state, ShuttingDownState):
-            # TODO: move to __del__ after https://github.com/ray-project/ray/issues/53169
-            failure_result = self._shutdown()
-            if failure_result:
-                return failure_result
-            return TrainControllerLoopIterationResult(
-                run_attempt_id=self._get_run_attempt_id(),
-                previous_state=controller_state,
-                next_state=controller_state.next_state,
-            )
+            return self._shutdown()
         else:
             raise ValueError(f"Unexpected controller state: {controller_state}")
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -192,8 +192,6 @@ class TrainController:
 
         # Generate an initial run attempt ID so that `_run_controller_hook`
         # can reference it if a callback fails during `_start`.
-        # The first control-loop iteration will regenerate it because
-        # `InitializingState.needs_new_run_attempt` is True.
         self._generate_run_attempt_id()
         self._start()
 
@@ -267,9 +265,7 @@ class TrainController:
         )
 
         if optional_controller_error:
-            failure_decision = self._failure_policy.make_decision(
-                training_failed_error=optional_controller_error,
-            )
+            failure_decision = self._make_failure_decision(optional_controller_error)
             return self._execute_failure_decision(
                 failure_decision,
                 training_failed_error=optional_controller_error,
@@ -581,9 +577,7 @@ class TrainController:
                 raise
             except Exception as e:
                 training_failed_error = ControllerError(e)
-                failure_decision = self._failure_policy.make_decision(
-                    training_failed_error=training_failed_error,
-                )
+                failure_decision = self._make_failure_decision(training_failed_error)
                 return self._execute_failure_decision(
                     failure_decision, training_failed_error=training_failed_error
                 )
@@ -598,9 +592,7 @@ class TrainController:
                 )
             if worker_group_status.errors:
                 worker_group_error = worker_group_status.get_worker_group_error()
-                failure_decision = self._failure_policy.make_decision(
-                    training_failed_error=worker_group_error,
-                )
+                failure_decision = self._make_failure_decision(worker_group_error)
                 return self._execute_failure_decision(
                     failure_decision, training_failed_error=worker_group_error
                 )
@@ -681,7 +673,9 @@ class TrainController:
 
         # Call after_controller_finish with the final result.
         result = self._build_result()
-        failure_result = self._run_controller_hook("after_controller_finish", result)
+        failure_result = self._run_controller_hook(
+            "after_controller_finish", result, invoke_failure_decision_callbacks=False
+        )
         # Since we are already in a terminal state, a callback failure should
         # not overwrite the training outcome — log and preserve the result.
         if failure_result:

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -299,6 +299,28 @@ class TrainController:
             if failure_result:
                 return failure_result
 
+        if isinstance(controller_state, ShuttingDownState):
+            if isinstance(controller_state.next_state, ErroredState):
+                logger.warning(
+                    "Another error occurred during shutdown after a training error. "
+                    "This error is being ignored to preserve the original "
+                    "training error. Error: %s",
+                    training_failed_error,
+                )
+                return TrainControllerLoopIterationResult(
+                    run_attempt_id=self._get_run_attempt_id(),
+                    previous_state=controller_state,
+                    next_state=controller_state.next_state,
+                    training_failed_error=controller_state.next_state.training_failed_error,
+                )
+
+            return TrainControllerLoopIterationResult(
+                run_attempt_id=self._get_run_attempt_id(),
+                previous_state=controller_state,
+                next_state=ErroredState(training_failed_error=training_failed_error),
+                training_failed_error=training_failed_error,
+            )
+
         # TODO: What should we do here?
         # This currently never happens because there must be errors.
         if failure_decision == FailureDecision.NOOP:
@@ -425,12 +447,13 @@ class TrainController:
         for callback in self._controller_callbacks:
             callback.after_controller_start(self._train_run_context)
 
-    async def _shutdown(self):
+    def _shutdown(self) -> Optional["TrainControllerLoopIterationResult"]:
         if self._worker_group:
             self._shutdown_worker_group()
 
-        for callback in self._controller_callbacks:
-            await callback.before_controller_shutdown()
+        return self._run_controller_hook(
+            "before_controller_shutdown",
+        )
 
     def _shutdown_worker_group(self):
         """Shutdown the worker group and set the worker group to None."""
@@ -587,7 +610,9 @@ class TrainController:
             )
         elif isinstance(controller_state, ShuttingDownState):
             # TODO: move to __del__ after https://github.com/ray-project/ray/issues/53169
-            await self._shutdown()
+            failure_result = self._shutdown()
+            if failure_result:
+                return failure_result
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
                 previous_state=controller_state,

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -711,6 +711,10 @@ class TrainController:
         if self.get_state().is_terminal():
             return
 
+        # Use a manual for-loop instead of CallbackManager here because abort
+        # requires best-effort semantics: every callback must be attempted even
+        # if earlier ones fail. CallbackManager.invoke is fail-fast (raises on
+        # the first error), which would skip remaining callbacks.
         for callback in self._controller_callbacks:
             try:
                 callback.before_controller_abort()

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -725,10 +725,10 @@ class TrainController:
         if self._worker_group:
             try:
                 self._worker_group.abort()
+                self._set_state(AbortedState())
             except Exception as e:
                 logger.exception("Error aborting worker group: %s", e)
 
-        self._set_state(AbortedState())
         ray.actor.exit_actor()
 
     def _build_result(self) -> Result:

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -190,6 +190,11 @@ class TrainController:
         # TODO: These can be attributes of a RunAttempt?
         self._latest_poll_time = float("-inf")
 
+        # Generate an initial run attempt ID so that `_run_controller_hook`
+        # can reference it if a callback fails during `_start`.
+        # The first control-loop iteration will regenerate it because
+        # `InitializingState.needs_new_run_attempt` is True.
+        self._generate_run_attempt_id()
         self._start()
 
     def _run_controller_hook(
@@ -454,8 +459,11 @@ class TrainController:
         return None
 
     def _start(self):
-        for callback in self._controller_callbacks:
-            callback.after_controller_start(self._train_run_context)
+        failure_result = self._run_controller_hook(
+            "after_controller_start", self._train_run_context
+        )
+        if failure_result:
+            self._set_state(failure_result.next_state)
 
     def _shutdown(self) -> Optional["TrainControllerLoopIterationResult"]:
         if self._worker_group:
@@ -469,9 +477,7 @@ class TrainController:
                     training_failed_error=controller_error,
                 )
 
-        return self._run_controller_hook(
-            "before_controller_shutdown",
-        )
+        return self._run_controller_hook("before_controller_shutdown")
 
     def _shutdown_worker_group(self):
         """Shutdown the worker group and set the worker group to None."""
@@ -673,10 +679,18 @@ class TrainController:
         while not self.get_state().is_terminal():
             await self._run_control_loop_iteration()
 
-        # Call after_controller_finish with the final result
+        # Call after_controller_finish with the final result.
         result = self._build_result()
-        for callback in self._controller_callbacks:
-            callback.after_controller_finish(result)
+        failure_result = self._run_controller_hook("after_controller_finish", result)
+        # Since we are already in a terminal state, a callback failure should
+        # not overwrite the training outcome — log and preserve the result.
+        if failure_result:
+            logger.warning(
+                "A callback failed after training finished. "
+                "This failure is being ignored to preserve the original "
+                "training result. Error: %s",
+                failure_result.training_failed_error,
+            )
 
     async def abort(self):
         """Trigger callback abort hooks and terminate the controller process."""

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -391,7 +391,6 @@ class TrainController:
                         f"with label_selector returned by user-specified callback {selector}"
                     )
                 label_selector = [selector.copy() for _ in range(num_workers)]
-                break
 
         # Calculate num_slices for the worker group if using TPU.
         num_slices = 1
@@ -639,6 +638,15 @@ class TrainController:
 
     async def _run_control_loop_iteration(self):
         """Run a single iteration of the control loop.
+
+        Steps:
+        1. Poll the worker group for status.
+        2. If the worker group is initializing or recovering from an error,
+            make a scaling decision and execute it.
+        3. If the worker group has finished, set the controller state to FINISHED.
+        4. If the worker group has errors, make a failure decision and execute it.
+        5. Otherwise, the worker group is running healthily.
+            Query the scaling policy for a scaling decision and execute it.
 
         Errors raised by ``_step`` are caught and routed through the failure
         policy (retry / raise).  If the failure policy itself fails, the

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -238,7 +238,11 @@ class TrainController:
     def _execute_resize_decision(
         self, decision: ResizeDecision
     ) -> TrainControllerLoopIterationResult:
-        """Executes resize decisions."""
+        """Executes resize decisions.
+
+        Errors from worker group shutdown, callbacks, or worker group startup
+        are allowed to propagate to the catch-all in ``run()``.
+        """
 
         failure_result = self._run_controller_hook(
             "before_controller_execute_resize_decision", decision
@@ -247,27 +251,22 @@ class TrainController:
             return failure_result
 
         if self._worker_group:
-            self._shutdown_worker_group()
+            try:
+                self._shutdown_worker_group()
+            except Exception:
+                logger.exception("Error shutting down worker group during resize.")
+                raise
 
-        optional_controller_error = self._start_worker_group(
+        self._start_worker_group(
             num_workers=decision.num_workers,
             resources_per_worker=decision.resources_per_worker,
         )
 
-        if optional_controller_error:
-            failure_decision = self._failure_policy.make_decision(
-                training_failed_error=optional_controller_error,
-            )
-            return self._execute_failure_decision(
-                failure_decision,
-                training_failed_error=optional_controller_error,
-            )
-        else:
-            return TrainControllerLoopIterationResult(
-                run_attempt_id=self._get_run_attempt_id(),
-                previous_state=self._state,
-                next_state=RunningState(),
-            )
+        return TrainControllerLoopIterationResult(
+            run_attempt_id=self._get_run_attempt_id(),
+            previous_state=self._state,
+            next_state=RunningState(),
+        )
 
     def _get_retry_state(
         self,
@@ -360,18 +359,15 @@ class TrainController:
         self._latest_poll_time = time_monotonic()
         return status
 
-    def _start_worker_group(
-        self, num_workers: int, resources_per_worker: dict
-    ) -> Optional[ControllerError]:
+    def _start_worker_group(self, num_workers: int, resources_per_worker: dict) -> None:
         """Start the worker group and launch the train function.
 
         Args:
             num_workers: The number of workers to start.
             resources_per_worker: The resources per worker to start.
 
-        Returns:
-            None if the worker group was successfully started,
-            ControllerError if the worker group failed to start.
+        Raises:
+            Exception: If the worker group failed to start.
         """
         placement_strategy = self._scaling_policy.scaling_config.placement_strategy
         scaling_config = self._train_run_context.scaling_config
@@ -384,21 +380,18 @@ class TrainController:
             label_selector = [
                 scaling_config.label_selector.copy() for _ in range(num_workers)
             ]
-        try:
-            for callback in self._controller_callbacks:
-                selector = callback.on_controller_start_worker_group(
-                    scaling_config=scaling_config, num_workers=num_workers
-                )
-                if selector:
-                    if label_selector:
-                        logger.warning(
-                            f"Overriding `ScalingConfig.label_selector` {label_selector} "
-                            f"with label_selector returned by user-specified callback {selector}"
-                        )
-                    label_selector = [selector.copy() for _ in range(num_workers)]
-                    break
-        except Exception as e:
-            return ControllerError(e)
+        for callback in self._controller_callbacks:
+            selector = callback.on_controller_start_worker_group(
+                scaling_config=scaling_config, num_workers=num_workers
+            )
+            if selector:
+                if label_selector:
+                    logger.warning(
+                        f"Overriding `ScalingConfig.label_selector` {label_selector} "
+                        f"with label_selector returned by user-specified callback {selector}"
+                    )
+                label_selector = [selector.copy() for _ in range(num_workers)]
+                break
 
         # Calculate num_slices for the worker group if using TPU.
         num_slices = 1
@@ -419,16 +412,11 @@ class TrainController:
             label_selector=label_selector,
             num_slices=num_slices,
         )
-        try:
-            self._worker_group = self.worker_group_cls.create(
-                train_run_context=self._train_run_context,
-                worker_group_context=worker_group_context,
-                callbacks=self._worker_group_callbacks_to_propagate,
-            )
-        except Exception as e:
-            return ControllerError(e)
-
-        return None
+        self._worker_group = self.worker_group_cls.create(
+            train_run_context=self._train_run_context,
+            worker_group_context=worker_group_context,
+            callbacks=self._worker_group_callbacks_to_propagate,
+        )
 
     def _start(self):
         failure_result = self._run_controller_hook(
@@ -592,18 +580,7 @@ class TrainController:
             assert isinstance(controller_state.scaling_decision, ResizeDecision)
             return self._execute_resize_decision(controller_state.scaling_decision)
         elif isinstance(controller_state, RunningState):
-            try:
-                worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
-            except AsyncioActorExit:
-                raise
-            except Exception as e:
-                training_failed_error = ControllerError(e)
-                failure_decision = self._failure_policy.make_decision(
-                    training_failed_error=training_failed_error,
-                )
-                return self._execute_failure_decision(
-                    failure_decision, training_failed_error=training_failed_error
-                )
+            worker_group_status: WorkerGroupPollStatus = await self._poll_workers()
 
             if worker_group_status.finished and not worker_group_status.errors:
                 return TrainControllerLoopIterationResult(
@@ -614,33 +591,32 @@ class TrainController:
                     ),
                 )
             if worker_group_status.errors:
-                worker_group_error = worker_group_status.get_worker_group_error()
-                failure_decision = self._failure_policy.make_decision(
-                    training_failed_error=worker_group_error,
-                )
-                return self._execute_failure_decision(
-                    failure_decision, training_failed_error=worker_group_error
-                )
-            else:
-                scaling_decision = self._scaling_policy.make_decision_for_running_worker_group(
+                # Raise the worker group error so it is handled by the
+                # catch-all in run(), which routes it through the failure
+                # policy (retry / raise) like any other error.
+                raise worker_group_status.get_worker_group_error()
+
+            scaling_decision = (
+                self._scaling_policy.make_decision_for_running_worker_group(
                     worker_group_state=self.get_worker_group().get_worker_group_state(),
                     worker_group_status=worker_group_status,
                 )
+            )
 
-                if isinstance(scaling_decision, NoopDecision):
-                    next_state = RunningState()
-                elif isinstance(scaling_decision, ResizeDecision):
-                    next_state = ResizingState(
-                        scaling_decision=scaling_decision,
-                    )
-                else:
-                    raise ValueError(f"Unexpected scaling decision: {scaling_decision}")
-
-                return TrainControllerLoopIterationResult(
-                    run_attempt_id=self._get_run_attempt_id(),
-                    previous_state=controller_state,
-                    next_state=next_state,
+            if isinstance(scaling_decision, NoopDecision):
+                next_state = RunningState()
+            elif isinstance(scaling_decision, ResizeDecision):
+                next_state = ResizingState(
+                    scaling_decision=scaling_decision,
                 )
+            else:
+                raise ValueError(f"Unexpected scaling decision: {scaling_decision}")
+
+            return TrainControllerLoopIterationResult(
+                run_attempt_id=self._get_run_attempt_id(),
+                previous_state=controller_state,
+                next_state=next_state,
+            )
         elif isinstance(controller_state, ResizingState):
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
@@ -664,14 +640,12 @@ class TrainController:
     async def _run_control_loop_iteration(self):
         """Run a single iteration of the control loop.
 
-        Steps:
-        1. Poll the worker group for status.
-        2. If the worker group is initializing or recovering from an error,
-            make a scaling decision and execute it.
-        3. If the worker group has finished, set the controller state to FINISHED.
-        4. If the worker group has errors, make a failure decision and execute it.
-        5. Otherwise, the worker group is running healthily.
-            Query the scaling policy for a scaling decision and execute it.
+        Errors raised by ``_step`` are caught and routed through the failure
+        policy (retry / raise).  If the failure policy itself fails, the
+        controller is forced into ``ErroredState`` as a last resort.
+
+        ``AsyncioActorExit`` is always re-raised so that the actor can shut
+        down cleanly.
         """
         controller_state = self.get_state()
         assert not controller_state.is_terminal()
@@ -679,33 +653,42 @@ class TrainController:
         if controller_state.needs_new_run_attempt():
             self._generate_run_attempt_id()
 
-        result = await self._step()
+        try:
+            result = await self._step()
+        except AsyncioActorExit:
+            raise
+        except Exception as e:
+            # Preserve the original error type if it is already a
+            # TrainingFailedError (e.g. WorkerGroupError); otherwise
+            # wrap it in a ControllerError.
+            if isinstance(e, TrainingFailedError):
+                training_error = e
+            else:
+                # Log the full traceback only for unexpected errors.
+                logger.exception("Error in control loop iteration: %s", e)
+                training_error = ControllerError(e)
+            try:
+                failure_decision = self._failure_policy.make_decision(
+                    training_failed_error=training_error,
+                )
+                result = self._execute_failure_decision(
+                    failure_decision,
+                    training_failed_error=training_error,
+                )
+            except Exception:
+                # Last resort: force into errored state, bypassing callbacks.
+                logger.exception(
+                    "Failed to execute failure decision, forcing error state."
+                )
+                self._state = ErroredState(training_failed_error=training_error)
+                return
 
         self._set_state(result.next_state)
 
     async def run(self):
         """Run the main control loop. Exits when training is finished or errored."""
         while not self.get_state().is_terminal():
-            try:
-                await self._run_control_loop_iteration()
-            except Exception as e:
-                logger.exception("Unhandled error in control loop: %s", e)
-                controller_error = ControllerError(e)
-                try:
-                    failure_decision = self._failure_policy.make_decision(
-                        training_failed_error=controller_error,
-                    )
-                    result = self._execute_failure_decision(
-                        failure_decision,
-                        training_failed_error=controller_error,
-                    )
-                    self._set_state(result.next_state)
-                except Exception:
-                    # Last resort: force into errored state, bypassing callbacks.
-                    logger.exception(
-                        "Failed to execute failure decision, " "forcing error state."
-                    )
-                    self._state = ErroredState(training_failed_error=controller_error)
+            await self._run_control_loop_iteration()
 
         # Call after_controller_finish with the final result.
         result = self._build_result()

--- a/python/ray/train/v2/tests/test_callback_manager.py
+++ b/python/ray/train/v2/tests/test_callback_manager.py
@@ -68,5 +68,19 @@ def test_invoke_callback_error_returns_controller_error():
     assert isinstance(exc_info.value.controller_failure, ValueError)
 
 
+def test_invoke_best_effort_calls_all_callbacks_even_on_failure():
+    """invoke_best_effort continues calling remaining callbacks after failure."""
+    callback1 = MagicMock()
+    callback1.test_hook = MagicMock(side_effect=ValueError("fail"))
+    callback2 = MagicMock()
+    callback2.test_hook = MagicMock()
+
+    manager = CallbackManager([callback1, callback2])
+    manager.invoke_best_effort("test_hook", "arg")
+
+    callback1.test_hook.assert_called_once_with("arg")
+    callback2.test_hook.assert_called_once_with("arg")
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -8,12 +8,11 @@ from ray.train.v2._internal.exceptions import (
     WorkerGroupStartupFailedError,
     WorkerGroupStartupTimeoutError,
 )
-from ray.train.v2._internal.execution.callback import ControllerCallback
-from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.controller import TrainController
 from ray.train.v2._internal.execution.controller.state import (
     AbortedState,
     ErroredState,
+    FinishedState,
     InitializingState,
     ReschedulingState,
     ResizingState,
@@ -21,7 +20,6 @@ from ray.train.v2._internal.execution.controller.state import (
     RunningState,
     SchedulingState,
     ShuttingDownState,
-    TrainControllerState,
 )
 from ray.train.v2._internal.execution.failure_handling import FailureDecision
 from ray.train.v2._internal.execution.scaling_policy import (
@@ -373,52 +371,63 @@ async def test_controller_abort(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_controller_callback_error_during_state_update_is_handled():
-    """A controller callback hook failure is surfaced via CallbackManager.
+async def test_shutdown_worker_group_failure():
+    """Worker group shutdown failures are routed through the failure decision pipeline.
 
-    This should not crash the control loop; it should transition into shutdown and
-    eventually into an errored terminal state. Callback failures during terminal
-    state transitions should not cause the controller to loop indefinitely.
+    Case 1 (Finished path): failure transitions to ErroredState.
+    Case 2 (Errored path): original training error is preserved.
     """
 
-    class FailingStateUpdateCallback(ControllerCallback):
-        def after_controller_state_update(
-            self,
-            previous_state: TrainControllerState,
-            current_state: TrainControllerState,
-        ):
-            raise ValueError("Intentional error in state update callback")
+    def failing_shutdown():
+        raise RuntimeError("Simulated shutdown failure")
 
+    # --- Case 1: ShuttingDownState(FinishedState) → ErroredState ---
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
-    train_run_context = create_dummy_run_context()
-
     controller = TrainController(
         train_fn_ref=DummyObjectRefWrapper(lambda: None),
-        train_run_context=train_run_context,
+        train_run_context=create_dummy_run_context(),
         scaling_policy=scaling_policy,
         failure_policy=failure_policy,
-        callbacks=[FailingStateUpdateCallback()],
     )
-
-    # When the state-update callback raises, the controller should surface the error
-    # via the failure policy and transition into shutdown -> errored.
-    failure_policy.queue_decision(FailureDecision.RAISE)
-
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=2, resources_per_worker={})
     )
+    await controller._run_control_loop_iteration()  # Init -> Scheduling
+    await controller._run_control_loop_iteration()  # Scheduling -> Running
+    for i in range(2):
+        controller.get_worker_group().finish_worker(i)
+    await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Finished)
+    assert isinstance(controller.get_state().next_state, FinishedState)
 
-    await controller._run_control_loop_iteration()
-    assert isinstance(controller.get_state(), ShuttingDownState)
-    assert isinstance(controller.get_state().next_state, ErroredState)
-    assert isinstance(
-        controller.get_state().next_state.training_failed_error, ControllerError
-    )
-
+    controller.get_worker_group().shutdown = failing_shutdown
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), ErroredState)
     assert isinstance(controller.get_state().training_failed_error, ControllerError)
+
+    # --- Case 2: ShuttingDownState(ErroredState) → preserves original error ---
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(),
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+    )
+    scaling_policy.queue_recovery_decision(
+        ResizeDecision(num_workers=2, resources_per_worker={})
+    )
+    await controller._run_control_loop_iteration()  # Init -> Scheduling
+    await controller._run_control_loop_iteration()  # Scheduling -> Running
+    controller.get_worker_group().error_worker(0)
+    failure_policy.queue_decision(FailureDecision.RAISE)
+    await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Errored)
+    original_error = controller.get_state().next_state.training_failed_error
+
+    controller.get_worker_group().shutdown = failing_shutdown
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ErroredState)
+    assert controller.get_state().training_failed_error is original_error
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -371,17 +371,12 @@ async def test_controller_abort(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_shutdown_worker_group_failure():
-    """Worker group shutdown failures are routed through the failure decision pipeline.
-
-    Case 1 (Finished path): failure transitions to ErroredState.
-    Case 2 (Errored path): original training error is preserved.
-    """
+async def test_shutdown_failure_on_finished_path():
+    """Shutdown failure on the finished path transitions to ErroredState."""
 
     def failing_shutdown():
         raise RuntimeError("Simulated shutdown failure")
 
-    # --- Case 1: ShuttingDownState(FinishedState) → ErroredState ---
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     controller = TrainController(
@@ -395,6 +390,7 @@ async def test_shutdown_worker_group_failure():
     )
     await controller._run_control_loop_iteration()  # Init -> Scheduling
     await controller._run_control_loop_iteration()  # Scheduling -> Running
+
     for i in range(2):
         controller.get_worker_group().finish_worker(i)
     await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Finished)
@@ -405,7 +401,14 @@ async def test_shutdown_worker_group_failure():
     assert isinstance(controller.get_state(), ErroredState)
     assert isinstance(controller.get_state().training_failed_error, ControllerError)
 
-    # --- Case 2: ShuttingDownState(ErroredState) → preserves original error ---
+
+@pytest.mark.asyncio
+async def test_shutdown_failure_on_errored_path():
+    """Shutdown failure on the errored path preserves the original training error."""
+
+    def failing_shutdown():
+        raise RuntimeError("Simulated shutdown failure")
+
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     failure_policy = MockFailurePolicy(failure_config=None)
     controller = TrainController(
@@ -419,6 +422,7 @@ async def test_shutdown_worker_group_failure():
     )
     await controller._run_control_loop_iteration()  # Init -> Scheduling
     await controller._run_control_loop_iteration()  # Scheduling -> Running
+
     controller.get_worker_group().error_worker(0)
     failure_policy.queue_decision(FailureDecision.RAISE)
     await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Errored)

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -475,7 +475,7 @@ async def test_shutdown_and_callback_both_fail_on_finished_path():
     assert isinstance(controller.get_state().training_failed_error, ControllerError)
     assert (
         "shutdown"
-        in str(controller.get_state().training_failed_error.__cause__).lower()
+        in str(controller.get_state().training_failed_error.controller_failure).lower()
     )
 
 

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -445,7 +445,7 @@ async def test_shutdown_and_callback_both_fail_on_finished_path():
         raise RuntimeError("Simulated shutdown failure")
 
     class FailingShutdownHookCallback(ControllerCallback):
-        def before_controller_shutdown(self):
+        async def before_controller_shutdown(self):
             raise ValueError("Intentional error in shutdown callback")
 
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -8,6 +8,8 @@ from ray.train.v2._internal.exceptions import (
     WorkerGroupStartupFailedError,
     WorkerGroupStartupTimeoutError,
 )
+from ray.train.v2._internal.execution.callback import ControllerCallback
+from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.controller import TrainController
 from ray.train.v2._internal.execution.controller.state import (
     AbortedState,
@@ -20,6 +22,7 @@ from ray.train.v2._internal.execution.controller.state import (
     RunningState,
     SchedulingState,
     ShuttingDownState,
+    TrainControllerState,
 )
 from ray.train.v2._internal.execution.failure_handling import FailureDecision
 from ray.train.v2._internal.execution.scaling_policy import (
@@ -310,7 +313,6 @@ async def test_controller_callback(monkeypatch):
         callbacks=[callback],
     )
 
-    controller._start()
     assert callback.start_called
 
     mock_exit_actor = create_autospec(ray.actor.exit_actor)
@@ -432,6 +434,74 @@ async def test_shutdown_failure_on_errored_path():
     await controller._run_control_loop_iteration()
     assert isinstance(controller.get_state(), ErroredState)
     assert controller.get_state().training_failed_error is original_error
+
+
+@pytest.mark.asyncio
+async def test_shutdown_and_callback_both_fail_on_finished_path():
+    """When both worker group shutdown and shutdown callback fail on the finished
+    path, the shutdown error takes precedence (callback error is logged)."""
+
+    def failing_shutdown():
+        raise RuntimeError("Simulated shutdown failure")
+
+    class FailingShutdownHookCallback(ControllerCallback):
+        def before_controller_shutdown(self):
+            raise ValueError("Intentional error in shutdown callback")
+
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(),
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+        callbacks=[FailingShutdownHookCallback()],
+    )
+    scaling_policy.queue_recovery_decision(
+        ResizeDecision(num_workers=2, resources_per_worker={})
+    )
+    await controller._run_control_loop_iteration()  # Init -> Scheduling
+    await controller._run_control_loop_iteration()  # Scheduling -> Running
+
+    for i in range(2):
+        controller.get_worker_group().finish_worker(i)
+    await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Finished)
+    assert isinstance(controller.get_state().next_state, FinishedState)
+
+    controller.get_worker_group().shutdown = failing_shutdown
+    await controller._run_control_loop_iteration()
+    # Shutdown error takes precedence over callback error.
+    assert isinstance(controller.get_state(), ErroredState)
+    assert isinstance(controller.get_state().training_failed_error, ControllerError)
+    assert (
+        "shutdown"
+        in str(controller.get_state().training_failed_error.__cause__).lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_abort_resilient_to_callback_failure(monkeypatch):
+    """abort() completes even when a callback raises."""
+
+    class FailingAbortCallback(ControllerCallback):
+        def before_controller_abort(self):
+            raise ValueError("Intentional error in abort callback")
+
+    mock_exit_actor = create_autospec(ray.actor.exit_actor)
+    monkeypatch.setattr("ray.actor.exit_actor", mock_exit_actor)
+
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(),
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+        callbacks=[FailingAbortCallback()],
+    )
+    await controller.abort()
+    assert mock_exit_actor.call_count == 1
+    assert isinstance(controller.get_state(), AbortedState)
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_controller_callback_behaviour.py
+++ b/python/ray/train/v2/tests/test_controller_callback_behaviour.py
@@ -127,7 +127,6 @@ async def test_controller_callback_hooks_are_invoked():
         callbacks=[callback],
     )
 
-    controller._start()
     assert callback.start_called
 
     scaling_policy.queue_recovery_decision(

--- a/python/ray/train/v2/tests/test_controller_callback_behaviour.py
+++ b/python/ray/train/v2/tests/test_controller_callback_behaviour.py
@@ -1,0 +1,315 @@
+"""Tests for controller callback behaviour.
+
+Verifies that controller callback hooks are invoked at the correct lifecycle
+points, and that callback exceptions are properly caught, routed through the
+failure decision pipeline, and do not crash the control loop.
+"""
+
+import pytest
+
+import ray
+from ray.train.v2._internal.constants import HEALTH_CHECK_INTERVAL_S_ENV_VAR
+from ray.train.v2._internal.execution.callback import ControllerCallback
+from ray.train.v2._internal.execution.context import TrainRunContext
+from ray.train.v2._internal.execution.controller import TrainController
+from ray.train.v2._internal.execution.controller.state import (
+    ErroredState,
+    FinishedState,
+    InitializingState,
+    RunningState,
+    SchedulingState,
+    ShuttingDownState,
+    TrainControllerState,
+)
+from ray.train.v2._internal.execution.failure_handling import FailureDecision
+from ray.train.v2._internal.execution.scaling_policy import ResizeDecision
+from ray.train.v2.api.config import ScalingConfig
+from ray.train.v2.api.exceptions import ControllerError
+from ray.train.v2.tests.util import (
+    DummyObjectRefWrapper,
+    DummyWorkerGroup,
+    MockFailurePolicy,
+    MockScalingPolicy,
+    create_dummy_run_context,
+)
+
+pytestmark = pytest.mark.usefixtures("mock_runtime_context")
+
+
+@pytest.fixture(autouse=True)
+def patch_worker_group(monkeypatch):
+    monkeypatch.setattr(TrainController, "worker_group_cls", DummyWorkerGroup)
+    monkeypatch.setenv(HEALTH_CHECK_INTERVAL_S_ENV_VAR, "0")
+    yield
+    DummyWorkerGroup.set_poll_failure(None)
+    DummyWorkerGroup.set_start_failure(None)
+
+
+@pytest.fixture(autouse=True)
+def ray_start():
+    ray.init()
+    yield
+    ray.shutdown()
+
+
+async def _create_controller_and_drive_to_running(callbacks=None, num_workers=2):
+    """Create a controller and drive it to RunningState."""
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(),
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+        callbacks=callbacks or [],
+    )
+    scaling_policy.queue_recovery_decision(
+        ResizeDecision(num_workers=num_workers, resources_per_worker={})
+    )
+    await controller._run_control_loop_iteration()  # Init -> Scheduling
+    await controller._run_control_loop_iteration()  # Scheduling -> Running
+    assert isinstance(controller.get_state(), RunningState)
+    return controller, scaling_policy, failure_policy
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: verify hooks are invoked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_controller_callback_hooks_are_invoked():
+    """Check that all controller callback hooks are called at the right time."""
+
+    class AssertCallback(ControllerCallback):
+        def __init__(self):
+            self.start_called = False
+            self.latest_state_update = None
+            self.failure_decision_called = False
+            self.resize_decision_called = False
+            self.shutdown_called = False
+
+        def after_controller_start(self, train_run_context: TrainRunContext):
+            self.start_called = True
+
+        def after_controller_state_update(
+            self,
+            previous_state: TrainControllerState,
+            current_state: TrainControllerState,
+        ):
+            self.latest_state_update = (previous_state, current_state)
+
+        def before_controller_execute_failure_decision(
+            self,
+            failure_decision: FailureDecision,
+        ):
+            self.failure_decision_called = True
+
+        def before_controller_execute_resize_decision(
+            self,
+            resize_decision: ResizeDecision,
+        ):
+            self.resize_decision_called = True
+
+        def before_controller_shutdown(self):
+            self.shutdown_called = True
+
+    callback = AssertCallback()
+
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(),
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+        callbacks=[callback],
+    )
+
+    controller._start()
+    assert callback.start_called
+
+    scaling_policy.queue_recovery_decision(
+        ResizeDecision(num_workers=2, resources_per_worker={})
+    )
+
+    await controller._run_control_loop_iteration()
+    assert not callback.resize_decision_called
+    assert isinstance(callback.latest_state_update[0], InitializingState)
+    assert isinstance(callback.latest_state_update[1], SchedulingState)
+
+    await controller._run_control_loop_iteration()
+    assert callback.resize_decision_called
+    assert isinstance(callback.latest_state_update[0], SchedulingState)
+    assert isinstance(callback.latest_state_update[1], RunningState)
+
+    controller.get_worker_group().error_worker(1)
+    failure_policy.queue_decision(FailureDecision.RAISE)
+
+    assert not callback.failure_decision_called
+    await controller._run_control_loop_iteration()
+    assert callback.failure_decision_called
+    assert isinstance(callback.latest_state_update[0], RunningState)
+    assert isinstance(callback.latest_state_update[1], ShuttingDownState)
+
+    await controller._run_control_loop_iteration()
+    assert isinstance(callback.latest_state_update[0], ShuttingDownState)
+    assert isinstance(callback.latest_state_update[1], ErroredState)
+    assert callback.shutdown_called
+
+
+# ---------------------------------------------------------------------------
+# Error handling: callback failures during lifecycle hooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_callback_error_during_state_update():
+    """A callback error in after_controller_state_update should not crash the
+    control loop; it should transition into shutdown → errored. Callback
+    failures during terminal state transitions must not loop indefinitely."""
+
+    class FailingStateUpdateCallback(ControllerCallback):
+        def after_controller_state_update(
+            self,
+            previous_state: TrainControllerState,
+            current_state: TrainControllerState,
+        ):
+            raise ValueError("Intentional error in state update callback")
+
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(),
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+        callbacks=[FailingStateUpdateCallback()],
+    )
+
+    failure_policy.queue_decision(FailureDecision.RAISE)
+    scaling_policy.queue_recovery_decision(
+        ResizeDecision(num_workers=2, resources_per_worker={})
+    )
+
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ShuttingDownState)
+    assert isinstance(controller.get_state().next_state, ErroredState)
+    assert isinstance(
+        controller.get_state().next_state.training_failed_error, ControllerError
+    )
+
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ErroredState)
+    assert isinstance(controller.get_state().training_failed_error, ControllerError)
+
+
+@pytest.mark.asyncio
+async def test_callback_error_during_start():
+    """A callback error in after_controller_start routes through the failure
+    policy and transitions into ShuttingDownState(ErroredState)."""
+
+    class FailingStartCallback(ControllerCallback):
+        def after_controller_start(self, train_run_context):
+            raise ValueError("Intentional error in start callback")
+
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    failure_policy.queue_decision(FailureDecision.RAISE)
+
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(),
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+        callbacks=[FailingStartCallback()],
+    )
+
+    # _start() failed during __init__.
+    assert isinstance(controller.get_state(), ShuttingDownState)
+    assert isinstance(controller.get_state().next_state, ErroredState)
+    assert isinstance(
+        controller.get_state().next_state.training_failed_error, ControllerError
+    )
+
+    # Complete shutdown → terminal ErroredState.
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ErroredState)
+    assert isinstance(controller.get_state().training_failed_error, ControllerError)
+
+
+@pytest.mark.asyncio
+async def test_callback_error_during_finish_is_suppressed():
+    """A callback error in after_controller_finish is caught and suppressed.
+    The controller's terminal state must be preserved."""
+
+    class FailingFinishCallback(ControllerCallback):
+        def after_controller_finish(self, result):
+            raise ValueError("Intentional error in finish callback")
+
+    controller, _, _ = await _create_controller_and_drive_to_running(
+        callbacks=[FailingFinishCallback()]
+    )
+
+    # Finish all workers → ShuttingDown(Finished) → Finished.
+    for i in range(2):
+        controller.get_worker_group().finish_worker(i)
+    await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Finished)
+    await controller._run_control_loop_iteration()  # ShuttingDown -> Finished
+    assert isinstance(controller.get_state(), FinishedState)
+
+    # Simulate what run() does after the loop: invoke after_controller_finish.
+    result = controller._build_result()
+    failure_result = controller._run_controller_hook("after_controller_finish", result)
+
+    # Callback error produces a failure result, but state stays FinishedState.
+    assert failure_result is not None
+    assert isinstance(controller.get_state(), FinishedState)
+
+
+@pytest.mark.asyncio
+async def test_callback_error_during_shutdown_hook():
+    """A before_controller_shutdown callback failure is routed through the
+    failure decision pipeline.
+
+    Case 1 (Finished path): failure transitions to ErroredState.
+    Case 2 (Errored path): original training error is preserved.
+    """
+
+    class FailingShutdownHookCallback(ControllerCallback):
+        def before_controller_shutdown(self):
+            raise ValueError("Intentional error in shutdown callback")
+
+    # --- Case 1: ShuttingDownState(FinishedState) → ErroredState ---
+    controller, _, _ = await _create_controller_and_drive_to_running(
+        callbacks=[FailingShutdownHookCallback()]
+    )
+    for i in range(2):
+        controller.get_worker_group().finish_worker(i)
+    await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Finished)
+    assert isinstance(controller.get_state().next_state, FinishedState)
+
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ErroredState)
+    assert isinstance(controller.get_state().training_failed_error, ControllerError)
+
+    # --- Case 2: ShuttingDownState(ErroredState) → preserves original error ---
+    controller, _, failure_policy = await _create_controller_and_drive_to_running(
+        callbacks=[FailingShutdownHookCallback()]
+    )
+    controller.get_worker_group().error_worker(0)
+    failure_policy.queue_decision(FailureDecision.RAISE)
+    await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Errored)
+    original_error = controller.get_state().next_state.training_failed_error
+
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ErroredState)
+    assert controller.get_state().training_failed_error is original_error
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_controller_callback_behaviour.py
+++ b/python/ray/train/v2/tests/test_controller_callback_behaviour.py
@@ -312,6 +312,98 @@ async def test_callback_error_during_shutdown_hook_on_errored_path():
     assert controller.get_state().training_failed_error is original_error
 
 
+@pytest.mark.asyncio
+async def test_async_shutdown_callback_is_awaited():
+    """Verify that an async before_controller_shutdown callback is actually
+    awaited (not silently dropped)."""
+
+    class AsyncShutdownCallback(ControllerCallback):
+        def __init__(self):
+            self.shutdown_called = False
+
+        async def before_controller_shutdown(self):
+            self.shutdown_called = True
+
+    callback = AsyncShutdownCallback()
+    controller, _, _ = await _create_controller_and_drive_to_running(
+        callbacks=[callback]
+    )
+    for i in range(2):
+        controller.get_worker_group().finish_worker(i)
+    await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Finished)
+    await controller._run_control_loop_iteration()  # ShuttingDown -> Finished
+    assert isinstance(controller.get_state(), FinishedState)
+    assert callback.shutdown_called
+
+
+@pytest.mark.asyncio
+async def test_async_shutdown_callback_error_is_caught():
+    """An async before_controller_shutdown callback that raises is caught
+    and transitions to ErroredState on the finished path."""
+
+    class FailingAsyncShutdownCallback(ControllerCallback):
+        async def before_controller_shutdown(self):
+            raise ValueError("Async shutdown callback failure")
+
+    controller, _, _ = await _create_controller_and_drive_to_running(
+        callbacks=[FailingAsyncShutdownCallback()]
+    )
+    for i in range(2):
+        controller.get_worker_group().finish_worker(i)
+    await controller._run_control_loop_iteration()  # Running -> ShuttingDown(Finished)
+    assert isinstance(controller.get_state().next_state, FinishedState)
+
+    await controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ErroredState)
+    assert isinstance(controller.get_state().training_failed_error, ControllerError)
+
+
+@pytest.mark.asyncio
+async def test_top_level_safety_net_catches_unhandled_error():
+    """The top-level safety net in run() catches exceptions that escape
+    _run_control_loop_iteration and forces the controller into ErroredState."""
+
+    class CrashingStateUpdateCallback(ControllerCallback):
+        """Raises a non-ControllerError that bypasses _set_state's handling."""
+
+        def __init__(self):
+            self._crash_count = 0
+
+        def after_controller_state_update(
+            self,
+            previous_state: TrainControllerState,
+            current_state: TrainControllerState,
+        ):
+            # Only crash on the first few transitions to test the safety net,
+            # then allow terminal transitions to proceed.
+            if isinstance(current_state, (ErroredState, ShuttingDownState)):
+                return
+            self._crash_count += 1
+            if self._crash_count <= 1:
+                raise RuntimeError("Unexpected crash in state update")
+
+    scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
+    failure_policy = MockFailurePolicy(failure_config=None)
+    failure_policy.queue_decision(FailureDecision.RAISE)
+    failure_policy.queue_decision(FailureDecision.RAISE)
+
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(),
+        scaling_policy=scaling_policy,
+        failure_policy=failure_policy,
+        callbacks=[CrashingStateUpdateCallback()],
+    )
+
+    scaling_policy.queue_recovery_decision(
+        ResizeDecision(num_workers=2, resources_per_worker={})
+    )
+
+    # The run() method should not raise — the safety net catches it.
+    await controller.run()
+    assert controller.get_state().is_terminal()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/v2/tests/test_controller_callback_behaviour.py
+++ b/python/ray/train/v2/tests/test_controller_callback_behaviour.py
@@ -360,8 +360,8 @@ async def test_async_shutdown_callback_error_is_caught():
 
 @pytest.mark.asyncio
 async def test_top_level_safety_net_catches_unhandled_error():
-    """The top-level safety net in run() catches exceptions that escape
-    _run_control_loop_iteration and forces the controller into ErroredState."""
+    """The safety net in _run_control_loop_iteration catches exceptions that
+    escape _step and forces the controller into ErroredState."""
 
     class CrashingStateUpdateCallback(ControllerCallback):
         """Raises a non-ControllerError that bypasses _set_state's handling."""

--- a/python/ray/train/v2/tests/test_controller_callback_behaviour.py
+++ b/python/ray/train/v2/tests/test_controller_callback_behaviour.py
@@ -111,7 +111,7 @@ async def test_controller_callback_hooks_are_invoked():
         ):
             self.resize_decision_called = True
 
-        def before_controller_shutdown(self):
+        async def before_controller_shutdown(self):
             self.shutdown_called = True
 
     callback = AssertCallback()
@@ -274,7 +274,7 @@ async def test_callback_error_during_shutdown_hook_on_finished_path():
     transitions to ErroredState with a ControllerError."""
 
     class FailingShutdownHookCallback(ControllerCallback):
-        def before_controller_shutdown(self):
+        async def before_controller_shutdown(self):
             raise ValueError("Intentional error in shutdown callback")
 
     controller, _, _ = await _create_controller_and_drive_to_running(
@@ -296,7 +296,7 @@ async def test_callback_error_during_shutdown_hook_on_errored_path():
     preserves the original training error."""
 
     class FailingShutdownHookCallback(ControllerCallback):
-        def before_controller_shutdown(self):
+        async def before_controller_shutdown(self):
             raise ValueError("Intentional error in shutdown callback")
 
     controller, _, failure_policy = await _create_controller_and_drive_to_running(

--- a/python/ray/train/v2/tests/test_controller_callback_behaviour.py
+++ b/python/ray/train/v2/tests/test_controller_callback_behaviour.py
@@ -5,9 +5,12 @@ points, and that callback exceptions are properly caught, routed through the
 failure decision pipeline, and do not crash the control loop.
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 import ray
+from ray.exceptions import AsyncioActorExit
 from ray.train.v2._internal.constants import HEALTH_CHECK_INTERVAL_S_ENV_VAR
 from ray.train.v2._internal.execution.callback import ControllerCallback
 from ray.train.v2._internal.execution.context import TrainRunContext
@@ -402,6 +405,20 @@ async def test_top_level_safety_net_catches_unhandled_error():
     # The run() method should not raise — the safety net catches it.
     await controller.run()
     assert controller.get_state().is_terminal()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_actor_exit_is_reraised():
+    """AsyncioActorExit raised by _step must propagate through
+    _run_control_loop_iteration without being caught by the safety net."""
+
+    controller, _, _ = await _create_controller_and_drive_to_running()
+
+    with patch.object(
+        controller, "_step", new_callable=AsyncMock, side_effect=AsyncioActorExit()
+    ):
+        with pytest.raises(AsyncioActorExit):
+            await controller._run_control_loop_iteration()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
1. Follow-up to #60117. Makes the train controller resilient to errors in **all** controller lifecycle hooks (`_start`, `_shutdown`, `after_controller_state_update`, `after_controller_finish`, etc.) — previously only the callback manager's `invoke` path was hardened.
Key changes:

- **Centralize error handling in `_run_control_loop_iteration`**: Replace 4 scattered `make_decision` → `_execute_failure_decision` call sites with a single catch-all that routes all errors through the failure policy. Preserves `WorkerGroupError` type (no double-wrapping in `ControllerError`). Falls back to force `ErroredState` if the failure policy itself fails.
- **Route all lifecycle hooks through `CallbackManager`**: Add `async_invoke` for async hooks (e.g. `before_controller_shutdown`). Replace direct `for callback in ...` loops with `_run_controller_hook` / `CallbackManager`, which catches and wraps callback errors as `ControllerError`.
- **Harden `_shutdown`**: Guard `_shutdown_worker_group()` and `before_controller_shutdown` callback with try/except. Prioritize original training error over shutdown errors. Never retry during shutdown.
- **Harden `_set_state`**: Suppress callback failures during terminal state transitions to preserve the root-cause error. Prevent re-entry into `after_controller_state_update` when handling a callback failure.
- **Simplify `_start_worker_group`**: Raise on failure instead of returning `Optional[ControllerError]` — let errors propagate naturally to the catch-all.
- **Guard `AsyncioActorExit`**: Re-raise at `_run_control_loop_iteration` level so it's handled correctly regardless of which state the controller is in.
- **Reduce log noise**: Log detailed tracebacks once at the point of capture; use `logger.warning` for suppression messages instead of `logger.exception`

Please refer to this diagram: 
<img width="1568" height="1208" alt="6eeb7df37cfc0f6acc09fb329d863fe8" src="https://github.com/user-attachments/assets/99ab1edb-ca54-4b87-9465-cb64dddfe537" />


2. see the difference table below:

| Aspect | Before (master) | After (this PR) |
|---|---|---|
| **Callback crashes** | 6 hooks crash the controller | All hooks caught and handled |
| **Error routing** | 4 separate `make_decision` call sites + catch-all | 1 centralized catch-all in `_run_control_loop_iteration` + `_run_controller_hook` for callback-specific guard |
| **`WorkerGroupError` type** | Preserved (handled inline) | Preserved (catch-all checks `isinstance(TrainingFailedError)`) |
| **`AsyncioActorExit`** | Only caught in `_step` RunningState | Caught at `_run_control_loop_iteration` level (covers all states) |
| **Shutdown errors** | Crash controller | Logged + suppressed or → ErroredState (never retry) |
| **`_shutdown_worker_group` in resize** | Unguarded (crashes) | Logged + bubbles to catch-all |
| **Duplicate tracebacks** | `logger.exception` at multiple layers | Traceback logged once at capture point; suppression messages use `logger.warning` |
| **`_start_worker_group`** | Returns `Optional[ControllerError]` | Raises on failure (simpler API) |


## Additional information
1. see repro script and corresponding logs sample here: https://gist.github.com/liulehui/b3c01a6a061250fd1b3da6ab07acd1e5
2. an example of error log ares:
```
class ReproCallback(ControllerCallback, WorkerGroupCallback):
    def before_controller_shutdown(self):
        raise Exception("error raised in ReproCallback with before_controller_shutdown")

def train_func(config):
    # ray.train.report({"success": 1})
    raise Exception("fail train_func")

trainer = TorchTrainer(
    train_func, 
    scaling_config=ray.train.ScalingConfig(num_workers=2),
    run_config=ray.train.RunConfig(
        callbacks=[ReproCallback()]
    )
)
trainer.fit()
```

corresponding log:
```
(TrainController pid=23510) [FailurePolicy] RAISE
(TrainController pid=23510)   Source: worker group
(TrainController pid=23510)   Error count: 1 (max allowed: 0)
(TrainController pid=23510) Error: Training failed due to worker errors:
(TrainController pid=23510) [Rank 0 Error Snippet]:
(TrainController pid=23510) Traceback (most recent call last):
(TrainController pid=23510)   File "/var/folders/gh/t3_93fyn3gvfwyxq_29m82440000gp/T/ipykernel_23459/1460648966.py", line 27, in train_func
(TrainController pid=23510) Exception: fail train_func
(TrainController pid=23510) ray.train.WorkerGroupError: Training failed due to worker errors:
(TrainController pid=23510) [Rank 0 Error Snippet]:
(TrainController pid=23510) Traceback (most recent call last):
(TrainController pid=23510)   File "/var/folders/gh/t3_93fyn3gvfwyxq_29m82440000gp/T/ipykernel_23459/1460648966.py", line 27, in train_func
(TrainController pid=23510) Exception: fail train_func
(TrainController pid=23510) 
(RayTrainWorker pid=23729) Error in training function:
(RayTrainWorker pid=23729) 
(RayTrainWorker pid=23796) 
(TrainController pid=23510) Exception raised in callback hook 'before_controller_shutdown' from callback 'ReproCallback'.
(TrainController pid=23510)   File "/Users/lehui/Desktop/ray/python/ray/train/v2/_internal/execution/callback_manager.py", line 44, in async_invoke
(TrainController pid=23510)     result = method(*args, **context)
(TrainController pid=23510)              ^^^^^^^^^^^^^^^^^^^^^^^^
(TrainController pid=23510)   File "/var/folders/gh/t3_93fyn3gvfwyxq_29m82440000gp/T/ipykernel_23459/1460648966.py", line 22, in before_controller_shutdown
(TrainController pid=23510) Exception: error raised in ReproCallback with before_controller_shutdown
(TrainController pid=23510) Another error occurred during shutdown after a training error. This error is being ignored to preserve the original training error. Error: Training failed due to controller error:
(TrainController pid=23510) error raised in ReproCallback with before_controller_shutdown
---------------------------------------------------------------------------
WorkerGroupError                          Traceback (most recent call last)
Cell In[1], line 40
     27     raise Exception("fail train_func")
     31 trainer = TorchTrainer(
     32     train_func, 
     33     scaling_config=ray.train.ScalingConfig(num_workers=2),
   (...)     38 
     39 )
---> 40 trainer.fit()

File ~/Desktop/ray/python/ray/train/v2/api/data_parallel_trainer.py:194, in DataParallelTrainer.fit(self)
    179 result = self._initialize_and_run_controller(
    180     train_fn_ref=train_fn_ref,
    181     scaling_policy=create_scaling_policy(self.scaling_config),
   (...)    185     validation_config=self.validation_config,
    186 )
    188 if result.error:
    189     # NOTE: If the training run errored out, raise an error back to the
    190     # user's driver script.
    191     # For example, if the Train `FailurePolicy` runs out of retries,
    192     # and one of the workers errors. The controller will exit, and
    193     # the error will be raised here.
--> 194     raise result.error
    196 return result

WorkerGroupError: Training failed due to worker errors:
[Rank 0 Error Snippet]:
Traceback (most recent call last):
  File "/var/folders/gh/t3_93fyn3gvfwyxq_29m82440000gp/T/ipykernel_23459/1460648966.py", line 27, in train_func
Exception: fail train_func
```
