### PR TITLE
[Data] Add local aggregation fast-path for small datasets

### DIFF
--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -34,6 +34,7 @@ from ray.data.context import DataContext, ShuffleStrategy
 
 
 def _estimate_input_size_bytes(refs: List[RefBundle]) -> int:
+    """Estimate the total size in bytes of the input ref bundles."""
     return sum(bundle.size_bytes() for bundle in refs)
 
 
@@ -42,6 +43,7 @@ def _generate_local_aggregate_fn(
     aggs: Tuple[AggregateFn, ...],
     batch_format: str,
 ):
+    """Generate a local aggregation function for small datasets."""
     from ray.data._internal.planner.exchange.aggregate_task_spec import (
         SortAggregateTaskSpec,
     )
@@ -125,7 +127,7 @@ def _plan_hash_shuffle_repartition(
     return HashShuffleOperator(
         input_physical_op,
         data_context,
-        key_columns=tuple(normalized_key_columns),  # noqa: type
+        key_columns=tuple(normalized_key_columns),  # type: ignore[arg-type]
         # NOTE: In case number of partitions is not specified, we fall back to
         #       default min parallelism configured
         num_partitions=logical_op.num_outputs,

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -149,8 +149,8 @@ def _plan_hash_shuffle_aggregate(
     return HashAggregateOperator(
         data_context,
         input_physical_op,
-        key_columns=tuple(normalized_key_columns),  # type: ignore
-        aggregation_fns=tuple(logical_op.aggs),  # type: ignore
+        key_columns=tuple(normalized_key_columns),  # type: ignore[arg-type]
+        aggregation_fns=tuple(logical_op.aggs),  # type: ignore[arg-type]
         num_partitions=logical_op.num_partitions,
     )
 
@@ -270,7 +270,7 @@ def plan_all_to_all_op(
         fn = generate_aggregate_fn(
             op.key,
             op.aggs,
-            op.batch_format,  # type: ignore
+            op.batch_format,  # type: ignore[arg-type]
             data_context,
             debug_limit_shuffle_execution_to_num_blocks,
         )

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -1,6 +1,14 @@
-from typing import List
+from typing import List, Optional, Tuple
 
-from ray.data._internal.execution.interfaces import PhysicalOperator
+import ray
+from ray.data._internal.execution.interfaces import (
+    PhysicalOperator,
+    RefBundle,
+    TaskContext,
+)
+from ray.data._internal.execution.interfaces.transform_fn import (
+    AllToAllTransformFnResult,
+)
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
 )
@@ -13,11 +21,93 @@ from ray.data._internal.logical.operators import (
     Sort,
 )
 from ray.data._internal.planner.aggregate import generate_aggregate_fn
+from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
+from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 from ray.data._internal.planner.random_shuffle import generate_random_shuffle_fn
 from ray.data._internal.planner.randomize_blocks import generate_randomize_blocks_fn
 from ray.data._internal.planner.repartition import generate_repartition_fn
 from ray.data._internal.planner.sort import generate_sort_fn
+from ray.data._internal.table_block import TableBlockAccessor
+from ray.data.aggregate import AggregateFn
+from ray.data.block import Block, BlockAccessor, BlockMetadataWithSchema
 from ray.data.context import DataContext, ShuffleStrategy
+
+
+def _estimate_input_size_bytes(refs: List[RefBundle]) -> int:
+    return sum(bundle.size_bytes() for bundle in refs)
+
+
+def _generate_local_aggregate_fn(
+    key: Optional[str],
+    aggs: Tuple[AggregateFn, ...],
+    batch_format: str,
+):
+    from ray.data._internal.planner.exchange.aggregate_task_spec import (
+        SortAggregateTaskSpec,
+    )
+    from ray.data._internal.util import unify_ref_bundles_schema
+
+    if len(aggs) == 0:
+        raise ValueError("Aggregate requires at least one aggregation")
+
+    def fn(
+        refs: List[RefBundle],
+        ctx: TaskContext,
+    ) -> AllToAllTransformFnResult:
+        blocks = []
+        for ref_bundle in refs:
+            blocks.extend(ref_bundle.block_refs)
+        if len(blocks) == 0:
+            return ([], {})
+
+        unified_schema = unify_ref_bundles_schema(refs)
+        for agg_fn in aggs:
+            agg_fn._validate(unified_schema)
+
+        sort_key = SortKey(key)
+
+        all_blocks: List[Block] = ray.get(blocks)
+
+        pruned_blocks = [
+            SortAggregateTaskSpec._prune_unused_columns(block, sort_key, aggs)
+            for block in all_blocks
+        ]
+
+        if sort_key.get_columns():
+            pruned_blocks = [
+                BlockAccessor.for_block(block).sort(sort_key) for block in pruned_blocks
+            ]
+
+        aggregated_blocks = [
+            BlockAccessor.for_block(block)._aggregate(sort_key, aggs)
+            for block in pruned_blocks
+        ]
+
+        target_block_type = ExchangeTaskSpec._derive_target_block_type(batch_format)
+        normalized_blocks = TableBlockAccessor.normalize_block_types(
+            aggregated_blocks, target_block_type=target_block_type
+        )
+
+        final_block, _ = BlockAccessor.for_block(
+            normalized_blocks[0]
+        )._combine_aggregated_blocks(
+            list(normalized_blocks), sort_key, aggs, finalize=True
+        )
+
+        final_metadata = BlockMetadataWithSchema.from_block(final_block)
+
+        return (
+            [
+                RefBundle(
+                    [(ray.put(final_block), final_metadata.metadata)],
+                    schema=final_metadata.schema,
+                    owns_blocks=True,
+                )
+            ],
+            {},
+        )
+
+    return fn
 
 
 def _plan_hash_shuffle_repartition(
@@ -59,12 +149,9 @@ def _plan_hash_shuffle_aggregate(
     return HashAggregateOperator(
         data_context,
         input_physical_op,
-        key_columns=tuple(normalized_key_columns),  # noqa: type
-        aggregation_fns=tuple(logical_op.aggs),  # noqa: type
-        # NOTE: In case number of partitions is not specified, we fall back to
-        #       default min parallelism configured
+        key_columns=tuple(normalized_key_columns),  # type: ignore
+        aggregation_fns=tuple(logical_op.aggs),  # type: ignore
         num_partitions=logical_op.num_partitions,
-        # TODO wire in aggregator args overrides
     )
 
 
@@ -83,8 +170,6 @@ def plan_all_to_all_op(
 
     if isinstance(op, RandomizeBlocks):
         fn = generate_randomize_blocks_fn(op)
-        # Randomize block order does not actually compute anything, so we
-        # want to inherit the upstream op's target max block size.
 
     elif isinstance(op, RandomShuffle):
         debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
@@ -140,13 +225,52 @@ def plan_all_to_all_op(
         if data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE:
             return _plan_hash_shuffle_aggregate(data_context, op, input_physical_dag)
 
+        if data_context.small_data_threshold_for_local_aggregation > 0:
+            local_fn = _generate_local_aggregate_fn(
+                op.key,
+                tuple(op.aggs),
+                op.batch_format or "default",
+            )
+
+            debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
+                "debug_limit_shuffle_execution_to_num_blocks", None
+            )
+            distributed_fn = generate_aggregate_fn(
+                op.key,
+                op.aggs,
+                op.batch_format or "default",
+                data_context,
+                debug_limit_shuffle_execution_to_num_blocks,
+            )
+
+            def aggregate_fn_with_local_fallback(
+                refs: List[RefBundle],
+                ctx: TaskContext,
+            ) -> AllToAllTransformFnResult:
+                input_size = _estimate_input_size_bytes(refs)
+                if (
+                    input_size
+                    <= data_context.small_data_threshold_for_local_aggregation
+                ):
+                    return local_fn(refs, ctx)
+                return distributed_fn(refs, ctx)
+
+            return AllToAllOperator(
+                aggregate_fn_with_local_fallback,
+                input_physical_dag,
+                data_context,
+                num_outputs=op.num_partitions,
+                sub_progress_bar_names=op.sub_progress_bar_names,
+                name=op.name,
+            )
+
         debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
             "debug_limit_shuffle_execution_to_num_blocks", None
         )
         fn = generate_aggregate_fn(
             op.key,
             op.aggs,
-            op.batch_format,
+            op.batch_format,  # type: ignore
             data_context,
             debug_limit_shuffle_execution_to_num_blocks,
         )

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -120,7 +120,6 @@ def _plan_hash_shuffle_repartition(
     from ray.data._internal.execution.operators.hash_shuffle import (
         HashShuffleOperator,
     )
-    from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 
     normalized_key_columns = SortKey(logical_op.keys).get_columns()
 
@@ -144,7 +143,6 @@ def _plan_hash_shuffle_aggregate(
     from ray.data._internal.execution.operators.hash_aggregate import (
         HashAggregateOperator,
     )
-    from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 
     normalized_key_columns = SortKey(logical_op.key).get_columns()
 

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -90,6 +90,9 @@ def _generate_local_aggregate_fn(
             aggregated_blocks, target_block_type=target_block_type
         )
 
+        if not normalized_blocks:
+            return ([], {})
+
         final_block, _ = BlockAccessor.for_block(
             normalized_blocks[0]
         )._combine_aggregated_blocks(

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -652,9 +652,9 @@ class DataContext:
     )
     write_file_retry_on_errors: List[str] = DEFAULT_WRITE_FILE_RETRY_ON_ERRORS
     warn_on_driver_memory_usage_bytes: int = DEFAULT_WARN_ON_DRIVER_MEMORY_USAGE_BYTES
-    actor_task_retry_on_errors: Union[bool, List[BaseException]] = (
-        DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
-    )
+    actor_task_retry_on_errors: Union[
+        bool, List[BaseException]
+    ] = DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
     actor_init_retry_on_errors: bool = DEFAULT_ACTOR_INIT_RETRY_ON_ERRORS
     actor_init_max_retries: int = DEFAULT_ACTOR_INIT_MAX_RETRIES
     op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
@@ -694,9 +694,9 @@ class DataContext:
         default_factory=_issue_detectors_config_factory
     )
 
-    downstream_capacity_backpressure_ratio: Optional[float] = (
-        DEFAULT_DOWNSTREAM_CAPACITY_BACKPRESSURE_RATIO
-    )
+    downstream_capacity_backpressure_ratio: Optional[
+        float
+    ] = DEFAULT_DOWNSTREAM_CAPACITY_BACKPRESSURE_RATIO
 
     enable_dynamic_output_queue_size_backpressure: bool = (
         DEFAULT_ENABLE_DYNAMIC_OUTPUT_QUEUE_SIZE_BACKPRESSURE

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -721,7 +721,9 @@ class DataContext:
         self._kv_configs: Dict[str, Any] = {}
 
         # Sync hash shuffle aggregator fields to its detector config
-        self.issue_detectors_config.hash_shuffle_detector_config.detection_time_interval_s = self.hash_shuffle_aggregator_health_warning_interval_s
+        self.issue_detectors_config.hash_shuffle_detector_config.detection_time_interval_s = (
+            self.hash_shuffle_aggregator_health_warning_interval_s
+        )
         self.issue_detectors_config.hash_shuffle_detector_config.min_wait_time_s = (
             self.min_hash_shuffle_aggregator_wait_time_in_s
         )

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -101,6 +101,10 @@ DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED = True
 
 DEFAULT_MIN_PARALLELISM = env_integer("RAY_DATA_DEFAULT_MIN_PARALLELISM", 200)
 
+DEFAULT_SMALL_DATA_THRESHOLD_FOR_LOCAL_AGGREGATION = env_integer(
+    "RAY_DATA_SMALL_DATA_THRESHOLD_FOR_LOCAL_AGGREGATION", 10 * 1024 * 1024
+)
+
 DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = env_bool(
     "RAY_DATA_ENABLE_TENSOR_EXTENSION_CASTING",
     True,
@@ -528,6 +532,11 @@ class DataContext:
             allocation per partition for hash shuffle operator actors.
         hash_aggregate_operator_actor_num_cpus_per_partition_override: Override CPU
             allocation per partition for hash aggregate operator actors.
+        small_data_threshold_for_local_aggregation: Threshold in bytes below which
+            aggregation operations are executed locally without distributed coordination.
+            This improves performance for small datasets by avoiding actor pool startup
+            and remote task scheduling overhead. Set to 0 to disable local aggregation.
+            Defaults to 10MB (10 * 1024 * 1024 bytes).
         use_polars_sort: Whether to use Polars for tabular dataset sorting operations.
         enable_per_node_metrics: Enable per node metrics reporting for Ray Data,
             disabled by default.
@@ -606,6 +615,10 @@ class DataContext:
     hash_shuffle_operator_actor_num_cpus_override: float = None
     hash_aggregate_operator_actor_num_cpus_override: float = None
 
+    small_data_threshold_for_local_aggregation: int = (
+        DEFAULT_SMALL_DATA_THRESHOLD_FOR_LOCAL_AGGREGATION
+    )
+
     scheduling_strategy: SchedulingStrategyT = DEFAULT_SCHEDULING_STRATEGY
     scheduling_strategy_large_args: SchedulingStrategyT = (
         DEFAULT_SCHEDULING_STRATEGY_LARGE_ARGS
@@ -639,9 +652,9 @@ class DataContext:
     )
     write_file_retry_on_errors: List[str] = DEFAULT_WRITE_FILE_RETRY_ON_ERRORS
     warn_on_driver_memory_usage_bytes: int = DEFAULT_WARN_ON_DRIVER_MEMORY_USAGE_BYTES
-    actor_task_retry_on_errors: Union[
-        bool, List[BaseException]
-    ] = DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
+    actor_task_retry_on_errors: Union[bool, List[BaseException]] = (
+        DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
+    )
     actor_init_retry_on_errors: bool = DEFAULT_ACTOR_INIT_RETRY_ON_ERRORS
     actor_init_max_retries: int = DEFAULT_ACTOR_INIT_MAX_RETRIES
     op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
@@ -681,9 +694,9 @@ class DataContext:
         default_factory=_issue_detectors_config_factory
     )
 
-    downstream_capacity_backpressure_ratio: Optional[
-        float
-    ] = DEFAULT_DOWNSTREAM_CAPACITY_BACKPRESSURE_RATIO
+    downstream_capacity_backpressure_ratio: Optional[float] = (
+        DEFAULT_DOWNSTREAM_CAPACITY_BACKPRESSURE_RATIO
+    )
 
     enable_dynamic_output_queue_size_backpressure: bool = (
         DEFAULT_ENABLE_DYNAMIC_OUTPUT_QUEUE_SIZE_BACKPRESSURE
@@ -708,9 +721,7 @@ class DataContext:
         self._kv_configs: Dict[str, Any] = {}
 
         # Sync hash shuffle aggregator fields to its detector config
-        self.issue_detectors_config.hash_shuffle_detector_config.detection_time_interval_s = (
-            self.hash_shuffle_aggregator_health_warning_interval_s
-        )
+        self.issue_detectors_config.hash_shuffle_detector_config.detection_time_interval_s = self.hash_shuffle_aggregator_health_warning_interval_s
         self.issue_detectors_config.hash_shuffle_detector_config.min_wait_time_s = (
             self.min_hash_shuffle_aggregator_wait_time_in_s
         )

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -1449,8 +1449,6 @@ def test_local_aggregation_global_agg(
 
 def test_estimate_input_size_bytes(ray_start_regular_shared_2_cpus):
     """Test the _estimate_input_size_bytes function."""
-    import pyarrow as pa
-
     from ray.data._internal.execution.interfaces import RefBundle
     from ray.data._internal.planner.plan_all_to_all_op import (
         _estimate_input_size_bytes,

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -1341,8 +1341,6 @@ def test_small_data_local_aggregation(
     disable_fallback_to_object_extension,
 ):
     """Test that small datasets use local aggregation fast-path."""
-    from ray.data.context import DataContext, ShuffleStrategy
-
     ctx = DataContext.get_current()
     original_shuffle_strategy = ctx.shuffle_strategy
     original_threshold = ctx.small_data_threshold_for_local_aggregation
@@ -1370,8 +1368,6 @@ def test_local_aggregation_threshold_disabled(
     disable_fallback_to_object_extension,
 ):
     """Test that setting threshold to 0 disables local aggregation."""
-    from ray.data.context import DataContext, ShuffleStrategy
-
     ctx = DataContext.get_current()
     original_shuffle_strategy = ctx.shuffle_strategy
     original_threshold = ctx.small_data_threshold_for_local_aggregation
@@ -1399,8 +1395,6 @@ def test_local_aggregation_mean(
     disable_fallback_to_object_extension,
 ):
     """Test that Mean aggregation works correctly with local aggregation."""
-    from ray.data.context import DataContext, ShuffleStrategy
-
     ctx = DataContext.get_current()
     original_shuffle_strategy = ctx.shuffle_strategy
     original_threshold = ctx.small_data_threshold_for_local_aggregation
@@ -1427,8 +1421,6 @@ def test_local_aggregation_global_agg(
     disable_fallback_to_object_extension,
 ):
     """Test that global aggregation (groupby None) works with local aggregation."""
-    from ray.data.context import DataContext, ShuffleStrategy
-
     ctx = DataContext.get_current()
     original_shuffle_strategy = ctx.shuffle_strategy
     original_threshold = ctx.small_data_threshold_for_local_aggregation

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -1336,6 +1336,155 @@ def test_map_groups_generator_udf(ray_start_regular_shared_2_cpus):
     assert result_ds.count() == 6
 
 
+def test_small_data_local_aggregation(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """Test that small datasets use local aggregation fast-path."""
+    from ray.data.context import DataContext, ShuffleStrategy
+
+    ctx = DataContext.get_current()
+    original_shuffle_strategy = ctx.shuffle_strategy
+    original_threshold = ctx.small_data_threshold_for_local_aggregation
+
+    try:
+        ctx.shuffle_strategy = ShuffleStrategy.SORT_SHUFFLE_PULL_BASED
+        ctx.small_data_threshold_for_local_aggregation = 1024 * 1024
+
+        ds = ray.data.from_items([{"group": x % 3, "value": x} for x in range(100)])
+
+        result = ds.groupby("group").sum("value").sort("group").take_all()
+
+        assert result == [
+            {"group": 0, "sum(value)": 1683},
+            {"group": 1, "sum(value)": 1617},
+            {"group": 2, "sum(value)": 1650},
+        ]
+    finally:
+        ctx.shuffle_strategy = original_shuffle_strategy
+        ctx.small_data_threshold_for_local_aggregation = original_threshold
+
+
+def test_local_aggregation_threshold_disabled(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """Test that setting threshold to 0 disables local aggregation."""
+    from ray.data.context import DataContext, ShuffleStrategy
+
+    ctx = DataContext.get_current()
+    original_shuffle_strategy = ctx.shuffle_strategy
+    original_threshold = ctx.small_data_threshold_for_local_aggregation
+
+    try:
+        ctx.shuffle_strategy = ShuffleStrategy.SORT_SHUFFLE_PULL_BASED
+        ctx.small_data_threshold_for_local_aggregation = 0
+
+        ds = ray.data.from_items([{"group": x % 3, "value": x} for x in range(100)])
+
+        result = ds.groupby("group").sum("value").sort("group").take_all()
+
+        assert result == [
+            {"group": 0, "sum(value)": 1683},
+            {"group": 1, "sum(value)": 1617},
+            {"group": 2, "sum(value)": 1650},
+        ]
+    finally:
+        ctx.shuffle_strategy = original_shuffle_strategy
+        ctx.small_data_threshold_for_local_aggregation = original_threshold
+
+
+def test_local_aggregation_mean(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """Test that Mean aggregation works correctly with local aggregation."""
+    from ray.data.context import DataContext, ShuffleStrategy
+
+    ctx = DataContext.get_current()
+    original_shuffle_strategy = ctx.shuffle_strategy
+    original_threshold = ctx.small_data_threshold_for_local_aggregation
+
+    try:
+        ctx.shuffle_strategy = ShuffleStrategy.SORT_SHUFFLE_PULL_BASED
+        ctx.small_data_threshold_for_local_aggregation = 1024 * 1024
+
+        ds = ray.data.from_items([{"group": x % 3, "value": x} for x in range(100)])
+
+        result = ds.groupby("group").mean("value").sort("group").take_all()
+
+        for row in result:
+            assert "group" in row
+            assert "mean(value)" in row
+            assert row["mean(value)"] is not None
+    finally:
+        ctx.shuffle_strategy = original_shuffle_strategy
+        ctx.small_data_threshold_for_local_aggregation = original_threshold
+
+
+def test_local_aggregation_global_agg(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """Test that global aggregation (groupby None) works with local aggregation."""
+    from ray.data.context import DataContext, ShuffleStrategy
+
+    ctx = DataContext.get_current()
+    original_shuffle_strategy = ctx.shuffle_strategy
+    original_threshold = ctx.small_data_threshold_for_local_aggregation
+
+    try:
+        ctx.shuffle_strategy = ShuffleStrategy.SORT_SHUFFLE_PULL_BASED
+        ctx.small_data_threshold_for_local_aggregation = 1024 * 1024
+
+        ds = ray.data.range(10)
+
+        result = ds.groupby(None).min()
+
+        assert result.take_all() == [{"min(id)": 0}]
+
+        result = ds.groupby(None).max()
+
+        assert result.take_all() == [{"max(id)": 9}]
+
+        result = ds.groupby(None).sum("id")
+
+        assert result.take_all() == [{"sum(id)": 45}]
+    finally:
+        ctx.shuffle_strategy = original_shuffle_strategy
+        ctx.small_data_threshold_for_local_aggregation = original_threshold
+
+
+def test_estimate_input_size_bytes(ray_start_regular_shared_2_cpus):
+    """Test the _estimate_input_size_bytes function."""
+    import pyarrow as pa
+
+    from ray.data._internal.execution.interfaces import RefBundle
+    from ray.data._internal.planner.plan_all_to_all_op import (
+        _estimate_input_size_bytes,
+    )
+    from ray.data.block import BlockMetadata
+
+    block = pa.table({"a": [1, 2, 3], "b": [4, 5, 6]})
+    ray_block = ray.put(block)
+    metadata = BlockMetadata(
+        num_rows=3,
+        size_bytes=100,
+        exec_stats=None,
+        input_files=None,
+    )
+
+    ref_bundle = RefBundle(
+        [(ray_block, metadata)],
+        schema=None,
+        owns_blocks=True,
+    )
+
+    size = _estimate_input_size_bytes([ref_bundle])
+
+    assert size > 0
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
Fixes #61016

For small datasets, Ray Data's groupby/aggregate operations were extremely slow compared to pure pandas due to overhead from actor pool startup and distributed coordination.

This PR adds a local aggregation fast-path that detects small datasets at runtime and executes aggregation locally for datasets below a configurable threshold (default 10MB), falling back to distributed aggregation for larger datasets.

Configurable via DataContext.small_data_threshold_for_local_aggregation or RAY_DATA_SMALL_DATA_THRESHOLD_FOR_LOCAL_AGGREGATION env variable.