### PR TITLE
[ci] add Google Cloud CLI to forge

### DIFF
--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -47,13 +47,21 @@ Components: main
 Architectures: $(dpkg --print-architecture)
 Signed-by: /etc/apt/keyrings/microsoft.gpg" | tee /etc/apt/sources.list.d/azure-cli.sources
 
+# Add Google Cloud CLI repository
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg |
+  gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg
+echo "deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] \
+  https://packages.cloud.google.com/apt cloud-sdk main" |
+  tee /etc/apt/sources.list.d/google-cloud-sdk.list
+
 # Install packages
 
 apt-get update
 apt-get install -y \
   awscli nodejs build-essential python-is-python3 \
   python3-pip openjdk-8-jre wget jq \
-  docker-ce-cli azure-cli="${AZ_VER}"-1~"${AZ_DIST}"
+  docker-ce-cli azure-cli="${AZ_VER}"-1~"${AZ_DIST}" \
+  google-cloud-cli
 
 # Install uv
 curl -fsSL https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
@@ -140,4 +148,4 @@ ENV DOCKER_API_VERSION=1.43
 CMD ["echo", "ray forge"]
 
 
-# last update: 2026-01-13
+# last update: 2026-02-10

--- a/release/gcloud_docker_login.sh
+++ b/release/gcloud_docker_login.sh
@@ -4,27 +4,31 @@
 
 set -euo pipefail
 
-ARCH=$(uname -m)
-case "$ARCH" in
-    x86_64)
-        GCLOUD_ARCH="x86_64"
-        ;;
-    aarch64|arm64)
-        GCLOUD_ARCH="arm"
-        ;;
-    *)
-        echo "Unsupported architecture: $ARCH"
-        exit 1
-        ;;
-esac
+# Only install gcloud if not already available
+if ! command -v gcloud &> /dev/null; then
+  ARCH=$(uname -m)
+  case "$ARCH" in
+      x86_64)
+          GCLOUD_ARCH="x86_64"
+          ;;
+      aarch64|arm64)
+          GCLOUD_ARCH="arm"
+          ;;
+      *)
+          echo "Unsupported architecture: $ARCH"
+          exit 1
+          ;;
+  esac
 
-GCLOUD_VERSION="550.0.0"
-GCLOUD_TARBALL="google-cloud-cli-${GCLOUD_VERSION}-linux-${GCLOUD_ARCH}.tar.gz"
+  GCLOUD_VERSION="550.0.0"
+  GCLOUD_TARBALL="google-cloud-cli-${GCLOUD_VERSION}-linux-${GCLOUD_ARCH}.tar.gz"
 
-curl -fO "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TARBALL}"
-tar -xf "$GCLOUD_TARBALL"
-./google-cloud-sdk/install.sh -q
-PATH="$(pwd)/google-cloud-sdk/bin:$PATH"
-export PATH
+  curl -fO "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TARBALL}"
+  tar -xf "$GCLOUD_TARBALL"
+  ./google-cloud-sdk/install.sh -q
+  PATH="$(pwd)/google-cloud-sdk/bin:$PATH"
+  export PATH
+fi
+
 gcloud auth login --cred-file="$1" --quiet
 gcloud auth configure-docker us-west1-docker.pkg.dev --quiet


### PR DESCRIPTION
Needed for simplfying the release test push process. Adding optional skip in gcloud_docker_login in case other workflows outside of Forge depend on it.

See: https://github.com/ray-project/ray/pull/60796

Topic: forge-google-cli
Signed-off-by: andrew <andrew@anyscale.com>