### PR TITLE
[core] fix dataclass.asdict with None in dashboard list_jobs api

### DIFF
--- a/python/ray/dashboard/modules/job/common.py
+++ b/python/ray/dashboard/modules/job/common.py
@@ -412,7 +412,10 @@ class JobInfoStorageClient:
             job_info = await self.get_info(job_id, timeout)
             return job_id, job_info
 
-        return dict(await asyncio.gather(*[get_job_info(job_id) for job_id in job_ids]))
+        results = await asyncio.gather(*[get_job_info(job_id) for job_id in job_ids])
+        return {
+            job_id: job_info for job_id, job_info in results if job_info is not None
+        }
 
 
 def uri_to_http_components(package_uri: str) -> Tuple[str, str]:


### PR DESCRIPTION
## Description

The `/api/jobs/` endpoint in the dashboard will:

1. List all the job keys in the KV.
2. Get each job info by key.

But it doesn't expect any jobs to be deleted during these 2 steps, and if that happens, the api will fail and throw an `TypeError` exception because the deleted job will result in a `None` in the second step. For example:

```python
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/aiohttp/web_protocol.py", line 510, in _handle_request
    resp = await request_handler(request)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/aiohttp/web_app.py", line 569, in _handle
    return await handler(request)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/job/job_head.py", line 514, in list_jobs
    submission_jobs = [
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/job/job_head.py", line 516, in <listcomp>
    **dataclasses.asdict(job),
  File "/home/ray/anaconda3/lib/python3.10/dataclasses.py", line 1237, in asdict
    raise TypeError("asdict() should be called on dataclass instances")
TypeError: asdict() should be called on dataclass instances
```

This PR fixes this by excluding `None` jobs.

## Related issues

Part of https://github.com/anyscale/ray/issues/700

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
