### PR TITLE
[Data] Add checkpoint benchmark release tests  

### DIFF
--- a/release/nightly_tests/dataset/checkpoint_benchmark.py
+++ b/release/nightly_tests/dataset/checkpoint_benchmark.py
@@ -1,0 +1,342 @@
+import argparse
+import math
+import os
+import random
+import time
+from typing import Optional
+
+import numpy
+from benchmark import Benchmark, BenchmarkMetric
+from pyarrow.fs import FileSelector, FileSystem, FileType
+
+import ray
+from ray.data.checkpoint import CheckpointBackend, CheckpointConfig
+from ray.data import DataContext
+from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
+from ray.data.datasource import WriteResult
+
+
+def _parse_checkpoint_config(args: argparse.Namespace) -> Optional[CheckpointConfig]:
+    backend_str = args.checkpoint_backend.upper()
+    if backend_str == "NONE":
+        return None
+    elif backend_str == "FILE_STORAGE":
+        backend = CheckpointBackend.FILE_STORAGE
+    elif backend_str == "CLOUD_OBJECT_STORAGE":
+        backend = CheckpointBackend.CLOUD_OBJECT_STORAGE
+    else:
+        raise ValueError(f"Unknown checkpoint backend: {backend_str}")
+
+    return CheckpointConfig(
+        id_column="id",
+        checkpoint_path=args.checkpoint_output_path,
+        override_backend=backend,
+    )
+
+
+def run_dataset(
+    checkpoint_config: Optional[CheckpointConfig],
+    input_data_path: str,
+    transform_sleep_s: float,
+    inference_sleep_s: float,
+    inference_batch_size: int,
+    inference_concurrency: int,
+    data_output_path: str,
+    num_output_files: int,
+    num_rows: Optional[int] = None,
+) -> int:
+    ctx = DataContext.get_current()
+    ctx.checkpoint_config = checkpoint_config
+
+    # Make read_parquet and transform fuse.
+    ctx._enable_read_files_fusion_override = True
+
+    READ_TASK_MEMORY = 8 * 1024 * 1024 * 1024  # 8GB
+
+    ds = ray.data.read_parquet(
+        input_data_path, ray_remote_args={"memory": READ_TASK_MEMORY}
+    )
+    if not num_rows:
+        num_rows = ds.count()
+
+    # TODO(srinathk10): Remove this once hash shuffle parallelism is system configurable.
+    if num_rows == 10_000_000:
+        ctx.default_hash_shuffle_parallelism = 25
+    elif num_rows == 3_000_000_000:
+        ctx.default_hash_shuffle_parallelism = 500
+
+    def transform(batch):
+        time.sleep(transform_sleep_s)
+        return batch
+
+    ds = ds.map_batches(transform, batch_size=None, memory=READ_TASK_MEMORY)
+
+    class Inference:
+        INFER_RESULT_DIMENSION = 16
+
+        def __call__(self, batch):
+            time.sleep(inference_sleep_s)
+            batch["inference"] = numpy.random.random(
+                (len(batch["data"]), self.INFER_RESULT_DIMENSION)
+            )
+            # Remove the data column to make the write op run faster.
+            # We want the Inference op to be the main bottleneck of the pipeline.
+            del batch["data"]
+            return batch
+
+    ds = ds.map_batches(
+        Inference,
+        batch_size=inference_batch_size,
+        concurrency=inference_concurrency,
+        num_gpus=1,
+    )
+
+    # Patch `on_write_complete` to get the WriteResult.
+    # TODO(hchen): make `write_parquet` expose the WriteResult directly.
+    num_rows_written = None
+    original_on_write_complete = ParquetDatasink.on_write_complete
+
+    def patched_on_write_complete(self, write_result: WriteResult[None]):
+        nonlocal num_rows_written
+        num_rows_written = write_result.num_rows
+        return original_on_write_complete(self, write_result)
+
+    ParquetDatasink.on_write_complete = patched_on_write_complete
+
+    try:
+        ds.write_parquet(
+            data_output_path,
+            min_rows_per_file=num_rows // num_output_files,
+        )
+        return int(num_rows_written)
+    finally:
+        ParquetDatasink.on_write_complete = original_on_write_complete
+
+
+def _delete_pct_of_checkpoint_files(
+    checkpoint_config: CheckpointConfig,
+    percentage: float,
+    *,
+    recursive: bool = True,
+    seed: Optional[int] = 42,
+) -> int:
+    """Delete a percentage of checkpoint files to test recovery scenarios."""
+    if not (0.0 <= percentage <= 1.0):
+        raise ValueError(f"percentage must be in [0, 1], got {percentage}")
+
+    if seed is not None:
+        random.seed(seed)
+
+    checkpoint_path = checkpoint_config.checkpoint_path
+
+    # Handle both local paths and S3 URIs
+    if checkpoint_path.startswith(("s3://", "gs://", "file://", "http://", "https://")):
+        # For URIs, get the filesystem and strip the scheme
+        fs, base_path = FileSystem.from_uri(checkpoint_path)
+    else:
+        # For local paths, use the provided filesystem
+        fs = checkpoint_config.filesystem
+        base_path = checkpoint_path
+
+    # Get list of files
+    info = fs.get_file_info(base_path)
+    if info.type == FileType.Directory:
+        selector = FileSelector(base_path, recursive=recursive)
+        file_infos = fs.get_file_info(selector)
+        files = [
+            checkpoint_path.rstrip("/") + "/" + fi.path[len(base_path) :].lstrip("/")
+            for fi in file_infos
+            if fi.type == FileType.File
+        ]
+    elif info.type == FileType.File:
+        files = [checkpoint_path]
+    else:
+        files = []
+
+    if not files:
+        print(f"No checkpoint files found in {checkpoint_path}")
+        return 0
+
+    if percentage == 0.0:
+        print(f"percentage=0.0, no files selected from {checkpoint_path}")
+        return 0
+
+    # Select and delete files
+    num_to_delete = min(len(files), max(1, math.ceil(len(files) * percentage)))
+    chosen = random.sample(files, num_to_delete)
+
+    print(
+        f"Deleting {len(chosen)} out of {len(files)} checkpoint files ({percentage*100:.0f}%)"
+    )
+
+    # Count rows before deletion
+    ds = ray.data.read_parquet(chosen)
+    total_rows_deleted = ds.count()
+    print(f"Selected {len(chosen)} files contain {total_rows_deleted} total rows")
+
+    # Delete files (strip s3:// prefix for filesystem operations)
+    for p in chosen:
+        delete_path = p[5:] if p.startswith("s3://") else p
+        fs.delete_file(delete_path)
+
+    return total_rows_deleted
+
+
+def run_checkpoints_benchmark(
+    benchmark: Benchmark,
+    checkpoint_config: Optional[CheckpointConfig],
+    input_data_path: str,
+    transform_sleep_s: float,
+    inference_sleep_s: float,
+    inference_batch_size: int,
+    inference_concurrency: int,
+    data_output_path: str,
+    num_output_files: int,
+    benchmark_name: str = "",
+    num_rows: Optional[int] = None,
+):
+    def run():
+        start_time = time.time()
+        print(f"[{benchmark_name}] Running dataset from scratch")
+        if checkpoint_config is not None:
+            # Keep the checkpoint files. We'll test loading them in the second run.
+            checkpoint_config.delete_checkpoint_on_success = False
+            print(f"checkpoint_path = {checkpoint_config.checkpoint_path}")
+
+        num_rows_written = run_dataset(
+            checkpoint_config,
+            input_data_path,
+            transform_sleep_s,
+            inference_sleep_s,
+            inference_batch_size,
+            inference_concurrency,
+            data_output_path,
+            num_output_files,
+            num_rows=num_rows,
+        )
+        runtime = time.time() - start_time
+        print(f"[{benchmark_name}] dataset finished in {runtime:.2f} seconds")
+
+        benchmark_results = {
+            BenchmarkMetric.RUNTIME: runtime,
+            BenchmarkMetric.THROUGHPUT: num_rows_written // runtime,
+            "num_rows_written": num_rows_written,
+        }
+
+        if checkpoint_config is not None:
+            if num_rows == 10_000_000:
+                # For small scale, we test all scenarios
+                test_scenarios = [
+                    ("full_checkpoint", 1.0),  # Full completion
+                    ("90_percent_completion", 0.90),  # 90% completion
+                    ("75_percent_completion", 0.75),  # 75% completion
+                    ("50_percent_completion", 0.5),  # 50% completion
+                    ("25_percent_completion", 0.25),  # 25% completion
+                    ("10_percent_completion", 0.1),  # 10% completion
+                ]
+            elif num_rows == 3_000_000_000:
+                # For large scale, we only test full completion
+                test_scenarios = [
+                    ("full_checkpoint", 1.0),  # Full completion
+                ]
+
+            for scenario_name, completion_percentage in test_scenarios:
+                if completion_percentage < 1.0:
+                    rows_to_recover = _delete_pct_of_checkpoint_files(
+                        checkpoint_config, 1.0 - completion_percentage
+                    )
+                    print(
+                        f"[{benchmark_name}] Testing checkpoint recovery with {completion_percentage*100:.0f}% completion, {num_rows} total rows, {rows_to_recover} rows to recover"
+                    )
+                else:
+                    rows_to_recover = 0
+                    print(
+                        f"[{benchmark_name}] Rerunning dataset with full checkpoint, {num_rows} total rows"
+                    )
+
+                start_time = time.time()
+                num_rows_written = run_dataset(
+                    checkpoint_config,
+                    input_data_path,
+                    transform_sleep_s,
+                    inference_sleep_s,
+                    inference_batch_size,
+                    inference_concurrency,
+                    data_output_path,
+                    num_output_files,
+                    num_rows=num_rows,
+                )
+                assert (
+                    num_rows_written == rows_to_recover
+                ), f"num_rows_written: {num_rows_written}, rows_to_recover: {rows_to_recover}"
+                runtime = time.time() - start_time
+                benchmark_results[f"runtime_with_{scenario_name}"] = runtime
+                print(
+                    f"[{benchmark_name}] dataset with {scenario_name} finished in {runtime:.2f} seconds"
+                )
+
+        return benchmark_results
+
+    benchmark.run_fn(benchmark_name, run)
+
+
+def clean_up_output_files(
+    checkpoint_config: Optional[CheckpointConfig],
+    data_output_path: str,
+):
+    print("Cleaning up output files")
+    output_paths = [data_output_path]
+    if checkpoint_config is not None:
+        assert checkpoint_config.checkpoint_path is not None
+        output_paths.append(checkpoint_config.checkpoint_path)
+    for checkpoint_path in output_paths:
+        print(f"Cleaning up {checkpoint_path}")
+        if checkpoint_path.startswith("s3://"):
+            import boto3
+
+            s3 = boto3.client("s3")
+            bucket, key = checkpoint_path[len("s3://") :].split("/", 1)
+            s3.delete_object(Bucket=bucket, Key=key)
+        else:
+            if not os.path.exists(checkpoint_path):
+                continue
+            import shutil
+
+            shutil.rmtree(checkpoint_path)
+
+
+# This benchmark is triggered by `run_checkpoint_benchmark.py` in CI.
+# This is only used for manual run.
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument("--checkpoint_backend", type=str, default="None")
+    _ = parser.add_argument("--input_data_path", type=str)
+    _ = parser.add_argument("--data_output_path", type=str)
+    _ = parser.add_argument("--checkpoint_output_path", type=str)
+    _ = parser.add_argument("--inference_concurrency", type=int)
+    _ = parser.add_argument("--inference_batch_size", type=int)
+    _ = parser.add_argument("--inference_sleep_s", type=float)
+    _ = parser.add_argument("--transform_sleep_s", type=float, default=0.001)
+    _ = parser.add_argument("--num_output_files", type=int, default=50)
+    args = parser.parse_args()
+
+    checkpoint_config = _parse_checkpoint_config(args)
+    try:
+        benchmark = Benchmark()
+        run_checkpoints_benchmark(
+            benchmark,
+            checkpoint_config,
+            args.input_data_path,
+            args.transform_sleep_s,
+            args.inference_sleep_s,
+            args.inference_batch_size,
+            args.inference_concurrency,
+            args.data_output_path,
+            args.num_output_files,
+        )
+        benchmark.write_result()
+    finally:
+        clean_up_output_files(
+            checkpoint_config,
+            args.data_output_path,
+        )

