### PR TITLE
[rllib] Add APPO release tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1979,28 +1979,228 @@
 # RLlib tests #
 ###############
 
-# -----------------
-# RLlib - APPO test
-# -----------------
-- name: rllib_learning_tests_pong_appo_torch
+# --------------------------
+# APPO
+#
+# | APPO (12 total tests)          |         |                Number of Learners (Device)                                                      |
+# | Environment                    | Success | Local (CPU) | Single (CPU)    | Single (GPU) | Multi (GPU) Single Node | Multi (GPU) Multi Node |
+# |--------------------------------|---------|-------------|-----------------|--------------|-------------------------|------------------------|
+# | (SA/D) Cartpole                | 450     | ✅          | ✅              | ❌            | ❌                      | ❌                     |
+# | (SA/D/LSTM) Stateless Cartpole | 350     | ✅          | ❌              | ✅            | ❌                      | ❌                     |
+# | (MA/D) TicTacToe               | -0.5    | ✅          | ✅              | ❌            | ✅                      | ❌                     |
+# | (SA/D) Atari (Pong)            | 18      | ❌          | ❌              | ❌            | ✅                      | ✅                     |
+# | (MA/D) Footsies                | 7       | ❌          | ❌              | ✅            | ❌                      | ✅                     |
+# | (SA/C) IsaacLab (Humanoid)     | ??      | ❌          | ✅ (with 1 GPU) | ⚠️            | ❌                      | ❌                     |
+#
+# --------------------------
+
+- name: rllib_appo_cartpole_local
   python: "3.10"
   group: RLlib tests
   working_dir: rllib_tests
 
-  frequency: nightly
+  frequency: nightly-3x
+  team: rllib
+
+  cluster:
+    byod:
+      post_build_script: byod_rllib.sh
+    cluster_compute: cpu_single_node.yaml
+
+  run:
+    timeout: 3000  # 50 minutes; expected 1000 seconds (~16 minutes)
+    script: |
+      python example_algorithms/appo/cartpole_appo.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-env-runners=4 \
+        --num-learners=0
+
+- name: rllib_appo_cartpole_single_cpu
+  python: "3.10"
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  frequency: nightly-3x
+  team: rllib
+
+  cluster:
+    byod:
+      post_build_script: byod_rllib.sh
+    cluster_compute: cpu_single_node.yaml
+
+  run:
+    timeout: 3000  # 50 minutes; expected 2000 seconds (~30 minutes)
+    script: |
+      python example_algorithms/appo/cartpole_appo.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-cpus-per-learner=1 \
+        --num-env-runners=4 \
+        --num-learners=1
+
+- name: rllib_appo_stateless_cartpole_local
+  python: "3.10"
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  frequency: nightly-3x
+  team: rllib
+
+  cluster:
+    byod:
+      post_build_script: byod_rllib.sh
+    cluster_compute: cpu_single_node.yaml
+
+  run:
+    timeout: 3000  # 50 minutes; expected 2000 seconds (~30 minutes)
+    script: |
+      python example_algorithms/appo/stateless_cartpole_appo_with_lstm.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-env-runners=4 \
+        --num-learners=0
+
+- name: rllib_appo_stateless_cartpole_single_gpu
+  python: "3.10"
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  frequency: nightly-3x
   team: rllib
 
   cluster:
     byod:
       type: gpu
       post_build_script: byod_rllib.sh
-      runtime_env:
-        - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_compute: 1gpu_16cpus.yaml
+    cluster_compute: single_gpu_single_node.yaml
 
   run:
