### PR TITLE
[RLlib] Optimise `SingleAgentEnvRunner` use of `validate`

### DIFF
--- a/rllib/env/single_agent_episode.py
+++ b/rllib/env/single_agent_episode.py
@@ -456,9 +456,6 @@ class SingleAgentEpisode:
                     f"action_space: {self.action_space}!"
                 )
 
-        # Validate our data.
-        self.validate()
-
         # Step time stats.
         self._last_step_time = time.perf_counter()
         if self._start_time is None:
@@ -583,6 +580,8 @@ class SingleAgentEpisode:
         Returns:
              This `SingleAgentEpisode` object with the converted numpy data.
         """
+        # Check that the episode data is correct
+        self.validate()
 
         self.observations.finalize()
         if len(self) > 0:
@@ -616,7 +615,8 @@ class SingleAgentEpisode:
         assert not self.is_done
         # Make sure the timesteps match.
         assert self.t == other.t_started, f"{self.t=}, {other.t_started=}"
-        # Validate `other`.
+        # Validate both this and the other episode
+        self.validate()
         other.validate()
 
         # Make sure, end matches other episode chunk's beginning.


### PR DESCRIPTION
## Description
This PR is the first of a series looking at optimising RLlib's `SingleAgentEnvRunner.sample`
We found that the `SingleAgentEnvRunner.validate` method took a surprising amount of time, 13.86% of the cumulative time.
The reason for this is that its called in every `__init__`, `add_reset_data`, `add_step_data`.
This PR removes the call from `add_step_data` and adds it to `to_numpy` and `concat_episode` which are used on full episodes providing similar levels of testing without the overhead. 

In testing, I found the `add_step_data` previously took 16.7 seconds (13.86%) and is now 5.43 seconds (4.52%), a 3.1x reduction.
 