### PR TITLE
[Serve] Add support for class-based autoscaling policies with `policy_kwargs`

### DIFF
--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -703,6 +703,33 @@ In your policy, access custom metrics via:
 * **`ctx.aggregated_metrics[metric_name]`** — A time-weighted average computed from the raw metric values for each replica.
 
 
+### Class-based policies
+
+When your policy needs long-running setup — such as polling an external metrics service, maintaining a persistent connection, or running background computation — you can define it as a **class** instead of a plain function. Pass the class reference through `policy_function` and supply constructor arguments through `policy_kwargs`.
+
+Ray Serve instantiates the class once on the controller when the deployment starts. `__init__` runs one-time setup, and `__call__` runs on every autoscaling tick with the current [`AutoscalingContext`](../api/doc/ray.serve.config.AutoscalingContext.rst).
+
+The following example shows a policy that reads a target replica count from a JSON file in a background loop. In production you could replace the file read with an HTTP call, a message-queue consumer, or any other async IO operation:
+
+`class_based_autoscaling_policy.py` file:
+```{literalinclude} ../doc_code/class_based_autoscaling_policy.py
+:language: python
+:start-after: __begin_class_based_autoscaling_policy__
+:end-before: __end_class_based_autoscaling_policy__
+```
+
+`main.py` file:
+```{literalinclude} ../doc_code/class_based_autoscaling.py
+:language: python
+:start-after: __serve_example_begin__
+:end-before: __serve_example_end__
+```
+
+:::{note}
+The instance lives only on the Serve controller and is never serialized after creation, so it's safe to hold non-picklable state such as `asyncio.Task` objects, open connections, or thread pools. `policy_kwargs` values must be JSON-serializable because they travel through the deployment config.
+:::
+
+
 ### Application level autoscaling
 
 By default, each deployment in Ray Serve autoscales independently. When you have multiple deployments that need to scale in a coordinated way—such as deployments that share backend resources, have dependencies on each other, or need load-aware routing—you can define an **application-level autoscaling policy**. This policy makes scaling decisions for all deployments within an application simultaneously.

--- a/doc/source/serve/doc_code/class_based_autoscaling.py
+++ b/doc/source/serve/doc_code/class_based_autoscaling.py
@@ -1,0 +1,46 @@
+# __serve_example_begin__
+import json
+import tempfile
+
+from ray import serve
+from ray.serve.config import AutoscalingConfig, AutoscalingPolicy
+
+# Create a JSON file with the initial target replica count.
+# In production this file would be written by an external system.
+scaling_file = tempfile.NamedTemporaryFile(
+    mode="w", suffix=".json", delete=False
+)
+json.dump({"replicas": 2}, scaling_file)
+scaling_file.close()
+
+
+@serve.deployment(
+    autoscaling_config=AutoscalingConfig(
+        min_replicas=1,
+        max_replicas=10,
+        upscale_delay_s=3,
+        downscale_delay_s=10,
+        policy=AutoscalingPolicy(
+            policy_function="class_based_autoscaling_policy:FileBasedAutoscalingPolicy",
+            policy_kwargs={
+                "file_path": scaling_file.name,
+                "poll_interval_s": 2.0,
+            },
+        ),
+    ),
+    max_ongoing_requests=100,
+)
+class MyDeployment:
+    async def __call__(self) -> str:
+        return "Hello, world!"
+
+
+app = MyDeployment.bind()
+# __serve_example_end__
+
+if __name__ == "__main__":
+    import requests  # noqa
+
+    serve.run(app)
+    resp = requests.get("http://localhost:8000/")
+    assert resp.text == "Hello, world!"

