### PR TITLE
[ci] refactor: extract shared RayImage dataclass from push_ray_image

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -2,6 +2,36 @@ load("@py_deps_py310//:requirements.bzl", ci_require = "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 py_library(
+    name = "ray_image_lib",
+    srcs = [
+        "configs.py",
+        "container.py",
+        "docker_container.py",
+        "linux_container.py",
+        "ray_image.py",
+    ],
+    visibility = [
+        "//ci/build:__pkg__",
+        "//ci/ray_ci:__subpackages__",
+    ],
+)
+
+py_test(
+    name = "test_ray_image",
+    size = "small",
+    srcs = ["test_ray_image.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_image_lib",
+        ci_require("pytest"),
+    ],
+)
+
+py_library(
     name = "ray_ci_lib",
     srcs = glob(
         ["*.py"],

--- a/ci/ray_ci/ray_image.py
+++ b/ci/ray_ci/ray_image.py
@@ -1,0 +1,137 @@
+"""
+Shared RayImage dataclass for image identity logic.
+
+Centralizes wanda image naming, validation, repo lookup, arch suffix,
+and variation suffix computation used by both ci/build/build_image.py
+and ci/ray_ci/automation/push_ray_image.py.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ci.ray_ci.configs import DEFAULT_ARCHITECTURE, DEFAULT_PYTHON_TAG_VERSION
+from ci.ray_ci.docker_container import (
+    ARCHITECTURES_RAY,
+    ARCHITECTURES_RAY_LLM,
+    PLATFORMS_RAY,
+    PLATFORMS_RAY_LLM,
+    PYTHON_VERSIONS_RAY,
+    PYTHON_VERSIONS_RAY_LLM,
+    RAY_REPO_MAP,
+    RayType,
+)
+
+
+class RayImageError(Exception):
+    """Raised when a RayImage field combination is invalid."""
+
+
+# Per-type configuration: valid python versions, platforms, architectures,
+# and the default python/platform (used for nightly aliases and CLI defaults).
+IMAGE_TYPE_CONFIG: dict[str, dict] = {
+    RayType.RAY: {
+        "python_versions": PYTHON_VERSIONS_RAY,
+        "platforms": PLATFORMS_RAY,
+        "architectures": ARCHITECTURES_RAY,
+        "default_python": DEFAULT_PYTHON_TAG_VERSION,
+        "default_platform": "cpu",
+    },
+    RayType.RAY_EXTRA: {
+        "python_versions": PYTHON_VERSIONS_RAY,
+        "platforms": PLATFORMS_RAY,
+        "architectures": ARCHITECTURES_RAY,
+        "default_python": DEFAULT_PYTHON_TAG_VERSION,
+        "default_platform": "cpu",
+    },
+    RayType.RAY_LLM: {
+        "python_versions": PYTHON_VERSIONS_RAY_LLM,
+        "platforms": PLATFORMS_RAY_LLM,
+        "architectures": ARCHITECTURES_RAY_LLM,
+        "default_python": "3.11",
+        "default_platform": "cu12.8.1-cudnn",
+    },
+    RayType.RAY_LLM_EXTRA: {
+        "python_versions": PYTHON_VERSIONS_RAY_LLM,
+        "platforms": PLATFORMS_RAY_LLM,
+        "architectures": ARCHITECTURES_RAY_LLM,
+        "default_python": "3.11",
+        "default_platform": "cu12.8.1-cudnn",
+    },
+}
+
+
+@dataclass(frozen=True)
+class RayImage:
+    """Immutable identity of a Ray Docker image variant."""
+
+    image_type: str
+    python_version: str
+    platform: str
+    architecture: str = DEFAULT_ARCHITECTURE
+
+    def __post_init__(self):
+        # Normalize RayType enum values to plain strings so f-strings
+        # produce "ray" instead of "RayType.RAY" (Python 3.12+ changed
+        # str(Enum) formatting).
+        if isinstance(self.image_type, RayType):
+            object.__setattr__(self, "image_type", self.image_type.value)
+
+    @property
+    def wanda_image_name(self) -> str:
+        """Wanda output image name (without registry prefix)."""
+        if self.platform == "cpu":
+            return f"{self.image_type}-py{self.python_version}-cpu{self.arch_suffix}"
+        return f"{self.image_type}-py{self.python_version}-{self.platform}{self.arch_suffix}"
+
+    @property
+    def arch_suffix(self) -> str:
+        """Architecture suffix for image names (empty for default arch)."""
+        if self.architecture == DEFAULT_ARCHITECTURE:
+            return ""
+        return f"-{self.architecture}"
+
+    @property
+    def repo(self) -> str:
+        """Docker Hub repository name (e.g. 'ray', 'ray-ml', 'ray-llm')."""
+        return RAY_REPO_MAP[self.image_type]
+
+    @property
+    def variation_suffix(self) -> str:
+        """Variation suffix: '-extra' for extra types, '' otherwise."""
+        if self.image_type in (
+            RayType.RAY_EXTRA,
+            RayType.RAY_ML_EXTRA,
+            RayType.RAY_LLM_EXTRA,
+        ):
+            return "-extra"
+        return ""
+
+    def validate(self) -> None:
+        """
+        Validate that image_type, python_version, platform, and architecture
+        are a valid combination. Raises RayImageError on invalid input.
+        """
+        if self.image_type not in IMAGE_TYPE_CONFIG:
+            valid = ", ".join(IMAGE_TYPE_CONFIG.keys())
+            raise RayImageError(
+                f"Unknown image type {self.image_type!r}. Valid types: {valid}"
+            )
+        cfg = IMAGE_TYPE_CONFIG[self.image_type]
+        if self.python_version not in cfg["python_versions"]:
+            raise RayImageError(
+                f"Invalid python version {self.python_version} "
+                f"for {self.image_type}. "
+                f"Valid versions: {', '.join(cfg['python_versions'])}"
+            )
+        if self.platform not in cfg["platforms"]:
+            raise RayImageError(
+                f"Invalid platform {self.platform} "
+                f"for {self.image_type}. "
+                f"Valid platforms: {', '.join(cfg['platforms'])}"
+            )
+        if self.architecture not in cfg["architectures"]:
+            raise RayImageError(
+                f"Invalid architecture {self.architecture} "
+                f"for {self.image_type}. "
+                f"Valid architectures: {', '.join(cfg['architectures'])}"
+            )

--- a/ci/ray_ci/test_ray_image.py
+++ b/ci/ray_ci/test_ray_image.py
@@ -1,0 +1,178 @@
+"""Tests for ci.ray_ci.ray_image.RayImage."""
+import sys
+
+import pytest
+
+from ci.ray_ci.configs import DEFAULT_ARCHITECTURE
+from ci.ray_ci.docker_container import RayType
+from ci.ray_ci.ray_image import IMAGE_TYPE_CONFIG, RayImage, RayImageError
+
+
+class TestWandaImageName:
+    DEFAULT_TEST_CUDA_PLATFORM = "cu12.1.1-cudnn8"
+
+    @pytest.mark.parametrize(
+        ("image_type", "python_version", "platform", "architecture", "expected"),
+        [
+            # CPU images
+            (RayType.RAY, "3.10", "cpu", DEFAULT_ARCHITECTURE, "ray-py3.10-cpu"),
+            (RayType.RAY, "3.10", "cpu", "aarch64", "ray-py3.10-cpu-aarch64"),
+            (
+                RayType.RAY_EXTRA,
+                "3.10",
+                "cpu",
+                DEFAULT_ARCHITECTURE,
+                "ray-extra-py3.10-cpu",
+            ),
+            # CUDA images
+            (
+                RayType.RAY,
+                "3.11",
+                DEFAULT_TEST_CUDA_PLATFORM,
+                DEFAULT_ARCHITECTURE,
+                f"ray-py3.11-{DEFAULT_TEST_CUDA_PLATFORM}",
+            ),
+            (
+                RayType.RAY,
+                "3.11",
+                DEFAULT_TEST_CUDA_PLATFORM,
+                "aarch64",
+                f"ray-py3.11-{DEFAULT_TEST_CUDA_PLATFORM}-aarch64",
+            ),
+            (
+                RayType.RAY_EXTRA,
+                "3.11",
+                DEFAULT_TEST_CUDA_PLATFORM,
+                DEFAULT_ARCHITECTURE,
+                f"ray-extra-py3.11-{DEFAULT_TEST_CUDA_PLATFORM}",
+            ),
+            (
+                RayType.RAY_LLM,
+                "3.11",
+                DEFAULT_TEST_CUDA_PLATFORM,
+                DEFAULT_ARCHITECTURE,
+                f"ray-llm-py3.11-{DEFAULT_TEST_CUDA_PLATFORM}",
+            ),
+            (
+                RayType.RAY_LLM_EXTRA,
+                "3.11",
+                DEFAULT_TEST_CUDA_PLATFORM,
+                DEFAULT_ARCHITECTURE,
+                f"ray-llm-extra-py3.11-{DEFAULT_TEST_CUDA_PLATFORM}",
+            ),
+            # ray-ml types
+            (RayType.RAY_ML, "3.10", "cpu", DEFAULT_ARCHITECTURE, "ray-ml-py3.10-cpu"),
+            (
+                RayType.RAY_ML_EXTRA,
+                "3.10",
+                DEFAULT_TEST_CUDA_PLATFORM,
+                DEFAULT_ARCHITECTURE,
+                f"ray-ml-extra-py3.10-{DEFAULT_TEST_CUDA_PLATFORM}",
+            ),
+        ],
+    )
+    def test_wanda_image_name(
+        self, image_type, python_version, platform, architecture, expected
+    ):
+        img = RayImage(image_type, python_version, platform, architecture)
+        assert img.wanda_image_name == expected
+
+
+class TestArchSuffix:
+    def test_default_architecture_empty(self):
+        img = RayImage("ray", "3.10", "cpu", DEFAULT_ARCHITECTURE)
+        assert img.arch_suffix == ""
+
+    def test_aarch64(self):
+        img = RayImage("ray", "3.10", "cpu", "aarch64")
+        assert img.arch_suffix == "-aarch64"
+
+
+class TestRepo:
+    @pytest.mark.parametrize(
+        ("image_type", "expected"),
+        [
+            (RayType.RAY, "ray"),
+            (RayType.RAY_EXTRA, "ray"),
+            (RayType.RAY_ML, "ray-ml"),
+            (RayType.RAY_ML_EXTRA, "ray-ml"),
+            (RayType.RAY_LLM, "ray-llm"),
+            (RayType.RAY_LLM_EXTRA, "ray-llm"),
+        ],
+    )
+    def test_repo(self, image_type, expected):
+        img = RayImage(image_type, "3.10", "cpu")
+        assert img.repo == expected
+
+
+class TestVariationSuffix:
+    @pytest.mark.parametrize(
+        ("image_type", "expected"),
+        [
+            (RayType.RAY, ""),
+            (RayType.RAY_EXTRA, "-extra"),
+            (RayType.RAY_ML, ""),
+            (RayType.RAY_ML_EXTRA, "-extra"),
+            (RayType.RAY_LLM, ""),
+            (RayType.RAY_LLM_EXTRA, "-extra"),
+        ],
+    )
+    def test_variation_suffix(self, image_type, expected):
+        img = RayImage(image_type, "3.10", "cpu")
+        assert img.variation_suffix == expected
+
+
+class TestValidateValid:
+    def test_ray_cpu(self):
+        RayImage("ray", "3.10", "cpu").validate()
+
+    def test_ray_cuda(self):
+        RayImage("ray", "3.13", "cu12.8.1-cudnn").validate()
+
+    def test_ray_extra(self):
+        RayImage("ray-extra", "3.12", "cu11.8.0-cudnn8").validate()
+
+    def test_ray_llm(self):
+        RayImage("ray-llm", "3.11", "cu12.8.1-cudnn").validate()
+
+    def test_ray_llm_extra(self):
+        RayImage("ray-llm-extra", "3.11", "cu12.8.1-cudnn").validate()
+
+    def test_ray_aarch64(self):
+        RayImage("ray", "3.10", "cpu", "aarch64").validate()
+
+
+class TestValidateInvalid:
+    def test_unknown_image_type(self):
+        with pytest.raises(RayImageError, match="Unknown image type"):
+            RayImage("ray-foo", "3.10", "cpu").validate()
+
+    def test_invalid_python_for_ray_llm(self):
+        with pytest.raises(
+            RayImageError, match="Invalid python version 3.10 for ray-llm"
+        ):
+            RayImage("ray-llm", "3.10", "cu12.8.1-cudnn").validate()
+
+    def test_invalid_platform_for_ray_llm(self):
+        with pytest.raises(RayImageError, match="Invalid platform cpu for ray-llm"):
+            RayImage("ray-llm", "3.11", "cpu").validate()
+
+    def test_invalid_platform_for_ray(self):
+        with pytest.raises(RayImageError, match="Invalid platform cu99.9.9 for ray"):
+            RayImage("ray", "3.10", "cu99.9.9").validate()
+
+    def test_invalid_architecture_for_ray_llm(self):
+        with pytest.raises(
+            RayImageError, match="Invalid architecture aarch64 for ray-llm"
+        ):
+            RayImage("ray-llm", "3.11", "cu12.8.1-cudnn", "aarch64").validate()
+
+
+class TestImageTypeConfig:
+    def test_expected_types_covered(self):
+        expected = {"ray", "ray-extra", "ray-llm", "ray-llm-extra"}
+        assert set(IMAGE_TYPE_CONFIG.keys()) == expected
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-vv", __file__]))


### PR DESCRIPTION
Extract image identity logic (wanda naming, validation, repo lookup, arch suffix, variation suffix) into a shared RayImage dataclass in ci/ray_ci/ray_image.py.

Refactor will be used for building Ray Images locally.

Topic: ray-image-refactor
Signed-off-by: andrew <andrew@anyscale.com>