### PR TITLE
[Data] Bump `with_column` timeout

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -791,7 +791,7 @@ py_test(
 
 py_test(
     name = "test_with_column",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_with_column.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/61026 updated the test sizes of most Ray Data Bazel rules in accordance with the Bazel warnings.

I think we might've made the `with_column` timeout too small in that change, because `with_column` is now flaking. To avoid that flakiness, this PR bumps the timeout one level.