### PR TITLE
[docker] Upgrade production ray images from Ubuntu 22.04 to 24.04

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,9 @@
 Overview of how the ray images are built:
 
-Images without a "-cpu" or "-gpu" tag are built on ``ubuntu:22.04``. They are just an alias for **-cpu** (e.g. ``ray:latest`` is the same as ``ray:latest-cpu``).
+Images without a "-cpu" or "-gpu" tag are built on ``ubuntu:24.04``. They are just an alias for **-cpu** (e.g. ``ray:latest`` is the same as ``ray:latest-cpu``).
 
 ```
-ubuntu:22.04
+ubuntu:24.04
 └── base-deps:cpu
     └── ray:cpu
 

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -3,7 +3,7 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
 # The GPU options are NVIDIA CUDA developer images.
-ARG BASE_IMAGE="ubuntu:22.04"
+ARG BASE_IMAGE="ubuntu:24.04"
 
 # --- HAProxy Build Stage ---
 FROM ${BASE_IMAGE} AS haproxy-builder

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -94,6 +94,8 @@ APT_PKGS=(
 
 apt-get install -y "${APT_PKGS[@]}"
 
+# Ubuntu 24.04 creates a default 'ubuntu' user with UID 1000; remove it first.
+userdel -r ubuntu 2>/dev/null || true
 useradd -ms /bin/bash -d /home/ray ray --uid $RAY_UID --gid $RAY_GID
 usermod -aG sudo ray
 echo 'ray ALL=NOPASSWD: ALL' >> /etc/sudoers

--- a/docker/base-deps/cpu.wanda.yaml
+++ b/docker/base-deps/cpu.wanda.yaml
@@ -1,5 +1,5 @@
 name: "ray-py$PYTHON_VERSION-cpu-base$ARCH_SUFFIX"
-froms: ["ubuntu:22.04"]
+froms: ["ubuntu:24.04"]
 dockerfile: docker/base-deps/Dockerfile
 srcs:
   - python/requirements_compiled.txt
@@ -7,6 +7,6 @@ srcs:
   - python/deplocks/base_deps/ray_base_deps_py$PYTHON_VERSION.lock
 build_args:
   - PYTHON_VERSION
-  - BASE_IMAGE=ubuntu:22.04
+  - BASE_IMAGE=ubuntu:24.04
 tags:
   - cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cpu-base$ARCH_SUFFIX

--- a/docker/base-deps/cuda.wanda.yaml
+++ b/docker/base-deps/cuda.wanda.yaml
@@ -1,5 +1,5 @@
 name: "ray-py$PYTHON_VERSION-cu$CUDA_VERSION-base$ARCH_SUFFIX"
-froms: ["nvidia/cuda:$CUDA_VERSION-devel-ubuntu22.04"]
+froms: ["nvidia/cuda:$CUDA_VERSION-devel-ubuntu24.04"]
 dockerfile: docker/base-deps/Dockerfile
 srcs:
   - python/requirements_compiled.txt
@@ -7,6 +7,6 @@ srcs:
   - python/deplocks/base_deps/ray_base_deps_py$PYTHON_VERSION.lock
 build_args:
   - PYTHON_VERSION
-  - BASE_IMAGE=nvidia/cuda:$CUDA_VERSION-devel-ubuntu22.04
+  - BASE_IMAGE=nvidia/cuda:$CUDA_VERSION-devel-ubuntu24.04
 tags:
   - cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cu$CUDA_VERSION-base$ARCH_SUFFIX

--- a/docker/base-slim/Dockerfile
+++ b/docker/base-slim/Dockerfile
@@ -41,6 +41,8 @@ apt-get update
 apt-get install -y --no-install-recommends "${APT_PKGS[@]}"
 rm -rf /var/lib/apt/lists/*
 
+# Ubuntu 24.04 creates a default 'ubuntu' user with UID 1000; remove it first.
+userdel -r ubuntu 2>/dev/null || true
 useradd -ms /bin/bash -d /home/ray ray --uid 1000 --gid 100
 usermod -aG sudo ray
 echo 'ray ALL=NOPASSWD: ALL' >> /etc/sudoers

--- a/docker/base-slim/cpu.wanda.yaml
+++ b/docker/base-slim/cpu.wanda.yaml
@@ -1,5 +1,5 @@
 name: "ray-slim-py$PYTHON_VERSION-cpu-base$ARCH_SUFFIX"
-froms: ["ubuntu:22.04"]
+froms: ["ubuntu:24.04"]
 dockerfile: docker/base-slim/Dockerfile
 srcs:
   - python/requirements_compiled.txt
@@ -7,6 +7,6 @@ srcs:
   - python/deplocks/base_slim/ray_base_slim_py$PYTHON_VERSION.lock
 build_args:
   - PYTHON_VERSION
-  - BASE_IMAGE=ubuntu:22.04
+  - BASE_IMAGE=ubuntu:24.04
 tags:
   - cr.ray.io/rayproject/ray-slim-py$PYTHON_VERSION-cpu-base$ARCH_SUFFIX

--- a/docker/base-slim/cuda.wanda.yaml
+++ b/docker/base-slim/cuda.wanda.yaml
@@ -1,5 +1,5 @@
 name: "ray-slim-py$PYTHON_VERSION-cu$CUDA_VERSION-base$ARCH_SUFFIX"
-froms: ["nvidia/cuda:$CUDA_VERSION-runtime-ubuntu22.04"]
+froms: ["nvidia/cuda:$CUDA_VERSION-runtime-ubuntu24.04"]
 dockerfile: docker/base-slim/Dockerfile
 srcs:
   - python/requirements_compiled.txt
@@ -7,6 +7,6 @@ srcs:
   - python/deplocks/base_slim/ray_base_slim_py$PYTHON_VERSION.lock
 build_args:
   - PYTHON_VERSION
-  - BASE_IMAGE=nvidia/cuda:$CUDA_VERSION-runtime-ubuntu22.04
+  - BASE_IMAGE=nvidia/cuda:$CUDA_VERSION-runtime-ubuntu24.04
 tags:
   - cr.ray.io/rayproject/ray-slim-py$PYTHON_VERSION-cu$CUDA_VERSION-base$ARCH_SUFFIX

--- a/docker/ray-ml/install-ml-docker-requirements.sh
+++ b/docker/ray-ml/install-ml-docker-requirements.sh
@@ -10,7 +10,7 @@ sudo apt-get update \
         cmake \
         libgtk2.0-dev \
         libgl1-mesa-dev \
-        libgl1-mesa-glx \
+        libgl1 \
         libosmesa6 \
         libosmesa6-dev \
         libglfw3 \

--- a/release/ray_release/byod/byod.Dockerfile
+++ b/release/ray_release/byod/byod.Dockerfile
@@ -20,7 +20,7 @@ APT_PKGS=(
     ca-certificates
     htop
     libaio1
-    libgl1-mesa-glx
+    libgl1
     libglfw3
     libjemalloc-dev
     libosmesa6-dev

--- a/release/ray_release/byod/byod_e2e_rag.sh
+++ b/release/ray_release/byod/byod_e2e_rag.sh
@@ -4,7 +4,7 @@ set -exo pipefail
 
 # Install system dependencies
 sudo apt-get update && \
-    sudo apt-get install -y libgl1-mesa-glx libmagic1 poppler-utils tesseract-ocr libreoffice && \
+    sudo apt-get install -y libgl1 libmagic1 poppler-utils tesseract-ocr libreoffice && \
     sudo rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies

--- a/release/ray_release/byod/byod_unstructured_data_ingestion.sh
+++ b/release/ray_release/byod/byod_unstructured_data_ingestion.sh
@@ -3,7 +3,7 @@
 set -exo pipefail
 
 sudo apt-get update -y
-sudo apt-get install --no-install-recommends -y libgl1-mesa-glx libmagic1 poppler-utils tesseract-ocr libreoffice
+sudo apt-get install --no-install-recommends -y libgl1 libmagic1 poppler-utils tesseract-ocr libreoffice
 sudo rm -f /etc/apt/sources.list.d/*
 
 # Install runtime deps


### PR DESCRIPTION
Base image swap for all production Docker images to Noble Numbat.
No toolchain changes needed, since these don't re-compile C++.

- base-deps: ubuntu:22.04 → ubuntu:24.04 (CPU and CUDA variants)
- base-slim: ubuntu:22.04 → ubuntu:24.04 (CPU and CUDA variants)
- Downstream images (base-extra, ray, ray-ml, ray-llm) inherit automatically

Topic: ubuntu-24-04-prod
Labels: draft

Signed-off-by: andrew <andrew@anyscale.com>