### PR TITLE
[release auto] update ray-cpp wheels to use py3-none

### DIFF
--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -19,7 +19,6 @@ ALL_PLATFORMS = [
     "macosx_12_0_arm64",
     "win_amd64",
 ]
-RAY_TYPES = ["ray", "ray_cpp"]
 
 
 def _check_downloaded_wheels(directory_path: str, wheels: List[str]) -> None:
@@ -49,13 +48,18 @@ def _check_downloaded_wheels(directory_path: str, wheels: List[str]) -> None:
 def _get_wheel_names(ray_version: str) -> List[str]:
     """List all wheel names for the given ray version."""
     wheel_names = []
+
     for python_version in PYTHON_VERSIONS:
         for platform in ALL_PLATFORMS:
-            for ray_type in RAY_TYPES:
-                if python_version == "cp313-cp313" and platform == "win_amd64":
-                    continue
-                wheel_name = f"{ray_type}-{ray_version}-{python_version}-{platform}"
-                wheel_names.append(wheel_name)
+            if python_version == "cp313-cp313" and platform == "win_amd64":
+                continue
+            wheel_name = f"ray-{ray_version}-{python_version}-{platform}"
+            wheel_names.append(wheel_name)
+
+    for platform in ALL_PLATFORMS:
+        wheel_name = f"ray_cpp-{ray_version}-py3-none-{platform}"
+        wheel_names.append(wheel_name)
+
     return wheel_names
 
 

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -9,7 +9,6 @@ from botocore.exceptions import ClientError
 from ci.ray_ci.automation.ray_wheels_lib import (
     ALL_PLATFORMS,
     PYTHON_VERSIONS,
-    RAY_TYPES,
     _check_downloaded_wheels,
     _get_wheel_names,
     add_build_tag_to_wheel,
@@ -32,8 +31,9 @@ def test_get_wheel_names():
 
     assert (
         len(wheel_names)
-        == len(PYTHON_VERSIONS) * len(ALL_PLATFORMS) * len(RAY_TYPES) - 2
-    )  # Except for the win_amd64 wheel for cp313 on ray and ray-cpp
+        == len(PYTHON_VERSIONS) * len(ALL_PLATFORMS) + len(ALL_PLATFORMS) - 1
+    )  # Except for the win_amd64 wheel for cp313
+    python_versions = list(PYTHON_VERSIONS) + ["py3-none"]
 
     for wheel_name in wheel_names:
         assert len(wheel_name.split("-")) == 5
@@ -46,9 +46,9 @@ def test_get_wheel_names():
         ) = wheel_name.split("-")
         platform = platform.split(".")[0]  # Remove the .whl suffix
 
-        assert ray_type in RAY_TYPES
+        assert ray_type in ["ray", "ray_cpp"]
         assert ray_version == ray_version
-        assert f"{python_version}-{python_version2}" in PYTHON_VERSIONS
+        assert f"{python_version}-{python_version2}" in python_versions
         assert platform in ALL_PLATFORMS
 
 


### PR DESCRIPTION
we are building generic python version wheels now for ray-cpp
