### PR TITLE
Fix typo: prom_addreses -> prom_addresses

### DIFF
--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -477,11 +477,11 @@ def fetch_prometheus(prom_addresses):
 
 
 def fetch_prometheus_timeseries(
-    prom_addreses: List[str],
+    prom_addresses: List[str],
     result: PrometheusTimeseries,
 ) -> PrometheusTimeseries:
     components_dict, metric_descriptors, metric_samples = fetch_prometheus(
-        prom_addreses
+        prom_addresses
     )
     for address, components in components_dict.items():
         if address not in result.components_dict:


### PR DESCRIPTION
## Summary
Fixed a typo in the parameter name `prom_addreses` which should be `prom_addresses` in the `fetch_prometheus_timeseries` function.

## Changes
- Fixed typo in function signature (line 480)
- Fixed typo in function call (line 484)

Fixes #60874