### PR TITLE
[Core] Fix py_modules not added to worker sys.path when combined with working_dir

### DIFF
--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -785,15 +785,12 @@ def test_actor_inherits_job_runtime_env_with_working_dir_and_py_modules(
     @ray.remote
     class TestActor:
         def check_imports(self):
-            import sys
-
             # Both working_dir and py_modules should be in sys.path
             results = {
                 "can_import_from_working_dir": False,
                 "can_import_from_py_module": False,
                 "working_dir_value": None,
                 "py_module_value": None,
-                "sys_path": sys.path[:10],  # First 10 entries for debugging
             }
 
             try:

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -656,136 +656,54 @@ def test_default_excludes_disabled_via_env_var(start_cluster, monkeypatch):
         def check_git():
             return os.path.exists(".git")
 
-        assert ray.get(check_git.remote()), (
-            ".git should be included when defaults disabled"
+        assert ray.get(
+            check_git.remote()
+        ), ".git should be included when defaults disabled"
+
+
+@pytest.mark.parametrize("use_actor", [False, True], ids=["task", "actor"])
+def test_inherits_job_runtime_env_with_working_dir_and_py_modules(
+    start_cluster, tmp_working_dir, use_actor
+):
+    """Test that tasks/actors inherit both working_dir and py_modules from job.
+
+    This is a regression test for a bug where tasks/actors created from a job with both
+    working_dir and py_modules in the runtime_env would only get working_dir in their
+    sys.path, missing py_modules.
+
+    The bug was in core_worker.cc where URIs were copied from parent to child runtime_env
+    but the serialized_runtime_env JSON was not updated, causing the runtime_env agent
+    to not set up py_modules for workers.
+    """
+    cluster, address = start_cluster
+
+    # Create a module in the working_dir - fixture already creates test_module dir
+    working_dir_module = Path(tmp_working_dir) / "test_module"
+    working_dir_module.mkdir(exist_ok=True)
+    (working_dir_module / "__init__.py").write_text("")
+    (working_dir_module / "workdir_mod.py").write_text(
+        "def get_value(): return 'from_working_dir'"
+    )
+
+    # Create py_modules directory OUTSIDE working_dir to properly test the fix
+    # If py_modules is inside working_dir, it would be accessible anyway
+    with tempfile.TemporaryDirectory() as external_module_dir:
+        py_module_path = Path(external_module_dir) / "external_module"
+        py_module_path.mkdir()
+        (py_module_path / "__init__.py").write_text("")
+        (py_module_path / "helper.py").write_text(
+            "def get_helper_value(): return 'from_py_module'"
         )
 
+        ray.init(
+            address,
+            runtime_env={
+                "working_dir": tmp_working_dir,
+                "py_modules": [str(py_module_path)],
+            },
+        )
 
-def test_task_inherits_job_runtime_env_with_working_dir_and_py_modules(
-    start_cluster, tmp_working_dir
-):
-    """Test that tasks inherit both working_dir and py_modules from job runtime_env.
-
-    This is a regression test for a bug where tasks created from a job with both
-    working_dir and py_modules in the runtime_env would only get working_dir in their
-    sys.path, missing py_modules.
-
-    The bug was in core_worker.cc where URIs were copied from parent to child runtime_env
-    but the serialized_runtime_env JSON was not updated, causing the runtime_env agent
-    to not set up py_modules for workers.
-    """
-    cluster, address = start_cluster
-
-    # Set up test files
-    test_module_dir = Path(tmp_working_dir) / "test_module"
-    test_module_dir.mkdir()
-    (test_module_dir / "__init__.py").write_text("")
-    (test_module_dir / "mod.py").write_text(
-        "def get_value(): return 'from_working_dir'"
-    )
-
-    py_module_dir = Path(tmp_working_dir) / "separate_module"
-    py_module_dir.mkdir()
-    (py_module_dir / "__init__.py").write_text("")
-    (py_module_dir / "helper.py").write_text(
-        "def get_helper_value(): return 'from_py_module'"
-    )
-
-    ray.init(
-        address,
-        runtime_env={
-            "working_dir": tmp_working_dir,
-            "py_modules": [str(py_module_dir)],
-        },
-    )
-
-    @ray.remote
-    def check_imports():
-        results = {
-            "can_import_from_working_dir": False,
-            "can_import_from_py_module": False,
-            "working_dir_value": None,
-            "py_module_value": None,
-        }
-
-        try:
-            from test_module import mod
-
-            results["can_import_from_working_dir"] = True
-            results["working_dir_value"] = mod.get_value()
-        except ImportError as e:
-            results["working_dir_error"] = str(e)
-
-        try:
-            from separate_module import helper
-
-            results["can_import_from_py_module"] = True
-            results["py_module_value"] = helper.get_helper_value()
-        except ImportError as e:
-            results["py_module_error"] = str(e)
-
-        return results
-
-    result = ray.get(check_imports.remote())
-
-    assert result["can_import_from_working_dir"], (
-        f"Failed to import from working_dir. Result: {result}"
-    )
-    assert result["can_import_from_py_module"], (
-        f"Failed to import from py_modules. Result: {result}"
-    )
-    assert result["working_dir_value"] == "from_working_dir"
-    assert result["py_module_value"] == "from_py_module"
-
-    ray.shutdown()
-
-
-def test_actor_inherits_job_runtime_env_with_working_dir_and_py_modules(
-    start_cluster, tmp_working_dir
-):
-    """Test that actors inherit both working_dir and py_modules from job runtime_env.
-
-    This is a regression test for a bug where actors created from a job with both
-    working_dir and py_modules in the runtime_env would only get working_dir in their
-    sys.path, missing py_modules.
-
-    The bug was in core_worker.cc where URIs were copied from parent to child runtime_env
-    but the serialized_runtime_env JSON was not updated, causing the runtime_env agent
-    to not set up py_modules for workers.
-    """
-    cluster, address = start_cluster
-
-    # Set up test files
-    # Create a module in tmp_working_dir
-    test_module_dir = Path(tmp_working_dir) / "test_module"
-    test_module_dir.mkdir()
-    (test_module_dir / "__init__.py").write_text("")
-    (test_module_dir / "mod.py").write_text(
-        "def get_value(): return 'from_working_dir'"
-    )
-
-    # Create a separate py_module directory
-    py_module_dir = Path(tmp_working_dir) / "separate_module"
-    py_module_dir.mkdir()
-    (py_module_dir / "__init__.py").write_text("")
-    (py_module_dir / "helper.py").write_text(
-        "def get_helper_value(): return 'from_py_module'"
-    )
-
-    # Initialize Ray with both working_dir and py_modules
-    ray.init(
-        address,
-        runtime_env={
-            "working_dir": tmp_working_dir,
-            "py_modules": [str(py_module_dir)],
-        },
-    )
-
-    # Test with an actor that should inherit the job's runtime_env
-    @ray.remote
-    class TestActor:
-        def check_imports(self):
-            # Both working_dir and py_modules should be in sys.path
+        def check_imports_impl():
             results = {
                 "can_import_from_working_dir": False,
                 "can_import_from_py_module": False,
@@ -794,15 +712,15 @@ def test_actor_inherits_job_runtime_env_with_working_dir_and_py_modules(
             }
 
             try:
-                from test_module import mod
+                from test_module import workdir_mod
 
                 results["can_import_from_working_dir"] = True
-                results["working_dir_value"] = mod.get_value()
+                results["working_dir_value"] = workdir_mod.get_value()
             except ImportError as e:
                 results["working_dir_error"] = str(e)
 
             try:
-                from separate_module import helper
+                from external_module import helper
 
                 results["can_import_from_py_module"] = True
                 results["py_module_value"] = helper.get_helper_value()
@@ -811,20 +729,33 @@ def test_actor_inherits_job_runtime_env_with_working_dir_and_py_modules(
 
             return results
 
-    actor = TestActor.remote()
-    result = ray.get(actor.check_imports.remote())
+        if use_actor:
 
-    # Both imports should succeed
-    assert result["can_import_from_working_dir"], (
-        f"Failed to import from working_dir. Result: {result}"
-    )
-    assert result["can_import_from_py_module"], (
-        f"Failed to import from py_modules. Result: {result}"
-    )
-    assert result["working_dir_value"] == "from_working_dir"
-    assert result["py_module_value"] == "from_py_module"
+            @ray.remote
+            class TestActor:
+                def check_imports(self):
+                    return check_imports_impl()
 
-    ray.shutdown()
+            actor = TestActor.remote()
+            result = ray.get(actor.check_imports.remote())
+        else:
+
+            @ray.remote
+            def check_imports():
+                return check_imports_impl()
+
+            result = ray.get(check_imports.remote())
+
+        assert result[
+            "can_import_from_working_dir"
+        ], f"Failed to import from working_dir. Result: {result}"
+        assert result[
+            "can_import_from_py_module"
+        ], f"Failed to import from py_modules. Result: {result}"
+        assert result["working_dir_value"] == "from_working_dir"
+        assert result["py_module_value"] == "from_py_module"
+
+        ray.shutdown()
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1849,7 +1849,7 @@ std::shared_ptr<rpc::RuntimeEnvInfo> CoreWorker::OverrideTaskOrActorRuntimeEnvIn
     uris_updated = true;
   }
 
-  // Bug fix: When URIs are copied from parent, also update serialized_runtime_env JSON
+  // When URIs are copied from parent, also update serialized_runtime_env JSON.
   // The runtime_env agent only looks at serialized_runtime_env, not the uris field.
   // Without this, py_modules and working_dir from the job-level runtime_env are not
   // applied to workers even though the URIs are copied for reference counting.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1832,10 +1832,13 @@ std::shared_ptr<rpc::RuntimeEnvInfo> CoreWorker::OverrideTaskOrActorRuntimeEnvIn
   auto override_runtime_env = OverrideRuntimeEnv(child_runtime_env, parent);
   auto serialized_override_runtime_env = override_runtime_env.dump();
   runtime_env_info->set_serialized_runtime_env(serialized_override_runtime_env);
+  // Update URIs from parent if child doesn't specify them
+  bool uris_updated = false;
   if (runtime_env_info->uris().working_dir_uri().empty() &&
       !parent_runtime_env_info->uris().working_dir_uri().empty()) {
     runtime_env_info->mutable_uris()->set_working_dir_uri(
         parent_runtime_env_info->uris().working_dir_uri());
+    uris_updated = true;
   }
   if (runtime_env_info->uris().py_modules_uris().empty() &&
       !parent_runtime_env_info->uris().py_modules_uris().empty()) {
@@ -1843,6 +1846,39 @@ std::shared_ptr<rpc::RuntimeEnvInfo> CoreWorker::OverrideTaskOrActorRuntimeEnvIn
     for (const std::string &uri : parent_runtime_env_info->uris().py_modules_uris()) {
       runtime_env_info->mutable_uris()->add_py_modules_uris(uri);
     }
+    uris_updated = true;
+  }
+
+  // Bug fix: When URIs are copied from parent, also update serialized_runtime_env JSON
+  // The runtime_env agent only looks at serialized_runtime_env, not the uris field.
+  // Without this, py_modules and working_dir from the job-level runtime_env are not
+  // applied to workers even though the URIs are copied for reference counting.
+  if (uris_updated) {
+    json runtime_env_json = json::parse(runtime_env_info->serialized_runtime_env());
+
+    // Add working_dir to JSON if URI was copied but JSON doesn't have it
+    if (!runtime_env_info->uris().working_dir_uri().empty() &&
+        (!runtime_env_json.contains("working_dir") ||
+         runtime_env_json["working_dir"].is_null() ||
+         (runtime_env_json["working_dir"].is_string() &&
+          runtime_env_json["working_dir"].get<std::string>().empty()))) {
+      runtime_env_json["working_dir"] = runtime_env_info->uris().working_dir_uri();
+    }
+
+    // Add py_modules to JSON if URIs were copied but JSON doesn't have them
+    if (!runtime_env_info->uris().py_modules_uris().empty() &&
+        (!runtime_env_json.contains("py_modules") ||
+         runtime_env_json["py_modules"].is_null() ||
+         (runtime_env_json["py_modules"].is_array() &&
+          runtime_env_json["py_modules"].empty()))) {
+      json py_modules_array = json::array();
+      for (const std::string &uri : runtime_env_info->uris().py_modules_uris()) {
+        py_modules_array.push_back(uri);
+      }
+      runtime_env_json["py_modules"] = py_modules_array;
+    }
+
+    runtime_env_info->set_serialized_runtime_env(runtime_env_json.dump());
   }
 
   runtime_env_json_serialization_cache_.Put(serialized_runtime_env_info,


### PR DESCRIPTION
## Problem

When a Ray job is submitted with both `working_dir` and `py_modules` in the `runtime_env`, tasks and actors created within that job only have `working_dir` added to their `sys.path`, but not the `py_modules`. This causes `ImportError` when trying to import modules from `py_modules`.

Example:
```python
ray.init(runtime_env={
    "working_dir": "/path/to/workdir",
    "py_modules": ["/path/to/module"]
})

@ray.remote
def my_task():
    import my_module  # ImportError: No module named 'my_module'
    ...
```

## Root Cause

The bug is in `src/ray/core_worker/core_worker.cc` in the `OverrideTaskOrActorRuntimeEnvInfoImpl` function (lines 1835-1846). 

When a task/actor inherits runtime_env from its parent (the job), the code correctly copies the URIs from the parent's runtime_env:
- `working_dir_uri`
- `py_modules_uris`

However, it does **not** update the `serialized_runtime_env` JSON field. The runtime_env agent only reads `serialized_runtime_env` to configure the worker environment - it doesn't use the URIs directly. As a result:
- The URIs are copied (for reference counting)
- But the JSON still shows an empty runtime_env
- The runtime_env agent doesn't know about `py_modules`
- Workers only get `working_dir` in their `sys.path`

## Fix

After copying URIs from parent to child, the fix updates the `serialized_runtime_env` JSON to match:
1. Check if URIs were copied from parent
2. Parse the `serialized_runtime_env` JSON
3. Add `working_dir` to JSON if the URI was copied but JSON doesn't have it
4. Add `py_modules` to JSON if URIs were copied but JSON doesn't have them
5. Serialize the updated JSON back to `serialized_runtime_env`

This ensures the runtime_env agent sees the complete runtime_env and correctly sets up the worker's `sys.path`.

## Tests

Added two regression tests in `python/ray/tests/test_runtime_env_working_dir.py`:

1. `test_task_inherits_job_runtime_env_with_working_dir_and_py_modules` - Verifies tasks can import from both working_dir and py_modules
2. `test_actor_inherits_job_runtime_env_with_working_dir_and_py_modules` - Verifies actors can import from both working_dir and py_modules

Both tests:
- Initialize Ray with both `working_dir` and `py_modules` in runtime_env
- Create a task/actor that imports from both locations
- Verify imports succeed and return expected values