--- a/release/nightly_tests/dataset/checkpoint_benchmark_compute_large.yaml
+++ b/release/nightly_tests/dataset/checkpoint_benchmark_compute_large.yaml
@@ -1,0 +1,21 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+head_node_type:
+    name: head_node
+    instance_type: m5.2xlarge
+    resources:
+      cpu: 0
+
+worker_node_types:
+    - name: fake_gpu_node
+      # m5.8xlarge, 32 vCPU, 128 GiB memory
+      instance_type: m5.8xlarge
+      max_workers: 50
+      min_workers: 50
+      use_spot: true
+      fallback_to_ondemand: true
+      resources:
+        gpu: 4
+        # Larger object store memory make the test run faster.
+        object_store_memory: 64000000000

--- a/release/nightly_tests/dataset/checkpoint_benchmark_compute_small.yaml
+++ b/release/nightly_tests/dataset/checkpoint_benchmark_compute_small.yaml
@@ -1,0 +1,21 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+head_node_type:
+    name: head_node
+    instance_type: m5.2xlarge
+    resources:
+      cpu: 0
+
+worker_node_types:
+    - name: fake_gpu_node
+      # m5.8xlarge, 32 vCPU, 128 GiB memory
+      instance_type: m5.8xlarge
+      max_workers: 4
+      min_workers: 4
+      use_spot: true
+      fallback_to_ondemand: true
+      resources:
+        gpu: 4
+        # Larger object store memory make the test run faster.
+        object_store_memory: 64000000000

