### PR TITLE
[ci] use prebuilt wheel for wheel tests instead of rebuilding via Bazel

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -256,6 +256,7 @@ steps:
       - manylinux-x86_64
       - corebuild-multipy
       - forge
+      - ray-wheel-build
 
   - label: ":ray: core: minimal tests {{matrix}}"
     tags:

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -430,6 +430,7 @@ steps:
       - manylinux-aarch64
       - oss-ci-base_build-aarch64
       - forge-aarch64
+      - ray-wheel-build-aarch64
     job_env: forge-aarch64
 
   - label: ":ray-serve: serve: wheel-aarch64 tests"
@@ -447,4 +448,5 @@ steps:
       - manylinux-aarch64
       - oss-ci-base_build-aarch64
       - forge-aarch64
+      - ray-wheel-build-aarch64
     job_env: forge-aarch64

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -143,6 +143,7 @@ steps:
       - manylinux-x86_64
       - servebuild-multipy
       - forge
+      - ray-wheel-build
 
   - label: ":ray-serve: serve: doc tests"
     tags:

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -5,11 +5,7 @@ from typing import List, Optional, Set, Tuple
 import click
 import yaml
 
-from ci.ray_ci.builder_container import BuilderContainer
 from ci.ray_ci.configs import (
-    DEFAULT_ARCHITECTURE,
-    DEFAULT_BUILD_TYPE,
-    DEFAULT_PYTHON_VERSION,
     PYTHON_VERSIONS,
 )
 from ci.ray_ci.container import _DOCKER_ECR_REPO
@@ -231,11 +227,6 @@ def main(
     ci_init()
     ecr_docker_login(_DOCKER_ECR_REPO.split("/")[0])
 
-    if build_type == "wheel" or build_type == "wheel-aarch64":
-        # for wheel testing, we first build the wheel and then use it for running tests
-        architecture = DEFAULT_ARCHITECTURE if build_type == "wheel" else "aarch64"
-        wheel_python_version = python_version or DEFAULT_PYTHON_VERSION
-        BuilderContainer(wheel_python_version, DEFAULT_BUILD_TYPE, architecture).run()
     bisect_run_test_target = bisect_run_test_target or os.environ.get(
         "RAYCI_BISECT_TEST_TARGET"
     )

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -115,7 +115,7 @@ INSTALL_FLAGS=(--no-deps --force-reinstall -v)
 case "$BUILD_TYPE" in
   wheel|wheel-aarch64)
     echo "--- Install Ray (prebuilt wheel)"
-    pip install "${INSTALL_FLAGS[@]}" /opt/ray-wheel/*.whl
+    pip install "${INSTALL_FLAGS[@]}" /opt/ray-wheel/opt/artifacts/*.whl
 
     RAY_SITE_DIR=$(python -c "import ray; print(ray.__path__[0])")
 
@@ -132,7 +132,7 @@ case "$BUILD_TYPE" in
     # (RAY_CI_POST_WHEEL_TESTS path): Path(ray.__file__).resolve().parents[2] / ".whl"
     RAY_WHEEL_PARENT=$(python -c "import ray, pathlib; print(pathlib.Path(ray.__file__).resolve().parents[2])")
     mkdir -p "${RAY_WHEEL_PARENT}/.whl"
-    cp /opt/ray-wheel/*.whl "${RAY_WHEEL_PARENT}/.whl/"
+    cp /opt/ray-wheel/opt/artifacts/*.whl "${RAY_WHEEL_PARENT}/.whl/"
     ;;
   optimized)
     if [[ -e /opt/ray-core/ray_pkg.zip && "$RAY_DISABLE_EXTRA_CPP" == "1" ]]; then

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -3,9 +3,11 @@
 ARG BASE_IMAGE
 ARG RAY_CORE_IMAGE=scratch
 ARG RAY_DASHBOARD_IMAGE=scratch
+ARG RAY_WHEEL_IMAGE=scratch
 
 FROM "$RAY_CORE_IMAGE" AS ray_core
 FROM "$RAY_DASHBOARD_IMAGE" AS ray_dashboard
+FROM "$RAY_WHEEL_IMAGE" AS ray_wheel
 
 FROM "$BASE_IMAGE"
 
@@ -36,6 +38,7 @@ COPY . .
 
 RUN --mount=type=bind,from=ray_core,target=/opt/ray-core \
     --mount=type=bind,from=ray_dashboard,target=/opt/ray-dashboard \
+    --mount=type=bind,from=ray_wheel,target=/opt/ray-wheel \
 <<EOF
 #!/bin/bash -i
 
@@ -110,6 +113,27 @@ INSTALL_FLAGS=(--no-deps --force-reinstall -v)
 
 # --- Install Ray per build type ---
 case "$BUILD_TYPE" in
+  wheel|wheel-aarch64)
+    echo "--- Install Ray (prebuilt wheel)"
+    pip install "${INSTALL_FLAGS[@]}" /opt/ray-wheel/*.whl
+
+    RAY_SITE_DIR=$(python -c "import ray; print(ray.__path__[0])")
+
+    install_redis "${RAY_SITE_DIR}/core/src/ray/thirdparty/redis/src"
+
+    # The wheel doesn't ship test files, but some test conftest.py files
+    # import from ray.tests.conftest. Symlink the source tree's tests dir
+    # into site-packages so these imports resolve.
+    ln -s /rayci/python/ray/tests "${RAY_SITE_DIR}/tests"
+
+    apply_install_mask "${RAY_SITE_DIR}"
+
+    # Must match the wheel lookup in python/ray/_private/runtime_env/conda.py
+    # (RAY_CI_POST_WHEEL_TESTS path): Path(ray.__file__).resolve().parents[2] / ".whl"
+    RAY_WHEEL_PARENT=$(python -c "import ray, pathlib; print(pathlib.Path(ray.__file__).resolve().parents[2])")
+    mkdir -p "${RAY_WHEEL_PARENT}/.whl"
+    cp /opt/ray-wheel/*.whl "${RAY_WHEEL_PARENT}/.whl/"
+    ;;
   optimized)
     if [[ -e /opt/ray-core/ray_pkg.zip && "$RAY_DISABLE_EXTRA_CPP" == "1" ]]; then
       echo "--- Extract prebuilt ray core"


### PR DESCRIPTION
Revert the revert commit b14f098259 to restore prebuilt wheel usage
in wheel tests.

Topic: reland-prebuilt

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: andrew <andrew@anyscale.com>