### PR TITLE
[Serve] Propagate tracing context in gRPC inter-deployment mode

### DIFF
--- a/python/ray/serve/tests/test_serve_with_tracing.py
+++ b/python/ray/serve/tests/test_serve_with_tracing.py
@@ -62,11 +62,6 @@ def get_span_list():
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Temp directory cleanup fails on Windows"
 )
-@pytest.mark.skipif(
-    os.environ.get("RAY_SERVE_USE_GRPC_BY_DEFAULT", "0") == "1",
-    reason="Tracing context propagation not yet supported in gRPC mode. "
-    "See https://github.com/ray-project/ray/issues/60223",
-)
 def test_deployment_remote_calls_with_tracing(ray_serve_with_tracing):
     serve.start()
 


### PR DESCRIPTION
## Description
Previously in https://github.com/ray-project/ray/commit/ba5cd1c8435a37f6dd89988733d6134323ee7f87, trace context propagation was extended to Ray Serve. However, it missed the case for propagating the context through the gRPC path. https://github.com/ray-project/ray/pull/60209 applied a test skip for the gRPC case as a short-term solution for passing CI until support was properly extended to gRPC.

This PR extends context propagation support to gRPC by serializing the trace context into the request.

## Related issues
Fixes #60223

## Additional information
The implementation uses an existing Ray helper function that calls opentelemetry inject.

https://github.com/ray-project/ray/blob/8882b9045ab8cb3b1764f8b6dbc13aabb1113ff8/python/ray/util/tracing/tracing_helper.py#L165-L170