### PR TITLE
[Core] Check process is non-null when setting process in worker

### DIFF
--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -110,6 +110,10 @@ WorkerID Worker::WorkerId() const { return worker_id_; }
 const ProcessInterface &Worker::GetProcess() const { return *proc_; }
 
 void Worker::SetProcess(std::unique_ptr<ProcessInterface> proc) {
+  RAY_CHECK(proc != nullptr) << absl::StrFormat(
+      "Failed to set process for worker: %s because the process is null. "
+      "Was the process spawned successfully?",
+      worker_id_.Hex());
   RAY_CHECK(proc_ == nullptr || proc_->IsNull()) << absl::StrFormat(
       "Failed to set process: %d on worker: %s because it already has a process: %d",
       proc->GetId(),


### PR DESCRIPTION
## Description
This PR adds a simple check to ensure the process pointer being passed into `Worker::SetProcess` is non-null. 

This is an immediate followup item from https://github.com/ray-project/ray/pull/59604 which introduces process interface to abstract away `Process` class and allow us to mock it using fakes. However, the PR had an immediate followup where if the process passed to `SetProcess` was null, we would get a segfault instead of the ray check message. 

https://github.com/ray-project/ray/pull/59604/changes#diff-ede707121373d9e3cb36580a82f098a799b34e9adf8a1691b5cd642705d388f1R112-R117

This PR provides the immediate followup.

## Related issues
This is a followup item of: https://github.com/ray-project/ray/pull/59604

## Additional information
