### PR TITLE
update intro-ray-serve template

### DIFF
--- a/doc/source/ray-overview/examples/intro-serve/serve.ipynb
+++ b/doc/source/ray-overview/examples/intro-serve/serve.ipynb
@@ -1,0 +1,1500 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Introduction to Ray Serve\n",
+    "\n",
+    "This template introduces Ray Serve, a scalable model-serving framework built on Ray. You will learn **what** Ray Serve is, **why** it is a good fit for online ML inference, and **how** to build, deploy, and operate a real model service — starting from a familiar PyTorch classifier and progressively adding features like composition, autoscaling, batching, fault tolerance, and observability.\n",
+    "\n",
+    "**Part 1: Core**\n",
+    "\n",
+    "1. Why Ray Serve?\n",
+    "2. Build Your First Deployment (MNIST Classifier)\n",
+    "3. Integrating with FastAPI\n",
+    "4. Composing Deployments\n",
+    "5. Resource Specification and Fractional GPUs\n",
+    "6. Autoscaling\n",
+    "7. Observability\n",
+    "\n",
+    "**Part 2: Advanced topics**\n",
+    "\n",
+    "8. Dynamic Request Batching\n",
+    "9. Model Multiplexing\n",
+    "10. Asynchronous Inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Any\n",
+    "\n",
+    "import json\n",
+    "import logging\n",
+    "import time\n",
+    "\n",
+    "import numpy as np\n",
+    "import requests\n",
+    "import torch\n",
+    "from torchvision import transforms\n",
+    "\n",
+    "import ray\n",
+    "from ray import serve\n",
+    "from ray.serve.handle import DeploymentHandle\n",
+    "from ray.serve import metrics\n",
+    "from fastapi import FastAPI\n",
+    "from pydantic import BaseModel\n",
+    "from starlette.requests import Request\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "source": [
+    "### Note on Storage\n",
+    "\n",
+    "Throughout this tutorial, we use `/mnt/cluster_storage` to represent a shared storage location. In a multi-node cluster, Ray workers on different nodes cannot access the head node's local file system. Use a [shared storage solution](https://docs.anyscale.com/configuration/storage#shared) accessible from every node."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Why Ray Serve?\n",
+    "\n",
+    "Consider using Ray Serve when your serving workload has one or more of the following needs:\n",
+    "\n",
+    "| **Challenge** | **Ray Serve Solution** |\n",
+    "|---|---|\n",
+    "| **Scalability** — needs to handle variable or high traffic | Autoscaling replicas based on request queue depth; scales across a Ray cluster |\n",
+    "| **Hardware utilization** — GPUs underutilized by one-at-a-time inference | Dynamic request batching and fractional GPU allocation |\n",
+    "| **Service composition** — multiple models or processing stages | Compose deployments; Ray's object store for efficient data sharing |\n",
+    "| **Expensive startup** — large model weights to load | Stateful replicas (Ray actors) keep models in memory across requests |\n",
+    "| **Slow iteration speed** — Kubernetes YAML, container builds | Python-first API; develop locally, deploy distributed with the same code |\n",
+    "\n",
+    "#### Key Ray Serve Features\n",
+    "\n",
+    "- [Response streaming](https://docs.ray.io/en/latest/serve/tutorials/streaming.html)\n",
+    "- [Dynamic request batching](https://docs.ray.io/en/latest/serve/advanced-guides/dyn-req-batch.html)\n",
+    "- [Model multiplexing](https://docs.ray.io/en/latest/serve/model-multiplexing.html)\n",
+    "- [Fractional compute resource usage](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. Build Your First Deployment\n",
+    "\n",
+    "Let's migrate a standard PyTorch classifier to Ray Serve. We start with a familiar offline `MNISTClassifier` and turn it into an online service.\n",
+    "\n",
+    "### 2.1 The Offline Classifier\n",
+    "\n",
+    "Here is a standard PyTorch inference class that loads a TorchScript model and classifies images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class OfflineMNISTClassifier:\n",
+    "    def __init__(self, local_path: str):\n",
+    "        self.model = torch.jit.load(local_path)\n",
+    "        self.model.to(\"cuda\")\n",
+    "        self.model.eval()\n",
+    "\n",
+    "    def __call__(self, batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:\n",
+    "        return self.predict(batch)\n",
+    "    \n",
+    "    def predict(self, batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:\n",
+    "        images = torch.tensor(batch[\"image\"]).float().to(\"cuda\")\n",
+    "\n",
+    "        with torch.no_grad():\n",
+    "            logits = self.model(images).cpu().numpy()\n",
+    "\n",
+    "        batch[\"predicted_label\"] = np.argmax(logits, axis=1)\n",
+    "        return batch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "source": [
+    "Download the pre-trained model to shared storage:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "download: s3://anyscale-public-materials/ray-ai-libraries/mnist/model/model.pt to ../../../mnt/cluster_storage/model.pt\n"
+     ]
+    }
+   ],
+   "source": [
+    "!aws s3 cp s3://anyscale-public-materials/ray-ai-libraries/mnist/model/model.pt /mnt/cluster_storage/model.pt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "### 2.2 Migrating to Ray Serve\n",
+    "\n",
+    "To turn this into an online service, we make three changes:\n",
+    "\n",
+    "1. Add the `@serve.deployment()` decorator — this turns the class into a **Deployment**, Ray Serve's fundamental unit that can be independently scaled and configured\n",
+    "2. Change `__call__` to accept a Starlette `Request` object\n",
+    "3. Parse the incoming JSON body"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@serve.deployment()\n",
+    "class OnlineMNISTClassifier:\n",
+    "    def __init__(self, local_path: str):\n",
+    "        self.model = torch.jit.load(local_path)\n",
+    "        self.model.to(\"cuda\")\n",
+    "        self.model.eval()\n",
+    "\n",
+    "    async def __call__(self, request: Request) -> dict[str, Any]:\n",
+    "        batch = json.loads(await request.json())\n",
+    "        return await self.predict(batch)\n",
+    "    \n",
+    "    async def predict(self, batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:\n",
+    "        images = torch.tensor(batch[\"image\"]).float().to(\"cuda\")\n",
+    "\n",
+    "        with torch.no_grad():\n",
+    "            logits = self.model(images).cpu().numpy()\n",
+    "\n",
+    "        batch[\"predicted_label\"] = np.argmax(logits, axis=1)\n",
+    "        return batch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "### 2.3 Deploy and Test\n",
+    "\n",
+    "Use `.bind()` to pass constructor arguments and `serve.run()` to deploy. Setting `num_replicas=1` creates a single **Replica** — a Ray actor that holds your model in memory and processes requests.\n",
+    "\n",
+    "`.options()` configures the deployment — replicas, resources, autoscaling, and more. See the [full list of deployment configuration options](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mnist_deployment = OnlineMNISTClassifier.options(\n",
+    "    num_replicas=1,\n",
+    "    ray_actor_options={\"num_gpus\": 1},\n",
+    ")\n",
+    "\n",
+    "mnist_app = mnist_deployment.bind(local_path=\"/mnt/cluster_storage/model.pt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "source": [
+    "> **Note:** `.bind()` is a lazy call — it captures the constructor arguments without creating instances. Replicas are created when `serve.run()` is called.\n",
+    "\n",
+    "`serve.run()` creates an **Application** — a group of deployments deployed together — and starts the Serve system:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-02-18 02:49:14,197\tINFO worker.py:1821 -- Connecting to existing Ray cluster at address: 10.0.140.139:6379...\n",
+      "2026-02-18 02:49:14,209\tINFO worker.py:1998 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-phfra92v85r9zs48xih8i8wr56.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
+      "2026-02-18 02:49:14,212\tINFO packaging.py:463 -- Pushing file package 'gcs://_ray_pkg_9a5034543e25b79b6f1e2feb4fa1b1c85a4a0f51.zip' (0.07MiB) to Ray cluster...\n",
+      "2026-02-18 02:49:14,213\tINFO packaging.py:476 -- Successfully pushed file package 'gcs://_ray_pkg_9a5034543e25b79b6f1e2feb4fa1b1c85a4a0f51.zip'.\n",
+      "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/worker.py:2046: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0\n",
+      "  warnings.warn(\n",
+      "\u001b[36m(ProxyActor pid=4600)\u001b[0m INFO 2026-02-18 02:49:20,336 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
+      "INFO 2026-02-18 02:49:20,456 serve 4350 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=4600)\u001b[0m INFO 2026-02-18 02:49:20,450 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=4544)\u001b[0m INFO 2026-02-18 02:49:20,559 controller 4544 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 1).\n",
+      "\u001b[36m(ProxyActor pid=4600)\u001b[0m INFO 2026-02-18 02:49:20,562 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ServeController pid=4544)\u001b[0m INFO 2026-02-18 02:49:20,663 controller 4544 -- Adding 1 replica to Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
+      "\u001b[36m(ProxyActor pid=4600)\u001b[0m INFO 2026-02-18 02:49:20,594 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7e7666d33110>.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(autoscaler +15s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n",
+      "\u001b[36m(autoscaler +15s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
+      "\u001b[36m(autoscaler +15s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB|g4dn.2xlarge] [us-west-2c] [on-demand] Launched 1 instance.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:49:50,730 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {}. Use `ray status` for more details.\n",
+      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:50:20,787 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
+      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:50:50,855 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
+      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:51:20,915 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
+      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:51:50,981 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
+      "INFO 2026-02-18 02:51:52,835 serve 4350 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n",
+      "\u001b[36m(ProxyActor pid=2658, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:51:53,745 proxy 10.0.190.36 -- Proxy starting on node 9df8eee9130fc167b8bafaf41dcf9fe950124132c1f1501ff7a4a2f7 (HTTP port: 8000).\n",
+      "\u001b[36m(ProxyActor pid=2658, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:51:53,866 proxy 10.0.190.36 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n"
+     ]
+    }
+   ],
+   "source": [
+    "mnist_handle = serve.run(mnist_app, name=\"mnist_classifier\", blocking=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "source": [
+    "#### Under the hood\n",
+    "\n",
+    "When `serve.run()` returns, Ray Serve has started three types of actors:\n",
+    "\n",
+    "| Actor | Role |\n",
+    "|---|---|\n",
+    "| **Controller** | Global singleton. Manages the control plane, creates/destroys replicas, runs the autoscaler. |\n",
+    "| **Proxy** | Runs a Uvicorn HTTP server (one per head node by default). Accepts incoming HTTP requests and forwards them to replicas. |\n",
+    "| **Replica** | Executes your deployment code. Each replica is a Ray actor with its own request queue. |\n",
+    "\n",
+    "<img src=\"https://docs.ray.io/en/latest/_images/architecture-2.0.svg\" width=\"800\">\n",
+    "\n",
+    "These actors are self-healing: if a replica crashes, the Controller detects and replaces it; if the Proxy crashes, the Controller restarts it; if the Controller itself crashes, Ray restarts it. Application exceptions (bugs in your code) return HTTP 500 but don't take down the replica. For critical workloads, implement client-side retries with exponential backoff. See [End-to-End Fault Tolerance](https://docs.ray.io/en/latest/serve/production-guide/fault-tolerance.html) for details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "source": [
+    "#### Test via HTTP\n",
+    "\n",
+    "When you send a request to `localhost:8000`, the **Proxy** receives it, the **Router** selects a replica, and the replica executes your `__call__` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f8a9b0c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted labels: [1, 1]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ProxyActor pid=2658, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:51:53,901 proxy 10.0.190.36 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7bb0ae51eed0>.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted labels: [1, 6]\n"
+     ]
+    }
+   ],
+   "source": [
+    "images = np.random.rand(2, 1, 28, 28).tolist()\n",
+    "json_request = json.dumps({\"image\": images})\n",
+    "response = requests.post(\"http://localhost:8000/\", json=json_request)\n",
+    "print(\"Predicted labels:\", response.json()[\"predicted_label\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9b0c1d2",
+   "metadata": {},
+   "source": [
+    "#### Test via DeploymentHandle\n",
+    "\n",
+    "You can also call deployments in-process without HTTP overhead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b0c1d2e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO 2026-02-18 02:37:30,355 serve 226002 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7cd508d6ce60>.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted labels: [1 1 6 1 1 6 1 1 6 1]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2572, ip=10.0.144.150)\u001b[0m INFO 2026-02-18 02:37:30,294 mnist_classifier_OnlineMNISTClassifier inxgt6c9 648694cd-5c5a-4c47-b7ff-9f2e6f9b7b91 -- POST / 200 372.8ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2587, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:52:52,370 mnist_classifier_OnlineMNISTClassifier 7swb4ss8 951f3120-8266-4003-b2a1-890fd269f55c -- POST / 200 384.8ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO 2026-02-18 02:53:51,980 serve 4350 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b50c5602e40>.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted labels: [6 6 1 1 6 6 6 1 6 6]\n"
+     ]
+    }
+   ],
+   "source": [
+    "batch = {\"image\": np.random.rand(10, 1, 28, 28)}\n",
+    "response = await mnist_handle.predict.remote(batch)\n",
+    "print(\"Predicted labels:\", response[\"predicted_label\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2aec8cde",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2572, ip=10.0.144.150)\u001b[0m INFO 2026-02-18 02:37:30,442 mnist_classifier_OnlineMNISTClassifier inxgt6c9 ad8887c4-d53a-4f3e-9ea1-61cae84dd08a -- CALL predict OK 68.5ms\n",
+      "\u001b[36m(ServeController pid=226139)\u001b[0m INFO 2026-02-18 02:37:30,611 controller 226139 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
+      "\u001b[36m(ServeController pid=226139)\u001b[0m INFO 2026-02-18 02:37:32,644 controller 226139 -- Replica(id='inxgt6c9', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n",
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.listen_for_change failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2587, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:53:52,067 mnist_classifier_OnlineMNISTClassifier 7swb4ss8 424d7b88-4d7b-439d-a10e-286afab392d7 -- CALL predict OK 67.4ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeController pid=4544)\u001b[0m INFO 2026-02-18 02:54:52,042 controller 4544 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.listen_for_change failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n",
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeController pid=4544)\u001b[0m INFO 2026-02-18 02:54:54,053 controller 4544 -- Replica(id='7swb4ss8', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n"
+     ]
+    }
+   ],
+   "source": [
+    "serve.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Integrating with FastAPI\n",
+    "\n",
+    "Ray Serve integrates with FastAPI to provide HTTP routing, Pydantic validation, and auto-generated OpenAPI docs. Use `@serve.ingress(fastapi_app)` to designate a FastAPI app as the HTTP entrypoint.\n",
+    "\n",
+    "Here we wrap our existing `OnlineMNISTClassifier` pattern into a FastAPI-powered deployment to demonstrate the integration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d2e3f4a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fastapi_app = FastAPI()\n",
+    "\n",
+    "@serve.deployment\n",
+    "@serve.ingress(fastapi_app)\n",
+    "class MNISTFastAPIService:\n",
+    "    \"\"\"Same model logic as OnlineMNISTClassifier, but using FastAPI for HTTP routing.\"\"\"\n",
+    "    def __init__(self, local_path: str):\n",
+    "        self.model = torch.jit.load(local_path)\n",
+    "        self.model.to(\"cuda\")\n",
+    "        self.model.eval()\n",
+    "\n",
+    "    @fastapi_app.post(\"/predict\")\n",
+    "    async def predict(self, request: Request):\n",
+    "        batch = json.loads(await request.json())\n",
+    "        images = torch.tensor(batch[\"image\"]).float().to(\"cuda\")\n",
+    "        with torch.no_grad():\n",
+    "            logits = self.model(images).cpu().numpy()\n",
+    "        return {\"predicted_label\": np.argmax(logits, axis=1).tolist()}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e3f4a5b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO 2026-02-18 02:56:03,951 serve 4350 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:03,883 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
+      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:03,947 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=6893)\u001b[0m INFO 2026-02-18 02:56:04,052 controller 6893 -- Deploying new version of Deployment(name='MNISTFastAPIService', app='mnist_fastapi') (initial target replicas: 1).\n",
+      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:04,055 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ServeController pid=6893)\u001b[0m INFO 2026-02-18 02:56:04,156 controller 6893 -- Adding 1 replica to Deployment(name='MNISTFastAPIService', app='mnist_fastapi').\n",
+      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:04,090 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x719bf44b0350>.\n",
+      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:07,984 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=[RoutePattern(methods=['GET', 'HEAD'], path='/docs'), RoutePattern(methods=['GET', 'HEAD'], path='/docs/oauth2-redirect'), RoutePattern(methods=['GET', 'HEAD'], path='/openapi.json'), RoutePattern(methods=['POST'], path='/predict'), RoutePattern(methods=['GET', 'HEAD'], path='/redoc')])}.\n",
+      "INFO 2026-02-18 02:56:08,068 serve 4350 -- Application 'mnist_fastapi' is ready at http://0.0.0.0:8000/.\n",
+      "\u001b[36m(ProxyActor pid=3192, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:09,078 proxy 10.0.190.36 -- Proxy starting on node 9df8eee9130fc167b8bafaf41dcf9fe950124132c1f1501ff7a4a2f7 (HTTP port: 8000).\n",
+      "INFO 2026-02-18 02:56:09,142 serve 4350 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b5211948a40>.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DeploymentHandle(deployment='MNISTFastAPIService')"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "app = MNISTFastAPIService.options(\n",
+    "        num_replicas=1,\n",
+    "        ray_actor_options={\"num_gpus\": 1},\n",
+    "    ).bind(local_path=\"/mnt/cluster_storage/model.pt\")\n",
+    "serve.run(app, name=\"mnist_fastapi\", blocking=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f4a5b6c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ProxyActor pid=3192, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:09,144 proxy 10.0.190.36 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=[RoutePattern(methods=['GET', 'HEAD'], path='/docs'), RoutePattern(methods=['GET', 'HEAD'], path='/docs/oauth2-redirect'), RoutePattern(methods=['GET', 'HEAD'], path='/openapi.json'), RoutePattern(methods=['POST'], path='/predict'), RoutePattern(methods=['GET', 'HEAD'], path='/redoc')])}.\n",
+      "\u001b[36m(ProxyActor pid=3192, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:09,181 proxy 10.0.190.36 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b5bcc37c680>.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted labels: [1, 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "images = np.random.rand(2, 1, 28, 28).tolist()\n",
+    "response = requests.post(\"http://localhost:8000/predict\", json=json.dumps({\"image\": images}))\n",
+    "print(\"Predicted labels:\", response.json()[\"predicted_label\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5b6c7d8",
+   "metadata": {},
+   "source": [
+    "Visit `http://localhost:8000/docs` for the auto-generated interactive API documentation.\n",
+    "\n",
+    "For more details on HTTP handling in Ray Serve, see the [HTTP Guide](https://docs.ray.io/en/latest/serve/http-guide.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b6c7d8e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:mnist_fastapi:MNISTFastAPIService pid=3123, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:09,594 mnist_fastapi_MNISTFastAPIService 4r6mu94r 67b52ae0-4f89-4c07-994e-c1e0f590ab28 -- POST /predict 200 359.2ms\n",
+      "\u001b[36m(ServeController pid=6893)\u001b[0m INFO 2026-02-18 02:56:09,733 controller 6893 -- Removing 1 replica from Deployment(name='MNISTFastAPIService', app='mnist_fastapi').\n",
+      "\u001b[36m(ServeController pid=6893)\u001b[0m INFO 2026-02-18 02:56:11,749 controller 6893 -- Replica(id='4r6mu94r', deployment='MNISTFastAPIService', app='mnist_fastapi') is stopped.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.listen_for_change failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n",
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "serve.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7d8e9f0",
+   "metadata": {},
+   "source": [
+    "Now that we have a working single-deployment service, let's see how to compose multiple deployments into a pipeline.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 4. Composing Deployments\n",
+    "\n",
+    "Ray Serve lets you compose multiple deployments into a single application. This is useful when you need:\n",
+    "- **Independent scaling** — each component scales separately\n",
+    "- **Hardware disaggregation** — CPU preprocessing + GPU inference\n",
+    "- **Reusable components** — share a preprocessor across models\n",
+    "\n",
+    "### 4.1 Define a Preprocessor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d8e9f0a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@serve.deployment\n",
+    "class OnlineMNISTPreprocessor:\n",
+    "    def __init__(self):\n",
+    "        self.transform = transforms.Compose([\n",
+    "            transforms.ToTensor(),\n",
+    "            transforms.Normalize((0.5,), (0.5,))\n",
+    "        ])\n",
+    "        \n",
+    "    async def run(self, batch: dict[str, Any]) -> dict[str, Any]:\n",
+    "        images = batch[\"image\"]\n",
+    "        images = [self.transform(np.array(image, dtype=np.uint8)).cpu().numpy() for image in images]\n",
+    "        return {\"image\": images}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9f0a1b2",
+   "metadata": {},
+   "source": [
+    "### 4.2 Build a Composed Application\n",
+    "\n",
+    "Wire the preprocessor and classifier together via an ingress deployment:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f0a1b2c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@serve.deployment\n",
+    "class ImageServiceIngress:\n",
+    "    def __init__(self, preprocessor, model):\n",
+    "        self.preprocessor = preprocessor\n",
+    "        self.model = model\n",
+    "\n",
+    "    async def __call__(self, request: Request):\n",
+    "        batch = json.loads(await request.json())\n",
+    "        response = await self.preprocessor.run.remote(batch)\n",
+    "        return await self.model.predict.remote(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a1b2c3d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO 2026-02-18 02:56:16,051 serve 4350 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=7148)\u001b[0m INFO 2026-02-18 02:56:15,980 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
+      "\u001b[36m(ProxyActor pid=7148)\u001b[0m INFO 2026-02-18 02:56:16,047 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,144 controller 7083 -- Deploying new version of Deployment(name='OnlineMNISTPreprocessor', app='image_classifier') (initial target replicas: 1).\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,145 controller 7083 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='image_classifier') (initial target replicas: 1).\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,146 controller 7083 -- Deploying new version of Deployment(name='ImageServiceIngress', app='image_classifier') (initial target replicas: 1).\n",
+      "\u001b[36m(ProxyActor pid=7148)\u001b[0m INFO 2026-02-18 02:56:16,150 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='ImageServiceIngress', app='image_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=7148)\u001b[0m INFO 2026-02-18 02:56:16,159 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x747108407fb0>.\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,251 controller 7083 -- Adding 1 replica to Deployment(name='OnlineMNISTPreprocessor', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,253 controller 7083 -- Adding 1 replica to Deployment(name='OnlineMNISTClassifier', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,254 controller 7083 -- Adding 1 replica to Deployment(name='ImageServiceIngress', app='image_classifier').\n",
+      "INFO 2026-02-18 02:56:21,172 serve 4350 -- Application 'image_classifier' is ready at http://0.0.0.0:8000/.\n"
+     ]
+    }
+   ],
+   "source": [
+    "image_classifier_app = ImageServiceIngress.bind(\n",
+    "    preprocessor=OnlineMNISTPreprocessor.bind(),\n",
+    "    model=OnlineMNISTClassifier.options(\n",
+    "        num_replicas=1,\n",
+    "        ray_actor_options={\"num_gpus\": 0.1},\n",
+    "    ).bind(local_path=\"/mnt/cluster_storage/model.pt\"),\n",
+    ")\n",
+    "\n",
+    "handle = serve.run(image_classifier_app, name=\"image_classifier\", blocking=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e6",
+   "metadata": {},
+   "source": [
+    "### 4.3 Test the Composed App"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "c3d4e5f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-02-18 02:56:24,235\tINFO logging.py:397 -- Registered dataset logger for dataset dataset_1_0\n",
+      "2026-02-18 02:56:24,304\tINFO streaming_executor.py:178 -- Starting execution of Dataset dataset_1_0. Full logs are in /tmp/ray/session_2026-02-18_02-46-49_468518_2351/logs/ray-data\n",
+      "2026-02-18 02:56:24,304\tINFO streaming_executor.py:179 -- Execution plan of Dataset dataset_1_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> LimitOperator[limit=10] -> TaskPoolMapOperator[ReadFiles]\n",
+      "2026-02-18 02:56:24,306\tINFO streaming_executor.py:687 -- [dataset]: A new progress UI is available. To enable, set `ray.data.DataContext.get_current().enable_rich_progress_bars = True` and `ray.data.DataContext.get_current().use_ray_tqdm = False`.\n",
+      "2026-02-18 02:56:24,306\tINFO progress_bar.py:155 -- Progress bar disabled because stdout is a non-interactive terminal.\n",
+      "2026-02-18 02:56:24,307\tWARNING resource_manager.py:136 -- ⚠️  Ray's object store is configured to use only 27.6% of available memory (17.7GiB out of 64.0GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n",
+      "2026-02-18 02:56:25,392\tINFO progress_bar.py:213 -- === Ray Data Progress {ListFiles} ===\n",
+      "2026-02-18 02:56:25,393\tINFO progress_bar.py:215 -- ListFiles: Tasks: 1; Actors: 0; Queued blocks: 0 (0.0B); Resources: 1.0 CPU, 384.0MiB object store: Progress Completed 0 / ?\n",
+      "2026-02-18 02:56:25,394\tINFO progress_bar.py:213 -- === Ray Data Progress {limit=10} ===\n",
+      "2026-02-18 02:56:25,395\tINFO progress_bar.py:215 -- limit=10: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: Progress Completed 0 / ?\n",
+      "2026-02-18 02:56:25,396\tINFO progress_bar.py:213 -- === Ray Data Progress {ReadFiles} ===\n",
+      "2026-02-18 02:56:25,397\tINFO progress_bar.py:215 -- ReadFiles: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: Progress Completed 0 / ?\n",
+      "2026-02-18 02:56:25,397\tINFO progress_bar.py:213 -- === Ray Data Progress {Running Dataset} ===\n",
+      "2026-02-18 02:56:25,398\tINFO progress_bar.py:215 -- Running Dataset: dataset_1_0. Active & requested resources: 0/8 CPU, 0.0B/6.7GiB object store: Progress Completed 0 / ?\n",
+      "2026-02-18 02:56:30,126\tINFO streaming_executor.py:305 -- ✔️  Dataset dataset_1_0 execution finished in 5.82 seconds\n",
+      "INFO:openlineage.client.client:OpenLineageClient will use `composite` transport\n",
+      "INFO:openlineage.client.transport.composite:Stopping OpenLineage CompositeTransport emission after the first successful delivery because `continue_on_success=False`. Transport that emitted the event: <HttpTransport(name=first, kind=http, priority=1)>\n"
+     ]
+    }
+   ],
+   "source": [
+    "ds = ray.data.read_images(\"s3://anyscale-public-materials/ray-ai-libraries/mnist/50_per_index/\", include_paths=True)\n",
+    "image_batch = ds.take_batch(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "d4e5f6a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:image_classifier:ImageServiceIngress pid=3272, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:30,207 image_classifier_ImageServiceIngress 6a9x1pnn 4b9bcafb-8e14-4b64-8d6e-754d2f75903b -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b0bedd185f0>.\n",
+      "\u001b[36m(ServeReplica:image_classifier:OnlineMNISTPreprocessor pid=3270, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:30,227 image_classifier_OnlineMNISTPreprocessor tfgu42hj 4b9bcafb-8e14-4b64-8d6e-754d2f75903b -- CALL run OK 4.1ms\n",
+      "\u001b[36m(ServeReplica:image_classifier:OnlineMNISTClassifier pid=3271, ip=10.0.190.36)\u001b[0m /tmp/ipykernel_4350/4200536773.py:13: UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:253.)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted labels: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "json_request = json.dumps({\"image\": image_batch[\"image\"].tolist()})\n",
+    "response = requests.post(\"http://localhost:8000/\", json=json_request)\n",
+    "print(\"Predicted labels:\", response.json()[\"predicted_label\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "e5f6a7b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:image_classifier:ImageServiceIngress pid=3272, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:30,606 image_classifier_ImageServiceIngress 6a9x1pnn 4b9bcafb-8e14-4b64-8d6e-754d2f75903b -- POST / 200 415.8ms\n",
+      "\u001b[36m(ServeReplica:image_classifier:OnlineMNISTClassifier pid=3271, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:30,601 image_classifier_OnlineMNISTClassifier wf7hdn2g 4b9bcafb-8e14-4b64-8d6e-754d2f75903b -- CALL predict OK 358.8ms\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:30,727 controller 7083 -- Removing 1 replica from Deployment(name='OnlineMNISTPreprocessor', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:30,727 controller 7083 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:30,727 controller 7083 -- Removing 1 replica from Deployment(name='ImageServiceIngress', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:32,764 controller 7083 -- Replica(id='tfgu42hj', deployment='OnlineMNISTPreprocessor', app='image_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:32,765 controller 7083 -- Replica(id='wf7hdn2g', deployment='OnlineMNISTClassifier', app='image_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:32,765 controller 7083 -- Replica(id='6a9x1pnn', deployment='ImageServiceIngress', app='image_classifier') is stopped.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "serve.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b8ca",
+   "metadata": {},
+   "source": [
+    "With the composition pattern in hand, let's explore how to fine-tune resource allocation for each deployment.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 5. Resource Specification and Fractional GPUs\n",
+    "\n",
+    "Each replica can specify its resource requirements. For small models like our MNIST classifier, you can use **fractional GPUs** to pack multiple replicas on a single GPU:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "a7b8c9d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ProxyActor pid=7559)\u001b[0m INFO 2026-02-18 02:56:36,835 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
+      "INFO 2026-02-18 02:56:36,898 serve 4350 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=7559)\u001b[0m INFO 2026-02-18 02:56:36,895 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:36,988 controller 7494 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 4).\n",
+      "\u001b[36m(ProxyActor pid=7559)\u001b[0m INFO 2026-02-18 02:56:36,991 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=7559)\u001b[0m INFO 2026-02-18 02:56:37,000 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7287501f02f0>.\n",
+      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:37,092 controller 7494 -- Adding 4 replicas to Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
+      "INFO 2026-02-18 02:56:42,015 serve 4350 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n"
+     ]
+    }
+   ],
+   "source": [
+    "mnist_app = OnlineMNISTClassifier.options(\n",
+    "    num_replicas=4,\n",
+    "    ray_actor_options={\"num_gpus\": 0.1},  # 10% of a GPU per replica → up to 10 replicas per GPU\n",
+    ").bind(local_path=\"/mnt/cluster_storage/model.pt\")\n",
+    "\n",
+    "mnist_handle = serve.run(mnist_app, name=\"mnist_classifier\", blocking=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e2",
+   "metadata": {},
+   "source": [
+    "#### Request routing\n",
+    "\n",
+    "With multiple replicas, Serve uses the **Power of Two Choices** algorithm by default: randomly sample 2 replicas, pick the one with the shorter queue. You can also implement [custom routing logic](https://docs.ray.io/en/latest/serve/advanced-guides/custom-request-router.html) by subclassing `RequestRouter`.\n",
+    "\n",
+    "Test the fractional GPU deployment:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "c9d0e1f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted labels: [1, 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "images = np.random.rand(2, 1, 28, 28).tolist()\n",
+    "response = requests.post(\"http://localhost:8000/\", json=json.dumps({\"image\": images}))\n",
+    "print(\"Predicted labels:\", response.json()[\"predicted_label\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "d0e1f2a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=3699, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:42,439 mnist_classifier_OnlineMNISTClassifier ar6t5cad 6c229dbb-04d6-4858-be65-2c1c3758ba8a -- POST / 200 357.2ms\n",
+      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:42,609 controller 7494 -- Removing 4 replicas from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
+      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:44,642 controller 7494 -- Replica(id='ar6t5cad', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:44,642 controller 7494 -- Replica(id='3ykvd446', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:44,643 controller 7494 -- Replica(id='7d3n141m', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:44,644 controller 7494 -- Replica(id='5blwjqfh', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "serve.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3b5",
+   "metadata": {},
+   "source": [
+    "Next, let's see how Ray Serve can automatically scale replicas up and down based on traffic.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 6. Autoscaling\n",
+    "\n",
+    "Ray Serve automatically adjusts the number of replicas based on traffic. The key settings are:\n",
+    "\n",
+    "- **`target_ongoing_requests`** — the desired average number of active requests per replica. The autoscaler adds replicas when the actual ratio exceeds this target.\n",
+    "- **`max_ongoing_requests`** — the upper limit per replica. Set 20-50% higher than `target_ongoing_requests`. While `max_ongoing_requests` limits concurrency per replica, `max_queued_requests` limits how many requests wait in the caller's queue. When reached, new requests immediately receive HTTP 503.\n",
+    "- **`upscale_delay_s`** / **`downscale_delay_s`** — how long to wait before adding or removing replicas.\n",
+    "- **`look_back_period_s`** — the time window for averaging ongoing requests when making scaling decisions.\n",
+    "\n",
+    "### Autoscaling in action\n",
+    "\n",
+    "With `initial_replicas=0` and `min_replicas=0`, no GPU resources are allocated until a request arrives:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "f2a3b4c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ProxyActor pid=7758)\u001b[0m INFO 2026-02-18 02:56:48,824 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
+      "INFO 2026-02-18 02:56:48,890 serve 4350 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=7758)\u001b[0m INFO 2026-02-18 02:56:48,886 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:48,986 controller 7695 -- Registering autoscaling state for deployment Deployment(name='OnlineMNISTClassifier', app='mnist_classifier')\n",
+      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:48,987 controller 7695 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 0).\n",
+      "\u001b[36m(ProxyActor pid=7758)\u001b[0m INFO 2026-02-18 02:56:48,990 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=7758)\u001b[0m INFO 2026-02-18 02:56:49,000 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x73655146c620>.\n",
+      "INFO 2026-02-18 02:56:50,000 serve 4350 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n"
+     ]
+    }
+   ],
+   "source": [
+    "mnist_app = OnlineMNISTClassifier.options(\n",
+    "    ray_actor_options={\"num_cpus\": 0.5, \"num_gpus\": 0.1},\n",
+    "    autoscaling_config={\n",
+    "        \"target_ongoing_requests\": 10,\n",
+    "        \"initial_replicas\": 0,\n",
+    "        \"min_replicas\": 0,\n",
+    "        \"max_replicas\": 8,\n",
+    "        \"upscale_delay_s\": 5,\n",
+    "        \"downscale_delay_s\": 60,\n",
+    "        \"look_back_period_s\": 5,\n",
+    "    },\n",
+    ").bind(local_path=\"/mnt/cluster_storage/model.pt\")\n",
+    "\n",
+    "mnist_handle = serve.run(mnist_app, name=\"mnist_classifier\", blocking=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5d7",
+   "metadata": {},
+   "source": [
+    "Send requests to trigger scale-up:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "b4c5d6e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO 2026-02-18 02:56:50,059 serve 4350 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b50801b9880>.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<ray.serve.handle.DeploymentResponse at 0x7b50801bb0e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802e22d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801bb4d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801bb890>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801bbb00>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801bbce0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801bbec0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc0e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc2c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc4a0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc680>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc860>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dca40>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dccb0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dce90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dd070>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dd250>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5211950710>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b521194d100>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b521194fcb0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b521194d400>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5211a35d00>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5211a3b590>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dcaa0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801ddf40>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dd100>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801de600>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801decf0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801de030>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801df9b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801df2f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802000e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50801dfdd0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080200560>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080200290>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802009e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080200ce0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080200f80>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080201220>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080201580>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080201820>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080201ac0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080201d60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080202000>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802025d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080202870>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080202b10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080202db0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5211a39280>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021c0b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021c710>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021c9b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021c920>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021cdd0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021d3d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021d670>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021d9d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021dc70>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021df10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021de80>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021e330>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021e180>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021e7b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021ea50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021e8a0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021eed0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021ed20>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021f350>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021f1a0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021f7d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021f620>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021fc50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021faa0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080230110>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508021ff20>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080230590>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802303e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080230a10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080230860>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080230bc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080231070>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080230ec0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802314f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080231340>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080231970>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802317c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080231b20>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080231fd0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080232180>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802325d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802328d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080232840>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080232cf0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080232b40>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080233170>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080232fc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802338f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080233740>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080233dd0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080233d40>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080250230>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080233ec0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802503e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802505c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080250a70>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802508c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080250fb0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080250e00>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080252c30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080252a80>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50802536b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080253500>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080253b30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080253980>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080253ce0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800681d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080253fe0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080068650>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800684a0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080068800>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800689e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080069610>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080069460>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080069c10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080069a60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080069dc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b5080069fa0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006a150>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006a120>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006a990>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006a7e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006af30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006b170>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006afc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006b5f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006b440>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006ba70>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006bc50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508006bf50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008c230>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008c470>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008c2c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008c620>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008c800>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008ccb0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008ce90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008d070>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008d250>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008d430>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008d610>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008d7f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008cb00>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008d9a0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008db80>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008dd60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008e690>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008e510>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008eb10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008e960>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008ef90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008f290>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008f0e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008eff0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008f320>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008fcb0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b508008fb00>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8170>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8470>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a83e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8890>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a86e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8d10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8b60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9190>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8fe0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9790>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a95e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9c10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9a60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa090>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9ee0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa510>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa360>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa990>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa7e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800aae10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800aac60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800ab290>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800ab590>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c00b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0350>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c05f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0560>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0a70>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c09e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0bc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0da0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c1250>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c1430>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7b50800c16d0>]"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch = {\"image\": np.random.rand(10, 1, 28, 28)}\n",
+    "[mnist_handle.predict.remote(batch) for _ in range(200)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f9",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-auto-scaling.png\" width=\"800\">"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "d6e7f8aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:50,117 controller 7695 -- Upscaling Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') from 0 to 1 replicas. Current ongoing requests: 13.00, current running replicas: 0.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:50,228 controller 7695 -- Deregistering autoscaling state for deployment Deployment(name='OnlineMNISTClassifier', app='mnist_classifier')\n",
+      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:50,229 controller 7695 -- Deregistering autoscaling state for application mnist_classifier\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.listen_for_change failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n",
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "serve.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f8a9b1",
+   "metadata": {},
+   "source": [
+    "For advanced use cases, Ray Serve supports [custom autoscaling policies](https://docs.ray.io/en/latest/serve/advanced-guides/advanced-autoscaling.html#custom-autoscaling-policies) that go beyond queue-depth — such as pre-scaling based on time of day, scaling on CPU/memory utilization, or targeting a P90 latency SLA.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 7. Observability\n",
+    "\n",
+    "### Metrics\n",
+    "\n",
+    "Ray Serve exposes metrics at multiple granularity levels through the Serve dashboard and Grafana:\n",
+    "\n",
+    "- **Throughput metrics** — QPS and error QPS, available per application, per deployment, and per replica\n",
+    "\n",
+    "<img src=\"https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-throughput-metrics.png\" width=\"800\">\n",
+    "\n",
+    "- **Latency metrics** — P50, P90, P99 latencies at the same granularity levels\n",
+    "\n",
+    "<img src=\"https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-latency-metrics.png\" width=\"800\">\n",
+    "\n",
+    "- **Deployment metrics** — replica count and queue size per deployment\n",
+    "\n",
+    "<img src=\"https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-replica-metrics.png\" width=\"400\">\n",
+    "\n",
+    "<img src=\"https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-queuesize-metrics.png\" width=\"400\">\n",
+    "\n",
+    "Access these through the Ray Dashboard by navigating to **Ray Dashboard > Serve > VIEW IN GRAFANA**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a9b0c2",
+   "metadata": {},
+   "source": [
+    "### Custom metrics\n",
+    "\n",
+    "Define custom metrics using `ray.serve.metrics`:\n",
+    "\n",
+    "```python\n",
+    "@serve.deployment(num_replicas=2)\n",
+    "class InstrumentedService:\n",
+    "    def __init__(self):\n",
+    "        self.request_counter = metrics.Counter(\n",
+    "            \"my_request_counter\",\n",
+    "            description=\"Total requests processed.\",\n",
+    "            tag_keys=(\"model\",),\n",
+    "        )\n",
+    "        self.request_counter.set_default_tags({\"model\": \"mnist\"})\n",
+    "\n",
+    "    async def __call__(self, request: Request):\n",
+    "        self.request_counter.inc()\n",
+    "        return \"ok\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c1d2e4",
+   "metadata": {},
+   "source": [
+    "To create custom dashboards for monitoring your custom metrics, see [Custom dashboards and alerting](https://docs.anyscale.com/monitoring/custom-dashboards-and-alerting).\n",
+    "\n",
+    "Here is how the custom metric looks like in the Anyscale dashboard.\n",
+    "\n",
+    "<img src=\"https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-custom-request-counter.png\" width=\"400\">\n",
+    "\n",
+    "### Tracing\n",
+    "\n",
+    "For end-to-end request tracing across composed deployments, use the Anyscale Tracing integration. A single request's trace displays the hierarchical structure of how it flows through your deployment graph:\n",
+    "\n",
+    "```text\n",
+    "1. proxy_http_request (Root) - Duration: 245ms\n",
+    "   └── 2. proxy_route_to_replica (APIGateway) - Duration: 240ms\n",
+    "       └── 3. replica_handle_request (APIGateway) - Duration: 235ms\n",
+    "           └── 4. proxy_route_to_replica (UserService) - Duration: 180ms\n",
+    "               └── 5. replica_handle_request (UserService) - Duration: 175ms\n",
+    "```\n",
+    "\n",
+    "For details, see the [Anyscale Tracing guide](https://docs.anyscale.com/monitoring/tracing/).\n",
+    "\n",
+    "### Alerts\n",
+    "\n",
+    "Ray integrates with Prometheus and Grafana for an enhanced observability experience. [Grafana alerting](https://grafana.com/docs/grafana/latest/alerting/) lets you set up alerts based on Prometheus metrics — for example, alerting when P90 latency exceeds your SLA or error QPS spikes. Grafana supports multiple notification channels including Slack and PagerDuty.\n",
+    "\n",
+    "For a comprehensive overview of monitoring and debugging on Anyscale, see the [Anyscale monitoring guide](https://docs.anyscale.com/monitoring) and [custom dashboards and alerting](https://docs.anyscale.com/monitoring/custom-dashboards-and-alerting)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d2e3f5",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "# Part 2: Advanced Topics\n",
+    "\n",
+    "The following sections cover additional serving patterns, operational features, and production concerns. They don't require running code in sequence and can be read as reference material.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 8. Dynamic Request Batching\n",
+    "\n",
+    "When your model can process multiple inputs efficiently (such as GPU inference), batching improves throughput. Ray Serve provides the `@serve.batch` decorator:\n",
+    "\n",
+    "```python\n",
+    "@serve.deployment\n",
+    "class BatchMNISTClassifier:\n",
+    "    def __init__(self, local_path: str):\n",
+    "        self.model = torch.jit.load(local_path).to(\"cuda\").eval()\n",
+    "\n",
+    "    @serve.batch(max_batch_size=8, batch_wait_timeout_s=0.1)\n",
+    "    async def __call__(self, images_list: list[np.ndarray]) -> list[dict]:\n",
+    "        # images_list is a list of individual request payloads, automatically batched\n",
+    "        stacked = torch.tensor(np.stack(images_list)).float().to(\"cuda\")\n",
+    "        with torch.no_grad():\n",
+    "            logits = self.model(stacked).cpu().numpy()\n",
+    "        predictions = np.argmax(logits, axis=1)\n",
+    "        return [{\"predicted_label\": int(p)} for p in predictions]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3f4a5b7",
+   "metadata": {},
+   "source": [
+    "Under the hood:\n",
+    "- Requests are buffered in a queue\n",
+    "- Once `max_batch_size` requests arrive (or `batch_wait_timeout_s` elapses), the batch is sent to your method\n",
+    "- Responses are split and returned individually\n",
+    "\n",
+    "This is most effective for **vectorized operations on CPUs** and **parallelizable operations on GPUs**.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 9. Model Multiplexing\n",
+    "\n",
+    "When serving many models with the same shape but different weights (such as per-customer fine-tuned models), model multiplexing lets a shared pool of replicas efficiently serve all of them. The router inspects the `serve_multiplexed_model_id` request header and routes each request to a replica that already has that model loaded, avoiding redundant loading. Each replica caches up to `max_num_models_per_replica` models and evicts the least recently used one when full.\n",
+    "\n",
+    "<img src=\"https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/model_multiplexing_architecture.png\" width=\"800\">\n",
+    "\n",
+    "For the full API walkthrough — including code examples, client headers, and `DeploymentHandle` options — see the [Model Multiplexing docs](https://docs.ray.io/en/latest/serve/model-multiplexing.html).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 10. Asynchronous Inference\n",
+    "\n",
+    "Synchronous APIs block until processing completes, which is problematic for long-running tasks such as video processing or document analysis. Asynchronous inference decouples request submission from result retrieval — clients submit a task, receive a task ID immediately, and poll for the result later.\n",
+    "\n",
+    "<img src=\"https://anyscale-materials.s3.us-west-2.amazonaws.com/ray-serve-deep-dive/async_inference_architecture.png\" width=\"900\">\n",
+    "\n",
+    "The architecture consists of an HTTP ingress that enqueues tasks into a broker (such as Redis or RabbitMQ), a `@task_consumer` deployment that pulls and processes tasks, and a backend that stores results and status. This provides natural backpressure, built-in retries, and dead letter queues for failed tasks.\n",
+    "\n",
+    "For the full walkthrough — including configuration, code examples, and monitoring — see the [Asynchronous Inference docs](https://docs.ray.io/en/latest/serve/asynchronous-inference.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4a5b6c8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary and Next Steps\n",
+    "\n",
+    "In this template, you learned how to:\n",
+    "\n",
+    "- **Build** a Ray Serve deployment from a standard PyTorch model\n",
+    "- **Integrate** with FastAPI for HTTP routing and validation\n",
+    "- **Compose** multiple deployments into a pipeline\n",
+    "- **Configure** autoscaling, fractional GPUs, and resource allocation\n",
+    "- **Monitor** with built-in metrics, custom metrics, tracing, and alerts\n",
+    "- **Understand** batching, model multiplexing, and async inference patterns\n",
+    "\n",
+    "### Next Steps\n",
+    "\n",
+    "1. [Ray Serve documentation](https://docs.ray.io/en/latest/serve/index.html) — full API reference\n",
+    "2. [Production guide](https://docs.ray.io/en/latest/serve/production-guide/index.html) — deploying and managing Serve in production\n",
+    "3. [Anyscale monitoring guide](https://docs.anyscale.com/monitoring) — dashboards, alerts, and debugging\n",
+    "4. [Configure Serve deployments](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html) — full configuration options"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/source/ray-overview/examples/intro-serve/serve.ipynb
+++ b/doc/source/ray-overview/examples/intro-serve/serve.ipynb
@@ -87,7 +87,7 @@
     "|---|---|\n",
     "| **Scalability** — needs to handle variable or high traffic | Autoscaling replicas based on request queue depth; scales across a Ray cluster |\n",
     "| **Hardware utilization** — GPUs underutilized by one-at-a-time inference | Dynamic request batching and fractional GPU allocation |\n",
-    "| **Service composition** — multiple models or processing stages | Compose deployments; Ray's object store for efficient data sharing |\n",
+    "| **Model composition** — multiple models or processing stages | Compose heterogeneous deployments with independent scaling; Efficient data transfer between deployments through the Ray object store |\n",
     "| **Expensive startup** — large model weights to load | Stateful replicas (Ray actors) keep models in memory across requests |\n",
     "| **Slow iteration speed** — Kubernetes YAML, container builds | Python-first API; develop locally, deploy distributed with the same code |\n",
     "\n",

--- a/doc/source/ray-overview/examples/intro-serve/serve.ipynb
+++ b/doc/source/ray-overview/examples/intro-serve/serve.ipynb
@@ -23,7 +23,9 @@
     "\n",
     "8. Dynamic Request Batching\n",
     "9. Model Multiplexing\n",
-    "10. Asynchronous Inference"
+    "10. Asynchronous Inference\n",
+    "11. Custom Request Routing\n",
+    "12. Custom Autoscaling"
    ]
   },
   {
@@ -88,15 +90,7 @@
     "| **Scalability** — needs to handle variable or high traffic | Autoscaling replicas based on request queue depth; scales across a Ray cluster |\n",
     "| **Hardware utilization** — GPUs underutilized by one-at-a-time inference | Dynamic request batching and fractional GPU allocation |\n",
     "| **Model composition** — multiple models or processing stages | Compose heterogeneous deployments with independent scaling; Efficient data transfer between deployments through the Ray object store |\n",
-    "| **Expensive startup** — large model weights to load | Stateful replicas (Ray actors) keep models in memory across requests |\n",
-    "| **Slow iteration speed** — Kubernetes YAML, container builds | Python-first API; develop locally, deploy distributed with the same code |\n",
-    "\n",
-    "#### Key Ray Serve Features\n",
-    "\n",
-    "- [Response streaming](https://docs.ray.io/en/latest/serve/tutorials/streaming.html)\n",
-    "- [Dynamic request batching](https://docs.ray.io/en/latest/serve/advanced-guides/dyn-req-batch.html)\n",
-    "- [Model multiplexing](https://docs.ray.io/en/latest/serve/model-multiplexing.html)\n",
-    "- [Fractional compute resource usage](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html)"
+    "| **Slow iteration speed** — Kubernetes YAML, container builds | Python-first API; develop locally, deploy distributed with the same code |"
    ]
   },
   {
@@ -196,11 +190,11 @@
     "        self.model.eval()\n",
     "\n",
     "    async def __call__(self, request: Request) -> dict[str, Any]:\n",
-    "        batch = json.loads(await request.json())\n",
+    "        batch = await request.json()\n",
     "        return await self.predict(batch)\n",
     "    \n",
     "    async def predict(self, batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:\n",
-    "        images = torch.tensor(batch[\"image\"]).float().to(\"cuda\")\n",
+    "        images = torch.from_numpy(np.stack(batch[\"image\"])).float().to(\"cuda\")\n",
     "\n",
     "        with torch.no_grad():\n",
     "            logits = self.model(images).cpu().numpy()\n",
@@ -218,7 +212,32 @@
     "\n",
     "Use `.bind()` to pass constructor arguments and `serve.run()` to deploy. Setting `num_replicas=1` creates a single **Replica** — a Ray actor that holds your model in memory and processes requests.\n",
     "\n",
-    "`.options()` configures the deployment — replicas, resources, autoscaling, and more. See the [full list of deployment configuration options](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html)."
+    "Deployment configuration — replicas, resources, autoscaling, and more — can be specified in three ways:\n",
+    "\n",
+    "- **`@serve.deployment` decorator** — set defaults at class definition time; useful when the config is stable across environments\n",
+    "- **`.options()`** — override at bind time; useful for environment-specific tuning without changing source code\n",
+    "- **Anyscale Service YAML** — declarative configuration for production deployments on Anyscale; supports per-environment overrides without code changes. See the [Anyscale Services docs](https://docs.anyscale.com/services/tutorial) for details.\n",
+    "\n",
+    "Using the decorator:\n",
+    "\n",
+    "```python\n",
+    "@serve.deployment(num_replicas=1, ray_actor_options={\"num_gpus\": 1})\n",
+    "class OnlineMNISTClassifier:\n",
+    "    ...\n",
+    "\n",
+    "mnist_app = OnlineMNISTClassifier.bind(local_path=\"/mnt/cluster_storage/model.pt\")\n",
+    "```\n",
+    "\n",
+    "Using `.options()` (overrides decorator defaults):\n",
+    "\n",
+    "```python\n",
+    "mnist_app = OnlineMNISTClassifier.options(\n",
+    "    num_replicas=2,\n",
+    "    ray_actor_options={\"num_gpus\": 1},\n",
+    ").bind(local_path=\"/mnt/cluster_storage/model.pt\")\n",
+    "```\n",
+    "\n",
+    "See the [full list of deployment configuration options](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html)."
    ]
   },
   {
@@ -241,8 +260,6 @@
    "id": "b4c5d6e7",
    "metadata": {},
    "source": [
-    "> **Note:** `.bind()` is a lazy call — it captures the constructor arguments without creating instances. Replicas are created when `serve.run()` is called.\n",
-    "\n",
     "`serve.run()` creates an **Application** — a group of deployments deployed together — and starts the Serve system:"
    ]
   },
@@ -256,42 +273,41 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-02-18 02:49:14,197\tINFO worker.py:1821 -- Connecting to existing Ray cluster at address: 10.0.140.139:6379...\n",
-      "2026-02-18 02:49:14,209\tINFO worker.py:1998 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-phfra92v85r9zs48xih8i8wr56.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
-      "2026-02-18 02:49:14,212\tINFO packaging.py:463 -- Pushing file package 'gcs://_ray_pkg_9a5034543e25b79b6f1e2feb4fa1b1c85a4a0f51.zip' (0.07MiB) to Ray cluster...\n",
-      "2026-02-18 02:49:14,213\tINFO packaging.py:476 -- Successfully pushed file package 'gcs://_ray_pkg_9a5034543e25b79b6f1e2feb4fa1b1c85a4a0f51.zip'.\n",
+      "2026-02-18 23:52:56,387\tINFO worker.py:1821 -- Connecting to existing Ray cluster at address: 10.0.131.103:6379...\n",
+      "2026-02-18 23:52:56,400\tINFO worker.py:1998 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-phfra92v85r9zs48xih8i8wr56.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
+      "2026-02-18 23:52:56,403\tINFO packaging.py:463 -- Pushing file package 'gcs://_ray_pkg_757b787e094d46c7db829002f91704aa5e3a34f1.zip' (0.04MiB) to Ray cluster...\n",
+      "2026-02-18 23:52:56,404\tINFO packaging.py:476 -- Successfully pushed file package 'gcs://_ray_pkg_757b787e094d46c7db829002f91704aa5e3a34f1.zip'.\n",
       "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/worker.py:2046: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0\n",
       "  warnings.warn(\n",
-      "\u001b[36m(ProxyActor pid=4600)\u001b[0m INFO 2026-02-18 02:49:20,336 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
-      "INFO 2026-02-18 02:49:20,456 serve 4350 -- Started Serve in namespace \"serve\".\n",
-      "\u001b[36m(ProxyActor pid=4600)\u001b[0m INFO 2026-02-18 02:49:20,450 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
-      "\u001b[36m(ServeController pid=4544)\u001b[0m INFO 2026-02-18 02:49:20,559 controller 4544 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 1).\n",
-      "\u001b[36m(ProxyActor pid=4600)\u001b[0m INFO 2026-02-18 02:49:20,562 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
-      "\u001b[36m(ServeController pid=4544)\u001b[0m INFO 2026-02-18 02:49:20,663 controller 4544 -- Adding 1 replica to Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
-      "\u001b[36m(ProxyActor pid=4600)\u001b[0m INFO 2026-02-18 02:49:20,594 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7e7666d33110>.\n"
+      "\u001b[36m(ProxyActor pid=15273)\u001b[0m INFO 2026-02-18 23:53:02,815 proxy 10.0.131.103 -- Proxy starting on node 996579d33caf1df76f44c3162f028c02409791fbac5732546ee2d059 (HTTP port: 8000).\n",
+      "INFO 2026-02-18 23:53:02,949 serve 14598 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=15273)\u001b[0m INFO 2026-02-18 23:53:02,946 proxy 10.0.131.103 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=15203)\u001b[0m INFO 2026-02-18 23:53:02,967 controller 15203 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 1).\n",
+      "\u001b[36m(ProxyActor pid=15273)\u001b[0m INFO 2026-02-18 23:53:02,970 proxy 10.0.131.103 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=15273)\u001b[0m INFO 2026-02-18 23:53:02,980 proxy 10.0.131.103 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7241eabd2e40>.\n",
+      "\u001b[36m(ServeController pid=15203)\u001b[0m INFO 2026-02-18 23:53:03,070 controller 15203 -- Adding 1 replica to Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(autoscaler +15s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n",
-      "\u001b[36m(autoscaler +15s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
-      "\u001b[36m(autoscaler +15s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB|g4dn.2xlarge] [us-west-2c] [on-demand] Launched 1 instance.\n"
+      "\u001b[36m(autoscaler +19s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n",
+      "\u001b[36m(autoscaler +20s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB] Attempting to add 1 node to the cluster (increasing from 0 to 1).\n",
+      "\u001b[36m(autoscaler +20s)\u001b[0m [autoscaler] [1xT4:8CPU-32GB|g4dn.2xlarge] [us-west-2c] [on-demand] Launched 1 instance.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:49:50,730 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {}. Use `ray status` for more details.\n",
-      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:50:20,787 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
-      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:50:50,855 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
-      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:51:20,915 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
-      "\u001b[36m(ServeController pid=4544)\u001b[0m WARNING 2026-02-18 02:51:50,981 controller 4544 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
-      "INFO 2026-02-18 02:51:52,835 serve 4350 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n",
-      "\u001b[36m(ProxyActor pid=2658, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:51:53,745 proxy 10.0.190.36 -- Proxy starting on node 9df8eee9130fc167b8bafaf41dcf9fe950124132c1f1501ff7a4a2f7 (HTTP port: 8000).\n",
-      "\u001b[36m(ProxyActor pid=2658, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:51:53,866 proxy 10.0.190.36 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n"
+      "\u001b[36m(ServeController pid=15203)\u001b[0m WARNING 2026-02-18 23:53:33,131 controller 15203 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {}. Use `ray status` for more details.\n",
+      "\u001b[36m(ServeController pid=15203)\u001b[0m WARNING 2026-02-18 23:54:03,181 controller 15203 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
+      "\u001b[36m(ServeController pid=15203)\u001b[0m WARNING 2026-02-18 23:54:33,241 controller 15203 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
+      "\u001b[36m(ServeController pid=15203)\u001b[0m WARNING 2026-02-18 23:55:03,304 controller 15203 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
+      "\u001b[36m(ServeController pid=15203)\u001b[0m WARNING 2026-02-18 23:55:33,371 controller 15203 -- Deployment 'OnlineMNISTClassifier' in application 'mnist_classifier' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {\"CPU\": 1, \"GPU\": 1, \"accelerator_type:T4\": 0.001}, total resources available: {\"CPU\": 7.0, \"accelerator_type:T4\": 0.999}. Use `ray status` for more details.\n",
+      "INFO 2026-02-18 23:55:36,355 serve 14598 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n",
+      "\u001b[36m(ProxyActor pid=2658, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:36,417 proxy 10.0.172.72 -- Proxy starting on node b15a859f02c6ec2a463e3a88ed4e014938c8c6c1efe9ef854e34054b (HTTP port: 8000).\n"
      ]
     }
    ],
@@ -336,31 +352,24 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predicted labels: [1, 1]\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ProxyActor pid=2658, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:51:53,901 proxy 10.0.190.36 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7bb0ae51eed0>.\n"
+      "\u001b[36m(ProxyActor pid=2658, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:36,538 proxy 10.0.172.72 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=2658, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:36,575 proxy 10.0.172.72 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x799b4777a9c0>.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Predicted labels: [1, 6]\n"
+      "Predicted labels: [6, 1]\n"
      ]
     }
    ],
    "source": [
     "images = np.random.rand(2, 1, 28, 28).tolist()\n",
-    "json_request = json.dumps({\"image\": images})\n",
-    "response = requests.post(\"http://localhost:8000/\", json=json_request)\n",
+    "response = requests.post(\"http://localhost:8000/\", json={\"image\": images})\n",
     "print(\"Predicted labels:\", response.json()[\"predicted_label\"])"
    ]
   },
