### PR TITLE
add gpu power and temperature graphs

### DIFF
--- a/python/ray/dashboard/client/src/type/node.d.ts
+++ b/python/ray/dashboard/client/src/type/node.d.ts
@@ -68,6 +68,10 @@ export type GPUStats = {
   memoryUsed: number;
   memoryTotal: number;
   processesPids?: ProcessGPUUsage[];
+  /** Current power draw in milliwatts (e.g. NVIDIA, AMD) */
+  powerMw?: number;
+  /** Temperature in Celsius (e.g. NVIDIA) */
+  temperatureC?: number;
 };
 
 export type NodeDetailExtend = {

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -573,10 +573,10 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
         id=62,
         title="Node GPU Power",
         description="Current GPU power draw per node. Reported in milliwatts; displayed in watts. Supported on NVIDIA and AMD GPUs.",
-        unit="watts",
+        unit="mwatt",
         targets=[
             Target(
-                expr='sum(ray_node_gpu_power_milliwatts{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType, GpuIndex, GpuDeviceName) / 1000',
+                expr='sum(ray_node_gpu_power_milliwatts{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType, GpuIndex, GpuDeviceName)',
                 legend="Power: {{instance}} ({{RayNodeType}}), gpu.{{GpuIndex}}, {{GpuDeviceName}}",
             ),
         ],

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -570,7 +570,7 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
         stack=False,
     ),
     Panel(
-        id=57,
+        id=62,
         title="Node GPU Power",
         description="Current GPU power draw per node. Reported in milliwatts; displayed in watts. Supported on NVIDIA and AMD GPUs.",
         unit="watts",
@@ -584,7 +584,7 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
         stack=False,
     ),
     Panel(
-        id=58,
+        id=63,
         title="Node GPU Temperature",
         description="Current GPU temperature per node in Celsius. Supported on NVIDIA GPUs.",
         unit="celsius",

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -570,6 +570,34 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
         stack=False,
     ),
     Panel(
+        id=57,
+        title="Node GPU Power",
+        description="Current GPU power draw per node. Reported in milliwatts; displayed in watts. Supported on NVIDIA and AMD GPUs.",
+        unit="watts",
+        targets=[
+            Target(
+                expr='sum(ray_node_gpu_power_milliwatts{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType, GpuIndex, GpuDeviceName) / 1000',
+                legend="Power: {{instance}} ({{RayNodeType}}), gpu.{{GpuIndex}}, {{GpuDeviceName}}",
+            ),
+        ],
+        fill=0,
+        stack=False,
+    ),
+    Panel(
+        id=58,
+        title="Node GPU Temperature",
+        description="Current GPU temperature per node in Celsius. Supported on NVIDIA GPUs.",
+        unit="celsius",
+        targets=[
+            Target(
+                expr='sum(ray_node_gpu_temperature_celsius{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType, GpuIndex, GpuDeviceName)',
+                legend="Temperature: {{instance}} ({{RayNodeType}}), gpu.{{GpuIndex}}, {{GpuDeviceName}}",
+            ),
+        ],
+        fill=0,
+        stack=False,
+    ),
+    Panel(
         id=32,
         title="Node Disk IO Speed",
         description="Disk IO per node.",

--- a/python/ray/dashboard/modules/reporter/gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/gpu_providers.py
@@ -11,6 +11,11 @@ import subprocess
 import time
 from typing import Dict, List, Optional, TypedDict, Union
 
+try:
+    from typing import NotRequired
+except ImportError:
+    from typing_extensions import NotRequired
+
 logger = logging.getLogger(__name__)
 
 # Constants
@@ -47,6 +52,9 @@ class GpuUtilizationInfo(TypedDict):
     memory_used: Megabytes
     memory_total: Megabytes
     processes_pids: Optional[Dict[int, ProcessGPUInfo]]
+    # Optional: power in milliwatts, temperature in Celsius (e.g. from NVIDIA/AMD)
+    power_mw: NotRequired[Optional[int]]
+    temperature_c: NotRequired[Optional[int]]
 
 
 # tpu utilization for google tpu
@@ -289,6 +297,8 @@ class NvidiaGpuProvider(GpuProvider):
                 memory_used=int(memory_info.used) // MB,
                 memory_total=int(memory_info.total) // MB,
                 processes_pids=processes_pids,
+                power_mw=None,  # MIG devices don't expose per-slice power in NVML
+                temperature_c=None,
             )
 
         except Exception as e:
