### PR TITLE
[deps] updating uv flags for depsets

### DIFF
--- a/ci/raydepsets/configs/ci_serve.depsets.yaml
+++ b/ci/raydepsets/configs/ci_serve.depsets.yaml
@@ -17,7 +17,7 @@ depsets:
       - /tmp/ray-deps/requirements_compiled_py3.13.txt
     output: python/deplocks/ci/serve_base_depset_py${PYTHON_VERSION}.lock
     append_flags:
-      - --extra-index-url https://download.pytorch.org/whl/cpu
+      - --index https://download.pytorch.org/whl/cpu
       - --python-version=${PYTHON_VERSION}
       - --python-platform=linux
       - --unsafe-package ray

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -417,12 +417,12 @@ class TestCli(unittest.TestCase):
             [
                 "--no-annotate",
                 "--no-header",
-                "--extra-index-url https://download.pytorch.org/whl/cu128",
+                "--index https://download.pytorch.org/whl/cu128",
             ]
         ) == [
             "--no-annotate",
             "--no-header",
-            "--extra-index-url",
+            "--index",
             "https://download.pytorch.org/whl/cu128",
         ]
 
@@ -1028,7 +1028,7 @@ class TestCli(unittest.TestCase):
             for pkg in expected_packages:
                 assert pkg in names, f"Expected package {pkg} not found"
 
-            # Verify options (--index-url and --extra-index-url)
+            # Verify options (--index-url and --index)
             assert len(rf.options) >= 1
 
             # Verify packages with environment markers are parsed


### PR DESCRIPTION
Uv has deprecated --extra-index-url and --index-url in favor of --index.

Purely a config change in this case