### PR TITLE
[ci] feat: add local Docker image builder (build_image.py)

### DIFF
--- a/.wandaspecs
+++ b/.wandaspecs
@@ -8,3 +8,6 @@
 # to have been built by prior pipeline steps and are pulled from the work repo.
 
 ci/docker/
+docker/base-deps/
+docker/base-extra/
+docker/ray-llm/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,6 +20,11 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+exports_files([
+    ".rayciversion",
+    "ray-images.yaml",
+])
+
 # C/C++ toolchain constraint configs.
 
 config_setting(

--- a/ci/build/BUILD.bazel
+++ b/ci/build/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@py_deps_py310//:requirements.bzl", ci_require = "requirement")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 py_library(
@@ -50,4 +51,26 @@ py_test(
         "team:ci",
     ],
     deps = [":build_wheel"],
+)
+
+py_library(
+    name = "build_image",
+    srcs = ["build_image.py"],
+    data = ["//:ray-images.yaml"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":build_common",
+        ci_require("pyyaml"),
+    ],
+)
+
+py_test(
+    name = "build_image_test",
+    size = "small",
+    srcs = ["build_image_test.py"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [":build_image"],
 )

--- a/ci/build/build_image.py
+++ b/ci/build/build_image.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["pyyaml"]
+# ///
+"""
+Build Ray Docker images locally using raymake.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from ci.build.build_common import (
+    BuildError,
+    detect_host_arch,
+    find_ray_root,
+    get_git_commit,
+    log,
+    parse_file,
+)
+
+DEFAULT_ARCHITECTURE = "x86_64"
+
+# Maps base image type string to its YAML config key.
+_BASE_TYPE_MAP: dict[str, str] = {
+    "ray": "ray",
+    "ray-extra": "ray",
+    "ray-llm": "ray-llm",
+    "ray-llm-extra": "ray-llm",
+}
+
+# Maps image type to its Docker Hub repo name.
+_REPO_MAP: dict[str, str] = {
+    "ray": "ray",
+    "ray-extra": "ray",
+    "ray-llm": "ray-llm",
+    "ray-llm-extra": "ray-llm",
+}
+
+
+def _load_ray_images_yaml() -> dict:
+    """Load ray-images.yaml from the repository root (relative to this file)."""
+    path = Path(__file__).resolve().parent.parent.parent / "ray-images.yaml"
+    if not path.exists():
+        raise BuildError(f"Missing {path}")
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _build_image_type_config() -> dict[str, dict]:
+    """Build IMAGE_TYPE_CONFIG from ray-images.yaml."""
+    raw = _load_ray_images_yaml()
+    config: dict[str, dict] = {}
+    for image_type, yaml_key in _BASE_TYPE_MAP.items():
+        yaml_cfg = raw[yaml_key]
+        defaults = yaml_cfg["defaults"]
+        platforms = yaml_cfg["platforms"]
+        config[image_type] = {
+            "python_versions": yaml_cfg["python"],
+            "platforms": platforms,
+            "architectures": yaml_cfg["architectures"],
+            "default_python": defaults["python"],
+            "default_platform": "cpu"
+            if "cpu" in platforms
+            else defaults["gpu_platform"],
+        }
+    return config
+
+
+IMAGE_TYPE_CONFIG: dict[str, dict] = _build_image_type_config()
+
+
+class RayImageError(Exception):
+    """Raised when a RayImage field combination is invalid."""
+
+
+@dataclass(frozen=True)
+class RayImage:
+    """Immutable identity of a Ray Docker image variant."""
+
+    image_type: str
+    python_version: str
+    platform: str
+    architecture: str = DEFAULT_ARCHITECTURE
+
+    @property
+    def wanda_image_name(self) -> str:
+        """Wanda output image name (without registry prefix)."""
+        if self.platform == "cpu":
+            return f"{self.image_type}-py{self.python_version}-cpu{self.arch_suffix}"
+        return f"{self.image_type}-py{self.python_version}-{self.platform}{self.arch_suffix}"
+
+    @property
+    def arch_suffix(self) -> str:
+        if self.architecture == DEFAULT_ARCHITECTURE:
+            return ""
+        return f"-{self.architecture}"
+
+    @property
+    def repo(self) -> str:
+        return _REPO_MAP[self.image_type]
+
+    @property
+    def variation_suffix(self) -> str:
+        if self.image_type.endswith("-extra"):
+            return "-extra"
+        return ""
+
+    def validate(self) -> None:
+        if self.image_type not in IMAGE_TYPE_CONFIG:
+            valid = ", ".join(IMAGE_TYPE_CONFIG)
+            raise RayImageError(
+                f"Unknown image type {self.image_type!r}. Valid types: {valid}"
+            )
+        cfg = IMAGE_TYPE_CONFIG[self.image_type]
+        if self.python_version not in cfg["python_versions"]:
+            raise RayImageError(
+                f"Invalid python version {self.python_version} "
+                f"for {self.image_type}. "
+                f"Valid versions: {', '.join(cfg['python_versions'])}"
+            )
+        if self.platform not in cfg["platforms"]:
+            raise RayImageError(
+                f"Invalid platform {self.platform} "
+                f"for {self.image_type}. "
+                f"Valid platforms: {', '.join(cfg['platforms'])}"
+            )
+        if self.architecture not in cfg["architectures"]:
+            raise RayImageError(
+                f"Invalid architecture {self.architecture} "
+                f"for {self.image_type}. "
+                f"Valid architectures: {', '.join(cfg['architectures'])}"
+            )
+
+
+# (image_type, platform_class) where platform_class is "cpu" or "cuda".
+WandaSpecKey = tuple[str, str]
+
+WANDA_SPEC_PATHS: dict[WandaSpecKey, str] = {
+    ("ray", "cpu"): "ci/docker/ray-image-cpu.wanda.yaml",
+    ("ray", "cuda"): "ci/docker/ray-image-cuda.wanda.yaml",
+    ("ray-extra", "cpu"): "ci/docker/ray-extra-image-cpu.wanda.yaml",
+    ("ray-extra", "cuda"): "ci/docker/ray-extra-image-cuda.wanda.yaml",
+    ("ray-llm", "cuda"): "ci/docker/ray-llm-image-cuda.wanda.yaml",
+    ("ray-llm-extra", "cuda"): "ci/docker/ray-llm-extra-image-cuda.wanda.yaml",
+}
+
+SUPPORTED_IMAGE_TYPES: list[str] = list(dict.fromkeys(t for t, _ in WANDA_SPEC_PATHS))
+REGISTRY_PREFIX = "cr.ray.io/rayproject/"
+
+
+@dataclass(frozen=True)
+class ImageBuildConfig:
+    ray_image: RayImage
+    ray_root: Path
+
+    @property
+    def raymake_version(self) -> str:
+        return (self.ray_root / ".rayciversion").read_text().strip()
+
+    @property
+    def manylinux_version(self) -> str:
+        return parse_file(
+            self.ray_root / "rayci.env", r'MANYLINUX_VERSION=["\']?([^"\'\s]+)'
+        )
+
+    @property
+    def ray_version(self) -> str:
+        return parse_file(self.ray_root / "rayci.env", r'RAY_VERSION=["\']?([^"\'\s]+)')
+
+    @property
+    def commit(self) -> str:
+        return get_git_commit(self.ray_root)
+
+    @property
+    def wanda_spec_path(self) -> str:
+        key: WandaSpecKey = (
+            self.ray_image.image_type,
+            "cpu" if self.ray_image.platform == "cpu" else "cuda",
+        )
+        if key not in WANDA_SPEC_PATHS:
+            raise BuildError(
+                f"No wanda spec for image_type={self.ray_image.image_type!r}, "
+                f"platform={self.ray_image.platform!r}"
+            )
+        return WANDA_SPEC_PATHS[key]
+
+    @property
+    def wanda_image_tag(self) -> str:
+        return f"{REGISTRY_PREFIX}{self.ray_image.wanda_image_name}"
+
+    @property
+    def nightly_alias(self) -> str | None:
+        cfg = IMAGE_TYPE_CONFIG[self.ray_image.image_type]
+        if (
+            self.ray_image.python_version != cfg["default_python"]
+            or self.ray_image.platform != cfg["default_platform"]
+            or self.ray_image.architecture != DEFAULT_ARCHITECTURE
+        ):
+            return None
+        return f"{REGISTRY_PREFIX}{self.ray_image.repo}:nightly{self.ray_image.variation_suffix}"
+
+    @property
+    def build_env(self) -> dict[str, str]:
+        env = {
+            "PYTHON_VERSION": self.ray_image.python_version,
+            "MANYLINUX_VERSION": self.manylinux_version,
+            "HOSTTYPE": self.ray_image.architecture,
+            "ARCH_SUFFIX": self.ray_image.arch_suffix,
+            "BUILDKITE_COMMIT": self.commit,
+            "RAY_VERSION": self.ray_version,
+            "IS_LOCAL_BUILD": "true",
+            "IMAGE_TYPE": self.ray_image.repo,
+        }
+        if self.ray_image.platform != "cpu":
+            env["CUDA_VERSION"] = self.ray_image.platform.removeprefix("cu")
+        return env
+
+    @classmethod
+    def from_args(
+        cls,
+        image_type: str,
+        python_version: str,
+        image_platform: str,
+    ) -> ImageBuildConfig:
+        if image_type not in SUPPORTED_IMAGE_TYPES:
+            raise BuildError(
+                f"Unknown image type {image_type!r}. "
+                f"Valid types: {', '.join(SUPPORTED_IMAGE_TYPES)}"
+            )
+
+        root = find_ray_root()
+        ray_image = RayImage(
+            image_type=image_type,
+            python_version=python_version,
+            platform=image_platform,
+            architecture=cls._detect_host_arch(),
+        )
+        try:
+            ray_image.validate()
+        except RayImageError as e:
+            raise BuildError(str(e)) from e
+        return cls(ray_image=ray_image, ray_root=root)
+
+    @staticmethod
+    def _detect_host_arch() -> str:
+        return detect_host_arch()
+
+
+class ImageBuilder:
+    def __init__(self, config: ImageBuildConfig):
+        self.config = config
+
+    def build(self) -> str:
+        """Build the image and return the primary image tag."""
+        if not shutil.which("raymake"):
+            raise BuildError("raymake not found. Run via ./build-image.sh")
+
+        log.info("Build configuration:")
+        summary = {
+            "Image Type": self.config.ray_image.image_type,
+            "Python": self.config.ray_image.python_version,
+            "Platform": self.config.ray_image.platform,
+            "Arch": self.config.ray_image.architecture,
+            "Commit": self.config.commit,
+            "Raymake": self.config.raymake_version,
+            "Ray Version": self.config.ray_version,
+            "Wanda Spec": self.config.wanda_spec_path,
+        }
+        print("-" * 50)
+        for k, v in summary.items():
+            print(f"{k:<12}: {v}")
+        print("-" * 50)
+
+        cmd = [
+            "raymake",
+            str(self.config.wanda_spec_path),
+        ]
+
+        log.info(f"Running raymake: {self.config.wanda_spec_path}")
+        log.info(f"Build environment: {self.config.build_env}")
+        proc = subprocess.Popen(
+            cmd,
+            cwd=self.config.ray_root,
+            env={**os.environ, **self.config.build_env},
+        )
+        try:
+            if proc.wait() != 0:
+                raise BuildError("raymake failed")
+        except KeyboardInterrupt:
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            raise
+
+        image_tag = self.config.wanda_image_tag
+        log.info(f"Built image: {image_tag}")
+
+        alias = self.config.nightly_alias
+        if alias:
+            self._docker_tag(image_tag, alias)
+            log.info(f"Tagged alias: {alias}")
+
+        return image_tag
+
+    @staticmethod
+    def _docker_tag(source: str, dest: str) -> None:
+        result = subprocess.run(
+            ["docker", "tag", source, dest],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise BuildError(f"docker tag failed: {result.stderr.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _image_type_table() -> str:
+    """Build an ASCII table of all image types from IMAGE_TYPE_CONFIG."""
+
+    def _tag_default(items, default):
+        return [f"{v} (default)" if v == default else v for v in items]
+
+    def _wrap(items, width):
+        """Join items with ', ' and wrap into lines that fit in *width*."""
+        lines: list[str] = []
+        cur = ""
+        for item in items:
+            entry = item if not cur else f", {item}"
+            if cur and len(cur) + len(entry) > width:
+                lines.append(cur)
+                cur = item
+            else:
+                cur += entry
+        if cur:
+            lines.append(cur)
+        return lines
+
+    headers = ("IMAGE TYPE", "PYTHON VERSIONS (-p)", "PLATFORMS (--platform)")
+    plat_width = 52  # wrap platforms to this width
+
+    def _build_rows(type_list):
+        rows: list[tuple[str, str, list[str]]] = []
+        for name in type_list:
+            cfg = IMAGE_TYPE_CONFIG[name]
+            py_cell = ", ".join(
+                _tag_default(cfg["python_versions"], cfg["default_python"])
+            )
+            plat_lines = _wrap(
+                _tag_default(cfg["platforms"], cfg["default_platform"]),
+                plat_width,
+            )
+            rows.append((name, py_cell, plat_lines))
+        return rows
+
+    rows = _build_rows(SUPPORTED_IMAGE_TYPES)
+
+    # Compute column widths.
+    widths = [len(h) for h in headers]
+    for label, py_cell, plat_lines in rows:
+        widths[0] = max(widths[0], len(label))
+        widths[1] = max(widths[1], len(py_cell))
+        widths[2] = max(widths[2], *(len(l) for l in plat_lines))
+
+    sep = "  "
+
+    def fmt(cells):
+        return sep.join(c.ljust(widths[i]) for i, c in enumerate(cells))
+
+    lines = [fmt(headers), sep.join("-" * w for w in widths)]
+    for label, py_cell, plat_lines in rows:
+        lines.append(fmt((label, py_cell, plat_lines[0])))
+        for cont in plat_lines[1:]:
+            lines.append(fmt(("", "", cont)))
+
+    return "\n".join(lines)
+
+
+def _nightly_table() -> str:
+    """Build a table mapping build commands to nightly docker run commands."""
+    headers = ("BUILD", "RUN")
+    rows = []
+    for name in SUPPORTED_IMAGE_TYPES:
+        cfg = IMAGE_TYPE_CONFIG[name]
+        img = RayImage(name, cfg["default_python"], cfg["default_platform"])
+        tag = f"{REGISTRY_PREFIX}{img.repo}:nightly{img.variation_suffix}"
+        rows.append((f"./build-image.sh {name}", f"docker run -it {tag}"))
+
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    sep = "  "
+
+    def fmt(cells):
+        return sep.join(c.ljust(widths[i]) for i, c in enumerate(cells))
+
+    lines = [fmt(headers), sep.join("-" * w for w in widths)]
+    lines.extend(fmt(row) for row in rows)
+    return "\n".join(lines)
+
+
+def _build_examples() -> str:
+    """Generate non-default example commands from IMAGE_TYPE_CONFIG."""
+    ray_cfg = IMAGE_TYPE_CONFIG["ray"]
+    ray_py = ray_cfg["default_python"]
+    alt_py = next((v for v in ray_cfg["python_versions"] if v != ray_py), None)
+    alt_plat = next((p for p in ray_cfg["platforms"] if p != "cpu"), None)
+
+    examples: list[tuple[str, str]] = []
+    if alt_py:
+        examples.append(
+            (f"ray -p {alt_py}", f"ray cpu py{alt_py}"),
+        )
+    if alt_plat:
+        examples.append(
+            (f"ray --platform {alt_plat}", f"ray {alt_plat} py{ray_py}"),
+        )
+    if alt_py and alt_plat:
+        examples.append(
+            (f"ray -p {alt_py} --platform {alt_plat}", f"ray {alt_plat} py{alt_py}"),
+        )
+
+    if not examples:
+        return ""
+
+    cmd_prefix = "  ./build-image.sh "
+    cmds = [cmd_prefix + args for args, _ in examples]
+    max_cmd = max(len(c) for c in cmds)
+    lines = []
+    for cmd, (_, comment) in zip(cmds, examples):
+        lines.append(f"{cmd:<{max_cmd}}  # {comment}")
+    return "\n".join(lines)
+
+
+def main():
+    epilog_parts = [
+        "Supported image types:",
+        _image_type_table(),
+        "",
+        "Nightly images (built with defaults):",
+        _nightly_table(),
+        "",
+        "Examples:",
+        _build_examples(),
+    ]
+
+    parser = argparse.ArgumentParser(
+        prog="./build-image.sh",
+        description="Build Ray Docker images locally using raymake.",
+        epilog="\n".join(epilog_parts),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "image_type",
+        choices=SUPPORTED_IMAGE_TYPES,
+        metavar="IMAGE_TYPE",
+        help=f"Image type: {', '.join(SUPPORTED_IMAGE_TYPES)}",
+    )
+    parser.add_argument(
+        "-p",
+        "--python-version",
+        default=None,
+        metavar="VERSION",
+        help="Python version (default depends on image type; see table below)",
+    )
+    parser.add_argument(
+        "--platform",
+        default=None,
+        metavar="PLATFORM",
+        help="Target platform (default depends on image type; see table below)",
+    )
+    parser.add_argument(
+        "--list-platforms",
+        action="store_true",
+        help="List valid platforms for the given image type and exit",
+    )
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
+    args = parser.parse_args()
+
+    cfg = IMAGE_TYPE_CONFIG[args.image_type]
+
+    if args.list_platforms:
+        print(f"Valid platforms for {args.image_type}:")
+        for p in cfg["platforms"]:
+            marker = " (default)" if p == cfg["default_platform"] else ""
+            print(f"  {p}{marker}")
+        sys.exit(0)
+
+    python_version = args.python_version or cfg["default_python"]
+    platform_choice = args.platform or cfg["default_platform"]
+
+    try:
+        config = ImageBuildConfig.from_args(
+            args.image_type, python_version, platform_choice
+        )
+        builder = ImageBuilder(config)
+        image_tag = builder.build()
+
+        print()
+        log.info("Success!")
+        print(f"  docker run -it {image_tag}")
+        alias = config.nightly_alias
+        if alias:
+            print(f"  docker run -it {alias}")
+    except BuildError as e:
+        log.error(e)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build/build_image_test.py
+++ b/ci/build/build_image_test.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Tests for build_image.py"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from build_image import (
+    REGISTRY_PREFIX,
+    SUPPORTED_IMAGE_TYPES,
+    BuildError,
+    ImageBuildConfig,
+    RayImage,
+    main,
+)
+
+
+class TestGetWandaSpec(unittest.TestCase):
+    """Test wanda_spec_path returns correct paths."""
+
+    def _spec(self, image_type, platform):
+        ri = RayImage(image_type=image_type, python_version="3.10", platform=platform)
+        return ImageBuildConfig(ray_image=ri, ray_root=Path("/fake")).wanda_spec_path
+
+    def test_ray_cpu(self):
+        self.assertEqual(self._spec("ray", "cpu"), "ci/docker/ray-image-cpu.wanda.yaml")
+
+    def test_ray_cuda(self):
+        self.assertEqual(
+            self._spec("ray", "cu12.8.1-cudnn"),
+            "ci/docker/ray-image-cuda.wanda.yaml",
+        )
+
+    def test_ray_extra_cpu(self):
+        self.assertEqual(
+            self._spec("ray-extra", "cpu"),
+            "ci/docker/ray-extra-image-cpu.wanda.yaml",
+        )
+
+    def test_ray_extra_cuda(self):
+        self.assertEqual(
+            self._spec("ray-extra", "cu12.1.1-cudnn8"),
+            "ci/docker/ray-extra-image-cuda.wanda.yaml",
+        )
+
+    def test_ray_llm_cuda(self):
+        self.assertEqual(
+            self._spec("ray-llm", "cu12.8.1-cudnn"),
+            "ci/docker/ray-llm-image-cuda.wanda.yaml",
+        )
+
+    def test_ray_llm_extra_cuda(self):
+        self.assertEqual(
+            self._spec("ray-llm-extra", "cu12.8.1-cudnn"),
+            "ci/docker/ray-llm-extra-image-cuda.wanda.yaml",
+        )
+
+    def test_ray_llm_cpu_raises(self):
+        with self.assertRaises(BuildError):
+            self._spec("ray-llm", "cpu")
+
+
+class TestValidation(unittest.TestCase):
+    """Test from_args() rejects invalid combinations."""
+
+    def test_unknown_build_image_type(self):
+        with self.assertRaises(BuildError) as ctx:
+            ImageBuildConfig.from_args("ray-ml", "3.10", "cpu")
+        self.assertIn("Unknown image type", str(ctx.exception))
+
+    def test_invalid_python_raises_build_error(self):
+        with self.assertRaises(BuildError):
+            ImageBuildConfig.from_args("ray-llm", "3.10", "cu12.8.1-cudnn")
+
+
+def _config(**kwargs):
+    image_type = kwargs.pop("image_type", "ray")
+    python_version = kwargs.pop("python_version", "3.10")
+    image_platform = kwargs.pop("platform", "cpu")
+    architecture = kwargs.pop("architecture", "x86_64")
+    kwargs.pop("arch_suffix", None)
+
+    ray_image = RayImage(
+        image_type=image_type,
+        python_version=python_version,
+        platform=image_platform,
+        architecture=architecture,
+    )
+
+    defaults = dict(
+        ray_image=ray_image,
+        ray_root=Path("/fake/ray"),
+    )
+    defaults.update(kwargs)
+    return ImageBuildConfig(**defaults)
+
+
+class TestConfigWandaImageTag(unittest.TestCase):
+    """Test wanda_image_name and wanda_image_tag on ImageBuildConfig."""
+
+    def test_ray_cpu(self):
+        c = _config()
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-py3.10-cpu")
+        self.assertEqual(c.wanda_image_tag, f"{REGISTRY_PREFIX}ray-py3.10-cpu")
+
+    def test_ray_cuda(self):
+        c = _config(platform="cu12.8.1-cudnn")
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-py3.10-cu12.8.1-cudnn")
+
+    def test_ray_extra_cpu(self):
+        c = _config(image_type="ray-extra")
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-extra-py3.10-cpu")
+
+    def test_ray_llm_cuda(self):
+        c = _config(
+            image_type="ray-llm", python_version="3.11", platform="cu12.8.1-cudnn"
+        )
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-llm-py3.11-cu12.8.1-cudnn")
+
+    def test_aarch64_suffix(self):
+        c = _config(architecture="aarch64")
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-py3.10-cpu-aarch64")
+
+
+class TestConfigNightlyAlias(unittest.TestCase):
+    """Test nightly_alias on ImageBuildConfig."""
+
+    def test_ray_default_has_nightly(self):
+        c = _config()
+        self.assertEqual(c.nightly_alias, f"{REGISTRY_PREFIX}ray:nightly")
+
+    def test_ray_extra_default_has_nightly_extra(self):
+        c = _config(image_type="ray-extra")
+        self.assertEqual(c.nightly_alias, f"{REGISTRY_PREFIX}ray:nightly-extra")
+
+    def test_ray_llm_default_has_nightly(self):
+        c = _config(
+            image_type="ray-llm", python_version="3.11", platform="cu12.8.1-cudnn"
+        )
+        self.assertEqual(c.nightly_alias, f"{REGISTRY_PREFIX}ray-llm:nightly")
+
+    def test_ray_llm_extra_default_has_nightly_extra(self):
+        c = _config(
+            image_type="ray-llm-extra",
+            python_version="3.11",
+            platform="cu12.8.1-cudnn",
+        )
+        self.assertEqual(c.nightly_alias, f"{REGISTRY_PREFIX}ray-llm:nightly-extra")
+
+    def test_non_default_python_no_alias(self):
+        c = _config(python_version="3.12")
+        self.assertIsNone(c.nightly_alias)
+
+    def test_non_default_platform_no_alias(self):
+        c = _config(platform="cu12.8.1-cudnn")
+        self.assertIsNone(c.nightly_alias)
+
+
+def _make_ray_root(tmpdir):
+    """Create a minimal ray root with config files for property tests."""
+    root = Path(tmpdir)
+    (root / ".rayciversion").write_text("0.31.0")
+    (root / "rayci.env").write_text(
+        "MANYLINUX_VERSION=260128.221a193\nRAY_VERSION=3.0.0.dev0\n"
+    )
+    return root
+
+
+class TestBuildEnv(unittest.TestCase):
+    """Test build_env returns correct environment variables."""
+
+    def _config(self, **kwargs):
+        kwargs.setdefault("ray_root", self._ray_root)
+        return _config(**kwargs)
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._ray_root = _make_ray_root(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_cpu_env(self):
+        env = self._config().build_env
+        self.assertEqual(env["PYTHON_VERSION"], "3.10")
+        self.assertEqual(env["HOSTTYPE"], "x86_64")
+        self.assertEqual(env["ARCH_SUFFIX"], "")
+        self.assertEqual(env["IS_LOCAL_BUILD"], "true")
+        self.assertEqual(env["IMAGE_TYPE"], "ray")
+        self.assertEqual(env["RAY_VERSION"], "3.0.0.dev0")
+        self.assertNotIn("CUDA_VERSION", env)
+
+    def test_cuda_env(self):
+        env = self._config(platform="cu12.8.1-cudnn").build_env
+        self.assertEqual(env["CUDA_VERSION"], "12.8.1-cudnn")
+
+    def test_ray_extra_image_type(self):
+        env = self._config(image_type="ray-extra").build_env
+        self.assertEqual(env["IMAGE_TYPE"], "ray")
+
+    def test_ray_llm_image_type(self):
+        env = self._config(
+            image_type="ray-llm", python_version="3.11", platform="cu12.8.1-cudnn"
+        ).build_env
+        self.assertEqual(env["IMAGE_TYPE"], "ray-llm")
+
+    def test_ray_llm_extra_image_type(self):
+        env = self._config(
+            image_type="ray-llm-extra",
+            python_version="3.11",
+            platform="cu12.8.1-cudnn",
+        ).build_env
+        self.assertEqual(env["IMAGE_TYPE"], "ray-llm")
+
+
+class TestPlatformDetection(unittest.TestCase):
+    """Test _detect_host_arch() returns correct values."""
+
+    def test_darwin_arm64(self):
+        with mock.patch(
+            "ci.build.build_common._platform.system", return_value="Darwin"
+        ), mock.patch("ci.build.build_common._platform.machine", return_value="arm64"):
+            arch = ImageBuildConfig._detect_host_arch()
+        self.assertEqual(arch, "aarch64")
+
+    def test_linux_x86_64(self):
+        with mock.patch(
+            "ci.build.build_common._platform.system", return_value="Linux"
+        ), mock.patch("ci.build.build_common._platform.machine", return_value="x86_64"):
+            arch = ImageBuildConfig._detect_host_arch()
+        self.assertEqual(arch, "x86_64")
+
+    def test_linux_aarch64(self):
+        with mock.patch(
+            "ci.build.build_common._platform.system", return_value="Linux"
+        ), mock.patch(
+            "ci.build.build_common._platform.machine", return_value="aarch64"
+        ):
+            arch = ImageBuildConfig._detect_host_arch()
+        self.assertEqual(arch, "aarch64")
+
+    def test_unsupported_platform_raises(self):
+        with mock.patch(
+            "ci.build.build_common._platform.system", return_value="Windows"
+        ), mock.patch("ci.build.build_common._platform.machine", return_value="AMD64"):
+            with self.assertRaises(BuildError):
+                ImageBuildConfig._detect_host_arch()
+
+
+class TestFromArgs(unittest.TestCase):
+    """Test ImageBuildConfig.from_args() factory method."""
+
+    def test_from_args_creates_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ray_root = _make_ray_root(tmpdir)
+
+            with mock.patch(
+                "ci.build.build_common._platform.system", return_value="Linux"
+            ), mock.patch(
+                "ci.build.build_common._platform.machine", return_value="x86_64"
+            ), mock.patch(
+                "build_image.find_ray_root", return_value=ray_root
+            ), mock.patch(
+                "build_image.get_git_commit", return_value="abc1234"
+            ):
+                config = ImageBuildConfig.from_args("ray", "3.10", "cpu")
+
+            self.assertEqual(config.ray_image.image_type, "ray")
+            self.assertEqual(config.ray_image.python_version, "3.10")
+            self.assertEqual(config.ray_image.platform, "cpu")
+            self.assertEqual(config.ray_image.architecture, "x86_64")
+            self.assertEqual(config.ray_image.arch_suffix, "")
+            self.assertEqual(config.raymake_version, "0.31.0")
+            self.assertEqual(config.manylinux_version, "260128.221a193")
+            self.assertEqual(config.ray_version, "3.0.0.dev0")
+
+    def test_from_args_rejects_invalid(self):
+        with self.assertRaises(BuildError):
+            ImageBuildConfig.from_args("ray-llm", "3.10", "cpu")
+
+    def test_from_args_rejects_unsupported_arch(self):
+        """ray-llm only supports x86_64; aarch64 should be rejected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ray_root = _make_ray_root(tmpdir)
+            with mock.patch(
+                "ci.build.build_common._platform.system", return_value="Linux"
+            ), mock.patch(
+                "ci.build.build_common._platform.machine", return_value="aarch64"
+            ), mock.patch(
+                "build_image.find_ray_root", return_value=ray_root
+            ):
+                with self.assertRaises(BuildError):
+                    ImageBuildConfig.from_args("ray-llm", "3.11", "cu12.8.1-cudnn")
+
+
+class TestSupportedImageTypes(unittest.TestCase):
+    """Test SUPPORTED_IMAGE_TYPES covers all expected types."""
+
+    def test_contains_all_types(self):
+        for name in ("ray", "ray-extra", "ray-llm", "ray-llm-extra"):
+            self.assertIn(name, SUPPORTED_IMAGE_TYPES)
+
+    def test_all_plain_strings(self):
+        for name in SUPPORTED_IMAGE_TYPES:
+            self.assertIsInstance(name, str)
+            self.assertNotIn(".", name)  # not "RayType.RAY"
+
+
+class TestHelpOutput(unittest.TestCase):
+    """Test that --help prints without error."""
+
+    def test_no_args_prints_help_and_exits_zero(self):
+        with mock.patch("build_image.sys.argv", ["build_image"]):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -9,10 +9,18 @@ py_library(
         "docker_container.py",
         "linux_container.py",
         "ray_image.py",
+        "supported_images.py",
+    ],
+    data = [
+        "//:.rayciversion",
+        "//:ray-images.yaml",
     ],
     visibility = [
         "//ci/build:__pkg__",
         "//ci/ray_ci:__subpackages__",
+    ],
+    deps = [
+        ci_require("pyyaml"),
     ],
 )
 
