### PR TITLE
[data][llm] Use the default uniproc as the distributed backend

### DIFF
--- a/release/llm_tests/batch/test_batch_single_node_vllm.py
+++ b/release/llm_tests/batch/test_batch_single_node_vllm.py
@@ -93,7 +93,6 @@ def test_single_node_baseline_benchmark():
         sampling_params=VLLM_SAMPLING_PARAMS,
         pipeline_parallel_size=1,
         tensor_parallel_size=1,
-        distributed_executor_backend="mp",
     )
 
     result.show()


### PR DESCRIPTION
## Description
In Ray Data LLM release benchmarks, we use the `mp` distributed executor backend. `mp` is no longer the default for single-GPU workloads after https://github.com/ray-project/ray/pull/60403. We should do benchmark against the default case which is `uniproc`.

In this PR, we simply remove the `distributed_executor_backend` argument, and let Ray Data LLM auto-resolve to `uni` as the world size is 1. This results in 7s benchmark latency reduction which helps avoid release tests from exceeding the 150s threshold.

## Related issues
Fixes flaky data LLM release test -- `test_batch_single_node_vllm.py`.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
