### PR TITLE
[Data] Reset `DataContext` at the end of the task

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -753,10 +753,13 @@ def _map_task(
         ctx.op_name,
         ctx.task_idx,
     )
-    DataContext._set_current(data_context)
+
     ctx.kwargs.update(kwargs)
 
-    with TaskContext.current(ctx):
+    with (
+        DataContext.with_current(data_context),
+        TaskContext.current(ctx)
+    ):
         stats = BlockExecStats.builder()
         map_transformer.override_target_max_block_size(
             ctx.target_max_block_size_override

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -756,10 +756,7 @@ def _map_task(
 
     ctx.kwargs.update(kwargs)
 
-    with (
-        DataContext.current(data_context),
-        TaskContext.current(ctx)
-    ):
+    with (DataContext.current(data_context), TaskContext.current(ctx)):
         stats = BlockExecStats.builder()
         map_transformer.override_target_max_block_size(
             ctx.target_max_block_size_override

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -757,7 +757,7 @@ def _map_task(
     ctx.kwargs.update(kwargs)
 
     with (
-        DataContext.with_current(data_context),
+        DataContext.current(data_context),
         TaskContext.current(ctx)
     ):
         stats = BlockExecStats.builder()

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -812,7 +812,7 @@ class DataContext:
         remote workers used for parallelization.
         """
         global _default_context
-        if (
+        if context and (
             not _default_context
             or _default_context.dataset_logger_id != context.dataset_logger_id
         ):

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -797,10 +797,12 @@ class DataContext:
 
     @staticmethod
     @contextlib.contextmanager
-    def with_current(context: "DataContext"):
+    def current(context: "DataContext"):
         prev = DataContext._set_current(context)
-        yield
-        DataContext._set_current(prev)
+        try:
+            yield
+        finally:
+            DataContext._set_current(prev)
 
     @staticmethod
     def _set_current(context: "DataContext") -> "DataContext":

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -798,14 +798,14 @@ class DataContext:
     @staticmethod
     @contextlib.contextmanager
     def current(context: "DataContext"):
-        prev = DataContext._set_current(context)
+        prev: Optional[DataContext] = DataContext._set_current(context)
         try:
             yield
         finally:
             DataContext._set_current(prev)
 
     @staticmethod
-    def _set_current(context: "DataContext") -> "DataContext":
+    def _set_current(context: Optional["DataContext"]) -> Optional["DataContext"]:
         """Set the current context in a remote worker.
 
         This is used internally by Dataset to propagate the driver context to
@@ -819,7 +819,9 @@ class DataContext:
             update_dataset_logger_for_worker(context.dataset_logger_id)
 
         prev = _default_context
+        # Update current context
         _default_context = context
+
         return prev
 
     @property

--- a/python/ray/data/tests/test_context.py
+++ b/python/ray/data/tests/test_context.py
@@ -9,6 +9,33 @@ def test_write_file_retry_on_errors_emits_deprecation_warning(caplog):
         ctx.write_file_retry_on_errors = []
 
 
+def test_data_context_current_context_manager():
+    import copy
+
+    from ray.data.context import DataContext
+
+    original = DataContext.get_current()
+    ctx1 = copy.deepcopy(original)
+    ctx1.set_config("level", "1")
+
+    ctx2 = copy.deepcopy(original)
+    ctx2.set_config("level", "2")
+
+    with pytest.raises(ValueError):
+        with DataContext.current(ctx1):
+            assert DataContext.get_current() is ctx1
+            # Nested context manager
+            with DataContext.current(ctx2):
+                assert DataContext.get_current().get_config("level") == "2"
+
+            assert DataContext.get_current().get_config("level") == "1"
+
+            # Test that raising will reset context too
+            raise ValueError("boom")
+
+    assert DataContext.get_current() is original
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description

This change makes `_map_task` reset global `DataContext` to avoid global state to be unintentionally shared b/w tasks.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