@@ -384,42 +393,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO 2026-02-18 02:37:30,355 serve 226002 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7cd508d6ce60>.\n"
+      "INFO 2026-02-18 23:55:37,090 serve 14598 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7e3365e16240>.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Predicted labels: [1 1 6 1 1 6 1 1 6 1]\n"
+      "Predicted labels: [6 6 1 1 6 1 1 6 6 6]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2572, ip=10.0.144.150)\u001b[0m INFO 2026-02-18 02:37:30,294 mnist_classifier_OnlineMNISTClassifier inxgt6c9 648694cd-5c5a-4c47-b7ff-9f2e6f9b7b91 -- POST / 200 372.8ms\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2587, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:52:52,370 mnist_classifier_OnlineMNISTClassifier 7swb4ss8 951f3120-8266-4003-b2a1-890fd269f55c -- POST / 200 384.8ms\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO 2026-02-18 02:53:51,980 serve 4350 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b50c5602e40>.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predicted labels: [6 6 1 1 6 6 6 1 6 6]\n"
+      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2589, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:37,032 mnist_classifier_OnlineMNISTClassifier 3y1kk4s6 dd4c3140-76bd-47bb-a5ea-06dc60672732 -- POST / 200 390.3ms\n"
      ]
     }
    ],
@@ -439,31 +427,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2572, ip=10.0.144.150)\u001b[0m INFO 2026-02-18 02:37:30,442 mnist_classifier_OnlineMNISTClassifier inxgt6c9 ad8887c4-d53a-4f3e-9ea1-61cae84dd08a -- CALL predict OK 68.5ms\n",
-      "\u001b[36m(ServeController pid=226139)\u001b[0m INFO 2026-02-18 02:37:30,611 controller 226139 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
-      "\u001b[36m(ServeController pid=226139)\u001b[0m INFO 2026-02-18 02:37:32,644 controller 226139 -- Replica(id='inxgt6c9', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n",
-      "\u001b[33m(raylet)\u001b[0m Task ServeController.listen_for_change failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2587, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:53:52,067 mnist_classifier_OnlineMNISTClassifier 7swb4ss8 424d7b88-4d7b-439d-a10e-286afab392d7 -- CALL predict OK 67.4ms\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(ServeController pid=4544)\u001b[0m INFO 2026-02-18 02:54:52,042 controller 4544 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n"
+      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=2589, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:37,181 mnist_classifier_OnlineMNISTClassifier 3y1kk4s6 0a26fa62-aca1-425f-8005-013aafeddf4f -- CALL predict OK 70.3ms\n",
+      "\u001b[36m(ServeController pid=15203)\u001b[0m INFO 2026-02-18 23:55:37,295 controller 15203 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n"
      ]
     },
     {
@@ -478,7 +443,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeController pid=4544)\u001b[0m INFO 2026-02-18 02:54:54,053 controller 4544 -- Replica(id='7swb4ss8', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n"
+      "\u001b[36m(ServeController pid=15203)\u001b[0m INFO 2026-02-18 23:55:39,325 controller 15203 -- Replica(id='3y1kk4s6', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n"
      ]
     }
    ],