--- a/release/nightly_tests/dataset/run_checkpoint_benchmark.py
+++ b/release/nightly_tests/dataset/run_checkpoint_benchmark.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from datetime import datetime
+
+from benchmark import Benchmark
+from checkpoint_benchmark import (
+    clean_up_output_files,
+    run_checkpoints_benchmark,
+)
+
+from ray.data.checkpoint import CheckpointConfig
+
+if __name__ != "__main__":
+    raise RuntimeError("This script should be run as the main entry point")
+
+run_id = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+DATA_DIR = f"/mnt/cluster_storage/checkpoint_benchmark/data/{run_id}"
+CHECKPOINT_DIR_FILE_STORAGE = (
+    f"/mnt/cluster_storage/checkpoint_benchmark/checkpoints/{run_id}"
+)
+S3_BUCKET = os.environ["ANYSCALE_ARTIFACT_STORAGE"]
+CHECKPOINT_DIR_CLOUD_OBJECT_STORAGE = (
+    f"{S3_BUCKET}/ray-data-tests/checkpoint_benchmark/{run_id}"
+)
+TRANSFORM_SLEEP_S = 0.1
+BACKENDS = [
+    None,
+    "FILE_STORAGE",
+    "CLOUD_OBJECT_STORAGE",
+]
+
+
+benchmark = Benchmark()
+
+assert len(sys.argv) == 2, "Usage: python run_checkpoint_benchmark.py [small|large]"
+scale = sys.argv[1]
+assert scale in ["small", "large"], scale
+
+INPUT_DATA_PREFIX = (
+    "s3://ray-benchmark-data-internal-us-west-2/ray-data/checkpoint-benchmark"
+)
+
+if scale == "small":
+    # This dataset contains 10M rows, 5KB per row.
+    INPUT_DATA_PATH = f"{INPUT_DATA_PREFIX}/10M-rows/"
+    NUM_ROWS = 10_000_000
+    INFERENCE_CONCURRENCY = 16
+    INFERENCE_BATCH_SIZE = 1000
+    INFERENCE_SLEEP_S = 0.1
+    NUM_OUTPUT_FILES = 20
+else:
+    # This dataset contains 3B rows, 500B per row.
+    INPUT_DATA_PATH = f"{INPUT_DATA_PREFIX}/3B-rows/"
+    NUM_ROWS = 3_000_000_000
+    INFERENCE_CONCURRENCY = 200
+    INFERENCE_BATCH_SIZE = 10000
+    INFERENCE_SLEEP_S = 0.2
+    NUM_OUTPUT_FILES = 1500
+
+for backend in BACKENDS:
+    benchmark_name = f"checkpoint_benchmark:scale={scale}," f"backend={backend}"
+    path_suffix = f"{scale}-{backend}"
+    data_dir = f"{DATA_DIR}/{path_suffix}"
+
+    if backend is None:
+        checkpoint_config = None
+    elif backend == "FILE_STORAGE":
+        checkpoint_config = CheckpointConfig(
+            id_column="id",
+            checkpoint_path=f"{CHECKPOINT_DIR_FILE_STORAGE}/{path_suffix}",
+        )
+    elif backend == "CLOUD_OBJECT_STORAGE":
+        checkpoint_config = CheckpointConfig(
+            id_column="id",
+            checkpoint_path=f"{CHECKPOINT_DIR_CLOUD_OBJECT_STORAGE}/{path_suffix}",
+        )
+    else:
+        raise ValueError(f"Unknown checkpoint backend: {backend}")
+
+    try:
+        run_checkpoints_benchmark(
+            benchmark,
+            checkpoint_config=checkpoint_config,
+            input_data_path=INPUT_DATA_PATH,
+            transform_sleep_s=TRANSFORM_SLEEP_S,
+            inference_sleep_s=INFERENCE_SLEEP_S,
+            inference_batch_size=INFERENCE_BATCH_SIZE,
+            inference_concurrency=INFERENCE_CONCURRENCY,
+            data_output_path=data_dir,
+            num_output_files=NUM_OUTPUT_FILES,
+            benchmark_name=benchmark_name,
+            num_rows=NUM_ROWS,
+        )
+    finally:
+        clean_up_output_files(
+            checkpoint_config=checkpoint_config,
+            data_output_path=data_dir,
+        )
+
+benchmark.write_result()

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -826,6 +826,30 @@
       cluster:
         cluster_compute: dataset/cross_az_250_350_compute_aws.yaml
 