@@ -359,6 +369,21 @@ class NvidiaGpuProvider(GpuProvider):
                         f"Failed to retrieve GPU processes using `nvmlDeviceGetComputeRunningProcesses` and `nvmlDeviceGetGraphicsRunningProcesses`: {fallback_e}"
                     )
 
+            # Optional: power (milliwatts) and temperature (Celsius)
+            power_mw = None
+            temperature_c = None
+            try:
+                power_mw = self._pynvml.nvmlDeviceGetPowerUsage(gpu_handle)
+            except (self._pynvml.NVMLError, AttributeError) as e:
+                logger.debug(f"Failed to retrieve GPU power: {e}")
+            try:
+                # NVML_TEMPERATURE_GPU = 0
+                temperature_c = self._pynvml.nvmlDeviceGetTemperature(
+                    gpu_handle, self._pynvml.NVML_TEMPERATURE_GPU
+                )
+            except (self._pynvml.NVMLError, AttributeError) as e:
+                logger.debug(f"Failed to retrieve GPU temperature: {e}")
+
             return GpuUtilizationInfo(
                 index=gpu_index,
                 name=self._decode(self._pynvml.nvmlDeviceGetName(gpu_handle)),
@@ -367,6 +392,8 @@ class NvidiaGpuProvider(GpuProvider):
                 memory_used=int(memory_info.used) // MB,
                 memory_total=int(memory_info.total) // MB,
                 processes_pids=processes_pids,
+                power_mw=power_mw,
+                temperature_c=temperature_c,
             )
 
         except Exception as e:
@@ -451,6 +478,15 @@ class AmdGpuProvider(GpuProvider):
                             gpu_utilization=None,
                         )
 
+                # Optional: power in milliwatts (AMD returns watts)
+                power_mw = None
+                try:
+                    power_watts = self._pyamdsmi.smi_get_device_average_power(i)
+                    if power_watts >= 0:
+                        power_mw = int(power_watts * 1000)
+                except (AttributeError, Exception) as e:
+                    logger.debug(f"Failed to retrieve AMD GPU power: {e}")
+
                 info = GpuUtilizationInfo(
                     index=i,
                     name=self._decode(self._pyamdsmi.smi_get_device_name(i)),
@@ -460,6 +496,8 @@ class AmdGpuProvider(GpuProvider):
                     memory_total=int(self._pyamdsmi.smi_get_device_memory_total(i))
                     // MB,
                     processes_pids=processes_pids,
+                    power_mw=power_mw,
+                    temperature_c=None,  # not exposed in vendored pyamdsmi
                 )
                 gpu_utilizations.append(info)
 

--- a/python/ray/dashboard/modules/reporter/gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/gpu_providers.py
@@ -484,7 +484,7 @@ class AmdGpuProvider(GpuProvider):
                     power_watts = self._pyamdsmi.smi_get_device_average_power(i)
                     if power_watts >= 0:
                         power_mw = int(power_watts * 1000)
