### PR TITLE
[Data] Add instructions on how to replicate the behavior of `locality_with_output`

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -383,7 +383,9 @@ class ExecutionOptions:
         if value:
             warnings.warn(
                 "`ExecutionOptions.locality_with_output` has been removed and is now "
-                "a no-op.",
+                "a no-op. We don't recommend using it anymore, but if you still want "
+                "to replicate its behavior, follow the instructions in this gist: "
+                "https://gist.github.com/bveeramani/51e0383bb3680dd78fdfb92d76ea22a8.",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/61044 removed `locality_with_output`, a low-level optimization that is often a footgun.

In case users still really want to use this optimization for some reason, this PR links a gist with instructions on how to do so.