### PR TITLE
[Serve] Add `exception_type` tag to `ray_serve_deployment_error_counter_total` metric

### DIFF
--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -665,7 +665,7 @@ These metrics track request throughput, errors, and latency at the replica level
 | `ray_serve_replica_utilization_percent` **[D]** | Gauge | `deployment`, `replica`, `application` | Percentage of replica capacity used over a rolling window. Calculated as total user code execution time divided by maximum capacity (`window_duration × max_ongoing_requests`). Useful for capacity planning and identifying underutilized or overloaded replicas. Configure with `RAY_SERVE_REPLICA_UTILIZATION_WINDOW_S` (default: 600s), `RAY_SERVE_REPLICA_UTILIZATION_REPORT_INTERVAL_S` (default: 10s), and `RAY_SERVE_REPLICA_UTILIZATION_NUM_BUCKETS` (default: 60). |
 | `ray_serve_deployment_request_counter_total` **[D]** | Counter | `deployment`, `replica`, `route`, `application` | Total number of requests processed by the replica. |
 | `ray_serve_deployment_processing_latency_ms` **[D]** | Histogram | `deployment`, `replica`, `route`, `application` | Histogram of request processing time in milliseconds (excludes queue wait time). |
-| `ray_serve_deployment_error_counter_total` **[D]** | Counter | `deployment`, `replica`, `route`, `application` | Total number of exceptions raised while processing requests. |
+| `ray_serve_deployment_error_counter_total` **[D]** | Counter | `deployment`, `replica`, `route`, `application`, `exception_type` | Total number of exceptions raised while processing requests. |
 
 ### Batching metrics
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -889,6 +889,7 @@ def test_replica_metrics_fields(metrics_start_shutdown):
         err_requests[0]["deployment"],
         err_requests[0]["application"],
     ) == expected_output
+    assert err_requests[0]["exception_type"] == "ZeroDivisionError"
 
     wait_for_condition(
         lambda: len(get_metric_dictionaries("ray_serve_deployment_replica_healthy"))
@@ -905,6 +906,33 @@ def test_replica_metrics_fields(metrics_start_shutdown):
         (health_metric["deployment"], health_metric["application"])
         for health_metric in health_metrics
     } == expected_output
+
+
+def test_deployment_error_counter_exception_type(metrics_start_shutdown):
+    """Test that ray_serve_deployment_error_counter_total captures exception_type tag."""
+
+    @serve.deployment
+    def raises_value_error():
+        raise ValueError("intentional test error")
+
+    serve.run(
+        raises_value_error.bind(), name="value_error_app", route_prefix="/value_error"
+    )
+    url = get_application_url("HTTP", "value_error_app") + "/value_error"
+    assert httpx.get(url).status_code == 500
+
+    wait_for_condition(
+        lambda: len(get_metric_dictionaries("ray_serve_deployment_error_counter_total"))
+        == 1,
+        timeout=40,
+    )
+
+    err_metrics = get_metric_dictionaries("ray_serve_deployment_error_counter_total")
+    value_error_metrics = [
+        m for m in err_metrics if m.get("exception_type") == "ValueError"
+    ]
+    assert len(value_error_metrics) == 1
+    assert value_error_metrics[0]["exception_type"] == "ValueError"
 
 
 def test_queue_wait_time_metric(metrics_start_shutdown):

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -922,7 +922,9 @@ def test_deployment_error_counter_exception_type(metrics_start_shutdown):
     assert httpx.get(url).status_code == 500
 
     def check_metric():
-        err_metrics = get_metric_dictionaries("ray_serve_deployment_error_counter_total")
+        err_metrics = get_metric_dictionaries(
+            "ray_serve_deployment_error_counter_total"
+        )
         value_error_metrics = [
             m for m in err_metrics if m.get("exception_type") == "ValueError"
         ]


### PR DESCRIPTION
## Description
This PR adds a new `exception_type` tag to the existing `ray_serve_deployment_error_counter_total` metric. This is helpful so you can filter by the exception_type and see the count for that particular exception_type without the noise of unrelated exceptions. For example, this can be used to diagnose backpressure to a deployment, as suggested by the original issue.

## Related issues
Fixes #59695

## Additional information