--- a/doc/source/serve/doc_code/class_based_autoscaling_policy.py
+++ b/doc/source/serve/doc_code/class_based_autoscaling_policy.py
@@ -1,0 +1,57 @@
+# __begin_class_based_autoscaling_policy__
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from ray.serve.config import AutoscalingContext
+
+logger = logging.getLogger("ray.serve")
+
+
+class FileBasedAutoscalingPolicy:
+    """Scale replicas based on a target written to a JSON file.
+
+    A background asyncio task re-reads the file every ``poll_interval_s``
+    seconds.  ``__call__`` returns the latest value on every autoscaling
+    tick.  In production you could replace the file read with an HTTP
+    call, a message-queue consumer, or any other async IO operation.
+    """
+
+    def __init__(self, file_path: str, poll_interval_s: float = 5.0):
+        self._file_path = Path(file_path)
+        self._poll_interval_s = poll_interval_s
+        self._desired_replicas: int = 1
+        self._task: asyncio.Task = None
+        self._started: bool = False
+
+    def _ensure_started(self) -> None:
+        """Lazily start the background poll on the controller event loop."""
+        if self._started:
+            return
+        self._started = True
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._poll_file())
+
+    async def _poll_file(self) -> None:
+        """Read the target replica count from the JSON file in a loop."""
+        while True:
+            try:
+                text = self._file_path.read_text()
+                data = json.loads(text)
+                self._desired_replicas = int(data["replicas"])
+            except Exception:
+                pass  # Keep the last known value on failure.
+            await asyncio.sleep(self._poll_interval_s)
+
+    def __call__(
+        self, ctx: AutoscalingContext
+    ) -> Tuple[int, Dict[str, Any]]:
+        self._ensure_started()
+
+        desired = self._desired_replicas
+        return desired, {"last_polled_value": self._desired_replicas}
+
+
+# __end_class_based_autoscaling_policy__

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -52,6 +52,9 @@ def _resolve_policy_callable(policy: AutoscalingPolicy) -> Callable:
     """
     raw = policy.get_policy()
     if inspect.isclass(raw):
+        logger.info(
+            f"Instantiating class-callable autoscaling policy '{raw.__name__}' with kwargs: {policy.policy_kwargs}"
+        )
         return raw(**policy.policy_kwargs)
     return raw
 

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import math
 import time
@@ -38,6 +39,21 @@ from ray.serve.config import AutoscalingContext, AutoscalingPolicy
 from ray.util import metrics
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+
+def _resolve_policy_callable(policy: AutoscalingPolicy) -> Callable:
+    """Return a ready-to-call policy callable from an ``AutoscalingPolicy``.
+
+    If the deserialized policy is a class (rather than a plain function),
+    instantiate it once — forwarding any ``policy_kwargs`` — so that the
+    framework invokes ``instance.__call__(ctx)`` on every autoscaling tick
+    instead of ``Class(ctx)`` (which would create a new, stateless instance
+    each time).
+    """
+    raw = policy.get_policy()
+    if inspect.isclass(raw):
+        return raw(**policy.policy_kwargs)
+    return raw
 
 
 class DeploymentAutoscalingState:
@@ -125,7 +141,9 @@ class DeploymentAutoscalingState:
         self._deployment_info = info
         self._config = config
         # Apply default autoscaling config to the policy
-        self._policy = _apply_autoscaling_config(self._config.policy.get_policy())
+        self._policy = _apply_autoscaling_config(
+            _resolve_policy_callable(self._config.policy)
+        )
         self._target_capacity = info.target_capacity
         self._target_capacity_direction = info.target_capacity_direction
         self._policy_state = {}
@@ -864,7 +882,7 @@ class ApplicationAutoscalingState:
         """
         # Apply default autoscaling config to the policy
         self._policy = _apply_app_level_autoscaling_config(
-            autoscaling_policy.get_policy()
+            _resolve_policy_callable(autoscaling_policy)
         )
         self._policy_state = {}
 

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -359,6 +359,25 @@ class AutoscalingPolicy(BaseModel):
         description="Policy function can be a string import path or a function callable. "
         "If it's a string import path, it must be of the form `path.to.module:function_name`. ",
     )
