### PR TITLE
[serve][1/n] Introduce gang scheduling

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -90,6 +90,9 @@ See the [model composition guide](serve-model-composition) for how to update cod
    serve.autoscaling_policy.async_inference_autoscaling_policy
    serve.config.AggregationFunction
    serve.config.RequestRouterConfig
+   serve.config.GangSchedulingConfig
+   serve.config.GangPlacementStrategy
+   serve.config.GangRuntimeFailurePolicy
 ```
 
 ### Schemas
@@ -138,6 +141,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
 
    serve.get_replica_context
    serve.context.ReplicaContext
+   serve.context.GangContext
    serve.get_multiplexed_model_id
    serve.get_app_handle
    serve.get_deployment_handle

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -48,7 +48,12 @@ from ray.serve._private.utils import (
     validate_route_prefix,
 )
 from ray.serve.api import ASGIAppReplicaWrapper
-from ray.serve.config import AutoscalingConfig, AutoscalingPolicy, RequestRouterConfig
+from ray.serve.config import (
+    AutoscalingConfig,
+    AutoscalingPolicy,
+    GangSchedulingConfig,
+    RequestRouterConfig,
+)
 from ray.serve.exceptions import RayServeException
 from ray.serve.generated.serve_pb2 import (
     ApplicationArgs as ApplicationArgsProto,
@@ -1737,6 +1742,13 @@ def override_deployment_info(
             placement_group_fallback_strategy=override_fallback_strategy,
         )
         override_options["replica_config"] = replica_config
+
+        if "gang_scheduling_config" in options:
+            gang_scheduling_config = options.get("gang_scheduling_config")
+            if gang_scheduling_config and isinstance(gang_scheduling_config, dict):
+                options["gang_scheduling_config"] = GangSchedulingConfig(
+                    **gang_scheduling_config
+                )
 
         if "request_router_config" in options:
             request_router_config = options.get("request_router_config")

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -17,8 +17,10 @@ from ray.serve.generated.serve_pb2 import (
 )
 from ray.serve.grpc_util import RayServegRPCContext
 from ray.util.annotations import PublicAPI
+from ray.util.placement_group import PlacementGroup
 
 REPLICA_ID_FULL_ID_STR_PREFIX = "SERVE_REPLICA::"
+GANG_PG_NAME_PREFIX = "SERVE_GANG::"
 
 
 @dataclass(frozen=True)
@@ -872,6 +874,48 @@ class CreatePlacementGroupRequest:
     runtime_env: Optional[str] = None
     bundle_label_selector: Optional[List[Dict[str, str]]] = None
     fallback_strategy: Optional[List[Dict[str, Any]]] = None
+
+
+@PublicAPI(stability="alpha")
+@dataclass
+class GangContext:
+    """Context information for a replica that is part of a gang."""
+
+    gang_id: str
+    """Unique identifier for this gang."""
+
+    rank: int
+    """This replica's rank within the gang (0-indexed)."""
+
+    world_size: int
+    """Total number of replicas in this gang."""
+
+    member_replica_ids: List[str]
+    """List of replica IDs in this gang, ordered by rank."""
+
+
+@dataclass
+class GangPlacementGroupRequest:
+    """Request to reserve gang placement groups for a deployment."""
+
+    deployment_id: DeploymentID
+    gang_size: int
+    gang_placement_strategy: str
+    num_replicas_to_add: int
+    replica_resource_dict: Dict[str, float]
+    """Resource requirements for a single replica, used as the bundle
+    template for every bundle in the gang placement group.
+    Example: ``{"CPU": 4, "GPU": 1}``."""
+
+
+@dataclass
+class GangReservationResult:
+    """Result of gang placement group reservation."""
+
+    success: bool
+    """True when all gang PGs were created successfully."""
+    error_message: Optional[str] = None
+    gang_pgs: Dict[int, PlacementGroup] = field(default_factory=dict)
 
 
 # This error is used to raise when a by-value DeploymentResponse is converted to an

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -20,7 +20,6 @@ from ray.util.annotations import PublicAPI
 from ray.util.placement_group import PlacementGroup
 
 REPLICA_ID_FULL_ID_STR_PREFIX = "SERVE_REPLICA::"
-GANG_PG_NAME_PREFIX = "SERVE_GANG::"
 
 
 @dataclass(frozen=True)
@@ -915,7 +914,7 @@ class GangReservationResult:
     success: bool
     """True when all gang PGs were created successfully."""
     error_message: Optional[str] = None
-    gang_pgs: Dict[int, PlacementGroup] = field(default_factory=dict)
+    gang_pgs: Optional[List[PlacementGroup]] = None
 
 
 # This error is used to raise when a by-value DeploymentResponse is converted to an

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -875,24 +875,6 @@ class CreatePlacementGroupRequest:
     fallback_strategy: Optional[List[Dict[str, Any]]] = None
 
 
-@PublicAPI(stability="alpha")
-@dataclass
-class GangContext:
-    """Context information for a replica that is part of a gang."""
-
-    gang_id: str
-    """Unique identifier for this gang."""
-
-    rank: int
-    """This replica's rank within the gang (0-indexed)."""
-
-    world_size: int
-    """Total number of replicas in this gang."""
-
-    member_replica_ids: List[str]
-    """List of replica IDs in this gang, ordered by rank."""
-
-
 @dataclass
 class GangPlacementGroupRequest:
     """Request to reserve gang placement groups for a deployment."""

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -48,7 +48,6 @@ from ray.serve import metrics
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
     DeploymentID,
-    GangContext,
     ReplicaID,
     ReplicaMetricReport,
     ReplicaQueueLengthInfo,
@@ -143,7 +142,7 @@ from ray.serve._private.utils import (
 )
 from ray.serve._private.version import DeploymentVersion
 from ray.serve.config import AutoscalingConfig, HTTPOptions, gRPCOptions
-from ray.serve.context import _get_in_flight_requests
+from ray.serve.context import GangContext, _get_in_flight_requests
 from ray.serve.deployment import Deployment
 from ray.serve.exceptions import (
     BackPressureError,

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -790,6 +790,7 @@ class gRPCOptions(BaseModel):
         return callables
 
 
+@PublicAPI(stability="alpha")
 class GangPlacementStrategy(str, Enum):
     """Placement strategy for replicas within a gang."""
 
@@ -800,6 +801,7 @@ class GangPlacementStrategy(str, Enum):
     """Spread replicas across distinct nodes as evenly as possible (best effort)."""
 
 
+@PublicAPI(stability="alpha")
 class GangRuntimeFailurePolicy(str, Enum):
     """Policy for handling runtime failures of replicas in a gang."""
 

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -788,3 +788,65 @@ class gRPCOptions(BaseModel):
                 raise ModuleNotFoundError(message) from e
 
         return callables
+
+
+class GangPlacementStrategy(str, Enum):
+    """Placement strategy for replicas within a gang."""
+
+    PACK = "PACK"
+    """Pack replicas on as few nodes as possible (best effort)."""
+
+    SPREAD = "SPREAD"
+    """Spread replicas across distinct nodes as evenly as possible (best effort)."""
+
+
+class GangRuntimeFailurePolicy(str, Enum):
+    """Policy for handling runtime failures of replicas in a gang."""
+
+    RESTART_GANG = "RESTART_GANG"
+    """Tear down and restart entire gang atomically when any replica fails."""
+
+    RESTART_REPLICA = "RESTART_REPLICA"
+    """
+    Tear down and restart individual replica when it fails.
+    Other replicas in the gang will continue running.
+    """
+
+
+@PublicAPI(stability="alpha")
+class GangSchedulingConfig(BaseModel):
+    """Configuration for gang scheduling of deployment replicas."""
+
+    # Please keep these options in sync with those in `src/ray/protobuf/serve.proto`.
+
+    gang_size: int = Field(
+        description=(
+            "Number of replicas per gang. "
+            "num_replicas must be a multiple of gang_size."
+        ),
+        ge=1,
+    )
+
+    gang_placement_strategy: GangPlacementStrategy = Field(
+        default=GangPlacementStrategy.PACK,
+        description=(
+            "Placement strategy for replicas within a gang. "
+            "Options: PACK (pack with best effort, default), "
+            "SPREAD (maximize availability)."
+        ),
+    )
+
+    runtime_failure_policy: GangRuntimeFailurePolicy = Field(
+        default=GangRuntimeFailurePolicy.RESTART_GANG,
+        description=(
+            "What to do when a replica fails after gang is running. "
+            "RESTART_GANG: kill and restart entire gang atomically. "
+            "RESTART_REPLICA: kill and restart individual replica."
+        ),
+    )
+
+    @validator("runtime_failure_policy", always=True)
+    def _validate_runtime_failure_policy(cls, v):
+        if v == GangRuntimeFailurePolicy.RESTART_REPLICA:
+            raise NotImplementedError("RESTART_REPLICA policy is not yet implemented.")
+        return v

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -13,7 +13,7 @@ from typing import Callable, Dict, List, Optional
 import ray
 from ray.exceptions import RayActorError
 from ray.serve._private.client import ServeControllerClient
-from ray.serve._private.common import DeploymentID, ReplicaID
+from ray.serve._private.common import DeploymentID, GangContext, ReplicaID
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     SERVE_CONTROLLER_NAME,
@@ -44,6 +44,7 @@ class ReplicaContext:
         - servable_object: instance of the user class/function this replica is running.
         - rank: the rank of the replica.
         - world_size: the number of replicas in the deployment.
+        - gang_context: context information for the gang the replica is part of.
     """
 
     replica_id: ReplicaID
@@ -52,6 +53,7 @@ class ReplicaContext:
     rank: ReplicaRank
     world_size: int
     _handle_registration_callback: Optional[Callable[[DeploymentID], None]] = None
+    gang_context: Optional[GangContext] = None
 
     @property
     def app_name(self) -> str:
@@ -117,6 +119,7 @@ def _set_internal_replica_context(
     rank: ReplicaRank,
     world_size: int,
     handle_registration_callback: Optional[Callable[[str, str], None]] = None,
+    gang_context: Optional[GangContext] = None,
 ):
     global _INTERNAL_REPLICA_CONTEXT
     _INTERNAL_REPLICA_CONTEXT = ReplicaContext(
@@ -126,6 +129,7 @@ def _set_internal_replica_context(
         rank=rank,
         world_size=world_size,
         _handle_registration_callback=handle_registration_callback,
+        gang_context=gang_context,
     )
 
 

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -13,7 +13,7 @@ from typing import Callable, Dict, List, Optional
 import ray
 from ray.exceptions import RayActorError
 from ray.serve._private.client import ServeControllerClient
-from ray.serve._private.common import DeploymentID, GangContext, ReplicaID
+from ray.serve._private.common import DeploymentID, ReplicaID
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     SERVE_CONTROLLER_NAME,
@@ -30,6 +30,24 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 _INTERNAL_REPLICA_CONTEXT: "ReplicaContext" = None
 _global_client: ServeControllerClient = None
+
+
+@DeveloperAPI
+@dataclass
+class GangContext:
+    """Context information for a replica that is part of a gang."""
+
+    gang_id: str
+    """Unique identifier for this gang."""
+
+    rank: int
+    """This replica's rank within the gang (0-indexed)."""
+
+    world_size: int
+    """Total number of replicas in this gang."""
+
+    member_replica_ids: List[str]
+    """List of replica IDs in this gang, ordered by rank."""
 
 
 @DeveloperAPI

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -259,11 +259,7 @@ class Deployment:
         if max_ongoing_requests is None:
             raise ValueError("`max_ongoing_requests` must be non-null, got None.")
 
-        # Later used to validate compatibility with gang_scheduling_config
-        auto_replicas_requested = num_replicas == "auto"
-
         if num_replicas == "auto":
-            num_replicas = None
             max_ongoing_requests, autoscaling_config = handle_num_replicas_auto(
                 max_ongoing_requests, autoscaling_config
             )
@@ -310,7 +306,7 @@ class Deployment:
                 "future!"
             )
 
-        elif num_replicas not in [DEFAULT.VALUE, None]:
+        elif num_replicas not in [DEFAULT.VALUE, None, "auto"]:
             new_deployment_config.num_replicas = num_replicas
 
         if user_config is not DEFAULT.VALUE:
@@ -396,7 +392,7 @@ class Deployment:
             new_deployment_config.gang_scheduling_config = gang_scheduling_config
 
         gc = new_deployment_config.gang_scheduling_config
-        if gc is not None and auto_replicas_requested:
+        if gc is not None and num_replicas == "auto":
             raise ValueError(
                 'num_replicas="auto" is not allowed when '
                 "gang_scheduling_config is provided. Set "

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -12,7 +12,7 @@ from ray.serve._private.config import (
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import DEFAULT, Default
-from ray.serve.config import AutoscalingConfig
+from ray.serve.config import AutoscalingConfig, GangSchedulingConfig
 from ray.serve.schema import DeploymentSchema, LoggingConfig, RayActorOptionsSchema
 from ray.util.annotations import PublicAPI
 
@@ -237,6 +237,9 @@ class Deployment:
         _init_kwargs: Default[Dict[Any, Any]] = DEFAULT.VALUE,
         _internal: bool = False,
         max_constructor_retry_count: Default[int] = DEFAULT.VALUE,
+        gang_scheduling_config: Default[
+            Union[Dict, GangSchedulingConfig, None]
+        ] = DEFAULT.VALUE,
     ) -> "Deployment":
         """Return a copy of this deployment with updated options.
 
@@ -256,6 +259,15 @@ class Deployment:
         if max_ongoing_requests is None:
             raise ValueError("`max_ongoing_requests` must be non-null, got None.")
         if num_replicas == "auto":
+            gang_config = gang_scheduling_config
+            if gang_config is DEFAULT.VALUE:
+                gang_config = self._deployment_config.gang_scheduling_config
+            if gang_config is not None:
+                raise ValueError(
+                    'num_replicas="auto" is not allowed when '
+                    "gang_scheduling_config is provided. Please set "
+                    "num_replicas to a fixed multiple of gang_size."
+                )
             num_replicas = None
             max_ongoing_requests, autoscaling_config = handle_num_replicas_auto(
                 max_ongoing_requests, autoscaling_config
@@ -385,6 +397,17 @@ class Deployment:
                 logging_config = logging_config.dict()
             new_deployment_config.logging_config = logging_config
 
+        if gang_scheduling_config is not DEFAULT.VALUE:
+            new_deployment_config.gang_scheduling_config = gang_scheduling_config
+
+        gc = new_deployment_config.gang_scheduling_config
+        if gc is not None and isinstance(new_deployment_config.num_replicas, int):
+            if new_deployment_config.num_replicas % gc.gang_size != 0:
+                raise ValueError(
+                    f"num_replicas ({new_deployment_config.num_replicas}) must "
+                    f"be a multiple of gang_size ({gc.gang_size})."
+                )
+
         new_replica_config = ReplicaConfig.create(
             func_or_class,
             init_args=_init_args,
@@ -456,6 +479,7 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
         "max_replicas_per_node": d._replica_config.max_replicas_per_node,
         "logging_config": d._deployment_config.logging_config,
         "request_router_config": d._deployment_config.request_router_config,
+        "gang_scheduling_config": d._deployment_config.gang_scheduling_config,
     }
 
     # Let non-user-configured options be set to defaults. If the schema
@@ -517,6 +541,7 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         health_check_timeout_s=s.health_check_timeout_s,
         logging_config=s.logging_config,
         request_router_config=s.request_router_config,
+        gang_scheduling_config=s.gang_scheduling_config,
     )
     deployment_config.user_configured_option_names = (
         s._get_user_configured_option_names()

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -113,6 +113,7 @@ py_test_module_list(
         "test_deployment_scheduler.py",
         "test_deployment_topology.py",
         "test_failure.py",
+        "test_gang_scheduling.py",
         "test_grpc_e2e.py",
         "test_grpc_replica_wrapper.py",
         "test_handle.py",
@@ -508,6 +509,7 @@ py_test_module_list(
     env = {"RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY": "1"},
     files = [
         "test_deployment_scheduler.py",
+        "test_gang_scheduling.py",
         "test_standalone_2.py",
     ],
     name_suffix = "_with_pack_scheduling",

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -812,6 +812,20 @@ def test_deploy_use_custom_autoscaling(serve_instance):
     )
 
 
+def test_deploy_gang_scheduling(serve_instance):
+    """Test that gang scheduling config can be deployed via YAML config."""
+    config_file = os.path.join(
+        os.path.dirname(__file__),
+        "test_config_files",
+        "gang_scheduling.yaml",
+    )
+    subprocess.check_output(["serve", "deploy", config_file], stderr=subprocess.STDOUT)
+    wait_for_condition(
+        lambda: httpx.post(f"{get_application_url(app_name='app1')}/").text
+        == "hello_from_gang_scheduling"
+    )
+
+
 def test_controller_health(serve_instance):
 
     # Wait for control loops to run

--- a/python/ray/serve/tests/test_config_files/gang_scheduling.py
+++ b/python/ray/serve/tests/test_config_files/gang_scheduling.py
@@ -1,0 +1,10 @@
+from ray import serve
+
+
+@serve.deployment
+class GangApp:
+    def __call__(self, *args):
+        return "hello_from_gang_scheduling"
+
+
+app = GangApp.bind()

--- a/python/ray/serve/tests/test_config_files/gang_scheduling.yaml
+++ b/python/ray/serve/tests/test_config_files/gang_scheduling.yaml
@@ -1,0 +1,12 @@
+applications:
+- name: app1
+  route_prefix: /
+  import_path: ray.serve.tests.test_config_files.gang_scheduling:app
+  deployments:
+  - name: GangApp
+    num_replicas: 4
+    ray_actor_options:
+      num_cpus: 0.25
+    gang_scheduling_config:
+      gang_size: 2
+      gang_placement_strategy: PACK

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -668,9 +668,9 @@ async def test_e2e_serve_label_selector_unschedulable(
 class TestGangScheduling:
     """Tests for gang scheduling with placement groups."""
 
-    def test_sufficient_resources(self, ray_start_cluster):
+    def test_sufficient_resources(self, ray_cluster):
         """Verifies that gang scheduling succeeds when cluster has sufficient resources."""
-        cluster = ray_start_cluster
+        cluster = ray_cluster
         cluster.add_node(num_cpus=1)
         cluster.add_node(num_cpus=1)
         cluster.wait_for_nodes()
@@ -700,9 +700,9 @@ class TestGangScheduling:
         serve.delete("gang_app_success")
         serve.shutdown()
 
-    def test_sufficient_resources_with_options(self, ray_start_cluster):
+    def test_sufficient_resources_with_options(self, ray_cluster):
         """Verifies gang scheduling via .options() succeeds and responds to requests."""
-        cluster = ray_start_cluster
+        cluster = ray_cluster
         cluster.add_node(num_cpus=1)
         cluster.add_node(num_cpus=1)
         cluster.wait_for_nodes()

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -15,6 +15,7 @@ from ray.serve._private.deployment_scheduler import (
 )
 from ray.serve._private.test_utils import check_apps_running, get_node_id
 from ray.serve._private.utils import get_head_node_id
+from ray.serve.config import GangSchedulingConfig
 from ray.tests.conftest import *  # noqa
 
 
@@ -662,6 +663,76 @@ async def test_e2e_serve_label_selector_unschedulable(
 
     serve.delete("unschedulable_label_app")
     cluster.remove_node(new_node)
+
+
+class TestGangScheduling:
+    """Tests for gang scheduling with placement groups."""
+
+    def test_sufficient_resources(self, ray_start_cluster):
+        """Verifies that gang scheduling succeeds when cluster has sufficient resources."""
+        cluster = ray_start_cluster
+        cluster.add_node(num_cpus=1)
+        cluster.add_node(num_cpus=1)
+        cluster.wait_for_nodes()
+        ray.init(address=cluster.address)
+        serve.start()
+
+        @serve.deployment(
+            num_replicas=8,
+            ray_actor_options={"num_cpus": 0.25},
+            gang_scheduling_config=GangSchedulingConfig(gang_size=4),
+        )
+        class GangDeployment:
+            def __call__(self):
+                return ray.get_runtime_context().get_node_id()
+
+        handle = serve.run(GangDeployment.bind(), name="gang_app_success")
+        wait_for_condition(
+            check_apps_running,
+            apps=["gang_app_success"],
+        )
+
+        # Verify all replicas are running and responding
+        refs = [handle.remote() for _ in range(8)]
+        results = [ref.result() for ref in refs]
+        assert len(results) == 8
+
+        serve.delete("gang_app_success")
+        serve.shutdown()
+
+    def test_sufficient_resources_with_options(self, ray_start_cluster):
+        """Verifies gang scheduling via .options() succeeds and responds to requests."""
+        cluster = ray_start_cluster
+        cluster.add_node(num_cpus=1)
+        cluster.add_node(num_cpus=1)
+        cluster.wait_for_nodes()
+        ray.init(address=cluster.address)
+        serve.start()
+
+        @serve.deployment(num_replicas=1, ray_actor_options={"num_cpus": 0})
+        class GangDeployment:
+            def __call__(self):
+                return ray.get_runtime_context().get_node_id()
+
+        app = GangDeployment.options(
+            num_replicas=8,
+            ray_actor_options={"num_cpus": 0.25},
+            gang_scheduling_config=GangSchedulingConfig(gang_size=4),
+        ).bind()
+
+        handle = serve.run(app, name="gang_app_options")
+        wait_for_condition(
+            check_apps_running,
+            apps=["gang_app_options"],
+        )
+
+        # Verify all replicas are running and responding
+        refs = [handle.remote() for _ in range(8)]
+        results = [ref.result() for ref in refs]
+        assert len(results) == 8
+
+        serve.delete("gang_app_options")
+        serve.shutdown()
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -15,7 +15,6 @@ from ray.serve._private.deployment_scheduler import (
 )
 from ray.serve._private.test_utils import check_apps_running, get_node_id
 from ray.serve._private.utils import get_head_node_id
-from ray.serve.config import GangSchedulingConfig
 from ray.tests.conftest import *  # noqa
 
 
@@ -663,76 +662,6 @@ async def test_e2e_serve_label_selector_unschedulable(
 
     serve.delete("unschedulable_label_app")
     cluster.remove_node(new_node)
-
-
-class TestGangScheduling:
-    """Tests for gang scheduling with placement groups."""
-
-    def test_sufficient_resources(self, ray_cluster):
-        """Verifies that gang scheduling succeeds when cluster has sufficient resources."""
-        cluster = ray_cluster
-        cluster.add_node(num_cpus=1)
-        cluster.add_node(num_cpus=1)
-        cluster.wait_for_nodes()
-        ray.init(address=cluster.address)
-        serve.start()
-
-        @serve.deployment(
-            num_replicas=8,
-            ray_actor_options={"num_cpus": 0.25},
-            gang_scheduling_config=GangSchedulingConfig(gang_size=4),
-        )
-        class GangDeployment:
-            def __call__(self):
-                return ray.get_runtime_context().get_node_id()
-
-        handle = serve.run(GangDeployment.bind(), name="gang_app_success")
-        wait_for_condition(
-            check_apps_running,
-            apps=["gang_app_success"],
-        )
-
-        # Verify all replicas are running and responding
-        refs = [handle.remote() for _ in range(8)]
-        results = [ref.result() for ref in refs]
-        assert len(results) == 8
-
-        serve.delete("gang_app_success")
-        serve.shutdown()
-
-    def test_sufficient_resources_with_options(self, ray_cluster):
-        """Verifies gang scheduling via .options() succeeds and responds to requests."""
-        cluster = ray_cluster
-        cluster.add_node(num_cpus=1)
-        cluster.add_node(num_cpus=1)
-        cluster.wait_for_nodes()
-        ray.init(address=cluster.address)
-        serve.start()
-
-        @serve.deployment(num_replicas=1, ray_actor_options={"num_cpus": 0})
-        class GangDeployment:
-            def __call__(self):
-                return ray.get_runtime_context().get_node_id()
-
-        app = GangDeployment.options(
-            num_replicas=8,
-            ray_actor_options={"num_cpus": 0.25},
-            gang_scheduling_config=GangSchedulingConfig(gang_size=4),
-        ).bind()
-
-        handle = serve.run(app, name="gang_app_options")
-        wait_for_condition(
-            check_apps_running,
-            apps=["gang_app_options"],
-        )
-
-        # Verify all replicas are running and responding
-        refs = [handle.remote() for _ in range(8)]
-        results = [ref.result() for ref in refs]
-        assert len(results) == 8
-
-        serve.delete("gang_app_options")
-        serve.shutdown()
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -1,0 +1,84 @@
+import sys
+
+import pytest
+
+import ray
+from ray import serve
+from ray._common.test_utils import wait_for_condition
+from ray.serve._private.test_utils import check_apps_running
+from ray.serve.config import GangSchedulingConfig
+from ray.tests.conftest import *  # noqa
+
+
+class TestGangScheduling:
+    """Tests for gang scheduling with placement groups."""
+
+    def test_sufficient_resources(self, ray_cluster):
+        """Verifies that gang scheduling succeeds when cluster has sufficient resources."""
+        cluster = ray_cluster
+        cluster.add_node(num_cpus=1)
+        cluster.add_node(num_cpus=1)
+        cluster.wait_for_nodes()
+        ray.init(address=cluster.address)
+        serve.start()
+
+        @serve.deployment(
+            num_replicas=8,
+            ray_actor_options={"num_cpus": 0.25},
+            gang_scheduling_config=GangSchedulingConfig(gang_size=4),
+        )
+        class GangDeployment:
+            def __call__(self):
+                return ray.get_runtime_context().get_node_id()
+
+        handle = serve.run(GangDeployment.bind(), name="gang_app_success")
+        wait_for_condition(
+            check_apps_running,
+            apps=["gang_app_success"],
+        )
+
+        # Verify all replicas are running and responding
+        refs = [handle.remote() for _ in range(8)]
+        results = [ref.result() for ref in refs]
+        assert len(results) == 8
+
+        serve.delete("gang_app_success")
+        serve.shutdown()
+
+    def test_sufficient_resources_with_options(self, ray_cluster):
+        """Verifies gang scheduling via .options() succeeds and responds to requests."""
+        cluster = ray_cluster
+        cluster.add_node(num_cpus=1)
+        cluster.add_node(num_cpus=1)
+        cluster.wait_for_nodes()
+        ray.init(address=cluster.address)
+        serve.start()
+
+        @serve.deployment(num_replicas=1, ray_actor_options={"num_cpus": 0})
+        class GangDeployment:
+            def __call__(self):
+                return ray.get_runtime_context().get_node_id()
+
+        app = GangDeployment.options(
+            num_replicas=8,
+            ray_actor_options={"num_cpus": 0.25},
+            gang_scheduling_config=GangSchedulingConfig(gang_size=4),
+        ).bind()
+
+        handle = serve.run(app, name="gang_app_options")
+        wait_for_condition(
+            check_apps_running,
+            apps=["gang_app_options"],
+        )
+
+        # Verify all replicas are running and responding
+        refs = [handle.remote() for _ in range(8)]
+        results = [ref.result() for ref in refs]
+        assert len(results) == 8
+
+        serve.delete("gang_app_options")
+        serve.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -22,6 +22,9 @@ from ray.serve.autoscaling_policy import default_autoscaling_policy
 from ray.serve.config import (
     AutoscalingConfig,
     DeploymentMode,
+    GangPlacementStrategy,
+    GangRuntimeFailurePolicy,
+    GangSchedulingConfig,
     HTTPOptions,
     ProxyLocation,
     RequestRouterConfig,
@@ -742,6 +745,170 @@ class TestAutoscalingConfig:
         )
         assert autoscaling_config.get_upscaling_factor() == 0.5
         assert autoscaling_config.get_downscaling_factor() == 0.6
+
+
+class TestGangSchedulingConfig:
+    def test_gang_scheduling_config_validation(self):
+        """Test GangSchedulingConfig field validation."""
+
+        with pytest.raises(ValidationError):
+            GangSchedulingConfig()
+
+        # gang_size must be >= 1
+        with pytest.raises(ValidationError):
+            GangSchedulingConfig(gang_size=0)
+        with pytest.raises(ValidationError):
+            GangSchedulingConfig(gang_size=-1)
+
+        config = GangSchedulingConfig(gang_size=1)
+        assert config.gang_size == 1
+        config = GangSchedulingConfig(gang_size=4)
+        assert config.gang_size == 4
+
+    def test_gang_scheduling_config_defaults(self):
+        """Test GangSchedulingConfig default values."""
+        config = GangSchedulingConfig(gang_size=4)
+
+        assert config.gang_placement_strategy == GangPlacementStrategy.PACK
+        assert config.runtime_failure_policy == GangRuntimeFailurePolicy.RESTART_GANG
+
+    def test_gang_scheduling_config_custom_values(self):
+        """Test GangSchedulingConfig with custom values."""
+        config = GangSchedulingConfig(
+            gang_size=8,
+            gang_placement_strategy=GangPlacementStrategy.SPREAD,
+        )
+        assert config.gang_size == 8
+        assert config.gang_placement_strategy == GangPlacementStrategy.SPREAD
+        assert config.runtime_failure_policy == GangRuntimeFailurePolicy.RESTART_GANG
+
+    def test_gang_placement_strategy_options(self):
+        """Test all GangPlacementStrategy options are valid."""
+        for strategy in GangPlacementStrategy:
+            config = GangSchedulingConfig(gang_size=4, gang_placement_strategy=strategy)
+            assert config.gang_placement_strategy == strategy
+
+    def test_gang_runtime_failure_policy_options(self):
+        """Test all GangRuntimeFailurePolicy options are valid."""
+        # RESTART_GANG should work.
+        config = GangSchedulingConfig(
+            gang_size=4,
+            runtime_failure_policy=GangRuntimeFailurePolicy.RESTART_GANG,
+        )
+        assert config.runtime_failure_policy == GangRuntimeFailurePolicy.RESTART_GANG
+
+        # RESTART_REPLICA is not yet implemented.
+        with pytest.raises(NotImplementedError):
+            GangSchedulingConfig(
+                gang_size=4,
+                runtime_failure_policy=GangRuntimeFailurePolicy.RESTART_REPLICA,
+            )
+
+    def test_gang_scheduling_config_via_decorator_error(self):
+        """Test that gang_scheduling_config validation errors are raised."""
+        with pytest.raises(
+            ValueError, match="num_replicas.*must be a multiple of gang_size"
+        ):
+
+            @serve.deployment(gang_scheduling_config=GangSchedulingConfig(gang_size=4))
+            def f():
+                return "test"
+
+    def test_gang_scheduling_config_auto_num_replicas(self):
+        """Test that num_replicas='auto' is rejected with gang_scheduling_config."""
+
+        with pytest.raises(ValueError, match='num_replicas="auto" is not allowed'):
+
+            @serve.deployment(
+                num_replicas="auto",
+                gang_scheduling_config=GangSchedulingConfig(gang_size=4),
+            )
+            def f():
+                return "test"
+
+    def test_gang_scheduling_config_auto_num_replicas_via_options(self):
+        """Test that num_replicas='auto' is rejected via .options() with gang config."""
+
+        @serve.deployment(
+            num_replicas=4,
+            gang_scheduling_config=GangSchedulingConfig(gang_size=4),
+        )
+        def f():
+            return "test"
+
+        with pytest.raises(ValueError, match='num_replicas="auto" is not allowed'):
+            f.options(num_replicas="auto")
+
+    def test_gang_scheduling_config_proto_roundtrip(self):
+        """Test roundtrip serialization of GangSchedulingConfig through protobuf."""
+
+        # Test with gang_scheduling_config
+        config = DeploymentConfig(
+            num_replicas=8,
+            gang_scheduling_config=GangSchedulingConfig(
+                gang_size=4,
+                gang_placement_strategy=GangPlacementStrategy.SPREAD,
+                runtime_failure_policy=GangRuntimeFailurePolicy.RESTART_GANG,
+            ),
+        )
+        deserialized = DeploymentConfig.from_proto_bytes(config.to_proto_bytes())
+        assert deserialized.gang_scheduling_config is not None
+        assert deserialized.gang_scheduling_config.gang_size == 4
+        assert (
+            deserialized.gang_scheduling_config.gang_placement_strategy
+            == GangPlacementStrategy.SPREAD
+        )
+        assert (
+            deserialized.gang_scheduling_config.runtime_failure_policy
+            == GangRuntimeFailurePolicy.RESTART_GANG
+        )
+
+        # Test without gang_scheduling_config
+        config = DeploymentConfig(num_replicas=2)
+        deserialized = DeploymentConfig.from_proto_bytes(config.to_proto_bytes())
+        assert deserialized.gang_scheduling_config is None
+
+    def test_gang_scheduling_config_via_decorator(self):
+        """Test that gang_scheduling_config can be passed via @serve.deployment decorator."""
+
+        @serve.deployment(
+            num_replicas=8, gang_scheduling_config=GangSchedulingConfig(gang_size=4)
+        )
+        def f():
+            return "test"
+
+        # Verify the config is properly set
+        assert f._deployment_config.gang_scheduling_config is not None
+        assert f._deployment_config.gang_scheduling_config.gang_size == 4
+
+    def test_gang_scheduling_config_invalid_num_replicas_via_options(self):
+        @serve.deployment(
+            num_replicas=4, gang_scheduling_config=GangSchedulingConfig(gang_size=2)
+        )
+        def f():
+            pass
+
+        with pytest.raises(ValueError, match="must be a multiple of gang_size"):
+            f.options(num_replicas=5)
+
+        with pytest.raises(ValueError, match="must be a multiple of gang_size"):
+            f.options(num_replicas=3)
+
+        d = f.options(num_replicas=6)
+        assert d.num_replicas == 6
+
+    def test_gang_scheduling_config_invalid_gang_size_via_options(self):
+        @serve.deployment(
+            num_replicas=4, gang_scheduling_config=GangSchedulingConfig(gang_size=2)
+        )
+        def f():
+            pass
+
+        with pytest.raises(ValueError, match="must be a multiple of gang_size"):
+            f.options(gang_scheduling_config=GangSchedulingConfig(gang_size=3))
+
+        d = f.options(gang_scheduling_config=GangSchedulingConfig(gang_size=4))
+        assert d._deployment_config.gang_scheduling_config.gang_size == 4
 
 
 def test_config_schemas_forward_compatible():

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -16,7 +16,7 @@ from ray.serve.config import (
     GangRuntimeFailurePolicy,
     GangSchedulingConfig,
 )
-from ray.serve.deployment import deployment_to_schema, schema_to_deployment
+from ray.serve.deployment import Deployment, deployment_to_schema, schema_to_deployment
 from ray.serve.schema import (
     DeploymentSchema,
     LoggingConfig,
@@ -986,9 +986,6 @@ def test_unset_fields_schema_to_deployment_ray_actor_options():
 
 def test_gang_scheduling_config_deployment_schema_roundtrip():
     # Ensure deployment_to_schema -> schema_to_deployment preserves gang config
-
-    from ray.serve.deployment import Deployment
-
     gang_config = GangSchedulingConfig(gang_size=2, gang_placement_strategy="SPREAD")
     dc = DeploymentConfig.from_default(
         num_replicas=4,
@@ -1004,7 +1001,6 @@ def test_gang_scheduling_config_deployment_schema_roundtrip():
         _internal=True,
     )
 
-    # deployment -> schema
     schema = deployment_to_schema(dep)
     assert isinstance(schema.gang_scheduling_config, GangSchedulingConfig)
     assert schema.gang_scheduling_config.gang_size == 2
@@ -1014,7 +1010,6 @@ def test_gang_scheduling_config_deployment_schema_roundtrip():
     )
     assert schema.num_replicas == 4
 
-    # schema -> deployment (exercises deployment.py schema_to_deployment)
     dep2 = schema_to_deployment(schema)
     gc2 = dep2._deployment_config.gang_scheduling_config
     assert isinstance(gc2, GangSchedulingConfig)
@@ -1026,7 +1021,6 @@ def test_gang_scheduling_config_deployment_schema_roundtrip():
 def test_schema_to_deployment_gang_scheduling_config_from_dict():
     # Ensure schema_to_deployment works when gang_scheduling_config
     # comes from a parsed dict (the YAML / declarative API path)
-
     schema = DeploymentSchema.parse_obj(
         {
             "name": "GangDep",
@@ -1038,7 +1032,6 @@ def test_schema_to_deployment_gang_scheduling_config_from_dict():
         }
     )
 
-    # Schema validator should have converted dict -> GangSchedulingConfig
     assert isinstance(schema.gang_scheduling_config, GangSchedulingConfig)
 
     dep = schema_to_deployment(schema)

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -8,7 +8,14 @@ import pytest
 
 from ray import serve
 from ray._common.pydantic_compat import ValidationError
-from ray.serve.config import AutoscalingConfig
+from ray.serve._private.config import DeploymentConfig, ReplicaConfig
+from ray.serve._private.utils import DEFAULT
+from ray.serve.config import (
+    AutoscalingConfig,
+    GangPlacementStrategy,
+    GangRuntimeFailurePolicy,
+    GangSchedulingConfig,
+)
 from ray.serve.deployment import deployment_to_schema, schema_to_deployment
 from ray.serve.schema import (
     DeploymentSchema,
@@ -420,6 +427,51 @@ class TestDeploymentSchema:
             {"a": "b"},
         ]
         DeploymentSchema.parse_obj(deployment_schema)
+
+    def test_gang_scheduling_config_basic(self):
+        deployment_schema = self.get_minimal_deployment_schema()
+        deployment_schema["num_replicas"] = 8
+        deployment_schema["gang_scheduling_config"] = {
+            "gang_size": 4,
+            "gang_placement_strategy": "SPREAD",
+        }
+
+        schema = DeploymentSchema.parse_obj(deployment_schema)
+        assert isinstance(schema.gang_scheduling_config, GangSchedulingConfig)
+        assert schema.gang_scheduling_config.gang_size == 4
+        assert (
+            schema.gang_scheduling_config.gang_placement_strategy
+            == GangPlacementStrategy.SPREAD
+        )
+        assert (
+            schema.gang_scheduling_config.runtime_failure_policy
+            == GangRuntimeFailurePolicy.RESTART_GANG
+        )
+
+    def test_gang_scheduling_config_unset(self):
+        deployment_schema = self.get_minimal_deployment_schema()
+        deployment_schema["num_replicas"] = 2
+
+        schema = DeploymentSchema.parse_obj(deployment_schema)
+        assert schema.gang_scheduling_config is DEFAULT.VALUE
+
+    def test_gang_scheduling_config_auto_replicas_rejected(self):
+        deployment_schema = self.get_minimal_deployment_schema()
+        deployment_schema["num_replicas"] = "auto"
+        deployment_schema["gang_scheduling_config"] = {"gang_size": 4}
+
+        with pytest.raises(ValueError, match='num_replicas="auto" is not allowed'):
+            DeploymentSchema.parse_obj(deployment_schema)
+
+    def test_gang_scheduling_config_invalid_num_replicas(self):
+        deployment_schema = self.get_minimal_deployment_schema()
+        deployment_schema["num_replicas"] = 5
+        deployment_schema["gang_scheduling_config"] = {"gang_size": 4}
+
+        with pytest.raises(
+            ValueError, match="num_replicas.*must be a multiple of gang_size"
+        ):
+            DeploymentSchema.parse_obj(deployment_schema)
 
 
 class TestServeApplicationSchema:
@@ -930,6 +982,71 @@ def test_unset_fields_schema_to_deployment_ray_actor_options():
     # Serve will set num_cpus to 1 if it's not set.
     assert len(deployment.ray_actor_options) == 1
     assert deployment.ray_actor_options["num_cpus"] == 1
+
+
+def test_gang_scheduling_config_deployment_schema_roundtrip():
+    # Ensure deployment_to_schema -> schema_to_deployment preserves gang config
+
+    from ray.serve.deployment import Deployment
+
+    gang_config = GangSchedulingConfig(gang_size=2, gang_placement_strategy="SPREAD")
+    dc = DeploymentConfig.from_default(
+        num_replicas=4,
+        gang_scheduling_config=gang_config,
+    )
+    dc.user_configured_option_names = {"num_replicas", "gang_scheduling_config"}
+
+    rc = ReplicaConfig.create(deployment_def="", init_args=(), init_kwargs={})
+    dep = Deployment(
+        name="GangDep",
+        deployment_config=dc,
+        replica_config=rc,
+        _internal=True,
+    )
+
+    # deployment -> schema
+    schema = deployment_to_schema(dep)
+    assert isinstance(schema.gang_scheduling_config, GangSchedulingConfig)
+    assert schema.gang_scheduling_config.gang_size == 2
+    assert (
+        schema.gang_scheduling_config.gang_placement_strategy
+        == GangPlacementStrategy.SPREAD
+    )
+    assert schema.num_replicas == 4
+
+    # schema -> deployment (exercises deployment.py schema_to_deployment)
+    dep2 = schema_to_deployment(schema)
+    gc2 = dep2._deployment_config.gang_scheduling_config
+    assert isinstance(gc2, GangSchedulingConfig)
+    assert gc2.gang_size == 2
+    assert gc2.gang_placement_strategy == GangPlacementStrategy.SPREAD
+    assert dep2.num_replicas == 4
+
+
+def test_schema_to_deployment_gang_scheduling_config_from_dict():
+    # Ensure schema_to_deployment works when gang_scheduling_config
+    # comes from a parsed dict (the YAML / declarative API path)
+
+    schema = DeploymentSchema.parse_obj(
+        {
+            "name": "GangDep",
+            "num_replicas": 6,
+            "gang_scheduling_config": {
+                "gang_size": 3,
+                "gang_placement_strategy": "PACK",
+            },
+        }
+    )
+
+    # Schema validator should have converted dict -> GangSchedulingConfig
+    assert isinstance(schema.gang_scheduling_config, GangSchedulingConfig)
+
+    dep = schema_to_deployment(schema)
+    gc = dep._deployment_config.gang_scheduling_config
+    assert isinstance(gc, GangSchedulingConfig)
+    assert gc.gang_size == 3
+    assert gc.gang_placement_strategy == GangPlacementStrategy.PACK
+    assert dep.num_replicas == 6
 
 
 def test_serve_instance_details_is_json_serializable():

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -126,6 +126,32 @@ message RequestRouterConfig {
 }
 //[End] ROUTING CONFIG
 
+//[Begin] GANG SCHEDULING CONFIG
+// Placement strategy for replicas within a gang.
+enum GangPlacementStrategy {
+  PACK = 0;
+  SPREAD = 1;
+}
+
+// Policy for handling runtime failures of replicas in a gang.
+enum GangRuntimeFailurePolicy {
+  RESTART_GANG = 0;
+  RESTART_REPLICA = 1;
+}
+
+// Configuration for gang scheduling of deployment replicas.
+message GangSchedulingConfig {
+  // Number of replicas per gang. num_replicas must be a multiple of gang_size.
+  int32 gang_size = 1;
+
+  // Placement strategy for replicas within a gang.
+  GangPlacementStrategy gang_placement_strategy = 2;
+
+  // What to do when a replica fails after gang is running.
+  GangRuntimeFailurePolicy runtime_failure_policy = 3;
+}
+//[End] GANG SCHEDULING CONFIG
+
 // Configuration options for a deployment, to be set by the user.
 message DeploymentConfig {
   // The number of processes to start up that will handle requests to this deployment.
@@ -175,6 +201,9 @@ message DeploymentConfig {
 
   // The maximum number of retries in case the deployment constructor results in failure
   int32 max_constructor_retry_count = 20;
+
+  // Gang scheduling configuration for atomic replica scheduling.
+  GangSchedulingConfig gang_scheduling_config = 21;
 }
 
 // Deployment language.


### PR DESCRIPTION
## Description
This PR introduces frontend changes for Ray Serve's gang scheduling feature, enabling atomic scheduling of replica groups. Gang scheduling ensures that sets of replicas are scheduled together -- either all succeed or all fail -- which is critical for distributed serving patterns requiring tight coordination between replicas or across multiple deployments. This is a stepping stone to achieve DP group fault tolerance in Ray Serve LLM.

Note that this PR contains only frontend changes and does not introduce any gang scheduling logic in the scheduler.

## Related issues
RFC: https://github.com/ray-project/ray/issues/60873.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
