### PR TITLE
[core] Surface warnings for scheduling rate limits that slow task ramp-up

### DIFF
--- a/src/ray/core_worker/task_submission/normal_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.cc
@@ -280,6 +280,15 @@ void NormalTaskSubmitter::RequestNewWorkerIfNeeded(const SchedulingKey &scheduli
 
   if (scheduling_key_entry.pending_lease_requests.size() >=
       kMaxPendingLeaseRequestsPerSchedulingCategory) {
+    size_t backlog_size = scheduling_key_entry.BacklogSize();
+    RAY_LOG_EVERY_MS(WARNING, 10000)
+        << "Task submission is being throttled: pending lease requests ("
+        << scheduling_key_entry.pending_lease_requests.size() << ") reached limit ("
+        << kMaxPendingLeaseRequestsPerSchedulingCategory << "), with " << backlog_size
+        << " tasks waiting for lease requests. "
+        << "This especially affects workloads submitting many tasks of the same type "
+           "to a cluster with few nodes but many cores per node. "
+        << "Consider increasing RAY_max_pending_lease_requests_per_scheduling_category.";
     RAY_LOG(DEBUG) << "Exceeding the pending request limit "
                    << kMaxPendingLeaseRequestsPerSchedulingCategory;
     return;

--- a/src/ray/raylet/scheduling/local_lease_manager.cc
+++ b/src/ray/raylet/scheduling/local_lease_manager.cc
@@ -292,8 +292,12 @@ void LocalLeaseManager::GrantScheduledLeasesToWorkers() {
           int64_t wait_time = sched_cls_cap_interval_ms_ * (1L << exp);
           if (wait_time > sched_cls_cap_max_ms_) {
             wait_time = sched_cls_cap_max_ms_;
-            RAY_LOG(WARNING) << "Starting too many worker processes for a single type of "
-                                "task. Worker process startup is being throttled.";
+            RAY_LOG(WARNING)
+                << "Starting too many worker processes for a single type of task. "
+                   "Worker process startup is being throttled (wait_time="
+                << wait_time << "ms). This limit prevents deadlocks for nested tasks. "
+                << "If your workload does not use nested tasks, consider setting "
+                   "RAY_worker_cap_enabled=false for faster worker startup.";
           }
 
           int64_t target_time = get_time_ms_() + wait_time;


### PR DESCRIPTION
## Description
A user ran a Ray Data pipeline on a 360 node cluster (each node with ～224 cores, 80K total). The pipeline has two stages: OP1 runs 120s per task, OP2 runs 1200s, each with concurrency=80K. Single driver, burst submission.

They hit two problems:

1. CPU utilization capped at ~43%. Ray Data's `resource_limits` auto-detects cluster resources at startup, but the cluster wasn't fully up yet, so it saw fewer CPUs than actually available.

2. Slow task ramp-up (~30 min). CPU utilization climbed in steps rather than shooting up. Tuning two Ray Core configs fixed it:

`RAY_max_pending_lease_requests_per_scheduling_category` defaults to number of nodes (360 here). The original design assumed each pending lease goes to a different node. If you already have one request per node, sending more just means they queue up waiting, so capping at node count seemed reasonable. But for this workload, 80K tasks all have the same scheduling key and each node needs to run 220 of them. With a window of only 360, the driver has to wait for replies before sending the next batch, requiring 222 rounds of lease requests instead of 1.

`RAY_worker_cap_enabled` applies exponential backoff when starting many workers of the same type. It's there to prevent deadlock for nested tasks, but this user doesn't use nested tasks.

I looked at the history and `RAY_max_pending_lease_requests_per_scheduling_category` has been tweaked a few times (#18647, #31934). Rather than pick another default that might break something else, this PR just adds warnings when these limits are hit, so users can see what's going on and tune accordingly.

## Related issues
Closes #60919
