### PR TITLE
[Data] Default LogicalOperator name to class name

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1120,12 +1120,6 @@ python/ray/data/_internal/logging.py
     DOC201: Function `register_dataset_logger` does not have a return section in docstring
     DOC201: Function `unregister_dataset_logger` does not have a return section in docstring
 --------------------
-python/ray/data/_internal/logical/operators/all_to_all_operator.py
-    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
-    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
-    DOC101: Method `AbstractAllToAll.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `AbstractAllToAll.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [input_op: LogicalOperator, name: str, num_outputs: Optional[int], ray_remote_args: Optional[Dict[str, Any]], sub_progress_bar_names: Optional[List[str]]].
---------------------
 python/ray/data/_internal/logical/operators/join_operator.py
     DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
     DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -19,9 +19,10 @@ class LogicalOperator(Operator):
 
     def __init__(
         self,
-        name: Optional[str],
         input_dependencies: List["LogicalOperator"],
         num_outputs: Optional[int] = None,
+        *,
+        name: Optional[str] = None,
     ):
         if name is None:
             name = self.__class__.__name__

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -23,6 +23,8 @@ class LogicalOperator(Operator):
         input_dependencies: List["LogicalOperator"],
         num_outputs: Optional[int] = None,
     ):
+        if name is None:
+            name = self.__class__.__name__
         super().__init__(
             name,
             input_dependencies,
@@ -31,13 +33,6 @@ class LogicalOperator(Operator):
             assert isinstance(x, LogicalOperator), x
 
         self.num_outputs: Optional[int] = num_outputs
-
-    @property
-    def name(self) -> str:
-        name = super().name
-        if name is None:
-            return self.__class__.__name__
-        return name
 
     def estimated_num_outputs(self) -> Optional[int]:
         """Returns the estimated number of blocks that

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -19,7 +19,7 @@ class LogicalOperator(Operator):
 
     def __init__(
         self,
-        name: str,
+        name: Optional[str],
         input_dependencies: List["LogicalOperator"],
         num_outputs: Optional[int] = None,
     ):
@@ -31,6 +31,13 @@ class LogicalOperator(Operator):
             assert isinstance(x, LogicalOperator), x
 
         self.num_outputs: Optional[int] = num_outputs
+
+    @property
+    def name(self) -> str:
+        name = super().name
+        if name is None:
+            return self.__class__.__name__
+        return name
 
     def estimated_num_outputs(self) -> Optional[int]:
         """Returns the estimated number of blocks that
@@ -77,6 +84,23 @@ class LogicalOperator(Operator):
         # Preserve legacy export shape even though output deps are no longer tracked.
         args["_output_dependencies"] = []
         return args
+
+    @property
+    def dag_str(self) -> str:
+        """String representation of the whole DAG."""
+        if self.input_dependencies:
+            out_str = ", ".join([x.dag_str for x in self.input_dependencies])
+            out_str += " -> "
+        else:
+            out_str = ""
+        out_str += f"{self.__class__.__name__}[{self.name}]"
+        return out_str
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}[{self.name}]"
+
+    def __str__(self) -> str:
+        return repr(self)
 
     def infer_schema(self) -> Optional["Schema"]:
         """Returns the inferred schema of the output blocks."""

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Callable, Iterator, List, Optional
+from typing import Callable, Iterator, List
 
 
 class Operator:
@@ -10,7 +10,7 @@ class Operator:
 
     def __init__(
         self,
-        name: Optional[str],
+        name: str,
         input_dependencies: List["Operator"],
     ):
         self._name = name
@@ -20,7 +20,7 @@ class Operator:
         self._wire_output_deps(input_dependencies)
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str:
         return self._name
 
     @property

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Callable, Iterator, List
+from typing import Callable, Iterator, List, Optional
 
 
 class Operator:
