### PR TITLE
[serve][llm] Add embeddings endpoint to SGLang example engine

### DIFF
--- a/python/ray/llm/examples/sglang/modules/sglang_engine.py
+++ b/python/ray/llm/examples/sglang/modules/sglang_engine.py
@@ -271,8 +271,19 @@ class SGLangServer:
             if not isinstance(results, list):
                 results = [results]
 
+            if not results:
+                raise RuntimeError(
+                    "SGLang engine returned an empty response for embedding request."
+                )
+
+            if len(results) != len(texts):
+                raise RuntimeError(
+                    f"SGLang engine returned {len(results)} results "
+                    f"for {len(texts)} inputs."
+                )
+
             for i, result in enumerate(results):
-                embedding = result["embedding"]
+                embedding = result.get("embedding", [])
                 meta = result.get("meta_info", {}) or {}
                 prompt_tokens = int(meta.get("prompt_tokens", 0))
                 total_prompt_tokens += prompt_tokens

--- a/python/ray/llm/examples/sglang/readme.md
+++ b/python/ray/llm/examples/sglang/readme.md
@@ -17,13 +17,13 @@ This document provides a guide for deploying and interacting with the custom **S
 What is NOT supported in this implementation:
 
 - Support for engine replicas
-- SGLangServer implemented chat and completions methods but no embeddings, transcriptions, and score methods
+- SGLangServer implements chat, completions, and embeddings methods but no tokenize, detokenize, transcriptions, and score methods
 - Support for TP/PP/DP
 
 ## Core Components
 
 Your custom deployment consists of two main components:
-1. `SGLangServer` (**Backend**): The core Ray Serve deployment that initializes the SGLang runtime and model. This deployment contains the model's business logic, including resource requirements and generation methods (`completions` and `chat_completions`).
+1. `SGLangServer` (**Backend**): The core Ray Serve deployment that initializes the SGLang runtime and model. This deployment contains the model's business logic, including resource requirements and generation methods (`completions`, `chat_completions`, and `embeddings`).
 2. enable ENV-VAR: `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0` on CUDA device or `RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=0` on ROCm device
 ### Deploy an LLM model using SGLang Engine
 

--- a/release/llm_tests/serve/test_llm_serve_sglang.py
+++ b/release/llm_tests/serve/test_llm_serve_sglang.py
@@ -66,6 +66,27 @@ def test_sglang_serve_e2e():
         temperature=0.0,
     )
     assert comp_resp.choices[0].text.strip()
+
+    # Embeddings - single input
+    emb_resp = client.embeddings.create(
+        model=RAY_MODEL_ID,
+        input="Hello world",
+    )
+    assert emb_resp.data
+    assert len(emb_resp.data) == 1
+    assert emb_resp.data[0].embedding
+    assert len(emb_resp.data[0].embedding) > 0
+    assert emb_resp.usage.prompt_tokens > 0
+
+    # Embeddings - batch input
+    emb_batch_resp = client.embeddings.create(
+        model=RAY_MODEL_ID,
+        input=["Hello world", "How are you"],
+    )
+    assert len(emb_batch_resp.data) == 2
+    assert emb_batch_resp.data[0].embedding
+    assert emb_batch_resp.data[1].embedding
+
     serve.shutdown()
 
 

--- a/release/llm_tests/serve/test_llm_serve_sglang.py
+++ b/release/llm_tests/serve/test_llm_serve_sglang.py
@@ -43,6 +43,7 @@ def sglang_client():
             "model_path": MODEL_ID,
             "tp_size": 1,
             "mem_fraction_static": 0.8,
+            "is_embedding": True,
         },
     )
 

--- a/release/llm_tests/serve/test_llm_serve_sglang.py
+++ b/release/llm_tests/serve/test_llm_serve_sglang.py
@@ -43,7 +43,6 @@ def sglang_client():
             "model_path": MODEL_ID,
             "tp_size": 1,
             "mem_fraction_static": 0.8,
-            "is_embedding": True,
         },
     )
 
@@ -76,10 +75,43 @@ def test_sglang_serve_e2e(sglang_client):
     assert comp_resp.choices[0].text.strip()
 
 
-def test_sglang_embeddings(sglang_client):
+@pytest.fixture(scope="module")
+def sglang_embedding_client():
+    """Start an SGLang server with is_embedding enabled for embedding tests."""
+    llm_config = LLMConfig(
+        model_loading_config={
+            "model_id": RAY_MODEL_ID,
+            "model_source": MODEL_ID,
+        },
+        deployment_config={
+            "autoscaling_config": {
+                "min_replicas": 1,
+                "max_replicas": 1,
+            }
+        },
+        server_cls=SGLangServer,
+        engine_kwargs={
+            "model_path": MODEL_ID,
+            "tp_size": 1,
+            "mem_fraction_static": 0.8,
+            "is_embedding": True,
+        },
+    )
+
+    app = build_openai_app({"llm_configs": [llm_config]})
+    serve.run(app, blocking=False)
+    wait_for_condition(_app_is_running, timeout=300)
+
+    client = OpenAI(base_url="http://localhost:8000/v1", api_key="fake-key")
+    yield client
+
+    serve.shutdown()
+
+
+def test_sglang_embeddings(sglang_embedding_client):
     """Verify embeddings endpoint works with single and batch inputs."""
     # Single input
-    emb_resp = sglang_client.embeddings.create(
+    emb_resp = sglang_embedding_client.embeddings.create(
         model=RAY_MODEL_ID,
         input="Hello world",
     )
@@ -90,7 +122,7 @@ def test_sglang_embeddings(sglang_client):
     assert emb_resp.usage.prompt_tokens > 0
 
     # Batch input
-    emb_batch_resp = sglang_client.embeddings.create(
+    emb_batch_resp = sglang_embedding_client.embeddings.create(
         model=RAY_MODEL_ID,
         input=["Hello world", "How are you"],
     )


### PR DESCRIPTION
## Description
Add `embeddings()` method to `SGLangServer` using SGLang's `async_encode()` API. Handles both `EmbeddingCompletionRequest` (string/token ID inputs) and `EmbeddingChatRequest` (chat messages) variants. Updates readme to reflect the newly supported endpoint.

## Related issues
Related to #61113

## Additional information
This is the first of two PRs to close #61113. A follow-up PR will add `tokenize` and `detokenize` endpoints.