### PR TITLE
Add perf metrics for 2.54.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 97.763328,
+    "_dashboard_memory_usage_mb": 271.314944,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.6,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3288\t2.22GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5688\t0.83GiB\tpython distributed/test_many_actors.py\n2638\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3508\t0.18GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3992\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2769\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1137\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3994\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3417\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5502\t0.07GiB\tray::JobSupervisor",
-    "actors_per_second": 403.97078934630366,
+    "_peak_memory": 4.72,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3604\t2.12GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5686\t0.88GiB\tpython distributed/test_many_actors.py\n3855\t0.22GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n592\t0.22GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4356\t0.18GiB\tray::DashboardAgent\n3122\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1137\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3767\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n4358\t0.08GiB\tray::RuntimeEnvAgent\n5405\t0.07GiB\tray::JobSupervisor",
+    "actors_per_second": 459.81218680374377,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 403.97078934630366
+            "perf_metric_value": 459.81218680374377
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.152
+            "perf_metric_value": 58.927
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3504.953
+            "perf_metric_value": 2981.926
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3993.037
+            "perf_metric_value": 3824.617
         }
     ],
-    "time": 24.754265069961548
+    "time": 21.74800992012024
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 93.601792,
+    "_dashboard_memory_usage_mb": 92.422144,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.34,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3115\t0.61GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2638\t0.31GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5058\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3328\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3810\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2789\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1088\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3244\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3812\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3326\t0.08GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import",
+    "_peak_memory": 2.41,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3474\t0.61GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2949\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n7994\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3706\t0.16GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4204\t0.12GiB\tray::DashboardAgent\n2879\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3608\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n1119\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3704\t0.09GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n8206\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 379.30168512953065
+            "perf_metric_value": 390.1742019218175
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.417
+            "perf_metric_value": 6.742
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.72
+            "perf_metric_value": 50.275
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 55.245
+            "perf_metric_value": 498.303
         }
     ],
-    "tasks_per_second": 379.30168512953065,
-    "time": 302.63642382621765,
+    "tasks_per_second": 390.1742019218175,
+    "time": 302.5629577636719,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 80.26112,
+    "_dashboard_memory_usage_mb": 245.57568,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.87,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3290\t1.04GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2748\t0.53GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4875\t0.38GiB\tpython distributed/test_many_pgs.py\n585\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3507\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3991\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2882\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1141\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2609\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n3993\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
+    "_peak_memory": 2.95,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3817\t1.08GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3286\t0.83GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5887\t0.38GiB\tpython distributed/test_many_pgs.py\n598\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4549\t0.16GiB\tray::DashboardAgent\n2280\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3319\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n4067\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4551\t0.08GiB\tray::RuntimeEnvAgent\n3072\t0.08GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.933742626442143
+            "perf_metric_value": 18.01684274004598
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.729
+            "perf_metric_value": 4.542
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 35.467
+            "perf_metric_value": 37.403
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 983.739
+            "perf_metric_value": 750.509
         }
     ],
-    "pgs_per_second": 18.933742626442143,
-    "time": 52.81575965881348
+    "pgs_per_second": 18.01684274004598,
+    "time": 55.50362038612366
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 99.9424,
+    "_dashboard_memory_usage_mb": 91.598848,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.61,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3286\t2.21GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3509\t1.06GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4691\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2777\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3512\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n3991\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2711\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1117\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3415\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3993\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
+    "_peak_memory": 5.91,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3657\t2.47GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3914\t1.07GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n5676\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3013\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3917\t0.16GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4396\t0.13GiB\tray::DashboardAgent\n3141\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3812\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n1184\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4398\t0.08GiB\tray::RuntimeEnvAgent",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 582.6440311743918
+            "perf_metric_value": 622.4387477998073
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.21
+            "perf_metric_value": 5.384
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 891.025
+            "perf_metric_value": 321.124
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2650.58
+            "perf_metric_value": 1071.251
         }
     ],
