### PR TITLE
test_metrics_3 flakiness

### DIFF
--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -638,7 +638,8 @@ def test_autoscaling_metrics(metrics_start_shutdown):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="Async Inference feature is flaky on Windows."
+    sys.platform == "win32",
+    reason="Async Inference feature testing is flaky on Windows.",
 )
 def test_async_inference_task_queue_metrics_delay(
     metrics_start_shutdown, external_redis  # noqa: F811

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -637,6 +637,9 @@ def test_autoscaling_metrics(metrics_start_shutdown):
     ray.get(signal.send.remote())
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Async Inference feature is flaky on Windows."
+)
 def test_async_inference_task_queue_metrics_delay(
     metrics_start_shutdown, external_redis  # noqa: F811
 ):


### PR DESCRIPTION
we already skipped the async inference test on the windows as they are flaky (i suspect this because of local redis requirement, but not sure), currently skipping this recently added async inference metrics test on windows.