### PR TITLE
[core] add perf metrics for 2.54.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 97.763328,
+    "_dashboard_memory_usage_mb": 240.713728,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.6,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3288\t2.22GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5688\t0.83GiB\tpython distributed/test_many_actors.py\n2638\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3508\t0.18GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3992\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2769\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1137\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3994\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3417\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5502\t0.07GiB\tray::JobSupervisor",
-    "actors_per_second": 403.97078934630366,
+    "_peak_memory": 4.73,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1150\t3.91GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3639\t2.22GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2942\t1.96GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5468\t0.84GiB\tpython distributed/test_many_actors.py\n3900\t0.21GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n602\t0.21GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4382\t0.18GiB\tray::DashboardAgent\n3123\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n4384\t0.08GiB\tray::RuntimeEnvAgent\n3800\t0.07GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da",
+    "actors_per_second": 415.592968300115,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 403.97078934630366
+            "perf_metric_value": 415.592968300115
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.152
+            "perf_metric_value": 68.326
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3504.953
+            "perf_metric_value": 3722.916
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3993.037
+            "perf_metric_value": 3908.365
         }
     ],
-    "time": 24.754265069961548
+    "time": 24.062004804611206
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 93.601792,
+    "_dashboard_memory_usage_mb": 115.93728,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.34,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3115\t0.61GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2638\t0.31GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5058\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3328\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3810\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2789\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1088\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3244\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3812\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3326\t0.08GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import",
+    "_peak_memory": 2.5,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3427\t0.62GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2760\t0.37GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n17152\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3662\t0.16GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4158\t0.12GiB\tray::DashboardAgent\n3660\t0.11GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n3023\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3578\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n1086\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n17312\t0.08GiB\tray::DashboardTester.run",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 379.30168512953065
+            "perf_metric_value": 302.9857172164898
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.417
+            "perf_metric_value": 6.98
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.72
+            "perf_metric_value": 116.561
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 55.245
+            "perf_metric_value": 176.997
         }
     ],
-    "tasks_per_second": 379.30168512953065,
-    "time": 302.63642382621765,
+    "tasks_per_second": 302.9857172164898,
+    "time": 303.3004856109619,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 80.26112,
+    "_dashboard_memory_usage_mb": 165.36371200000002,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.87,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3290\t1.04GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2748\t0.53GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4875\t0.38GiB\tpython distributed/test_many_pgs.py\n585\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3507\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3991\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2882\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1141\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2609\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n3993\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
+    "_peak_memory": 2.91,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3100\t1.37GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3639\t1.03GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5490\t0.37GiB\tpython distributed/test_many_pgs.py\n602\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4382\t0.15GiB\tray::DashboardAgent\n3885\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3050\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1174\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3787\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n2925\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.933742626442143
+            "perf_metric_value": 17.52771503829712
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.729
+            "perf_metric_value": 4.786
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 35.467
+            "perf_metric_value": 22.535
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 983.739
+            "perf_metric_value": 650.905
         }
     ],
-    "pgs_per_second": 18.933742626442143,
-    "time": 52.81575965881348
+    "pgs_per_second": 17.52771503829712,
+    "time": 57.052502155303955
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 99.9424,
+    "_dashboard_memory_usage_mb": 95.780864,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.61,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3286\t2.21GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3509\t1.06GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4691\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2777\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3512\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n3991\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2711\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1117\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3415\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3993\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
+    "_peak_memory": 6.04,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3703\t2.06GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3950\t1.64GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n5968\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3086\t0.75GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n598\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3953\t0.15GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4453\t0.14GiB\tray::DashboardAgent\n3112\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1144\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3860\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 582.6440311743918
+            "perf_metric_value": 623.035598912693
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.21
+            "perf_metric_value": 6.198
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 891.025
+            "perf_metric_value": 234.221
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2650.58
+            "perf_metric_value": 1139.761
         }
     ],
