### PR TITLE
[Data] add pathlib.Path support to read_* functions

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -357,10 +357,10 @@ def _is_local_scheme(paths: Union[str, List[str]]) -> bool:
         paths = [str(paths)]
     elif isinstance(paths, list):
         paths = [str(p) if isinstance(p, pathlib.Path) else p for p in paths]
-        if any(not isinstance(p, str) for p in paths):
-            raise ValueError("paths must be a path string or a list of path strings.")
-        if len(paths) == 0:
+        if not paths:
             raise ValueError("Must provide at least one path.")
+        if any(not isinstance(p, str) for p in paths):
+            raise ValueError("All paths must be str or pathlib.Path")
     else:
         raise ValueError(f"paths must be str, pathlib.Path, or list, got {type(paths)}")
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -346,23 +346,36 @@ def _resolve_custom_scheme(path: str) -> str:
     return path
 
 
+def _normalize_paths_to_strings(
+    paths: Union[str, pathlib.Path, List[Union[str, pathlib.Path]]]
+) -> List[str]:
+    """Normalize path input to a list of strings.
+
+    Accepts a single path (str or pathlib.Path) or a list of paths.
+    Returns a list of string paths. Raises ValueError if paths is empty
+    or contains invalid types.
+    """
+    if isinstance(paths, str):
+        return [paths]
+    elif isinstance(paths, pathlib.Path):
+        return [str(paths)]
+    elif isinstance(paths, list):
+        normalized = [str(p) if isinstance(p, pathlib.Path) else p for p in paths]
+        if not normalized:
+            raise ValueError("Must provide at least one path.")
+        if any(not isinstance(p, str) for p in normalized):
+            raise ValueError("All paths must be str or pathlib.Path")
+        return normalized
+    else:
+        raise ValueError(f"paths must be str, pathlib.Path, or list, got {type(paths)}")
+
+
 def _is_local_scheme(paths: Union[str, List[str]]) -> bool:
     """Returns True if the given paths are in local scheme.
     Note: The paths must be in same scheme, i.e. it's invalid and
     will raise error if paths are mixed with different schemes.
     """
-    if isinstance(paths, str):
-        paths = [paths]
-    elif isinstance(paths, pathlib.Path):
-        paths = [str(paths)]
-    elif isinstance(paths, list):
-        paths = [str(p) if isinstance(p, pathlib.Path) else p for p in paths]
-        if not paths:
-            raise ValueError("Must provide at least one path.")
-        if any(not isinstance(p, str) for p in paths):
-            raise ValueError("All paths must be str or pathlib.Path")
-    else:
-        raise ValueError(f"paths must be str, pathlib.Path, or list, got {type(paths)}")
+    paths = _normalize_paths_to_strings(paths)
 
     num = sum(urllib.parse.urlparse(path).scheme == _LOCAL_SCHEME for path in paths)
     if num > 0 and num < len(paths):

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -353,12 +353,17 @@ def _is_local_scheme(paths: Union[str, List[str]]) -> bool:
     """
     if isinstance(paths, str):
         paths = [paths]
-    if isinstance(paths, pathlib.Path):
+    elif isinstance(paths, pathlib.Path):
         paths = [str(paths)]
-    elif not isinstance(paths, list) or any(not isinstance(p, str) for p in paths):
-        raise ValueError("paths must be a path string or a list of path strings.")
-    elif len(paths) == 0:
-        raise ValueError("Must provide at least one path.")
+    elif isinstance(paths, list):
+        paths = [str(p) if isinstance(p, pathlib.Path) else p for p in paths]
+        if any(not isinstance(p, str) for p in paths):
+            raise ValueError("paths must be a path string or a list of path strings.")
+        if len(paths) == 0:
+            raise ValueError("Must provide at least one path.")
+    else:
+        raise ValueError(f"paths must be str, pathlib.Path, or list, got {type(paths)}")
+
     num = sum(urllib.parse.urlparse(path).scheme == _LOCAL_SCHEME for path in paths)
     if num > 0 and num < len(paths):
         raise ValueError(

--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -4,7 +4,11 @@ import sys
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 from urllib.parse import quote, unquote, urlparse
 
-from ray.data._internal.util import RetryingPyFileSystem, _resolve_custom_scheme
+from ray.data._internal.util import (
+    RetryingPyFileSystem,
+    _normalize_paths_to_strings,
+    _resolve_custom_scheme,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -289,18 +293,7 @@ def _resolve_paths_and_filesystem(
             filesystems inferred from the provided paths to ensure
             compatibility.
     """