@@ -520,8 +485,8 @@
     "\n",
     "    @fastapi_app.post(\"/predict\")\n",
     "    async def predict(self, request: Request):\n",
-    "        batch = json.loads(await request.json())\n",
-    "        images = torch.tensor(batch[\"image\"]).float().to(\"cuda\")\n",
+    "        batch = await request.json()\n",
+    "        images = torch.from_numpy(np.stack(batch[\"image\"])).float().to(\"cuda\")\n",
     "        with torch.no_grad():\n",
     "            logits = self.model(images).cpu().numpy()\n",
     "        return {\"predicted_label\": np.argmax(logits, axis=1).tolist()}"
@@ -537,17 +502,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO 2026-02-18 02:56:03,951 serve 4350 -- Started Serve in namespace \"serve\".\n",
-      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:03,883 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
-      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:03,947 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
-      "\u001b[36m(ServeController pid=6893)\u001b[0m INFO 2026-02-18 02:56:04,052 controller 6893 -- Deploying new version of Deployment(name='MNISTFastAPIService', app='mnist_fastapi') (initial target replicas: 1).\n",
-      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:04,055 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
-      "\u001b[36m(ServeController pid=6893)\u001b[0m INFO 2026-02-18 02:56:04,156 controller 6893 -- Adding 1 replica to Deployment(name='MNISTFastAPIService', app='mnist_fastapi').\n",
-      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:04,090 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x719bf44b0350>.\n",
-      "\u001b[36m(ProxyActor pid=6955)\u001b[0m INFO 2026-02-18 02:56:07,984 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=[RoutePattern(methods=['GET', 'HEAD'], path='/docs'), RoutePattern(methods=['GET', 'HEAD'], path='/docs/oauth2-redirect'), RoutePattern(methods=['GET', 'HEAD'], path='/openapi.json'), RoutePattern(methods=['POST'], path='/predict'), RoutePattern(methods=['GET', 'HEAD'], path='/redoc')])}.\n",
-      "INFO 2026-02-18 02:56:08,068 serve 4350 -- Application 'mnist_fastapi' is ready at http://0.0.0.0:8000/.\n",
-      "\u001b[36m(ProxyActor pid=3192, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:09,078 proxy 10.0.190.36 -- Proxy starting on node 9df8eee9130fc167b8bafaf41dcf9fe950124132c1f1501ff7a4a2f7 (HTTP port: 8000).\n",
-      "INFO 2026-02-18 02:56:09,142 serve 4350 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b5211948a40>.\n"
+      "\u001b[36m(ProxyActor pid=16407)\u001b[0m INFO 2026-02-18 23:55:43,309 proxy 10.0.131.103 -- Proxy starting on node 996579d33caf1df76f44c3162f028c02409791fbac5732546ee2d059 (HTTP port: 8000).\n",
+      "INFO 2026-02-18 23:55:43,389 serve 14598 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=16407)\u001b[0m INFO 2026-02-18 23:55:43,385 proxy 10.0.131.103 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=16329)\u001b[0m INFO 2026-02-18 23:55:43,485 controller 16329 -- Deploying new version of Deployment(name='MNISTFastAPIService', app='mnist_fastapi') (initial target replicas: 1).\n",
+      "\u001b[36m(ProxyActor pid=16407)\u001b[0m INFO 2026-02-18 23:55:43,489 proxy 10.0.131.103 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=16407)\u001b[0m INFO 2026-02-18 23:55:43,500 proxy 10.0.131.103 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7d2d047fc3b0>.\n",
+      "\u001b[36m(ServeController pid=16329)\u001b[0m INFO 2026-02-18 23:55:43,590 controller 16329 -- Adding 1 replica to Deployment(name='MNISTFastAPIService', app='mnist_fastapi').\n",
+      "\u001b[36m(ProxyActor pid=16407)\u001b[0m INFO 2026-02-18 23:55:47,535 proxy 10.0.131.103 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=[RoutePattern(methods=['GET', 'HEAD'], path='/docs'), RoutePattern(methods=['GET', 'HEAD'], path='/docs/oauth2-redirect'), RoutePattern(methods=['GET', 'HEAD'], path='/openapi.json'), RoutePattern(methods=['POST'], path='/predict'), RoutePattern(methods=['GET', 'HEAD'], path='/redoc')])}.\n",
+      "INFO 2026-02-18 23:55:48,509 serve 14598 -- Application 'mnist_fastapi' is ready at http://0.0.0.0:8000/.\n",
+      "\u001b[36m(ProxyActor pid=2803, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:48,715 proxy 10.0.172.72 -- Proxy starting on node b15a859f02c6ec2a463e3a88ed4e014938c8c6c1efe9ef854e34054b (HTTP port: 8000).\n",
+      "INFO 2026-02-18 23:55:48,786 serve 14598 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7e3365d37da0>.\n"
      ]
     },
     {
@@ -564,7 +529,7 @@
    "source": [
     "app = MNISTFastAPIService.options(\n",
     "        num_replicas=1,\n",
-    "        ray_actor_options={\"num_gpus\": 1},\n",
+    "        ray_actor_options={\"num_gpus\": 0.1},\n",
     "    ).bind(local_path=\"/mnt/cluster_storage/model.pt\")\n",
     "serve.run(app, name=\"mnist_fastapi\", blocking=False)"
    ]
@@ -579,8 +544,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ProxyActor pid=3192, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:09,144 proxy 10.0.190.36 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=[RoutePattern(methods=['GET', 'HEAD'], path='/docs'), RoutePattern(methods=['GET', 'HEAD'], path='/docs/oauth2-redirect'), RoutePattern(methods=['GET', 'HEAD'], path='/openapi.json'), RoutePattern(methods=['POST'], path='/predict'), RoutePattern(methods=['GET', 'HEAD'], path='/redoc')])}.\n",
-      "\u001b[36m(ProxyActor pid=3192, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:09,181 proxy 10.0.190.36 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b5bcc37c680>.\n"
+      "\u001b[36m(ProxyActor pid=2803, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:48,801 proxy 10.0.172.72 -- Got updated endpoints: {Deployment(name='MNISTFastAPIService', app='mnist_fastapi'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=[RoutePattern(methods=['GET', 'HEAD'], path='/docs'), RoutePattern(methods=['GET', 'HEAD'], path='/docs/oauth2-redirect'), RoutePattern(methods=['GET', 'HEAD'], path='/openapi.json'), RoutePattern(methods=['POST'], path='/predict'), RoutePattern(methods=['GET', 'HEAD'], path='/redoc')])}.\n",
+      "\u001b[36m(ProxyActor pid=2803, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:48,843 proxy 10.0.172.72 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x73f3a81fc680>.\n"
      ]
     },
     {
@@ -593,7 +558,7 @@
    ],
    "source": [
     "images = np.random.rand(2, 1, 28, 28).tolist()\n",
-    "response = requests.post(\"http://localhost:8000/predict\", json=json.dumps({\"image\": images}))\n",
+    "response = requests.post(\"http://localhost:8000/predict\", json={\"image\": images})\n",
     "print(\"Predicted labels:\", response.json()[\"predicted_label\"])"
    ]
   },
