### PR TITLE
[Data] Move output_dependencies responsibilities to PhysicalOperator

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -414,6 +414,8 @@ class PhysicalOperator(Operator):
         # 3) Apply transform on the current node itself. If transform replaces
         # the current node, rewire reverse dependencies from old node inputs
         # to the returned replacement node inputs.
+        # Returning the same node must not mutate inputs in-place.
+        original_inputs = tuple(target.input_dependencies)
         transformed_target = transform(target)
         if transformed_target is not target:
             for input_op in target.input_dependencies:
@@ -424,6 +426,10 @@ class PhysicalOperator(Operator):
             transformed_target._rewire_output_deps(
                 target, transformed_target.input_dependencies
             )
+        else:
+            assert (
+                tuple(transformed_target.input_dependencies) == original_inputs
+            ), "In-place input mutation is not supported; return a new node instead."
         return transformed_target
 
     def _copy_for_transform(self) -> "PhysicalOperator":

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -332,9 +332,11 @@ class PhysicalOperator(Operator):
         target_max_block_size_override: Optional[int] = None,
     ):
         super().__init__(name, input_dependencies)
+        self._output_dependencies: List["PhysicalOperator"] = []
 
         for x in input_dependencies:
             assert isinstance(x, PhysicalOperator), x
+        self._wire_output_deps(input_dependencies)
         self._inputs_complete = not input_dependencies
         self._output_block_size_option_override = OutputBlockSizeOption.of(
             target_max_block_size=target_max_block_size_override
@@ -368,7 +370,7 @@ class PhysicalOperator(Operator):
     def data_context(self) -> DataContext:
         return self._data_context
 
-    # Override the following 3 methods to correct type hints.
+    # Override the following methods to correct type hints.
 
     @property
     def input_dependencies(self) -> List["PhysicalOperator"]:
@@ -376,10 +378,79 @@ class PhysicalOperator(Operator):
 
     @property
     def output_dependencies(self) -> List["PhysicalOperator"]:
-        return super().output_dependencies  # type: ignore
+        return self._output_dependencies
 
     def post_order_iter(self) -> Iterator["PhysicalOperator"]:
         return super().post_order_iter()  # type: ignore
+
+    def _apply_transform(
+        self, transform: Callable[["PhysicalOperator"], "PhysicalOperator"]
+    ) -> "PhysicalOperator":
+        # 1) Recursively transform input operators first.
+        transformed_input_ops = []
+        has_changes = False
+
+        for input_op in self.input_dependencies:
+            transformed_input_op = input_op._apply_transform(transform)
+            transformed_input_ops.append(transformed_input_op)
+            if transformed_input_op is not input_op:
+                has_changes = True
+
+        # 2) If any input changed, create a shallow copy of the current node,
+        # rebind its inputs, and rewire reverse dependencies from old inputs
+        # to transformed inputs.
+        if has_changes:
+            target = self._copy_for_transform()
+            for input_op in self.input_dependencies:
+                assert isinstance(input_op, PhysicalOperator), input_op
+                input_op._output_dependencies = [
+                    dep for dep in input_op._output_dependencies if dep is not self
+                ]
+            target._input_dependencies = transformed_input_ops
+            target._wire_output_deps(transformed_input_ops)
+        else:
+            target = self
+
+        # 3) Apply transform on the current node itself. If transform replaces
+        # the current node, rewire reverse dependencies from old node inputs
+        # to the returned replacement node inputs.
+        transformed_target = transform(target)
+        if transformed_target is not target:
+            for input_op in target.input_dependencies:
+                assert isinstance(input_op, PhysicalOperator), input_op
+                input_op._output_dependencies = [
+                    dep for dep in input_op._output_dependencies if dep is not target
+                ]
+            transformed_target._rewire_output_deps(
+                target, transformed_target.input_dependencies
+            )
+        return transformed_target
+
+    def _copy_for_transform(self) -> "PhysicalOperator":
+        target = object.__new__(type(self))
+        target.__dict__ = self.__dict__.copy()
+        # The copied node belongs to a new transformed DAG. Reverse edges are
+        # rewired by parents, so avoid carrying stale downstream references.
+        target._output_dependencies = []
+        return target
+
+    def _rewire_output_deps(
+        self,
+        source_op: "PhysicalOperator",
+        input_dependencies: List["PhysicalOperator"],
+    ) -> None:
+        for input_op in input_dependencies:
+            assert isinstance(input_op, PhysicalOperator), input_op
+            input_op._output_dependencies = [
+                dep for dep in input_op._output_dependencies if dep is not source_op
+            ]
+            if self not in input_op._output_dependencies:
+                input_op._output_dependencies.append(self)
+
+    def _wire_output_deps(self, input_dependencies: List["PhysicalOperator"]) -> None:
+        for input_op in input_dependencies:
+            assert isinstance(input_op, PhysicalOperator), input_op
+            input_op._output_dependencies.append(self)
 
     def set_logical_operators(
         self,

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -418,7 +418,7 @@ class PhysicalOperator(Operator):
         original_inputs = tuple(target.input_dependencies)
         transformed_target = transform(target)
         if transformed_target is not target:
-            for input_op in target.input_dependencies:
+            for input_op in original_inputs:
                 assert isinstance(input_op, PhysicalOperator), input_op
                 input_op._output_dependencies = [
                     dep for dep in input_op._output_dependencies if dep is not target

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -433,6 +433,9 @@ class PhysicalOperator(Operator):
         return transformed_target
 
     def _copy_for_transform(self) -> "PhysicalOperator":
+        # copy.copy() is not safe here because PhysicalOperator.__reduce__()
+        # intentionally raises. Use a side-effect-free shallow copy to avoid
+        # re-running __init__ wiring/ID/metrics initialization during transform.
         target = object.__new__(type(self))
         target.__dict__ = self.__dict__.copy()
         # The copied node belongs to a new transformed DAG. Reverse edges are

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -438,6 +438,9 @@ class PhysicalOperator(Operator):
         # re-running __init__ wiring/ID/metrics initialization during transform.
         target = object.__new__(type(self))
         target.__dict__ = self.__dict__.copy()
+        # The transformed node should have a distinct identity and metrics owner.
+        target._id = str(uuid.uuid4())
+        target._metrics = OpRuntimeMetrics(target)
         # The copied node belongs to a new transformed DAG. Reverse edges are
         # rewired by parents, so avoid carrying stale downstream references.
         target._output_dependencies = []

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -32,6 +32,20 @@ def test_logical_operator_defaults_name_to_class_name():
     assert op.dag_str == "LogicalOperator[LogicalOperator]"
 
 
+def test_logical_operator_does_not_track_output_dependencies():
+    source = LogicalOperator([], name="source")
+    sink = LogicalOperator([source], name="sink")
+
+    # Logical operators should not maintain reverse output-dependency state.
+    assert not hasattr(source, "_output_dependencies")
+    assert not hasattr(sink, "_output_dependencies")
+
+    transformed = sink._apply_transform(lambda op: op)
+    assert transformed is sink
+    assert not hasattr(source, "_output_dependencies")
+    assert not hasattr(sink, "_output_dependencies")
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -18,6 +18,77 @@ from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
 
 
+def test_physical_operator_tracks_output_dependencies():
+    input_op = PhysicalOperator("input", [], DataContext.get_current())
+    downstream_op = PhysicalOperator(
+        "downstream", [input_op], DataContext.get_current()
+    )
+
+    assert input_op.output_dependencies == [downstream_op]
+
+
+def test_physical_apply_transform_rewires_all_input_output_dependencies():
+    ctx = DataContext.get_current()
+    left_input = PhysicalOperator("left_input", [], ctx)
+    right_input = PhysicalOperator("right_input", [], ctx)
+    root = PhysicalOperator("root", [left_input, right_input], ctx)
+    left_replacement = PhysicalOperator("left_replacement", [], ctx)
+
+    transformed_root = root._apply_transform(
+        lambda op: left_replacement if op is left_input else op
+    )
+
+    assert transformed_root is not root
+    assert transformed_root.input_dependencies == [left_replacement, right_input]
+    assert transformed_root in left_replacement.output_dependencies
+    assert transformed_root in right_input.output_dependencies
+    assert root not in left_input.output_dependencies
+    assert root not in right_input.output_dependencies
+
+
+def test_physical_apply_transform_rewires_when_current_node_is_replaced():
+    ctx = DataContext.get_current()
+    left_input = PhysicalOperator("left_input", [], ctx)
+    right_input = PhysicalOperator("right_input", [], ctx)
+    root = PhysicalOperator("root", [left_input, right_input], ctx)
+
+    transformed_root = root._apply_transform(
+        lambda op: PhysicalOperator("replacement", [left_input], ctx)
+        if op is root
+        else op
+    )
+
+    assert transformed_root is not root
+    assert transformed_root in left_input.output_dependencies
+    assert root not in left_input.output_dependencies
+    assert root not in right_input.output_dependencies
+    assert transformed_root not in right_input.output_dependencies
+
+
+def test_physical_apply_transform_deep_chain_no_stale_downstream_refs():
+    ctx = DataContext.get_current()
+    leaf = PhysicalOperator("leaf", [], ctx)
+    mid = PhysicalOperator("mid", [leaf], ctx)
+    root = PhysicalOperator("root", [mid], ctx)
+
+    def transform(op: PhysicalOperator) -> PhysicalOperator:
+        if op is leaf:
+            return PhysicalOperator("leaf_replacement", [], ctx)
+        if op.name == "root":
+            return PhysicalOperator("root_replacement", op.input_dependencies, ctx)
+        return op
+
+    transformed_root = root._apply_transform(transform)
+    transformed_mid = transformed_root.input_dependencies[0]
+    transformed_leaf = transformed_mid.input_dependencies[0]
+
+    assert transformed_root.name == "root_replacement"
+    assert transformed_mid is not mid
+    assert transformed_leaf.name == "leaf_replacement"
+    assert root not in transformed_mid.output_dependencies
+    assert transformed_mid.output_dependencies == [transformed_root]
+
+
 def test_does_not_double_count_usage_from_union():
     """Regression test for https://github.com/ray-project/ray/pull/61040."""
     # Create a mock topology:

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -39,6 +39,8 @@ def test_physical_apply_transform_rewires_all_input_output_dependencies():
     )
 
     assert transformed_root is not root
+    assert transformed_root.id != root.id
+    assert transformed_root.metrics is not root.metrics
     assert transformed_root.input_dependencies == [left_replacement, right_input]
     assert transformed_root in left_replacement.output_dependencies
     assert transformed_root in right_input.output_dependencies


### PR DESCRIPTION
## Description

This PR moves output_dependencies tracking from the shared Operator base to PhysicalOperator.

#### Why this is needed:

- output_dependencies is execution/runtime state for the physical DAG.
- Logical operators should not maintain this reverse-edge state.
- This keeps logical/physical responsibilities cleaner and reduces logical-layer statefulness.

#### What this PR changes:

- Removes output_dependencies ownership from Operator:
    - no _output_dependencies initialization in Operator.__init__
    - no Operator.output_dependencies property
    - no Operator._wire_output_deps
- Keeps logical DAG transform focused on input rewrites only.
- Adds physical-side ownership in PhysicalOperator:
    - initializes and exposes _output_dependencies
    - wires reverse deps in constructor
    - maintains reverse deps during _apply_transform, including child replacement, current-node replacement, and deep-chain scenarios.

## Related issues

Link related issues: "Fixes #60312", or "Related to #60312".


## Additional information

This PR also addresses stale reverse-edge cases in physical transform rewiring:

- child replacement path
- current-node replacement path
- deep-chain copy + ancestor replacement path

Because reverse-edge rewiring was previously coupled to the shared Operator transform path, moving output-dependency ownership to PhysicalOperator requires preserving that rewiring semantics on the physical side (including replacement edge cases), with explicit regression coverage.

### Tests

Added/updated:

- python/ray/data/tests/unit/test_logical_plan.py
    - verifies logical operators do not track _output_dependencies
- python/ray/data/tests/unit/test_resource_manager.py
    - verifies physical reverse-edge tracking
    - verifies rewiring for child replacement
    - verifies rewiring when current node is replaced
    - verifies no stale downstream refs in deep-chain transform

Validated with targeted existing tests:

- python/ray/data/tests/test_operator_fusion.py
- python/ray/data/tests/test_downstream_capacity_backpressure_policy.py





### Stack Plan

To complete [#60312](https://github.com/ray-project/ray/issues/60312), the original stack was:

1. https://github.com/ray-project/ray/pull/60529
2. https://github.com/ray-project/ray/pull/60528
3. https://github.com/ray-project/ray/pull/60530
4. https://github.com/ray-project/ray/pull/60531

Since PR4 was still too large, it is being further split:

1. PR-A: default `LogicalOperator` naming behavior https://github.com/ray-project/ray/pull/61020
2. PR-B: move `output_dependencies` responsibility to physical side (this PR)
3. PR-C: make `LogicalOperator` an ABC with abstract `num_outputs`
4. PR-D: convert logical operators to frozen dataclasses in small groups (D1/D2/D3)
    - D1: one-to-one operators
    - D2: map operators
    - D3: all-to-all + join/read/write groups (as needed)

Planned follow-ups (not blocking this stack):
- Converting all `input_op` usage to `input_dependencies`
- Potential `AbstractFrom` restructuring
