### PR TITLE
Add perf metrics for 2.54.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 97.763328,
+    "_dashboard_memory_usage_mb": 155.65619199999998,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.6,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3288\t2.22GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5688\t0.83GiB\tpython distributed/test_many_actors.py\n2638\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3508\t0.18GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3992\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2769\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1137\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3994\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3417\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5502\t0.07GiB\tray::JobSupervisor",
-    "actors_per_second": 403.97078934630366,
+    "_peak_memory": 4.71,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3636\t2.2GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3050\t1.96GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n12074\t0.85GiB\tpython distributed/test_many_actors.py\n3887\t0.21GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4377\t0.18GiB\tray::DashboardAgent\n3205\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3791\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n1142\t0.08GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4379\t0.08GiB\tray::RuntimeEnvAgent\n11782\t0.07GiB\tray::JobSupervisor",
+    "actors_per_second": 421.58470204328825,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 403.97078934630366
+            "perf_metric_value": 421.58470204328825
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.152
+            "perf_metric_value": 9.916
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3504.953
+            "perf_metric_value": 3849.811
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3993.037
+            "perf_metric_value": 4939.24
         }
     ],
-    "time": 24.754265069961548
+    "time": 23.720025777816772
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 93.601792,
+    "_dashboard_memory_usage_mb": 95.154176,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.34,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3115\t0.61GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2638\t0.31GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5058\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3328\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3810\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2789\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1088\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3244\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3812\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/\n3326\t0.08GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import",
+    "_peak_memory": 2.4,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3647\t0.63GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3154\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3879\t0.16GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n7522\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4376\t0.12GiB\tray::DashboardAgent\n3111\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n2178\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3779\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n4378\t0.08GiB\tray::RuntimeEnvAgent\n7754\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 379.30168512953065
+            "perf_metric_value": 386.6133448073775
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.417
+            "perf_metric_value": 6.562
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.72
+            "perf_metric_value": 42.959
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 55.245
+            "perf_metric_value": 144.301
         }
     ],
-    "tasks_per_second": 379.30168512953065,
-    "time": 302.63642382621765,
+    "tasks_per_second": 386.6133448073775,
+    "time": 302.5865635871887,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 80.26112,
+    "_dashboard_memory_usage_mb": 247.144448,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.87,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3290\t1.04GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2748\t0.53GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4875\t0.38GiB\tpython distributed/test_many_pgs.py\n585\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3507\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3991\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2882\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1141\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2609\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n3993\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
+    "_peak_memory": 2.89,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3655\t1.04GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3167\t0.61GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5494\t0.38GiB\tpython distributed/test_many_pgs.py\n595\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4399\t0.16GiB\tray::DashboardAgent\n3130\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3904\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n1141\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2931\t0.08GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4401\t0.08GiB\tray::RuntimeEnvAgent",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.933742626442143
+            "perf_metric_value": 17.650687524827635
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.729
+            "perf_metric_value": 5.002
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 35.467
+            "perf_metric_value": 37.856
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 983.739
+            "perf_metric_value": 798.453
         }
     ],
-    "pgs_per_second": 18.933742626442143,
-    "time": 52.81575965881348
+    "pgs_per_second": 17.650687524827635,
+    "time": 56.65501689910889
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 99.9424,
+    "_dashboard_memory_usage_mb": 91.15648,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.61,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3286\t2.21GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3509\t1.06GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4691\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2777\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3512\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n3991\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard\n2711\t0.1GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n1117\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3415\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n3993\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 -u /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/",
+    "_peak_memory": 5.94,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3674\t2.49GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3916\t1.04GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n6585\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3090\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3919\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4412\t0.15GiB\tray::DashboardAgent\n3036\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1178\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3808\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n6805\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 582.6440311743918
+            "perf_metric_value": 594.0367087794571
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.21
+            "perf_metric_value": 6.859
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 891.025
+            "perf_metric_value": 272.748
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2650.58
+            "perf_metric_value": 1141.131
         }
     ],
