### PR TITLE
[Data] - Use sampling to estimate pandas df size in bytes

### DIFF
--- a/python/ray/data/_internal/output_buffer.py
+++ b/python/ray/data/_internal/output_buffer.py
@@ -190,12 +190,16 @@ class BlockOutputBuffer:
 
         if self._exceeded_block_row_slice_limit(accessor):
             target_num_rows = self._max_num_rows_per_block()
-        elif self._exceeded_block_size_slice_limit(accessor):
-            assert accessor.num_rows() > 0, "Block may not be empty"
-            num_bytes_per_row = accessor.size_bytes() / accessor.num_rows()
-            target_num_rows = max(
-                1, math.ceil(self._max_bytes_per_block() / num_bytes_per_row)
-            )
+        elif self._max_bytes_per_block() is not None:
+            # Compute size_bytes once and reuse — avoids a redundant expensive
+            # call when we need it again below for num_bytes_per_row.
+            block_size = accessor.size_bytes()
+            if block_size >= MAX_SAFE_BLOCK_SIZE_FACTOR * self._max_bytes_per_block():
+                assert accessor.num_rows() > 0, "Block may not be empty"
+                num_bytes_per_row = block_size / accessor.num_rows()
+                target_num_rows = max(
+                    1, math.ceil(self._max_bytes_per_block() / num_bytes_per_row)
+                )
 
         if target_num_rows is not None and target_num_rows < accessor.num_rows():
             block = accessor.slice(0, target_num_rows, copy=False)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -616,7 +616,6 @@ class PandasBlockAccessor(TableBlockAccessor):
             queue = collections.deque([obj])
             while queue:
                 current = queue.pop()
-                current_type = type(current)
 
                 # Immutable scalars — constant size, no dedup needed.
                 if isinstance(current, (str, bytes, int, float)):
@@ -637,16 +636,16 @@ class PandasBlockAccessor(TableBlockAccessor):
                     size = 0
                 total_size += size
 
-                if current_type is list or current_type is tuple:
+                if isinstance(current, (list, tuple)):
                     estimate = _estimate_list_contents(current, seen, get_deep_size)
                     if estimate is not None:
                         total_size += estimate
                     else:
                         queue.extend(current)
-                elif current_type is dict:
+                elif isinstance(current, dict):
                     queue.extend(current.keys())
                     queue.extend(current.values())
