### PR TITLE
[Data][Refactor] test_json/test_file_based_datasource

### DIFF
--- a/python/ray/data/tests/datasource/test_file_based_datasource.py
+++ b/python/ray/data/tests/datasource/test_file_based_datasource.py
@@ -91,17 +91,15 @@ def test_read_single_file(ray_start_regular_shared, filesystem, dir_path, endpoi
     assert rows == [{"data": b"spam"}]
 
 
-def test_read_single_directory_local(ray_start_regular_shared, tmp_path):
-    dir_path = os.path.join(tmp_path, "dir")
-    os.mkdir(dir_path)
+def test_read_single_directory(ray_start_regular_shared, tmp_path):
+    dir_path = tmp_path / "dir"
+    dir_path.mkdir()
 
-    p1 = os.path.join(dir_path, "a.txt")
-    with open(p1, "wb") as f:
-        f.write(b"a")
+    p1 = dir_path / "a.txt"
+    p1.write_bytes(b"a")
 
-    p2 = os.path.join(dir_path, "b.txt")
-    with open(p2, "wb") as f:
-        f.write(b"b")
+    p2 = dir_path / "b.txt"
+    p2.write_bytes(b"b")
 
     datasource = MockFileBasedDatasource(dir_path)
     rows = execute_read_tasks(datasource.get_read_tasks(1))
@@ -110,16 +108,14 @@ def test_read_single_directory_local(ray_start_regular_shared, tmp_path):
 
 
 def test_read_dir_and_file_mixed(ray_start_regular_shared, tmp_path):
-    dir_path = os.path.join(tmp_path, "dir")
-    os.mkdir(dir_path)
+    dir_path = tmp_path / "dir"
+    dir_path.mkdir()
 
-    p1 = os.path.join(dir_path, "a.txt")
-    with open(p1, "wb") as f:
-        f.write(b"a")
+    p1 = dir_path / "a.txt"
+    p1.write_bytes(b"a")
 
-    p2 = os.path.join(tmp_path, "c.txt")
-    with open(p2, "wb") as f:
-        f.write(b"c")
+    p2 = tmp_path / "c.txt"
+    p2.write_bytes(b"c")
 
     datasource = MockFileBasedDatasource([dir_path, p2])
     rows = execute_read_tasks(datasource.get_read_tasks(1))
@@ -130,9 +126,8 @@ def test_read_dir_and_file_mixed(ray_start_regular_shared, tmp_path):
 def test_single_file_infinite_target_max_block_size(
     ray_start_regular_shared, target_max_block_size_infinite_or_default, tmp_path
 ):
-    path = os.path.join(tmp_path, "file.txt")
-    with open(path, "wb") as f:
-        f.write(b"spam")
+    path = tmp_path / "file.txt"
+    path.write_bytes(b"spam")
 
     datasource = MockFileBasedDatasource(path)
     rows = execute_read_tasks(datasource.get_read_tasks(1))
@@ -324,9 +319,8 @@ def test_file_extensions(ray_start_regular_shared, tmp_path):
 
 
 def test_file_extensions_no_match_raises(ray_start_regular_shared, tmp_path):
-    txt_path = os.path.join(tmp_path, "file.txt")
-    with open(txt_path, "w") as file:
-        file.write("ham")
+    txt_path = tmp_path / "file.txt"
+    txt_path.write_bytes(b"ham")
 
     with pytest.raises(
         ValueError,

--- a/python/ray/data/tests/datasource/test_file_based_datasource.py
+++ b/python/ray/data/tests/datasource/test_file_based_datasource.py
@@ -117,7 +117,7 @@ def test_read_dir_and_file_mixed(ray_start_regular_shared, tmp_path):
     p2 = tmp_path / "c.txt"
     p2.write_bytes(b"c")
 
-    datasource = MockFileBasedDatasource([dir_path, p2])
+    datasource = MockFileBasedDatasource([str(dir_path), str(p2)])
     rows = execute_read_tasks(datasource.get_read_tasks(1))
 
     assert sorted(rows, key=lambda r: r["data"]) == [{"data": b"a"}, {"data": b"c"}]
@@ -326,7 +326,7 @@ def test_file_extensions_no_match_raises(ray_start_regular_shared, tmp_path):
         ValueError,
         match="No input files found to read with the following file extensions",
     ):
-        MockFileBasedDatasource([txt_path], file_extensions=["csv"])
+        MockFileBasedDatasource([str(txt_path)], file_extensions=["csv"])
 
 
 def test_flaky_read_task_retries(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/datasource/test_file_based_datasource.py
+++ b/python/ray/data/tests/datasource/test_file_based_datasource.py
@@ -322,12 +322,16 @@ def test_file_extensions(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_datasource(datasource)
     assert ds.input_files() == [csv_path]
 
+
 def test_file_extensions_no_match_raises(ray_start_regular_shared, tmp_path):
     txt_path = os.path.join(tmp_path, "file.txt")
     with open(txt_path, "w") as file:
         file.write("ham")
 
-    with pytest.raises(ValueError, match="No input files"):
+    with pytest.raises(
+        ValueError,
+        match="No input files found to read with the following file extensions",
+    ):
         MockFileBasedDatasource([txt_path], file_extensions=["csv"])
 
 


### PR DESCRIPTION
## Why are these changes needed?

Format-specific test files (JSON, CSV, etc.) have redundant tests for common file I/O behavior. This PR adds missing tests to `test_file_based_datasource.py` and simplifies `test_json.py` to only test format-specific functionality.


## What's included?

### Updated: `test_file_based_datasource.py`
Added missing tests for common file I/O patterns so it supports:
- Single directory ✅
- Single file (minor fix)
- Mix of directories + files ✅
- File extension filtering (existed)
- File extension with no matches ✅
- Single file with infinite target max block size ✅

### Simplified: `test_json.py`
- `test_json_read()` - now only tests single file read
- `test_zipped_json_read()` - now only tests single zipped file read

## Screenshots
<img width="709" height="576" alt="Screenshot 2026-02-11 at 16 38 15" src="https://github.com/user-attachments/assets/c9e764ee-651b-4b95-b721-1f8df77fa643" />
<img width="710" height="288" alt="Screenshot 2026-02-11 at 16 47 34" src="https://github.com/user-attachments/assets/718e584f-27d4-4553-bfd2-147c9bd37095" />


## Benefits

- Less redundancy across format tests
- Faster test execution
- Clearer separation of concerns (general file I/O vs format-specific logic)
- Foundation for future test suite improvements

## Note

- Ran `test_flaky_read_task_retries` and `test_include_paths` - both failed. These failures appear unrelated to this PR's changes.
- Pre-commit black hook failing with `module 'ast' has no attribute 'Str'` - this is a Python/Black version compatibility issue, not related to code changes.

Fixes https://github.com/ray-project/ray/issues/61052