### PR TITLE
[core] cache find_gcs_addresses

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -12,6 +12,7 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 from functools import cache
 from pathlib import Path
@@ -370,6 +371,9 @@ def find_node_ids():
     return _find_address_from_flag("--node_id")
 
 
+_find_gcs_addresses_lock = threading.Lock()
+
+
 @cache
 def _cached_find_gcs_addresses():
     return frozenset(_find_address_from_flag("--gcs-address"))
@@ -380,13 +384,19 @@ def find_gcs_addresses():
 
     Empty discovery results are not cached.
     """
-    addresses = _cached_find_gcs_addresses()
-    if not addresses:
+    with _find_gcs_addresses_lock:
+        addresses = _cached_find_gcs_addresses()
+        if not addresses:
+            _cached_find_gcs_addresses.cache_clear()
+        return addresses
+
+
+def _thread_safe_find_gcs_addresses_cache_clear():
+    with _find_gcs_addresses_lock:
         _cached_find_gcs_addresses.cache_clear()
-    return set(addresses)
 
 
-find_gcs_addresses.cache_clear = _cached_find_gcs_addresses.cache_clear
+find_gcs_addresses.cache_clear = _thread_safe_find_gcs_addresses_cache_clear
 
 
 def find_bootstrap_address(temp_dir: Optional[str]):
@@ -420,7 +430,7 @@ def get_ray_address_from_environment(addr: str, temp_dir: Optional[str]):
 
     if len(gcs_addrs) > 1 and bootstrap_addr is not None:
         logger.warning(
-            f"Found multiple active Ray instances: {gcs_addrs}. "
+            f"Found multiple active Ray instances: {set(gcs_addrs)}. "
             f"Connecting to latest cluster at {bootstrap_addr}. "
             "You can override this by setting the `--address` flag "
             "or `RAY_ADDRESS` environment variable."
@@ -428,7 +438,7 @@ def get_ray_address_from_environment(addr: str, temp_dir: Optional[str]):
     elif len(gcs_addrs) > 0 and addr == "auto":
         # Preserve legacy "auto" behavior of connecting to any cluster, even if not
         # started with ray start. However if addr is None, we will raise an error.
-        bootstrap_addr = list(gcs_addrs).pop()
+        bootstrap_addr = next(iter(gcs_addrs))
 
     if bootstrap_addr is None:
         if addr is None:
@@ -723,11 +733,11 @@ def canonicalize_bootstrap_address_or_die(
         )
     if len(running_gcs_addresses) > 1:
         raise ConnectionError(
-            f"Found multiple active Ray instances: {running_gcs_addresses}. "
+            f"Found multiple active Ray instances: {set(running_gcs_addresses)}. "
             "Please specify the one to connect to by setting the `--address` "
             "flag or `RAY_ADDRESS` environment variable."
         )
-    return running_gcs_addresses.pop()
+    return next(iter(running_gcs_addresses))
 
 
 def extract_ip_port(bootstrap_address: str):

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -13,6 +13,7 @@ import socket
 import subprocess
 import sys
 import time
+from functools import cache
 from pathlib import Path
 from typing import IO, AnyStr, List, Optional
 
@@ -369,9 +370,23 @@ def find_node_ids():
     return _find_address_from_flag("--node_id")
 
 
+@cache
+def _cached_find_gcs_addresses():
+    return frozenset(_find_address_from_flag("--gcs-address"))
+
+
 def find_gcs_addresses():
-    """Finds any local GCS processes based on grepping ps."""
-    return _find_address_from_flag("--gcs-address")
+    """Finds any local GCS processes based on grepping ps.
+
+    Empty discovery results are not cached.
+    """
+    addresses = _cached_find_gcs_addresses()
+    if not addresses:
+        _cached_find_gcs_addresses.cache_clear()
+    return set(addresses)
+
+
+find_gcs_addresses.cache_clear = _cached_find_gcs_addresses.cache_clear
 
 
 def find_bootstrap_address(temp_dir: Optional[str]):

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1800,6 +1800,7 @@ def init(
     if logging_config is not None:
         job_config.set_py_logging_config(logging_config)
 
+    services.find_gcs_addresses.cache_clear()
     redis_address, gcs_address = None, None
     bootstrap_address = services.canonicalize_bootstrap_address(address, _temp_dir)
     if bootstrap_address is not None:
@@ -2062,6 +2063,7 @@ def init(
             FutureWarning,
         )
 
+    services.find_gcs_addresses.cache_clear()
     node_id = global_worker.core_worker.get_current_node_id()
     global_node_address_info = _global_node.address_info.copy()
     global_node_address_info["webui_url"] = _remove_protocol_from_url(dashboard_url)
@@ -2151,6 +2153,7 @@ def shutdown(_exiting_interpreter: bool = False):
     # should simply set "global_worker" to equal "None" or something like that.
     global_worker.set_mode(None)
     global_worker.set_cached_job_id(None)
+    services.find_gcs_addresses.cache_clear()
 
 
 atexit.register(shutdown, True)

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -125,10 +125,12 @@ class AutoscalingCluster:
         if override_env:
             env.update(override_env)
         subprocess.check_call(cmd, env=env)
+        ray._private.services.find_gcs_addresses.cache_clear()
 
     def shutdown(self):
         """Terminate the cluster."""
         subprocess.check_call(["ray", "stop", "--force"])
+        ray._private.services.find_gcs_addresses.cache_clear()
 
 
 @DeveloperAPI
@@ -413,3 +415,4 @@ class Cluster:
         ray.experimental.internal_kv._internal_kv_reset()
         # Delete the cluster address.
         ray._common.utils.reset_ray_address()
+        ray._private.services.find_gcs_addresses.cache_clear()

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -3266,10 +3266,14 @@ def test_network_failure(shutdown_only):
     a = [f.remote() for _ in range(4)]  # noqa
     wait_for_condition(lambda: len(list_tasks()) == 4)
 
-    # Kill raylet so that list_tasks will have network error on querying raylets.
+    # Kill raylet will not make list_tasks raise exceptions.
     ray._private.worker._global_node.kill_raylet()
+    assert len(list_tasks()) == 4
 
-    with pytest.raises(ConnectionError):
+    # Kill GCS so that list_tasks will have network error on querying tasks.
+    ray._private.worker._global_node.kill_gcs_server()
+
+    with pytest.raises(ray.exceptions.RpcError):
         list_tasks(_explain=True)
 
 


### PR DESCRIPTION


## Description

Executing the `find_gcs_addresses` function on a head node, where the RAY_ADDRESS env is not set, will scan the user's process list and find GCS addresses from each of the command line arguments in the list. The process is super expensive, as shown in the screenshot below. It dominates the `detect` function in Ray Data's hanging detector.

<img width="3020" height="1360" alt="image" src="https://github.com/user-attachments/assets/771dad60-6b36-424c-a14e-f132878d6756" />

This PR caches the result of `find_gcs_addresses` if any.


