### PR TITLE
[Core] Add ray wait CLI and ray.wait_for_nodes() to wait for workers and prevent job failure

### DIFF
--- a/doc/source/ray-core/api/utility.rst
+++ b/doc/source/ray-core/api/utility.rst
@@ -24,6 +24,7 @@ Utility
    ray.util.tpu.slice_placement_group
 
    ray.nodes
+   ray.wait_for_nodes
    ray.cluster_resources
    ray.available_resources
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -110,6 +110,7 @@ from ray._private.state import (  # noqa: E402,F401
     timeline,
     cluster_resources,
     available_resources,
+    wait_for_nodes,
 )
 from ray._private.worker import (  # noqa: E402,F401
     SCRIPT_MODE,
@@ -199,6 +200,7 @@ __all__ = [
     "shutdown",
     "timeline",
     "wait",
+    "wait_for_nodes",
     "SCRIPT_MODE",
     "WORKER_MODE",
     "LoggingConfig",
@@ -238,6 +240,7 @@ NON_AUTO_INIT_APIS = {
     "remote",
     "shutdown",
     "timeline",
+    "wait_for_nodes",
     "LoggingConfig",
 }
 

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -1167,11 +1167,6 @@ def wait_for_nodes(
     Raises:
         TimeoutError: If timeout expires before reaching target nodes.
         ray.exceptions.RaySystemError: If Ray is not initialized.
-
-    Example:
-        >>> import ray
-        >>> ray.init()
-        >>> ray.wait_for_nodes(num_nodes=4, timeout=300)  # 1 head + 3 workers
     """
     start_time = time.time()
     next_log_time = start_time + log_interval_s

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+import time
 from collections import defaultdict
 from threading import Lock
 from typing import Dict, Optional
@@ -1143,3 +1144,58 @@ def get_worker_debugger_port(worker_id):
          Debugger port of the worker.
     """
     return state.get_worker_debugger_port(worker_id)
+
+
+@DeveloperAPI
+def wait_for_nodes(
+    num_nodes: int,
+    timeout: Optional[float] = None,
+    retry_interval_s: float = 1.0,
+    log_interval_s: float = 10.0,
+) -> int:
+    """Wait until at least num_nodes nodes are alive, or timeout expires.
+
+    Args:
+        num_nodes: Target number of nodes (including head node).
+        timeout: Max wait time in seconds. None means wait forever.
+        retry_interval_s: Sleep time between checks.
+        log_interval_s: Interval between progress log messages.
+
+    Returns:
+        The number of alive nodes when the target is reached.
+
+    Raises:
+        TimeoutError: If timeout expires before reaching target nodes.
+        ray.exceptions.RaySystemError: If Ray is not initialized.
+
+    Example:
+        >>> import ray
+        >>> ray.init()
+        >>> ray.wait_for_nodes(num_nodes=4, timeout=300)  # 1 head + 3 workers
+    """
+    start_time = time.time()
+    next_log_time = start_time + log_interval_s
+    while True:
+        current_nodes = sum(1 for node in nodes() if node["Alive"])
+        if current_nodes >= num_nodes:
+            logger.info(
+                f"Cluster ready: {current_nodes} nodes are up "
+                f"(target: {num_nodes})."
+            )
+            return current_nodes
+
+        if timeout is not None and time.time() - start_time > timeout:
+            raise TimeoutError(
+                f"Timed out waiting for cluster to reach {num_nodes} nodes. "
+                f"Current number of alive nodes: {current_nodes}."
+            )
+
+        now = time.time()
+        if now >= next_log_time:
+            logger.info(
+                f"Waiting for nodes: {current_nodes}/{num_nodes} "
+                f"({now - start_time:.0f}s elapsed)"
+            )
+            next_log_time = now + log_interval_s
+
+        time.sleep(retry_interval_s)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1226,6 +1226,32 @@ def start(
         # not-reachable
 
 
+@cli.command(name="wait")
+@click.option(
+    "--num-nodes",
+    required=True,
+    type=int,
+    help="Wait until at least this many nodes have joined (includes head node).",
+)
+@click.option(
+    "--timeout",
+    default=None,
+    type=float,
+    help="Timeout in seconds. If not specified, wait forever.",
+)
+@add_click_logging_options
+@PublicAPI
+def wait_for_nodes_cli(num_nodes: int, timeout: Optional[float]):
+    """Wait for the cluster to have at least the specified number of nodes."""
+    ray.init(address="auto")
+    try:
+        actual_nodes = ray.wait_for_nodes(num_nodes=num_nodes, timeout=timeout)
+        cli_logger.success(f"Cluster is ready with {actual_nodes} nodes.")
+    except TimeoutError as e:
+        cli_logger.error(str(e))
+        sys.exit(1)
+
+
 @cli.command()
 @click.option(
     "-f",

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -27,6 +27,7 @@ def test_api_functions():
         "shutdown",
         "method",
         "nodes",
+        "wait_for_nodes",
         "timeline",
         "cluster_resources",
         "available_resources",


### PR DESCRIPTION
## Description

When users submit/run user command, they sometime can only tell that the head node is ready. There's no way to wait until sufficient worker nodes have joined the cluster yet. This causes:

1. Job starts running right after head node is up
2. Worker nodes may not have registered yet
3. Placement group creation fails due to insufficient resources

This has bitten several users in the community:

**vllm-project/aibrix**: Hit this when deploying vLLM with KubeRay RayClusterFleet. Workers hadn't joined yet when the app started, so vLLM failed due to lack of resources. The workaround was adding `sleep 60` before the start command, which is neither reliable nor elegant. At that time, I discussed with @kevin85421 and proposed the `ray wait` CLI solution (see #51860).

**Reflection AI**: Ran into the same issue recently. Jobs start executing as soon as the head node is available, but workers may not have registered yet, causing placement group creation to fail. They also wanted a Python API in addition to CLI. [Link](https://anyscale-external.slack.com/archives/C09GQG43U87/p1770779740239529)
> "The concern is sometimes people submit jobs to a raycluster before the whole cluster is ready and then the job dies due to lack of resources when the worker bring up is slow."

This PR adds:

### CLI

```bash
ray wait --num-nodes=4 --timeout=300
```

### Python API

```python
import ray

ray.wait_for_nodes(num_nodes=4, timeout=300)
```

Note: `num_nodes` includes the head node. So `--num-nodes=4` means 1 head + 3 workers. If `timeout` is not specified, it waits forever.

## Related issues

Closes https://github.com/ray-project/ray/issues/51860

Related:
- https://github.com/vllm-project/aibrix/issues/245
- https://github.com/vllm-project/aibrix/issues/228

## Test

### Python API

```python
import ray
ray.init(address='auto')

# Case 1: Success
ray.wait_for_nodes(num_nodes=1, timeout=30)

# Case 2: Timeout
ray.wait_for_nodes(num_nodes=10, timeout=25)
```

Output:
```
# Case 1: Success
2026-02-13 06:05:36,977 INFO state.py:1183 -- Cluster ready: 1 nodes are up (target: 1).

# Case 2: Timeout (logs every 10 seconds)
2026-02-13 06:05:57,203 INFO state.py:1197 -- Waiting for nodes: 1/10 (10s elapsed)
2026-02-13 06:06:07,227 INFO state.py:1197 -- Waiting for nodes: 1/10 (20s elapsed)
TimeoutError: Timed out waiting for cluster to reach 10 nodes. Current number of alive nodes: 1.
```

### CLI

```bash
# Case 1: Success
$ ray wait --num-nodes=1 --timeout=10
2026-02-13 06:06:24,830 INFO state.py:1183 -- Cluster ready: 1 nodes are up (target: 1).
Cluster is ready with 1 nodes.

# Case 2: Timeout (logs every 10 seconds)
$ ray wait --num-nodes=5 --timeout=25
2026-02-13 06:06:46,110 INFO state.py:1197 -- Waiting for nodes: 1/5 (10s elapsed)
2026-02-13 06:06:56,136 INFO state.py:1197 -- Waiting for nodes: 1/5 (20s elapsed)
Timed out waiting for cluster to reach 5 nodes. Current number of alive nodes: 1.
(exit code 1)
```
