### PR TITLE
[serve] Downgrade multiplex model loading/unloading logs from INFO to DEBUG

### DIFF
--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -212,7 +212,7 @@ class _ModelMultiplexWrapper:
                         self._push_multiplexed_replica_info = True
 
                     # Load the model.
-                    logger.info(f"Loading model '{model_id}'.")
+                    logger.debug(f"Loading model '{model_id}'.")
                     self.models_load_counter.inc()
                     load_start_time = time.time()
                     if self.self_arg is None:
@@ -222,7 +222,7 @@ class _ModelMultiplexWrapper:
                             self.self_arg, model_id
                         )
                     load_latency_ms = (time.time() - load_start_time) * 1000.0
-                    logger.info(
+                    logger.debug(
                         f"Successfully loaded model '{model_id}' in "
                         f"{load_latency_ms:.1f}ms."
                     )

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -242,7 +242,7 @@ class _ModelMultiplexWrapper:
         self.models_unload_counter.inc()
         unload_start_time = time.time()
         model_id, model = self.models.popitem(last=False)
-        logger.info(f"Unloading model '{model_id}'.")
+        logger.debug(f"Unloading model '{model_id}'.")
 
         # If the model has __del__ attribute, call it.
         # This is to clean up the model resources eagerly.
@@ -254,7 +254,7 @@ class _ModelMultiplexWrapper:
             model.__del__ = lambda _: None
         unload_latency_ms = (time.time() - unload_start_time) * 1000.0
         self.model_unload_latency_ms.observe(unload_latency_ms)
-        logger.info(
+        logger.debug(
             f"Successfully unloaded model '{model_id}' in {unload_latency_ms:.1f}ms."
         )
         self.registered_model_gauge.set(0, tags={"model_id": model_id})


### PR DESCRIPTION
## Why are these changes needed?

The "Loading model '...'" / "Successfully loaded model '...'" / "Unloading model '...'" / "Successfully unloaded model '...'" messages fire on every request when using multiplexed model IDs (e.g., session-aware routing). At high concurrency this floods stdout with hundreds of lines per second, drowning out application logs.

Since model loading/unloading metrics are already tracked via counters (`models_load_counter`, `models_unload_counter`) and histograms (`model_load_latency_ms`, `model_unload_latency_ms`), these log lines are only useful for debugging. Downgrade to DEBUG.
