### PR TITLE
[ci] refactor: extract shared build utilities into build_common.py

### DIFF
--- a/build-wheel.sh
+++ b/build-wheel.sh
@@ -25,4 +25,4 @@ esac
 
 RAYMAKE_URL="https://github.com/ray-project/rayci/releases/download/v${RAYCI_VERSION}/raymake-${RAYCI_VERSION}-py3-none-${WHEEL_PLATFORM}.whl"
 
-exec uv run --with "$RAYMAKE_URL" "$RAY_ROOT/ci/build/build_wheel.py" "$@"
+PYTHONPATH="$RAY_ROOT${PYTHONPATH:+:$PYTHONPATH}" exec uv run --with "$RAYMAKE_URL" "$RAY_ROOT/ci/build/build_wheel.py" "$@"

--- a/ci/build/BUILD.bazel
+++ b/ci/build/BUILD.bazel
@@ -18,9 +18,27 @@ py_test(
 )
 
 py_library(
+    name = "build_common",
+    srcs = ["build_common.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "build_common_test",
+    size = "small",
+    srcs = ["build_common_test.py"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [":build_common"],
+)
+
+py_library(
     name = "build_wheel",
     srcs = ["build_wheel.py"],
     visibility = ["//visibility:public"],
+    deps = [":build_common"],
 )
 
 py_test(

--- a/ci/build/build_common.py
+++ b/ci/build/build_common.py
@@ -1,0 +1,83 @@
+"""Shared utilities for local build scripts (build_wheel.py, build_image.py)."""
+from __future__ import annotations
+
+import logging
+import platform as _platform
+import re
+import subprocess
+from pathlib import Path
+
+
+class BuildError(Exception):
+    """Raised when a build operation fails."""
+
+
+class _ColorFormatter(logging.Formatter):
+    BLUE, RED, RESET = "\033[34m", "\033[31m", "\033[0m"
+    COLORS = {logging.INFO: BLUE, logging.ERROR: RED}
+
+    def format(self, record: logging.LogRecord) -> str:
+        color = self.COLORS.get(record.levelno, "")
+        return f"{color}[{record.levelname}]{self.RESET} {record.getMessage()}"
+
+
+_handler = logging.StreamHandler()
+_handler.setFormatter(_ColorFormatter())
+log = logging.getLogger("raybuild")
+log.propagate = False
+log.addHandler(_handler)
+log.setLevel(logging.INFO)
+
+
+def find_ray_root() -> Path:
+    """Walk up from this file and cwd looking for .rayciversion."""
+    start = Path(__file__).resolve()
+    for parent in [start, *start.parents]:
+        if (parent / ".rayciversion").exists():
+            return parent
+    if (Path.cwd() / ".rayciversion").exists():
+        return Path.cwd()
+    raise BuildError("Could not find Ray root (missing .rayciversion).")
+
+
+def parse_file(path: Path, pattern: str) -> str:
+    """Extract a regex capture group from a file."""
+    if not path.exists():
+        raise BuildError(f"Missing {path}")
+    match = re.search(pattern, path.read_text(), re.M)
+    if not match:
+        raise BuildError(f"Pattern {pattern} not found in {path}")
+    return match.group(1).strip()
+
+
+def detect_host_arch() -> str:
+    """Return normalised host architecture (x86_64 or aarch64).
+
+    Raises BuildError on unsupported OS/architecture combinations.
+    """
+    sys_os = _platform.system().lower()
+    m = _platform.machine().lower()
+    arch = (
+        "x86_64"
+        if m in ("amd64", "x86_64")
+        else "aarch64"
+        if m in ("arm64", "aarch64")
+        else m
+    )
+    supported = {("darwin", "aarch64"), ("linux", "x86_64"), ("linux", "aarch64")}
+    if (sys_os, arch) not in supported:
+        raise BuildError(f"Unsupported platform: {sys_os}-{m}")
+    return arch
+
+
+def get_git_commit(root: Path) -> str:
+    """Return the current git HEAD commit hash, or 'unknown' on failure."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return "unknown"

--- a/ci/build/build_common_test.py
+++ b/ci/build/build_common_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Tests for build_common.py"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from ci.build.build_common import BuildError, parse_file
+
+
+class TestParseFile(unittest.TestCase):
+    """Test parse_file() extracts values from config files."""
+
+    def test_parses_quoted_value(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            self.addCleanup(Path(f.name).unlink, missing_ok=True)
+            f.write('MANYLINUX_VERSION="260128.221a193"\n')
+            f.flush()
+            result = parse_file(Path(f.name), r'MANYLINUX_VERSION=["\']?([^"\'\s]+)')
+        self.assertEqual(result, "260128.221a193")
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(BuildError) as ctx:
+            parse_file(Path("/nonexistent"), r".*")
+        self.assertIn("Missing", str(ctx.exception))
+
+    def test_missing_pattern_raises(self):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            self.addCleanup(Path(f.name).unlink, missing_ok=True)
+            f.write("OTHER_VAR=value\n")
+            f.flush()
+            with self.assertRaises(BuildError) as ctx:
+                parse_file(Path(f.name), r"MISSING_VAR=(\w+)")
+        self.assertIn("not found in", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extract duplicated utilities (BuildError, log, find_ray_root, parse_file, get_git_commit) from build_wheel.py into a shared build_common.py module.

Topic: build-common-refactor
Signed-off-by: andrew <andrew@anyscale.com>