### PR TITLE
[Core] Fix actor task queue blocked when head task's dependency resolution fails

### DIFF
--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -225,6 +225,8 @@ void ActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
                       } else {
                         fail_or_retry_task = true;
                         actor_submit_queue->MarkDependencyFailed(send_pos);
+                        queue->second.cur_pending_calls_--;
+                        SendPendingTasks(actor_id);
                       }
                     }
                   }


### PR DESCRIPTION
## Description
When the head actor task in the queue fails to resolve dependencies, subsequent tasks in the queue may get stuck forever


1. Task A is submitted with an unresolved dependency(depending on a yet creating actor), queued at the head of `SequentialActorSubmitQueue`
2. Task B (no dependencies) is submitted, queued behind A
3. Task B's dependency resolution callback fires, but it can't be sent yet (A is still at the head)
4. Task A's dependency resolution fails(actor registration failure). `MarkDependencyFailed` is called, which removes A from the queue
5. Bug: After `MarkDependencyFailed`, `SendPendingTasks` is not called and `cur_pending_calls_` is not decremented, so B remains stuck in the queue forever
6. Although Task B is now at the head of the queue, its callback has already fired, so nothing will trigger `SendPendingTasks` again

The dependency resolution failure occurs when a dependent actor fails to register, potentially due to GCS timeouts, GCS crashes during registration, name collisions, or actor death

### Fix
Updated the dependency resolution callback in `ActorTaskSubmitter::SubmitTask` to

* Triggers `SendPendingTasks(actor_id)`
* Decrements the `cur_pending_calls_` counter to free the slot.

## Related issues
Closes #60910
Relates to #60850

## Additional information
### Test
#### Before
```
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] AllowOutOfOrderExecution/ActorTaskSubmitterTest.TestTaskDependencyFailedUnblocksQueue/1, where GetParam() = false

 1 FAILED TEST
```

#### After
```
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from AllowOutOfOrderExecution/ActorTaskSubmitterTest
[  ... snip ... ]
[----------] 2 tests from AllowOutOfOrderExecution/ActorTaskSubmitterTest (1 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 2 tests.
```

