### PR TITLE
[serve] [taskiq - 1/n] Enable async task handler support in task_handler decorator

### DIFF
--- a/python/ray/serve/task_consumer.py
+++ b/python/ray/serve/task_consumer.py
@@ -201,8 +201,17 @@ def task_handler(
         raise ValueError(f"Task name must be a non-empty string, got {name}")
 
     def decorator(f):
-        # async functions are not supported yet in celery `threads` worker pool
-        if not inspect.iscoroutinefunction(f):
+        # Handle both sync and async functions
+        if inspect.iscoroutinefunction(f):
+
+            @wraps(f)
+            async def async_wrapper(*args, **kwargs):
+                return await f(*args, **kwargs)
+
+            async_wrapper._is_task_handler = True  # type: ignore
+            async_wrapper._task_name = name or f.__name__  # type: ignore
+            return async_wrapper
+        else:
 
             @wraps(f)
             def wrapper(*args, **kwargs):
@@ -211,9 +220,6 @@ def task_handler(
             wrapper._is_task_handler = True  # type: ignore
             wrapper._task_name = name or f.__name__  # type: ignore
             return wrapper
-
-        else:
-            raise NotImplementedError("Async task handlers are not supported yet")
 
     if _func is not None:
         # Used without arguments: @task_handler

--- a/python/ray/serve/task_processor.py
+++ b/python/ray/serve/task_processor.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import threading
 import time
@@ -137,6 +138,13 @@ class CeleryTaskProcessorAdapter(TaskProcessorAdapter):
             task_unknown.connect(self._handle_unknown_task)
 
     def register_task_handle(self, func, name=None):
+        # Celery does not support async task handlers
+        if asyncio.iscoroutinefunction(func):
+            raise NotImplementedError(
+                "Async task handlers are not supported yet. "
+                "Please use synchronous functions for task handlers."
+            )
+
         task_options = {
             "autoretry_for": (Exception,),
             "retry_kwargs": {"max_retries": self._config.max_retries},


### PR DESCRIPTION
## Summary
- Moves the async handler restriction from the shared `@task_handler` decorator to Celery's `register_task_handle()`, since it's a Celery-specific limitation (not framework-wide)
- `@task_handler` now accepts both sync and async functions, unblocking async-capable adapters (e.g. Taskiq)
- Updates test to verify the error is raised at deploy-time (adapter registration) rather than decoration-time

## Why is this change needed?
The `@task_handler` decorator was blanket-rejecting async functions with `NotImplementedError`. This is only a Celery limitation — other adapters (like Taskiq) natively support async. By moving the check to `CeleryTaskProcessorAdapter.register_task_handle()`, we keep the Celery guard in place while allowing the decorator to be adapter-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)