@@ -602,8 +567,6 @@
    "id": "a5b6c7d8",
    "metadata": {},
    "source": [
-    "Visit `http://localhost:8000/docs` for the auto-generated interactive API documentation.\n",
-    "\n",
     "For more details on HTTP handling in Ray Serve, see the [HTTP Guide](https://docs.ray.io/en/latest/serve/http-guide.html)."
    ]
   },
@@ -617,9 +580,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeReplica:mnist_fastapi:MNISTFastAPIService pid=3123, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:09,594 mnist_fastapi_MNISTFastAPIService 4r6mu94r 67b52ae0-4f89-4c07-994e-c1e0f590ab28 -- POST /predict 200 359.2ms\n",
-      "\u001b[36m(ServeController pid=6893)\u001b[0m INFO 2026-02-18 02:56:09,733 controller 6893 -- Removing 1 replica from Deployment(name='MNISTFastAPIService', app='mnist_fastapi').\n",
-      "\u001b[36m(ServeController pid=6893)\u001b[0m INFO 2026-02-18 02:56:11,749 controller 6893 -- Replica(id='4r6mu94r', deployment='MNISTFastAPIService', app='mnist_fastapi') is stopped.\n"
+      "\u001b[36m(ServeReplica:mnist_fastapi:MNISTFastAPIService pid=2735, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:55:49,243 mnist_fastapi_MNISTFastAPIService hd1qcs16 a6e8854c-cbd7-4afe-a2fe-8333a2b5bf93 -- POST /predict 200 374.6ms\n",
+      "\u001b[36m(ServeController pid=16329)\u001b[0m INFO 2026-02-18 23:55:49,391 controller 16329 -- Removing 1 replica from Deployment(name='MNISTFastAPIService', app='mnist_fastapi').\n",
+      "\u001b[36m(ServeController pid=16329)\u001b[0m INFO 2026-02-18 23:55:51,418 controller 16329 -- Replica(id='hd1qcs16', deployment='MNISTFastAPIService', app='mnist_fastapi') is stopped.\n"
      ]
     },
     {
@@ -699,7 +662,7 @@
     "        self.model = model\n",
     "\n",
     "    async def __call__(self, request: Request):\n",
-    "        batch = json.loads(await request.json())\n",
+    "        batch = await request.json()\n",
     "        response = await self.preprocessor.run.remote(batch)\n",
     "        return await self.model.predict.remote(response)"
    ]
