### PR TITLE
[core] improve the err msg printed from the dashboard event publisher

### DIFF
--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -156,7 +156,7 @@ class AsyncHttpPublisherClient(PublisherClientInterface):
 
             return await self._send_http_request(filtered_json, num_filtered_out)
         except Exception as e:
-            logger.error("Failed to send events to external service. Error: %s", str(e) or repr(e))
+            logger.error("Failed to send events to external service. Error: %r", e)
             return PublishStats(
                 is_publish_successful=False,
                 num_events_published=0,

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -156,7 +156,7 @@ class AsyncHttpPublisherClient(PublisherClientInterface):
 
             return await self._send_http_request(filtered_json, num_filtered_out)
         except Exception as e:
-            logger.error("Failed to send events to external service. Error: %s", e)
+            logger.error("Failed to send events to external service. Error: %s", str(e) or repr(e))
             return PublishStats(
                 is_publish_successful=False,
                 num_events_published=0,


### PR DESCRIPTION
## Description

We noticed that the dashboard event publisher can print the error as an empty string:

<img width="980" height="106" alt="image" src="https://github.com/user-attachments/assets/9879c54f-3115-4b30-a80e-bad01c258481" />

That isn't really helpful. This PR uses `repr` to print the error instead. The `repr` will print out the error type at least.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