@@ -42,7 +50,10 @@ py_library(
             "build_in_docker_windows.py",
         ],
     ),
-    data = glob(["*.yaml"]),
+    data = glob(["*.yaml"]) + [
+        "//:.rayciversion",
+        "//:ray-images.yaml",
+    ],
     visibility = ["//ci/ray_ci:__subpackages__"],
     deps = [
         "//release:bazel",
@@ -269,4 +280,24 @@ py_test(
         "team:ci",
     ],
     deps = [ci_require("pytest")],
+)
+
+py_test(
+    name = "test_supported_images",
+    size = "small",
+    srcs = ["test_supported_images.py"],
+    data = [
+        "//:.rayciversion",
+        "//:ray-images.yaml",
+    ],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_image_lib",
+        ci_require("pytest"),
+        ci_require("pyyaml"),
+    ],
 )

--- a/ci/ray_ci/docker_container.py
+++ b/ci/ray_ci/docker_container.py
@@ -5,32 +5,24 @@ from typing import Dict, List
 
 from ci.ray_ci.configs import DEFAULT_ARCHITECTURE, DEFAULT_PYTHON_TAG_VERSION
 from ci.ray_ci.linux_container import LinuxContainer
+from ci.ray_ci.supported_images import (
+    get_architectures,
+    get_default,
+    get_platforms,
+    get_python_versions,
+)
 
