### PR TITLE
[Data][Refactor] clean up test_csv.py to focus on CSV-specific tests

### DIFF
--- a/python/ray/data/tests/datasource/test_file_based_datasource.py
+++ b/python/ray/data/tests/datasource/test_file_based_datasource.py
@@ -10,7 +10,10 @@ import ray
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.datasource import ReadTask
-from ray.data.datasource.file_based_datasource import FileBasedDatasource
+from ray.data.datasource.file_based_datasource import (
+    FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
+    FileBasedDatasource,
+)
 from ray.data.datasource.partitioning import (
     Partitioning,
     PartitionStyle,
@@ -444,10 +447,7 @@ def test_read_s3_file_error(shutdown_only, s3_path):
 
 def test_read_many_files_basic(ray_start_regular_shared, tmp_path):
 
-    from ray.data.datasource.file_based_datasource import (
-        FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
-    )
-
+    # Use 4x the threshold to trigger parallel file size fetching
     num_files = 4 * FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
 
     for i in range(num_files):
@@ -468,15 +468,12 @@ def test_read_many_files_basic(ray_start_regular_shared, tmp_path):
 
 def test_read_many_files_diff_dirs(ray_start_regular_shared, tmp_path):
 
-    from ray.data.datasource.file_based_datasource import (
-        FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
-    )
-
     dir1 = tmp_path / "dir1"
     dir2 = tmp_path / "dir2"
     dir1.mkdir()
     dir2.mkdir()
 
+    # Use 2x per directory (2 directories = 4x total) to trigger parallel file size fetching
     num_files_per_dir = 2 * FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
     total_files = 0
 

--- a/python/ray/data/tests/datasource/test_file_based_datasource.py
+++ b/python/ray/data/tests/datasource/test_file_based_datasource.py
@@ -11,7 +11,6 @@ from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.datasource import ReadTask
 from ray.data.datasource.file_based_datasource import (
-    FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
     FileBasedDatasource,
 )
 from ray.data.datasource.partitioning import (
@@ -443,59 +442,6 @@ def test_read_s3_file_error(shutdown_only, s3_path):
             "Error [code 15]: No response body.. Is this a 'parquet' file?"
         )
         _handle_read_os_error(error, dummy_path)
-
-
-def test_read_many_files_basic(ray_start_regular_shared, tmp_path):
-
-    # Use 4x the threshold to trigger parallel file size fetching
-    num_files = 4 * FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
-
-    for i in range(num_files):
-        path = tmp_path / f"test_{i}.txt"
-        path.write_bytes(f"file_{i}".encode())
-
-    datasource = MockFileBasedDatasource(str(tmp_path))
-    tasks = datasource.get_read_tasks(1)
-    rows = execute_read_tasks(tasks)
-
-    assert len(rows) == num_files
-
-    # Verify actual content - rows are dicts with "data" key containing bytes
-    expected_content = {f"file_{i}".encode() for i in range(num_files)}
-    actual_content = {row["data"] for row in rows}
-    assert actual_content == expected_content
-
-
-def test_read_many_files_diff_dirs(ray_start_regular_shared, tmp_path):
-
-    dir1 = tmp_path / "dir1"
-    dir2 = tmp_path / "dir2"
-    dir1.mkdir()
-    dir2.mkdir()
-
-    # Use 2x per directory (2 directories = 4x total) to trigger parallel file size fetching
-    num_files_per_dir = 2 * FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
-    total_files = 0
-
-    for dir_path in [dir1, dir2]:
-        for i in range(num_files_per_dir):
-            path = dir_path / f"test_{i}.txt"
-            path.write_bytes(f"data_from_{dir_path.name}_{i}".encode())
-            total_files += 1
-
-    datasource = MockFileBasedDatasource([str(dir1), str(dir2)])
-    tasks = datasource.get_read_tasks(1)
-    rows = execute_read_tasks(tasks)
-
-    assert len(rows) == total_files
-
-    # Verify actual content - files from both directories should be read
-    expected_content = set()
-    for dir_name in ["dir1", "dir2"]:
-        for i in range(num_files_per_dir):
-            expected_content.add(f"data_from_{dir_name}_{i}".encode())
-    actual_content = {row["data"] for row in rows}
-    assert actual_content == expected_content
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Following #60993, `test_csv.py` has redundant tests for common file I/O behavior that belong at the `FileBasedDatasource` level. This PR removes generic file operations and focuses on CSV-specific parsing, type conversion, and error handling.

## What's included?

**Refactored:**
- `test_csv_read` - removed ~75 lines of generic directory/filtering tests 
- `test_csv_read_filter_non_csv_file` → `test_csv_read_invalid_format` - focused on CSV error handling only 

**Kept:**
- All CSV-specific tests: parsing options, type conversion, error handling, serialization 

## Screenshots
<img width="711" height="631" alt="Screenshot 2026-02-16 at 03 21 44" src="https://github.com/user-attachments/assets/26414997-f889-4ad9-9c63-9c5efb7b92f9" />
<img width="710" height="480" alt="Screenshot 2026-02-17 at 16 30 39" src="https://github.com/user-attachments/assets/9a0f620a-a297-4c65-885b-0302090fe258" />

## Benefits

- ~95 lines of redundant code removed
- Clearer separation of generic file I/O vs CSV parsing
- Generic tests now in correct location for reuse across all file formats

## Note

Closes #61052