### PR TITLE
Revert "[Data] Disable throttling for UnionOperator (#60631)"

### DIFF
--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -132,14 +132,6 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def get_stats(self) -> StatsDict:
         return self._stats
 
-    def throttling_disabled(self) -> bool:
-        """Disables resource-based throttling.
-
-        Union operator only manipulates bundle metadata and doesn't launch
-        any tasks, so it doesn't need resource allocation.
-        """
-        return True
-
     def _try_round_robin(self) -> None:
         """Try to move blocks from input buffers to output in round-robin order.
 


### PR DESCRIPTION
This reverts commit 021e7e10e9afbadb85fb7486b8d2aa42a65a3f9a.

UnionOperator doesn't launch and tasks or actors. It just manipulates RefBundles. So, it doesn't make sense that it receives a user allocations.

However, by disabling throttling for UnionOperator (i.e., making it not receive an allocation), we exposed another bug where we double-count resource usage. In the worst case, this can lead to deadlocks.

This PR reverts the change until we've fixed the underlying resource account bug.