-                except (AttributeError, Exception) as e:
+                except Exception as e:
                     logger.debug(f"Failed to retrieve AMD GPU power: {e}")
 
                 info = GpuUtilizationInfo(

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1506,6 +1506,8 @@ class ReporterAgent(
                 gram_total += gpu["memory_total"]
                 gpu_index = gpu.get("index")
                 gpu_name = gpu.get("name")
+                gpu_power_mw = gpu.get("power_mw")
+                gpu_temperature_c = gpu.get("temperature_c")
 
                 gram_available = gram_total - gram_used
 
@@ -1542,19 +1544,19 @@ class ReporterAgent(
                         gram_available_record,
                     ]
                     # Optional GPU power and temperature (e.g. NVIDIA, AMD)
-                    if gpu.get("power_mw") is not None:
+                    if gpu_power_mw is not None:
                         gpu_records_to_add.append(
                             Record(
                                 gauge=METRICS_GAUGES["node_gpu_power_milliwatts"],
-                                value=gpu["power_mw"],
+                                value=gpu_power_mw,
                                 tags=gpu_tags,
                             )
                         )
-                    if gpu.get("temperature_c") is not None:
+                    if gpu_temperature_c is not None:
                         gpu_records_to_add.append(
                             Record(
                                 gauge=METRICS_GAUGES["node_gpu_temperature_celsius"],
-                                value=gpu["temperature_c"],
+                                value=gpu_temperature_c,
                                 tags=gpu_tags,
                             )
                         )

--- a/python/ray/dashboard/modules/reporter/reporter_models.py
+++ b/python/ray/dashboard/modules/reporter/reporter_models.py
@@ -36,6 +36,8 @@ if PYDANTIC_INSTALLED:
         processesPids: Optional[
             List[ProcessGPUInfo]
         ] = None  # converted to list in _compose_stats_payload
+        powerMw: Optional[int] = None  # current power draw in milliwatts
+        temperatureC: Optional[int] = None  # temperature in Celsius
 
     class TpuUtilizationInfo(BaseModel):
         """

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -490,6 +490,101 @@ def test_report_stats_gpu(tmp_path):
     assert isinstance(stats_payload, str)
 
 
+def test_report_stats_gpu_power_and_temperature(tmp_path):
+    """Test that GPU power and temperature metrics are reported when present in stats."""
+    dashboard_agent = MagicMock()
+    dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
+    raylet_client = MagicMock()
+    agent = ReporterAgent(dashboard_agent, raylet_client)
+    agent._is_head_node = True
+
+    stats = copy.deepcopy(STATS_TEMPLATE)
+    stats["gpus"] = [
+        {
+            "index": 0,
+            "uuid": "GPU-aaa",
+            "name": "NVIDIA A10G",
+            "utilization_gpu": 10,
+            "memory_used": 100,
+            "memory_total": 1024,
+            "processes": [],
+            "power_mw": 125000,  # 125 W
+            "temperature_c": 65,
+        },
+        {
+            "index": 1,
+            "uuid": "GPU-bbb",
+            "name": "NVIDIA A10G",
+            "utilization_gpu": 20,
+            "memory_used": 200,
+            "memory_total": 1024,
+            "processes": [],
+            "power_mw": 200000,  # 200 W
+            "temperature_c": 72,
+        },
+    ]
+
+    records = agent._to_records(stats, {})
+
+    power_records = [r for r in records if r.gauge.name == "node_gpu_power_milliwatts"]
+    temp_records = [
+        r for r in records if r.gauge.name == "node_gpu_temperature_celsius"
+    ]
+
+    assert len(power_records) == 2
+    assert len(temp_records) == 2
+
+    power_by_index = {r.tags["GpuIndex"]: r.value for r in power_records}
+    assert power_by_index["0"] == 125000
+    assert power_by_index["1"] == 200000
+
+    temp_by_index = {r.tags["GpuIndex"]: r.value for r in temp_records}
+    assert temp_by_index["0"] == 65
+    assert temp_by_index["1"] == 72
+
+    # Tags should include GpuIndex and GpuDeviceName
+    for r in power_records + temp_records:
+        assert "GpuIndex" in r.tags
+        assert r.tags.get("GpuDeviceName") == "NVIDIA A10G"
+
+
+def test_report_stats_gpu_without_power_temperature(tmp_path):
+    """Test that no power/temperature records are emitted when fields are absent."""
+    dashboard_agent = MagicMock()
+    dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
+    raylet_client = MagicMock()
+    agent = ReporterAgent(dashboard_agent, raylet_client)
+    agent._is_head_node = True
+
+    stats = copy.deepcopy(STATS_TEMPLATE)
+    stats["gpus"] = [
+        {
+            "index": 0,
+            "uuid": "GPU-ccc",
+            "name": "NVIDIA A10G",
+            "utilization_gpu": 0,
+            "memory_used": 0,
+            "memory_total": 1024,
+            "processes": [],
+            # no power_mw or temperature_c
+        },
+    ]
+
+    records = agent._to_records(stats, {})
+
+    power_records = [r for r in records if r.gauge.name == "node_gpu_power_milliwatts"]
+    temp_records = [
+        r for r in records if r.gauge.name == "node_gpu_temperature_celsius"
+    ]
+
+    assert len(power_records) == 0
+    assert len(temp_records) == 0
+
+
 def test_get_tpu_usage(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)


### PR DESCRIPTION
## Description
GPU power and temperature are alternative metrics to gpu utilizatio that be useful to determine the activity of the GPU

<img width="1427" height="310" alt="Screenshot 2026-02-10 at 3 29 21 PM" src="https://github.com/user-attachments/assets/36fe1a8f-a468-490e-bc23-31d5f37850b3" />