+    policy_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Keyword arguments passed to the policy class constructor when "
+            "policy_function refers to a class. Ignored when policy_function "
+            "is a plain function. Values must be JSON-serializable."
+        ),
+    )
+
+    @validator("policy_kwargs", always=True)
+    def policy_kwargs_json_serializable(cls, v):
+        if isinstance(v, bytes):
+            return v
+        if v is not None:
+            try:
+                json.dumps(v)
+            except TypeError as e:
+                raise ValueError(f"policy_kwargs is not JSON-serializable: {str(e)}.")
+        return v
 
     def __init__(self, **kwargs):
         serialized_policy_def = kwargs.pop("_serialized_policy_def", None)

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -2005,6 +2005,266 @@ class TestAppLevelAutoscalingPolicy:
         assert all(result.result(timeout_s=10) for result in results)
 
 
+class AppLevelClassCallableAutoscalingPolicy:
+    """App-level autoscaling policy using the class-callable pattern.
+
+    Receives ``Dict[DeploymentID, AutoscalingContext]`` and returns per-
+    deployment replica decisions.  Constructor kwargs configure the target
+    replica counts per deployment name.
+    """
+
+    def __init__(self, targets_low: Dict[str, int], targets_high: Dict[str, int]):
+        self._targets_low = targets_low
+        self._targets_high = targets_high
+
+    def __call__(self, ctxs: Dict[DeploymentID, AutoscalingContext]):
+        decisions: Dict[DeploymentID, int] = {}
+        for deployment_id, ctx in ctxs.items():
+            high_threshold = 50 if deployment_id.name == "A" else 60
+            if ctx.total_num_requests > high_threshold:
+                decisions[deployment_id] = self._targets_high[deployment_id.name]
+            else:
+                decisions[deployment_id] = self._targets_low[deployment_id.name]
+        return decisions, {}
+
+
+APP_LEVEL_CLASS_CALLABLE_POLICY_KWARGS = {
+    "targets_low": {"A": 2, "B": 3},
+    "targets_high": {"A": 4, "B": 5},
+}
+
+
+class TestAppLevelClassCallablePolicy:
+    @pytest.fixture
+    def serve_instance_with_two_signal(self, serve_instance):
+        client = serve_instance
+
+        signal_a = SignalActor.options(name="signal_A").remote()
+        signal_b = SignalActor.options(name="signal_B").remote()
+
+        yield client, signal_a, signal_b
+
+        ray.kill(signal_a)
+        ray.kill(signal_b)
+
+    @pytest.mark.parametrize(
+        "policy",
+        [
+            {
+                "policy_function": "ray.serve.tests.test_autoscaling_policy.AppLevelClassCallableAutoscalingPolicy",
+                "policy_kwargs": APP_LEVEL_CLASS_CALLABLE_POLICY_KWARGS,
+            },
+            AutoscalingPolicy(
+                policy_function="ray.serve.tests.test_autoscaling_policy.AppLevelClassCallableAutoscalingPolicy",
+                policy_kwargs=APP_LEVEL_CLASS_CALLABLE_POLICY_KWARGS,
+            ),
+            AutoscalingPolicy(
+                policy_function=AppLevelClassCallableAutoscalingPolicy,
+                policy_kwargs=APP_LEVEL_CLASS_CALLABLE_POLICY_KWARGS,
+            ),
+        ],
+    )
+    def test_app_level_class_callable_policy(
+        self, serve_instance_with_two_signal, policy
+    ):
+        """Test app-level autoscaling with a class-callable policy and policy_kwargs.
+
+        Uses the same multi-deployment app and verification logic as the
+        existing ``TestAppLevelAutoscalingPolicy`` but with a class-based
+        policy whose thresholds are supplied via ``policy_kwargs``.
+        """
+        client, signal_A, signal_B = serve_instance_with_two_signal
+
+        config_template = {
+            "import_path": "ray.serve.tests.test_config_files.get_multi_deployment_signal_app.app",
+            "autoscaling_policy": policy,
+            "deployments": [
+                {
+                    "name": "A",
+                    "max_ongoing_requests": 1000,
+                    "autoscaling_config": {
+                        "min_replicas": 1,
+                        "max_replicas": 10,
+                        "metrics_interval_s": 0.1,
+                        "upscale_delay_s": 0.1,
+                        "downscale_delay_s": 0.5,
+                        "look_back_period_s": 1,
+                    },
+                    "graceful_shutdown_timeout_s": 0.1,
+                },
+                {
+                    "name": "B",
+                    "max_ongoing_requests": 1000,
+                    "autoscaling_config": {
+                        "min_replicas": 1,
+                        "max_replicas": 10,
+                        "metrics_interval_s": 0.1,
+                        "upscale_delay_s": 0.1,
+                        "downscale_delay_s": 0.5,
+                        "look_back_period_s": 1,
+                    },
+                    "graceful_shutdown_timeout_s": 0.1,
+                },
+            ],
+        }
+
+        print(time.ctime(), "Deploying app with class-callable app-level policy.")
+        client.deploy_apps(
+            ServeDeploySchema.parse_obj({"applications": [config_template]})
+        )
+        wait_for_condition(check_running, timeout=15)
+        print(time.ctime(), "Application is RUNNING.")
+
+        hA = serve.get_deployment_handle("A", app_name=SERVE_DEFAULT_APP_NAME)
+        hB = serve.get_deployment_handle("B", app_name=SERVE_DEFAULT_APP_NAME)
+
+        # ---- Deployment A: low load → targets_low["A"] = 2 ----
+        ray.get(signal_A.send.remote(clear=True))
+        results = [hA.remote() for _ in range(40)]
+        wait_for_condition(lambda: ray.get(signal_A.cur_num_waiters.remote()) == 40)
+        wait_for_condition(check_num_replicas_eq, name="A", target=2)
+        print("A scaled to 2 (low).")
+
+        # ---- Deployment A: high load → targets_high["A"] = 4 ----
+        ray.get(signal_A.send.remote(clear=True))
+        assert all(r.result(timeout_s=10) for r in results)
+        results = [hA.remote() for _ in range(70)]
+        wait_for_condition(lambda: ray.get(signal_A.cur_num_waiters.remote()) == 70)
+        wait_for_condition(check_num_replicas_eq, name="A", target=4)
+        ray.get(signal_A.send.remote())
+        assert all(r.result(timeout_s=10) for r in results)
+        print("A scaled to 4 (high).")
+
+        # ---- Deployment B: low load → targets_low["B"] = 3 ----
+        ray.get(signal_B.send.remote(clear=True))
+        results = [hB.remote() for _ in range(50)]
+        wait_for_condition(lambda: ray.get(signal_B.cur_num_waiters.remote()) == 50)
+        wait_for_condition(check_num_replicas_eq, name="B", target=3)
+        print("B scaled to 3 (low).")
+
+        # ---- Deployment B: high load → targets_high["B"] = 5 ----
+        ray.get(signal_B.send.remote(clear=True))
+        assert all(r.result(timeout_s=10) for r in results)
+        results = [hB.remote() for _ in range(120)]
+        wait_for_condition(lambda: ray.get(signal_B.cur_num_waiters.remote()) == 120)
+        wait_for_condition(check_num_replicas_eq, name="B", target=5)
+        ray.get(signal_B.send.remote())
+        assert all(r.result(timeout_s=10) for r in results)
+        print("B scaled to 5 (high).")
+
+
+class ClassCallableAutoscalingPolicy:
+    """Custom autoscaling policy using the class-callable pattern.
+
+    The *class itself* (not an instance) is passed to ``AutoscalingPolicy``,
+    and constructor arguments are supplied via ``policy_kwargs``."""
+
+    def __init__(self, signal_actor_name: str, target_when_ready: int = 3):
+        self._signal_actor_name = signal_actor_name
+        self._target_when_ready = target_when_ready
+        self._ready = False
+        self._task: asyncio.Task = None
+        self._started = False
+
+    # -- lazy start: schedule onto the controller's running event loop ------
+    def _ensure_started(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._background_work())
+
+    async def _background_work(self) -> None:
+        """Simulate a long-running async IO task that eventually flips a flag.
+
+        In a real policy this could poll an external metrics service, listen
+        on a message queue, etc.
+        """
+        signal = ray.get_actor(self._signal_actor_name)
+        while True:
+            try:
+                await signal.wait.remote()
+                self._ready = True
+                return
+            except Exception:
+                await asyncio.sleep(0.1)
+
+    # -- the policy callable ------------------------------------------------
+    def __call__(self, ctx: AutoscalingContext):
+        self._ensure_started()
+        if self._ready:
+            return self._target_when_ready, {"ready": True}
+        else:
+            return ctx.current_num_replicas, {"ready": False}
+
+
+CLASS_CALLABLE_POLICY_KWARGS = {
+    "signal_actor_name": "class_callable_signal",
+    "target_when_ready": 3,
+}
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {
+            "policy_function": "ray.serve.tests.test_autoscaling_policy.ClassCallableAutoscalingPolicy",
+            "policy_kwargs": CLASS_CALLABLE_POLICY_KWARGS,
+        },
+        AutoscalingPolicy(
+            policy_function="ray.serve.tests.test_autoscaling_policy.ClassCallableAutoscalingPolicy",
+            policy_kwargs=CLASS_CALLABLE_POLICY_KWARGS,
+        ),
+        AutoscalingPolicy(
+            policy_function=ClassCallableAutoscalingPolicy,
+            policy_kwargs=CLASS_CALLABLE_POLICY_KWARGS,
+        ),
+    ],
+)
+def test_class_callable_autoscaling_policy(serve_instance, policy):
+    """Test class-callable autoscaling policy in all three registration modes:
+    raw dict, AutoscalingPolicy with string import path, and AutoscalingPolicy
+    with direct class reference.
+    """
+    signal = SignalActor.options(name="class_callable_signal").remote()
+
+    @serve.deployment(
+        autoscaling_config={
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "downscale_delay_s": 0.5,
+            "upscale_delay_s": 0,
+            "metrics_interval_s": 0.1,
+            "look_back_period_s": 1,
+            "policy": policy,
+        },
+        graceful_shutdown_timeout_s=1,
+        max_ongoing_requests=1000,
+    )
+    class B:
+        async def __call__(self):
+            return "ok"
+
+    serve.run(B.bind())
+    wait_for_condition(
+        check_deployment_status, name="B", expected_status=DeploymentStatus.HEALTHY
+    )
+
+    # Before the signal fires the background task hasn't completed, so the
+    # policy should keep the replica count at the initial value (1).
+    wait_for_condition(check_num_replicas_eq, name="B", target=1)
+    print("Replicas stayed at 1 while background task is pending.")
+
+    # Fire the signal — the background task completes and flips _ready.
+    ray.get(signal.send.remote())
+
+    # The policy now returns target_when_ready=3, so Serve should scale up.
+    wait_for_condition(check_num_replicas_eq, name="B", target=3, timeout=30)
+    print("Scaled up to 3 replicas after background task completed.")
+
+    ray.kill(signal)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -2123,7 +2123,6 @@ class TestAppLevelClassCallablePolicy:
         results = [hA.remote() for _ in range(40)]
         wait_for_condition(lambda: ray.get(signal_A.cur_num_waiters.remote()) == 40)
         wait_for_condition(check_num_replicas_eq, name="A", target=2)