-    timeout: 1500  # expected 1000 seconds
-    script: python example_algorithms/appo/pong_appo.py --num-learners=1 --num-env-runners=12 --as-release-test
+    timeout: 3000  # 50 minutes; expected 2000 seconds (~30 minutes)
+    script: |
+      python example_algorithms/appo/stateless_cartpole_appo_with_lstm.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-env-runners=4 \
+        --num-gpus-per-learner=1 \
+        --num-learners=1
+
+- name: rllib_appo_tictactoe_local
+  python: "3.10"
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  frequency: nightly-3x
+  team: rllib
+
+  cluster:
+    byod:
+      post_build_script: byod_rllib.sh
+    cluster_compute: cpu_single_node.yaml
+
+  run:
+    timeout: 3000  # 50 minutes; expected 2000 seconds (~30 minutes)
+    script: |
+      python example_algorithms/appo/tictactoe_appo.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-env-runners=4 \
+        --num-learners=0
+
+- name: rllib_appo_tictactoe_single_cpu
+  python: "3.10"
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  frequency: nightly-3x
+  team: rllib
+
+  cluster:
+    byod:
+      post_build_script: byod_rllib.sh
+    cluster_compute: cpu_single_node.yaml
+
+  run:
+    timeout: 3000  # 50 minutes; expected 2000 seconds (~30 minutes)
+    script: |
+      python example_algorithms/appo/tictactoe_appo.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-cpus-per-learner=1 \
+        --num-env-runners=4 \
+        --num-learners=1
+
+- name: rllib_appo_tictactoe_multi_gpu_single_node
+  python: "3.10"
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  frequency: nightly-3x
+  team: rllib
+
+  cluster:
+    byod:
+      type: gpu
+      post_build_script: byod_rllib.sh
+    cluster_compute: multi_gpu_single_node.yaml
+
+  run:
+    timeout: 3000  # 50 minutes; expected 2000 seconds (~30 minutes)
+    script: |
+      python example_algorithms/appo/tictactoe_appo.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-env-runners=8 \
+        --num-gpus-per-learner=1 \
+        --num-learners=2
+
+- name: rllib_appo_atari_multi_gpu_single_node
+  python: "3.10"
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  frequency: nightly-3x
+  team: rllib
+
+  cluster:
+    byod:
+      type: gpu
+      post_build_script: byod_rllib.sh
+    cluster_compute: multi_gpu_single_node.yaml
+
+  run:
+    timeout: 3000  # 50 minutes; expected 2000 seconds (~30 minutes)
+    script: |
+      python example_algorithms/appo/atari_appo.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-env-runners=8 \
+        --num-gpus-per-learner=1 \
+        --num-learners=2
+
+- name: rllib_appo_atari_multi_gpu_multi_node
+  python: "3.10"
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  frequency: nightly-3x
+  team: rllib
+
+  cluster:
+    byod:
+      type: gpu
+      post_build_script: byod_rllib.sh
+    cluster_compute: multi_gpu_multi_node.yaml
+
+  run:
+    timeout: 3000  # 50 minutes; expected 2000 seconds (~30 minutes)
+    script: |
+      python example_algorithms/appo/atari_appo.py \
+        --as-release-test \
+        --num-aggregator-actors-per-learner=2 \
+        --num-env-runners=8 \
+        --num-gpus-per-learner=1 \
+        --num-learners=2
 
 ########################
 # Core Nightly Tests

--- a/release/rllib_tests/cpu_single_node.yaml
+++ b/release/rllib_tests/cpu_single_node.yaml
@@ -5,7 +5,7 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: g5.4xlarge
+    instance_type: r7a.2xlarge  # 0 gpus with 8 cpus
 
 worker_node_types: []
 

--- a/release/rllib_tests/multi_gpu_multi_node.yaml
+++ b/release/rllib_tests/multi_gpu_multi_node.yaml
@@ -1,13 +1,20 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-max_workers: 2
+max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: g5.24xlarge
+    instance_type: r7a.2xlarge
+    resources:
+      cpu: 0
 
-worker_node_types: []
+worker_node_types:
+    - name: worker_node
+      instance_type: g5.2xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false
 
 advanced_configurations_json:
     BlockDeviceMappings:

--- a/release/rllib_tests/multi_gpu_single_node.yaml
+++ b/release/rllib_tests/multi_gpu_single_node.yaml
@@ -5,7 +5,7 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: g4dn.12xlarge
+    instance_type: g5.12xlarge  # 4 gpus with 48 cpus
 
 worker_node_types: []
 

--- a/release/rllib_tests/single_gpu_single_node.yaml
+++ b/release/rllib_tests/single_gpu_single_node.yaml
@@ -1,18 +1,13 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-max_workers: 2
+max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: g5.12xlarge
+    instance_type: g5.4xlarge  # 1 gpu with 16 cpus
 
-worker_node_types:
-    - name: worker_node
-      instance_type: m5.4xlarge
-      min_workers: 1
-      max_workers: 1
-      use_spot: false
+worker_node_types: []
 
 advanced_configurations_json:
     BlockDeviceMappings:


### PR DESCRIPTION
## Description
This PR adds a number of APPO examples to our release tests to help ensure RLlib performance over time

These release tests are run three times per week (nightly 3x) with a timeout of 3000 seconds.
We'll be monitoring the results from a dashboard to understand how performance changes over time. 

## Related issues
Release tests from https://github.com/ray-project/ray/pull/59007

