### PR TITLE
[Data] 2 phase commit for checkpointing to avoid duplicates

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -188,8 +188,8 @@ class ParquetDatasink(_FileDatasink):
             block for block in blocks if BlockAccessor.for_block(block).num_rows() > 0
         ]
 
-        filename = self.filename_provider.get_filename_for_block(
-            blocks[0], ctx.kwargs[WRITE_UUID_KWARG_NAME], ctx.task_idx, 0
+        filename = self.filename_provider.get_filename_for_task(
+            ctx.kwargs[WRITE_UUID_KWARG_NAME], ctx.task_idx
         )
         write_kwargs = _resolve_kwargs(
             self.arrow_parquet_args_fn, **self.arrow_parquet_args

--- a/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
@@ -1,6 +1,6 @@
-import itertools
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_transformer import (
@@ -8,45 +8,99 @@ from ray.data._internal.execution.operators.map_transformer import (
 )
 from ray.data._internal.logical.operators import Write
 from ray.data._internal.planner.plan_write_op import (
+    PENDING_CHECKPOINTS_KWARG_NAME,
+    WRITE_UUID_KWARG_NAME,
     _plan_write_op_internal,
     generate_collect_write_stats_fn,
 )
 from ray.data.block import Block, BlockAccessor
-from ray.data.checkpoint.checkpoint_writer import CheckpointWriter
+from ray.data.checkpoint.checkpoint_writer import (
+    CheckpointWriter,
+    PendingCheckpoint,
+)
 from ray.data.checkpoint.interfaces import (
     InvalidCheckpointingOperators,
 )
 from ray.data.context import DataContext
 from ray.data.datasource.datasink import Datasink
+from ray.data.datasource.file_datasink import _FileDatasink
+
+
+def _validate_id_column_exists(id_column: str, block: Block) -> None:
+    """Validate that the ID column exists in the block.
+
+    Args:
+        id_column: The name of the ID column to validate.
+        block: The block to check.
+
+    Raises:
+        ValueError: If the ID column is not present in the block.
+    """
+    block_accessor = BlockAccessor.for_block(block)
+    if id_column not in block_accessor.column_names():
+        raise ValueError(
+            f"ID column {id_column} is "
+            f"absent in the block to be written. Do not drop or rename "
+            f"this column."
+        )
+
+
+def _combine_blocks(
+    blocks: Iterable[Block],
+) -> Tuple[List[Block], Block]:
+    """Combine multiple blocks into a single block.
+
+    This is used by checkpoint transforms to match the behavior of _FileDatasink.write(),
+    which combines all input blocks into one output file.
+
+    Args:
+        blocks: Iterable of blocks to combine.
+
+    Returns:
+        A tuple of (block_list, combined_block) where:
+        - block_list: The original blocks as a list (for later iteration)
+        - combined_block: A single block combining all input blocks
+    """
+    block_list = list(blocks)
+    builder = DelegatingBlockBuilder()
+    for block in block_list:
+        builder.add_block(block)
+    combined_block = builder.build()
+    return block_list, combined_block
 
 
 def plan_write_op_with_checkpoint_writer(
     op: Write, physical_children: List[PhysicalOperator], data_context: DataContext
 ) -> PhysicalOperator:
+    """Plan a write operation with checkpoint support.
+
+    For file-based datasinks (_FileDatasink):
+        Uses 2-phase commit for atomicity:
+        1. Pre-write: computes expected paths, write pending checkpoints
+        2. Write: writes data files
+        3. Post-write: commits checkpoints (renames pending -> committed)
+
+    Recovery is possible in both orders (writing checkpoints before data files,
+    or writing data files before checkpoints), but writing checkpoints first
+    (file-based sinks) makes recovery simpler: we just list pending checkpoint
+    files to know exactly which data files need to be deleted if present, then
+    retry cleanly.
+
+    For non-file datasinks (SQLDatasink, etc.):
+        Falls back to post-write checkpointing:
+        1. Write: Write data to destination
+        2. Post-write: Write checkpoints
+
+    Non-file sinks (SQL, MongoDB, etc.) cannot predict a "file path" - data goes
+    to database rows or documents. So we fall back to writing data first, then
+    checkpointing. Recovery is still possible, but if failure occurs after data
+    write but before checkpoint write, the same data may be written again on
+    retry without removing the old data (at-least-once semantics for
+    non-idempotent operations).
+    """
     assert data_context.checkpoint_config is not None
 
-    collect_stats_fn = generate_collect_write_stats_fn()
-    write_checkpoint_for_block_fn = _generate_checkpoint_writing_transform(
-        data_context, op
-    )
-
-    physical_op = _plan_write_op_internal(
-        op,
-        physical_children,
-        data_context,
-        extra_transformations=[
-            write_checkpoint_for_block_fn,
-            collect_stats_fn,
-        ],
-    )
-
-    return physical_op
-
-
-def _generate_checkpoint_writing_transform(
-    data_context: DataContext, logical_op: Write
-) -> BlockMapTransformFn:
-    datasink = logical_op.datasink_or_legacy_datasource
+    datasink = op.datasink_or_legacy_datasource
     if not isinstance(datasink, Datasink):
         raise InvalidCheckpointingOperators(
             f"To enable checkpointing, Write operation must use a "
@@ -55,27 +109,238 @@ def _generate_checkpoint_writing_transform(
         )
 
     checkpoint_writer = CheckpointWriter.create(data_context.checkpoint_config)
+    collect_stats_fn = generate_collect_write_stats_fn()
 
-    # MapTransformFn for writing checkpoint files after write completes.
-    def write_checkpoint_for_block(
+    if isinstance(datasink, _FileDatasink):
+        # File-based datasink: use 2-phase commit for atomicity
+        # Pre-write transform: compute expected paths and write pending checkpoints
+        prepare_checkpoint_fn = _generate_prepare_checkpoint_transform(
+            data_context, datasink, checkpoint_writer
+        )
+
+        # Post-write transform: commit checkpoints
+        commit_checkpoint_fn = _generate_commit_checkpoint_transform(checkpoint_writer)
+
+        pre_transformations = [
+            prepare_checkpoint_fn,
+        ]
+        post_transformations = [
+            commit_checkpoint_fn,
+            collect_stats_fn,
+        ]
+    else:
+        # Non-file datasink (SQL, Mongo, etc.): fall back to non-atomic checkpoint
+        # No 2-phase commit - write checkpoint after data write
+        # This might cause duplicate writes if the write operation is retried.
+        write_checkpoint_fn = _generate_non_atomic_write_checkpoint_transform(
+            data_context, checkpoint_writer
+        )
+        post_transformations = [
+            write_checkpoint_fn,
+            collect_stats_fn,
+        ]
+        pre_transformations = []
+
+    physical_op = _plan_write_op_internal(
+        op,
+        physical_children,
+        data_context,
+        post_transformations=post_transformations,
+        pre_transformations=pre_transformations,
+    )
+
+    return physical_op
+
+
+def _generate_base_filename(
+    datasink: _FileDatasink,
+    ctx: TaskContext,
+) -> str:
+    """Compute the base filename (without extension) for this task's data files.
+
+    This is called BEFORE writing to determine the filename prefix for data files
+    that will be written by this task. Datasinks may write multiple files (with
+    partitioning, max_rows_per_file, etc.), all sharing this base filename.
+
+    Args:
+        datasink: The file datasink being used.
+        ctx: The task context.
+
+    Returns:
+        The base filename without extension (e.g., "write_uuid_000000_000000").
+        Used both as a checkpoint ID for deterministic naming and as a prefix
+        for matching data files during recovery.
+    """
+    write_uuid = ctx.kwargs.get(WRITE_UUID_KWARG_NAME)
+    assert write_uuid is not None, "WRITE_UUID_KWARG_NAME is required"
+
+    filename = datasink.filename_provider.get_filename_for_task(
+        write_uuid, ctx.task_idx
+    )
+
+    # All file datasinks can potentially generate multiple files (e.g., with
+    # partitioning, max_rows_per_file, etc.). Use prefix matching to handle
+    # cases like "{filename}-{i}.parquet".
+    # Remove file extension to get the base filename for prefix matching.
+    if "." in filename:
+        return filename.rsplit(".", 1)[0]
+    return filename
+
+
+def _generate_prepare_checkpoint_transform(
+    data_context: DataContext,
+    datasink: _FileDatasink,
+    checkpoint_writer: CheckpointWriter,
+) -> BlockMapTransformFn:
+    """Generate transform for preparing checkpoints BEFORE data write.
+
+    This transform runs BEFORE the data write to enable rollback on failure.
+    By recording the expected file path in a pending checkpoint first, we can
+    clean up orphaned data files if the task fails after writing data but
+    before committing.
+
+    Steps:
+    1. Combines all blocks (matching _FileDatasink behavior)
+    2. Computes expected data file path prefix from FilenameProvider
+    3. Writes pending checkpoint with expected path prefix in metadata
+    4. Stores pending checkpoint info in ctx.kwargs for later commit
+
+    For datasinks that can write multiple files (ParquetDatasink), the expected
+    path is stored as a prefix so recovery can delete any matching files.
+    """
+
+    def prepare_checkpoint(
         blocks: Iterable[Block], ctx: TaskContext
     ) -> Iterable[Block]:
-        it1, it2 = itertools.tee(blocks, 2)
-        for block in it1:
-            ba = BlockAccessor.for_block(block)
-            if ba.num_rows() > 0:
-                if data_context.checkpoint_config.id_column not in ba.column_names():
-                    raise ValueError(
-                        f"ID column {data_context.checkpoint_config.id_column} is "
-                        f"absent in the block to be written. Do not drop or rename "
-                        f"this column."
-                    )
-            checkpoint_writer.write_block_checkpoint(ba)
+        # Combine all blocks to match _FileDatasink.write() behavior
+        # which combines all input blocks into one output file
+        block_list, combined_block = _combine_blocks(blocks)
+        ba = BlockAccessor.for_block(combined_block)
 
-        return list(it2)
+        if ba.num_rows() > 0:
+            # Validate ID column exists
+            id_column = data_context.checkpoint_config.id_column
+            _validate_id_column_exists(id_column, combined_block)
+
+            # Compute base filename using FilenameProvider
+            # Note: This only depends on write_uuid and task_idx, NOT block content
+            # base_filename is the filename without extension, used as checkpoint_id
+            # for deterministic naming (same on retry, enabling idempotent writes)
+            base_filename = _generate_base_filename(datasink, ctx)
+
+            # Extract ID column data for checkpoint
+            # Project to the single column first, then convert to Arrow to
+            # avoid materializing the entire block as an Arrow table.
+            id_column_data = BlockAccessor.for_block(
+                ba.select(columns=[id_column])
+            ).to_arrow()[id_column]
+
+            # Write pending checkpoint with data file directory and prefix
+            # stored separately. The directory (unresolved_path) preserves the
+            # protocol prefix (e.g., s3://bucket/path) so that recovery can
+            # resolve the correct filesystem.
+            pending = checkpoint_writer.write_pending_checkpoint(
+                id_column_data,
+                data_file_dir=datasink.unresolved_path,
+                data_file_prefix=base_filename,
+                checkpoint_id=base_filename,
+            )
+
+            # Store pending checkpoint for commit phase
+            if pending is not None:
+                if PENDING_CHECKPOINTS_KWARG_NAME not in ctx.kwargs:
+                    ctx.kwargs[PENDING_CHECKPOINTS_KWARG_NAME] = []
+                ctx.kwargs[PENDING_CHECKPOINTS_KWARG_NAME].append(pending)
+
+        # Return original blocks for the write transform
+        return iter(block_list)
 
     return BlockMapTransformFn(
-        write_checkpoint_for_block,
+        prepare_checkpoint,
+        is_udf=False,
+        disable_block_shaping=True,
+    )
+
+
+def _generate_commit_checkpoint_transform(
+    checkpoint_writer: CheckpointWriter,
+) -> BlockMapTransformFn:
+    """Generate transform for committing checkpoints AFTER data write.
+
+    This transform runs AFTER the data write succeeds, completing the 2-phase
+    commit. The commit operation (renaming pending -> committed) is the atomic
+    point: once committed, the data is considered durably written. If failure
+    occurs before this point, recovery will find the pending checkpoint and
+    can safely delete the orphaned data files using the stored path.
+
+    Steps:
+    1. Retrieves pending checkpoints from ctx.kwargs
+    2. Commits each pending checkpoint (rename pending -> committed)
+    """
+
+    def commit_checkpoints(
+        blocks: Iterable[Block], ctx: TaskContext
+    ) -> Iterable[Block]:
+        # Get pending checkpoints written in pre-write phase
+        pending_checkpoints: List[PendingCheckpoint] = ctx.kwargs.get(
+            PENDING_CHECKPOINTS_KWARG_NAME, []
+        )
+
+        # Commit each pending checkpoint
+        for pending in pending_checkpoints:
+            checkpoint_writer.commit_checkpoint(pending)
+
+        return blocks
+
+    return BlockMapTransformFn(
+        commit_checkpoints,
+        is_udf=False,
+        disable_block_shaping=True,
+    )
+
+
+def _generate_non_atomic_write_checkpoint_transform(
+    data_context: DataContext,
+    checkpoint_writer: CheckpointWriter,
+) -> BlockMapTransformFn:
+    """Generate transform for writing checkpoints AFTER data write (non-file datasinks).
+
+    This is a fallback for non-file datasinks (SQL, Mongo, etc.) that don't
+    support deletions. Unlike file-based sinks where we can delete orphaned
+    data files during recovery, these sinks have no way to undo a write once
+    data has been inserted into rows or documents.
+
+    The checkpoint is written directly after the data write completes. This
+    provides at-least-once semantics: if failure occurs after data write but
+    before checkpoint write, the same data will be written again on retry
+    without removing the old data.
+
+    For idempotent operations (upserts with unique keys), this is safe. For
+    non-idempotent operations (inserts), duplicates may result.
+
+    TODO: For datasinks that support deletions (e.g., SQL DELETE by ID), we
+    could store written IDs in pending checkpoints and delete them on recovery,
+    avoiding duplicates even for non-idempotent operations.
+    """
+
+    def write_checkpoint(blocks: Iterable[Block], ctx: TaskContext) -> Iterable[Block]:
+        # Combine all blocks
+        block_list, combined_block = _combine_blocks(blocks)
+        ba = BlockAccessor.for_block(combined_block)
+
+        if ba.num_rows() > 0:
+            # Validate ID column exists
+            id_column = data_context.checkpoint_config.id_column
+            _validate_id_column_exists(id_column, combined_block)
+
+            # Write checkpoint directly (no 2-phase commit)
+            # No data_file_path since non-file datasinks don't have file paths
+            checkpoint_writer.write_block_checkpoint(ba)
+
+        return iter(block_list)
+
+    return BlockMapTransformFn(
+        write_checkpoint,
         is_udf=False,
         # NOTE: No need for block-shaping
         disable_block_shaping=True,

--- a/python/ray/data/checkpoint/checkpoint_writer.py
+++ b/python/ray/data/checkpoint/checkpoint_writer.py
@@ -2,8 +2,11 @@ import logging
 import os
 import uuid
 from abc import abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
 
 from pyarrow import parquet as pq
+from pyarrow.fs import FileType
 
 from ray.data._internal.util import call_with_retry
 from ray.data.block import BlockAccessor
@@ -11,14 +14,44 @@ from ray.data.checkpoint import CheckpointBackend, CheckpointConfig
 from ray.data.context import DataContext
 from ray.data.datasource.path_util import _unwrap_protocol
 
+if TYPE_CHECKING:
+    import pyarrow
+
 logger = logging.getLogger(__name__)
+
+# Metadata keys for storing data file location in checkpoint parquet files.
+# The directory and filename prefix are stored separately to avoid unnecessary
+# join/split round-tripping, and to make partitioned write handling explicit.
+DATA_FILE_DIR_METADATA_KEY = b"ray.data.checkpoint.data_file_dir"
+DATA_FILE_PREFIX_METADATA_KEY = b"ray.data.checkpoint.data_file_prefix"
+
+# Suffix for pending checkpoint files (2-phase commit)
+PENDING_CHECKPOINT_SUFFIX = ".pending"
+
+
+@dataclass
+class PendingCheckpoint:
+    """Represents a pending checkpoint file for 2-phase commit.
+
+    Attributes:
+        pending_path: Path to the pending checkpoint file.
+        committed_path: Path where the checkpoint will be after commit.
+    """
+
+    pending_path: str
+    committed_path: str
 
 
 class CheckpointWriter:
     """Abstract class which defines the interface for writing row-level
     checkpoints based on varying backends.
 
-    Subclasses must implement `.write_block_checkpoint()`."""
+    Subclasses must implement `.write_block_checkpoint()`.
+
+    For 2-phase commit support, subclasses should also implement:
+    - `.write_pending_checkpoint()`: Write checkpoint as pending file
+    - `.commit_checkpoint()`: Rename pending to committed
+    """
 
     def __init__(self, config: CheckpointConfig):
         self.ckpt_config = config
@@ -34,8 +67,62 @@ class CheckpointWriter:
         """Write a checkpoint for all rows in a single block to the checkpoint
         output directory given by `self.checkpoint_path`.
 
+        This is used for non-file datasinks (SQL, MongoDB, etc.) where there's
+        no predictable file path to store in checkpoint metadata. For file-based
+        datasinks that need 2-phase commit with data file path tracking, use
+        `write_pending_checkpoint()` and `commit_checkpoint()` instead.
+
+        Args:
+            block: The block accessor containing the data to checkpoint.
+
         Subclasses of `CheckpointWriter` must implement this method."""
         ...
+
+    def write_pending_checkpoint(
+        self,
+        id_column_data: "pyarrow.Array",
+        data_file_dir: str,
+        data_file_prefix: str,
+        checkpoint_id: str,
+    ) -> Optional[PendingCheckpoint]:
+        """Write a pending checkpoint for 2-phase commit.
+
+        This is called BEFORE the data file is written. The checkpoint is
+        written as a pending file with the expected data file location in metadata.
+
+        Note: This method intentionally receives only the ID column data, not
+        the full block. The expected data file path must be computable without
+        block content (from write_uuid and task_idx only) to enable 2-phase
+        commit - we need to know the path BEFORE writing to support rollback.
+
+        Args:
+            id_column_data: PyArrow array containing the ID column values.
+            data_file_dir: The directory where data files will be written.
+                May include a protocol prefix (e.g., s3://bucket/path).
+            data_file_prefix: The filename prefix for data files (without
+                extension). Used for prefix matching during recovery.
+            checkpoint_id: Deterministic identifier for the checkpoint file,
+                derived from write_uuid and task_idx. Must be the same on retry
+                to ensure idempotent writes.
+
+        Returns:
+            PendingCheckpoint object for later commit, or None if empty.
+        """
+        raise NotImplementedError(
+            "2-phase commit not implemented for this checkpoint writer"
+        )
+
+    def commit_checkpoint(self, pending: PendingCheckpoint) -> None:
+        """Commit a pending checkpoint by renaming it to committed.
+
+        This is called AFTER the data file is successfully written.
+
+        Args:
+            pending: The PendingCheckpoint to commit.
+        """
+        raise NotImplementedError(
+            "2-phase commit not implemented for this checkpoint writer"
+        )
 
     @staticmethod
     def create(config: CheckpointConfig) -> "CheckpointWriter":
@@ -59,21 +146,73 @@ class BatchBasedCheckpointWriter(CheckpointWriter):
 
         self.filesystem.create_dir(self.checkpoint_path_unwrapped, recursive=True)
 
-    def write_block_checkpoint(self, block: BlockAccessor):
+    def _prepare_checkpoint_table_from_block(self, block: BlockAccessor):
+        """Prepare the checkpoint table from a block.
+
+        Args:
+            block: The block accessor containing the data to checkpoint.
+
+        Returns:
+            PyArrow table with checkpoint IDs.
+        """
+        checkpoint_ids_block = block.select(columns=[self.id_col])
+        # `pyarrow.parquet.write_parquet` requires a PyArrow table.
+        return BlockAccessor.for_block(checkpoint_ids_block).to_arrow()
+
+    def _prepare_checkpoint_table_from_id_column(
+        self,
+        id_column_data: "pyarrow.Array",
+        data_file_dir: Optional[str] = None,
+        data_file_prefix: Optional[str] = None,
+    ):
+        """Prepare the checkpoint table from ID column data with optional data file location metadata.
+
+        Args:
+            id_column_data: PyArrow array containing the ID column values.
+            data_file_dir: Optional directory where data files are written.
+            data_file_prefix: Optional filename prefix for data files.
+
+        Returns:
+            PyArrow table with checkpoint IDs and metadata.
+        """
+        import pyarrow as pa
+
+        checkpoint_ids_table = pa.table({self.id_col: id_column_data})
+        return self._add_data_file_path_metadata(
+            checkpoint_ids_table, data_file_dir, data_file_prefix
+        )
+
+    def _add_data_file_path_metadata(
+        self, table, data_file_dir: Optional[str], data_file_prefix: Optional[str]
+    ):
+        """Add data file directory and prefix to table schema metadata."""
+        if data_file_dir is not None and data_file_prefix is not None:
+            existing_metadata = table.schema.metadata or {}
+            new_metadata = {
+                **existing_metadata,
+                DATA_FILE_DIR_METADATA_KEY: data_file_dir.encode("utf-8"),
+                DATA_FILE_PREFIX_METADATA_KEY: data_file_prefix.encode("utf-8"),
+            }
+            table = table.replace_schema_metadata(new_metadata)
+        return table
+
+    def write_block_checkpoint(self, block: BlockAccessor) -> None:
         """Write a checkpoint for all rows in a single block to the checkpoint
         output directory given by `self.checkpoint_path`.
 
-        Subclasses of `CheckpointWriter` must implement this method."""
+        This is used for non-file datasinks (SQL, MongoDB, etc.) where there's
+        no predictable file path to store in checkpoint metadata.
+
+        Args:
+            block: The block accessor containing the data to checkpoint.
+        """
         if block.num_rows() == 0:
             return
 
         file_name = f"{uuid.uuid4()}.parquet"
         ckpt_file_path = os.path.join(self.checkpoint_path_unwrapped, file_name)
 
-        checkpoint_ids_block = block.select(columns=[self.id_col])
-        # `pyarrow.parquet.write_parquet` requires a PyArrow table. It errors if the block is
-        # a pandas DataFrame.
-        checkpoint_ids_table = BlockAccessor.for_block(checkpoint_ids_block).to_arrow()
+        checkpoint_ids_table = self._prepare_checkpoint_table_from_block(block)
 
         def _write():
             pq.write_table(
@@ -83,7 +222,7 @@ class BatchBasedCheckpointWriter(CheckpointWriter):
             )
 
         try:
-            return call_with_retry(
+            call_with_retry(
                 _write,
                 description=f"Write checkpoint file: {file_name}",
                 match=DataContext.get_current().retried_io_errors,
@@ -91,3 +230,84 @@ class BatchBasedCheckpointWriter(CheckpointWriter):
         except Exception:
             logger.exception(f"Checkpoint write failed: {file_name}")
             raise
+
+    def write_pending_checkpoint(
+        self,
+        id_column_data: "pyarrow.Array",
+        data_file_dir: str,
+        data_file_prefix: str,
+        checkpoint_id: str,
+    ) -> Optional[PendingCheckpoint]:
+        if len(id_column_data) == 0:
+            return None
+        pending_file_name = f"{checkpoint_id}{PENDING_CHECKPOINT_SUFFIX}.parquet"
+        committed_file_name = f"{checkpoint_id}.parquet"
+
+        pending_path = os.path.join(self.checkpoint_path_unwrapped, pending_file_name)
+        committed_path = os.path.join(
+            self.checkpoint_path_unwrapped, committed_file_name
+        )
+
+        checkpoint_ids_table = self._prepare_checkpoint_table_from_id_column(
+            id_column_data, data_file_dir, data_file_prefix
+        )
+
+        def _write():
+            pq.write_table(
+                checkpoint_ids_table,
+                pending_path,
+                filesystem=self.filesystem,
+            )
+
+        call_with_retry(
+            _write,
+            description=f"Write pending checkpoint file: {pending_file_name}",
+            match=DataContext.get_current().retried_io_errors,
+        )
+        return PendingCheckpoint(
+            pending_path=pending_path,
+            committed_path=committed_path,
+        )
+
+    def commit_checkpoint(self, pending: PendingCheckpoint) -> None:
+        """Commit a pending checkpoint by renaming it to committed.
+
+        This is called AFTER the data file is successfully written.
+
+        This operation is idempotent: if the committed file already exists
+        (and pending doesn't), it's considered already committed. This handles
+        the case where a retry happens after successful commit (e.g., network
+        timeout after move succeeded but before acknowledgment).
+
+        Args:
+            pending: The PendingCheckpoint to commit.
+        """
+
+        def _rename():
+            # Check if already committed (idempotent)
+            committed_info = self.filesystem.get_file_info(pending.committed_path)
+            pending_info = self.filesystem.get_file_info(pending.pending_path)
+
+            committed_exists = committed_info.type != FileType.NotFound
+            pending_exists = pending_info.type != FileType.NotFound
+
+            if committed_exists:
+                # Already committed. Clean up pending file if it exists.
+                if pending_exists:
+                    self.filesystem.delete_file(pending.pending_path)
+                return
+
+            if not pending_exists:
+                raise FileNotFoundError(
+                    f"Neither pending ({pending.pending_path}) nor committed "
+                    f"({pending.committed_path}) checkpoint exists"
+                )
+
+            # Normal case: move pending to committed
+            self.filesystem.move(pending.pending_path, pending.committed_path)
+
+        call_with_retry(
+            _rename,
+            description=f"Commit checkpoint: {pending.pending_path}",
+            match=DataContext.get_current().retried_io_errors,
+        )

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -273,8 +273,8 @@ class BlockBasedFileDatasink(_FileDatasink):
         raise NotImplementedError
 
     def write_block(self, block: BlockAccessor, block_index: int, ctx: TaskContext):
-        filename = self.filename_provider.get_filename_for_block(
-            block, ctx.kwargs[WRITE_UUID_KWARG_NAME], ctx.task_idx, block_index
+        filename = self.filename_provider.get_filename_for_task(
+            ctx.kwargs[WRITE_UUID_KWARG_NAME], ctx.task_idx
         )
         write_path = posixpath.join(self.path, filename)
 

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -14,14 +14,24 @@ from pytest_lazy_fixtures import lf as lazy_fixture
 import ray
 from ray.data._internal.datasource.csv_datasource import CSVDatasource
 from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
+from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
 from ray.data._internal.logical.operators import Read, Write
 from ray.data._internal.logical.optimizers import get_execution_plan
+from ray.data._internal.planner.checkpoint.plan_write_op import (
+    WRITE_UUID_KWARG_NAME,
+    _generate_base_filename,
+    _generate_prepare_checkpoint_transform,
+)
 from ray.data.block import BlockAccessor
 from ray.data.checkpoint.checkpoint_filter import (
     BatchBasedCheckpointFilter,
+    _delete_matching_data_files,
 )
 from ray.data.checkpoint.checkpoint_writer import (
+    DATA_FILE_DIR_METADATA_KEY,
+    DATA_FILE_PREFIX_METADATA_KEY,
+    PENDING_CHECKPOINT_SUFFIX,
     BatchBasedCheckpointWriter,
 )
 from ray.data.checkpoint.interfaces import (
@@ -30,6 +40,7 @@ from ray.data.checkpoint.interfaces import (
     InvalidCheckpointingConfig,
 )
 from ray.data.context import DataContext
+from ray.data.datasource import BlockBasedFileDatasink
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
@@ -524,6 +535,505 @@ def test_recovery_skips_checkpointed_rows(
     assert actual_output == expected_output
 
 
+def test_pending_checkpoint_write_and_commit(tmp_path):
+    """Test the two-phase commit (2PC) checkpoint write and commit workflow.
+
+    This verifies that:
+    1. write_pending_checkpoint() creates a checkpoint file with PENDING suffix
+    2. The pending checkpoint exists but the committed version does not
+    3. commit_checkpoint() renames the pending file to committed (removes suffix)
+    4. After commit, the pending file no longer exists and committed file exists
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    os.makedirs(checkpoint_path, exist_ok=True)
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    df = pd.DataFrame({ID_COL: [1, 2], "col1": [0.1, 0.2]})
+    data_dir = os.path.join(tmp_path, "data")
+    os.makedirs(data_dir, exist_ok=True)
+    expected_data_path = os.path.join(data_dir, "file.csv")
+    with open(expected_data_path, "w", encoding="utf-8") as f:
+        f.write("id,col1\n1,0.1\n2,0.2\n")
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    # Pass only the ID column data (not the full block) to make explicit that
+    # the checkpoint only needs IDs, and the expected path is independent of
+    # block content (required for 2-phase commit rollback support)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        data_file_dir=data_dir,
+        data_file_prefix="file",
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+    assert os.path.exists(pending.pending_path)
+    assert not os.path.exists(pending.committed_path)
+
+    writer.commit_checkpoint(pending)
+    assert not os.path.exists(pending.pending_path)
+    assert os.path.exists(pending.committed_path)
+
+
+def test_commit_checkpoint_idempotent_already_committed(tmp_path):
+    """Test that commit_checkpoint is idempotent when already committed.
+
+    If the committed file already exists and pending doesn't, calling
+    commit_checkpoint should succeed without error (no-op).
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    os.makedirs(checkpoint_path, exist_ok=True)
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    df = pd.DataFrame({ID_COL: [1, 2]})
+    data_dir = os.path.join(tmp_path, "data")
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        data_file_dir=data_dir,
+        data_file_prefix="file",
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+
+    # First commit succeeds
+    writer.commit_checkpoint(pending)
+    assert not os.path.exists(pending.pending_path)
+    assert os.path.exists(pending.committed_path)
+
+    # Second commit should be idempotent (no error)
+    writer.commit_checkpoint(pending)
+    assert not os.path.exists(pending.pending_path)
+    assert os.path.exists(pending.committed_path)
+
+
+def test_commit_checkpoint_idempotent_both_exist(tmp_path):
+    """Test that commit_checkpoint cleans up when both files exist.
+
+    If both committed and pending files exist (edge case), the pending
+    file should be deleted and committed file preserved.
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    os.makedirs(checkpoint_path, exist_ok=True)
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    df = pd.DataFrame({ID_COL: [1, 2]})
+    data_dir = os.path.join(tmp_path, "data")
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        data_file_dir=data_dir,
+        data_file_prefix="file",
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+
+    # Commit normally
+    writer.commit_checkpoint(pending)
+
+    # Manually recreate the pending file to simulate edge case
+    with open(pending.pending_path, "w") as f:
+        f.write("dummy")
+
+    assert os.path.exists(pending.pending_path)
+    assert os.path.exists(pending.committed_path)
+
+    # Commit should clean up the pending file
+    writer.commit_checkpoint(pending)
+    assert not os.path.exists(pending.pending_path)
+    assert os.path.exists(pending.committed_path)
+
+
+def test_commit_checkpoint_neither_exists(tmp_path):
+    """Test that commit_checkpoint raises error when neither file exists."""
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    os.makedirs(checkpoint_path, exist_ok=True)
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    df = pd.DataFrame({ID_COL: [1, 2]})
+    data_dir = os.path.join(tmp_path, "data")
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        data_file_dir=data_dir,
+        data_file_prefix="file",
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+
+    # Delete the pending file to simulate missing state
+    os.remove(pending.pending_path)
+    assert not os.path.exists(pending.pending_path)
+    assert not os.path.exists(pending.committed_path)
+
+    # Commit should raise FileNotFoundError
+    with pytest.raises(FileNotFoundError):
+        writer.commit_checkpoint(pending)
+
+
+@pytest.mark.parametrize("data_file_exists", [True, False])
+def test_clean_pending_checkpoint(tmp_path, data_file_exists):
+    """Test pending checkpoint cleanup removes incomplete writes.
+
+    When a write fails after creating a pending checkpoint but before commit,
+    the cleanup process must:
+    1. Delete the pending checkpoint file
+    2. Delete associated data files matching the path prefix (if they exist)
+
+    This test verifies cleanup works correctly whether the data file was
+    actually written (data_file_exists=True) or not (data_file_exists=False).
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    os.makedirs(checkpoint_path, exist_ok=True)
+    data_dir = os.path.join(tmp_path, "data")
+    os.makedirs(data_dir, exist_ok=True)
+    base_prefix = os.path.join(data_dir, "file")
+    data_path = f"{base_prefix}.csv"
+
+    if data_file_exists:
+        with open(data_path, "w", encoding="utf-8") as f:
+            f.write("id\n0\n")
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    df = pd.DataFrame({ID_COL: [0], "col1": [0.1]})
+    # Pass only the ID column data (not the full block)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        data_file_dir=data_dir,
+        data_file_prefix="file",
+        checkpoint_id="test_000000_000000",
+    )
+
+    assert pending is not None
+    assert os.path.exists(data_path) == data_file_exists
+    assert os.path.exists(pending.pending_path)
+
+    filter_instance = BatchBasedCheckpointFilter(ctx.checkpoint_config)
+    filter_instance._clean_pending_checkpoints()
+
+    assert not os.path.exists(data_path)
+    assert not os.path.exists(pending.pending_path)
+
+
+def test_clean_pending_checkpoint_with_partitioned_data(
+    tmp_path, ray_start_10_cpus_shared
+):
+    """Test pending checkpoint cleanup removes files in partition subdirectories.
+
+    When using ParquetDatasink with partition_cols, data files are written to
+    subdirectories like output/col=val/file.parquet. The cleanup process must
+    recursively search subdirectories to find and delete orphaned data files.
+
+    This test simulates a failed partitioned write by:
+    1. Creating data files in partition subdirectories
+    2. Creating a pending checkpoint with a path prefix
+    3. Verifying cleanup deletes files in ALL partition subdirectories
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    os.makedirs(checkpoint_path, exist_ok=True)
+    data_dir = os.path.join(tmp_path, "data")
+    os.makedirs(data_dir, exist_ok=True)
+
+    # Simulate partitioned write structure: data/partition_col=value/file.parquet
+    # All files share the same base filename prefix (as ParquetDatasink does)
+    base_filename = "write_uuid_000000_000000"
+    partition_dirs = ["partition_col=a", "partition_col=b", "partition_col=c"]
+    created_files = []
+
+    for partition_dir in partition_dirs:
+        partition_path = os.path.join(data_dir, partition_dir)
+        os.makedirs(partition_path, exist_ok=True)
+        # ParquetDatasink uses basename_template like "{base}-{i}.parquet"
+        data_file = os.path.join(partition_path, f"{base_filename}-0.parquet")
+        with open(data_file, "w", encoding="utf-8") as f:
+            f.write("dummy data")
+        created_files.append(data_file)
+
+    # Also create a file directly in base dir (non-partitioned case)
+    non_partitioned_file = os.path.join(data_dir, f"{base_filename}-0.parquet")
+    with open(non_partitioned_file, "w", encoding="utf-8") as f:
+        f.write("dummy data")
+    created_files.append(non_partitioned_file)
+
+    # Verify all files were created
+    for f in created_files:
+        assert os.path.exists(f), f"Expected file to exist: {f}"
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    df = pd.DataFrame({ID_COL: [0, 1, 2], "partition_col": ["a", "b", "c"]})
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        data_file_dir=data_dir,
+        data_file_prefix=base_filename,
+        checkpoint_id="test_000000_000000",
+    )
+
+    assert pending is not None
+    assert os.path.exists(pending.pending_path)
+
+    # Run cleanup
+    filter_instance = BatchBasedCheckpointFilter(ctx.checkpoint_config)
+    filter_instance._clean_pending_checkpoints()
+
+    # Verify ALL data files were deleted (including those in subdirectories)
+    for f in created_files:
+        assert not os.path.exists(f), f"Expected file to be deleted: {f}"
+
+    # Verify pending checkpoint was also deleted
+    assert not os.path.exists(pending.pending_path)
+
+
+def test_delete_matching_data_files_resolves_filesystem_from_path(tmp_path):
+    """Test that _delete_matching_data_files resolves filesystem from data_file_path.
+
+    This verifies the fix for the cross-filesystem scenario where checkpoint and
+    output are on different filesystem types (e.g., checkpoint on local disk,
+    output on S3). The function must resolve the correct filesystem from the
+    data_file_path itself, not rely on a passed-in checkpoint filesystem.
+
+    We test this by:
+    1. Creating a data file in a local directory
+    2. Calling _delete_matching_data_files with a file:// protocol prefix
+       (which requires filesystem resolution from the path)
+    3. Verifying the file is deleted correctly
+
+    This simulates the recovery scenario where the data_file_path stored in
+    checkpoint metadata includes a protocol prefix (e.g., s3://bucket/path).
+    """
+    data_dir = os.path.join(tmp_path, "data")
+    os.makedirs(data_dir, exist_ok=True)
+
+    # Create test data files
+    base_filename = "test_write_uuid_000000_000000"
+    data_file = os.path.join(data_dir, f"{base_filename}.parquet")
+    with open(data_file, "w", encoding="utf-8") as f:
+        f.write("dummy data")
+
+    assert os.path.exists(data_file)
+
+    # Call _delete_matching_data_files with file:// protocol prefix on the dir
+    # This tests that the function resolves the filesystem from the path
+    # rather than relying on a passed-in filesystem
+    data_file_dir_with_protocol = f"file://{data_dir}"
+    cache = {}
+    deleted_files = _delete_matching_data_files(
+        data_file_dir_with_protocol,
+        base_filename,
+        cache,
+    )
+
+    # Verify file was deleted
+    assert not os.path.exists(data_file)
+    assert len(deleted_files) == 1
+    assert base_filename in deleted_files[0]
+
+
+def test_clean_pending_checkpoints_task_failure(ray_start_10_cpus_shared, tmp_path):
+    """Test that _clean_pending_checkpoints raises when the cleanup task fails.
+
+    This verifies that:
+    1. When the underlying Ray task fails, the exception is propagated
+    2. The error is logged properly before re-raising
+    """
+    ctx = ray.data.DataContext.get_current()
+    # Use a non-existent path to trigger a failure when trying to list files
+    checkpoint_path = os.path.join(tmp_path, "nonexistent", "deeply", "nested", "path")
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    filter_instance = BatchBasedCheckpointFilter(ctx.checkpoint_config)
+
+    # The cleanup task should fail because the checkpoint directory doesn't exist
+    # and get_file_info on a non-existent path will raise an error
+    with pytest.raises(ray.exceptions.RayTaskError):
+        filter_instance._clean_pending_checkpoints()
+
+
+def test_pending_checkpoint_transform_writes_metadata(tmp_path):
+    """Test that the checkpoint transform embeds expected data file path in metadata.
+
+    The 2PC checkpoint system needs to know which data file corresponds to each
+    pending checkpoint, so that on recovery it can delete the data file if the
+    write was incomplete. This test verifies that:
+    1. _generate_prepare_checkpoint_transform() creates a transform that writes
+       pending checkpoints with DATA_FILE_PATH_METADATA_KEY in the parquet metadata
+    2. The metadata value matches the expected data file path from the datasink
+    """
+
+    class MockFileDatasink(BlockBasedFileDatasink):
+        def write_block_to_file(self, block: BlockAccessor, file: "pyarrow.NativeFile"):
+            file.write(b"")
+
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    os.makedirs(checkpoint_path, exist_ok=True)
+    data_output_path = os.path.join(tmp_path, "output")
+    os.makedirs(data_output_path, exist_ok=True)
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    datasink = MockFileDatasink(data_output_path, file_format="csv")
+    checkpoint_writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    transform = _generate_prepare_checkpoint_transform(ctx, datasink, checkpoint_writer)
+
+    ctx_task = TaskContext(task_idx=0, op_name="test")
+    ctx_task.kwargs[WRITE_UUID_KWARG_NAME] = "test-write-uuid"
+
+    df = pd.DataFrame({ID_COL: [0], "col1": [0.1]})
+    list(transform._apply_transform(ctx_task, [df]))
+
+    pending_files = [
+        f
+        for f in os.listdir(checkpoint_path)
+        if f.endswith(f"{PENDING_CHECKPOINT_SUFFIX}.parquet")
+    ]
+    assert len(pending_files) == 1
+    pending_path = os.path.join(checkpoint_path, pending_files[0])
+
+    base_filename = _generate_base_filename(datasink, ctx_task)
+    parquet_file = pq.ParquetFile(pending_path)
+    metadata = parquet_file.schema_arrow.metadata
+    assert metadata is not None
+    assert (
+        metadata[DATA_FILE_DIR_METADATA_KEY].decode("utf-8") == datasink.unresolved_path
+    )
+    assert metadata[DATA_FILE_PREFIX_METADATA_KEY].decode("utf-8") == base_filename
+
+
+def test_2pc_fail_retry_cleans_pending_checkpoints(
+    ray_start_10_cpus_shared,
+    tmp_path,
+):
+    """Test end-to-end 2PC cleanup: fail during write, retry succeeds after cleanup.
+
+    This is an integration test for the full two-phase commit cleanup flow:
+    1. First write attempt: datasink writes partial data then fails, leaving
+       pending checkpoint files
+    2. Retry: the checkpoint filter's _clean_pending_checkpoints() detects
+       pending files, deletes them along with partial data files
+    3. Second write attempt: succeeds, writing complete data with no duplicates
+
+    Verifies that after cleanup, all pending checkpoints are removed and
+    the final output contains the correct data.
+    """
+    ctx = ray.data.DataContext.get_current()
+    ctx.raise_original_map_exception = True
+    ctx.default_hash_shuffle_parallelism = 1
+
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    data_output_path = os.path.join(tmp_path, "output")
+    os.makedirs(checkpoint_path, exist_ok=True)
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    @ray.remote(num_cpus=0)
+    class FailController:
+        def __init__(self):
+            self._should_fail = True
+
+        def should_fail(self):
+            return self._should_fail
+
+        def disable_failure(self):
+            self._should_fail = False
+
+    controller = FailController.remote()
+
+    class FailOnceCSVDatasink(BlockBasedFileDatasink):
+        def __init__(self, path: str, controller):
+            super().__init__(path, file_format="csv")
+            self._controller = controller
+
+        def write_block_to_file(self, block: BlockAccessor, file: "pyarrow.NativeFile"):
+            if ray.get(self._controller.should_fail.remote()):
+                # Write a partial file and then fail to simulate incomplete write.
+                file.write(b"id\n0\n")
+                raise RuntimeError("Simulated write failure")
+            block.to_pandas().to_csv(file, index=False)
+
+    datasink = FailOnceCSVDatasink(data_output_path, controller)
+    ds = ray.data.range(SAMPLE_DATA_NUM_ROWS, override_num_blocks=1)
+
+    with pytest.raises(RuntimeError, match="Simulated write failure"):
+        ds.write_datasink(datasink, ray_remote_args={"max_retries": 0})
+
+    pending_files = [
+        f
+        for f in os.listdir(checkpoint_path)
+        if f.endswith(f"{PENDING_CHECKPOINT_SUFFIX}.parquet")
+    ]
+    assert pending_files, "Expected pending checkpoint files after failed write."
+
+    ray.get(controller.disable_failure.remote())
+    ds.write_datasink(datasink, ray_remote_args={"max_retries": 0})
+
+    pending_files_after = [
+        f
+        for f in os.listdir(checkpoint_path)
+        if f.endswith(f"{PENDING_CHECKPOINT_SUFFIX}.parquet")
+    ]
+    assert pending_files_after == []
+
+    ctx.checkpoint_config = None
+    ds_readback = ray.data.read_csv(data_output_path)
+    actual_output = sorted([row[ID_COL] for row in ds_readback.iter_rows()])
+    expected_output = sorted(range(SAMPLE_DATA_NUM_ROWS))
+    assert actual_output == expected_output
+
+
 @pytest.mark.parametrize(
     "backend,fs,data_path",
     [
@@ -766,6 +1276,224 @@ def test_checkpoint_restore_after_full_execution(
     assert (
         num_rows_second == 0  # No rows should be written
     ), f"Expected 0 rows, got {num_rows_second}"
+
+
+class FailAfterWriteParquetDatasink(ParquetDatasink):
+    """Test helper: ParquetDatasink that fails AFTER writing data (simulates post-write crash).
+
+    This simulates the failure scenario where:
+    - Data is successfully written to the output file
+    - But the process crashes/fails before the checkpoint can be committed
+    This is the critical case that 2PC is designed to handle - the data file
+    exists but is "uncommitted" and should be cleaned up on recovery.
+    """
+
+    def __init__(self, path: str, fail_threshold: int = 100, **kwargs):
+        super().__init__(path, **kwargs)
+        self._fail_threshold = fail_threshold
+
+    def write(self, blocks, ctx):
+        blocks_list = list(blocks)
+
+        # Check if any block has id > threshold
+        should_fail = False
+        for block in blocks_list:
+            accessor = BlockAccessor.for_block(block)
+            df = accessor.to_pandas()
+            if ID_COL in df.columns and df[ID_COL].max() > self._fail_threshold:
+                should_fail = True
+                break
+
+        # First, write the blocks normally
+        result = super().write(iter(blocks_list), ctx)
+
+        # Then fail if threshold exceeded (simulates post-write failure)
+        if should_fail:
+            raise RuntimeError(
+                f"Simulated failure: block contains {ID_COL} > {self._fail_threshold}"
+            )
+
+        return result
+
+
+def test_partial_failure_no_duplicates(
+    ray_start_10_cpus_shared,
+    tmp_path,
+):
+    """Test checkpoint deduplication: partial failure + retry produces no duplicate rows.
+
+    This is the key correctness test for the 2PC checkpoint deduplication feature.
+    It verifies that when a write pipeline fails partway through:
+    1. Already-committed rows (from successful blocks before failure) are tracked
+    2. Uncommitted rows (from blocks that failed after writing data) are cleaned up
+    3. On retry, only uncommitted rows are re-written
+    4. Final output has exactly the expected rows with NO duplicates
+
+    The test uses run_tag to verify which rows came from which run, confirming
+    that committed rows from run 1 are preserved and not re-written in run 2.
+    """
+    num_rows = 1000
+    fail_threshold = 100
+
+    # Create paths
+    input_path = tmp_path / "input"
+    output_path = tmp_path / "output"
+    checkpoint_path_dir = tmp_path / "checkpoint"
+    for path in [input_path, output_path, checkpoint_path_dir]:
+        path.mkdir(exist_ok=True)
+
+    # Create sample data (1000 rows with unique IDs)
+    df = pd.DataFrame(
+        {ID_COL: range(num_rows), "value": [f"row_{i}" for i in range(num_rows)]}
+    )
+    df.to_parquet(input_path / "data.parquet", index=False)
+
+    # Configure checkpointing
+    ctx = DataContext.get_current()
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=str(checkpoint_path_dir),
+        delete_checkpoint_on_success=False,
+    )
+
+    def add_run_tag(batch, run_tag):
+        """Add a run_tag column to identify which run wrote the data."""
+        batch["run_tag"] = [run_tag] * len(batch[ID_COL])
+        return batch
+
+    # Run 1: Use the failing datasink - should write some blocks then fail
+    with pytest.raises(RuntimeError, match="Simulated failure"):
+        ds = ray.data.read_parquet(str(input_path))
+        ds = ds.repartition(200)  # 200 blocks
+        ds = ds.map_batches(lambda b: add_run_tag(b, "first"), batch_size=None)
+        failing_datasink = FailAfterWriteParquetDatasink(
+            str(output_path), fail_threshold=fail_threshold
+        )
+        ds.write_datasink(failing_datasink, ray_remote_args={"max_retries": 0})
+
+    # Shutdown Ray to ensure all in-flight tasks complete before checking state.
+    # This addresses the race condition where background tasks may still be writing
+    # checkpoint files after the exception is raised.
+    ray.shutdown()
+    ray.init()
+
+    # Run 2: Use regular write_parquet - should resume from checkpoint
+    ds2 = ray.data.read_parquet(str(input_path))
+    ds2 = ds2.repartition(200)
+    ds2 = ds2.map_batches(lambda b: add_run_tag(b, "second"), batch_size=None)
+    ds2.write_parquet(str(output_path))
+
+    result = ray.data.read_parquet(str(output_path)).to_pandas()
+
+    assert len(result) == num_rows, f"Expected {num_rows} rows, got {len(result)}"
+
+    # Check for duplicates
+    assert result[ID_COL].is_unique, (
+        f"Duplicate IDs found: "
+        f"{sorted(result[result.duplicated(ID_COL, keep=False)][ID_COL].unique().tolist())}"
+    )
+
+    # Verify that some rows came from first run (before failure) and rest from second
+    run_tag_counts = result["run_tag"].value_counts()
+    assert "first" in run_tag_counts.index, "Expected some rows from first run"
+    assert "second" in run_tag_counts.index, "Expected some rows from second run"
+
+
+def test_partial_failure_no_duplicates_partitioned(
+    ray_start_10_cpus_shared,
+    tmp_path,
+):
+    """Test checkpoint deduplication with multi-level partitioned parquet output.
+
+    Same as test_partial_failure_no_duplicates, but writes partitioned output
+    using 3 partition columns, creating deeply nested subdirectories
+    (e.g., output/region=us/category=x/tier=1/file.parquet). This exercises
+    the recovery path where data files must be found via recursive search
+    using the stored data_file_dir and data_file_prefix metadata.
+    """
+    num_rows = 1000
+    fail_threshold = 100
+
+    # Create paths
+    input_path = tmp_path / "input"
+    output_path = tmp_path / "output"
+    checkpoint_path_dir = tmp_path / "checkpoint"
+    for path in [input_path, output_path, checkpoint_path_dir]:
+        path.mkdir(exist_ok=True)
+
+    # Create sample data with 3 partition columns for deeply nested output
+    # (e.g., output/region=us/category=x/tier=1/file.parquet)
+    regions = ["us", "eu"]
+    categories = ["x", "y", "z"]
+    tiers = [1, 2]
+    df = pd.DataFrame(
+        {
+            ID_COL: range(num_rows),
+            "value": [f"row_{i}" for i in range(num_rows)],
+            "region": [regions[i % len(regions)] for i in range(num_rows)],
+            "category": [categories[i % len(categories)] for i in range(num_rows)],
+            "tier": [tiers[i % len(tiers)] for i in range(num_rows)],
+        }
+    )
+    df.to_parquet(input_path / "data.parquet", index=False)
+
+    # Configure checkpointing
+    ctx = DataContext.get_current()
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=str(checkpoint_path_dir),
+        delete_checkpoint_on_success=False,
+    )
+
+    def add_run_tag(batch, run_tag):
+        """Add a run_tag column to identify which run wrote the data."""
+        batch["run_tag"] = [run_tag] * len(batch[ID_COL])
+        return batch
+
+    partition_cols = ["region", "category", "tier"]
+
+    # Run 1: Use the failing datasink with partition_cols
+    with pytest.raises(RuntimeError, match="Simulated failure"):
+        ds = ray.data.read_parquet(str(input_path))
+        ds = ds.repartition(200)
+        ds = ds.map_batches(lambda b: add_run_tag(b, "first"), batch_size=None)
+        failing_datasink = FailAfterWriteParquetDatasink(
+            str(output_path),
+            fail_threshold=fail_threshold,
+            partition_cols=partition_cols,
+        )
+        ds.write_datasink(failing_datasink, ray_remote_args={"max_retries": 0})
+
+    # Shutdown Ray to ensure all in-flight tasks complete before checking state.
+    ray.shutdown()
+    ray.init()
+
+    # Run 2: Use regular write_parquet with partition_cols - should resume
+    ds2 = ray.data.read_parquet(str(input_path))
+    ds2 = ds2.repartition(200)
+    ds2 = ds2.map_batches(lambda b: add_run_tag(b, "second"), batch_size=None)
+    ds2.write_parquet(str(output_path), partition_cols=partition_cols)
+
+    result = ray.data.read_parquet(str(output_path)).to_pandas()
+
+    assert len(result) == num_rows, f"Expected {num_rows} rows, got {len(result)}"
+
+    # Check for duplicates
+    assert result[ID_COL].is_unique, (
+        f"Duplicate IDs found: "
+        f"{sorted(result[result.duplicated(ID_COL, keep=False)][ID_COL].unique().tolist())}"
+    )
+
+    # Verify that some rows came from first run (before failure) and rest from second
+    run_tag_counts = result["run_tag"].value_counts()
+    assert "first" in run_tag_counts.index, "Expected some rows from first run"
+    assert "second" in run_tag_counts.index, "Expected some rows from second run"
+
+    # Verify partitioned output structure: partition subdirectories should exist
+    output_subdirs = [
+        d for d in os.listdir(str(output_path)) if os.path.isdir(output_path / d)
+    ]
+    assert len(output_subdirs) > 0, "Expected partition subdirectories in output"
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/test_filename_provider.py
+++ b/python/ray/data/tests/unit/test_filename_provider.py
@@ -21,7 +21,21 @@ def test_default_filename_for_row_is_deterministic(filename_provider):
     assert first_filename == second_filename
 
 
+def test_default_get_filename_for_task_is_deterministic(filename_provider):
+    """Test the new get_filename_for_task() method is deterministic."""
+
+    first_filename = filename_provider.get_filename_for_task(
+        write_uuid="spam", task_index=0
+    )
+    second_filename = filename_provider.get_filename_for_task(
+        write_uuid="spam", task_index=0
+    )
+
+    assert first_filename == second_filename
+
+
 def test_default_filename_for_block_is_deterministic(filename_provider):
+    """Test backward compatibility with deprecated get_filename_for_block()."""
     block = pd.DataFrame()
 
     first_filename = filename_provider.get_filename_for_block(
@@ -50,18 +64,28 @@ def test_default_filename_for_row_is_unique(filename_provider):
     assert len(set(filenames)) == len(filenames)
 
 
-def test_default_filename_for_block_is_unique(filename_provider):
+def test_default_get_filename_for_task_is_unique(filename_provider):
+    """Test the new get_filename_for_task() method generates unique filenames."""
     filenames = [
-        filename_provider.get_filename_for_block(
-            pd.DataFrame(),
+        filename_provider.get_filename_for_task(
             write_uuid="spam",
             task_index=task_index,
-            block_index=block_index,
         )
-        for task_index in range(2)
-        for block_index in range(2)
+        for task_index in range(4)
     ]
     assert len(set(filenames)) == len(filenames)
+
+
+def test_get_filename_for_task_matches_deprecated_with_block_index_0(filename_provider):
+    """Test that get_filename_for_task() returns same result as get_filename_for_block(block_index=0)."""
+    new_filename = filename_provider.get_filename_for_task(
+        write_uuid="spam", task_index=0
+    )
+    old_filename = filename_provider.get_filename_for_block(
+        None, write_uuid="spam", task_index=0, block_index=0
+    )
+
+    assert new_filename == old_filename
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Reproduce script:** https://gist.github.com/xinyuangui2/0be60bb7fd629afdf462a480519be86c

### Current Issue

This is a typical Ray Data pipeline: `read_parquet -> map_batches -> write`. In the checkpointing introduced in https://github.com/ray-project/ray/pull/59409, every block is first written and then checkpointed. If a failure occurs after data is written but before the checkpoint is saved, there will be duplicates in the final result.

### Solution: 2-Phase Commit

Only for file-based datasinks (`_FileDatasink` and its subclasses) for now.

#### Write Stage

1. Fetch the result filenames using `FilenameProvider`. Create pending checkpoint files (`{id}.pending.parquet`) and store the result filenames in the parquet metadata.
2. Write data to the output path.
3. Commit the pending checkpoint files by renaming `{id}.pending.parquet` to `{id}.parquet`.

#### Restore Stage

1. Find any pending parquet files (`*.pending.parquet`).
2. Fetch the result filenames from the parquet metadata.
3. Delete any files that match the filenames (pattern-based matching).
4. Delete the pending parquet files.
5. Continue with the existing checkpoint loading stage.

### Correctness Guarantees

The 2-phase commit ensures correctness because:

1. **Failure at any step of the write stage doesn't affect the final result** - If failure occurs before commit, the pending checkpoint is cleaned up during restore.
2. **Restore stage is idempotent** - Running restore multiple times produces the same result.

---

## Other Changes

### Deprecate `block_index` Parameter in `FilenameProvider`

The `block_index` parameter in `FilenameProvider.get_filename_for_block()` is always 0 in `_FileDatasink` because datasinks merge all blocks into one before writing. Additionally, this parameter makes fetching filenames inside pending checkpoints tricky (we need to predict the filename before writing).

A new method `get_filename_for_task()` is introduced without the `block_index` parameter. Custom `FilenameProvider` implementations should not depend on `block_index` to ensure checkpointing correctness.

## Release tests (to add)
