### PR TITLE
[Data] Fixed min_scheduling_resources to fallback to incremental_resource_usage by default

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -510,7 +510,7 @@ class PhysicalOperator(Operator):
         For regular tasks, this is the resources required to schedule a task. For actor
         tasks, this is the resources required to schedule an actor.
         """
-        return ExecutionResources.zero()
+        return self.incremental_resource_usage()
 
     def progress_str(self) -> str:
         """Return any extra status to be displayed in the operator progress bar.

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1047,6 +1047,9 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
             gpu=0,
         )
 
+    def min_scheduling_resources(self) -> ExecutionResources:
+        return self.incremental_resource_usage()
+
     def has_completed(self) -> bool:
         # TODO separate marking as completed from the check
         return self._is_finalized() and super().has_completed()


### PR DESCRIPTION
## Description

 - Fixed min_scheduling_resources to fallback to incremental_resource_usage by default
 - Explicitly overridden for `HashShufflingOperatorBase`

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