-        print("A scaled to 2 (low).")
 
         # ---- Deployment A: high load → targets_high["A"] = 4 ----
         ray.get(signal_A.send.remote(clear=True))
@@ -2133,14 +2132,12 @@ class TestAppLevelClassCallablePolicy:
         wait_for_condition(check_num_replicas_eq, name="A", target=4)
         ray.get(signal_A.send.remote())
         assert all(r.result(timeout_s=10) for r in results)
-        print("A scaled to 4 (high).")
 
         # ---- Deployment B: low load → targets_low["B"] = 3 ----
         ray.get(signal_B.send.remote(clear=True))
         results = [hB.remote() for _ in range(50)]
         wait_for_condition(lambda: ray.get(signal_B.cur_num_waiters.remote()) == 50)
         wait_for_condition(check_num_replicas_eq, name="B", target=3)
-        print("B scaled to 3 (low).")
 
         # ---- Deployment B: high load → targets_high["B"] = 5 ----
         ray.get(signal_B.send.remote(clear=True))
@@ -2150,7 +2147,6 @@ class TestAppLevelClassCallablePolicy:
         wait_for_condition(check_num_replicas_eq, name="B", target=5)
         ray.get(signal_B.send.remote())
         assert all(r.result(timeout_s=10) for r in results)
