### PR TITLE
[data][llm] Enable autoscaling GPU stages

### DIFF
--- a/doc/source/data/doc_code/working-with-llms/basic_llm_example.py
+++ b/doc/source/data/doc_code/working-with-llms/basic_llm_example.py
@@ -415,6 +415,20 @@ config = vLLMEngineProcessorConfig(
 )
 # __concurrent_config_example_end__
 
+
+# __concurrent_config_fixed_pool_example_start__
+config = vLLMEngineProcessorConfig(
+    model_source="unsloth/Llama-3.1-8B-Instruct",
+    engine_kwargs={
+        "enable_chunked_prefill": True,
+        "max_num_batched_tokens": 4096,
+        "max_model_len": 16384,
+    },
+    concurrency=(10, 10),
+    batch_size=64,
+)
+# __concurrent_config_fixed_pool_example_end__
+
 # __concurrent_batches_tuning_example_start__
 # Tuning concurrent batch processing
 # Configure both parameters together for optimal throughput

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -93,7 +93,7 @@ Ray Data LLM uses a **multi-stage processor pipeline** to transform your data th
 - **Detokenize**: Converts output token IDs back to readable text.
 - **Postprocess**: Your custom function that extracts and formats the final output.
 
-Each stage runs as a separate Ray actor pool, enabling independent scaling and resource allocation. CPU stages (ChatTemplate, Tokenize, Detokenize, and HttpRequestStage) use autoscaling actor pools (except for ServeDeployment stage), while the GPU stage uses a fixed pool.
+Each stage runs as a separate Ray actor pool, enabling independent scaling and resource allocation. All stages (CPU and GPU) use autoscaling actor pools by default, except for the ServeDeployment stage which uses a fixed pool.
 
 .. _horizontal_scaling:
 
@@ -108,6 +108,13 @@ Horizontally scale the LLM stage to multiple GPU replicas using the ``concurrenc
     :end-before: __concurrent_config_example_end__
 
 Each replica runs an independent inference engine. Set ``concurrency`` to match the number of available GPUs or GPU nodes.
+
+By default, when you set ``concurrency`` to an integer ``n``, GPU stages autoscale from 1 to ``n`` actors. To use a fixed pool of ``n`` actors, set ``concurrency`` to ``(n, n)``.
+
+.. literalinclude:: doc_code/working-with-llms/basic_llm_example.py
+    :language: python
+    :start-after: __concurrent_config_fixed_pool_example_start__
+    :end-before: __concurrent_config_fixed_pool_example_end__
 
 .. _text_generation:
 

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -153,8 +153,8 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
         concurrency: The number of workers for data parallelism. Default to 1.
             If ``concurrency`` is a tuple ``(m, n)``, Ray creates an autoscaling
             actor pool that scales between ``m`` and ``n`` workers (``1 <= m <= n``).
-            If ``concurrency`` is an ``int`` ``n``, CPU stages use an autoscaling
-            pool from ``(1, n)``, while GPU stages use a fixed pool of ``n`` workers.
+            If ``concurrency`` is an ``int`` ``n``, both CPU and GPU stages use an autoscaling
+            pool from ``(1, n)``.
             Stage-specific concurrency can be set via nested stage configs.
 
     Examples:
@@ -251,8 +251,8 @@ class SGLangEngineProcessorConfig(_SGLangEngineProcessorConfig):
         concurrency: The number of workers for data parallelism. Default to 1.
             If ``concurrency`` is a tuple ``(m, n)``, Ray creates an autoscaling
             actor pool that scales between ``m`` and ``n`` workers (``1 <= m <= n``).