@@ -714,18 +677,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO 2026-02-18 02:56:16,051 serve 4350 -- Started Serve in namespace \"serve\".\n",
-      "\u001b[36m(ProxyActor pid=7148)\u001b[0m INFO 2026-02-18 02:56:15,980 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
-      "\u001b[36m(ProxyActor pid=7148)\u001b[0m INFO 2026-02-18 02:56:16,047 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,144 controller 7083 -- Deploying new version of Deployment(name='OnlineMNISTPreprocessor', app='image_classifier') (initial target replicas: 1).\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,145 controller 7083 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='image_classifier') (initial target replicas: 1).\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,146 controller 7083 -- Deploying new version of Deployment(name='ImageServiceIngress', app='image_classifier') (initial target replicas: 1).\n",
-      "\u001b[36m(ProxyActor pid=7148)\u001b[0m INFO 2026-02-18 02:56:16,150 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='ImageServiceIngress', app='image_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
-      "\u001b[36m(ProxyActor pid=7148)\u001b[0m INFO 2026-02-18 02:56:16,159 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x747108407fb0>.\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,251 controller 7083 -- Adding 1 replica to Deployment(name='OnlineMNISTPreprocessor', app='image_classifier').\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,253 controller 7083 -- Adding 1 replica to Deployment(name='OnlineMNISTClassifier', app='image_classifier').\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:16,254 controller 7083 -- Adding 1 replica to Deployment(name='ImageServiceIngress', app='image_classifier').\n",
-      "INFO 2026-02-18 02:56:21,172 serve 4350 -- Application 'image_classifier' is ready at http://0.0.0.0:8000/.\n"
+      "\u001b[36m(ProxyActor pid=16601)\u001b[0m INFO 2026-02-18 23:55:56,310 proxy 10.0.131.103 -- Proxy starting on node 996579d33caf1df76f44c3162f028c02409791fbac5732546ee2d059 (HTTP port: 8000).\n",
+      "INFO 2026-02-18 23:55:56,392 serve 14598 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=16601)\u001b[0m INFO 2026-02-18 23:55:56,387 proxy 10.0.131.103 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:55:56,493 controller 16540 -- Deploying new version of Deployment(name='OnlineMNISTPreprocessor', app='image_classifier') (initial target replicas: 1).\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:55:56,495 controller 16540 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='image_classifier') (initial target replicas: 1).\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:55:56,496 controller 16540 -- Deploying new version of Deployment(name='ImageServiceIngress', app='image_classifier') (initial target replicas: 1).\n",
+      "\u001b[36m(ProxyActor pid=16601)\u001b[0m INFO 2026-02-18 23:55:56,500 proxy 10.0.131.103 -- Got updated endpoints: {Deployment(name='ImageServiceIngress', app='image_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=16601)\u001b[0m INFO 2026-02-18 23:55:56,510 proxy 10.0.131.103 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7e1d50308200>.\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:55:56,601 controller 16540 -- Adding 1 replica to Deployment(name='OnlineMNISTPreprocessor', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:55:56,603 controller 16540 -- Adding 1 replica to Deployment(name='OnlineMNISTClassifier', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:55:56,604 controller 16540 -- Adding 1 replica to Deployment(name='ImageServiceIngress', app='image_classifier').\n",
+      "INFO 2026-02-18 23:56:01,514 serve 14598 -- Application 'image_classifier' is ready at http://0.0.0.0:8000/.\n"
      ]
     }
    ],
@@ -759,21 +722,25 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-02-18 02:56:24,235\tINFO logging.py:397 -- Registered dataset logger for dataset dataset_1_0\n",
-      "2026-02-18 02:56:24,304\tINFO streaming_executor.py:178 -- Starting execution of Dataset dataset_1_0. Full logs are in /tmp/ray/session_2026-02-18_02-46-49_468518_2351/logs/ray-data\n",
-      "2026-02-18 02:56:24,304\tINFO streaming_executor.py:179 -- Execution plan of Dataset dataset_1_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> LimitOperator[limit=10] -> TaskPoolMapOperator[ReadFiles]\n",
-      "2026-02-18 02:56:24,306\tINFO streaming_executor.py:687 -- [dataset]: A new progress UI is available. To enable, set `ray.data.DataContext.get_current().enable_rich_progress_bars = True` and `ray.data.DataContext.get_current().use_ray_tqdm = False`.\n",
-      "2026-02-18 02:56:24,306\tINFO progress_bar.py:155 -- Progress bar disabled because stdout is a non-interactive terminal.\n",
-      "2026-02-18 02:56:24,307\tWARNING resource_manager.py:136 -- ⚠️  Ray's object store is configured to use only 27.6% of available memory (17.7GiB out of 64.0GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n",
-      "2026-02-18 02:56:25,392\tINFO progress_bar.py:213 -- === Ray Data Progress {ListFiles} ===\n",
-      "2026-02-18 02:56:25,393\tINFO progress_bar.py:215 -- ListFiles: Tasks: 1; Actors: 0; Queued blocks: 0 (0.0B); Resources: 1.0 CPU, 384.0MiB object store: Progress Completed 0 / ?\n",
-      "2026-02-18 02:56:25,394\tINFO progress_bar.py:213 -- === Ray Data Progress {limit=10} ===\n",
-      "2026-02-18 02:56:25,395\tINFO progress_bar.py:215 -- limit=10: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: Progress Completed 0 / ?\n",
-      "2026-02-18 02:56:25,396\tINFO progress_bar.py:213 -- === Ray Data Progress {ReadFiles} ===\n",
-      "2026-02-18 02:56:25,397\tINFO progress_bar.py:215 -- ReadFiles: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: Progress Completed 0 / ?\n",
-      "2026-02-18 02:56:25,397\tINFO progress_bar.py:213 -- === Ray Data Progress {Running Dataset} ===\n",
-      "2026-02-18 02:56:25,398\tINFO progress_bar.py:215 -- Running Dataset: dataset_1_0. Active & requested resources: 0/8 CPU, 0.0B/6.7GiB object store: Progress Completed 0 / ?\n",
-      "2026-02-18 02:56:30,126\tINFO streaming_executor.py:305 -- ✔️  Dataset dataset_1_0 execution finished in 5.82 seconds\n",
+      "2026-02-18 23:56:04,122\tINFO logging.py:397 -- Registered dataset logger for dataset dataset_1_0\n",
+      "2026-02-18 23:56:04,191\tINFO streaming_executor.py:178 -- Starting execution of Dataset dataset_1_0. Full logs are in /tmp/ray/session_2026-02-18_23-19-50_964816_2338/logs/ray-data\n",
+      "2026-02-18 23:56:04,192\tINFO streaming_executor.py:179 -- Execution plan of Dataset dataset_1_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ListFiles] -> LimitOperator[limit=10] -> TaskPoolMapOperator[ReadFiles]\n",
+      "2026-02-18 23:56:04,193\tINFO streaming_executor.py:687 -- [dataset]: A new progress UI is available. To enable, set `ray.data.DataContext.get_current().enable_rich_progress_bars = True` and `ray.data.DataContext.get_current().use_ray_tqdm = False`.\n",
+      "2026-02-18 23:56:04,194\tINFO progress_bar.py:155 -- Progress bar disabled because stdout is a non-interactive terminal.\n",
+      "2026-02-18 23:56:04,195\tWARNING resource_manager.py:136 -- ⚠️  Ray's object store is configured to use only 27.6% of available memory (17.7GiB out of 64.0GiB total). For optimal Ray Data performance, we recommend setting the object store to at least 50% of available memory. You can do this by setting the 'object_store_memory' parameter when calling ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable.\n",
+      "2026-02-18 23:56:05,365\tINFO progress_bar.py:213 -- === Ray Data Progress {ListFiles} ===\n",
+      "2026-02-18 23:56:05,366\tINFO progress_bar.py:215 -- ListFiles: Tasks: 1; Actors: 0; Queued blocks: 0 (0.0B); Resources: 1.0 CPU, 384.0MiB object store: Progress Completed 0 / ?\n",
+      "2026-02-18 23:56:05,366\tINFO progress_bar.py:213 -- === Ray Data Progress {limit=10} ===\n",
+      "2026-02-18 23:56:05,367\tINFO progress_bar.py:215 -- limit=10: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: Progress Completed 0 / ?\n",
+      "2026-02-18 23:56:05,368\tINFO progress_bar.py:213 -- === Ray Data Progress {ReadFiles} ===\n",
+      "2026-02-18 23:56:05,369\tINFO progress_bar.py:215 -- ReadFiles: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: Progress Completed 0 / ?\n",
+      "2026-02-18 23:56:05,369\tINFO progress_bar.py:213 -- === Ray Data Progress {Running Dataset} ===\n",
+      "2026-02-18 23:56:05,370\tINFO progress_bar.py:215 -- Running Dataset: dataset_1_0. Active & requested resources: 0/8 CPU, 0.0B/6.7GiB object store: Progress Completed 0 / ?\n",
+      "2026-02-18 23:56:10,368\tINFO progress_bar.py:215 -- ListFiles: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store: Progress Completed 500 / ?\n",
+      "2026-02-18 23:56:10,369\tINFO progress_bar.py:215 -- limit=10: Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 1011.0B object store: Progress Completed 10 / 10\n",
+      "2026-02-18 23:56:10,369\tINFO progress_bar.py:215 -- ReadFiles: Tasks: 1; Actors: 0; Queued blocks: 0 (0.0B); Resources: 1.0 CPU, 25.6KiB object store: Progress Completed 10 / ?\n",
+      "2026-02-18 23:56:10,370\tINFO progress_bar.py:215 -- Running Dataset: dataset_1_0. Active & requested resources: 1/8 CPU, 26.6KiB/6.7GiB object store: Progress Completed 10 / ?\n",
+      "2026-02-18 23:56:10,379\tINFO streaming_executor.py:305 -- ✔️  Dataset dataset_1_0 execution finished in 6.19 seconds\n",
       "INFO:openlineage.client.client:OpenLineageClient will use `composite` transport\n",
       "INFO:openlineage.client.transport.composite:Stopping OpenLineage CompositeTransport emission after the first successful delivery because `continue_on_success=False`. Transport that emitted the event: <HttpTransport(name=first, kind=http, priority=1)>\n"
      ]