-PLATFORMS_RAY = [
-    "cpu",
-    "cu11.7.1-cudnn8",
-    "cu11.8.0-cudnn8",
-    "cu12.1.1-cudnn8",
-    "cu12.3.2-cudnn9",
-    "cu12.4.1-cudnn",
-    "cu12.5.1-cudnn",
-    "cu12.6.3-cudnn",
-    "cu12.8.1-cudnn",
-    "cu12.9.1-cudnn",
-]
-PLATFORMS_RAY_ML = [
-    "cpu",
-    "cu12.1.1-cudnn8",
-]
-PLATFORMS_RAY_LLM = ["cu12.8.1-cudnn", "cu12.9.1-cudnn"]
-GPU_PLATFORM = "cu12.1.1-cudnn8"
+PLATFORMS_RAY = get_platforms("ray")
+PLATFORMS_RAY_ML = get_platforms("ray-ml")
+PLATFORMS_RAY_LLM = get_platforms("ray-llm")
+GPU_PLATFORM = get_default("ray", "gpu_platform")
 
-PYTHON_VERSIONS_RAY = ["3.10", "3.11", "3.12", "3.13"]
-PYTHON_VERSIONS_RAY_ML = ["3.10", "3.11"]
-PYTHON_VERSIONS_RAY_LLM = ["3.11", "3.12"]
-ARCHITECTURES_RAY = ["x86_64", "aarch64"]
-ARCHITECTURES_RAY_ML = ["x86_64"]
-ARCHITECTURES_RAY_LLM = ["x86_64"]
+PYTHON_VERSIONS_RAY = get_python_versions("ray")
+PYTHON_VERSIONS_RAY_ML = get_python_versions("ray-ml")
+PYTHON_VERSIONS_RAY_LLM = get_python_versions("ray-llm")
+ARCHITECTURES_RAY = get_architectures("ray")
+ARCHITECTURES_RAY_ML = get_architectures("ray-ml")
+ARCHITECTURES_RAY_LLM = get_architectures("ray-llm")
 
 
 class RayType(str, Enum):

