### PR TITLE
[Data] Make `RefBundle` and other classes properly frozen

### DIFF
--- a/python/ray/data/_internal/datasource/image_datasource.py
+++ b/python/ray/data/_internal/datasource/image_datasource.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
@@ -170,5 +171,7 @@ class ImageFileMetadataProvider(DefaultFileMetadataProvider):
             paths, rows_per_file=rows_per_file, file_sizes=file_sizes
         )
         if metadata.size_bytes is not None:
-            metadata.size_bytes = int(metadata.size_bytes * self._encoding_ratio)
+            metadata = replace(
+                metadata, size_bytes=int(metadata.size_bytes * self._encoding_ratio)
+            )
         return metadata

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -343,10 +343,24 @@ class RefBundle:
         )
 
     def __eq__(self, other: "RefBundle"):
-        return self is other
+        return (
+            self.blocks == other.blocks
+            and self.slices == other.slices
+            and self.schema == other.schema
+            and self.owns_blocks == other.owns_blocks
+            and self.output_split_idx == other.output_split_idx
+        )
 
     def __hash__(self) -> int:
-        return id(self)
+        return hash(
+            (
+                *self.blocks,
+                *self.slices,
+                self.schema,
+                self.owns_blocks,
+                self.output_split_idx,
+            )
+        )
 
     def __len__(self) -> int:
         return len(self.blocks)

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -360,9 +360,13 @@ class RefBundle:
             (
                 *self.blocks,
                 *self.slices,
-                # NOTE: Pyarrow < 23 schemas metadata contains dicts and therefore
-                #       isn't hashable
-                (tuple(self.schema.names), tuple(self.schema.types)) if self.schema is not None else None,
+                (
+                    # NOTE: Pyarrow < 23 schemas metadata contains dicts and therefore
+                    #       isn't hashable
+                    (tuple(self.schema.names), tuple(self.schema.types))
+                    if self.schema is not None
+                    else None
+                ),
                 self.owns_blocks,
                 self.output_split_idx,
             )

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -26,7 +26,7 @@ class BlockSlice:
         return self.end_offset - self.start_offset
 
 
-@dataclass
+@dataclass(frozen=True)
 class RefBundle:
     """A group of data block references and their metadata.
 
@@ -77,7 +77,7 @@ class RefBundle:
             object.__setattr__(self, "blocks", tuple(self.blocks))
 
         if self.slices is None:
-            self.slices = (None,) * len(self.blocks)
+            object.__setattr__(self, "slices", (None,) * len(self.blocks))
         else:
             if not isinstance(self.slices, tuple):
                 object.__setattr__(self, "slices", tuple(self.slices))
@@ -108,11 +108,6 @@ class RefBundle:
                 raise ValueError(
                     "The size in bytes of the block must be known: {}".format(b)
                 )
-
-    def __setattr__(self, key, value):
-        if hasattr(self, key) and key in ["blocks", "owns_blocks"]:
-            raise ValueError(f"The `{key}` field of RefBundle cannot be updated.")
-        object.__setattr__(self, key, value)
 
     @property
     def block_refs(self) -> List[ObjectRef[Block]]:
@@ -200,7 +195,9 @@ class RefBundle:
                 for loc in obj_meta.locs:
                     preferred_locs[loc] += obj_meta.size
 
-            self._cached_preferred_locations = preferred_locs
+            # NOTE: We're working around object being immutable to update cached
+            #       values (safe)
+            object.__setattr__(self, "_cached_preferred_locations", preferred_locs)
 
         return self._cached_preferred_locations
 
@@ -219,7 +216,9 @@ class RefBundle:
                 for ref in self.block_refs
             }
 
-            self._cached_object_meta = object_metas
+            # NOTE: We're working around object being immutable to update cached
+            #       values (safe)
+            object.__setattr__(self, "_cached_object_meta", object_metas)
 
         return self._cached_object_meta
 

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -344,13 +344,13 @@ class RefBundle:
 
     def __hash__(self) -> int:
         return hash(
-            tuple([
+            (
                 *self.blocks,
                 *self.slices,
                 self.schema,
                 self.owns_blocks,
                 self.output_split_idx,
-            ])
+            )
         )
 
     def __len__(self) -> int:

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -360,7 +360,9 @@ class RefBundle:
             (
                 *self.blocks,
                 *self.slices,
-                self.schema,
+                # NOTE: Pyarrow < 23 schemas metadata contains dicts and therefore
+                #       isn't hashable
+                (tuple(self.schema.names), tuple(self.schema.types)) if self.schema is not None else None,
                 self.owns_blocks,
                 self.output_split_idx,
             )

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -12,6 +12,54 @@ from ray.data.context import DataContext
 from ray.types import ObjectRef
 
 
+def _to_hashable(value):
+    """Convert a potentially unhashable object into a stable hashable form."""
+    try:
+        hash(value)
+        return value
+    except TypeError:
+        if isinstance(value, dict):
+            items = (
+                (_to_hashable(key), _to_hashable(item_value))
+                for key, item_value in value.items()
+            )
+            return tuple(sorted(items, key=repr))
+        if isinstance(value, (list, tuple)):
+            return tuple(_to_hashable(item) for item in value)
+        if isinstance(value, set):
+            return tuple(sorted((_to_hashable(item) for item in value), key=repr))
+        return repr(value)
+
+
+def _schema_hash_key(schema: Optional["Schema"]):
+    if schema is None:
+        return None
+
+    try:
+        hash(schema)
+        return schema
+    except TypeError:
+        pass
+
+    # Handle both PandasBlockSchema-like and pyarrow.Schema-like objects.
+    names = getattr(schema, "names", None)
+    types = getattr(schema, "types", None)
+    if names is not None and types is not None:
+        try:
+            return (tuple(names), tuple(_to_hashable(type_) for type_ in types))
+        except Exception:
+            pass
+
+    to_string = getattr(schema, "to_string", None)
+    if callable(to_string):
+        try:
+            return to_string()
+        except Exception:
+            pass
+
+    return repr(schema)
+
+
 @dataclass(frozen=True)
 class BlockSlice:
     """A slice of a block."""
@@ -360,7 +408,7 @@ class RefBundle:
             (
                 *self.blocks,
                 *self.slices,
-                self.schema,
+                _schema_hash_key(self.schema),
                 self.owns_blocks,
                 self.output_split_idx,
             )

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -26,7 +26,7 @@ class BlockSlice:
         return self.end_offset - self.start_offset
 
 
-@dataclass
+@dataclass(eq=True)
 class RefBundle:
     """A group of data block references and their metadata.
 
@@ -339,11 +339,16 @@ class RefBundle:
             slices=merged_slices,
         )
 
-    def __eq__(self, other) -> bool:
-        return self is other
-
     def __hash__(self) -> int:
-        return id(self)
+        return hash(
+            tuple([
+                *self.blocks,
+                *self.slices,
+                self.schema,
+                self.owns_blocks,
+                self.output_split_idx,
+            ])
+        )
 
     def __len__(self) -> int:
         return len(self.blocks)

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -343,24 +343,10 @@ class RefBundle:
         )
 
     def __eq__(self, other: "RefBundle"):