-        print("B scaled to 5 (high).")
 
 
 class ClassCallableAutoscalingPolicy:

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -185,7 +185,8 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy_nam
                                     "upscale_delay_s": 30.0,
                                     "aggregation_function": "mean",
                                     "policy": {
-                                        "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy"
+                                        "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",
+                                        "policy_kwargs": {},
                                     },
                                 },
                                 "graceful_shutdown_wait_loop_s": 2.0,

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -333,7 +333,8 @@ def test_num_replicas_auto_api(serve_instance, use_options):
         "initial_replicas": None,
         "aggregation_function": "mean",
         "policy": {
-            "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy"
+            "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",
+            "policy_kwargs": {},
         },
     }
 
@@ -399,7 +400,8 @@ def test_num_replicas_auto_basic(serve_instance, use_options):
         "initial_replicas": None,
         "aggregation_function": "mean",
         "policy": {
-            "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy"
+            "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",
+            "policy_kwargs": {},
         },
     }
 

--- a/python/ray/serve/tests/test_deploy_app_2.py
+++ b/python/ray/serve/tests/test_deploy_app_2.py
@@ -600,7 +600,8 @@ def test_num_replicas_auto_api(serve_instance):
         "initial_replicas": None,
         "aggregation_function": "mean",
         "policy": {
-            "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy"
+            "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",
+            "policy_kwargs": {},
         },
     }
 
