### PR TITLE
[core] Make ray.put() generic: put(value: R) -> ObjectRef[R]

### DIFF
--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -2,6 +2,9 @@ import os
 import threading
 from contextlib import contextmanager
 from functools import wraps
+from typing import Any, Callable, TypeVar, cast
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 from ray._private.auto_init_hook import auto_init_ray
 
@@ -79,7 +82,7 @@ def enable_client_mode():
         _explicitly_disable_client_mode()
 
 
-def client_mode_hook(func: callable):
+def client_mode_hook(func: F) -> F:
     """Decorator for whether to use the 'regular' ray version of a function,
     or the Ray Client version of that function.
 
@@ -103,7 +106,7 @@ def client_mode_hook(func: callable):
                 return getattr(ray, func.__name__)(*args, **kwargs)
         return func(*args, **kwargs)
 
-    return wrapper
+    return cast(F, wrapper)
 
 
 def client_mode_should_convert():

--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -4,9 +4,9 @@ from contextlib import contextmanager
 from functools import wraps
 from typing import Any, Callable, TypeVar, cast
 
-F = TypeVar("F", bound=Callable[..., Any])
-
 from ray._private.auto_init_hook import auto_init_ray
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 # Attr set on func defs to mark they have been converted to client mode.
 RAY_CLIENT_MODE_ATTR = "__ray_client_mode_key__"

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2980,11 +2980,11 @@ def get(
 @PublicAPI
 @client_mode_hook
 def put(
-    value: Any,
+    value: R,
     *,
     _owner: Optional["ray.actor.ActorHandle"] = None,
     _tensor_transport: Optional[str] = None,
-) -> "ray.ObjectRef":
+) -> "ray.ObjectRef[R]":
     """Store an object in the object store.
 
     The object may not be evicted while a reference to the returned ID exists.


### PR DESCRIPTION
## Summary
- Make `ray.put()` preserve the type of the value through to the returned `ObjectRef`, so `ray.put(42)` is typed as `ObjectRef[int]` instead of untyped `ObjectRef`
- Changes `value: Any` to `value: R` and `-> ObjectRef` to `-> ObjectRef[R]` using the existing `R` TypeVar

## Test plan
- [x] Verify pyright/mypy resolves `ray.put(42)` as `ObjectRef[int]`
- [x] Existing tests pass (no runtime behavior changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)