@@ -794,9 +761,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeReplica:image_classifier:ImageServiceIngress pid=3272, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:30,207 image_classifier_ImageServiceIngress 6a9x1pnn 4b9bcafb-8e14-4b64-8d6e-754d2f75903b -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b0bedd185f0>.\n",
-      "\u001b[36m(ServeReplica:image_classifier:OnlineMNISTPreprocessor pid=3270, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:30,227 image_classifier_OnlineMNISTPreprocessor tfgu42hj 4b9bcafb-8e14-4b64-8d6e-754d2f75903b -- CALL run OK 4.1ms\n",
-      "\u001b[36m(ServeReplica:image_classifier:OnlineMNISTClassifier pid=3271, ip=10.0.190.36)\u001b[0m /tmp/ipykernel_4350/4200536773.py:13: UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:253.)\n"
+      "\u001b[36m(ServeReplica:image_classifier:ImageServiceIngress pid=2884, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:56:10,485 image_classifier_ImageServiceIngress 46ybwxnn d7f84abe-88ec-4a87-a05e-a4141b0b9512 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x76984072b380>.\n",
+      "\u001b[36m(ServeReplica:image_classifier:OnlineMNISTPreprocessor pid=2883, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:56:10,507 image_classifier_OnlineMNISTPreprocessor b41c63rr d7f84abe-88ec-4a87-a05e-a4141b0b9512 -- CALL run OK 4.3ms\n"
      ]
     },
     {
@@ -805,11 +771,17 @@
      "text": [
       "Predicted labels: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(ServeReplica:image_classifier:OnlineMNISTClassifier pid=2882, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:56:10,906 image_classifier_OnlineMNISTClassifier 12afehlb d7f84abe-88ec-4a87-a05e-a4141b0b9512 -- CALL predict OK 382.5ms\n"
+     ]
     }
    ],
    "source": [
-    "json_request = json.dumps({\"image\": image_batch[\"image\"].tolist()})\n",
-    "response = requests.post(\"http://localhost:8000/\", json=json_request)\n",
+    "response = requests.post(\"http://localhost:8000/\", json={\"image\": image_batch[\"image\"].tolist()})\n",
     "print(\"Predicted labels:\", response.json()[\"predicted_label\"])"
    ]
   },
@@ -823,14 +795,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeReplica:image_classifier:ImageServiceIngress pid=3272, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:30,606 image_classifier_ImageServiceIngress 6a9x1pnn 4b9bcafb-8e14-4b64-8d6e-754d2f75903b -- POST / 200 415.8ms\n",
-      "\u001b[36m(ServeReplica:image_classifier:OnlineMNISTClassifier pid=3271, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:30,601 image_classifier_OnlineMNISTClassifier wf7hdn2g 4b9bcafb-8e14-4b64-8d6e-754d2f75903b -- CALL predict OK 358.8ms\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:30,727 controller 7083 -- Removing 1 replica from Deployment(name='OnlineMNISTPreprocessor', app='image_classifier').\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:30,727 controller 7083 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='image_classifier').\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:30,727 controller 7083 -- Removing 1 replica from Deployment(name='ImageServiceIngress', app='image_classifier').\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:32,764 controller 7083 -- Replica(id='tfgu42hj', deployment='OnlineMNISTPreprocessor', app='image_classifier') is stopped.\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:32,765 controller 7083 -- Replica(id='wf7hdn2g', deployment='OnlineMNISTClassifier', app='image_classifier') is stopped.\n",
-      "\u001b[36m(ServeController pid=7083)\u001b[0m INFO 2026-02-18 02:56:32,765 controller 7083 -- Replica(id='6a9x1pnn', deployment='ImageServiceIngress', app='image_classifier') is stopped.\n"
+      "\u001b[36m(ServeReplica:image_classifier:ImageServiceIngress pid=2884, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:56:10,911 image_classifier_ImageServiceIngress 46ybwxnn d7f84abe-88ec-4a87-a05e-a4141b0b9512 -- POST / 200 438.8ms\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:56:11,037 controller 16540 -- Removing 1 replica from Deployment(name='OnlineMNISTPreprocessor', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:56:11,037 controller 16540 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:56:11,037 controller 16540 -- Removing 1 replica from Deployment(name='ImageServiceIngress', app='image_classifier').\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:56:13,085 controller 16540 -- Replica(id='b41c63rr', deployment='OnlineMNISTPreprocessor', app='image_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:56:13,086 controller 16540 -- Replica(id='12afehlb', deployment='OnlineMNISTClassifier', app='image_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=16540)\u001b[0m INFO 2026-02-18 23:56:13,086 controller 16540 -- Replica(id='46ybwxnn', deployment='ImageServiceIngress', app='image_classifier') is stopped.\n"
      ]
     },
     {
@@ -869,14 +840,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ProxyActor pid=7559)\u001b[0m INFO 2026-02-18 02:56:36,835 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
-      "INFO 2026-02-18 02:56:36,898 serve 4350 -- Started Serve in namespace \"serve\".\n",
-      "\u001b[36m(ProxyActor pid=7559)\u001b[0m INFO 2026-02-18 02:56:36,895 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
-      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:36,988 controller 7494 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 4).\n",
-      "\u001b[36m(ProxyActor pid=7559)\u001b[0m INFO 2026-02-18 02:56:36,991 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
-      "\u001b[36m(ProxyActor pid=7559)\u001b[0m INFO 2026-02-18 02:56:37,000 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7287501f02f0>.\n",
-      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:37,092 controller 7494 -- Adding 4 replicas to Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
-      "INFO 2026-02-18 02:56:42,015 serve 4350 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n"
+      "\u001b[36m(ProxyActor pid=17018)\u001b[0m INFO 2026-02-18 23:56:17,206 proxy 10.0.131.103 -- Proxy starting on node 996579d33caf1df76f44c3162f028c02409791fbac5732546ee2d059 (HTTP port: 8000).\n",
+      "INFO 2026-02-18 23:56:17,290 serve 14598 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ProxyActor pid=17018)\u001b[0m INFO 2026-02-18 23:56:17,286 proxy 10.0.131.103 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ServeController pid=16952)\u001b[0m INFO 2026-02-18 23:56:17,369 controller 16952 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 4).\n",
+      "\u001b[36m(ProxyActor pid=17018)\u001b[0m INFO 2026-02-18 23:56:17,373 proxy 10.0.131.103 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=17018)\u001b[0m INFO 2026-02-18 23:56:17,383 proxy 10.0.131.103 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x716b988ac2c0>.\n",
+      "\u001b[36m(ServeController pid=16952)\u001b[0m INFO 2026-02-18 23:56:17,474 controller 16952 -- Adding 4 replicas to Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
+      "INFO 2026-02-18 23:56:22,408 serve 14598 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n"
      ]
     }
    ],
@@ -896,7 +867,7 @@
    "source": [
     "#### Request routing\n",
     "\n",
-    "With multiple replicas, Serve uses the **Power of Two Choices** algorithm by default: randomly sample 2 replicas, pick the one with the shorter queue. You can also implement [custom routing logic](https://docs.ray.io/en/latest/serve/advanced-guides/custom-request-router.html) by subclassing `RequestRouter`.\n",
+    "With multiple replicas, Serve uses the **Power of Two Choices** algorithm by default: randomly sample 2 replicas, pick the one with the shorter queue. For workloads requiring cache affinity, latency-aware selection, or priority queues, see [Section 11: Custom Request Routing](#11-custom-request-routing).\n",
     "\n",
     "Test the fractional GPU deployment:"
    ]
@@ -911,13 +882,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Predicted labels: [1, 1]\n"
+      "Predicted labels: [1, 6]\n"
      ]
     }
    ],
    "source": [
     "images = np.random.rand(2, 1, 28, 28).tolist()\n",
-    "response = requests.post(\"http://localhost:8000/\", json=json.dumps({\"image\": images}))\n",
+    "response = requests.post(\"http://localhost:8000/\", json={\"image\": images})\n",
     "print(\"Predicted labels:\", response.json()[\"predicted_label\"])"
    ]
   },
@@ -931,12 +902,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=3699, ip=10.0.190.36)\u001b[0m INFO 2026-02-18 02:56:42,439 mnist_classifier_OnlineMNISTClassifier ar6t5cad 6c229dbb-04d6-4858-be65-2c1c3758ba8a -- POST / 200 357.2ms\n",
-      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:42,609 controller 7494 -- Removing 4 replicas from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
-      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:44,642 controller 7494 -- Replica(id='ar6t5cad', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
-      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:44,642 controller 7494 -- Replica(id='3ykvd446', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
-      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:44,643 controller 7494 -- Replica(id='7d3n141m', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
-      "\u001b[36m(ServeController pid=7494)\u001b[0m INFO 2026-02-18 02:56:44,644 controller 7494 -- Replica(id='5blwjqfh', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n"
+      "\u001b[36m(ServeController pid=16952)\u001b[0m INFO 2026-02-18 23:56:22,912 controller 16952 -- Removing 4 replicas from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
+      "\u001b[36m(ServeReplica:mnist_classifier:OnlineMNISTClassifier pid=3309, ip=10.0.172.72)\u001b[0m INFO 2026-02-18 23:56:22,843 mnist_classifier_OnlineMNISTClassifier vo3o7rwe ab266a2a-f790-4e31-a942-78b44ad05221 -- POST / 200 364.0ms\n",
+      "\u001b[36m(ServeController pid=16952)\u001b[0m INFO 2026-02-18 23:56:24,954 controller 16952 -- Replica(id='q683yf2d', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=16952)\u001b[0m INFO 2026-02-18 23:56:24,954 controller 16952 -- Replica(id='pmvtssi7', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=16952)\u001b[0m INFO 2026-02-18 23:56:24,955 controller 16952 -- Replica(id='3hrjt7u7', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=16952)\u001b[0m INFO 2026-02-18 23:56:24,956 controller 16952 -- Replica(id='vo3o7rwe', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n"
      ]
     },
     {
@@ -984,14 +955,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ProxyActor pid=7758)\u001b[0m INFO 2026-02-18 02:56:48,824 proxy 10.0.140.139 -- Proxy starting on node 1349328c4c289b18250dbf2618fd3c610d08a4b682f4f4c62dc0157e (HTTP port: 8000).\n",
-      "INFO 2026-02-18 02:56:48,890 serve 4350 -- Started Serve in namespace \"serve\".\n",
-      "\u001b[36m(ProxyActor pid=7758)\u001b[0m INFO 2026-02-18 02:56:48,886 proxy 10.0.140.139 -- Got updated endpoints: {}.\n",
-      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:48,986 controller 7695 -- Registering autoscaling state for deployment Deployment(name='OnlineMNISTClassifier', app='mnist_classifier')\n",
-      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:48,987 controller 7695 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 0).\n",
-      "\u001b[36m(ProxyActor pid=7758)\u001b[0m INFO 2026-02-18 02:56:48,990 proxy 10.0.140.139 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
-      "\u001b[36m(ProxyActor pid=7758)\u001b[0m INFO 2026-02-18 02:56:49,000 proxy 10.0.140.139 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x73655146c620>.\n",
-      "INFO 2026-02-18 02:56:50,000 serve 4350 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n"
+      "\u001b[36m(ProxyActor pid=17208)\u001b[0m INFO 2026-02-18 23:56:29,212 proxy 10.0.131.103 -- Proxy starting on node 996579d33caf1df76f44c3162f028c02409791fbac5732546ee2d059 (HTTP port: 8000).\n",
+      "INFO 2026-02-18 23:56:29,294 serve 14598 -- Started Serve in namespace \"serve\".\n",
+      "\u001b[36m(ServeController pid=17147)\u001b[0m INFO 2026-02-18 23:56:29,374 controller 17147 -- Registering autoscaling state for deployment Deployment(name='OnlineMNISTClassifier', app='mnist_classifier')\n",
+      "\u001b[36m(ServeController pid=17147)\u001b[0m INFO 2026-02-18 23:56:29,375 controller 17147 -- Deploying new version of Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') (initial target replicas: 0).\n",
+      "\u001b[36m(ProxyActor pid=17208)\u001b[0m INFO 2026-02-18 23:56:29,289 proxy 10.0.131.103 -- Got updated endpoints: {}.\n",
+      "\u001b[36m(ProxyActor pid=17208)\u001b[0m INFO 2026-02-18 23:56:29,379 proxy 10.0.131.103 -- Got updated endpoints: {Deployment(name='OnlineMNISTClassifier', app='mnist_classifier'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.\n",
+      "\u001b[36m(ProxyActor pid=17208)\u001b[0m INFO 2026-02-18 23:56:29,388 proxy 10.0.131.103 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x73f3fb73c440>.\n",
+      "INFO 2026-02-18 23:56:30,407 serve 14598 -- Application 'mnist_classifier' is ready at http://0.0.0.0:8000/.\n"
      ]
     }
    ],
@@ -1030,212 +1001,212 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO 2026-02-18 02:56:50,059 serve 4350 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7b50801b9880>.\n"
+      "INFO 2026-02-18 23:56:30,473 serve 14598 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7e2f6816c1a0>.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[<ray.serve.handle.DeploymentResponse at 0x7b50801bb0e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802e22d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801bb4d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801bb890>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801bbb00>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801bbce0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801bbec0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc0e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc2c0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc4a0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc680>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dc860>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dca40>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dccb0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dce90>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dd070>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dd250>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5211950710>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b521194d100>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b521194fcb0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b521194d400>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5211a35d00>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5211a3b590>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dcaa0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801ddf40>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dd100>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801de600>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801decf0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801de030>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801df9b0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801df2f0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802000e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50801dfdd0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080200560>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080200290>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802009e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080200ce0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080200f80>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080201220>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080201580>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080201820>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080201ac0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080201d60>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080202000>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802025d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080202870>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080202b10>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080202db0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5211a39280>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021c0b0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021c710>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021c9b0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021c920>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021cdd0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021d3d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021d670>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021d9d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021dc70>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021df10>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021de80>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021e330>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021e180>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021e7b0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021ea50>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021e8a0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021eed0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021ed20>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021f350>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021f1a0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021f7d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021f620>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021fc50>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021faa0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080230110>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508021ff20>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080230590>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802303e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080230a10>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080230860>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080230bc0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080231070>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080230ec0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802314f0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080231340>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080231970>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802317c0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080231b20>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080231fd0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080232180>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802325d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802328d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080232840>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080232cf0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080232b40>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080233170>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080232fc0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802338f0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080233740>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080233dd0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080233d40>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080250230>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080233ec0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802503e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802505c0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080250a70>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802508c0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080250fb0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080250e00>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080252c30>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080252a80>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50802536b0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080253500>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080253b30>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080253980>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080253ce0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800681d0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080253fe0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080068650>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800684a0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080068800>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800689e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080069610>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080069460>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080069c10>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080069a60>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080069dc0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b5080069fa0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006a150>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006a120>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006a990>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006a7e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006af30>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006b170>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006afc0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006b5f0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006b440>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006ba70>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006bc50>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508006bf50>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008c230>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008c470>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008c2c0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008c620>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008c800>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008ccb0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008ce90>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008d070>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008d250>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008d430>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008d610>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008d7f0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008cb00>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008d9a0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008db80>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008dd60>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008e690>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008e510>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008eb10>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008e960>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008ef90>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008f290>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008f0e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008eff0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008f320>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008fcb0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b508008fb00>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8170>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8470>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a83e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8890>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a86e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8d10>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8b60>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9190>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a8fe0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9790>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a95e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9c10>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9a60>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa090>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800a9ee0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa510>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa360>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa990>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800aa7e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800aae10>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800aac60>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800ab290>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800ab590>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c00b0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0350>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c05f0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0560>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0a70>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c09e0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0bc0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c0da0>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c1250>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c1430>,\n",
-       " <ray.serve.handle.DeploymentResponse at 0x7b50800c16d0>]"
+       "[<ray.serve.handle.DeploymentResponse at 0x7e3365d3e0c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6816e270>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6816f170>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6816f740>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6816f980>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6816fbf0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6816fdd0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68190170>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e3365d3c320>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e3365d3d130>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e3365d38fe0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e3365d3bda0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e3365d3cd10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e3365d38710>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e3365d39640>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e3365e1c0b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e31d02be840>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681908c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68190290>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68191520>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68190c50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68192330>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68191c10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68192b10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68192840>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68192f90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68192cc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68193410>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68193140>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68193890>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681935c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68193aa0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b46b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b4950>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b47a0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b5910>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b5760>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b5ac0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b5f70>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b5dc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b63f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b6240>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b6870>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b66c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b6cf0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b6b40>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b6ea0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b7350>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b7080>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b7ad0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b7920>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b7c50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d4290>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d4530>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d47d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d4a70>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d49e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d4bc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d4da0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d4f80>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d5430>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d5730>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d59d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d5c70>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d5be0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d6090>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d5ee0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d6510>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d6360>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d6990>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d6c90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d6f30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d7c50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d7ef0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681d7e60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681e8350>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681e8080>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681e8500>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681e9bb0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681e9a00>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681ea030>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681ea330>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681ea5d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681ea870>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681ea7e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681eac90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681eaae0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681eb110>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681eaf60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681eb590>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681eb3e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681eb740>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681ebbf0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681ebef0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681ebe60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68208350>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68208650>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f681b6990>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68208770>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68208d10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68208b60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68209550>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f682093a0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f682099d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68209cd0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68209f70>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820a210>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820a4b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820a750>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820a9f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820ac90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820af30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820b1d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820b470>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820b710>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820b9b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820bc50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820bbc0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f682240b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f6820bec0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68224260>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68224710>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68224560>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68224b90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f682249e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68225010>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68224e60>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68225490>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f682252e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68225910>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68225760>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68225d90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68225be0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68225f40>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68226120>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68226300>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f682267b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68226600>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68226c30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68226a80>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68227ce0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68044410>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68044710>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680449b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68044920>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68044dd0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68044c20>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68045250>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68047230>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68047080>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680473e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68047890>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680476e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68047d10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68047fe0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680642f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68064260>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68064710>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68064a10>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68064c50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68064ef0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680651f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68065160>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68065610>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680658b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68065700>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68065d30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68065b80>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680661b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68066000>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68066630>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68066480>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68066ab0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68066900>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68066c30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680671d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68067470>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680672c0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680678f0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68067ad0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68067b30>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68067d40>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68084230>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68067ec0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680843b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68084950>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680847a0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68085310>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680855b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680858b0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68085b50>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68085df0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68086090>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68086330>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680865d0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68086870>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f680867e0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68086c90>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68086ae0>,\n",
+       " <ray.serve.handle.DeploymentResponse at 0x7e2f68086e40>]"
       ]
      },
      "execution_count": 24,
