### PR TITLE
[Data] Add `get_max_task_capacity` utility function

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -265,6 +265,25 @@ class ExecutionResources:
             memory=self.memory * f,
         )
 
+    def floordiv(self, other: "ExecutionResources") -> "ExecutionResources":
+        """Returns the floor division of resources."""
+
+        def _div(a, b):
+            if b == 0:
+                return float("inf")
+            if a == float("inf"):
+                return float("inf")
+            return math.floor(a / b)
+
+        return ExecutionResources(
+            cpu=_div(self.cpu, other.cpu),
+            gpu=_div(self.gpu, other.gpu),
+            object_store_memory=_div(
+                self.object_store_memory, other.object_store_memory
+            ),
+            memory=_div(self.memory, other.memory),
+        )
+
 
 @DeveloperAPI
 class ExecutionOptions:


### PR DESCRIPTION
## Description

Extract the max task capacity calculation into a reusable utility function `get_max_task_capacity` in `ray.data._internal.util`. This logic computes how many tasks can run given allocated resources and minimum scheduling resources, and is useful across execution components.

## Related issues

None.