-    "tasks_per_second": 582.6440311743918,
-    "time": 317.1631381511688,
+    "tasks_per_second": 594.0367087794571,
+    "time": 316.8339765071869,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.53.0"}
+{"release_version": "2.54.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8591.539773771437,
-        327.6473689212415
+        7527.784116619314,
+        686.70161998692
     ],
     "1_1_actor_calls_concurrent": [
-        4965.99522007048,
-        110.57050182691287
+        5055.6982704309885,
+        117.81188103317386
     ],
     "1_1_actor_calls_sync": [
-        1989.7334090798931,
-        25.505826231728204
+        1645.0106136032405,
+        32.423053096719755
     ],
     "1_1_async_actor_calls_async": [
-        3853.261228971964,
-        99.83936195976952
+        4406.2141950729665,
+        392.67069052261905
     ],
     "1_1_async_actor_calls_sync": [
-        1433.5390152119278,
-        17.93284593948981
+        1403.3196936007505,
+        23.38136965997657
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2490.991223668351,
-        63.57171243588424
+        2985.2594797119345,
+        72.10260029608293
     ],
     "1_n_actor_calls_async": [
-        6838.2845805526595,
-        314.82799922635735
+        6982.12785749039,
+        84.52093535167333
     ],
     "1_n_async_actor_calls_async": [
-        6280.583274671035,
-        151.9212740998498
+        6321.193126550936,
+        105.40625132604556
     ],
     "client__1_1_actor_calls_async": [
-        814.5335887693782,
-        4.838251093544874
+        1019.3488253694755,
+        40.97440169490378
     ],
     "client__1_1_actor_calls_concurrent": [
-        828.6299560282166,
-        29.552952884738705
+        1013.6459203927111,
+        36.42569600106788
     ],
     "client__1_1_actor_calls_sync": [
-        453.8059915017394,
-        8.187850810536593
+        453.03975429334184,
+        4.589809773066405
     ],
     "client__get_calls": [
-        925.594265020844,
-        38.537498340367016
+        1119.7606509262687,
+        10.216247991847167
     ],
     "client__put_calls": [
-        733.6703843739219,
-        27.03154164960252
+        851.7996054229982,
+        21.394281286045853
     ],
     "client__put_gigabytes": [
-        0.10217222369611438,
-        0.0009032714197567093
+        0.09739017021478441,
+        0.0001559510533309823
     ],
     "client__tasks_and_get_batch": [
-        0.8011125804259877,
-        0.02763619914898006
+        0.982001139120161,
+        0.007911403954563356
     ],
     "client__tasks_and_put_batch": [
-        9220.111790372692,
-        113.82433420954683
+        11564.646324370273,
+        197.74393620118164
     ],
     "multi_client_put_calls_Plasma_Store": [
-        9658.981678535481,
-        86.1679973849462
+        12328.429700852164,
+        65.30767292022132
     ],
     "multi_client_put_gigabytes": [
-        35.29689743165927,
-        1.8641014249003314
+        42.60577675231464,
+        2.093494970352258
     ],
     "multi_client_tasks_async": [
-        20114.199533908533,
-        2167.6533639918985
+        18575.069898088233,
+        1524.2708653751615
     ],
     "n_n_actor_calls_async": [
-        22593.67022851302,
-        1130.0768199962295
+        22974.891754744596,
+        801.8328425494504
     ],
     "n_n_actor_calls_with_arg_async": [
-        3263.220674257469,
-        15.530961554792869
+        3009.073515305312,
+        114.28060136202912
     ],
     "n_n_async_actor_calls_async": [
-        19945.253372184772,
-        1200.2869336158885
+        18829.374267162224,
+        451.3497379007174
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9361.068161075398
+            "perf_metric_value": 10155.173652668069
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4116.404938052882
+            "perf_metric_value": 4552.207208625433
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9658.981678535481
+            "perf_metric_value": 12328.429700852164
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.177676237873847
+            "perf_metric_value": 10.938074087722523
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.683136512909751
+            "perf_metric_value": 5.723101265712336
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35.29689743165927
+            "perf_metric_value": 42.60577675231464
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.521640061929554
+            "perf_metric_value": 10.363904163485511
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.716418799247922
+            "perf_metric_value": 4.273484814546707
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 844.7209532677355
+            "perf_metric_value": 751.1819830194418
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6769.634231009387
+            "perf_metric_value": 5781.3376960167725
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20114.199533908533
+            "perf_metric_value": 18575.069898088233
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1989.7334090798931
+            "perf_metric_value": 1645.0106136032405
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8591.539773771437
+            "perf_metric_value": 7527.784116619314
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4965.99522007048
+            "perf_metric_value": 5055.6982704309885
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6838.2845805526595
+            "perf_metric_value": 6982.12785749039
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22593.67022851302
+            "perf_metric_value": 22974.891754744596
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3263.220674257469
+            "perf_metric_value": 3009.073515305312
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1433.5390152119278
+            "perf_metric_value": 1403.3196936007505
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3853.261228971964
+            "perf_metric_value": 4406.2141950729665
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2490.991223668351
+            "perf_metric_value": 2985.2594797119345
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6280.583274671035
+            "perf_metric_value": 6321.193126550936
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19945.253372184772
+            "perf_metric_value": 18829.374267162224
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 678.9244842339416
+            "perf_metric_value": 588.8442875974866
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 925.594265020844
+            "perf_metric_value": 1119.7606509262687
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 733.6703843739219
+            "perf_metric_value": 851.7996054229982
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.10217222369611438
+            "perf_metric_value": 0.09739017021478441
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9220.111790372692
+            "perf_metric_value": 11564.646324370273
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 453.8059915017394
+            "perf_metric_value": 453.03975429334184
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 814.5335887693782
+            "perf_metric_value": 1019.3488253694755
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 828.6299560282166
+            "perf_metric_value": 1013.6459203927111
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8011125804259877
+            "perf_metric_value": 0.982001139120161
         }
     ],
     "placement_group_create/removal": [
-        678.9244842339416,
-        6.1808624839892765
+        588.8442875974866,
+        8.24413631861294
     ],
     "single_client_get_calls_Plasma_Store": [
-        9361.068161075398,
-        133.98238819244128
+        10155.173652668069,
+        152.66450548162283
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.521640061929554,
-        0.7656933312890627
+        10.363904163485511,
+        0.6892780427336627
     ],
     "single_client_put_calls_Plasma_Store": [
-        4116.404938052882,
-        47.31031901113499
+        4552.207208625433,
+        16.667769025520144
     ],
     "single_client_put_gigabytes": [
-        18.177676237873847,
-        5.672608875733518
+        10.938074087722523,
+        9.854324012193258
     ],
     "single_client_tasks_and_get_batch": [
-        5.683136512909751,
-        0.37988932464883635
+        5.723101265712336,
+        0.4762480593924589
     ],
     "single_client_tasks_async": [
-        6769.634231009387,
-        328.5600631566425
+        5781.3376960167725,
+        285.1993884608796
     ],
     "single_client_tasks_sync": [
-        844.7209532677355,
-        10.758093678954005
+        751.1819830194418,
+        13.417517883145772
     ],
     "single_client_wait_1k_refs": [
-        4.716418799247922,
-        0.039491139734240316
+        4.273484814546707,
+        0.2990099139939311
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.937953781000004,
+    "broadcast_time": 16.721766646000006,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.937953781000004
+            "perf_metric_value": 16.721766646000006
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.71234498399999,
-    "get_time": 23.304285948,
+    "args_time": 11.357349357000004,
+    "get_time": 15.349179023000005,
     "large_object_size": 107374182400,
-    "large_object_time": 28.68260234600001,
+    "large_object_time": 22.459637914999973,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.71234498399999
+            "perf_metric_value": 11.357349357000004
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.576066161
+            "perf_metric_value": 3.577688757000004
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.304285948
+            "perf_metric_value": 15.349179023000005
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 220.095988608
+            "perf_metric_value": 148.61821138700003
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 28.68260234600001
+            "perf_metric_value": 22.459637914999973
         }
     ],
