### PR TITLE
[WIP][core] Fix CHECK failure in HandleTaskExecutionResult caused by unhandled KeyboardInterrupt in Cython task handler

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1008,12 +1008,21 @@ cdef store_task_errors(
     for _ in range(returns[0].size()):
         errors.append(failure_object)
 
+    # DEBUG: Log store_task_errors entry and exit to trace the cancellation path.
+    logger.info(
+        "store_task_errors: storing %d error(s) of type %s",
+        len(errors), type(exc).__name__)
+
     num_errors_stored = core_worker.store_task_outputs(
         worker, errors,
         caller_address,
         returns,
         None,  # ref_generator_id
         NULL_TENSOR_TRANSPORT)
+
+    logger.info(
+        "store_task_errors: stored %d error(s) successfully",
+        num_errors_stored)
 
     if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
         raise ActorDiedError.from_task_error(failure_object)
@@ -2169,6 +2178,20 @@ cdef execute_task_with_cancellation_handler(
     except KeyboardInterrupt as e:
         # Catch and handle task cancellation, which will result in an interrupt being
         # raised.
+        #
+        # Immediately clear current_task_id to prevent further cancellation
+        # interrupts from arriving during error storage. kill_main_task
+        # checks current_task_id under the lock before sending
+        # _thread.interrupt_main(). Without this, a second ray.cancel()
+        # could interrupt store_task_errors, causing a KeyboardInterrupt to
+        # escape task_execution_handler entirely.
+        with current_task_id_lock:
+            logger.info(
+                "KeyboardInterrupt caught: clearing current_task_id "
+                "(was %s) to prevent further interrupts during "
+                "error storage.", current_task_id)
+            current_task_id = None
+
         e = TaskCancelledError(
             core_worker.get_current_task_id()).with_traceback(e.__traceback__)
 
@@ -2363,6 +2386,16 @@ cdef CRayStatus task_execution_handler(
             msg = "Unexpected exception raised in task execution handler: {}".format(e)
             logger.error(msg)
             return CRayStatus.UnexpectedSystemExit(msg)
+        except BaseException as e:
+            # Safety net: catch any BaseException (e.g. KeyboardInterrupt) that
+            # escapes inner handlers. Without this, Cython silently returns
+            # CRayStatus.OK() for unhandled non-Exception/non-SystemExit
+            # exceptions, causing a CHECK failure in HandleTaskExecutionResult
+            # when return objects are not populated.
+            msg = ("BaseException escaped task execution handlers: "
+                   f"{type(e).__name__}: {e}")
+            logger.error(msg)
+            return CRayStatus.UnexpectedSystemExit(msg)
 
     return CRayStatus.OK()
 
@@ -2371,7 +2404,17 @@ cdef c_bool kill_main_task(const CTaskID &task_id) nogil:
         task_id_to_kill = TaskID(task_id.Binary())
         with current_task_id_lock:
             if current_task_id != task_id_to_kill:
+                # DEBUG: Log when a cancel is skipped because
+                # current_task_id was already cleared (e.g. by the
+                # except KeyboardInterrupt handler).
+                logger.info(
+                    "kill_main_task: skipping interrupt, "
+                    "current_task_id=%s != task_id_to_kill=%s",
+                    current_task_id, task_id_to_kill)
                 return False
+            logger.info(
+                "kill_main_task: sending interrupt for task %s",
+                task_id_to_kill)
             _thread.interrupt_main()
             return True
 

--- a/test_core_2834.py
+++ b/test_core_2834.py
@@ -1,0 +1,100 @@
+"""
+Regression test for CHECK failure in HandleTaskExecutionResult.
+
+Bug: A double ray.cancel() could crash the worker with:
+    Check failed: objects_valid 1 return objects expected, 1 returned.
+    Object at idx 0 was not stored.
+
+The trigger sequence was:
+  1. Task is running
+  2. First ray.cancel() --> KeyboardInterrupt interrupts the task
+  3. execute_task re-raises KeyboardInterrupt
+  4. execute_task_with_cancellation_handler catches it, calls store_task_errors
+  5. Second ray.cancel() --> KeyboardInterrupt during store_task_errors
+     (current_task_id was still set, so kill_main_task sent the interrupt)
+  6. KeyboardInterrupt escaped all handlers in task_execution_handler
+  7. Cython silently returned default CRayStatus (OK)
+  8. HandleTaskExecutionResult found status=OK but return_objects[0]=nullptr
+  9. CHECK failure
+
+Fix (in _raylet.pyx):
+  - Layer 1: Clear current_task_id at the start of the except KeyboardInterrupt
+    handler in execute_task_with_cancellation_handler, preventing kill_main_task
+    from sending a second _thread.interrupt_main() during error storage.
+  - Layer 2: Added except BaseException handler in task_execution_handler as a
+    safety net, returning CRayStatus.UnexpectedSystemExit instead of letting
+    Cython fall through to CRayStatus.OK().
+
+USAGE:
+  Run this script with the fix applied:
+      python test_core_2834.py
+
+  Expected: [driver] Got TaskCancelledError (expected if fix is in place)
+
+REPRODUCING THE ORIGINAL BUG (requires reverting the fix):
+  1. Revert the two changes in _raylet.pyx (remove the early
+     current_task_id = None and the except BaseException handler).
+  2. Add a sleep to widen the error-storage window. In _raylet.pyx,
+     inside store_task_errors, add "import time; time.sleep(3)"
+     right before the store_task_outputs call (around line 1021).
+  3. Rebuild Ray: cd python && python setup.py build_ext --inplace
+  4. Run this script. The worker should crash with the CHECK failure.
+"""
+
+import time
+
+import ray
+
+
+@ray.remote(num_returns=1)
+def long_running_task():
+    """A task that uses a busy-wait loop so KeyboardInterrupt is delivered
+    promptly."""
+    import time as _time
+
+    end = _time.monotonic() + 120
+    while _time.monotonic() < end:
+        _time.sleep(0.05)
+    return 42
+
+
+def main():
+    ray.init(num_cpus=1)
+    try:
+        ref = long_running_task.remote()
+
+        # Wait for task to start executing on the worker
+        time.sleep(2)
+
+        print("[driver] Sending first cancel (interrupts the task)...")
+        ray.cancel(ref)
+
+        # The first cancel delivers KeyboardInterrupt, which propagates to
+        # execute_task_with_cancellation_handler's except handler, which calls
+        # store_task_errors. Wait briefly then send a second cancel. With the
+        # fix, the second cancel is harmless (current_task_id is already cleared).
+        # Without the fix, this second interrupt would escape and crash the worker.
+        time.sleep(1)
+
+        print("[driver] Sending second cancel (interrupts error storage)...")
+        ray.cancel(ref)
+
+        # Wait for the worker to process
+        time.sleep(5)
+
+        try:
+            result = ray.get(ref, timeout=30)
+            print(f"[driver] Unexpected success: {result}")
+        except ray.exceptions.TaskCancelledError:
+            print("[driver] Got TaskCancelledError (expected if fix is in place)")
+        except ray.exceptions.WorkerCrashedError as e:
+            print(f"[driver] Worker crashed (CHECK failure triggered): {e}")
+        except Exception as e:
+            print(f"[driver] Got exception: {type(e).__name__}: {e}")
+
+    finally:
+        ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

After many workers were OOM-killed, we observed workers crashing with:
```
 An unexpected system state has occurred. You have likely discovered a bug in Ray. Please report this issue at https://github.com/ray-project/ray/issues and we'll work with you to fix it. Check failed: objects_valid 1 return objects expected, 1 returned. Object at idx 0 was not stored.
*** StackTrace Information ***
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0x16cba5a) [0x7ace53ba0a5a] ray::operator<<()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(_ZN3ray6RayLogD1Ev+0x469) [0x7ace53ba3089] ray::RayLog::~RayLog()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0xb68d59) [0x7ace5303dd59] ray::core::TaskReceiver::HandleTask()::{lambda()#1}::operator()()::{lambda()#1}::operator()()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0xb848d2) [0x7ace530598d2] ray::core::InboundRequest::Accept()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0xb74fab) [0x7ace53049fab] ray::core::NormalSchedulingQueue::ScheduleRequests()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0x10237ab) [0x7ace534f87ab] EventTracker::RecordExecution()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0x101a2cb) [0x7ace534ef2cb] std::_Function_handler<>::_M_invoke()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0xb9862b) [0x7ace5306d62b] boost::asio::detail::executor_op<>::do_complete()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0x1696cdb) [0x7ace53b6bcdb] boost::asio::detail::scheduler::do_run_one()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0x1698679) [0x7ace53b6d679] boost::asio::detail::scheduler::run()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0x1698d82) [0x7ace53b6dd82] boost::asio::io_context::run()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(_ZN3ray4core10CoreWorker20RunTaskExecutionLoopEv+0x127) [0x7ace52eea2d7] ray::core::CoreWorker::RunTaskExecutionLoop()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(_ZN3ray4core21CoreWorkerProcessImpl26RunWorkerTaskExecutionLoopEv+0x41) [0x7ace52f3d0e1] ray::core::CoreWorkerProcessImpl::RunWorkerTaskExecutionLoop()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(_ZN3ray4core17CoreWorkerProcess20RunTaskExecutionLoopEv+0x1d) [0x7ace52f3d2fd] ray::core::CoreWorkerProcess::RunTaskExecutionLoop()
/home/ray/anaconda3/lib/python3.12/site-packages/ray/_raylet.so(+0x88a1d1) [0x7ace52d5f1d1] __pyx_pw_3ray_7_raylet_10CoreWorker_5run_task_loop()
ray::IDLE(PyObject_Vectorcall+0x2e) [0x5a716f14d55e] PyObject_Vectorcall
ray::IDLE(+0x1127e4) [0x5a716f0467e4] _PyEval_EvalFrameDefault.cold
ray::IDLE(PyEval_EvalCode+0xa1) [0x5a716f1ef341] PyEval_EvalCode
ray::IDLE(+0x2df9ba) [0x5a716f2139ba] run_eval_code_obj
ray::IDLE(+0x2da9c5) [0x5a716f20e9c5] run_mod
ray::IDLE(+0x2f32d0) [0x5a716f2272d0] pyrun_file
ray::IDLE(_PyRun_SimpleFileObject+0x1ce) [0x5a716f22694e] _PyRun_SimpleFileObject
ray::IDLE(_PyRun_AnyFileObject+0x44) [0x5a716f226614] _PyRun_AnyFileObject
ray::IDLE(Py_RunMain+0x2fe) [0x5a716f21f89e] Py_RunMain
ray::IDLE(Py_BytesMain+0x37) [0x5a716f1d9477] Py_BytesMain
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ace54750d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7ace54750e40] __libc_start_main
ray::IDLE(+0x2a5321) [0x5a716f1d9321]
```

The stack trace originated from `HandleTaskExecutionResult` in [task_receiver](https://github.com/ray-project/ray/blob/871bc89176a526f5725ee10caf4722e701dfbe84/src/ray/core_worker/task_execution/task_receiver.cc#L81), which asserts that when the task execution status is `OK`, all return objects must be populated (non-null).

This check only fires when two conditions are simultaneously true:
1. `status.ok()` - the task execution callback reported success
2. `objects_valid` is false i.e. at least one return object is `nullptr`

This means the Python/Cython task execution callback (`task_execution_handler` in [_raylet.pyx](https://github.com/ray-project/ray/blob/871bc89176a526f5725ee10caf4722e701dfbe84/python/ray/_raylet.pyx#L2272)) returned `CRayStatus.OK()` without having stored any return objects. I traced the only path where this could happen:

`task_execution_handler` is a `cdef` function declared `nogil` that returns `CRayStatus`. It catches `Exception` and `SystemExit`, but not `BaseException`. In Cython, when a non-`Exception`/non-`SystemExit` `BaseException` (like `KeyboardInterrupt`) escapes a `cdef` function that returns a C++ type, Cython cannot propagate the Python exception across the C/C++ boundary. Instead, it calls `__Pyx_WriteUnraisable` (which prints to stderr and clears the exception) and falls through to the default return: `return CRayStatus.OK()`.

### The trigger sequence

The OOM-kill scenario triggers `ray.cancel()` on tasks, which calls `kill_main_task` --> `_thread.interrupt_main()` to deliver `KeyboardInterrupt` to the worker's main thread. A double cancellation (or rapid OOM kills) creates this sequence:

1. First `ray.cancel()` --> `kill_main_task` sends `_thread.interrupt_main()`
2. `KeyboardInterrupt` interrupts the running task
3. `execute_task_with_cancellation_handler` catches it, calls `store_task_errors`
4. Second `ray.cancel()` --> `kill_main_task` checks `current_task_id` (still set) --> sends another `_thread.interrupt_main()`
5. Second `KeyboardInterrupt` interrupts `store_task_errors` before it completes
6. `KeyboardInterrupt` propagates out of the `except KeyboardInterrupt` handler
7. Reaches `task_execution_handler`, which has no `BaseException` handler
8. Cython swallows the exception, returns `CRayStatus.OK()`
9. `HandleTaskExecutionResult` finds `status=OK` but `return_objects[0]=nullptr` --> **CHECK failure**

I confirmed this with instrumented debug logging (still present for reviewer reference). Steps to repro is in `test_core_2834.py` for reference (i will cleanup and turn this into a proper test).

**Before fix** - second cancel sends the interrupt during error storage:
`kill_main_task`: sending interrupt for task <id> # 1st cancel
`store_task_errors`: storing 1 error(s) of type TaskCancelledError
`kill_main_task`: sending interrupt for task <id> # 2nd cancel - interrupts `store_task_errors`
`BaseException` escaped task execution handlers: KeyboardInterrupt # escapes to Cython --> CHECK failure


**After fix** - second cancel is rejected because `current_task_id` was already cleared:
`kill_main_task`: sending interrupt for task <id> # 1st cancel
`KeyboardInterrupt` caught: clearing `current_task_id` to prevent further interrupts
`store_task_errors`: storing 1 error(s) of type `TaskCancelledError`
`kill_main_task`: skipping interrupt, `current_task_id=None` # 2nd cancel - blocked
`store_task_errors`: stored 1 error(s) successfully # completes normally


## Fix

Two layers of defense in `_raylet.pyx`:

**Layer 1:** In `execute_task_with_cancellation_handler`'s `except KeyboardInterrupt` handler, clear `current_task_id` immediately *before* calling `store_task_errors`. Since `kill_main_task` checks `current_task_id` under a lock before sending `_thread.interrupt_main()`, this prevents any subsequent cancel from delivering a second interrupt during error storage.

**Layer 2 (safety net):** Add an `except BaseException` handler in `task_execution_handler` that returns `CRayStatus.UnexpectedSystemExit()`. This catches any `BaseException` (e.g. `KeyboardInterrupt`, `GeneratorExit`) that might escape inner handlers for any reason, preventing Cython's silent fallthrough to `CRayStatus.OK()`.
