### PR TITLE
[ci] add artifacts to Wanda Wheel step

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -78,6 +78,7 @@ steps:
       - release_wheels
       - linux_wheels
       - oss
+      - skip-on-premerge
 
   - name: ray-cpp-core-build
     label: "wanda: cpp core (x86_64)"
@@ -122,6 +123,7 @@ steps:
       - release_wheels
       - linux_wheels
       - oss
+      - skip-on-premerge
 
   - label: ":tapioca: build: jar"
     key: java_wheels

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -190,6 +190,7 @@ steps:
       - release_wheels
       - linux_wheels
       - oss
+      - skip-on-premerge
 
   - name: ray-cpp-core-build-aarch64
     label: "wanda: cpp core (aarch64)"
@@ -236,6 +237,7 @@ steps:
       - release_wheels
       - linux_wheels
       - oss
+      - skip-on-premerge
 
   - name: ray-image-cpu-build-aarch64
     label: "wanda: ray py{{matrix}} cpu (aarch64)"

--- a/ci/docker/ray-cpp-wheel.Dockerfile
+++ b/ci/docker/ray-cpp-wheel.Dockerfile
@@ -86,4 +86,4 @@ fi
 EOF
 
 FROM scratch
-COPY --from=builder /home/forge/ray/.whl/*.whl /
+COPY --from=builder /home/forge/ray/.whl/*.whl /opt/artifacts/

--- a/ci/docker/ray-cpp-wheel.wanda.yaml
+++ b/ci/docker/ray-cpp-wheel.wanda.yaml
@@ -26,3 +26,6 @@ build_args:
   - RAY_CPP_CORE_IMAGE=cr.ray.io/rayproject/ray-cpp-core$ARCH_SUFFIX
   - RAY_JAVA_IMAGE=cr.ray.io/rayproject/ray-java-build$ARCH_SUFFIX
   - RAY_DASHBOARD_IMAGE=cr.ray.io/rayproject/ray-dashboard$ARCH_SUFFIX
+artifacts:
+  - src: "/opt/artifacts/"
+    dst: "./"

--- a/ci/docker/ray-image.Dockerfile
+++ b/ci/docker/ray-image.Dockerfile
@@ -22,7 +22,7 @@ ARG RAY_VERSION=3.0.0.dev0
 LABEL io.ray.ray-commit="${RAY_COMMIT}"
 LABEL io.ray.ray-version="${RAY_VERSION}"
 
-COPY --from=wheel-source /*.whl /home/ray/
+COPY --from=wheel-source /opt/artifacts/*.whl /home/ray/
 
 # Install Ray wheel with all extras
 # Uses requirements_compiled.txt from base image (already at /home/ray/)

--- a/ci/docker/ray-wheel.Dockerfile
+++ b/ci/docker/ray-wheel.Dockerfile
@@ -86,4 +86,4 @@ fi
 EOF
 
 FROM scratch
-COPY --from=builder /home/forge/ray/.whl/*.whl /
+COPY --from=builder /home/forge/ray/.whl/*.whl /opt/artifacts/

--- a/ci/docker/ray-wheel.wanda.yaml
+++ b/ci/docker/ray-wheel.wanda.yaml
@@ -22,3 +22,6 @@ build_args:
   - RAY_CORE_IMAGE=cr.ray.io/rayproject/ray-core-py$PYTHON_VERSION$ARCH_SUFFIX
   - RAY_JAVA_IMAGE=cr.ray.io/rayproject/ray-java-build$ARCH_SUFFIX
   - RAY_DASHBOARD_IMAGE=cr.ray.io/rayproject/ray-dashboard$ARCH_SUFFIX
+artifacts:
+  - src: "/opt/artifacts/"
+    dst: "./"


### PR DESCRIPTION
rayci v0.29+ supports direct upload, so we can do that as part of the initial wheel step

We can also remove the duplicate upload in premerge, as that was only used for purposes of uploading Wheel to artifacts.

Topic: up-artifact
Relative: ci-029
Signed-off-by: andrew <andrew@anyscale.com>