--- a/ci/ray_ci/supported_images.py
+++ b/ci/ray_ci/supported_images.py
@@ -1,0 +1,45 @@
+from functools import lru_cache
+from pathlib import Path
+from typing import List
+
+import yaml
+
+_RAYCI_VERSION_FILE = ".rayciversion"
+
+
+def _find_ray_root() -> Path:
+    """Walk up from this file and cwd looking for .rayciversion."""
+    start = Path(__file__).resolve()
+    for parent in [start, *start.parents]:
+        if (parent / _RAYCI_VERSION_FILE).exists():
+            return parent
+    if (Path.cwd() / _RAYCI_VERSION_FILE).exists():
+        return Path.cwd()
+    raise FileNotFoundError("Could not find Ray root (missing .rayciversion).")
+
+
+@lru_cache(maxsize=1)
+def load_supported_images():
+    yaml_path = _find_ray_root() / "ray-images.yaml"
+    with open(yaml_path) as f:
+        return yaml.safe_load(f)
+
+
+def get_image_config(image_type: str) -> dict:
+    return load_supported_images()[image_type]
+
+
+def get_python_versions(image_type: str) -> List[str]:
+    return get_image_config(image_type)["python"]
+
+
+def get_platforms(image_type: str) -> List[str]:
+    return get_image_config(image_type)["platforms"]
+
+
+def get_architectures(image_type: str) -> List[str]:
+    return get_image_config(image_type)["architectures"]
+
+
+def get_default(image_type: str, key: str) -> str:
+    return get_image_config(image_type)["defaults"][key]