@@ -1266,23 +1237,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:50,117 controller 7695 -- Upscaling Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') from 0 to 1 replicas. Current ongoing requests: 13.00, current running replicas: 0.\n"
+      "\u001b[36m(ServeController pid=17147)\u001b[0m INFO 2026-02-18 23:56:30,508 controller 17147 -- Upscaling Deployment(name='OnlineMNISTClassifier', app='mnist_classifier') from 0 to 1 replicas. Current ongoing requests: 8.00, current running replicas: 0.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:50,228 controller 7695 -- Deregistering autoscaling state for deployment Deployment(name='OnlineMNISTClassifier', app='mnist_classifier')\n",
-      "\u001b[36m(ServeController pid=7695)\u001b[0m INFO 2026-02-18 02:56:50,229 controller 7695 -- Deregistering autoscaling state for application mnist_classifier\n"
+      "\u001b[36m(ServeController pid=17147)\u001b[0m INFO 2026-02-18 23:56:30,613 controller 17147 -- Adding 1 replica to Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
+      "\u001b[36m(ServeController pid=17147)\u001b[0m INFO 2026-02-18 23:56:30,750 controller 17147 -- Removing 1 replica from Deployment(name='OnlineMNISTClassifier', app='mnist_classifier').\n",
+      "\u001b[36m(ServeController pid=17147)\u001b[0m INFO 2026-02-18 23:56:33,932 controller 17147 -- Replica(id='nec1eyvx', deployment='OnlineMNISTClassifier', app='mnist_classifier') is stopped.\n",
+      "\u001b[36m(ServeController pid=17147)\u001b[0m INFO 2026-02-18 23:56:33,933 controller 17147 -- Deregistering autoscaling state for deployment Deployment(name='OnlineMNISTClassifier', app='mnist_classifier')\n",
+      "\u001b[36m(ServeController pid=17147)\u001b[0m INFO 2026-02-18 23:56:33,933 controller 17147 -- Deregistering autoscaling state for application mnist_classifier\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[33m(raylet)\u001b[0m Task ServeController.listen_for_change failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n",
-      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n",
+      "\u001b[33m(raylet)\u001b[0m Task ServeController.listen_for_change failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.\n"
      ]
     }
    ],