-        return (
-            self.blocks == other.blocks
-            and self.slices == other.slices
-            and self.schema == other.schema
-            and self.owns_blocks == other.owns_blocks
-            and self.output_split_idx == other.output_split_idx
-        )
+        return self is other
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                *self.blocks,
-                *self.slices,
-                self.schema,
-                self.owns_blocks,
-                self.output_split_idx,
-            )
-        )
+        return id(self)
 
     def __len__(self) -> int:
         return len(self.blocks)

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -344,6 +344,8 @@ class RefBundle:
     def __eq__(self, other: "RefBundle"):
         if self is other:
             return True
+        elif not isinstance(other, RefBundle):
+            return False
 
         return (
             self.blocks == other.blocks

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -343,8 +343,6 @@ class RefBundle:
         )
 
     def __hash__(self) -> int:
-        print(f">>> [DBG] RefBundle.__hash__:\n{self.blocks}\n{self.slices}\n{self.schema}")
-
         return hash(
             tuple([
                 *self.blocks,

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -343,6 +343,9 @@ class RefBundle:
         )
 
     def __eq__(self, other: "RefBundle"):
+        if self is other:
+            return True
+
         return (
             self.blocks == other.blocks
             and self.slices == other.slices

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -26,7 +26,7 @@ class BlockSlice:
         return self.end_offset - self.start_offset
 
 
-@dataclass(eq=True)
+@dataclass
 class RefBundle:
     """A group of data block references and their metadata.
 
@@ -340,6 +340,15 @@ class RefBundle:
             schema=schema,
             owns_blocks=owns_blocks,
             slices=merged_slices,
+        )
+
+    def __eq__(self, other: "RefBundle"):
+        return (
+            self.blocks == other.blocks
+            and self.slices == other.slices
+            and self.schema == other.schema
+            and self.owns_blocks == other.owns_blocks
+            and self.output_split_idx == other.output_split_idx
         )
 
     def __hash__(self) -> int:

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -7,7 +7,13 @@ from typing import Dict, Iterable, Iterator, List, Optional, Tuple
 import ray
 from .common import NodeIdStr
 from ray.data._internal.memory_tracing import trace_deallocation
-from ray.data.block import Block, BlockAccessor, BlockMetadata, Schema, _make_hashable_schema
+from ray.data.block import (
+    Block,
+    BlockAccessor,
+    BlockMetadata,
+    Schema,
+    _make_hashable_schema,
+)
 from ray.data.context import DataContext
 from ray.types import ObjectRef
 
@@ -365,13 +371,15 @@ class RefBundle:
         )
 
     def __hash__(self) -> int:
-        return hash((
-            *self.blocks,
-            *self.slices,
-            _make_hashable_schema(self.schema) if self.schema is not None else None,
-            self.owns_blocks,
-            self.output_split_idx,
-        ))
+        return hash(
+            (
+                *self.blocks,
+                *self.slices,
+                _make_hashable_schema(self.schema) if self.schema is not None else None,
+                self.owns_blocks,
+                self.output_split_idx,
+            )
+        )
 
     def __len__(self) -> int:
         return len(self.blocks)

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -73,6 +73,15 @@ class RefBundle:
     _cached_preferred_locations: Optional[Dict[NodeIdStr, int]] = None
 
     def __post_init__(self):
+        if self.schema is not None:
+            import pyarrow as pa
+
+            from ray.data._internal.pandas_block import PandasBlockSchema
+
+            assert isinstance(
+                self.schema, (pa.lib.Schema, PandasBlockSchema)
+            ), f"Schema must be a pyarrow or PandasBlockSchema, got {type(self.schema)}"
+
         if not isinstance(self.blocks, tuple):
             object.__setattr__(self, "blocks", tuple(self.blocks))
 

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -7,7 +7,7 @@ from typing import Dict, Iterable, Iterator, List, Optional, Tuple
 import ray
 from .common import NodeIdStr
 from ray.data._internal.memory_tracing import trace_deallocation
-from ray.data.block import Block, BlockAccessor, BlockMetadata, Schema
+from ray.data.block import Block, BlockAccessor, BlockMetadata, Schema, _make_hashable_schema
 from ray.data.context import DataContext
 from ray.types import ObjectRef
 
@@ -365,21 +365,13 @@ class RefBundle:
         )
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                *self.blocks,
-                *self.slices,
-                (
-                    # NOTE: Pyarrow < 23 schemas metadata contains dicts and therefore
-                    #       isn't hashable
-                    (tuple(self.schema.names), tuple(self.schema.types))
-                    if self.schema is not None
-                    else None
-                ),
-                self.owns_blocks,
-                self.output_split_idx,
-            )
-        )
+        return hash((
+            *self.blocks,
+            *self.slices,
+            _make_hashable_schema(self.schema) if self.schema is not None else None,
+            self.owns_blocks,
+            self.output_split_idx,
+        ))
 
     def __len__(self) -> int:
         return len(self.blocks)

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -3,7 +3,6 @@
 It should be deleted once we fully move to the new executor backend.
 """
 import logging
-from dataclasses import replace
 from typing import Iterator, Optional, Tuple
 
 from ray.data._internal.execution.execution_callback import get_execution_callbacks
@@ -89,11 +88,8 @@ def execute_to_legacy_bundle_iterator(
             """Collect the metadata from each output bundle and accumulate
             results, so we can access important information, such as
             row count, schema, etc., after iteration completes."""
-            self._collected_metadata = replace(
-                self._collected_metadata,
-                num_rows=self._num_rows + bundle.num_rows(),
-                size_bytes=self._size_bytes + bundle.size_bytes(),
-            )
+            self._num_rows += bundle.num_rows()
+            self._size_bytes += bundle.size_bytes()
             return bundle
 
     return CacheMetadataIterator(bundle_iter)

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -3,6 +3,7 @@
 It should be deleted once we fully move to the new executor backend.
 """
 import logging
+from dataclasses import replace
 from typing import Iterator, Optional, Tuple
 
 from ray.data._internal.execution.execution_callback import get_execution_callbacks
@@ -88,8 +89,11 @@ def execute_to_legacy_bundle_iterator(
             """Collect the metadata from each output bundle and accumulate
             results, so we can access important information, such as
             row count, schema, etc., after iteration completes."""
-            self._num_rows += bundle.num_rows()
-            self._size_bytes += bundle.size_bytes()
+            self._collected_metadata = replace(
+                self._collected_metadata,
+                num_rows=self._num_rows + bundle.num_rows(),
+                size_bytes=self._size_bytes + bundle.size_bytes(),
+            )
             return bundle
 
     return CacheMetadataIterator(bundle_iter)

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1788,15 +1788,16 @@ class HashShuffleAggregator:
             blocks = _shape_blocks(blocks, self._target_max_block_size)
 
         for block in blocks:
-            # Collect execution stats (and reset)
-            exec_stats = exec_stats_builder.build()
-            exec_stats_builder = BlockExecStats.builder()
+            # Finish processing before actually yielding!
+            exec_stats_builder.finish()
 
             stats: StreamingGeneratorStats = yield block
 
-            # Update block serialization time
-            if stats:
-                exec_stats.block_ser_time_s = stats.object_creation_dur_s
+            exec_stats = exec_stats_builder.build(
+                block_ser_time_s=(
+                    stats.object_creation_dur_s if stats else None
+                ),
+            )
 
             yield BlockMetadataWithSchema.from_block(
                 block,
@@ -1805,6 +1806,10 @@ class HashShuffleAggregator:
                     task_wall_time_s=time.perf_counter() - start_time_s,
                 ),
             )
+
+            # Reset the builder
+            exec_stats_builder = BlockExecStats.builder()
+
 
     def _debug_dump(self):
         """Periodically dumps the state of the HashShuffleAggregator for debugging."""

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1794,9 +1794,7 @@ class HashShuffleAggregator:
             stats: StreamingGeneratorStats = yield block
 
             exec_stats = exec_stats_builder.build(
-                block_ser_time_s=(
-                    stats.object_creation_dur_s if stats else None
-                ),
+                block_ser_time_s=(stats.object_creation_dur_s if stats else None),
             )
 
             yield BlockMetadataWithSchema.from_block(
@@ -1809,7 +1807,6 @@ class HashShuffleAggregator:
 
             # Reset the builder
             exec_stats_builder = BlockExecStats.builder()
-
 
     def _debug_dump(self):
         """Periodically dumps the state of the HashShuffleAggregator for debugging."""

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -1,5 +1,5 @@
-import copy
 from collections import deque
+from dataclasses import replace
 from typing import Deque, List, Optional, Tuple
 
 import ray
@@ -57,9 +57,11 @@ class LimitOperator(OneToOneOperator):
                     block = BlockAccessor.for_block(block).slice(
                         0, num_rows, copy=False
                     )
-                    metadata = copy.deepcopy(metadata)
-                    metadata.num_rows = num_rows
-                    metadata.size_bytes = BlockAccessor.for_block(block).size_bytes()
+                    metadata = replace(
+                        metadata,
+                        num_rows=num_rows,
+                        size_bytes=BlockAccessor.for_block(block).size_bytes(),
+                    )
                     return block, metadata
 
                 block, metadata_ref = cached_remote_fn(

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -776,8 +776,8 @@ def _map_task(
                 # TODO figure out a better way to track task total duration
                 task_dur_s = time.perf_counter() - task_start_s
 
-                yield BlockMetadataWithSchema(
-                    metadata=replace(
+                yield BlockMetadataWithSchema.from_metadata(
+                    replace(
                         block_meta,
                         exec_stats=blk_exec_stats,
                         task_exec_stats=TaskExecWorkerStats(

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -760,16 +760,20 @@ def _map_task(
                 block_meta = BlockAccessor.for_block(block).get_metadata()
                 block_schema = BlockAccessor.for_block(block).schema()
 
-                # Derive block execution stats
-                blk_exec_stats = blk_exec_stats_builder.build()
+                # Finish processing before yielding the block!
+                blk_exec_stats_builder.finish()
+
                 # Yield block and retrieve its Ray object serialization timing
                 gen_stats: StreamingGeneratorStats = yield block
-                if gen_stats:
-                    blk_exec_stats.block_ser_time_s = gen_stats.object_creation_dur_s
 
-                blk_exec_stats.udf_time_s = map_transformer.udf_time_s(reset=True)
-                blk_exec_stats.task_idx = ctx.task_idx
-                blk_exec_stats.max_uss_bytes = profiler.estimate_max_uss()
+                exec_stats = blk_exec_stats_builder.build(
+                    block_ser_time_s=(
+                        gen_stats.object_creation_dur_s if gen_stats else None
+                    ),
+                    udf_time_s=map_transformer.udf_time_s(reset=True),
+                    task_idx=ctx.task_idx,
+                    max_uss_bytes=profiler.estimate_max_uss(),
+                )
 
                 # NOTE: This tracks task duration up to this point, though we're primarily
                 #       interested in task total duration
@@ -779,7 +783,7 @@ def _map_task(
                 yield BlockMetadataWithSchema.from_metadata(
                     replace(
                         block_meta,
-                        exec_stats=blk_exec_stats,
+                        exec_stats=exec_stats,
                         task_exec_stats=TaskExecWorkerStats(
                             task_wall_time_s=task_dur_s
                         ),

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -1,5 +1,6 @@
 import math
 import time
+from dataclasses import replace
 from typing import Any, Collection, Dict, List, Optional, Tuple
 
 from ray._common.utils import env_float
@@ -179,7 +180,7 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
         for i, count in enumerate(allocation):
             bundles = self._split_from_buffer(count)
             for b in bundles:
-                b.output_split_idx = i
+                b = replace(b, output_split_idx=i)
                 self._output_queue.add(b)
                 self._metrics.on_output_queued(b)
         self._buffer.clear()
@@ -258,7 +259,7 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
             self._buffer.remove(target_bundle)
             self._metrics.on_input_dequeued(target_bundle, input_index=0)
 
-            target_bundle.output_split_idx = target_output_index
+            target_bundle = replace(target_bundle, output_split_idx=target_output_index)
 
             self._num_output[target_output_index] += target_bundle.num_rows()
             self._output_queue.add(target_bundle)

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -1,5 +1,6 @@
 import collections
 import itertools
+from dataclasses import replace
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import ray
@@ -294,8 +295,7 @@ class ZipOperator(InternalQueueOperatorMixin, NAryOperator):
                 # Need to fetch number of rows or size in bytes, so just fetch both.
                 num_rows, size_bytes = ray.get(get_num_rows_and_bytes.remote(block))
                 # Cache on the block metadata.
-                metadata.num_rows = num_rows
-                metadata.size_bytes = size_bytes
+                metadata = replace(metadata, num_rows=num_rows, size_bytes=size_bytes)
             block_rows.append(metadata.num_rows)
             block_bytes.append(metadata.size_bytes)
         return block_rows, block_bytes

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -110,14 +110,14 @@ class Read(
         # Legacy datasources might not implement `get_read_tasks`.
         if self.datasource.should_create_reader:
             empty_meta = BlockMetadata(None, None, None, None)
-            return BlockMetadataWithSchema(metadata=empty_meta, schema=None)
+            return BlockMetadataWithSchema.from_metadata(empty_meta, schema=None)
 
         # HACK: Try to get a single read task to get the metadata.
         read_tasks = self.datasource.get_read_tasks(1)
         if len(read_tasks) == 0:
             # If there are no read tasks, the dataset is probably empty.
             empty_meta = BlockMetadata(None, None, None, None)
-            return BlockMetadataWithSchema(metadata=empty_meta, schema=None)
+            return BlockMetadataWithSchema.from_metadata(empty_meta, schema=None)
 
         # `get_read_tasks` isn't guaranteed to return exactly one read task.
         metadata = [read_task.metadata for read_task in read_tasks]
@@ -163,7 +163,7 @@ class Read(
         schema = None
         if schemas:
             schema = unify_schemas_with_validation(schemas)
-        return BlockMetadataWithSchema(metadata=meta, schema=schema)
+        return BlockMetadataWithSchema.from_metadata(meta, schema=schema)
 
     def supports_projection_pushdown(self) -> bool:
         return self.datasource.supports_projection_pushdown()

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -87,6 +87,10 @@ class Read(
     def _estimate_num_outputs(self) -> Optional[int]:
         metadata = self._cached_output_metadata.metadata
 
+        # Handle edge-case of empty dataset
+        if metadata.size_bytes == 0:
+            return 0
+
         target_max_block_size = DataContext.get_current().target_max_block_size
 
         # In either case of
@@ -116,7 +120,12 @@ class Read(
         read_tasks = self.datasource.get_read_tasks(1)
         if len(read_tasks) == 0:
             # If there are no read tasks, the dataset is probably empty.
-            empty_meta = BlockMetadata(None, None, None, None)
+            empty_meta = BlockMetadata(
+                num_rows=0,
+                size_bytes=0,
+                input_files=None,
+                exec_stats=None,
+            )
             return BlockMetadataWithSchema.from_metadata(empty_meta, schema=None)
 
         # `get_read_tasks` isn't guaranteed to return exactly one read task.

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 import sys
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -345,9 +346,18 @@ class PandasBlockBuilder(TableBlockBuilder):
         return BlockType.PANDAS
 
 
-# This is to be compatible with pyarrow.lib.schema
-# TODO (kfstorm): We need a format-independent way to represent schema.
-PandasBlockSchema = collections.namedtuple("PandasBlockSchema", ["names", "types"])
+# NOTE: This has to be compatible with pyarrow.lib.schema
+@dataclass(frozen=True)
+class PandasBlockSchema:
+
+    names: Tuple[str]
+    types: Tuple["pandas.DataType"]
+
+    def __post_init__(self):
+        if not isinstance(self.names, tuple):
+            object.__setattr__(self, "names", tuple(self.names))
+        if not isinstance(self.types, tuple):
+            object.__setattr__(self, "types", tuple(self.types))
 
 
 class PandasBlockAccessor(TableBlockAccessor):
@@ -414,7 +424,8 @@ class PandasBlockAccessor(TableBlockAccessor):
     def schema(self) -> PandasBlockSchema:
         dtypes = self._table.dtypes
         schema = PandasBlockSchema(
-            names=dtypes.index.tolist(), types=dtypes.values.tolist()
+            names=tuple(dtypes.index.tolist()),
+            types=tuple(dtypes.values.tolist()),
         )
         # Column names with non-str types of a pandas DataFrame is not
         # supported by Ray Dataset.

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -347,17 +347,23 @@ class PandasBlockBuilder(TableBlockBuilder):
 
 
 # NOTE: This has to be compatible with pyarrow.lib.schema
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class PandasBlockSchema:
+    # Stored as tuples for hash-ability; exposed as lists via properties.
+    _names: Tuple[str, ...]
+    _types: Tuple
 
-    names: Tuple[str]
-    types: Tuple["pandas.DataType"]
+    def __init__(self, names, types):
+        object.__setattr__(self, "_names", tuple(names))
+        object.__setattr__(self, "_types", tuple(types))
 
-    def __post_init__(self):
-        if not isinstance(self.names, tuple):
-            object.__setattr__(self, "names", tuple(self.names))
-        if not isinstance(self.types, tuple):
-            object.__setattr__(self, "types", tuple(self.types))
+    @property
+    def names(self) -> List[str]:
+        return list(self._names)
+
+    @property
+    def types(self) -> List:
+        return list(self._types)
 
 
 class PandasBlockAccessor(TableBlockAccessor):

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -349,21 +349,13 @@ class PandasBlockBuilder(TableBlockBuilder):
 # NOTE: This has to be compatible with pyarrow.lib.schema
 @dataclass(frozen=True, init=False)
 class PandasBlockSchema:
-    # Stored as tuples for hash-ability; exposed as lists via properties.
-    _names: Tuple[str, ...]
-    _types: Tuple
+    # Stored as tuples for hash-ability.
+    names: Tuple[str, ...]
+    types: Tuple
 
     def __init__(self, names, types):
-        object.__setattr__(self, "_names", tuple(names))
-        object.__setattr__(self, "_types", tuple(types))
-
-    @property
-    def names(self) -> List[str]:
-        return list(self._names)
-
-    @property
-    def types(self) -> List:
-        return list(self._types)
+        object.__setattr__(self, "names", tuple(names))
+        object.__setattr__(self, "types", tuple(types))
 
 
 class PandasBlockAccessor(TableBlockAccessor):

--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -750,7 +750,7 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
             input_files=None,
             exec_stats=stats.build(),
         )
-        meta_with_schema = BlockMetadataWithSchema(metadata=meta, schema=schema)
+        meta_with_schema = BlockMetadataWithSchema.from_metadata(meta, schema=schema)
         yield meta_with_schema
 
     @staticmethod

--- a/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
@@ -116,7 +116,7 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
 
         meta = block.get_metadata(block_exec_stats=stats.build())
         schema = block.schema()
-        meta_with_schema = BlockMetadataWithSchema(metadata=meta, schema=schema)
+        meta_with_schema = BlockMetadataWithSchema.from_metadata(meta, schema=schema)
         return slices + [meta_with_schema]
 
     @staticmethod
@@ -146,7 +146,7 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
         )
         from ray.data.block import BlockMetadataWithSchema
 
-        meta_with_schema = BlockMetadataWithSchema(
-            metadata=new_metadata, schema=accessor.schema()
+        meta_with_schema = BlockMetadataWithSchema.from_metadata(
+            new_metadata, schema=accessor.schema()
         )
         return new_block, meta_with_schema

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+from dataclasses import replace
 from typing import Iterable, List, Tuple, Union
 
 import ray
@@ -27,7 +28,7 @@ def _calculate_blocks_rows(
         if metadata.num_rows is None:
             # Need to fetch number of rows.
             num_rows = ray.get(get_num_rows.remote(block))
-            metadata.num_rows = num_rows
+            metadata = replace(metadata, num_rows=num_rows)
         else:
             num_rows = metadata.num_rows
         block_rows.append(num_rows)

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -1,7 +1,7 @@
 import collections
 import logging
 import time
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field, fields, field
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -227,7 +227,7 @@ class _BlockExecStatsBuilder:
 
 
 @DeveloperAPI
-@dataclass
+@dataclass(frozen=True)
 class BlockStats:
     """Statistics about the block produced"""
 
@@ -252,7 +252,7 @@ _BLOCK_STATS_FIELD_NAMES = {f.name for f in fields(BlockStats)}
 
 
 @DeveloperAPI
-@dataclass
+@dataclass(frozen=True)
 class BlockMetadata(BlockStats):
     """Metadata about the block."""
 
@@ -266,15 +266,8 @@ class BlockMetadata(BlockStats):
             **{key: self.__getattribute__(key) for key in _BLOCK_STATS_FIELD_NAMES}
         )
 
-    def __post_init__(self):
-        super().__post_init__()
-
-        if self.input_files is None:
-            self.input_files = []
-
-
 @DeveloperAPI(stability="alpha")
-@dataclass
+@dataclass(frozen=True)
 class BlockMetadataWithSchema(BlockMetadata):
     schema: Optional[Schema] = None
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -52,7 +52,7 @@ Block = Union["pyarrow.Table", "pandas.DataFrame"]
 
 # Represents the schema of a block, which can be either a Python type or a
 # pyarrow schema. This is used to describe the structure of the data in a block.
-Schema = Union[type, "PandasBlockSchema", "pyarrow.lib.Schema"]
+Schema = Union["PandasBlockSchema", "pyarrow.lib.Schema"]
 
 # Represents a single column of the ``Block``
 BlockColumn = Union["pyarrow.ChunkedArray", "pyarrow.Array", "pandas.Series"]
@@ -282,10 +282,22 @@ class BlockMetadata(BlockStats):
         )
 
 
+def _make_hashable_schema(schema: Schema) -> Tuple[Tuple[str, ...], Tuple]:
+    # NOTE: Pyarrow < 23 schemas metadata contains dicts and therefore
+    #       isn't hashable
+    return (tuple(schema.names), tuple(schema.types))
+
+
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True)
 class BlockMetadataWithSchema(BlockMetadata):
     schema: Optional[Schema] = None
+
+    def __hash__(self):
+        return hash((
+            BlockMetadata.__hash__(self),
+            _make_hashable_schema(self.schema) if self.schema is not None else None,
+        ))
 
     @staticmethod
     def from_metadata(
@@ -827,6 +839,8 @@ class BlockColumnAccessor:
                 f"Expected either a pandas.Series or pyarrow.Array (ChunkedArray) "
                 f"(got {type(col)})"
             )
+
+
 
 
 def _get_group_boundaries_sorted_numpy(columns: list[np.ndarray]) -> np.ndarray:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -168,7 +168,7 @@ class TaskExecWorkerStats:
 
 
 @DeveloperAPI
-@dataclass
+@dataclass(frozen=True)
 class BlockExecStats:
     """Execution stats for a single output block produced by a task."""
 
@@ -213,16 +213,24 @@ class _BlockExecStatsBuilder:
     def __init__(self):
         self._start_time = time.perf_counter()
         self._start_cpu = time.process_time()
+        self._end_time = None
+        self._end_cpu = None
 
-    def build(self, block_ser_time_s: Optional[int] = None) -> "BlockExecStats":
-        end_time = time.perf_counter()
-        end_cpu = time.process_time()
+    def finish(self):
+        """Capture timing now, to be used by a later build() call."""
+        self._end_time = time.perf_counter()
+        self._end_cpu = time.process_time()
+
+    def build(self, **kwargs) -> "BlockExecStats":
+        if self._end_time is None:
+            self.finish()
+
         return BlockExecStats(
             start_time_s=self._start_time,
-            end_time_s=end_time,
-            wall_time_s=end_time - self._start_time,
-            cpu_time_s=end_cpu - self._start_cpu,
-            block_ser_time_s=block_ser_time_s,
+            end_time_s=self._end_time,
+            wall_time_s=self._end_time - self._start_time,
+            cpu_time_s=self._end_cpu - self._start_cpu,
+            **kwargs,
         )
 
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -1,7 +1,7 @@
 import collections
 import logging
 import time
-from dataclasses import dataclass, field, fields, field
+from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -265,6 +265,7 @@ class BlockMetadata(BlockStats):
         return BlockStats(
             **{key: self.__getattribute__(key) for key in _BLOCK_STATS_FIELD_NAMES}
         )
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True)

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -279,7 +279,7 @@ class BlockMetadataWithSchema(BlockMetadata):
             exec_stats=metadata.exec_stats,
             task_exec_stats=metadata.task_exec_stats,
         )
-        self.schema = schema
+        object.__setattr__(self, "schema", schema)
 
     def from_block(
         block: Block,
@@ -451,7 +451,7 @@ class BlockAccessor:
         return BlockMetadata(
             num_rows=self.num_rows(),
             size_bytes=self.size_bytes(),
-            input_files=input_files,
+            input_files=tuple(input_files) if input_files is not None else None,
             exec_stats=block_exec_stats,
             task_exec_stats=task_exec_stats,
         )

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -314,6 +314,7 @@ class BlockMetadataWithSchema(BlockMetadata):
             schema=schema,
         )
 
+    @staticmethod
     def from_block(
         block: Block,
         block_exec_stats: Optional["BlockExecStats"] = None,

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -272,15 +272,18 @@ class BlockMetadata(BlockStats):
 class BlockMetadataWithSchema(BlockMetadata):
     schema: Optional[Schema] = None
 
-    def __init__(self, metadata: BlockMetadata, schema: Optional["Schema"] = None):
-        super().__init__(
-            input_files=metadata.input_files,
-            size_bytes=metadata.size_bytes,
+    @staticmethod
+    def from_metadata(
+        metadata: "BlockMetadata", schema: Optional["Schema"] = None
+    ) -> "BlockMetadataWithSchema":
+        return BlockMetadataWithSchema(
             num_rows=metadata.num_rows,
+            size_bytes=metadata.size_bytes,
             exec_stats=metadata.exec_stats,
             task_exec_stats=metadata.task_exec_stats,
+            input_files=metadata.input_files,
+            schema=schema,
         )
-        object.__setattr__(self, "schema", schema)
 
     def from_block(
         block: Block,
@@ -289,7 +292,7 @@ class BlockMetadataWithSchema(BlockMetadata):
     ) -> "BlockMetadataWithSchema":
         accessor = BlockAccessor.for_block(block)
 
-        return BlockMetadataWithSchema(
+        return BlockMetadataWithSchema.from_metadata(
             metadata=accessor.get_metadata(
                 block_exec_stats=block_exec_stats,
                 task_exec_stats=task_exec_stats,

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -294,10 +294,12 @@ class BlockMetadataWithSchema(BlockMetadata):
     schema: Optional[Schema] = None
 
     def __hash__(self):
-        return hash((
-            BlockMetadata.__hash__(self),
-            _make_hashable_schema(self.schema) if self.schema is not None else None,
-        ))
+        return hash(
+            (
+                BlockMetadata.__hash__(self),
+                _make_hashable_schema(self.schema) if self.schema is not None else None,
+            )
+        )
 
     @staticmethod
     def from_metadata(
@@ -839,8 +841,6 @@ class BlockColumnAccessor:
                 f"Expected either a pandas.Series or pyarrow.Array (ChunkedArray) "
                 f"(got {type(col)})"
             )
-
-
 
 
 def _get_group_boundaries_sorted_numpy(columns: list[np.ndarray]) -> np.ndarray:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -267,7 +267,14 @@ class BlockMetadata(BlockStats):
     # The pyarrow schema or types of the block elements, or None.
     # The list of file paths used to generate this block, or
     # the empty list if indeterminate.
-    input_files: Optional[List[str]] = field(default=None)
+    # Stored as a tuple for hash-ability.
+    input_files: Optional[Tuple[str, ...]] = field(default=None)
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.input_files is not None and not isinstance(self.input_files, tuple):
+            object.__setattr__(self, "input_files", tuple(self.input_files))
 
     def to_stats(self):
         return BlockStats(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -7113,7 +7113,7 @@ class Schema:
     @property
     def names(self) -> List[str]:
         """Lists the columns of this Dataset."""
-        return self.base_schema.names
+        return list(self.base_schema.names)
 
     @property
     def types(self) -> List[Union[type[object], "pyarrow.lib.DataType"]]:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1922,7 +1922,7 @@ class Dataset:
         import pandas as pd
         import pyarrow as pa
 
-        if self._plan.initial_num_blocks() == 0:
+        if not self._plan.initial_num_blocks():
             raise ValueError("Cannot sample from an empty Dataset.")
 
         if fraction < 0 or fraction > 1:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1922,7 +1922,7 @@ class Dataset:
         import pandas as pd
         import pyarrow as pa
 
-        if not self._plan.initial_num_blocks():
+        if self._plan.initial_num_blocks() == 0:
             raise ValueError("Cannot sample from an empty Dataset.")
 
         if fraction < 0 or fraction > 1:

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -486,18 +486,18 @@ def op_two_block():
     block_delay = 20
     block_meta_list = []
     for i in range(len(block_params["num_rows"])):
-        block_exec_stats = BlockExecStats()
+        start_time_s = time.perf_counter() + i * block_delay
         # The blocks are executing from [0, 5] and [20, 30].
-        block_exec_stats.start_time_s = time.perf_counter() + i * block_delay
-        block_exec_stats.end_time_s = (
-            block_exec_stats.start_time_s + block_params["wall_time"][i]
+        block_exec_stats = BlockExecStats(
+            start_time_s=start_time_s,
+            end_time_s=start_time_s + block_params["wall_time"][i],
+            wall_time_s=block_params["wall_time"][i],
+            cpu_time_s=block_params["cpu_time"][i],
+            udf_time_s=block_params["udf_time"][i],
+            node_id=block_params["node_id"][i],
+            max_uss_bytes=block_params["uss_bytes"][i],
+            task_idx=block_params["task_idx"][i],
         )
-        block_exec_stats.wall_time_s = block_params["wall_time"][i]
-        block_exec_stats.cpu_time_s = block_params["cpu_time"][i]
-        block_exec_stats.udf_time_s = block_params["udf_time"][i]
-        block_exec_stats.node_id = block_params["node_id"][i]
-        block_exec_stats.max_uss_bytes = block_params["uss_bytes"][i]
-        block_exec_stats.task_idx = block_params["task_idx"][i]
         block_meta_list.append(
             BlockMetadata(
                 num_rows=block_params["num_rows"][i],

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -24,10 +24,11 @@ def test_average_max_uss_per_task():
 
     def create_bundle(uss_bytes: int):
         block = ray.put(pa.Table.from_pydict({}))
-        stats = BlockExecStats()
-        stats.max_uss_bytes = uss_bytes
-        stats.wall_time_s = 0
-        stats.block_ser_time_s = 0
+        stats = BlockExecStats(
+            max_uss_bytes=uss_bytes,
+            wall_time_s=0,
+            block_ser_time_s=0,
+        )
         metadata = BlockMetadata(
             num_rows=0,
             size_bytes=0,
@@ -166,10 +167,11 @@ def test_task_completion_time_excl_backpressure(mock_perf_counter):
 
     def create_output_bundle(gen_time_s, ser_time_s):
         block = ray.put(pa.Table.from_pydict({}))
-        stats = BlockExecStats()
-        stats.wall_time_s = gen_time_s
-        stats.block_ser_time_s = ser_time_s
-        stats.max_uss_bytes = 0
+        stats = BlockExecStats(
+            wall_time_s=gen_time_s,
+            block_ser_time_s=ser_time_s,
+            max_uss_bytes=0,
+        )
         metadata = BlockMetadata(
             num_rows=1,
             size_bytes=0,
@@ -270,10 +272,11 @@ def test_block_size_bytes_histogram():
 
     def create_bundle_with_size(size_bytes):
         block = ray.put(pa.Table.from_pydict({}))
-        stats = BlockExecStats()
-        stats.max_uss_bytes = 0
-        stats.wall_time_s = 0
-        stats.block_ser_time_s = 0
+        stats = BlockExecStats(
+            max_uss_bytes=0,
+            wall_time_s=0,
+            block_ser_time_s=0,
+        )
         metadata = BlockMetadata(
             num_rows=0,
             size_bytes=size_bytes,
@@ -318,10 +321,11 @@ def test_block_size_rows_histogram():
 
     def create_bundle_with_rows(num_rows):
         block = ray.put(pa.Table.from_pydict({}))
-        stats = BlockExecStats()
-        stats.max_uss_bytes = 0
-        stats.wall_time_s = 0
-        stats.block_ser_time_s = 0
+        stats = BlockExecStats(
+            max_uss_bytes=0,
+            wall_time_s=0,
+            block_ser_time_s=0,
+        )
         metadata = BlockMetadata(
             num_rows=num_rows,
             size_bytes=0,

--- a/python/ray/data/tests/test_ref_bundle.py
+++ b/python/ray/data/tests/test_ref_bundle.py
@@ -146,9 +146,7 @@ def test_slice_ref_bundle_basic():
         BlockSlice(start_offset=0, end_offset=6),
         BlockSlice(start_offset=0, end_offset=2),
     )
-    assert remaining.slices == (
-        BlockSlice(start_offset=2, end_offset=4),
-    )
+    assert remaining.slices == (BlockSlice(start_offset=2, end_offset=4),)
 
 
 def test_slice_ref_bundle_should_raise_error_if_needed_rows_is_not_less_than_num_rows():
@@ -196,9 +194,7 @@ def test_slice_ref_bundle_with_existing_slices():
     consumed, remaining = bundle.slice(7)
 
     assert consumed.num_rows() == 7
-    assert consumed.slices == (
-        BlockSlice(start_offset=2, end_offset=9),
-    )
+    assert consumed.slices == (BlockSlice(start_offset=2, end_offset=9),)
     assert consumed.size_bytes() == 70
     assert remaining.num_rows() == 4
     assert remaining.slices == (
@@ -333,9 +329,7 @@ def test_slice_ref_bundle_with_none_slices():
         BlockSlice(start_offset=0, end_offset=6),
         BlockSlice(start_offset=0, end_offset=2),
     )
-    assert remaining.slices == (
-        BlockSlice(start_offset=2, end_offset=4),
-    )
+    assert remaining.slices == (BlockSlice(start_offset=2, end_offset=4),)
 
 
 def test_ref_bundle_str():
@@ -460,7 +454,7 @@ def test_ref_bundle_eq_and_hash():
     # Non-RefBundle comparison returns False (not TypeError)
     assert bundle != "not a bundle"
     assert bundle != 42
-    assert bundle != None
+    assert bundle != None  # noqa: E711
 
     # Differing any field should break equality and hash
     diff_bundle_1 = replace(bundle, owns_blocks=False)

--- a/python/ray/data/tests/test_ref_bundle.py
+++ b/python/ray/data/tests/test_ref_bundle.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from unittest.mock import patch
 
 import pytest
@@ -79,13 +80,16 @@ def test_ref_bundle_num_rows_size_bytes():
     assert bundle.num_rows() == 15
     assert bundle.size_bytes() == 150
     # After slice
-    bundle.slices = [
-        BlockSlice(start_offset=2, end_offset=6),  # 4 rows
-        BlockSlice(start_offset=0, end_offset=2),  # 2 rows
-    ]
+    sliced = replace(
+        bundle,
+        slices=(
+            BlockSlice(start_offset=2, end_offset=6),  # 4 rows
+            BlockSlice(start_offset=0, end_offset=2),  # 2 rows
+        ),
+    )
 
-    assert bundle.num_rows() == 6
-    assert bundle.size_bytes() == 60
+    assert sliced.num_rows() == 6
+    assert sliced.size_bytes() == 60
 
 
 @pytest.mark.parametrize(
@@ -138,13 +142,13 @@ def test_slice_ref_bundle_basic():
     assert consumed.num_rows() == 8
     assert remaining.num_rows() == 2
 
-    assert consumed.slices == [
+    assert consumed.slices == (
         BlockSlice(start_offset=0, end_offset=6),
         BlockSlice(start_offset=0, end_offset=2),
-    ]
-    assert remaining.slices == [
+    )
+    assert remaining.slices == (
         BlockSlice(start_offset=2, end_offset=4),
-    ]
+    )
 
 
 def test_slice_ref_bundle_should_raise_error_if_needed_rows_is_not_less_than_num_rows():
@@ -192,15 +196,15 @@ def test_slice_ref_bundle_with_existing_slices():
     consumed, remaining = bundle.slice(7)
 
     assert consumed.num_rows() == 7
-    assert consumed.slices == [
+    assert consumed.slices == (
         BlockSlice(start_offset=2, end_offset=9),
-    ]
+    )
     assert consumed.size_bytes() == 70
     assert remaining.num_rows() == 4
-    assert remaining.slices == [
+    assert remaining.slices == (
         BlockSlice(start_offset=9, end_offset=10),
         BlockSlice(start_offset=0, end_offset=3),
-    ]
+    )
     assert remaining.size_bytes() == 40
 
 
@@ -325,13 +329,13 @@ def test_slice_ref_bundle_with_none_slices():
     assert remaining.num_rows() == 2
 
     # The None slices should be converted to explicit BlockSlice objects
-    assert consumed.slices == [
+    assert consumed.slices == (
         BlockSlice(start_offset=0, end_offset=6),
         BlockSlice(start_offset=0, end_offset=2),
-    ]
-    assert remaining.slices == [
+    )
+    assert remaining.slices == (
         BlockSlice(start_offset=2, end_offset=4),
-    ]
+    )
 
 
 def test_ref_bundle_str():
@@ -415,12 +419,12 @@ def test_merge_ref_bundles():
     # blocks.
     assert merged.owns_blocks is False
     assert len(merged.blocks) == 4
-    assert merged.slices == [
+    assert merged.slices == (
         BlockSlice(start_offset=0, end_offset=1),
         BlockSlice(start_offset=1, end_offset=2),
         BlockSlice(start_offset=2, end_offset=3),
         BlockSlice(start_offset=3, end_offset=4),
-    ]
+    )
 
 
 def test_ref_bundle_eq_and_hash():

--- a/python/ray/data/tests/test_ref_bundle.py
+++ b/python/ray/data/tests/test_ref_bundle.py
@@ -478,34 +478,6 @@ def test_ref_bundle_eq_and_hash():
     assert bundle != diff_meta_bundle
 
 
-def test_ref_bundle_hash_with_unhashable_schema_types():
-    class DummySchema:
-        def __init__(self, names, types):
-            self.names = names
-            self.types = types
-
-        def __eq__(self, other):
-            return (
-                isinstance(other, DummySchema)
-                and self.names == other.names
-                and self.types == other.types
-            )
-
-    ref = ObjectRef(b"1" * 28)
-    meta = BlockMetadata(num_rows=1, size_bytes=1, exec_stats=None, input_files=None)
-
-    # Mimics schemas where a field type carries nested dict metadata and isn't hashable.
-    schema_1 = DummySchema(names=["col"], types=[{"encoding": {"kind": "dict"}}])
-    schema_2 = DummySchema(names=["col"], types=[{"encoding": {"kind": "dict"}}])
-
-    bundle_1 = RefBundle(blocks=[(ref, meta)], owns_blocks=True, schema=schema_1)
-    bundle_2 = RefBundle(blocks=[(ref, meta)], owns_blocks=True, schema=schema_2)
-
-    assert bundle_1 == bundle_2
-    assert hash(bundle_1) == hash(bundle_2)
-    assert {bundle_1: "ok"}[bundle_2] == "ok"
-
-
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_ref_bundle.py
+++ b/python/ray/data/tests/test_ref_bundle.py
@@ -1,11 +1,14 @@
 from dataclasses import replace
 from unittest.mock import patch
 
+import pyarrow as pa
 import pytest
 
 from ray import ObjectRef
 from ray.data._internal.execution.interfaces import BlockSlice, RefBundle
 from ray.data.block import BlockMetadata
+
+_TEST_SCHEMA = pa.schema([("col", pa.int64())])
 
 
 def test_get_preferred_locations():
@@ -134,7 +137,7 @@ def test_slice_ref_bundle_basic():
             (block_ref_two, meta_two),
         ],
         owns_blocks=True,
-        schema="schema",
+        schema=_TEST_SCHEMA,
     )
 
     consumed, remaining = bundle.slice(8)
@@ -184,7 +187,7 @@ def test_slice_ref_bundle_with_existing_slices():
             (block_ref_two, meta_two),
         ],
         owns_blocks=True,
-        schema="schema",
+        schema=_TEST_SCHEMA,
         slices=[
             BlockSlice(start_offset=2, end_offset=10),
             BlockSlice(start_offset=0, end_offset=3),
@@ -314,7 +317,7 @@ def test_slice_ref_bundle_with_none_slices():
             (block_ref_two, meta_two),
         ],
         owns_blocks=True,
-        schema="schema",
+        schema=_TEST_SCHEMA,
         slices=[None, None],
     )
 
@@ -356,13 +359,13 @@ def test_ref_bundle_str():
             (block_ref_three, meta_three),
         ],
         owns_blocks=True,
-        schema="test_schema",
+        schema=_TEST_SCHEMA,
         slices=[None, None, slice_three],
     )
 
-    expected = """RefBundle(3 blocks,
+    expected = f"""RefBundle(3 blocks,
   18 rows,
-  schema=test_schema,
+  schema={_TEST_SCHEMA},
   owns_blocks=True,
   blocks=(
     0: 10 rows, 100 bytes, slice=None (full block)
@@ -389,7 +392,7 @@ def test_merge_ref_bundles():
     bundle_one = RefBundle(
         blocks=[(block_ref_one, metadata_one), (block_ref_one, metadata_one)],
         owns_blocks=True,
-        schema="schema",
+        schema=_TEST_SCHEMA,
         slices=[
             BlockSlice(start_offset=0, end_offset=1),
             BlockSlice(start_offset=1, end_offset=2),
@@ -398,7 +401,7 @@ def test_merge_ref_bundles():
     bundle_two = RefBundle(
         blocks=[(block_ref_two, metadata_two), (block_ref_two, metadata_two)],
         owns_blocks=False,
-        schema="schema",
+        schema=_TEST_SCHEMA,
         slices=[
             BlockSlice(start_offset=2, end_offset=3),
             BlockSlice(start_offset=3, end_offset=4),
@@ -407,7 +410,7 @@ def test_merge_ref_bundles():
 
     merged = RefBundle.merge_ref_bundles([bundle_one, bundle_two])
 
-    assert merged.schema == "schema"
+    assert merged.schema == _TEST_SCHEMA
     # The merged bundle should own the blocks if all input bundles own their blocks.
     # Since bundle_two doesn't own its blocks, the merged bundle should not own its
     # blocks.
@@ -433,7 +436,7 @@ def test_ref_bundle_eq_and_hash():
     bundle = RefBundle(
         blocks=[(ref_a, meta)],
         owns_blocks=True,
-        schema="schema",
+        schema=_TEST_SCHEMA,
         slices=[BlockSlice(start_offset=0, end_offset=5)],
         output_split_idx=1,
     )
@@ -463,7 +466,7 @@ def test_ref_bundle_eq_and_hash():
     diff_bundle_2 = replace(bundle, output_split_idx=2)
     assert bundle != diff_bundle_2 and hash(bundle) != hash(diff_bundle_2)
 
-    diff_bundle_3 = replace(bundle, schema="other")
+    diff_bundle_3 = replace(bundle, schema=pa.schema([("other", pa.string())]))
     assert bundle != diff_bundle_3 and hash(bundle) != hash(diff_bundle_3)
 
     diff_bundle_4 = replace(bundle, slices=(None,))

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -1,5 +1,6 @@
 import math
 import time
+from dataclasses import replace
 from datetime import timedelta
 from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
@@ -306,7 +307,8 @@ class TestResourceManager:
 
     def test_object_store_usage(self, restore_data_context):
         input = make_ref_bundles([[x] for x in range(1)])[0]
-        input.size_bytes = MagicMock(return_value=1)
+        block_ref, block_meta = input.blocks[0]
+        input = replace(input, blocks=[(block_ref, replace(block_meta, size_bytes=1))])
 
         o1 = InputDataBuffer(DataContext.get_current(), [input])
         o2 = mock_map_op(o1)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1712,11 +1712,13 @@ def test_dataset_throughput_calculation(ray_start_regular_shared):
     """Test throughput calculations using mock block stats."""
 
     def create_block_stats(start_time, end_time, num_rows):
-        exec_stats = BlockExecStats()
-        exec_stats.start_time_s = start_time
-        exec_stats.end_time_s = end_time
-        exec_stats.wall_time_s = end_time - start_time
-        exec_stats.cpu_time_s = exec_stats.wall_time_s
+        wall_time_s = end_time - start_time
+        exec_stats = BlockExecStats(
+            start_time_s=start_time,
+            end_time_s=end_time,
+            wall_time_s=wall_time_s,
+            cpu_time_s=wall_time_s,
+        )
         return BlockStats(num_rows=num_rows, size_bytes=None, exec_stats=exec_stats)
 
     blocks_stats = [
@@ -1739,13 +1741,14 @@ def test_operator_throughput_calculation(ray_start_regular_shared):
     """Test operator throughput calculations using mock BlockStats."""
 
     def create_block_stats(start_time, end_time, num_rows, task_idx):
-        exec_stats = BlockExecStats()
-        exec_stats.start_time_s = start_time
-        exec_stats.end_time_s = end_time
-        exec_stats.wall_time_s = end_time - start_time
-        exec_stats.cpu_time_s = exec_stats.wall_time_s
-        exec_stats.task_idx = task_idx
-
+        wall_time_s = end_time - start_time
+        exec_stats = BlockExecStats(
+            start_time_s=start_time,
+            end_time_s=end_time,
+            wall_time_s=wall_time_s,
+            cpu_time_s=wall_time_s,
+            task_idx=task_idx,
+        )
         return BlockStats(num_rows=num_rows, size_bytes=None, exec_stats=exec_stats)
 
     blocks_stats = [

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -2,6 +2,7 @@ import os
 import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from typing import List, Literal, Optional, Union
 from unittest.mock import MagicMock, patch
 
@@ -702,7 +703,7 @@ class OpBufferQueueTest(unittest.TestCase):
 
         queue = OpBufferQueue()
         for i, ref_bundle in enumerate(ref_bundles):
-            ref_bundle.output_split_idx = i % num_splits
+            ref_bundle = replace(ref_bundle, output_split_idx=i % num_splits)
             queue.append(ref_bundle)
 
         def consume(output_split_idx):

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1133,7 +1133,7 @@ def create_stub_streaming_gen(
                     task_wall_time_s=_time.perf_counter() - task_start_s,
                 )
             )
-            yield BlockMetadataWithSchema(
+            yield BlockMetadataWithSchema.from_metadata(
                 block_metadata, schema=block_accessor.schema()
             )
 

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -246,7 +246,7 @@ def test_strict_schema(ray_start_regular_shared_2_cpus, tensor_format_context):
 
     assert isinstance(schema.base_schema, PandasBlockSchema)
     assert schema.names == ["data"]
-    assert schema.base_schema.types == [TensorDtype(shape=(10,), dtype=pa.float64())]
+    assert schema.base_schema.types == (TensorDtype(shape=(10,), dtype=pa.float64()),)
     # NOTE: Schema by default returns Arrow types
     assert schema.types == [expected_arrow_ext_type]
 


### PR DESCRIPTION
## Description

 - Cleaning up to make `BundleClass`, `BlockMetadata`, `BlockSlice` and other classes properly frozen;
 - Added `PandasBlockSchema` as data class

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
