### PR TITLE
[Train] Unwrap UserExceptionWithTraceback in WorkerGroupError.worker_failures

### DIFF
--- a/python/ray/train/v2/tests/test_async_checkpointing_validation.py
+++ b/python/ray/train/v2/tests/test_async_checkpointing_validation.py
@@ -232,7 +232,7 @@ def test_report_checkpoint_upload_error(monkeypatch, tmp_path):
     )
     with pytest.raises(WorkerGroupError, match="error") as exc_info:
         trainer.fit()
-    assert isinstance(exc_info.value.worker_failures[0]._base_exc, ValueError)
+    assert isinstance(exc_info.value.worker_failures[0], ValueError)
 
 
 def test_report_validation_without_validation_fn():
@@ -249,7 +249,7 @@ def test_report_validation_without_validation_fn():
         match="`validation_config` was not set on the trainer, but a validation was requested.",
     ) as exc_info:
         trainer.fit()
-    assert isinstance(exc_info.value.worker_failures[0]._base_exc, ValueError)
+    assert isinstance(exc_info.value.worker_failures[0], ValueError)
 
 
 def test_report_validation_without_checkpoint():
@@ -264,7 +264,7 @@ def test_report_validation_without_checkpoint():
         WorkerGroupError, match="Validation requires a checkpoint to be provided."
     ) as exc_info:
         trainer.fit()
-    assert isinstance(exc_info.value.worker_failures[0]._base_exc, ValueError)
+    assert isinstance(exc_info.value.worker_failures[0], ValueError)
 
 
 def test_report_validation_fn_keeps_correct_checkpoints(tmp_path):


### PR DESCRIPTION
## Description

 - Unwrap `UserExceptionWithTraceback` in `WorkerGroupPollStatus.errors` so that `WorkerGroupError.worker_failures` returns the user's original exceptions (e.g., `ValueError`) instead of the internal wrapper
- The full traceback string is still preserved in `WorkerGroupError.__str__()` via `get_error_string()`, which accesses `status.error` directly
- Update test assertions that previously accessed `._base_exc` to check the unwrapped exception directly