@@ -1295,7 +1269,7 @@
    "id": "e7f8a9b1",
    "metadata": {},
    "source": [
-    "For advanced use cases, Ray Serve supports [custom autoscaling policies](https://docs.ray.io/en/latest/serve/advanced-guides/advanced-autoscaling.html#custom-autoscaling-policies) that go beyond queue-depth — such as pre-scaling based on time of day, scaling on CPU/memory utilization, or targeting a P90 latency SLA.\n",
+    "For workloads where request count doesn't correlate with actual load — predictable traffic patterns, resource-constrained stages, latency SLAs, or multi-deployment pipelines — see [Section 12: Custom Autoscaling](#12-custom-autoscaling).\n",
     "\n",
     "---\n",
     "\n",
@@ -1451,6 +1425,64 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a2b3c4d5",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 11. Custom Request Routing\n",
+    "\n",
+    "For routing decisions that require replica-specific state — which KV-cache prefix is loaded, per-user session affinity, or request priority — subclass `RequestRouter` and implement `choose_replicas()`, which returns a ranked list of candidate groups. The base class handles queue-length probing, exponential backoff, and dead-replica removal.\n",
+    "\n",
+    "```python\n",
+    "from ray.serve._private.request_router import RequestRouter, FIFOMixin, LocalityMixin\n",
+    "\n",
+    "class MyRouter(FIFOMixin, LocalityMixin, RequestRouter):\n",
+    "    async def choose_replicas(self, candidate_replicas, pending_request):\n",
+    "        candidates = self.apply_locality_routing(pending_request)\n",
+    "        # sort by a custom stat exposed via record_routing_stats()\n",
+    "        return [sorted(candidates, key=lambda r: r.routing_stats.get(\"load\", 0))]\n",
+    "```\n",
+    "\n",
+    "Optional mixins compose common behaviors: `FIFOMixin` for FIFO ordering, `LocalityMixin` for same-node → same-AZ preference, and `MultiplexMixin` for model-affinity routing. Replicas report custom statistics to the router by implementing `record_routing_stats() -> dict[str, float]`, polled periodically by the Controller.\n",
+    "\n",
+    "For the full walkthrough — uniform random router, throughput-aware router, and the complete `RunningReplica` API — see the [Custom Request Routing docs](https://docs.ray.io/en/latest/serve/advanced-guides/custom-request-router.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3c4d5e6",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 12. Custom Autoscaling\n",
+    "\n",
+    "Custom policies let you encode any scaling logic in Python — pre-scale by time of day, respond to CPU/memory metrics reported by replicas, target a P90 latency SLA, or coordinate replica counts across a multi-deployment pipeline.\n",
+    "\n",
+    "```python\n",
+    "from ray.serve.config import AutoscalingConfig, AutoscalingPolicy\n",
+    "\n",
+    "def scheduled_policy(ctx: AutoscalingContext) -> tuple[int, dict]:\n",
+    "    hour = datetime.now(ZoneInfo(\"America/Los_Angeles\")).hour\n",
+    "    desired = 8 if 9 <= hour < 17 else (4 if 7 <= hour < 20 else 1)\n",
+    "    return max(ctx.capacity_adjusted_min_replicas,\n",
+    "               min(ctx.capacity_adjusted_max_replicas, desired)), {}\n",
+    "\n",
+    "@serve.deployment(autoscaling_config=AutoscalingConfig(\n",
+    "    min_replicas=1, max_replicas=12,\n",
+    "    policy=AutoscalingPolicy(policy_function=scheduled_policy),\n",
+    "))\n",
+    "class MyDeployment: ...\n",
+    "```\n",
+    "\n",
+    "The Controller calls your policy at each tick with an `AutoscalingContext` containing the current target replica count, per-replica metrics from `record_autoscaling_stats()`, and state returned from the previous tick. Always use `ctx.target_num_replicas` as the baseline — not `ctx.current_num_replicas` — since it reflects pending decisions that haven't materialized yet. Application-level policies receive contexts for all deployments at once and return joint scaling decisions, enabling proportional scaling across pipeline stages.\n",
+    "\n",
+    "For the full walkthrough — schedule-based, CPU/memory metrics, Prometheus latency SLA, and the external scaler REST API — see the [Custom Autoscaling docs](https://docs.ray.io/en/latest/serve/advanced-guides/advanced-autoscaling.html#custom-autoscaling-policies)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f4a5b6c8",
    "metadata": {},
    "source": [
@@ -1466,6 +1498,8 @@
     "- **Configure** autoscaling, fractional GPUs, and resource allocation\n",
     "- **Monitor** with built-in metrics, custom metrics, tracing, and alerts\n",
     "- **Understand** batching, model multiplexing, and async inference patterns\n",
+    "- **Customize** autoscaling with custom policies (schedule, resource, latency SLA, pipeline coordination)\n",
+    "- **Extend** request routing with custom replica selection logic (cache affinity, priority, latency-aware)\n",
     "\n",
     "### Next Steps\n",
     "\n",
@@ -1478,7 +1512,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/doc/source/ray-overview/examples/intro-serve/serve.md
+++ b/doc/source/ray-overview/examples/intro-serve/serve.md
@@ -58,15 +58,8 @@ Consider using Ray Serve when your serving workload has one or more of the follo
 |---|---|
 | **Scalability** — needs to handle variable or high traffic | Autoscaling replicas based on request queue depth; scales across a Ray cluster |
 | **Hardware utilization** — GPUs underutilized by one-at-a-time inference | Dynamic request batching and fractional GPU allocation |
-| **Service composition** — multiple models or processing stages | Compose deployments; Ray's object store for efficient data sharing |
+| **Model composition** — multiple models or processing stages | Compose heterogeneous deployments with independent scaling; Efficient data transfer between deployments through the Ray object store |
 | **Slow iteration speed** — Kubernetes YAML, container builds | Python-first API; develop locally, deploy distributed with the same code |
-
-#### Key Ray Serve Features
-
-- [Response streaming](https://docs.ray.io/en/latest/serve/tutorials/streaming.html)
-- [Dynamic request batching](https://docs.ray.io/en/latest/serve/advanced-guides/dyn-req-batch.html)
-- [Model multiplexing](https://docs.ray.io/en/latest/serve/model-multiplexing.html)
-- [Fractional compute resource usage](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html)
 
 ---
 
@@ -151,7 +144,7 @@ Deployment configuration — replicas, resources, autoscaling, and more — can 
 
 - **`@serve.deployment` decorator** — set defaults at class definition time; useful when the config is stable across environments
 - **`.options()`** — override at bind time; useful for environment-specific tuning without changing source code
-- **Anyscale Service YAML** — declarative configuration for production deployments on Anyscale; supports per-environment overrides without code changes. See the [Anyscale Services docs](https://docs.anyscale.com/services/get-started) for details.
+- **Anyscale Service YAML** — declarative configuration for production deployments on Anyscale; supports per-environment overrides without code changes. See the [Anyscale Services docs](https://docs.anyscale.com/services/tutorial) for details.
 
 Using the decorator:
 
@@ -258,8 +251,6 @@ images = np.random.rand(2, 1, 28, 28).tolist()
 response = requests.post("http://localhost:8000/predict", json={"image": images})
 response.json()["predicted_label"]
 ```
-
-Visit `http://localhost:8000/docs` for the auto-generated interactive API documentation.
 
 For more details on HTTP handling in Ray Serve, see the [HTTP Guide](https://docs.ray.io/en/latest/serve/http-guide.html).
 

--- a/doc/source/ray-overview/examples/intro-serve/serve.md
+++ b/doc/source/ray-overview/examples/intro-serve/serve.md
@@ -1,0 +1,548 @@
+# Introduction to Ray Serve
+
+This template introduces Ray Serve, a scalable model-serving framework built on Ray. You will learn **what** Ray Serve is, **why** it is a good fit for online ML inference, and **how** to build, deploy, and operate a real model service — starting from a familiar PyTorch classifier and progressively adding features like composition, autoscaling, batching, fault tolerance, and observability.
+
+**Part 1: Core**
+
+1. Why Ray Serve?
+2. Build Your First Deployment (MNIST Classifier)
+3. Integrating with FastAPI
+4. Composing Deployments
+5. Resource Specification and Fractional GPUs
+6. Autoscaling
+7. Observability
+
+**Part 2: Advanced topics**
+
+8. Dynamic Request Batching
+9. Model Multiplexing
+10. Asynchronous Inference
+
+## Imports
+
+```python
+from typing import Any
+
+import json
+import logging
+import time
+
+import numpy as np
+import requests
+import torch
+from torchvision import transforms
+
+import ray
+from ray import serve
+from ray.serve.handle import DeploymentHandle
+from ray.serve import metrics
+from fastapi import FastAPI
+from pydantic import BaseModel
+from starlette.requests import Request
+from matplotlib import pyplot as plt
+```
+
+### Note on Storage
+
+Throughout this tutorial, we use `/mnt/cluster_storage` to represent a shared storage location. In a multi-node cluster, Ray workers on different nodes cannot access the head node's local file system. Use a [shared storage solution](https://docs.anyscale.com/configuration/storage#shared) accessible from every node.
+
+---
+
+## 1. Why Ray Serve?
+
+Consider using Ray Serve when your serving workload has one or more of the following needs:
+
+| **Challenge** | **Ray Serve Solution** |
+|---|---|
+| **Scalability** — needs to handle variable or high traffic | Autoscaling replicas based on request queue depth; scales across a Ray cluster |
+| **Hardware utilization** — GPUs underutilized by one-at-a-time inference | Dynamic request batching and fractional GPU allocation |
+| **Service composition** — multiple models or processing stages | Compose deployments; Ray's object store for efficient data sharing |
+| **Expensive startup** — large model weights to load | Stateful replicas (Ray actors) keep models in memory across requests |
+| **Slow iteration speed** — Kubernetes YAML, container builds | Python-first API; develop locally, deploy distributed with the same code |
+
+#### Key Ray Serve Features
+
+- [Response streaming](https://docs.ray.io/en/latest/serve/tutorials/streaming.html)
+- [Dynamic request batching](https://docs.ray.io/en/latest/serve/advanced-guides/dyn-req-batch.html)
+- [Model multiplexing](https://docs.ray.io/en/latest/serve/model-multiplexing.html)
+- [Fractional compute resource usage](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html)
+
+---
+
+## 2. Build Your First Deployment
+
+Let's migrate a standard PyTorch classifier to Ray Serve. We start with a familiar offline `MNISTClassifier` and turn it into an online service.
+
+### 2.1 The Offline Classifier
+
+Here is a standard PyTorch inference class that loads a TorchScript model and classifies images.
+
+```python
+class OfflineMNISTClassifier:
+    def __init__(self, local_path: str):
+        self.model = torch.jit.load(local_path)
+        self.model.to("cuda")
+        self.model.eval()
+
+    def __call__(self, batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        return self.predict(batch)
+    
+    def predict(self, batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        images = torch.tensor(batch["image"]).float().to("cuda")
+
+        with torch.no_grad():
+            logits = self.model(images).cpu().numpy()
+
+        batch["predicted_label"] = np.argmax(logits, axis=1)
+        return batch
+```
+
+Download the pre-trained model to shared storage:
+
+```python
+!aws s3 cp s3://anyscale-public-materials/ray-ai-libraries/mnist/model/model.pt /mnt/cluster_storage/model.pt
+```
+
+### 2.2 Migrating to Ray Serve
+
+To turn this into an online service, we make three changes:
+
+1. Add the `@serve.deployment()` decorator — this turns the class into a **Deployment**, Ray Serve's fundamental unit that can be independently scaled and configured
+2. Change `__call__` to accept a Starlette `Request` object
+3. Parse the incoming JSON body
+
+```python
+@serve.deployment()
+class OnlineMNISTClassifier:
+    def __init__(self, local_path: str):
+        self.model = torch.jit.load(local_path)
+        self.model.to("cuda")
+        self.model.eval()
+
+    async def __call__(self, request: Request) -> dict[str, Any]:
+        batch = json.loads(await request.json())
+        return await self.predict(batch)
+    
+    async def predict(self, batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        images = torch.tensor(batch["image"]).float().to("cuda")
+
+        with torch.no_grad():
+            logits = self.model(images).cpu().numpy()
+
+        batch["predicted_label"] = np.argmax(logits, axis=1)
+        return batch
+```
+
+### 2.3 Deploy and Test
+
+Use `.bind()` to pass constructor arguments and `serve.run()` to deploy. Setting `num_replicas=1` creates a single **Replica** — a Ray actor that holds your model in memory and processes requests.
+
+```python
+mnist_deployment = OnlineMNISTClassifier.options(
+    num_replicas=1,
+    ray_actor_options={"num_gpus": 1},
+)
+
+mnist_app = mnist_deployment.bind(local_path="/mnt/cluster_storage/model.pt")
+```
+
+`.options()` configures the deployment — replicas, resources, autoscaling, and more. See the [full list of deployment configuration options](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html).
+
+> **Note:** `.bind()` is a lazy call — it captures the constructor arguments without creating instances. Replicas are created when `serve.run()` is called.
+
+`serve.run()` creates an **Application** — a group of deployments deployed together — and starts the Serve system:
+
+```python
+mnist_handle = serve.run(mnist_app, name="mnist_classifier", blocking=False)
+```
+
+#### Under the hood
+
+When `serve.run()` returns, Ray Serve has started three types of actors:
+
+| Actor | Role |
+|---|---|
+| **Controller** | Global singleton. Manages the control plane, creates/destroys replicas, runs the autoscaler. |
+| **Proxy** | Runs a Uvicorn HTTP server (one per head node by default). Accepts incoming HTTP requests and forwards them to replicas. |
+| **Replica** | Executes your deployment code. Each replica is a Ray actor with its own request queue. |
+
+<img src="https://docs.ray.io/en/latest/_images/architecture-2.0.svg" width="800">
+
+These actors are self-healing: if a replica crashes, the Controller detects and replaces it; if the Proxy crashes, the Controller restarts it; if the Controller itself crashes, Ray restarts it. Application exceptions (bugs in your code) return HTTP 500 but don't take down the replica. For critical workloads, implement client-side retries with exponential backoff. See [End-to-End Fault Tolerance](https://docs.ray.io/en/latest/serve/production-guide/fault-tolerance.html) for details.
+
+#### Test via HTTP
+
+When you send a request to `localhost:8000`, the **Proxy** receives it, the **Router** selects a replica, and the replica executes your `__call__` method:
+
+```python
+images = np.random.rand(2, 1, 28, 28).tolist()
+json_request = json.dumps({"image": images})
+response = requests.post("http://localhost:8000/", json=json_request)
+response.json()["predicted_label"]
+```
+
+#### Test via DeploymentHandle
+
+You can also call deployments in-process without HTTP overhead:
+
+```python
+batch = {"image": np.random.rand(10, 1, 28, 28)}
+response = await mnist_handle.predict.remote(batch)
+response["predicted_label"]
+```
+
+```python
+serve.shutdown()
+```
+
+---
+
+## 3. Integrating with FastAPI
+
+Ray Serve integrates with FastAPI to provide HTTP routing, Pydantic validation, and auto-generated OpenAPI docs. Use `@serve.ingress(fastapi_app)` to designate a FastAPI app as the HTTP entrypoint.
+
+Here we wrap our existing `OnlineMNISTClassifier` pattern into a FastAPI-powered deployment to demonstrate the integration:
+
+```python
+fastapi_app = FastAPI()
+
+@serve.deployment
+@serve.ingress(fastapi_app)
+class MNISTFastAPIService:
+    """Same model logic as OnlineMNISTClassifier, but using FastAPI for HTTP routing."""
+    def __init__(self, local_path: str):
+        self.model = torch.jit.load(local_path)
+        self.model.to("cuda")
+        self.model.eval()
+
+    @fastapi_app.post("/predict")
+    async def predict(self, request: Request):
+        batch = json.loads(await request.json())
+        images = torch.tensor(batch["image"]).float().to("cuda")
+        with torch.no_grad():
+            logits = self.model(images).cpu().numpy()
+        return {"predicted_label": np.argmax(logits, axis=1).tolist()}
+
+app = MNISTFastAPIService.options(
+        num_replicas=1,
+        ray_actor_options={"num_gpus": 0.1},
+    ).bind(local_path="/mnt/cluster_storage/model.pt")
+serve.run(app, name="mnist_fastapi", blocking=False)
+```
+
+```python
+images = np.random.rand(2, 1, 28, 28).tolist()
+response = requests.post("http://localhost:8000/predict", json=json.dumps({"image": images}))
+response.json()["predicted_label"]
+```
+
+Visit `http://localhost:8000/docs` for the auto-generated interactive API documentation.
+
+For more details on HTTP handling in Ray Serve, see the [HTTP Guide](https://docs.ray.io/en/latest/serve/http-guide.html).
+
+```python
+serve.shutdown()
+```
+
+Now that we have a working single-deployment service, let's see how to compose multiple deployments into a pipeline.
+
+---
+
+## 4. Composing Deployments
+
+Ray Serve lets you compose multiple deployments into a single application. This is useful when you need:
+- **Independent scaling** — each component scales separately
+- **Hardware disaggregation** — CPU preprocessing + GPU inference
+- **Reusable components** — share a preprocessor across models
+
+### 4.1 Define a Preprocessor
+
+```python
+@serve.deployment
+class OnlineMNISTPreprocessor:
+    def __init__(self):
+        self.transform = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.5,), (0.5,))
+        ])
+        
+    async def run(self, batch: dict[str, Any]) -> dict[str, Any]:
+        images = batch["image"]
+        images = [self.transform(np.array(image, dtype=np.uint8)).cpu().numpy() for image in images]
+        return {"image": images}
+```
+
+### 4.2 Build a Composed Application
+
+Wire the preprocessor and classifier together via an ingress deployment:
+
+```python
+@serve.deployment
+class ImageServiceIngress:
+    def __init__(self, preprocessor, model):
+        self.preprocessor = preprocessor
+        self.model = model
+
+    async def __call__(self, request: Request):
+        batch = json.loads(await request.json())
+        response = await self.preprocessor.run.remote(batch)
+        return await self.model.predict.remote(response)
+```
+
+```python
+image_classifier_app = ImageServiceIngress.bind(
+    preprocessor=OnlineMNISTPreprocessor.bind(),
+    model=OnlineMNISTClassifier.options(
+        num_replicas=1,
+        ray_actor_options={"num_gpus": 0.1},
+    ).bind(local_path="/mnt/cluster_storage/model.pt"),
+)
+
+handle = serve.run(image_classifier_app, name="image_classifier", blocking=False)
+```
+
+### 4.3 Test the Composed App
+
+```python
+ds = ray.data.read_images("s3://anyscale-public-materials/ray-ai-libraries/mnist/50_per_index/", include_paths=True)
+image_batch = ds.take_batch(10)
+
+json_request = json.dumps({"image": image_batch["image"].tolist()})
+response = requests.post("http://localhost:8000/", json=json_request)
+response.json()["predicted_label"]
+```
+
+```python
+serve.shutdown()
+```
+
+With the composition pattern in hand, let's explore how to fine-tune resource allocation for each deployment.
+
+---
+
+## 5. Resource Specification and Fractional GPUs
+
+Each replica can specify its resource requirements. For small models like our MNIST classifier, you can use **fractional GPUs** to pack multiple replicas on a single GPU:
+
+```python
+mnist_app = OnlineMNISTClassifier.options(
+    num_replicas=4,
+    ray_actor_options={"num_gpus": 0.1},  # 10% of a GPU per replica → up to 10 replicas per GPU
+).bind(local_path="/mnt/cluster_storage/model.pt")
+
+mnist_handle = serve.run(mnist_app, name="mnist_classifier", blocking=False)
+```
+
+#### Request routing
+With multiple replicas, Serve uses the **Power of Two Choices** algorithm by default: randomly sample 2 replicas, pick the one with the shorter queue. You can also implement [custom routing logic](https://docs.ray.io/en/latest/serve/advanced-guides/custom-request-router.html) by subclassing `RequestRouter`.
+
+---
+Test the fractional GPU deployment
+```python
+images = np.random.rand(2, 1, 28, 28).tolist()
+response = requests.post("http://localhost:8000/", json=json.dumps({"image": images}))
+response.json()["predicted_label"]
+```
+
+```python
+serve.shutdown()
+```
+
+Next, let's see how Ray Serve can automatically scale replicas up and down based on traffic.
+
+---
+
+## 6. Autoscaling
+
+Ray Serve automatically adjusts the number of replicas based on traffic. The key settings are:
+
+- **`target_ongoing_requests`** — the desired average number of active requests per replica. The autoscaler adds replicas when the actual ratio exceeds this target.
+- **`max_ongoing_requests`** — the upper limit per replica. Set 20-50% higher than `target_ongoing_requests`. While `max_ongoing_requests` limits concurrency per replica, `max_queued_requests` limits how many requests wait in the caller's queue. When reached, new requests immediately receive HTTP 503.
+- **`upscale_delay_s`** / **`downscale_delay_s`** — how long to wait before adding or removing replicas.
+- **`look_back_period_s`** — the time window for averaging ongoing requests when making scaling decisions.
+
+### Autoscaling in action
+
+With `initial_replicas=0` and `min_replicas=0`, no GPU resources are allocated until a request arrives:
+
+```python
+mnist_app = OnlineMNISTClassifier.options(
+    ray_actor_options={"num_cpus": 0.5, "num_gpus": 0.1},
+    autoscaling_config={
+        "target_ongoing_requests": 10,
+        "initial_replicas": 0,
+        "min_replicas": 0,
+        "max_replicas": 8,
+        "upscale_delay_s": 5,
+        "downscale_delay_s": 60,
+        "look_back_period_s": 5,
+    },
+).bind(local_path="/mnt/cluster_storage/model.pt")
+
+mnist_handle = serve.run(mnist_app, name="mnist_classifier", blocking=False)
+```
+
+Send requests to trigger scale-up:
+
+```python
+batch = {"image": np.random.rand(10, 1, 28, 28)}
+[mnist_handle.predict.remote(batch) for _ in range(200)]
+```
+
+<img src="https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-auto-scaling.png" width="800">
+
+
+```python
+serve.shutdown()
+```
+
+For advanced use cases, Ray Serve supports [custom autoscaling policies](https://docs.ray.io/en/latest/serve/advanced-guides/advanced-autoscaling.html#custom-autoscaling-policies) that go beyond queue-depth — such as pre-scaling based on time of day, scaling on CPU/memory utilization, or targeting a P90 latency SLA.
+
+---
+
+## 7. Observability
+
+### Metrics
+
+Ray Serve exposes metrics at multiple granularity levels through the Serve dashboard and Grafana:
+
+- **Throughput metrics** — QPS and error QPS, available per application, per deployment, and per replica
+
+<img src="https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-throughput-metrics.png" width="800">
+
+- **Latency metrics** — P50, P90, P99 latencies at the same granularity levels
+
+<img src="https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-latency-metrics.png" width="800">
+
+- **Deployment metrics** — replica count and queue size per deployment
+
+<img src="https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-replica-metrics.png" width="400">
+
+<img src="https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-queuesize-metrics.png" width="400">
+
+Access these through the Ray Dashboard by navigating to **Ray Dashboard > Serve > VIEW IN GRAFANA**.
+
+### Custom metrics
+
+Define custom metrics using `ray.serve.metrics`:
+
+```python
+@serve.deployment(num_replicas=2)
+class InstrumentedService:
+    def __init__(self):
+        self.request_counter = metrics.Counter(
+            "my_request_counter",
+            description="Total requests processed.",
+            tag_keys=("model",),
+        )
+        self.request_counter.set_default_tags({"model": "mnist"})
+
+    async def __call__(self, request: Request):
+        self.request_counter.inc()
+        return "ok"
+```
+
+To create custom dashboards for monitoring your custom metrics, see [Custom dashboards and alerting](https://docs.anyscale.com/monitoring/custom-dashboards-and-alerting).
+
+Here is how the custom metric looks like in the Anyscale dashboard.
+
+<img src="https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/serve-custom-request-counter.png" width="400">
+
+### Tracing
+
+For end-to-end request tracing across composed deployments, use the Anyscale Tracing integration. A single request's trace displays the hierarchical structure of how it flows through your deployment graph:
+
+```text
+1. proxy_http_request (Root) - Duration: 245ms
+   └── 2. proxy_route_to_replica (APIGateway) - Duration: 240ms
+       └── 3. replica_handle_request (APIGateway) - Duration: 235ms
+           └── 4. proxy_route_to_replica (UserService) - Duration: 180ms
+               └── 5. replica_handle_request (UserService) - Duration: 175ms
+```
+
+For details, see the [Anyscale Tracing guide](https://docs.anyscale.com/monitoring/tracing/).
+
+### Alerts
+
+Ray integrates with Prometheus and Grafana for an enhanced observability experience. Grafana alerting lets you set up alerts based on Prometheus metrics — for example, alerting when P90 latency exceeds your SLA or error QPS spikes. Grafana supports multiple notification channels including Slack and PagerDuty.
+
+For a comprehensive overview of monitoring and debugging on Anyscale, see the [Anyscale monitoring guide](https://docs.anyscale.com/monitoring) and [custom dashboards and alerting](https://docs.anyscale.com/monitoring/custom-dashboards-and-alerting).
+
+---
+
+# Part 2: Advanced Topics
+
+The following sections cover additional serving patterns, operational features, and production concerns. They don't require running code in sequence and can be read as reference material.
+
+---
+
+## 8. Dynamic Request Batching
+
+When your model can process multiple inputs efficiently (such as GPU inference), batching improves throughput. Ray Serve provides the `@serve.batch` decorator:
+
+```python
+@serve.deployment
+class BatchMNISTClassifier:
+    def __init__(self, local_path: str):
+        self.model = torch.jit.load(local_path).to("cuda").eval()
+
+    @serve.batch(max_batch_size=8, batch_wait_timeout_s=0.1)
+    async def __call__(self, images_list: list[np.ndarray]) -> list[dict]:
+        # images_list is a list of individual request payloads, automatically batched
+        stacked = torch.tensor(np.stack(images_list)).float().to("cuda")
+        with torch.no_grad():
+            logits = self.model(stacked).cpu().numpy()
+        predictions = np.argmax(logits, axis=1)
+        return [{"predicted_label": int(p)} for p in predictions]
+```
+
+Under the hood:
+- Requests are buffered in a queue
+- Once `max_batch_size` requests arrive (or `batch_wait_timeout_s` elapses), the batch is sent to your method
+- Responses are split and returned individually
+
+This is most effective for **vectorized operations on CPUs** and **parallelizable operations on GPUs**.
+
+---
+
+## 9. Model Multiplexing
+
+When serving many models with the same shape but different weights (such as per-customer fine-tuned models), model multiplexing lets a shared pool of replicas efficiently serve all of them. The router inspects the `serve_multiplexed_model_id` request header and routes each request to a replica that already has that model loaded, avoiding redundant loading. Each replica caches up to `max_num_models_per_replica` models and evicts the least recently used one when full.
+
+<img src="https://anyscale-public-materials.s3.us-west-2.amazonaws.com/intro-ai-libraries/model_multiplexing_architecture.png" width="800">
+
+For the full API walkthrough — including code examples, client headers, and `DeploymentHandle` options — see the [Model Multiplexing docs](https://docs.ray.io/en/latest/serve/model-multiplexing.html).
+
+---
+
+## 10. Asynchronous Inference
+
+Synchronous APIs block until processing completes, which is problematic for long-running tasks such as video processing or document analysis. Asynchronous inference decouples request submission from result retrieval — clients submit a task, receive a task ID immediately, and poll for the result later.
+
+<img src="https://anyscale-materials.s3.us-west-2.amazonaws.com/ray-serve-deep-dive/async_inference_architecture.png" width="900">
+
+The architecture consists of an HTTP ingress that enqueues tasks into a broker (such as Redis or RabbitMQ), a `@task_consumer` deployment that pulls and processes tasks, and a backend that stores results and status. This provides natural backpressure, built-in retries, and dead letter queues for failed tasks.
+
+For the full walkthrough — including configuration, code examples, and monitoring — see the [Asynchronous Inference docs](https://docs.ray.io/en/latest/serve/asynchronous-inference.html).
+
+---
+
+## Summary and Next Steps
+
+In this template, you learned how to:
+
+- **Build** a Ray Serve deployment from a standard PyTorch model
+- **Integrate** with FastAPI for HTTP routing and validation
+- **Compose** multiple deployments into a pipeline
+- **Configure** autoscaling, fractional GPUs, and resource allocation
+- **Monitor** with built-in metrics, custom metrics, tracing, and alerts
+- **Understand** batching, model multiplexing, and async inference patterns
+
+### Next Steps
+
+1. [Ray Serve documentation](https://docs.ray.io/en/latest/serve/index.html) — full API reference
+2. [Production guide](https://docs.ray.io/en/latest/serve/production-guide/index.html) — deploying and managing Serve in production
+3. [Anyscale monitoring guide](https://docs.anyscale.com/monitoring) — dashboards, alerts, and debugging
+4. [Configure Serve deployments](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html) — full configuration options
+
+---


### PR DESCRIPTION
Update intro-templates for Ray serve.

 Content-only update — won't be merged into /ray directly. Refer to .ipynb file for code outputs.

  New sections:
  - Observability
  - Dynamic Request Batching
  - Model Multiplexing
  - Asynchronous Inference

other sections have minor structural adjustments.

main source of update is from @marwan116's [central enablement](https://docs.google.com/document/d/1M29kZSzXLoLbDBaNF3MMeil806CCmAk9dqRumlKYCnw/edit?tab=t.0). 
Initial draft reviewed together with Naila and Xing.