### PR TITLE
[Core] Fix test_failed_task_runtime_env_setup failure on windows (#60852)

### DIFF
--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -246,7 +246,12 @@ def test_failed_task_runtime_env_setup(shutdown_only):
     def f():
         pass
 
-    bad_env = RuntimeEnv(conda={"dependencies": ["_this_does_not_exist"]})
+    bad_env = RuntimeEnv(
+        conda={
+            "channels": ["defaults"],
+            "dependencies": ["_this_does_not_exist"],
+        }
+    )
     with pytest.raises(
         RuntimeEnvSetupError,
     ):


### PR DESCRIPTION
cherry pick [338087b](https://github.com/ray-project/ray/commit/338087b8b03251be29e9b7008f6ac7b5f9378492) into 2.54.0 release branch

## Description
Fix test_failed_task_runtime_env_setup failure on windows by setting conda channel


https://buildkite.com/ray-project/microcheck/builds/37778#019c40d7-bbd1-42fb-92cb-098a04061767/L11749

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
