### PR TITLE
[Data]Warn if hash shuffle aggregator mem falls back to default

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1155,7 +1155,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                     f"per aggregator (50% of available cluster memory / "
                     f"{num_aggregators} aggregators). This may lead to OOMs "
                     f"if the actual dataset is larger. Consider scaling up "
-                    f"the cluster or reducing num_partitions."
+                    f"the cluster or increasing num_partitions."
                 )
             else:
                 logger.warning(

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1141,6 +1141,33 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                 DEFAULT_HASH_SHUFFLE_AGGREGATOR_MEMORY_ALLOCATION,
             )
 
+            is_cluster_memory_constrained = (
+                modest_memory_per_aggregator
+                < DEFAULT_HASH_SHUFFLE_AGGREGATOR_MEMORY_ALLOCATION
+            )
+
+            if is_cluster_memory_constrained:
+                logger.warning(
+                    f"Unable to estimate dataset size for {self.name}: "
+                    f"input operator(s) returned unknown size_bytes from "
+                    f"infer_metadata(). Falling back to "
+                    f"{estimated_aggregator_memory_required / GiB:.1f}GiB "
+                    f"per aggregator (50% of available cluster memory / "
+                    f"{num_aggregators} aggregators). This may lead to OOMs "
+                    f"if the actual dataset is larger. Consider scaling up "
+                    f"the cluster or reducing num_partitions."
+                )
+            else:
+                logger.warning(
+                    f"Unable to estimate dataset size for {self.name}: "
+                    f"input operator(s) returned unknown size_bytes from "
+                    f"infer_metadata(). Falling back to default cap of "
+                    f"{estimated_aggregator_memory_required / GiB:.1f}GiB "
+                    f"per aggregator. This may lead to OOMs if the actual "
+                    f"dataset is larger than "
+                    f"{estimated_aggregator_memory_required * num_partitions / GiB:.1f}GiB."
+                )
+
         remote_args = {
             "num_cpus": self._get_aggregator_num_cpus(
                 total_available_cluster_resources,

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1164,8 +1164,8 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                     f"infer_metadata(). Falling back to default cap of "
                     f"{estimated_aggregator_memory_required / GiB:.1f}GiB "
                     f"per aggregator. This may lead to OOMs if the actual "
-                    f"dataset is larger than "
-                    f"{estimated_aggregator_memory_required * num_partitions / GiB:.1f}GiB."
+                    f"dataset is large. Consider increasing num_partitions "
+                    f"to reduce per-partition memory pressure."
                 )
 
         remote_args = {


### PR DESCRIPTION
**Description:**
When `_try_estimate_output_bytes()` returns `None` (because input operators don't implement `infer_metadata()`), hash shuffle aggregators silently fall back to a 1 GiB default memory request. This can lead to OOMs on large joins where the actual per-actor memory need exceeds 1 GiB, as the scheduler over-packs actors onto nodes.

This PR adds a warning log when the fallback is triggered, distinguishing two scenarios:
- **Cluster-constrained:** available cluster memory per aggregator is below the 1 GiB default
- **Default-capped:** cluster has sufficient memory but the estimate is capped at 1 GiB

This makes the issue visible in logs so users can take action (e.g., provide `partition_size_hint` or scale up the cluster) rather than hitting an unexplained OOM.