### PR TITLE
[data][llm][doc] Add custom tokenizer example

### DIFF
--- a/doc/source/data/doc_code/working-with-llms/custom_tokenizer_example.py
+++ b/doc/source/data/doc_code/working-with-llms/custom_tokenizer_example.py
@@ -1,0 +1,195 @@
+"""
+Documentation example and test for custom tokenizer batch inference.
+
+Demonstrates how to use vLLM's tokenizer infrastructure for models whose
+tokenizers are not natively supported by HuggingFace (e.g. Mistral Tekken,
+DeepSeek-V3.2, Grok-2 tiktoken).
+
+This example uses a standard model to demonstrate the pattern. For models
+that truly require vLLM's custom tokenizer (e.g. deepseek-ai/DeepSeek-V3-0324),
+replace the model ID and adjust tokenizer_mode accordingly.
+"""
+
+# __custom_chat_template_start__
+from typing import Any, Dict, List
+from vllm.tokenizers import get_tokenizer
+
+
+class VLLMChatTemplate:
+    """Apply a chat template using vLLM's tokenizer."""
+
+    def __init__(self, model_id: str, tokenizer_mode: str = "auto"):
+        self.tokenizer = get_tokenizer(
+            model_id,
+            tokenizer_mode=tokenizer_mode,
+            trust_remote_code=True,
+        )
+
+    async def __call__(self, batch: Dict[str, Any]) -> Dict[str, Any]:
+        prompts: List[str] = []
+        all_messages: list = []
+
+        for messages in batch["messages"]:
+            if hasattr(messages, "tolist"):
+                messages = messages.tolist()
+            all_messages.append(messages)
+
+            add_generation_prompt = messages[-1]["role"] == "user"
+            prompt = self.tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=add_generation_prompt,
+                continue_final_message=not add_generation_prompt,
+            )
+            prompts.append(prompt)
+
+        return {
+            "prompt": prompts,
+            "messages": all_messages,
+            "sampling_params": batch["sampling_params"],
+        }
+
+
+# __custom_chat_template_end__
+
+
+# __custom_tokenize_start__
+class VLLMTokenize:
+    """Tokenize text prompts using vLLM's tokenizer."""
+
+    def __init__(self, model_id: str, tokenizer_mode: str = "auto"):
+        self.tokenizer = get_tokenizer(
+            model_id,
+            tokenizer_mode=tokenizer_mode,
+            trust_remote_code=True,
+        )
+
+    async def __call__(self, batch: Dict[str, Any]) -> Dict[str, Any]:
+        all_tokenized: List[List[int]] = []
+        for prompt in batch["prompt"]:
+            all_tokenized.append(self.tokenizer.encode(prompt))
+
+        return {
+            "tokenized_prompt": all_tokenized,
+            "messages": batch["messages"],
+            "sampling_params": batch["sampling_params"],
+        }
+
+
+# __custom_tokenize_end__
+
+
+# __custom_detokenize_start__
+class VLLMDetokenize:
+    """Detokenize generated token IDs using vLLM's tokenizer."""
+
+    def __init__(self, model_id: str, tokenizer_mode: str = "auto"):
+        self.tokenizer = get_tokenizer(
+            model_id,
+            tokenizer_mode=tokenizer_mode,
+            trust_remote_code=True,
+        )
+
+    async def __call__(self, batch: Dict[str, Any]) -> Dict[str, Any]:
+        decoded: List[str] = []
+        for tokens in batch["generated_tokens"]:
+            if hasattr(tokens, "tolist"):
+                tokens = tokens.tolist()
+            decoded.append(self.tokenizer.decode(tokens, skip_special_tokens=True))
+
+        return {
+            **batch,
+            "generated_text_custom": decoded,
+        }
+
+
+# __custom_detokenize_end__
+
+
+def run_custom_tokenizer_example():
+    import ray
+    from ray.data.llm import vLLMEngineProcessorConfig, build_processor
+
+    # Input dataset with sampling_params per row.
+    ds = ray.data.from_items(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "What is the capital of France?"}
+                ],
+                "sampling_params": {"max_tokens": 256, "temperature": 0.7},
+            },
+            {
+                "messages": [
+                    {"role": "user", "content": "Write a haiku about computing."}
+                ],
+                "sampling_params": {"max_tokens": 256, "temperature": 0.7},
+            },
+        ]
+    )
+
+    # __custom_tokenizer_pipeline_start__
+    MODEL_ID = "unsloth/Llama-3.1-8B-Instruct"
+
+    config = vLLMEngineProcessorConfig(
+        model_source=MODEL_ID,
+        engine_kwargs=dict(
+            max_model_len=4096,
+            trust_remote_code=True,
+            tokenizer_mode="auto",
+        ),
+        batch_size=4,
+        concurrency=1,
+        # Disable built-in stages -- we handle them via map_batches.
+        chat_template_stage=False,
+        tokenize_stage=False,
+        detokenize_stage=False,
+    )
+
+    processor = build_processor(
+        config,
+        postprocess=lambda row: {
+            "generated_text": row.get("generated_text", ""),
+            "generated_tokens": row.get("generated_tokens", []),
+            "num_input_tokens": row.get("num_input_tokens", 0),
+            "num_generated_tokens": row.get("num_generated_tokens", 0),
+        },
+    )
+
+    ds = ds.map_batches(
+        VLLMChatTemplate,
+        fn_constructor_kwargs={"model_id": MODEL_ID},
+        concurrency=1,
+        batch_size=4,
+    )
+
+    ds = ds.map_batches(
+        VLLMTokenize,
+        fn_constructor_kwargs={"model_id": MODEL_ID},
+        concurrency=1,
+        batch_size=4,
+    )
+
+    ds = processor(ds)
+
+    ds = ds.map_batches(
+        VLLMDetokenize,
+        fn_constructor_kwargs={"model_id": MODEL_ID},
+        concurrency=1,
+        batch_size=4,
+    )
+
+    # __custom_tokenizer_pipeline_end__
+    ds.show(limit=2)
+
+
+if __name__ == "__main__":
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            run_custom_tokenizer_example()
+        else:
+            print("Skipping custom tokenizer example (no GPU available)")
+    except Exception as e:
+        print(f"Skipping custom tokenizer example: {e}")

