### PR TITLE
[data] add checkpoint data load method on LoadCheckpointCallback

### DIFF
--- a/python/ray/data/checkpoint/load_checkpoint_callback.py
+++ b/python/ray/data/checkpoint/load_checkpoint_callback.py
@@ -33,11 +33,15 @@ class LoadCheckpointCallback(ExecutionCallback):
         """
         return BatchBasedCheckpointFilter(config)
 
+    def _load_checkpoint_data(self) -> ObjectRef[Block]:
+        """Load checkpoint data from storage (via the checkpoint filter)."""
+        return self._ckpt_filter.load_checkpoint()
+
     def before_execution_starts(self, executor: StreamingExecutor):
         assert self._config is executor._data_context.checkpoint_config
 
         # Load checkpoint data before execution starts.
-        self._checkpoint_ref = self._ckpt_filter.load_checkpoint()
+        self._checkpoint_ref = self._load_checkpoint_data()
 
     def after_execution_succeeds(self, executor: StreamingExecutor):
         assert self._config is executor._data_context.checkpoint_config

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ray._private.ray_constants import env_bool, env_float, env_integer
 from ray.data._internal.logging import update_dataset_logger_for_worker
-from ray.data.checkpoint.interfaces import CheckpointBackend, CheckpointConfig
+from ray.data.checkpoint import CheckpointBackend, CheckpointConfig
 from ray.util.annotations import DeveloperAPI
 from ray.util.scheduling_strategies import SchedulingStrategyT
 

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -18,6 +18,7 @@ from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
 from ray.data._internal.logical.operators import Read, Write
 from ray.data._internal.logical.optimizers import get_execution_plan
 from ray.data.block import BlockAccessor
+from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_filter import (
     BatchBasedCheckpointFilter,
 )
@@ -26,7 +27,6 @@ from ray.data.checkpoint.checkpoint_writer import (
 )
 from ray.data.checkpoint.interfaces import (
     CheckpointBackend,
-    CheckpointConfig,
     InvalidCheckpointingConfig,
 )
 from ray.data.context import DataContext


### PR DESCRIPTION
## Description

Update the LoadCheckpointCallback to have an explicit method for loading the checkpoint block, for testing and patchability/subclassing purposes. Also update some imports from the `ray.data.checkpoint` alias instead of from the full path.