-    "tasks_per_second": 582.6440311743918,
-    "time": 317.1631381511688,
+    "tasks_per_second": 622.4387477998073,
+    "time": 316.0658378601074,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.53.0"}
+{"release_version": "2.54.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8591.539773771437,
-        327.6473689212415
+        7960.637112432392,
+        306.7361631633194
     ],
     "1_1_actor_calls_concurrent": [
-        4965.99522007048,
-        110.57050182691287
+        5458.510610819038,
+        59.74149736924471
     ],
     "1_1_actor_calls_sync": [
-        1989.7334090798931,
-        25.505826231728204
+        1438.1394559624368,
+        19.50940076704496
     ],
     "1_1_async_actor_calls_async": [
-        3853.261228971964,
-        99.83936195976952
+        4741.787250826319,
+        117.33131700277013
     ],
     "1_1_async_actor_calls_sync": [
-        1433.5390152119278,
-        17.93284593948981
+        1354.4224221827776,
+        13.281404575291099
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2490.991223668351,
-        63.57171243588424
+        2984.4870738644113,
+        162.55204382262178
     ],
     "1_n_actor_calls_async": [
-        6838.2845805526595,
-        314.82799922635735
+        6729.9166699866555,
+        251.23316256211064
     ],
     "1_n_async_actor_calls_async": [
-        6280.583274671035,
-        151.9212740998498
+        6210.8917374227,
+        94.48469402591317
     ],
     "client__1_1_actor_calls_async": [
-        814.5335887693782,
-        4.838251093544874
+        1029.961672718045,
+        6.9202177613502025
     ],
     "client__1_1_actor_calls_concurrent": [
-        828.6299560282166,
-        29.552952884738705
+        1040.369140688717,
+        32.24779965856968
     ],
     "client__1_1_actor_calls_sync": [
-        453.8059915017394,
-        8.187850810536593
+        551.4244433815825,
+        7.438612220267101
     ],
     "client__get_calls": [
-        925.594265020844,
-        38.537498340367016
+        1140.0189616901123,
+        17.290062393772132
     ],
     "client__put_calls": [
-        733.6703843739219,
-        27.03154164960252
+        855.6194016437415,
+        26.01123556131865
     ],
     "client__put_gigabytes": [
-        0.10217222369611438,
-        0.0009032714197567093
+        0.09776606229253682,
+        0.0008733566363076798
     ],
     "client__tasks_and_get_batch": [
-        0.8011125804259877,
-        0.02763619914898006
+        0.9763436530100315,
+        0.020543022888636672
     ],
     "client__tasks_and_put_batch": [
-        9220.111790372692,
-        113.82433420954683
+        11838.151950028365,
+        171.13215600813666
     ],
     "multi_client_put_calls_Plasma_Store": [
-        9658.981678535481,
-        86.1679973849462
+        12523.493733890984,
+        81.41405935024245
     ],
     "multi_client_put_gigabytes": [
-        35.29689743165927,
-        1.8641014249003314
+        30.038185949654384,
+        1.0468021617488146
     ],
     "multi_client_tasks_async": [
-        20114.199533908533,
-        2167.6533639918985
+        19230.858427922078,
+        1218.1845606871964
     ],
     "n_n_actor_calls_async": [
-        22593.67022851302,
-        1130.0768199962295
+        22124.48750457105,
+        270.6921474860911
     ],
     "n_n_actor_calls_with_arg_async": [
-        3263.220674257469,
-        15.530961554792869
+        3057.8444859634224,
+        102.65626390829318
     ],
     "n_n_async_actor_calls_async": [
-        19945.253372184772,
-        1200.2869336158885
+        21045.84895345613,
+        810.9436961861563
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9361.068161075398
+            "perf_metric_value": 10230.621457364432
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4116.404938052882
+            "perf_metric_value": 4486.740359046563
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9658.981678535481
+            "perf_metric_value": 12523.493733890984
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.177676237873847
+            "perf_metric_value": 7.450449580228844
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.683136512909751
+            "perf_metric_value": 6.429947006060258
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35.29689743165927
+            "perf_metric_value": 30.038185949654384
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.521640061929554
+            "perf_metric_value": 11.051940097889997
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.716418799247922
+            "perf_metric_value": 4.760671957105953
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 844.7209532677355
+            "perf_metric_value": 714.290149058106
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6769.634231009387
+            "perf_metric_value": 5930.7480641101465
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20114.199533908533
+            "perf_metric_value": 19230.858427922078
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1989.7334090798931
+            "perf_metric_value": 1438.1394559624368
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8591.539773771437
+            "perf_metric_value": 7960.637112432392
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4965.99522007048
+            "perf_metric_value": 5458.510610819038
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6838.2845805526595
+            "perf_metric_value": 6729.9166699866555
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22593.67022851302
+            "perf_metric_value": 22124.48750457105
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3263.220674257469
+            "perf_metric_value": 3057.8444859634224
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1433.5390152119278
+            "perf_metric_value": 1354.4224221827776
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3853.261228971964
+            "perf_metric_value": 4741.787250826319
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2490.991223668351
+            "perf_metric_value": 2984.4870738644113
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6280.583274671035
+            "perf_metric_value": 6210.8917374227
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19945.253372184772
+            "perf_metric_value": 21045.84895345613
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 678.9244842339416
+            "perf_metric_value": 619.0377973585646
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 925.594265020844
+            "perf_metric_value": 1140.0189616901123
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 733.6703843739219
+            "perf_metric_value": 855.6194016437415
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.10217222369611438
+            "perf_metric_value": 0.09776606229253682
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9220.111790372692
+            "perf_metric_value": 11838.151950028365
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 453.8059915017394
+            "perf_metric_value": 551.4244433815825
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 814.5335887693782
+            "perf_metric_value": 1029.961672718045
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 828.6299560282166
+            "perf_metric_value": 1040.369140688717
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8011125804259877
+            "perf_metric_value": 0.9763436530100315
         }
     ],
     "placement_group_create/removal": [
-        678.9244842339416,
-        6.1808624839892765
+        619.0377973585646,
+        1.0007500224910233
     ],
     "single_client_get_calls_Plasma_Store": [
-        9361.068161075398,
-        133.98238819244128
+        10230.621457364432,
+        147.93236545974628
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.521640061929554,
-        0.7656933312890627
+        11.051940097889997,
+        0.09334754932634848
     ],
     "single_client_put_calls_Plasma_Store": [
-        4116.404938052882,
-        47.31031901113499
+        4486.740359046563,
+        44.95432971814441
     ],
     "single_client_put_gigabytes": [
-        18.177676237873847,
-        5.672608875733518
+        7.450449580228844,
+        3.6839621882554088
     ],
     "single_client_tasks_and_get_batch": [
-        5.683136512909751,
-        0.37988932464883635
+        6.429947006060258,
+        0.2843827652345195
     ],
     "single_client_tasks_async": [
-        6769.634231009387,
-        328.5600631566425
+        5930.7480641101465,
+        231.60583076352856
     ],
     "single_client_tasks_sync": [
-        844.7209532677355,
-        10.758093678954005
+        714.290149058106,
+        7.971851770249507
     ],
     "single_client_wait_1k_refs": [
-        4.716418799247922,
-        0.039491139734240316
+        4.760671957105953,
+        0.11119142807037143
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.937953781000004,
+    "broadcast_time": 17.067615579999995,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.937953781000004
+            "perf_metric_value": 17.067615579999995
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.71234498399999,
-    "get_time": 23.304285948,
+    "args_time": 11.249662556000004,
+    "get_time": 14.931569648999997,
     "large_object_size": 107374182400,
-    "large_object_time": 28.68260234600001,
+    "large_object_time": 22.932367658999965,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.71234498399999
+            "perf_metric_value": 11.249662556000004
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.576066161
+            "perf_metric_value": 3.653944867000007
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.304285948
+            "perf_metric_value": 14.931569648999997
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 220.095988608
+            "perf_metric_value": 161.01869779999998
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 28.68260234600001
+            "perf_metric_value": 22.932367658999965
         }
     ],