--- a/ci/ray_ci/test_supported_images.py
+++ b/ci/ray_ci/test_supported_images.py
@@ -1,0 +1,74 @@
+"""
+Validates that ray-images.yaml is well-formed and internally consistent.
+"""
+
+import pytest
+
+from ci.ray_ci.supported_images import get_image_config, load_supported_images
+
+IMAGE_TYPES = list(load_supported_images().keys())
+REQUIRED_KEYS = ["defaults", "python", "platforms", "architectures"]
+REQUIRED_DEFAULTS = ["python", "gpu_platform", "architecture"]
+
+
+class TestRayImagesSchema:
+    def test_has_image_types(self):
+        assert len(IMAGE_TYPES) > 0, "ray-images.yaml has no image types defined"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_required_keys(self, image_type):
+        cfg = get_image_config(image_type)
+        for key in REQUIRED_KEYS:
+            assert key in cfg, f"{image_type}: missing required key '{key}'"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_required_defaults(self, image_type):
+        defaults = get_image_config(image_type)["defaults"]
+        for key in REQUIRED_DEFAULTS:
+            assert key in defaults, f"{image_type}: missing required default '{key}'"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_defaults_in_supported(self, image_type):
+        cfg = get_image_config(image_type)
+        defaults = cfg["defaults"]
+
+        assert defaults["python"] in cfg["python"], (
+            f"{image_type}: default python '{defaults['python']}' "
+            f"not in supported {cfg['python']}"
+        )
+        assert defaults["gpu_platform"] in cfg["platforms"], (
+            f"{image_type}: default gpu_platform '{defaults['gpu_platform']}' "
+            f"not in supported {cfg['platforms']}"
+        )
+        assert defaults["architecture"] in cfg["architectures"], (
+            f"{image_type}: default architecture '{defaults['architecture']}' "
+            f"not in supported {cfg['architectures']}"
+        )
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_no_empty_lists(self, image_type):
+        cfg = get_image_config(image_type)
+        for key in ["python", "platforms", "architectures"]:
+            assert len(cfg[key]) > 0, f"{image_type}: '{key}' list is empty"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_python_versions_are_strings(self, image_type):
+        for v in get_image_config(image_type)["python"]:
+            assert isinstance(v, str), (
+                f"{image_type}: python version {v!r} is {type(v).__name__}, "
+                f"not str (missing quotes in YAML?)"
+            )
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_platforms_are_strings(self, image_type):
+        for v in get_image_config(image_type)["platforms"]:
+            assert isinstance(
+                v, str
+            ), f"{image_type}: platform {v!r} is {type(v).__name__}, not str"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_architectures_are_strings(self, image_type):
+        for v in get_image_config(image_type)["architectures"]:
+            assert isinstance(
+                v, str
+            ), f"{image_type}: architecture {v!r} is {type(v).__name__}, not str"

