### PR TITLE
[Serve][LLM] SGLangServer cleanup and maintainability improvements

### DIFF
--- a/python/ray/llm/examples/sglang/modules/sglang_engine.py
+++ b/python/ray/llm/examples/sglang/modules/sglang_engine.py
@@ -229,9 +229,7 @@ class SGLangServer:
 
         # 2. Loop through all prompts in the batch
         for index, prompt_string in enumerate(prompts_to_process):
-            metadata = await self._generate_and_extract_metadata(
-                request, prompt_string
-            )
+            metadata = await self._generate_and_extract_metadata(request, prompt_string)
             last_metadata = metadata  # Keep track of the metadata from the last run
 
             total_prompt_tokens += metadata["prompt_tokens"]

--- a/python/ray/llm/examples/sglang/modules/sglang_engine.py
+++ b/python/ray/llm/examples/sglang/modules/sglang_engine.py
@@ -94,8 +94,6 @@ class SGLangServer:
                 }
 
             message_dict["role"] = str(message_dict.get("role", "user"))
-            content = message_dict.get("content", "")
-            message_dict["content"] = "" if content is None else content
             converted_messages.append(message_dict)
         return converted_messages
 
@@ -182,6 +180,8 @@ class SGLangServer:
         for message in messages:
             role = str(message.get("role", "user"))
             content = message.get("content", "")
+            if content is None:
+                content = ""
             prompt_lines.append(f"{role}: {content}")
         prompt_lines.append("assistant:")
         return "\n".join(prompt_lines)

--- a/python/ray/llm/examples/sglang/modules/sglang_engine.py
+++ b/python/ray/llm/examples/sglang/modules/sglang_engine.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import signal
 import time
 from typing import (
@@ -157,14 +156,10 @@ class SGLangServer:
         return
 
     async def check_health(self) -> None:
-        if not hasattr(self, "engine") or self.engine is None:
-            raise RuntimeError("SGLang engine is not initialized.")
-
-        engine_check_health = getattr(self.engine, "check_health", None)
-        if callable(engine_check_health):
-            maybe_awaitable = engine_check_health()
-            if inspect.isawaitable(maybe_awaitable):
-                await maybe_awaitable
+        # SGLang's in-process Engine API does not expose a health-check method.
+        # Its health endpoints exist only in HTTP/gRPC server entrypoints, which
+        # this integration does not run. Keep the protocol hook as a no-op.
+        return
 
     async def _generate_raw(
         self,


### PR DESCRIPTION
## Summary

Addresses issue #61108 for `python/ray/llm/examples/sglang/modules/sglang_engine.py`.

- Remove hand-rolled chat prompt formatting and use SGLang chat templating (`apply_chat_template=True`).
- Add `start()` and `check_health()` methods for protocol compatibility.
- Stop injecting hardcoded generation defaults; only forward explicitly user-set sampling params.
- Align method signatures with protocol (`raw_request_info: Optional[RawRequestInfo]`).
- Keep the signal monkey-patch for now, with TODO comment referencing `sgl-project/sglang#18752`.

## Notes

- The signal patch removal is intentionally deferred until the referenced upstream SGLang fix is confirmed merged *and released* in the minimum supported version used by this example.

## Testing

Environment: Ray branch `serve/sglangserver-cleanup-maintainability-61108` on Linux GPU instance.

Tested versions: `ray==2.53.0`, `sglang==0.5.2`, `vllm==0.15.0`.

- Chat completion with explicit `max_tokens=32`:
  - Request: `POST /v1/chat/completions` with `{"model":"Llama-3.1-8B-Instruct","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}`
  - Result: HTTP 200, valid short assistant response.

- Chat completion omitting `temperature` and `max_tokens`:
  - Request: `POST /v1/chat/completions` with `{"model":"Llama-3.1-8B-Instruct","messages":[{"role":"user","content":"Count to 200"}]}`
  - Result: HTTP 200; response used SGLang defaults in this env (`temperature=1.0`, `completion_tokens=128`, `finish_reason=length`).

<img width="1665" height="523" alt="sglang rsp" src="https://github.com/user-attachments/assets/76fabfd6-e047-47dc-8ab2-c8893e76a658" />