-    if isinstance(paths, str):
-        paths = [paths]
-    elif isinstance(paths, pathlib.Path):
-        paths = [str(paths)]
-    elif isinstance(paths, list):
-        paths = [str(p) if isinstance(p, pathlib.Path) else p for p in paths]
-        if not paths:
-            raise ValueError("Must provide at least one path.")
-        if any(not isinstance(p, str) for p in paths):
-            raise ValueError("All paths must be str or pathlib.Path")
-    else:
-        raise ValueError(f"paths must be str, pathlib.Path, or list, got {type(paths)}")
+    paths = _normalize_paths_to_strings(paths)
 
     # Validate/wrap filesystem upfront so we return a proper PyArrow filesystem
     filesystem = _validate_and_wrap_filesystem(filesystem)

--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -291,15 +291,16 @@ def _resolve_paths_and_filesystem(
     """
     if isinstance(paths, str):
         paths = [paths]
-    if isinstance(paths, pathlib.Path):
+    elif isinstance(paths, pathlib.Path):
         paths = [str(paths)]
-    elif not isinstance(paths, list) or any(not isinstance(p, str) for p in paths):
-        raise ValueError(
-            "Expected `paths` to be a `str`, `pathlib.Path`, or `list[str]`, but got "
-            f"`{paths}`"
-        )
-    elif len(paths) == 0:
-        raise ValueError("Must provide at least one path.")
+    elif isinstance(paths, list):
+        paths = [str(p) if isinstance(p, pathlib.Path) else p for p in paths]
+        if not paths:
+            raise ValueError("Must provide at least one path.")
+        if any(not isinstance(p, str) for p in paths):
+            raise ValueError("All paths must be str or pathlib.Path")
+    else:
+        raise ValueError(f"paths must be str, pathlib.Path, or list, got {type(paths)}")
 
     # Validate/wrap filesystem upfront so we return a proper PyArrow filesystem
     filesystem = _validate_and_wrap_filesystem(filesystem)

--- a/python/ray/data/tests/datasource/test_text.py
+++ b/python/ray/data/tests/datasource/test_text.py
@@ -44,6 +44,25 @@ def test_read_text(ray_start_regular_shared, tmp_path):
     assert ds.count() == 4
 
 
+def test_read_text_with_pathlib(ray_start_regular_shared, tmp_path):
+    from pathlib import Path
+
+    path = Path(tmp_path) / "test_pathlib"
+    path.mkdir()
+
+    file1 = path / "file1.txt"
+    file2 = path / "file2.txt"
+
+    file1.write_text("hello\nworld")
+    file2.write_text("goodbye")
+
+    ds = ray.data.read_text([file1, file2])
+    assert sorted(_to_lines(ds.take())) == ["goodbye", "hello", "world"]
+
+    ds = ray.data.read_text(file1)
+    assert sorted(_to_lines(ds.take())) == ["hello", "world"]
+
+
 def test_read_text_remote_args(ray_start_cluster, tmp_path):
     cluster = ray_start_cluster
     cluster.add_node(

--- a/python/ray/data/tests/datasource/test_text.py
+++ b/python/ray/data/tests/datasource/test_text.py
@@ -44,25 +44,6 @@ def test_read_text(ray_start_regular_shared, tmp_path):
     assert ds.count() == 4
 
 
-def test_read_text_with_pathlib(ray_start_regular_shared, tmp_path):
-    from pathlib import Path
-
-    path = Path(tmp_path) / "test_pathlib"
-    path.mkdir()
-
-    file1 = path / "file1.txt"
-    file2 = path / "file2.txt"
-
-    file1.write_text("hello\nworld")
-    file2.write_text("goodbye")
-
-    ds = ray.data.read_text([file1, file2])
-    assert sorted(_to_lines(ds.take())) == ["goodbye", "hello", "world"]
-
-    ds = ray.data.read_text(file1)
-    assert sorted(_to_lines(ds.take())) == ["hello", "world"]
-
-
 def test_read_text_remote_args(ray_start_cluster, tmp_path):
     cluster = ray_start_cluster
     cluster.add_node(


### PR DESCRIPTION
## Why are these changes needed?

`ray.data.read_*` functions don't accept `pathlib.Path` objects, forcing users to manually convert to strings. This PR adds native support for Path objects.

## What's included?

**Modified:**
- `path_util.py` - convert Path objects to strings in `_resolve_paths_and_filesystem()` ✅
- `util.py` - handle Path objects in `_is_local_scheme()` ✅

**Added:**
- `test_read_text_with_pathlib()` - test single Path and list of Paths ✅

## Screenshots
<img width="709" height="240" alt="Screenshot 2026-02-17 at 17 36 42" src="https://github.com/user-attachments/assets/4baefcd0-40bb-4686-a402-c588c3fa94f4" />


## Benefits

- More Pythonic API, works with modern path handling

## Note
Closes #61084