+#####################
+# Checkpoint tests
+#####################
+
+- name: "checkpoint_benchmark_{{scale}}"
+  python: "3.10"
+  group: data-tests
+  working_dir: nightly_tests/dataset
+
+  matrix:
+    setup:
+      scale: [small, large]
+
+  frequency: nightly
+  team: data
+  cluster:
+    byod:
+      type: gpu
+    cluster_compute: "checkpoint_benchmark_compute_{{scale}}.yaml"
+
+  run:
+    timeout: 4800
+    script: python ./run_checkpoint_benchmark.py {{scale}}
+
 ###################
 # Autoscaling tests
 ###################


### PR DESCRIPTION
## Summary
  - Add nightly checkpoint benchmark release tests (`checkpoint_benchmark_small` and `checkpoint_benchmark_large`) 
  - These benchmarks test end-to-end checkpoint write performance and recovery scenarios across FILE_STORAGE and CLOUD_OBJECT_STORAGE backends

  ## Details

  **Tests added:**
  - `checkpoint_benchmark_small`: 10M rows (5KB/row), 4x m5.8xlarge workers, tests 6 recovery scenarios (100%/90%/75%/50%/25%/10% completion)
  - `checkpoint_benchmark_large`: 3B rows (500B/row), 50x m5.8xlarge workers, tests full completion

  Each test runs against 3 backends: None (baseline), FILE_STORAGE, and CLOUD_OBJECT_STORAGE.

  **Files added:**
  - `release/nightly_tests/dataset/checkpoint_benchmark.py` — Core benchmark logic
  - `release/nightly_tests/dataset/run_checkpoint_benchmark.py` — CI entry point
  - `release/nightly_tests/dataset/checkpoint_benchmark_compute_{small,large}.yaml` — Cluster configs
  - `release/release_data_tests.yaml` — Test matrix entries