--- a/doc/source/data/doc_code/working-with-llms/custom_tokenizer_example.py
+++ b/doc/source/data/doc_code/working-with-llms/custom_tokenizer_example.py
@@ -27,7 +27,7 @@ class VLLMChatTemplate:
 
     async def __call__(self, batch: Dict[str, Any]) -> Dict[str, Any]:
         prompts: List[str] = []
-        all_messages: list = []
+        all_messages: List[List[Dict[str, Any]]] = []
 
         for messages in batch["messages"]:
             if hasattr(messages, "tolist"):
@@ -65,9 +65,9 @@ class VLLMTokenize:
         )
 
     async def __call__(self, batch: Dict[str, Any]) -> Dict[str, Any]:
-        all_tokenized: List[List[int]] = []
-        for prompt in batch["prompt"]:
-            all_tokenized.append(self.tokenizer.encode(prompt))
+        all_tokenized: List[List[int]] = [
+            self.tokenizer.encode(prompt) for prompt in batch["prompt"]
+        ]
 
         return {
             "tokenized_prompt": all_tokenized,

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -19,6 +19,7 @@ The :ref:`ray.data.llm <llm-ref>` module enables scalable batch inference on Ray
 * :ref:`Multimodality <multimodal>` - Batch inference with VLM / omni models on multimodal data
 * :ref:`OpenAI-compatible endpoints <openai_compatible_api_endpoint>` - Query deployed models
 * :ref:`Serve deployments <serve_deployments>` - Share vLLM engines across processors
+* :ref:`Custom tokenizers <custom_tokenizers>` - Use vLLM tokenizers for models not supported by HuggingFace
 
 **Operations:**
 
@@ -310,6 +311,46 @@ Query deployed models with an OpenAI-compatible API:
     :language: python
     :start-after: __openai_example_start__
     :end-before: __openai_example_end__
+
+.. _custom_tokenizers:
+
+Custom tokenizers
+-----------------
+
+Use this pattern when a model is supported by vLLM but not by HuggingFace ``transformers`` — for example, Mistral Tekken (``mistral``), DeepSeek-V3 (``deepseek_v32``), or Grok-2 (``grok2``).
+The built-in ChatTemplate, Tokenize, and Detokenize stages rely on HuggingFace and will fail for these models. In the following example, we disable the built-in CPU stages and replace them with ``map_batches`` callables.
+
+**Chat template**: Converts OpenAI-format messages into the prompt string the model expects. Required because each model family defines its own chat format:
+
+.. literalinclude:: doc_code/working-with-llms/custom_tokenizer_example.py
+    :language: python
+    :start-after: __custom_chat_template_start__
+    :end-before: __custom_chat_template_end__
+
+**Tokenize**: Converts the prompt string into token IDs for the model.
+
+.. literalinclude:: doc_code/working-with-llms/custom_tokenizer_example.py
+    :language: python
+    :start-after: __custom_tokenize_start__
+    :end-before: __custom_tokenize_end__
+
+**Detokenize** (optional): Decodes generated token IDs back to text. The vLLM engine already returns ``generated_text``, so this is only needed for custom decoding (e.g. different ``skip_special_tokens`` settings):
+
+.. literalinclude:: doc_code/working-with-llms/custom_tokenizer_example.py
+    :language: python
+    :start-after: __custom_detokenize_start__
+    :end-before: __custom_detokenize_end__
+
+Build a processor with built-in stages disabled and compose the full pipeline:
+
+.. literalinclude:: doc_code/working-with-llms/custom_tokenizer_example.py
+    :language: python
+    :start-after: __custom_tokenizer_pipeline_start__
+    :end-before: __custom_tokenizer_pipeline_end__
+    :dedent: 4
+
+.. note::
+    This example uses a standard model because models that truly require vLLM's custom tokenizer are too large for Ray CI environments. The pattern is identical — just replace ``MODEL_ID`` and set ``tokenizer_mode`` explicitly.
 
 .. _troubleshooting:
 


### PR DESCRIPTION
## Description
Some models supported by vLLM are not currently supported by Ray Data LLM because they are not supported by Hugging Face `transformers`, which Ray Data LLM depends on. To address this gap, we introduced a framework-level change https://github.com/ray-project/ray/pull/60854 that avoids failing fast when a model is not supported by `transformers`. We now provide a documentation example demonstrating how to integrate vLLM’s tokenizer implementation with Ray Data LLM to enable support for these models.

## Related issues
Closes #60780

## Additional information
Documentation:
<img width="3046" height="1241" alt="Screenshot 2026-02-16 at 10 27 16 PM" src="https://github.com/user-attachments/assets/6937dc5b-d1d5-499d-838f-a98f056971f1" />
<img width="3039" height="744" alt="Screenshot 2026-02-16 at 10 27 35 PM" src="https://github.com/user-attachments/assets/8b298bc0-4ae5-4953-9649-4e228827de44" />