-                elif current_type is set or current_type is frozenset:
+                elif isinstance(current, (set, frozenset)):
                     queue.extend(current)
                 elif isinstance(current, np.ndarray):
                     total_size += current.nbytes - size

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -97,9 +97,14 @@ def _estimate_list_contents(
 
     first_elem_type = type(items[0])
 
-    # Check homogeneity: if first and last element are the same type,
-    # assume all elements are (a reasonable heuristic for JSON data).
-    is_homogeneous = length < 3 or type(items[-1]) is first_elem_type
+    # Check homogeneity: verify first, middle, and last elements share the
+    # same type. This is a heuristic for JSON data where arrays are typically
+    # type-uniform. Checking three positions catches most mixed-type cases
+    # (e.g., [1, {"nested": ...}, 2]) at negligible cost.
+    is_homogeneous = length < 3 or (
+        type(items[-1]) is first_elem_type
+        and type(items[length // 2]) is first_elem_type
+    )
     if not is_homogeneous:
         return None
 


### PR DESCRIPTION
## Description
 
Optimize `PandasBlockAccessor.size_bytes()` for nested JSON data (up to 18x speedup)

### Problem

`size_bytes()` becomes a CPU bottleneck when processing DataFrames with nested JSON data (common with `ReadPandasJSON`). py-spy profiling shows it consuming ~98% of CPU time inside `get_deep_size`, which does a full BFS traversal calling `sys.getsizeof` on every reachable Python object.

For a cell containing a 1,536-element embedding list, this means 1,536 individual `sys.getsizeof` calls. For a cell with 40 event dicts each containing nested payloads, it means thousands of object visits. Multiply by 200 sampled cells per column and several object columns, and a single `size_bytes()` call takes ~115ms.

The problem is compounded in `output_buffer.next()`, which calls `size_bytes()` **twice** when a block exceeds the target size — once to check the limit, and again to compute `num_bytes_per_row`.

### Changes

**1. Fast-path estimation for homogeneous lists** (`pandas_block.py`)

Extracts list content sizing into `_estimate_list_contents()`, which detects common homogeneous list patterns and avoids O(n) traversal:

- **float/int lists** (e.g., embeddings): exact O(1) multiply using pre-computed constant element sizes.
- **str/dict/list lists** (e.g., JSON arrays-of-objects): stratified random sampling — divide the list into 5 equal-width strata, pick 1 random element from each, and extrapolate. This guarantees coverage across the full range while handling non-uniform element sizes (e.g., dicts with optional nested fields).
- **Heterogeneous or unrecognized lists**: falls back to full element-by-element traversal.

Also replaces `np.vectorize` (which is just a Python loop with numpy dispatch overhead) with a plain `sum()` generator.

**2. Cache `size_bytes()` in `output_buffer.next()`** (`output_buffer.py`)

Passes a precomputed `block_size` to `_exceeded_block_size_slice_limit()` so `size_bytes()` is computed once and reused for `num_bytes_per_row`, eliminating the redundant second call.

### Alternatives considered

We benchmarked 6 alternative approaches. None matched our optimization on the speed-accuracy tradeoff:

| Approach | Time | Speedup | Size error | Notes |
|---|---|---|---|---|
| **BEFORE** (original) | 228ms | — | (baseline) | Full BFS, correct but slow |
| objsize library | 353ms | 0.7x | -25% | Slower than baseline due to `gc.get_referents` overhead |
| gc.get_referents | 143ms | 1.6x | -22% | Faster but inaccurate — GC referents != memory layout |
| **AFTER (this PR)** | 11-28ms | **8-18x** | **-1%** | Stratified sampling + cached call |

### Benchmark results

Tested across 4 DataFrame shapes with intentionally diverse structure:


[Benchmark Code](https://gist.github.com/goutamvenkat-anyscale/d6a6ebb82ff4c1b42083770f718c9581)

### Benchmark results
```
==============================================================================
Benchmark: size_bytes() across different DataFrame shapes
==============================================================================

Building flat_strings...

──────────────────────────────────────────────────────────────────────────────
  flat_strings: 100K rows, string columns (no nesting)
  shape=(100000, 4)  object_cols=['name', 'description']
──────────────────────────────────────────────────────────────────────────────

  Approach                 Time (ms)   Speedup   Size (MB)      Err   target_rows
  ──────────────────────  ──────────  ────────  ──────────  ───────  ────────────
  BEFORE                         1.6                  17.9                      —
  AFTER (linspace)               1.6      1.0x        17.9    -0.0%             —
  AFTER (stratified)             1.6      1.0x        17.9    -0.1%             —

Building embeddings...

──────────────────────────────────────────────────────────────────────────────
  embeddings: 5K rows with 1536-d float list columns
  shape=(5000, 3)  object_cols=['text', 'embedding']
──────────────────────────────────────────────────────────────────────────────

  Approach                 Time (ms)   Speedup   Size (MB)      Err   target_rows
  ──────────────────────  ──────────  ────────  ──────────  ───────  ────────────
  BEFORE                        73.2                 248.4                   1056
  AFTER (linspace)               0.5    158.0x       248.4    +0.0%          1056
  AFTER (stratified)             0.4    174.8x       248.4    +0.0%          1056

Building uniform_json...

──────────────────────────────────────────────────────────────────────────────
  uniform_json: 1K rows, uniform nested JSON (same-schema lists)
  shape=(1000, 4)  object_cols=['metadata', 'events', 'embedding']
──────────────────────────────────────────────────────────────────────────────

  Approach                 Time (ms)   Speedup   Size (MB)      Err   target_rows
  ──────────────────────  ──────────  ────────  ──────────  ───────  ────────────
  BEFORE                        37.6                  61.4                      —
  AFTER (linspace)               5.9      6.4x        61.4    -0.0%             —
  AFTER (stratified)             4.3      8.8x        61.4    -0.0%             —

Building uneven_json...

──────────────────────────────────────────────────────────────────────────────
  uneven_json: 1K rows, uneven nested JSON (varying element sizes)
  shape=(1000, 4)  object_cols=['events', 'items', 'embedding']
──────────────────────────────────────────────────────────────────────────────

  Approach                 Time (ms)   Speedup   Size (MB)      Err   target_rows
  ──────────────────────  ──────────  ────────  ──────────  ───────  ────────────
  BEFORE                       195.4                 180.6                    287
  AFTER (linspace)              13.8     14.1x       181.2    +0.3%           290
  AFTER (stratified)            10.6     18.4x       178.4    -1.2%           294


==============================================================================
SUMMARY: speedup and accuracy across all datasets
==============================================================================

  Dataset           Approach                 Time (ms)   Speedup  Size err
  ────────────────  ──────────────────────  ──────────  ────────  ────────
  flat_strings      BEFORE                         1.6                    
  flat_strings      AFTER (linspace)               1.6      1.0x     -0.0%
  flat_strings      AFTER (stratified)             1.6      1.0x     -0.1%

  embeddings        BEFORE                        73.2                    
  embeddings        AFTER (linspace)               0.5    158.0x     +0.0%
  embeddings        AFTER (stratified)             0.4    174.8x     +0.0%

  uniform_json      BEFORE                        37.6                    
  uniform_json      AFTER (linspace)               5.9      6.4x     -0.0%
  uniform_json      AFTER (stratified)             4.3      8.8x     -0.0%

  uneven_json       BEFORE                       195.4                    
  uneven_json       AFTER (linspace)              13.8     14.1x     +0.3%
  uneven_json       AFTER (stratified)            10.6     18.4x     -1.2%

==============================================================================
```

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