@@ -10,7 +10,7 @@ class Operator:
 
     def __init__(
         self,
-        name: str,
+        name: Optional[str],
         input_dependencies: List["Operator"],
     ):
         self._name = name
@@ -20,7 +20,7 @@ class Operator:
         self._wire_output_deps(input_dependencies)
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         return self._name
 
     @property

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -143,7 +143,7 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
                 ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME,
             ]
         super().__init__(
-            "Repartition",
+            None,
             input_op,
             num_outputs=num_outputs,
             sub_progress_bar_names=sub_progress_bar_names,
@@ -179,7 +179,7 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
         batch_format: Optional[str] = "default",
     ):
         super().__init__(
-            "Sort",
+            None,
             input_op,
             sub_progress_bar_names=[
                 SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,
@@ -219,7 +219,7 @@ class Aggregate(AbstractAllToAll):
         batch_format: Optional[str] = "default",
     ):
         super().__init__(
-            "Aggregate",
+            None,
             input_op,
             sub_progress_bar_names=[
                 SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -32,23 +32,31 @@ class AbstractAllToAll(LogicalOperator):
 
     def __init__(
         self,
-        name: str,
         input_op: LogicalOperator,
         num_outputs: Optional[int] = None,
         sub_progress_bar_names: Optional[List[str]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        *,
+        name: Optional[str] = None,
     ):
-        """
+        """Initialize an ``AbstractAllToAll`` logical operator.
+
         Args:
-            name: Name for this operator. This is the name that will appear when
-                inspecting the logical plan of a Dataset.
             input_op: The operator preceding this operator in the plan DAG. The outputs
                 of `input_op` will be the inputs to this operator.
             num_outputs: The number of expected output bundles outputted by this
                 operator.
+            sub_progress_bar_names: Optional sub-stage progress bar names for this
+                operator.
             ray_remote_args: Args to provide to :func:`ray.remote`.
+            name: Name for this operator. This is the name that will appear when
+                inspecting the logical plan of a Dataset.
         """
-        super().__init__(name, [input_op], num_outputs=num_outputs)
+        super().__init__(
+            input_dependencies=[input_op],
+            num_outputs=num_outputs,
+            name=name,
+        )
         self.ray_remote_args = ray_remote_args or {}
         self.sub_progress_bar_names = sub_progress_bar_names
 
@@ -62,8 +70,8 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
         seed: Optional[int] = None,
     ):
         super().__init__(
-            "RandomizeBlockOrder",
             input_op,
+            name="RandomizeBlockOrder",
         )
         self.seed = seed
 
@@ -95,13 +103,13 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
-            name,
             input_op,
             sub_progress_bar_names=[
                 ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
             ray_remote_args=ray_remote_args,
+            name=name,
         )
         self.seed = seed
 
@@ -143,7 +151,6 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
                 ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME,
             ]
         super().__init__(
-            None,
             input_op,
             num_outputs=num_outputs,
             sub_progress_bar_names=sub_progress_bar_names,
@@ -179,7 +186,6 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
         batch_format: Optional[str] = "default",
     ):
         super().__init__(
-            None,
             input_op,
             sub_progress_bar_names=[
                 SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,
@@ -219,7 +225,6 @@ class Aggregate(AbstractAllToAll):
         batch_format: Optional[str] = "default",
     ):
         super().__init__(
-            None,
             input_op,
             sub_progress_bar_names=[
                 SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -19,4 +19,4 @@ class Count(LogicalOperator):
         self,
         input_op: LogicalOperator,
     ):
-        super().__init__("Count", [input_op])
+        super().__init__(None, [input_op])

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -19,4 +19,4 @@ class Count(LogicalOperator):
         self,
         input_op: LogicalOperator,
     ):
-        super().__init__(None, [input_op])
+        super().__init__(input_dependencies=[input_op])

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -36,7 +36,6 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
         input_metadata: List[BlockMetadataWithSchema],
     ):
         super().__init__(
-            name=self.__class__.__name__,
             input_dependencies=[],
             num_outputs=len(input_blocks),
         )

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -21,7 +21,7 @@ class InputData(LogicalOperator, SourceOperator):
         self,
         input_data: List[RefBundle],
     ):
-        super().__init__(None, [], len(input_data))
+        super().__init__(input_dependencies=[], num_outputs=len(input_data))
         self.input_data = input_data
 
     def output_data(self) -> Optional[List[RefBundle]]:

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -21,7 +21,7 @@ class InputData(LogicalOperator, SourceOperator):
         self,
         input_data: List[RefBundle],
     ):
-        super().__init__("InputData", [], len(input_data))
+        super().__init__(None, [], len(input_data))
         self.input_data = input_data
 
     def output_data(self) -> Optional[List[RefBundle]]:

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -36,7 +36,7 @@ class AbstractMap(AbstractOneToOne):
 
     def __init__(
         self,
-        name: str,
+        name: Optional[str] = None,
         input_op: Optional[LogicalOperator] = None,
         num_outputs: Optional[int] = None,
         *,
@@ -71,7 +71,12 @@ class AbstractMap(AbstractOneToOne):
                 to use Ray tasks, or ``ActorPoolStrategy`` to use an
                 autoscaling actor pool.
         """
-        super().__init__(name, input_op, can_modify_num_rows, num_outputs)
+        super().__init__(
+            input_op=input_op,
+            can_modify_num_rows=can_modify_num_rows,
+            num_outputs=num_outputs,
+            name=name,
+        )
         self.min_rows_per_bundled_input = min_rows_per_bundled_input
         self.ray_remote_args = ray_remote_args or {}
         self.ray_remote_args_fn = ray_remote_args_fn
@@ -321,7 +326,6 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
             compute = self._detect_and_get_compute_strategy(exprs)
 
         super().__init__(
-            None,
             input_op=input_op,
             can_modify_num_rows=False,
             ray_remote_args=ray_remote_args,
@@ -437,7 +441,7 @@ class StreamingRepartition(AbstractMap):
     ):
         super().__init__(
             f"StreamingRepartition[num_rows_per_block={target_num_rows_per_block}]",
-            input_op,
+            input_op=input_op,
             can_modify_num_rows=False,
         )
         self.target_num_rows_per_block = target_num_rows_per_block

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -198,7 +198,7 @@ class MapBatches(AbstractUDFMap):
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
-            "MapBatches",
+            self.__class__.__name__,
             input_op,
             fn,
             can_modify_num_rows=can_modify_num_rows,
@@ -272,7 +272,7 @@ class Filter(AbstractUDFMap):
         self.predicate_expr = predicate_expr
 
         super().__init__(
-            "Filter",
+            self.__class__.__name__,
             input_op,
             can_modify_num_rows=True,
             fn=fn,
@@ -321,7 +321,7 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
             compute = self._detect_and_get_compute_strategy(exprs)
 
         super().__init__(
-            "Project",
+            None,
             input_op=input_op,
             can_modify_num_rows=False,
             ray_remote_args=ray_remote_args,
@@ -409,7 +409,7 @@ class FlatMap(AbstractUDFMap):
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
-            "FlatMap",
+            self.__class__.__name__,
             input_op,
             fn,
             can_modify_num_rows=True,

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -25,7 +25,7 @@ class NAry(LogicalOperator):
         Args:
             input_ops: The input operators.
         """
-        super().__init__(self.__class__.__name__, list(input_ops), num_outputs)
+        super().__init__(None, list(input_ops), num_outputs)
 
 
 class Zip(NAry):

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -25,7 +25,10 @@ class NAry(LogicalOperator):
         Args:
             input_ops: The input operators.
         """
-        super().__init__(None, list(input_ops), num_outputs)
+        super().__init__(
+            input_dependencies=list(input_ops),
+            num_outputs=num_outputs,
+        )
 
 
 class Zip(NAry):

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -26,7 +26,7 @@ class AbstractOneToOne(LogicalOperator):
 
     def __init__(
         self,
-        name: str,
+        name: Optional[str],
         input_op: Optional[LogicalOperator],
         can_modify_num_rows: bool,
         num_outputs: Optional[int] = None,
@@ -118,7 +118,7 @@ class Download(AbstractOneToOne):
         ray_remote_args: Optional[Dict[str, Any]] = None,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     ):
-        super().__init__("Download", input_op, can_modify_num_rows=False)
+        super().__init__(None, input_op, can_modify_num_rows=False)
         if len(uri_column_names) != len(output_bytes_column_names):
             raise ValueError(
                 f"Number of URI columns ({len(uri_column_names)}) must match "

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -26,26 +26,27 @@ class AbstractOneToOne(LogicalOperator):
 
     def __init__(
         self,
-        name: Optional[str],
         input_op: Optional[LogicalOperator],
         can_modify_num_rows: bool,
         num_outputs: Optional[int] = None,
+        *,
+        name: Optional[str] = None,
     ):
         """Initialize an AbstractOneToOne operator.
 
         Args:
-            name: Name for this operator. This is the name that will appear when
-                inspecting the logical plan of a Dataset.
             input_op: The operator preceding this operator in the plan DAG. The outputs
                 of `input_op` will be the inputs to this operator.
             can_modify_num_rows: Whether the UDF can change the row count. False if
                 # of input rows = # of output rows. True otherwise.
             num_outputs: If known, the number of blocks produced by this operator.
+            name: Name for this operator. This is the name that will appear when
+                inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            name=name,
             input_dependencies=[input_op] if input_op else [],
             num_outputs=num_outputs,
+            name=name,
         )
         self.can_modify_num_rows = can_modify_num_rows
 
@@ -63,9 +64,9 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
         limit: int,
     ):
         super().__init__(
-            f"limit={limit}",
             input_op=input_op,
             can_modify_num_rows=True,
+            name=f"limit={limit}",
         )
         self.limit = limit
 
@@ -118,7 +119,7 @@ class Download(AbstractOneToOne):
         ray_remote_args: Optional[Dict[str, Any]] = None,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     ):
-        super().__init__(None, input_op, can_modify_num_rows=False)
+        super().__init__(input_op=input_op, can_modify_num_rows=False)
         if len(uri_column_names) != len(output_bytes_column_names):
             raise ValueError(
                 f"Number of URI columns ({len(uri_column_names)}) must match "

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -20,7 +20,7 @@ class StreamingSplit(LogicalOperator):
         equal: bool,
         locality_hints: Optional[List["NodeIdStr"]] = None,
     ):
-        super().__init__("StreamingSplit", [input_op])
+        super().__init__(None, [input_op])
         self.num_splits = num_splits
         self.equal = equal
         self.locality_hints = locality_hints

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -20,7 +20,7 @@ class StreamingSplit(LogicalOperator):
         equal: bool,
         locality_hints: Optional[List["NodeIdStr"]] = None,
     ):
-        super().__init__(None, [input_op])
+        super().__init__(input_dependencies=[input_op])
         self.num_splits = num_splits
         self.equal = equal
         self.locality_hints = locality_hints

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -30,7 +30,7 @@ class Write(AbstractMap):
             min_rows_per_bundled_input = None
 
         super().__init__(
-            "Write",
+            None,
             input_op,
             can_modify_num_rows=True,
             min_rows_per_bundled_input=min_rows_per_bundled_input,

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -30,8 +30,7 @@ class Write(AbstractMap):
             min_rows_per_bundled_input = None
 
         super().__init__(
-            None,
-            input_op,
+            input_op=input_op,
             can_modify_num_rows=True,
             min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -91,7 +91,7 @@ class DummyLogicalOperator(LogicalOperator):
     """A dummy logical operator for testing _get_logical_args with various data types."""
 
     def __init__(self, input_op=None):
-        super().__init__("DummyOperator", [])
+        super().__init__(input_dependencies=[], name="DummyOperator")
 
         # Test various data types that might be returned by _get_logical_args
         self._string_value = "test_string"

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -5,29 +5,29 @@ from ray.data.context import DataContext
 def test_sources_singleton():
     ctx = DataContext.get_current()
 
-    source = LogicalOperator("source", [])
+    source = LogicalOperator([], name="source")
     assert LogicalPlan(source, ctx).sources() == [source]
 
 
 def test_sources_chain():
     ctx = DataContext.get_current()
 
-    source = LogicalOperator("source", [])
-    sink = LogicalOperator("sink", [source])
+    source = LogicalOperator([], name="source")
+    sink = LogicalOperator([source], name="sink")
     assert LogicalPlan(sink, ctx).sources() == [source]
 
 
 def test_sources_multiple_sources():
     ctx = DataContext.get_current()
 
-    source1 = LogicalOperator("source1", [])
-    source2 = LogicalOperator("source2", [])
-    sink = LogicalOperator("sink", [source1, source2])
+    source1 = LogicalOperator([], name="source1")
+    source2 = LogicalOperator([], name="source2")
+    sink = LogicalOperator([source1, source2], name="sink")
     assert LogicalPlan(sink, ctx).sources() == [source1, source2]
 
 
 def test_logical_operator_defaults_name_to_class_name():
-    op = LogicalOperator(None, [])
+    op = LogicalOperator([])
     assert op.name == "LogicalOperator"
     assert op.dag_str == "LogicalOperator[LogicalOperator]"
 

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -26,6 +26,12 @@ def test_sources_multiple_sources():
     assert LogicalPlan(sink, ctx).sources() == [source1, source2]
 
 
+def test_logical_operator_defaults_name_to_class_name():
+    op = LogicalOperator(None, [])
+    assert op.name == "LogicalOperator"
+    assert op.dag_str == "LogicalOperator[LogicalOperator]"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description
This is PR-A in the split follow-up for [#60312](https://github.com/ray-project/ray/issues/60312).

Goal of this PR is narrow: introduce a default naming path for `LogicalOperator` while keeping the base `Operator` contract simple (`name` remains `str`) and applying minimal logical-operator call-site cleanup to remove redundant explicit class-name boilerplate.

#### What this PR does

- Adds a default naming path in `LogicalOperator.__init__`:
  - `name` is optional (keyword-only)
  - when omitted, it defaults to `self.__class__.__name__`
- Keeps `Operator`’s base contract unchanged for naming (`name: str`)
- Applies minimal call-site cleanup in logical operators to remove redundant class-name boilerplate where behavior is equivalent
- Keeps explicit names where semantically important (custom/dynamic/user-facing names)



## Related issues
> Link related issues: "Related to #60312".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.




#### Stack Plan

To complete [#60312](https://github.com/ray-project/ray/issues/60312), the original stack was:

1. https://github.com/ray-project/ray/pull/60529
2. https://github.com/ray-project/ray/pull/60528
3. https://github.com/ray-project/ray/pull/60530
4. https://github.com/ray-project/ray/pull/60531

Since PR4 was still too large, it is being further split:

1. PR-A: default `LogicalOperator` naming behavior (this PR)
2. PR-B: move `output_dependencies` responsibility to physical side
3. PR-C: make `LogicalOperator` an ABC with abstract `num_outputs`
4. PR-D: convert logical operators to frozen dataclasses in small groups (D1/D2/D3)
    - D1: one-to-one operators
    - D2: map operators
    - D3: all-to-all + join/read/write groups (as needed)

Planned follow-ups (not blocking this stack):
- Converting all `input_op` usage to `input_dependencies`
- Potential `AbstractFrom` restructuring


