### PR TITLE
[Serve] Add serve_async_inference_queue_length metric

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -403,6 +403,13 @@ class ServeController:
                 "application": report.deployment_id.app_name,
             },
         )
+        self.async_inference_queue_length_gauge.set(
+            report.queue_length,
+            tags={
+                "deployment": report.deployment_id.name,
+                "application": report.deployment_id.app_name,
+            },
+        )
         if latency_ms > RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS:
             logger.warning(
                 f"Received async inference task queue metrics for deployment "
@@ -783,6 +790,14 @@ class ServeController:
             description=(
                 "Time taken for the async inference task queue metrics to be reported "
                 "to the controller. High values may indicate a busy controller."
+            ),
+            tag_keys=("deployment", "application"),
+        )
+        self.async_inference_queue_length_gauge = metrics.Gauge(
+            "serve_async_inference_queue_length",
+            description=(
+                "Number of pending tasks in the broker queue for async inference. "
+                "High values indicate tasks are waiting longer to be processed."
             ),
             tag_keys=("deployment", "application"),
         )

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -395,21 +395,13 @@ class ServeController:
         """Record async inference task queue metrics pushed from QueueMonitor."""
         latency = time.time() - report.timestamp_s
         latency_ms = latency * 1000
-        # Record the metrics delay for observability
-        self.async_inference_task_queue_metrics_delay_gauge.set(
-            latency_ms,
-            tags={
-                "deployment": report.deployment_id.name,
-                "application": report.deployment_id.app_name,
-            },
-        )
-        self.async_inference_queue_length_gauge.set(
-            report.queue_length,
-            tags={
-                "deployment": report.deployment_id.name,
-                "application": report.deployment_id.app_name,
-            },
-        )
+        # Record the metrics delay and queue length for observability
+        tags = {
+            "deployment": report.deployment_id.name,
+            "application": report.deployment_id.app_name,
+        }
+        self.async_inference_task_queue_metrics_delay_gauge.set(latency_ms, tags=tags)
+        self.async_inference_queue_length_gauge.set(report.queue_length, tags=tags)
         if latency_ms > RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS:
             logger.warning(
                 f"Received async inference task queue metrics for deployment "

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -729,6 +729,114 @@ def test_async_inference_task_queue_metrics_delay(
             pass  # Actor may already be killed
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Async Inference feature testing is flaky on Windows.",
+)
+def test_async_inference_queue_length_metric(
+    metrics_start_shutdown, external_redis  # noqa: F811
+):
+    """Test that async inference queue length metric is emitted correctly.
+
+    This tests the metric:
+    - ray_serve_async_inference_queue_length
+        Tags: deployment, application
+
+    The QueueMonitor periodically pushes queue length metrics to the controller,
+    and the controller's autoscaling state records the queue length as a gauge.
+    """
+    # Setup Redis client
+    redis_address = os.environ.get("RAY_REDIS_ADDRESS")
+    host, port = redis_address.split(":")
+    redis_client = redis.Redis(host=host, port=int(port), db=0)
+    redis_broker_url = f"redis://{redis_address}/0"
+
+    test_deployment_id = DeploymentID("test_deployment", "test_app")
+    test_queue_name = "test_queue_length_metric_queue"
+
+    try:
+        # Create QueueMonitor with the Serve controller
+        controller = ray.get_actor(SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
+        queue_monitor = create_queue_monitor_actor(
+            deployment_id=test_deployment_id,
+            broker_url=redis_broker_url,
+            queue_name=test_queue_name,
+            controller_handle=controller,
+            namespace=SERVE_NAMESPACE,
+        )
+
+        # Push some messages to the queue
+        num_messages = 7
+        for i in range(num_messages):
+            redis_client.lpush(test_queue_name, f"message_{i}")
+
+        # Wait for the queue length to be picked up
+        def check_length():
+            return ray.get(queue_monitor.get_queue_length.remote()) == num_messages
+
+        wait_for_condition(check_length, timeout=30)
+
+        timeseries = PrometheusTimeseries()
+        base_tags = {
+            "deployment": test_deployment_id.name,
+            "application": test_deployment_id.app_name,
+        }
+
+        # Wait for the queue length metric to be emitted with correct value and tags
+        def check_queue_length_metric():
+            value = get_metric_float(
+                "ray_serve_async_inference_queue_length",
+                expected_tags=base_tags,
+                timeseries=timeseries,
+            )
+            if value != num_messages:
+                return False
+
+            # Verify correct tags are attached
+            metrics_dicts = get_metric_dictionaries(
+                "ray_serve_async_inference_queue_length",
+                timeout=5,
+                timeseries=timeseries,
+            )
+            for m in metrics_dicts:
+                if (
+                    m.get("deployment") == test_deployment_id.name
+                    and m.get("application") == test_deployment_id.app_name
+                ):
+                    assert "deployment" in m, "Missing 'deployment' tag"
+                    assert "application" in m, "Missing 'application' tag"
+                    return True
+            return False
+
+        wait_for_condition(check_queue_length_metric, timeout=30)
+
+        # Verify the metric updates when queue length changes
+        # Remove some messages
+        for i in range(3):
+            redis_client.rpop(test_queue_name)
+
+        expected_remaining = num_messages - 3
+
+        def check_updated_queue_length():
+            value = get_metric_float(
+                "ray_serve_async_inference_queue_length",
+                expected_tags=base_tags,
+                timeseries=timeseries,
+            )
+            return value == expected_remaining
+
+        wait_for_condition(check_updated_queue_length, timeout=30)
+
+    finally:
+        # Cleanup
+        redis_client.delete(test_queue_name)
+        redis_client.close()
+        try:
+            kill_queue_monitor_actor(test_deployment_id, namespace=SERVE_NAMESPACE)
+        except ValueError:
+            pass  # Actor may already be killed
+
+
 def test_user_autoscaling_stats_metrics(metrics_start_shutdown):
     """Test that user-defined autoscaling stats metrics are emitted correctly.
 

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -783,30 +783,15 @@ def test_async_inference_queue_length_metric(
         }
 
         # Wait for the queue length metric to be emitted with correct value and tags
+        # get_metric_float already filters by expected_tags, so if it
+        # returns a matching value the tags are guaranteed correct.
         def check_queue_length_metric():
             value = get_metric_float(
                 "ray_serve_async_inference_queue_length",
                 expected_tags=base_tags,
                 timeseries=timeseries,
             )
-            if value != num_messages:
-                return False
-
-            # Verify correct tags are attached
-            metrics_dicts = get_metric_dictionaries(
-                "ray_serve_async_inference_queue_length",
-                timeout=5,
-                timeseries=timeseries,
-            )
-            for m in metrics_dicts:
-                if (
-                    m.get("deployment") == test_deployment_id.name
-                    and m.get("application") == test_deployment_id.app_name
-                ):
-                    assert "deployment" in m, "Missing 'deployment' tag"
-                    assert "application" in m, "Missing 'application' tag"
-                    return True
-            return False
+            return value == num_messages
 
         wait_for_condition(check_queue_length_metric, timeout=30)
 


### PR DESCRIPTION
## Summary

- Adds a new `serve_async_inference_queue_length` Gauge metric that exports the number of pending tasks in the broker queue for async inference deployments
- Tags: `deployment`, `application`
- Includes an E2E test that verifies the metric is emitted with correct value and tags, and updates when queue length changes

## Why

This is the most critical observability signal for async inference. Without it, users are blind to queue buildup, which directly causes latency spikes and can indicate under-provisioned replicas. The queue length was already tracked internally (via `AsyncInferenceTaskQueueMetricReport` to the controller for autoscaling decisions) but was never exported as a Ray metric for external monitoring/alerting.

## Design: Two Approaches Considered

### Approach A: Emit from QueueMonitorActor

Add a `ray.util.metrics.Gauge` directly on the `QueueMonitorActor` and set it in `_push_metrics_to_controller()` alongside the existing broker query.

- (+) Zero additional broker queries — piggybacks on existing poll
- (+) Single source of truth — one actor per deployment
- (-) QueueMonitorActor currently has zero metrics — it's a lightweight data collection agent, not a metrics-emitting component
- (-) Inconsistent with existing patterns — all async inference and autoscaling metrics live on the controller

### Approach B: Emit from Controller (chosen)

Add the Gauge on the `ServeController` and set it in `record_autoscaling_metrics_from_async_inference_task_queue()`, right next to the existing `serve_autoscaling_async_inference_task_queue_metrics_delay_ms` gauge.

- (+) Consistent with existing patterns — the only existing async inference metric (`delay_ms`) is already set in this exact method
- (+) All autoscaling-related metrics (`desired_replicas`, `total_requests`, `policy_execution_time_ms`) live in the controller process
- (+) Always emits the metric regardless of whether the deployment has autoscaling configured (the autoscaling state manager silently drops reports for unregistered deployments)
- (+) Minimal code — `gauge.set()` next to the existing delay gauge
- (+) Negligible additional latency (QueueMonitor → Controller RPC is milliseconds, both on head node)

**We chose Approach B** because it is consistent with how every other async inference and autoscaling metric is implemented, and because emitting at the controller level guarantees the metric is always available.

## Test plan

- [x] New E2E test `test_async_inference_queue_length_metric` — creates QueueMonitor with Redis, pushes messages, verifies metric value and tags in Prometheus, then verifies the metric updates when messages are removed
- [x] Existing `test_async_inference_task_queue_metrics_delay` still passes
- [x] `test_autoscaling_policy.py` unit tests (28/28) pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)