### PR TITLE
[Core] Unified RayService worker readiness endpoint (Raylet + Serve)

### DIFF
--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -20,6 +20,7 @@ routes = dashboard_optional_utils.DashboardAgentRouteTable
 PUBLIC_EXACT_PATHS = [
     "/api/healthz",
     "/api/local_raylet_healthz",
+    "/api/ray_service_healthz",
 ]
 
 

--- a/python/ray/dashboard/modules/reporter/healthz_agent.py
+++ b/python/ray/dashboard/modules/reporter/healthz_agent.py
@@ -145,9 +145,9 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
                         f"{response.status}: {body}"
                     )
         except aiohttp.ClientError as e:
-            raise Exception(f"Serve proxy health check failed: {e}")
-        except asyncio.TimeoutError:
-            raise Exception("Serve proxy health check timed out")
+            raise Exception(f"Serve proxy health check failed: {e}") from e
+        except asyncio.TimeoutError as e:
+            raise Exception("Serve proxy health check timed out") from e
 
         return "success"
 

--- a/python/ray/dashboard/modules/reporter/healthz_agent.py
+++ b/python/ray/dashboard/modules/reporter/healthz_agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 
 from aiohttp.web import Request, Response
 
@@ -8,10 +9,17 @@ import ray.dashboard.utils as dashboard_utils
 import ray.exceptions
 from ray._raylet import NodeID
 from ray.dashboard.modules.reporter.utils import HealthChecker
+from ray.dashboard.optional_deps import aiohttp
 
 routes = optional_utils.DashboardAgentRouteTable
 
 logger = logging.getLogger(__name__)
+
+_RAY_SERVICE_HEALTHZ_PATH = "/api/ray_service_healthz"
+_SERVE_HEALTH_CHECK_PATH = "/-/healthz"
+_SERVE_HEALTH_CHECK_TIMEOUT_S = 1.0
+_SERVE_HEALTH_CHECK_PORT_ENV = "RAY_DASHBOARD_SERVE_HEALTH_CHECK_PORT"
+_SERVE_HEALTH_CHECK_HOST_ENV = "RAY_DASHBOARD_SERVE_HEALTH_CHECK_HOST"
 
 
 class HealthzAgent(dashboard_utils.DashboardAgentModule):
@@ -83,6 +91,75 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
         checks = {"raylet": raylet_check, "gcs": gcs_check}
 
         # Log failures.
+        status = 200
+        for name, result in checks.items():
+            if isinstance(result, Exception):
+                status = 503
+                logger.warning(f"health check {name} failed: {result}")
+
+        return Response(
+            status=status,
+            text="\n".join([f"{name}: {result}" for name, result in checks.items()]),
+            content_type="application/text",
+        )
+
+    def _is_serve_controller_running(self) -> bool:
+        try:
+            from ray.serve._private.constants import SERVE_NAMESPACE
+            from ray.serve._private.controller import (
+                CONFIG_CHECKPOINT_KEY,
+                LOGGING_CONFIG_CHECKPOINT_KEY,
+            )
+            from ray.serve._private.storage.kv_store import RayInternalKVStore
+        except ImportError:
+            return False
+
+        kv_store = RayInternalKVStore(
+            namespace=f"ray-serve-{SERVE_NAMESPACE}",
+            gcs_client=self._dashboard_agent.gcs_client,
+        )
+        return (
+            kv_store.get(LOGGING_CONFIG_CHECKPOINT_KEY) is not None
+            or kv_store.get(CONFIG_CHECKPOINT_KEY) is not None
+        )
+
+    async def local_serve_health(self) -> str:
+        serve_running = await asyncio.to_thread(self._is_serve_controller_running)
+        if not serve_running:
+            return "success (serve not running)"
+
+        serve_proxy_host = os.environ.get(_SERVE_HEALTH_CHECK_HOST_ENV, "127.0.0.1")
+        serve_proxy_port = os.environ.get(_SERVE_HEALTH_CHECK_PORT_ENV, "8000")
+        serve_health_url = (
+            f"http://{serve_proxy_host}:{serve_proxy_port}{_SERVE_HEALTH_CHECK_PATH}"
+        )
+
+        try:
+            async with self._dashboard_agent.http_session.get(
+                serve_health_url, timeout=_SERVE_HEALTH_CHECK_TIMEOUT_S
+            ) as response:
+                if response.status != 200:
+                    body = await response.text()
+                    raise Exception(
+                        "Serve proxy health check failed with status code "
+                        f"{response.status}: {body}"
+                    )
+        except aiohttp.ClientError as e:
+            raise Exception(f"Serve proxy health check failed: {e}")
+        except asyncio.TimeoutError:
+            raise Exception("Serve proxy health check timed out")
+
+        return "success"
+
+    @routes.get(_RAY_SERVICE_HEALTHZ_PATH)
+    async def ray_service_health(self, req: Request) -> Response:
+        [raylet_check, serve_check] = await asyncio.gather(
+            self.raylet_health(),
+            self.local_serve_health(),
+            return_exceptions=True,
+        )
+        checks = {"raylet": raylet_check, "serve": serve_check}
+
         status = 200
         for name, result in checks.items():
             if isinstance(result, Exception):


### PR DESCRIPTION
## Description
Today, RayService worker readiness in KubeRay is effectively composed outside Ray (via exec/shell checks that combine multiple internal endpoints). This makes readiness semantics fragmented and harder to maintain.

We propose a Ray-defined unified endpoint (for example `/api/ray_service_healthz`) on each worker node for serving readiness.

### Expected Outcome

- Return healthy only when the node is suitable for serving traffic.
- Combine:
  - local raylet health
  - local Serve proxy/application routing health (including intentional non-200 states such as draining)
  - If Serve is not running on the node, behavior should be explicitly defined (for example, fallback to raylet-only health).


## Related issues
Related to #60925 

## Additional information
Related discussion: https://github.com/ray-project/kuberay/pull/4480#pullrequestreview-3771013422