-    "tasks_per_second": 582.6440311743918,
-    "time": 317.1631381511688,
+    "tasks_per_second": 623.035598912693,
+    "time": 316.0504472255707,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.53.0"}
+{"release_version": "2.54.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8591.539773771437,
-        327.6473689212415
+        6778.77263118084,
+        335.1657965681111
     ],
     "1_1_actor_calls_concurrent": [
-        4965.99522007048,
-        110.57050182691287
+        4476.469992509627,
+        80.44369769183004
     ],
     "1_1_actor_calls_sync": [
-        1989.7334090798931,
-        25.505826231728204
+        1429.043792654831,
+        19.1512538952634
     ],
     "1_1_async_actor_calls_async": [
-        3853.261228971964,
-        99.83936195976952
+        3567.5020424578674,
+        64.99462058902336
     ],
     "1_1_async_actor_calls_sync": [
-        1433.5390152119278,
-        17.93284593948981
+        1006.5372823091388,
+        48.748714995546905
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2490.991223668351,
-        63.57171243588424
+        2375.9373482961805,
+        84.03539107708299
     ],
     "1_n_actor_calls_async": [
-        6838.2845805526595,
-        314.82799922635735
+        5761.245883325508,
+        179.6996299848719
     ],
     "1_n_async_actor_calls_async": [
-        6280.583274671035,
-        151.9212740998498
+        5523.506827202886,
+        26.629092832853726
     ],
     "client__1_1_actor_calls_async": [
-        814.5335887693782,
-        4.838251093544874
+        1052.0053126627577,
+        25.024316656613824
     ],
     "client__1_1_actor_calls_concurrent": [
-        828.6299560282166,
-        29.552952884738705
+        1042.8542596204961,
+        13.563016277404827
     ],
     "client__1_1_actor_calls_sync": [
-        453.8059915017394,
-        8.187850810536593
+        546.1287849134048,
+        2.4358930192910906
     ],
     "client__get_calls": [
-        925.594265020844,
-        38.537498340367016
+        1099.4514736525857,
+        74.37309884622977
     ],
     "client__put_calls": [
-        733.6703843739219,
-        27.03154164960252
+        834.969637203394,
+        14.019475486974024
     ],
     "client__put_gigabytes": [
-        0.10217222369611438,
-        0.0009032714197567093
+        0.09855542381003202,
+        0.0009329602534689346
     ],
     "client__tasks_and_get_batch": [
-        0.8011125804259877,
-        0.02763619914898006
+        0.9731104629693856,
+        0.04517174853068934
     ],
     "client__tasks_and_put_batch": [
-        9220.111790372692,
-        113.82433420954683
+        11925.484092890623,
+        180.6378566618586
     ],
     "multi_client_put_calls_Plasma_Store": [
-        9658.981678535481,
-        86.1679973849462
+        12336.647570130343,
+        87.45929916646352
     ],
     "multi_client_put_gigabytes": [
-        35.29689743165927,
-        1.8641014249003314
+        38.17801103086019,
+        2.4759559361927126
     ],
     "multi_client_tasks_async": [
-        20114.199533908533,
-        2167.6533639918985
+        17809.169218546187,
+        1507.075320819858
     ],
     "n_n_actor_calls_async": [
-        22593.67022851302,
-        1130.0768199962295
+        19019.07842122874,
+        894.5499611008987
     ],
     "n_n_actor_calls_with_arg_async": [
-        3263.220674257469,
-        15.530961554792869
+        2779.4109021768286,
+        22.728293461450036
     ],
     "n_n_async_actor_calls_async": [
-        19945.253372184772,
-        1200.2869336158885
+        17839.72259466486,
+        198.97033231495521
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9361.068161075398
+            "perf_metric_value": 10557.98332236027
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4116.404938052882
+            "perf_metric_value": 4440.779495893648
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9658.981678535481
+            "perf_metric_value": 12336.647570130343
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.177676237873847
+            "perf_metric_value": 9.534215154530786
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.683136512909751
+            "perf_metric_value": 6.498424579177726
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35.29689743165927
+            "perf_metric_value": 38.17801103086019
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.521640061929554
+            "perf_metric_value": 10.22955093525802
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.716418799247922
+            "perf_metric_value": 4.0053068721409355
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 844.7209532677355
+            "perf_metric_value": 647.4580540478063
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6769.634231009387
+            "perf_metric_value": 5518.2930278813765
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20114.199533908533
+            "perf_metric_value": 17809.169218546187
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1989.7334090798931
+            "perf_metric_value": 1429.043792654831
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8591.539773771437
+            "perf_metric_value": 6778.77263118084
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4965.99522007048
+            "perf_metric_value": 4476.469992509627
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6838.2845805526595
+            "perf_metric_value": 5761.245883325508
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22593.67022851302
+            "perf_metric_value": 19019.07842122874
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3263.220674257469
+            "perf_metric_value": 2779.4109021768286
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1433.5390152119278
+            "perf_metric_value": 1006.5372823091388
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3853.261228971964
+            "perf_metric_value": 3567.5020424578674
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2490.991223668351
+            "perf_metric_value": 2375.9373482961805
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6280.583274671035
+            "perf_metric_value": 5523.506827202886
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19945.253372184772
+            "perf_metric_value": 17839.72259466486
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 678.9244842339416
+            "perf_metric_value": 620.8842587027023
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 925.594265020844
+            "perf_metric_value": 1099.4514736525857
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 733.6703843739219
+            "perf_metric_value": 834.969637203394
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.10217222369611438
+            "perf_metric_value": 0.09855542381003202
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9220.111790372692
+            "perf_metric_value": 11925.484092890623
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 453.8059915017394
+            "perf_metric_value": 546.1287849134048
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 814.5335887693782
+            "perf_metric_value": 1052.0053126627577
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 828.6299560282166
+            "perf_metric_value": 1042.8542596204961
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8011125804259877
+            "perf_metric_value": 0.9731104629693856
         }
     ],
     "placement_group_create/removal": [
-        678.9244842339416,
-        6.1808624839892765
+        620.8842587027023,
+        6.680381562289942
     ],
     "single_client_get_calls_Plasma_Store": [
-        9361.068161075398,
-        133.98238819244128
+        10557.98332236027,
+        139.0230118276888
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.521640061929554,
-        0.7656933312890627
+        10.22955093525802,
+        0.8249295441176479
     ],
     "single_client_put_calls_Plasma_Store": [
-        4116.404938052882,
-        47.31031901113499
+        4440.779495893648,
+        74.89151409298678
     ],
     "single_client_put_gigabytes": [
-        18.177676237873847,
-        5.672608875733518
+        9.534215154530786,
+        7.55984015881539
     ],
     "single_client_tasks_and_get_batch": [
-        5.683136512909751,
-        0.37988932464883635
+        6.498424579177726,
+        0.35561659806400786
     ],
     "single_client_tasks_async": [
-        6769.634231009387,
-        328.5600631566425
+        5518.2930278813765,
+        125.15254661211448
     ],
     "single_client_tasks_sync": [
-        844.7209532677355,
-        10.758093678954005
+        647.4580540478063,
+        8.206524994926212
     ],
     "single_client_wait_1k_refs": [
-        4.716418799247922,
-        0.039491139734240316
+        4.0053068721409355,
+        0.20463681034332193
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.937953781000004,
+    "broadcast_time": 12.523903408999999,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.937953781000004
+            "perf_metric_value": 12.523903408999999
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.71234498399999,
-    "get_time": 23.304285948,
+    "args_time": 11.892729915000004,
+    "get_time": 15.529036740999999,
     "large_object_size": 107374182400,
-    "large_object_time": 28.68260234600001,
+    "large_object_time": 25.371255468000015,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.71234498399999
+            "perf_metric_value": 11.892729915000004
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.576066161
+            "perf_metric_value": 3.652995778999994
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.304285948
+            "perf_metric_value": 15.529036740999999
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 220.095988608
+            "perf_metric_value": 168.10168730499998
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 28.68260234600001
+            "perf_metric_value": 25.371255468000015
         }
     ],