@@ -657,7 +658,8 @@ def test_num_replicas_auto_basic(serve_instance):
         "initial_replicas": None,
         "aggregation_function": "mean",
         "policy": {
-            "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy"
+            "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",
+            "policy_kwargs": {},
         },
     }
 

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -2319,7 +2319,8 @@ def test_get_serve_instance_details_json_serializable(
                                     "upscale_delay_s": 30.0,
                                     "aggregation_function": "mean",
                                     "policy": {
-                                        "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy"
+                                        "policy_function": "ray.serve.autoscaling_policy:default_autoscaling_policy",
+                                        "policy_kwargs": {},
                                     },
                                 },
                                 "graceful_shutdown_wait_loop_s": 2.0,

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -29,6 +29,9 @@ message AutoscalingPolicy {
 
   // The cloudpickled policy definition.
   bytes _serialized_policy_def = 2;
+
+  // Keyword arguments for class-based policies (cloudpickled dict).
+  bytes policy_kwargs = 3;
 }
 
 // Configuration options for Serve's replica autoscaler.


### PR DESCRIPTION
- Add support for passing a **class reference** (not just a function) as `policy_function` in `AutoscalingPolicy`. The controller detects classes at resolution time, instantiates them once with `policy_kwargs`, and calls `instance.__call__(ctx)` on every autoscaling tick. This enables stateful policies that perform long-running setup in `__init__` (background polling, persistent connections, etc.).
- Add `policy_kwargs: Dict[str, Any]` field to `AutoscalingPolicy` config (JSON-serializable, analogous to `request_router_kwargs` on `RequestRouterConfig`). These kwargs are forwarded to the class constructor when instantiating class-based policies.

### Test plan

- [x] New parametrized `test_class_callable_autoscaling_policy` — tests all three registration modes (raw dict, `AutoscalingPolicy` with string path, `AutoscalingPolicy` with class ref) for deployment-level class-based policies with `policy_kwargs`
- [x] New parametrized `TestAppLevelClassCallablePolicy::test_app_level_class_callable_policy` — same three modes for application-level class-based policies with `policy_kwargs`
- [x] All existing `test_e2e_scale_up_down_basic_with_custom_policy` tests pass (backward compat)
- [x] All existing `test_custom_autoscaling_metrics.py` tests pass (backward compat)