--- a/ray-images.yaml
+++ b/ray-images.yaml
@@ -1,0 +1,41 @@
+# Ray image configurations, consumed by CI and build scripts.
+
+ray:
+  defaults:
+    python: "3.10"
+    gpu_platform: cu12.1.1-cudnn8
+    architecture: x86_64
+
+  python: ["3.10", "3.11", "3.12", "3.13"]
+  architectures: [x86_64, aarch64]
+  platforms:
+    - cpu
+    - cu11.7.1-cudnn8
+    - cu11.8.0-cudnn8
+    - cu12.1.1-cudnn8
+    - cu12.3.2-cudnn9
+    - cu12.4.1-cudnn
+    - cu12.5.1-cudnn
+    - cu12.6.3-cudnn
+    - cu12.8.1-cudnn
+    - cu12.9.1-cudnn
+
+ray-ml:
+  defaults:
+    python: "3.10"
+    gpu_platform: cu12.1.1-cudnn8
+    architecture: x86_64
+
+  python: ["3.10", "3.11"]
+  architectures: [x86_64]
+  platforms: [cpu, cu12.1.1-cudnn8]
+
+ray-llm:
+  defaults:
+    python: "3.11"
+    gpu_platform: cu12.8.1-cudnn
+    architecture: x86_64
+
+  python: ["3.11", "3.12"]
+  architectures: [x86_64]
+  platforms: [cu12.8.1-cudnn, cu12.9.1-cudnn]


### PR DESCRIPTION
Add build_image.py CLI tool and build-image.sh wrapper for building Ray Docker images locally using raymake/wanda. Supports ray, ray-extra, ray-llm, and ray-llm-extra image types with configurable Python version and platform.

Topic: build-image-local
Relative: ray-images-use
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>