-    "queued_time": 220.095988608,
-    "returns_time": 5.576066161,
+    "queued_time": 168.10168730499998,
+    "returns_time": 3.652995778999994,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 0.8959456539154053,
-    "max_iteration_time": 2.6714906692504883,
-    "min_iteration_time": 0.39049792289733887,
+    "avg_iteration_time": 1.4278212523460387,
+    "max_iteration_time": 6.0709967613220215,
+    "min_iteration_time": 0.2006666660308838,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8959456539154053
+            "perf_metric_value": 1.4278212523460387
         }
     ],
-    "total_time": 89.5946934223175
+    "total_time": 142.78226804733276
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.5611889362335205
+            "perf_metric_value": 7.005899667739868
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.662270617485046
+            "perf_metric_value": 18.467847657203674
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 41.472771883010864
+            "perf_metric_value": 45.90533618927002
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.3985865116119385
+            "perf_metric_value": 2.240680456161499
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2849.039920568466
+            "perf_metric_value": 2320.2838954925537
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4400494907723027
+            "perf_metric_value": 0.3100430865544767
         }
     ],
-    "stage_0_time": 5.5611889362335205,
-    "stage_1_avg_iteration_time": 14.662270617485046,
-    "stage_1_max_iteration_time": 16.892216205596924,
-    "stage_1_min_iteration_time": 13.176414012908936,
-    "stage_1_time": 146.62276768684387,
-    "stage_2_avg_iteration_time": 41.472771883010864,
-    "stage_2_max_iteration_time": 64.94682741165161,
-    "stage_2_min_iteration_time": 35.315046548843384,
-    "stage_2_time": 207.3643946647644,
-    "stage_3_creation_time": 1.3985865116119385,
-    "stage_3_time": 2849.039920568466,
-    "stage_4_spread": 0.4400494907723027
+    "stage_0_time": 7.005899667739868,
+    "stage_1_avg_iteration_time": 18.467847657203674,
+    "stage_1_max_iteration_time": 20.028173685073853,
+    "stage_1_min_iteration_time": 15.489178895950317,
+    "stage_1_time": 184.67854189872742,
+    "stage_2_avg_iteration_time": 45.90533618927002,
+    "stage_2_max_iteration_time": 46.532668352127075,
+    "stage_2_min_iteration_time": 44.63159370422363,
+    "stage_2_time": 229.52734303474426,
+    "stage_3_creation_time": 2.240680456161499,
+    "stage_3_time": 2320.2838954925537,
+    "stage_4_spread": 0.3100430865544767
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.573554048048569,
-    "avg_pg_remove_time_ms": 1.452357480480116,
+    "avg_pg_create_time_ms": 1.5111592957957434,
+    "avg_pg_remove_time_ms": 1.3006958018014732,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.573554048048569
+            "perf_metric_value": 1.5111592957957434
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.452357480480116
+            "perf_metric_value": 1.3006958018014732
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 47.55%: single_client_put_gigabytes (THROUGHPUT) regresses from 18.177676237873847 to 9.534215154530786 in microbenchmark.json
REGRESSION 29.79%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1433.5390152119278 to 1006.5372823091388 in microbenchmark.json
REGRESSION 28.18%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1989.7334090798931 to 1429.043792654831 in microbenchmark.json
REGRESSION 23.35%: single_client_tasks_sync (THROUGHPUT) regresses from 844.7209532677355 to 647.4580540478063 in microbenchmark.json
REGRESSION 21.10%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8591.539773771437 to 6778.77263118084 in microbenchmark.json
REGRESSION 20.12%: tasks_per_second (THROUGHPUT) regresses from 379.30168512953065 to 302.9857172164898 in benchmarks/many_nodes.json
REGRESSION 18.48%: single_client_tasks_async (THROUGHPUT) regresses from 6769.634231009387 to 5518.2930278813765 in microbenchmark.json
REGRESSION 18.31%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.521640061929554 to 10.22955093525802 in microbenchmark.json
REGRESSION 15.82%: n_n_actor_calls_async (THROUGHPUT) regresses from 22593.67022851302 to 19019.07842122874 in microbenchmark.json
REGRESSION 15.75%: 1_n_actor_calls_async (THROUGHPUT) regresses from 6838.2845805526595 to 5761.245883325508 in microbenchmark.json
REGRESSION 15.08%: single_client_wait_1k_refs (THROUGHPUT) regresses from 4.716418799247922 to 4.0053068721409355 in microbenchmark.json
REGRESSION 14.83%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 3263.220674257469 to 2779.4109021768286 in microbenchmark.json
REGRESSION 12.05%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 6280.583274671035 to 5523.506827202886 in microbenchmark.json
REGRESSION 11.46%: multi_client_tasks_async (THROUGHPUT) regresses from 20114.199533908533 to 17809.169218546187 in microbenchmark.json
REGRESSION 10.56%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 19945.253372184772 to 17839.72259466486 in microbenchmark.json
REGRESSION 9.86%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 4965.99522007048 to 4476.469992509627 in microbenchmark.json
REGRESSION 8.55%: placement_group_create/removal (THROUGHPUT) regresses from 678.9244842339416 to 620.8842587027023 in microbenchmark.json
REGRESSION 7.43%: pgs_per_second (THROUGHPUT) regresses from 18.933742626442143 to 17.52771503829712 in benchmarks/many_pgs.json
REGRESSION 7.42%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3853.261228971964 to 3567.5020424578674 in microbenchmark.json
REGRESSION 4.62%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2490.991223668351 to 2375.9373482961805 in microbenchmark.json
REGRESSION 3.54%: client__put_gigabytes (THROUGHPUT) regresses from 0.10217222369611438 to 0.09855542381003202 in microbenchmark.json
REGRESSION 353.19%: dashboard_p95_latency_ms (LATENCY) regresses from 25.72 to 116.561 in benchmarks/many_nodes.json
REGRESSION 220.39%: dashboard_p99_latency_ms (LATENCY) regresses from 55.245 to 176.997 in benchmarks/many_nodes.json
REGRESSION 126.61%: dashboard_p50_latency_ms (LATENCY) regresses from 30.152 to 68.326 in benchmarks/many_actors.json
REGRESSION 60.21%: stage_3_creation_time (LATENCY) regresses from 1.3985865116119385 to 2.240680456161499 in stress_tests/stress_test_many_tasks.json
REGRESSION 59.36%: avg_iteration_time (LATENCY) regresses from 0.8959456539154053 to 1.4278212523460387 in stress_tests/stress_test_dead_actors.json
REGRESSION 28.35%: dashboard_p50_latency_ms (LATENCY) regresses from 3.729 to 4.786 in benchmarks/many_pgs.json
REGRESSION 25.98%: stage_0_time (LATENCY) regresses from 5.5611889362335205 to 7.005899667739868 in stress_tests/stress_test_many_tasks.json
REGRESSION 25.95%: stage_1_avg_iteration_time (LATENCY) regresses from 14.662270617485046 to 18.467847657203674 in stress_tests/stress_test_many_tasks.json
REGRESSION 18.96%: dashboard_p50_latency_ms (LATENCY) regresses from 5.21 to 6.198 in benchmarks/many_tasks.json
REGRESSION 10.69%: stage_2_avg_iteration_time (LATENCY) regresses from 41.472771883010864 to 45.90533618927002 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.22%: dashboard_p95_latency_ms (LATENCY) regresses from 3504.953 to 3722.916 in benchmarks/many_actors.json
```