-    "queued_time": 220.095988608,
-    "returns_time": 5.576066161,
+    "queued_time": 148.61821138700003,
+    "returns_time": 3.577688757000004,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 0.8959456539154053,
-    "max_iteration_time": 2.6714906692504883,
-    "min_iteration_time": 0.39049792289733887,
+    "avg_iteration_time": 1.6285365343093872,
+    "max_iteration_time": 5.4259233474731445,
+    "min_iteration_time": 0.16121268272399902,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8959456539154053
+            "perf_metric_value": 1.6285365343093872
         }
     ],
-    "total_time": 89.5946934223175
+    "total_time": 162.85378408432007
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.5611889362335205
+            "perf_metric_value": 7.112839698791504
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.662270617485046
+            "perf_metric_value": 17.395077729225157
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 41.472771883010864
+            "perf_metric_value": 45.97143950462341
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.3985865116119385
+            "perf_metric_value": 2.621494770050049
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2849.039920568466
+            "perf_metric_value": 2659.2353205680847
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4400494907723027
+            "perf_metric_value": 0.3184540688712737
         }
     ],
-    "stage_0_time": 5.5611889362335205,
-    "stage_1_avg_iteration_time": 14.662270617485046,
-    "stage_1_max_iteration_time": 16.892216205596924,
-    "stage_1_min_iteration_time": 13.176414012908936,
-    "stage_1_time": 146.62276768684387,
-    "stage_2_avg_iteration_time": 41.472771883010864,
-    "stage_2_max_iteration_time": 64.94682741165161,
-    "stage_2_min_iteration_time": 35.315046548843384,
-    "stage_2_time": 207.3643946647644,
-    "stage_3_creation_time": 1.3985865116119385,
-    "stage_3_time": 2849.039920568466,
-    "stage_4_spread": 0.4400494907723027
+    "stage_0_time": 7.112839698791504,
+    "stage_1_avg_iteration_time": 17.395077729225157,
+    "stage_1_max_iteration_time": 20.159411668777466,
+    "stage_1_min_iteration_time": 14.787779331207275,
+    "stage_1_time": 173.95084357261658,
+    "stage_2_avg_iteration_time": 45.97143950462341,
+    "stage_2_max_iteration_time": 47.81036567687988,
+    "stage_2_min_iteration_time": 45.03093671798706,
+    "stage_2_time": 229.85781526565552,
+    "stage_3_creation_time": 2.621494770050049,
+    "stage_3_time": 2659.2353205680847,
+    "stage_4_spread": 0.3184540688712737
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.573554048048569,
-    "avg_pg_remove_time_ms": 1.452357480480116,
+    "avg_pg_create_time_ms": 1.5098637252248464,
+    "avg_pg_remove_time_ms": 1.154493106606675,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.573554048048569
+            "perf_metric_value": 1.5098637252248464
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.452357480480116
+            "perf_metric_value": 1.154493106606675
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 39.83%: single_client_put_gigabytes (THROUGHPUT) regresses from 18.177676237873847 to 10.938074087722523 in microbenchmark.json
REGRESSION 17.33%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1989.7334090798931 to 1645.0106136032405 in microbenchmark.json
REGRESSION 17.23%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.521640061929554 to 10.363904163485511 in microbenchmark.json
REGRESSION 14.60%: single_client_tasks_async (THROUGHPUT) regresses from 6769.634231009387 to 5781.3376960167725 in microbenchmark.json
REGRESSION 13.27%: placement_group_create/removal (THROUGHPUT) regresses from 678.9244842339416 to 588.8442875974866 in microbenchmark.json
REGRESSION 12.38%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8591.539773771437 to 7527.784116619314 in microbenchmark.json
REGRESSION 11.07%: single_client_tasks_sync (THROUGHPUT) regresses from 844.7209532677355 to 751.1819830194418 in microbenchmark.json
REGRESSION 9.39%: single_client_wait_1k_refs (THROUGHPUT) regresses from 4.716418799247922 to 4.273484814546707 in microbenchmark.json
REGRESSION 7.79%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 3263.220674257469 to 3009.073515305312 in microbenchmark.json
REGRESSION 7.65%: multi_client_tasks_async (THROUGHPUT) regresses from 20114.199533908533 to 18575.069898088233 in microbenchmark.json
REGRESSION 6.78%: pgs_per_second (THROUGHPUT) regresses from 18.933742626442143 to 17.650687524827635 in benchmarks/many_pgs.json
REGRESSION 5.59%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 19945.253372184772 to 18829.374267162224 in microbenchmark.json
REGRESSION 4.68%: client__put_gigabytes (THROUGHPUT) regresses from 0.10217222369611438 to 0.09739017021478441 in microbenchmark.json
REGRESSION 2.11%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1433.5390152119278 to 1403.3196936007505 in microbenchmark.json
REGRESSION 0.17%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 453.8059915017394 to 453.03975429334184 in microbenchmark.json
REGRESSION 161.20%: dashboard_p99_latency_ms (LATENCY) regresses from 55.245 to 144.301 in benchmarks/many_nodes.json
REGRESSION 87.44%: stage_3_creation_time (LATENCY) regresses from 1.3985865116119385 to 2.621494770050049 in stress_tests/stress_test_many_tasks.json
REGRESSION 81.77%: avg_iteration_time (LATENCY) regresses from 0.8959456539154053 to 1.6285365343093872 in stress_tests/stress_test_dead_actors.json
REGRESSION 67.03%: dashboard_p95_latency_ms (LATENCY) regresses from 25.72 to 42.959 in benchmarks/many_nodes.json
REGRESSION 34.14%: dashboard_p50_latency_ms (LATENCY) regresses from 3.729 to 5.002 in benchmarks/many_pgs.json
REGRESSION 31.65%: dashboard_p50_latency_ms (LATENCY) regresses from 5.21 to 6.859 in benchmarks/many_tasks.json
REGRESSION 27.90%: stage_0_time (LATENCY) regresses from 5.5611889362335205 to 7.112839698791504 in stress_tests/stress_test_many_tasks.json
REGRESSION 23.70%: dashboard_p99_latency_ms (LATENCY) regresses from 3993.037 to 4939.24 in benchmarks/many_actors.json
REGRESSION 18.64%: stage_1_avg_iteration_time (LATENCY) regresses from 14.662270617485046 to 17.395077729225157 in stress_tests/stress_test_many_tasks.json
REGRESSION 10.85%: stage_2_avg_iteration_time (LATENCY) regresses from 41.472771883010864 to 45.97143950462341 in stress_tests/stress_test_many_tasks.json
REGRESSION 9.84%: dashboard_p95_latency_ms (LATENCY) regresses from 3504.953 to 3849.811 in benchmarks/many_actors.json
REGRESSION 6.74%: dashboard_p95_latency_ms (LATENCY) regresses from 35.467 to 37.856 in benchmarks/many_pgs.json
```