-            If ``concurrency`` is an ``int`` ``n``, CPU stages use an autoscaling
-            pool from ``(1, n)``, while GPU stages use a fixed pool of ``n`` workers.
+            If ``concurrency`` is an ``int`` ``n``, both CPU and GPU stages use an autoscaling
+            pool from ``(1, n)``.
             Stage-specific concurrency can be set via nested stage configs.
 
     Examples:

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -176,7 +176,7 @@ def build_sglang_engine_processor(
                 # which initiates enough many overlapping UDF calls per actor, to
                 # saturate `max_concurrency`.
                 compute=ray.data.ActorPoolStrategy(
-                    **config.get_concurrency(autoscaling_enabled=False),
+                    **config.get_concurrency(autoscaling_enabled=True),
                     max_tasks_in_flight_per_actor=config.experimental.get(
                         "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
                     ),

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -293,7 +293,7 @@ def build_vllm_engine_processor(
                 # which initiates enough many overlapping UDF calls per actor, to
                 # saturate `max_concurrency`.
                 compute=ray.data.ActorPoolStrategy(
-                    **config.get_concurrency(autoscaling_enabled=False),
+                    **config.get_concurrency(autoscaling_enabled=True),
                     max_tasks_in_flight_per_actor=config.experimental.get(
                         "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
                     ),

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_no_blocking.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_no_blocking.py
@@ -59,14 +59,14 @@ class TestConcurrencyConfigPassthrough:
     Test that concurrency config correctly sets ActorPoolStrategy.
 
     This determines blocking behavior when wait_for_min_actors_s > 0:
-    - concurrency=N → min_size=N → blocks for N actors
-    - concurrency=(1, N) → min_size=1 → blocks for 1 actor
+    - concurrency=N → min_size=1, max_size=N → blocks for 1 actor (autoscaling)
+    - concurrency=(m, N) → min_size=m, max_size=N → blocks for m actors
     """
 
     @pytest.mark.parametrize(
         "concurrency,expected_min_size,expected_max_size",
         [
-            (4, 4, 4),  # int: fixed pool
+            (4, 1, 4),  # int: autoscaling pool with min_size=1
             ((1, 4), 1, 4),  # tuple: autoscaling pool
             ((2, 8), 2, 8),  # tuple: custom min
         ],

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -565,5 +565,74 @@ def test_vllm_placement_group(backend, placement_group_config):
     assert all("resp" in out for out in outs)
 
 
+def test_vllm_autoscaling_no_starvation():
+    """Test that chained vLLMEngineProcessor instances with autoscaling
+    concurrency can run without starving each other.
+    """
+    processor_config_1 = vLLMEngineProcessorConfig(
+        model_source="facebook/opt-1.3b",
+        chat_template_stage=False,
+        tokenize_stage=False,
+        detokenize_stage=False,
+        batch_size=16,
+        concurrency=(1, 4),
+    )
+
+    processor_config_2 = vLLMEngineProcessorConfig(
+        model_source="facebook/opt-1.3b",
+        chat_template_stage=False,
+        tokenize_stage=False,
+        detokenize_stage=False,
+        batch_size=16,
+        concurrency=(3, 4),
+    )
+
+    processor_1 = build_processor(
+        processor_config_1,
+        preprocess=lambda row: dict(
+            prompt=f"Calculate {row['id']} ** 2 = ",
+            sampling_params=dict(
+                temperature=0.3,
+                max_tokens=30,
+                detokenize=True,
+            ),
+        ),
+        postprocess=lambda row: {
+            "resp_1": row["generated_text"],
+            "id": row.get("id", None),
+        },
+    )
+
+    processor_2 = build_processor(
+        processor_config_2,
+        preprocess=lambda row: dict(
+            prompt=f"Previous result: {row.get('resp_1', 'N/A')}. Now calculate its cube: ",
+            sampling_params=dict(
+                temperature=0.3,
+                max_tokens=30,
+                detokenize=True,
+            ),
+        ),
+        postprocess=lambda row: {
+            "resp_2": row["generated_text"],
+            "resp_1": row.get("resp_1", None),
+            "id": row.get("id", None),
+        },
+    )
+
+    ds = ray.data.range(60)
+    ds = ds.map(lambda x: {"id": x["id"], "val": x["id"] + 1})
+
+    processed_ds = processor_2(processor_1(ds))
+    processed_ds = processed_ds.materialize()
+    results = processed_ds.take_all()
+
+    assert len(results) == 60
+    assert all("resp_1" in out for out in results)
+    assert all("resp_2" in out for out in results)
+    assert all("id" in out for out in results)
+    assert all(out.get("resp_1") for out in results)
+    assert all(out.get("resp_2") for out in results)
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -634,5 +634,6 @@ def test_vllm_autoscaling_no_starvation():
     assert all(out.get("resp_1") for out in results)
     assert all(out.get("resp_2") for out in results)
 
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description
To support preemption, the entire Ray Data LLM pipeline must be auto-scalable. Currently, GPU stages rely on fixed actor pools which limits elasticity.

In Ray Data, resources are allocated in two phases to prevent starvation:
- Phase 1: Reservation: Each operator gets `reservation_ratio * global_limits / num_ops` (default 50%), clamped to `min_resource_usage` (from `min_size`) and `max_resource_usage` (from `max_size`). Upstream operators are prioritized if resources are insufficient because downstream ops can wait for upstream ops to complete and release resources.
https://github.com/ray-project/ray/blob/f1a1039a891b1794a7aaeac8f02352dbae4fa921/python/ray/data/_internal/execution/resource_manager.py#L803-L819

- Phase 2: Shared Allocation: Remaining resources are allocated in reverse topological order (downstream first). Each operator receives remaining_shared / (num_ops - i), with borrowing allowed for operators below min_scheduling_resources. Total allocation is capped at max_resource_usage.
https://github.com/ray-project/ray/blob/f1a1039a891b1794a7aaeac8f02352dbae4fa921/python/ray/data/_internal/execution/resource_manager.py#L967-L978

All operators are guaranteed at least min(reservation_minimum, min_replicas) resources, and downstream operators get priority in shared allocation. Tune via RAY_DATA_OP_RESERVATION_RATIO (default: 0.5). Starvation is not a concern in chained processors.
https://github.com/ray-project/ray/blob/f1a1039a891b1794a7aaeac8f02352dbae4fa921/python/ray/data/context.py#L210

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
<img width="1324" height="439" alt="Screenshot 2026-02-17 at 6 30 18 PM" src="https://github.com/user-attachments/assets/da31524f-6dd6-4885-a30c-2e176846d5db" />