-    "queued_time": 220.095988608,
-    "returns_time": 5.576066161,
+    "queued_time": 161.01869779999998,
+    "returns_time": 3.653944867000007,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 0.8959456539154053,
-    "max_iteration_time": 2.6714906692504883,
-    "min_iteration_time": 0.39049792289733887,
+    "avg_iteration_time": 1.407882914543152,
+    "max_iteration_time": 4.7705652713775635,
+    "min_iteration_time": 0.14782309532165527,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8959456539154053
+            "perf_metric_value": 1.407882914543152
         }
     ],
-    "total_time": 89.5946934223175
+    "total_time": 140.7884156703949
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.5611889362335205
+            "perf_metric_value": 7.001889944076538
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.662270617485046
+            "perf_metric_value": 18.032764530181886
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 41.472771883010864
+            "perf_metric_value": 45.48144292831421
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.3985865116119385
+            "perf_metric_value": 2.3669638633728027
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2849.039920568466
+            "perf_metric_value": 2317.30717587471
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4400494907723027
+            "perf_metric_value": 0.29958807063367926
         }
     ],
-    "stage_0_time": 5.5611889362335205,
-    "stage_1_avg_iteration_time": 14.662270617485046,
-    "stage_1_max_iteration_time": 16.892216205596924,
-    "stage_1_min_iteration_time": 13.176414012908936,
-    "stage_1_time": 146.62276768684387,
-    "stage_2_avg_iteration_time": 41.472771883010864,
-    "stage_2_max_iteration_time": 64.94682741165161,
-    "stage_2_min_iteration_time": 35.315046548843384,
-    "stage_2_time": 207.3643946647644,
-    "stage_3_creation_time": 1.3985865116119385,
-    "stage_3_time": 2849.039920568466,
-    "stage_4_spread": 0.4400494907723027
+    "stage_0_time": 7.001889944076538,
+    "stage_1_avg_iteration_time": 18.032764530181886,
+    "stage_1_max_iteration_time": 19.80445384979248,
+    "stage_1_min_iteration_time": 14.954676389694214,
+    "stage_1_time": 180.32771492004395,
+    "stage_2_avg_iteration_time": 45.48144292831421,
+    "stage_2_max_iteration_time": 45.97227764129639,
+    "stage_2_min_iteration_time": 44.175697803497314,
+    "stage_2_time": 227.4078507423401,
+    "stage_3_creation_time": 2.3669638633728027,
+    "stage_3_time": 2317.30717587471,
+    "stage_4_spread": 0.29958807063367926
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.573554048048569,
-    "avg_pg_remove_time_ms": 1.452357480480116,
+    "avg_pg_create_time_ms": 1.4486116441442303,
+    "avg_pg_remove_time_ms": 1.2376836111108767,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.573554048048569
+            "perf_metric_value": 1.4486116441442303
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.452357480480116
+            "perf_metric_value": 1.2376836111108767
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 59.01%: single_client_put_gigabytes (THROUGHPUT) regresses from 18.177676237873847 to 7.450449580228844 in microbenchmark.json
REGRESSION 27.72%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1989.7334090798931 to 1438.1394559624368 in microbenchmark.json
REGRESSION 15.44%: single_client_tasks_sync (THROUGHPUT) regresses from 844.7209532677355 to 714.290149058106 in microbenchmark.json
REGRESSION 14.90%: multi_client_put_gigabytes (THROUGHPUT) regresses from 35.29689743165927 to 30.038185949654384 in microbenchmark.json
REGRESSION 12.39%: single_client_tasks_async (THROUGHPUT) regresses from 6769.634231009387 to 5930.7480641101465 in microbenchmark.json
REGRESSION 11.74%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.521640061929554 to 11.051940097889997 in microbenchmark.json
REGRESSION 8.82%: placement_group_create/removal (THROUGHPUT) regresses from 678.9244842339416 to 619.0377973585646 in microbenchmark.json
REGRESSION 7.34%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8591.539773771437 to 7960.637112432392 in microbenchmark.json
REGRESSION 6.29%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 3263.220674257469 to 3057.8444859634224 in microbenchmark.json
REGRESSION 5.52%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1433.5390152119278 to 1354.4224221827776 in microbenchmark.json
REGRESSION 4.84%: pgs_per_second (THROUGHPUT) regresses from 18.933742626442143 to 18.01684274004598 in benchmarks/many_pgs.json
REGRESSION 4.39%: multi_client_tasks_async (THROUGHPUT) regresses from 20114.199533908533 to 19230.858427922078 in microbenchmark.json
REGRESSION 4.31%: client__put_gigabytes (THROUGHPUT) regresses from 0.10217222369611438 to 0.09776606229253682 in microbenchmark.json
REGRESSION 2.08%: n_n_actor_calls_async (THROUGHPUT) regresses from 22593.67022851302 to 22124.48750457105 in microbenchmark.json
REGRESSION 1.58%: 1_n_actor_calls_async (THROUGHPUT) regresses from 6838.2845805526595 to 6729.9166699866555 in microbenchmark.json
REGRESSION 1.11%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 6280.583274671035 to 6210.8917374227 in microbenchmark.json
REGRESSION 801.99%: dashboard_p99_latency_ms (LATENCY) regresses from 55.245 to 498.303 in benchmarks/many_nodes.json
REGRESSION 95.47%: dashboard_p95_latency_ms (LATENCY) regresses from 25.72 to 50.275 in benchmarks/many_nodes.json
REGRESSION 95.43%: dashboard_p50_latency_ms (LATENCY) regresses from 30.152 to 58.927 in benchmarks/many_actors.json
REGRESSION 69.24%: stage_3_creation_time (LATENCY) regresses from 1.3985865116119385 to 2.3669638633728027 in stress_tests/stress_test_many_tasks.json
REGRESSION 57.14%: avg_iteration_time (LATENCY) regresses from 0.8959456539154053 to 1.407882914543152 in stress_tests/stress_test_dead_actors.json
REGRESSION 25.91%: stage_0_time (LATENCY) regresses from 5.5611889362335205 to 7.001889944076538 in stress_tests/stress_test_many_tasks.json
REGRESSION 22.99%: stage_1_avg_iteration_time (LATENCY) regresses from 14.662270617485046 to 18.032764530181886 in stress_tests/stress_test_many_tasks.json
REGRESSION 21.80%: dashboard_p50_latency_ms (LATENCY) regresses from 3.729 to 4.542 in benchmarks/many_pgs.json
REGRESSION 9.67%: stage_2_avg_iteration_time (LATENCY) regresses from 41.472771883010864 to 45.48144292831421 in stress_tests/stress_test_many_tasks.json
REGRESSION 5.46%: dashboard_p95_latency_ms (LATENCY) regresses from 35.467 to 37.403 in benchmarks/many_pgs.json
REGRESSION 3.34%: dashboard_p50_latency_ms (LATENCY) regresses from 5.21 to 5.384 in benchmarks/many_tasks.json
REGRESSION 0.77%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 16.937953781000004 to 17.067615579999995 in scalability/object_store.json
```